### PR TITLE
fix: guard against CancelledError on MCP startup future (Python 3.14)

### DIFF
--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -162,9 +162,11 @@ class MCPClientManager:
         future = asyncio.run_coroutine_threadsafe(self._connect_all(), self._loop)
         self._connected.wait(timeout=30)
         # Surface any exception from _connect_all (unlikely — per-server errors are caught)
-        if future.done() and future.exception():
-            self._error = str(future.exception())
-            log.error("MCP initialization error: %s", self._error)
+        if future.done() and not future.cancelled():
+            exc = future.exception()
+            if exc:
+                self._error = str(exc)
+                log.error("MCP initialization error: %s", self._error)
 
     async def _connect_all(self) -> None:
         """Connect to every configured server (runs on the background loop)."""


### PR DESCRIPTION
## Summary
- `Future.exception()` raises `CancelledError` on Python 3.14 instead of returning None
- MCP client startup crashed when the event loop shut down before `_connect_all` completed
- Add `future.cancelled()` check before calling `future.exception()`

## Test plan
- [x] All 270 MCP tests pass
- [x] ruff + mypy clean
- [ ] Deploy: `docker compose up` with MCP config — server starts without crash