### PR TITLE
test: add _get_registry_url three-tier fallback tests

### DIFF
--- a/tests/test_mcp_registry_api.py
+++ b/tests/test_mcp_registry_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from starlette.applications import Starlette
@@ -18,11 +18,13 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
 from turnstone.console.server import (
+    _get_registry_url,
     admin_registry_install,
     admin_registry_search,
 )
 from turnstone.core.auth import AuthResult
 from turnstone.core.mcp_registry import (
+    DEFAULT_REGISTRY_URL,
     MCPRegistryError,
     RegistryPackage,
     RegistryRemote,
@@ -549,3 +551,111 @@ class TestRegistryInstall:
 
         assert resp.status_code == 409
         assert "custom 'name'" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# _get_registry_url fallback chain tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_request(storage: Any = None) -> MagicMock:
+    """Build a mock Request with app.state.auth_storage."""
+    request = MagicMock()
+    request.app.state.auth_storage = storage
+    return request
+
+
+class TestGetRegistryUrl:
+    """Verify three-tier URL resolution: DB setting -> config.toml -> default."""
+
+    def test_returns_db_setting_when_available(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.return_value = {
+            "value": json.dumps("https://custom.registry.example.com"),
+        }
+        request = _mock_request(storage)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            url = _get_registry_url(request)
+
+        assert url == "https://custom.registry.example.com"
+        storage.get_system_setting.assert_called_once_with("mcp.registry_url")
+
+    def test_falls_back_to_config_when_db_has_no_setting(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.return_value = None
+        request = _mock_request(storage)
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"registry_url": "https://config.registry.example.com"},
+        ):
+            url = _get_registry_url(request)
+
+        assert url == "https://config.registry.example.com"
+
+    def test_falls_back_to_config_when_storage_raises_caught_error(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.side_effect = AttributeError("broken storage")
+        request = _mock_request(storage)
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"registry_url": "https://config.registry.example.com"},
+        ):
+            url = _get_registry_url(request)
+
+        assert url == "https://config.registry.example.com"
+
+    def test_uncaught_storage_error_propagates(self) -> None:
+        """Storage errors outside the except tuple are not swallowed."""
+        storage = MagicMock()
+        storage.get_system_setting.side_effect = RuntimeError("DB connection lost")
+        request = _mock_request(storage)
+
+        with (
+            patch("turnstone.core.config.load_config", return_value={}),
+            pytest.raises(RuntimeError, match="DB connection lost"),
+        ):
+            _get_registry_url(request)
+
+    def test_falls_back_to_default_when_both_unavailable(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.side_effect = KeyError("missing")
+        request = _mock_request(storage)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            url = _get_registry_url(request)
+
+        assert url == DEFAULT_REGISTRY_URL
+
+    def test_falls_back_to_default_when_no_storage(self) -> None:
+        request = _mock_request(storage=None)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            url = _get_registry_url(request)
+
+        assert url == DEFAULT_REGISTRY_URL
+
+    def test_skips_empty_db_value(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.return_value = {"value": json.dumps("")}
+        request = _mock_request(storage)
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"registry_url": "https://config.example.com"},
+        ):
+            url = _get_registry_url(request)
+
+        assert url == "https://config.example.com"
+
+    def test_skips_malformed_json_in_db(self) -> None:
+        storage = MagicMock()
+        storage.get_system_setting.return_value = {"value": "not-valid-json{"}
+        request = _mock_request(storage)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            url = _get_registry_url(request)
+
+        assert url == DEFAULT_REGISTRY_URL


### PR DESCRIPTION
## Summary
- 8 new tests for the DB → config → default URL resolution chain in `_get_registry_url`
- Covers: DB success, config fallback, storage errors, empty values, malformed JSON
- Documents that `RuntimeError` propagates uncaught through the except clause

## Test plan
- [x] All 25 MCP registry API tests pass
- [x] ruff + mypy clean