### PR TITLE
test: add governance SDK integration tests against real Starlette app

### DIFF
--- a/tests/test_sdk_governance.py
+++ b/tests/test_sdk_governance.py
@@ -117,13 +117,13 @@ def storage(tmp_path: Any) -> SQLiteBackend:
 
 
 @pytest.fixture
-async def sdk_client(storage: SQLiteBackend) -> AsyncTurnstoneConsole:
+async def sdk_client(storage: SQLiteBackend):
     """SDK client wired to a real Starlette app via ASGITransport."""
     app = _make_app()
     app.state.auth_storage = storage
     transport = httpx.ASGITransport(app=app)
-    hc = httpx.AsyncClient(transport=transport, base_url="http://testserver")
-    return AsyncTurnstoneConsole(httpx_client=hc)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as hc:
+        yield AsyncTurnstoneConsole(httpx_client=hc)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 24 new tests using `httpx.ASGITransport` to route SDK calls through real route handlers + SQLite
- Roles: 7 tests (CRUD lifecycle, error cases)
- Policies: 8 tests (CRUD lifecycle, invalid action, error cases)
- Orgs: 6 tests (list, get, update, error cases)
- Model validation: 3 tests verifying Pydantic field types

## Test plan
- [x] All 95 SDK tests pass (71 existing + 24 new)
- [x] ruff + mypy clean