### PR TITLE
chore: remove dead code and fix noisy JWT test warnings

### DIFF
--- a/docs/diagrams/03-core-engine-classes.puml
+++ b/docs/diagrams/03-core-engine-classes.puml
@@ -250,13 +250,11 @@ class "MCPClientManager" as MCPMgr {
 
 ' ToolSearchManager
 class "ToolSearchManager" as ToolSearchMgr {
-    - _all_tools: list[dict]
     - _always_on: list[dict]
     - _deferred: list[dict]
     - _expanded: dict[str, None]
     - _index: BM25Index
     --
-    + should_activate() → bool
     + get_visible_tools() → list[dict]
     + get_deferred_tools() → list[dict]
     + get_expanded_names() → list[str]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -591,9 +591,9 @@ CLI flags override the config file:
 
 ### How it works
 
-1. **Threshold check**: At session startup, `ToolSearchManager.should_activate()`
-   counts total tools (built-in + MCP). If the count is below the threshold, tool
-   search stays off and all tools are sent to the model directly.
+1. **Threshold check**: At session startup, if the total tool count (built-in + MCP)
+   is below the threshold, tool search stays off and all tools are sent to the model
+   directly.
 
 2. **Partitioning**: When active, tools are split into two sets:
    - **Always-on** -- the 17 built-in tools (members of `BUILTIN_TOOL_NAMES`).

--- a/tests/test_auth_identity.py
+++ b/tests/test_auth_identity.py
@@ -130,7 +130,7 @@ class TestParseScopes:
 
 
 class TestJWT:
-    SECRET = "test-secret-key-for-jwt"
+    SECRET = "test-secret-key-for-jwt-min-32b!"
 
     def test_round_trip(self):
         scopes = frozenset({"read", "write"})
@@ -155,7 +155,7 @@ class TestJWT:
 
     def test_invalid_signature(self):
         token = create_jwt("user1", frozenset({"read"}), "db", self.SECRET)
-        assert validate_jwt(token, "wrong-secret") is None
+        assert validate_jwt(token, "wrong-secret-key-for-jwt-min-32b") is None
 
     def test_malformed_token(self):
         assert validate_jwt("not.a.jwt", self.SECRET) is None
@@ -217,7 +217,7 @@ class TestAuthenticateToken:
         assert result.scopes == frozenset({"read", "write", "approve"})
 
     def test_jwt_token(self):
-        secret = "test-secret"
+        secret = "test-secret-key-for-jwt-min-32b!"
         jwt_tok = create_jwt("user1", frozenset({"read", "write"}), "db", secret)
         cfg = AuthConfig(enabled=True)
         result = _authenticate_token(jwt_tok, cfg, jwt_secret=secret)
@@ -304,7 +304,7 @@ class TestCheckRequestScopes:
         assert result.has_scope("approve")
 
     def test_jwt_with_scopes(self):
-        secret = "test"
+        secret = "test-secret-key-for-jwt-min-32b!"
         jwt_tok = create_jwt("u1", frozenset({"read", "write"}), "db", secret)
         cfg = AuthConfig(enabled=True)
         allowed, status, msg, result = check_request(
@@ -319,7 +319,7 @@ class TestCheckRequestScopes:
         assert result.user_id == "u1"
 
     def test_jwt_insufficient_scope(self):
-        secret = "test"
+        secret = "test-secret-key-for-jwt-min-32b!"
         jwt_tok = create_jwt("u1", frozenset({"read"}), "db", secret)
         cfg = AuthConfig(enabled=True)
         allowed, status, msg, _ = check_request(

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -182,7 +182,6 @@ class TestErrorHandling:
         result = judge._evaluate_single(
             _make_item(),
             [{"role": "user", "content": "test"}],
-            MagicMock(),
         )
         assert result is None
 
@@ -215,7 +214,6 @@ class TestErrorHandling:
         result = judge._evaluate_single(
             _make_item(),
             [{"role": "user", "content": "test"}],
-            MagicMock(),
         )
         assert result is None
 
@@ -259,7 +257,6 @@ class TestMultiTurnToolUse:
         verdict = judge._evaluate_single(
             _make_item(),
             [{"role": "user", "content": "test"}],
-            MagicMock(),
         )
         assert verdict is not None
         assert verdict.tier == "llm"
@@ -305,7 +302,6 @@ class TestMultiTurnToolUse:
         judge._evaluate_single(
             _make_item(),
             [{"role": "user", "content": "test"}],
-            MagicMock(),
         )
         # Should have called create_completion exactly _JUDGE_MAX_TURNS times
         assert provider.create_completion.call_count == 5

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -131,7 +131,7 @@ def authorize_client(storage: SQLiteBackend, oidc_config: OIDCConfig) -> TestCli
     )
     app.state.oidc_config = oidc_config
     app.state.auth_storage = storage
-    app.state.jwt_secret = "test-jwt-secret"
+    app.state.jwt_secret = "test-jwt-secret-key-padded-32b!!"
     app.state.jwks_data = {"keys": []}
     app.state.login_limiter = None
     return TestClient(app, raise_server_exceptions=False)
@@ -468,7 +468,7 @@ class TestOIDCCallback:
         )
         app.state.oidc_config = _make_oidc_config()
         app.state.auth_storage = backend
-        app.state.jwt_secret = "secret"
+        app.state.jwt_secret = "test-jwt-secret-key-padded-32b!!"
         app.state.jwks_data = {"keys": []}
         app.state.login_limiter = None
 
@@ -492,7 +492,7 @@ class TestOIDCCallback:
         )
         app.state.oidc_config = _make_oidc_config()
         app.state.auth_storage = storage
-        app.state.jwt_secret = "secret"
+        app.state.jwt_secret = "test-jwt-secret-key-padded-32b!!"
         app.state.jwks_data = {"keys": []}
         limiter = LoginRateLimiter(max_attempts=1, window_seconds=300)
         limiter.record("ip:testclient")

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -74,7 +74,7 @@ class TestSimEngine:
 
     def test_llm_response_returns_content(self, engine):
         async def _test():
-            content, tool_calls = await engine.simulate_llm_response(True, 1)
+            content, tool_calls = await engine.simulate_llm_response(True)
             assert isinstance(content, str)
             assert len(content) > 0
             assert isinstance(tool_calls, list)
@@ -85,8 +85,8 @@ class TestSimEngine:
         async def _test():
             e1 = SimEngine(fast_config, rng=random.Random(123))
             e2 = SimEngine(fast_config, rng=random.Random(123))
-            c1, t1 = await e1.simulate_llm_response(True, 1)
-            c2, t2 = await e2.simulate_llm_response(True, 1)
+            c1, t1 = await e1.simulate_llm_response(True)
+            c2, t2 = await e2.simulate_llm_response(True)
             assert c1 == c2
             assert len(t1) == len(t2)
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -128,16 +128,8 @@ class TestToolSearchManager:
         return ToolSearchManager(
             all_tools,
             always_on_names={"bash", "read_file", "edit_file"},
-            threshold=5,
             max_results=3,
         )
-
-    def test_should_activate_above_threshold(self, manager):
-        assert manager.should_activate()
-
-    def test_should_not_activate_below_threshold(self, builtin_tools):
-        mgr = ToolSearchManager(builtin_tools, always_on_names={"bash", "read_file", "edit_file"})
-        assert not mgr.should_activate()
 
     def test_visible_tools_initially_builtin_only(self, manager):
         visible = manager.get_visible_tools()
@@ -200,9 +192,6 @@ class TestToolSearchManager:
         deferred = manager.get_deferred_tools()
         names = {_tool_name(t) for t in deferred}
         assert "mcp__github__create_issue" not in names
-
-    def test_get_all_tools_returns_everything(self, manager, builtin_tools, mcp_tools):
-        assert len(manager.get_all_tools()) == len(builtin_tools) + len(mcp_tools)
 
     def test_search_tool_definition_format(self, manager):
         defn = manager.get_search_tool_definition()

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -975,7 +975,7 @@ class IntentJudge:
         """Daemon thread: run LLM judge for each item and invoke callback."""
         for item, h_verdict in zip(items, heuristic_verdicts, strict=True):
             try:
-                llm_verdict = self._evaluate_single(item, messages, h_verdict)
+                llm_verdict = self._evaluate_single(item, messages)
                 # Arbitrate: only callback when LLM upgrades the heuristic
                 if llm_verdict and llm_verdict.confidence > h_verdict.confidence:
                     callback(llm_verdict)
@@ -990,7 +990,6 @@ class IntentJudge:
         self,
         item: dict[str, Any],
         messages: list[dict[str, Any]],
-        heuristic: IntentVerdict,
     ) -> IntentVerdict | None:
         """Run LLM judge for a single tool call. Returns verdict or None."""
         start = time.monotonic()

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -347,7 +347,6 @@ class ChatSession:
             self._tool_search = ToolSearchManager(
                 self._tools,
                 always_on_names=set(BUILTIN_TOOL_NAMES),
-                threshold=tool_search_threshold,
                 max_results=tool_search_max_results,
             )
         # Skill: explicit name overrides is_default skills
@@ -527,7 +526,6 @@ class ChatSession:
             self._tool_search = ToolSearchManager(
                 self._tools,
                 always_on_names=set(BUILTIN_TOOL_NAMES),
-                threshold=self._tool_search_threshold,
                 max_results=self._tool_search_max_results,
             )
             # Restore previously expanded tools that still exist

--- a/turnstone/core/tool_search.py
+++ b/turnstone/core/tool_search.py
@@ -64,15 +64,12 @@ class ToolSearchManager:
         all_tools: list[dict[str, Any]],
         always_on_names: set[str],
         *,
-        threshold: int = 20,
         max_results: int = 5,
     ) -> None:
-        self._all_tools = all_tools
         self._always_on: list[dict[str, Any]] = []
         self._deferred: list[dict[str, Any]] = []
         self._deferred_by_name: dict[str, dict[str, Any]] = {}
         self._expanded: dict[str, None] = {}  # ordered set (preserves discovery order)
-        self._threshold = threshold
         self._max_results = max_results
 
         for tool in all_tools:
@@ -90,10 +87,6 @@ class ToolSearchManager:
         # Pre-compute server summary for the search tool description
         self._server_hint = _mcp_server_summary(self._deferred)
 
-    def should_activate(self) -> bool:
-        """Return True if tool search should be active (enough tools)."""
-        return len(self._all_tools) > self._threshold
-
     def get_visible_tools(self) -> list[dict[str, Any]]:
         """Return always-on tools + any expanded (discovered) tools."""
         result = list(self._always_on)
@@ -106,10 +99,6 @@ class ToolSearchManager:
     def get_deferred_tools(self) -> list[dict[str, Any]]:
         """Return tools that are currently deferred (not yet discovered)."""
         return [t for t in self._deferred if _tool_name(t) not in self._expanded]
-
-    def get_all_tools(self) -> list[dict[str, Any]]:
-        """Return the full tool list (for native provider modes)."""
-        return list(self._all_tools)
 
     def search(self, query: str) -> list[dict[str, Any]]:
         """Search deferred tools by query, return top-k matches.

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -32,7 +32,6 @@ MAX_WATCHES_PER_WS = 5
 MIN_INTERVAL = 10  # seconds
 MAX_INTERVAL = 86_400  # 24 hours
 DEFAULT_MAX_POLLS = 100
-DEFAULT_INTERVAL = 300  # 5 minutes
 MAX_OUTPUT_SIZE = 65_536  # truncate stored/dispatched output at 64 KB
 
 # Safe builtins exposed to condition expressions.

--- a/turnstone/sim/engine.py
+++ b/turnstone/sim/engine.py
@@ -66,9 +66,7 @@ class SimEngine:
         self._config = config
         self._rng = rng or random.Random(config.seed)
 
-    async def simulate_llm_response(
-        self, first_round: bool, turn_number: int
-    ) -> tuple[str, list[dict[str, Any]]]:
+    async def simulate_llm_response(self, first_round: bool) -> tuple[str, list[dict[str, Any]]]:
         """Simulate an LLM response.
 
         Returns ``(content_text, tool_calls)`` where *tool_calls* may be

--- a/turnstone/sim/node.py
+++ b/turnstone/sim/node.py
@@ -75,7 +75,6 @@ class SimWorkstream:
                 self._set_state("thinking", correlation_id)
                 content, tool_calls = await self._engine.simulate_llm_response(
                     rounds == 0,
-                    self._turn_count,
                 )
                 await self._stream_content(content, correlation_id)
 

--- a/turnstone/sim/scenario.py
+++ b/turnstone/sim/scenario.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from turnstone.mq.broker import RedisBroker
 from turnstone.mq.protocol import SendMessage
@@ -16,15 +16,6 @@ if TYPE_CHECKING:
     from turnstone.sim.metrics import MetricsCollector
 
 log = logging.getLogger("turnstone.sim.scenario")
-
-
-class Scenario(Protocol):
-    async def run(
-        self,
-        cluster: SimCluster,
-        config: SimConfig,
-        metrics: MetricsCollector,
-    ) -> None: ...
 
 
 class SteadyStateScenario:


### PR DESCRIPTION
Remove unused methods (ToolSearchManager.should_activate, get_all_tools), dead attributes (_all_tools, _threshold), unused constant (DEFAULT_INTERVAL), unused Scenario protocol class, and vestigial parameters (judge._evaluate_single heuristic, SimEngine.simulate_llm_response turn_number). Lengthen JWT test secrets to >= 32 bytes to suppress InsecureKeyLengthWarning from PyJWT.