### PR TITLE
fix: inject prompt template guardrails into plan agent system message

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -349,7 +349,7 @@ class TestPlanExec:
         assert ChatSession._PLAN_IDENTITY in sys_content
         # Template appears before plan identity
         tpl_pos = sys_content.index("SAFETY:")
-        identity_pos = sys_content.index("You are a planning agent.")
+        identity_pos = sys_content.index(ChatSession._PLAN_IDENTITY)
         assert tpl_pos < identity_pos
 
     def test_plan_no_template_is_identity_only(self, tmp_db, tmp_path, monkeypatch):
@@ -597,7 +597,7 @@ class TestPlanRefinement:
         assert "SAFETY: guardrails here" in sys_content
         assert ChatSession._PLAN_IDENTITY in sys_content
         tpl_pos = sys_content.index("SAFETY:")
-        identity_pos = sys_content.index("You are a planning agent.")
+        identity_pos = sys_content.index(ChatSession._PLAN_IDENTITY)
         assert tpl_pos < identity_pos
 
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3554,6 +3554,7 @@ class ChatSession:
             return self._PLAN_IDENTITY
         tpl = self._template_content
         if len(tpl) > _MAX_TEMPLATE_CONTENT:
+            log.warning("template_content.truncated", length=len(tpl), agent="plan")
             tpl = tpl[:_MAX_TEMPLATE_CONTENT]
         return tpl + "\n\n" + self._PLAN_IDENTITY
 
@@ -3635,7 +3636,8 @@ class ChatSession:
                                 break
 
         # Plan agent gets template guardrails + its own identity — no tool
-        # patterns, MCP resources, or conversation history.
+        # patterns, MCP resources, or general conversation history (only
+        # prior plan tool_call/result pairs are forwarded for refinement).
         agent_messages: list[dict[str, Any]] = [
             {"role": "system", "content": self._plan_system_content()},
         ]


### PR DESCRIPTION
Safety/behavioral templates were silently bypassed by the plan agent, which only used _PLAN_IDENTITY. Now _plan_system_content() prepends _template_content (when present) so admin-configured guardrails apply to both _exec_plan and _refine_plan, matching the task agent pattern.