### PR TITLE
fix: output guard detects single secret-bearing env lines

### DIFF
--- a/tests/test_output_guard.py
+++ b/tests/test_output_guard.py
@@ -184,6 +184,17 @@ class TestEnvSecretFalsePositives:
         r = evaluate_output("APP_NAME=myapp\nSECRET_KEY=abc123\nAPI_TOKEN=xyz789\nDEBUG=true")
         assert "env_file_leak" in r.flags
 
+    def test_single_secret_env_line(self) -> None:
+        """A single AWS_SECRET_ACCESS_KEY=... line should trigger."""
+        r = evaluate_output("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        assert "env_file_leak" in r.flags
+        assert r.risk_level == "high"
+
+    def test_substring_key_no_false_positive(self) -> None:
+        """MONKEY=banana should not trigger (KEY is a substring, not a segment)."""
+        r = evaluate_output("MONKEY=banana\nTURKEY=gobble\nDONKEY=hee-haw")
+        assert "env_file_leak" not in r.flags
+
 
 class TestOutputAssessment:
     """Verify OutputAssessment structure."""

--- a/turnstone/core/output_guard.py
+++ b/turnstone/core/output_guard.py
@@ -54,7 +54,10 @@ _RE_CONNECTION_STRING = re.compile(
     r"(?:postgresql|mysql|mongodb|redis|amqp)://[^:@\s]+:[^@\s]+@",
 )
 _RE_ENV_SECRET_LINE = re.compile(r"[A-Z][A-Z_0-9]+=\S+")
-_RE_ENV_SECRET_KEY = re.compile(r"SECRET|KEY|TOKEN|PASSWORD|CREDENTIAL", re.IGNORECASE)
+_RE_ENV_SECRET_KEY = re.compile(
+    r"(?:^|_)(?:SECRET|TOKEN|PASSWORD|CREDENTIAL)(?:_|$)|(?:^|_)KEY(?:_|$)",
+    re.IGNORECASE,
+)
 
 # (pattern, redact_label) — ordered most-specific first for redaction.
 _CREDENTIAL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -218,8 +221,7 @@ def _check_credentials(
         risk = "high"
 
     env_lines = _RE_ENV_SECRET_LINE.findall(text)
-    secret_env_lines = [ln for ln in env_lines if _RE_ENV_SECRET_KEY.search(ln.split("=", 1)[0])]
-    if secret_env_lines:
+    if any(_RE_ENV_SECRET_KEY.search(ln.split("=", 1)[0]) for ln in env_lines):
         _add_flag(flags, "credential_leak")
         flags.append("env_file_leak")
         ann.append("Output contains .env-style assignments with secret-bearing keys.")


### PR DESCRIPTION
The credential leak check required 3+ env-style lines before flagging. A single AWS_SECRET_ACCESS_KEY=... line was missed. Now flags whenever any env line has a secret-bearing key name (SECRET, KEY, TOKEN, PASSWORD, CREDENTIAL), regardless of how many total env lines exist.