### PR TITLE
fix: apt-get upgrade in Dockerfile to resolve CVE-2026-0861

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.title="turnstone" \
 COPY --from=ghcr.io/astral-sh/uv:0.10.10 /uv /usr/local/bin/uv
 
 # System dependencies for psycopg (PostgreSQL client library)
-RUN apt-get update && apt-get install -y --no-install-recommends libpq5 \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user


### PR DESCRIPTION
Trivy scan fails on HIGH for libc-bin/libc6 (2.41-12+deb13u1). The fix (2.41-12+deb13u2) is available in Debian repos but the base python:3.14-slim image hasn't been rebuilt yet. Adding apt-get upgrade pulls in all pending security patches at build time.