### PR TITLE
fix: use pgautoupgrade for seamless postgres major version upgrades

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,7 @@ services:
   # PostgreSQL — production database (profile: production)
   # -------------------------------------------------------------------
   postgres:
-    image: postgres:18-alpine
+    image: pgautoupgrade/pgautoupgrade:18-alpine
     profiles:
       - production
       - cluster
@@ -35,6 +35,7 @@ services:
       POSTGRES_DB: turnstone
       POSTGRES_USER: ${POSTGRES_USER:-turnstone}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required for production profile}
+      PGDATA: /var/lib/postgresql/data
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
@@ -44,7 +45,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-      start_period: 5s
+      start_period: 30s
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Replaces postgres:18-alpine with pgautoupgrade/pgautoupgrade:18-alpine in compose.yaml. Sets PGDATA=/var/lib/postgresql/data so pgautoupgrade detects existing pg17 data and runs pg_upgrade automatically on first start. No manual migration needed.

Also increases healthcheck start_period to 30s to accommodate the one-time upgrade process.