### PR TITLE
Adds "all" optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ sim = ["redis>=7.2"]
 anthropic = ["anthropic>=0.39"]
 postgres = ["psycopg[binary]>=3.2"]
 discord = ["discord.py>=2.4", "redis>=7.2"]
-
+all = ["turnstone[mq,console,sim,anthropic,postgres,discord]"]
 
 [project.scripts]
 turnstone = "turnstone.cli:main"


### PR DESCRIPTION
Include "all" option for anyone who wants to install all optional dependencies. FWIW, you may want to consider moving `dev` and `tests` from options to dependency groups:

```toml
[dependency-groups]
test = ["pytest>=9.0", "pytest-cov>=6.0", "croniter>=3.0"]
dev = ["ruff>=0.9", "mypy>=1.14", "types-redis>=4.6"]
```

My understanding from [PEP735](https://peps.python.org/pep-0735/) is that dependency groups don't ship with the package builds. Since those are more dev-related, probably can move those so they're not included in the build.


I have read the CLA and I agree to its terms.