### PR TITLE
fix: validate URL scheme after MCP registry template substitution

### DIFF
--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -432,6 +432,38 @@ class TestResolveInstallConfig:
         config = resolve_install_config(server, "remote", 0, variables={"host": "api"})
         assert config["url"] == "https://api.example.com/mcp"
 
+    def test_remote_variable_substitution_missing_hostname(self) -> None:
+        """URL like https:///mcp has valid scheme but no hostname."""
+        server = RegistryServer(
+            name="io.example/test",
+            version="1.0.0",
+            remotes=[
+                RegistryRemote(
+                    type="streamable-http",
+                    url="https:///mcp",
+                )
+            ],
+        )
+        with pytest.raises(MCPRegistryError, match="hostname is missing"):
+            resolve_install_config(server, "remote", 0)
+
+    def test_remote_variable_substitution_embedded_credentials(self) -> None:
+        server = RegistryServer(
+            name="io.example/test",
+            version="1.0.0",
+            remotes=[
+                RegistryRemote(
+                    type="streamable-http",
+                    url="https://{creds}@example.com/mcp",
+                    variables={
+                        "creds": RegistryRemoteVariable(is_required=True),
+                    },
+                )
+            ],
+        )
+        with pytest.raises(MCPRegistryError, match="embedded credentials"):
+            resolve_install_config(server, "remote", 0, variables={"creds": "user:pass"})
+
     def test_remote_no_remotes(self) -> None:
         server = RegistryServer(name="io.example/test", version="1.0.0")
         with pytest.raises(MCPRegistryError, match="no remote"):

--- a/turnstone/core/mcp_registry.py
+++ b/turnstone/core/mcp_registry.py
@@ -401,12 +401,16 @@ def resolve_install_config(
                     raise MCPRegistryError(f"Required URL variable '{var_name}' not provided")
                 url = url.replace(placeholder, value)
 
-        # Validate URL scheme after substitution to prevent SSRF-style redirection
+        # Validate URL after substitution to prevent SSRF-style redirection
         parsed = urlparse(url)
         if parsed.scheme not in ("http", "https"):
             raise MCPRegistryError(
                 f"Invalid URL scheme '{parsed.scheme}' after variable substitution"
             )
+        if not parsed.hostname:
+            raise MCPRegistryError("Invalid URL (hostname is missing) after variable substitution")
+        if parsed.username is not None or parsed.password is not None:
+            raise MCPRegistryError("URLs with embedded credentials are not allowed in MCP remotes")
 
         # Build headers dict (required keys only — values provided by user at install time)
         headers: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Validates `urlparse(url).scheme in ("http", "https")` after template variable substitution in `resolve_install_config()`
- Prevents SSRF-style redirection through crafted template variables (e.g. `file://`, `ftp://`)
- Raises `MCPRegistryError` with descriptive message on invalid scheme
- Two new tests: invalid scheme rejection + valid scheme passthrough

## Test plan
- [x] `test_remote_variable_substitution_invalid_scheme` — `file://` scheme rejected
- [x] `test_remote_variable_substitution_preserves_valid_scheme` — `https://` passes
- [x] All 34 MCP registry tests pass
- [x] ruff + mypy clean