### PR TITLE
test: add scope coverage for internal MCP/config reload endpoints

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -179,6 +179,15 @@ class TestRequiredScope:
     def test_internal_config_reload_needs_approve(self):
         assert required_scope("POST", "/api/_internal/config-reload") == "approve"
 
+    def test_v1_internal_config_reload_needs_approve(self):
+        assert required_scope("POST", "/v1/api/_internal/config-reload") == "approve"
+
+    def test_proxy_internal_config_reload_needs_approve(self):
+        assert required_scope("POST", "/node/n1/v1/api/_internal/config-reload") == "approve"
+
+    def test_proxy_no_v1_internal_config_reload_needs_approve(self):
+        assert required_scope("POST", "/node/n1/api/_internal/config-reload") == "approve"
+
     def test_proxy_internal_mcp_reload_needs_approve(self):
         assert required_scope("POST", "/node/n1/v1/api/_internal/mcp-reload") == "approve"
 


### PR DESCRIPTION
Verify required_scope() returns "approve" for _internal endpoints across all access patterns (bare, /v1/-prefixed, console proxy with and without /v1/), plus a GET negative test confirming only POST is elevated. Closes the "internal endpoints accept read scope" item in PROGRESS.md — the endpoints were already in APPROVE_PATHS.