### PR TITLE
feat: metacognitive nudge on tool error — search memories for guidance

### DIFF
--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -6,6 +6,7 @@ from turnstone.core.metacognition import (
     NUDGE_DENIAL,
     NUDGE_RESUME,
     NUDGE_START,
+    NUDGE_TOOL_ERROR,
     detect_completion,
     detect_correction,
     format_nudge,
@@ -263,5 +264,27 @@ class TestFormatNudge:
     def test_start(self):
         assert format_nudge("start") == NUDGE_START
 
+    def test_tool_error(self):
+        assert format_nudge("tool_error") == NUDGE_TOOL_ERROR
+
     def test_invalid(self):
         assert format_nudge("invalid") == ""
+
+
+class TestToolErrorNudge:
+    def test_fires(self):
+        state: dict[str, float] = {}
+        assert should_nudge("tool_error", state, message_count=5, memory_count=3) is True
+
+    def test_cooldown(self):
+        state: dict[str, float] = {}
+        assert should_nudge("tool_error", state, message_count=5, memory_count=3) is True
+        assert should_nudge("tool_error", state, message_count=6, memory_count=3) is False
+
+    def test_not_on_first_message(self):
+        state: dict[str, float] = {}
+        assert should_nudge("tool_error", state, message_count=1, memory_count=3) is False
+
+    def test_not_with_zero_memories(self):
+        state: dict[str, float] = {}
+        assert should_nudge("tool_error", state, message_count=5, memory_count=0) is False

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -44,12 +44,19 @@ NUDGE_START = (
     "user's request to find applicable context, preferences, or guidance."
 )
 
+NUDGE_TOOL_ERROR = (
+    "A tool just returned an error. Before retrying, check your memories — "
+    "the user may have given feedback about this tool or error pattern in a "
+    "previous session. Use memory(action='search') to find relevant guidance."
+)
+
 _NUDGE_MAP: dict[str, str] = {
     "correction": NUDGE_CORRECTION,
     "denial": NUDGE_DENIAL,
     "resume": NUDGE_RESUME,
     "completion": NUDGE_COMPLETION,
     "start": NUDGE_START,
+    "tool_error": NUDGE_TOOL_ERROR,
 }
 
 # ---------------------------------------------------------------------------
@@ -152,6 +159,9 @@ def should_nudge(
         return False
     # Start nudge only on first message
     if nudge_type == "start" and message_count != 1:
+        return False
+    # Tool error nudge only if there are memories to search
+    if nudge_type == "tool_error" and memory_count == 0:
         return False
     # Resume/start nudge only if there are memories to recall
     if nudge_type in ("resume", "start") and memory_count == 0:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1212,6 +1212,29 @@ class ChatSession:
                             _tname,
                             tool_call_id=tc_id,
                         )
+                # Metacognitive nudge: check memories on tool error
+                if (
+                    self._memory_config.nudges
+                    and any(
+                        isinstance(out, str)
+                        and (
+                            out.startswith("Error")
+                            or " error: " in out[:50]
+                            or out.startswith("Command timed out")
+                            or out.startswith("Unknown tool:")
+                        )
+                        for _, out in results
+                    )
+                    and should_nudge(
+                        "tool_error",
+                        self._metacog_state,
+                        message_count=len(self.messages),
+                        memory_count=self._visible_memory_count(),
+                        cooldown_secs=self._memory_config.nudge_cooldown,
+                    )
+                ):
+                    self._pending_nudge.append(format_nudge("tool_error"))
+                    self._init_system_messages()
                 # Inject user feedback from approval prompt (e.g. "y, use full path")
                 if user_feedback:
                     self.messages.append({"role": "user", "content": user_feedback})


### PR DESCRIPTION
Add tool_error nudge type that fires when a tool returns an error, prompting the model to search memories for prior feedback about the tool or error pattern before retrying. Respects existing cooldown (5 min) and rate limiting. 3 new tests.