### PR TITLE
chore: standardize logging to structlog get_logger across 19 modules

### DIFF
--- a/turnstone/core/audit.py
+++ b/turnstone/core/audit.py
@@ -7,14 +7,15 @@ call after mutations to create a persistent audit trail.
 from __future__ import annotations
 
 import json
-import logging
 import uuid
 from typing import TYPE_CHECKING, Any
+
+from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def record_audit(

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import logging
 import os
 import re
 import secrets
@@ -39,7 +38,9 @@ if TYPE_CHECKING:
 
     from turnstone.core.oidc import OIDCConfig
 
-log = logging.getLogger(__name__)
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/turnstone/core/config.py
+++ b/turnstone/core/config.py
@@ -6,15 +6,16 @@ Precedence: CLI args > env vars > config file > hardcoded defaults.
 
 from __future__ import annotations
 
-import logging
 import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core.log import get_logger
+
 if TYPE_CHECKING:
     import argparse
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 CONFIG_DIR = Path("~/.config/turnstone").expanduser()
 CONFIG_PATH = CONFIG_DIR / "config.toml"

--- a/turnstone/core/config_store.py
+++ b/turnstone/core/config_store.py
@@ -18,10 +18,10 @@ ConfigStore) — it is a standalone tool, not a cluster node.
 
 from __future__ import annotations
 
-import logging
 import threading
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core.log import get_logger
 from turnstone.core.settings_registry import (
     SETTINGS,
     deserialize_value,
@@ -33,7 +33,7 @@ from turnstone.core.settings_registry import (
 if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _UNSET: Any = object()
 

--- a/turnstone/core/healthcheck.py
+++ b/turnstone/core/healthcheck.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import enum
-import logging
 import threading
 import time
 from typing import TYPE_CHECKING
 
+from turnstone.core.log import get_logger
+
 if TYPE_CHECKING:
     from openai import OpenAI
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class CircuitState(enum.Enum):

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import fnmatch
 import json
-import logging
 import os
 import re
 import threading
@@ -20,12 +19,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core.log import get_logger
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from turnstone.core.providers._protocol import LLMProvider
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Data structures

--- a/turnstone/core/log.py
+++ b/turnstone/core/log.py
@@ -149,6 +149,24 @@ def configure_logging(
         logging.getLogger(name).setLevel(logging.WARNING)
 
 
+def _ensure_stdlib_factory() -> None:
+    """Ensure structlog routes through stdlib even before configure_logging().
+
+    Without this, ``structlog.get_logger()`` defaults to ``PrintLogger``
+    which bypasses stdlib handlers (and pytest caplog).  Calling
+    ``configure_logging()`` later overwrites this minimal config.
+    """
+    cfg = structlog.get_config()
+    if not isinstance(cfg.get("logger_factory"), structlog.stdlib.LoggerFactory):
+        structlog.configure(
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+        )
+
+
+_ensure_stdlib_factory()
+
+
 def get_logger(name: str) -> structlog.stdlib.BoundLogger:
     """Return a structlog bound logger backed by the stdlib."""
     result: structlog.stdlib.BoundLogger = structlog.get_logger(name)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -22,7 +22,6 @@ import asyncio
 import concurrent.futures
 import contextlib
 import json
-import logging
 import os
 import random
 import threading
@@ -41,8 +40,9 @@ from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from turnstone.core.config import load_config
+from turnstone.core.log import get_logger
 
-log = logging.getLogger("turnstone.mcp")
+log = get_logger("turnstone.mcp")
 
 _DEFAULT_REFRESH_INTERVAL: float = 14400  # 4 hours
 

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -11,17 +11,17 @@ rather than silently swallowed.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 
+from turnstone.core.log import get_logger
 from turnstone.core.storage import get_storage
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def normalize_key(key: str) -> str:

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -7,15 +7,15 @@ resilience when the primary model is unreachable.
 
 from __future__ import annotations
 
-import logging
 import threading
 from dataclasses import dataclass, field
 from typing import Any
 
 from turnstone.core.config import load_config
+from turnstone.core.log import get_logger
 from turnstone.core.providers import LLMProvider, create_client, create_provider
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -11,7 +11,6 @@ import base64
 import dataclasses
 import hashlib
 import ipaddress
-import logging
 import os
 import re
 import secrets
@@ -23,7 +22,9 @@ from typing import Any
 
 import httpx
 
-log = logging.getLogger(__name__)
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
 
 # Sentinel password hash for OIDC-provisioned users.
 # Not a valid bcrypt hash -- verify_password() always rejects it.

--- a/turnstone/core/policy.py
+++ b/turnstone/core/policy.py
@@ -7,13 +7,14 @@ a tool should be auto-allowed, denied, or require human approval.
 from __future__ import annotations
 
 import fnmatch
-import logging
 from typing import TYPE_CHECKING
+
+from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def evaluate_tool_policy(

--- a/turnstone/core/ratelimit.py
+++ b/turnstone/core/ratelimit.py
@@ -7,11 +7,12 @@ Thread-safe. Zero external dependencies.
 from __future__ import annotations
 
 import ipaddress
-import logging
 import threading
 import time
 
-log = logging.getLogger(__name__)
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
 
 _NetworkType = ipaddress.IPv4Network | ipaddress.IPv6Network
 

--- a/turnstone/core/skill_sources.py
+++ b/turnstone/core/skill_sources.py
@@ -7,7 +7,6 @@ and :func:`fetch_skill_from_github` for fetching SKILL.md from GitHub repos.
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -16,9 +15,10 @@ from urllib.parse import quote
 
 import httpx
 
+from turnstone.core.log import get_logger
 from turnstone.core.skill_parser import ParsedSkill, parse_skill_md
 
-logger = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 DEFAULT_DISCOVERY_URL = "https://skills.sh"
 
@@ -176,7 +176,7 @@ def _check_rate_limit(resp: httpx.Response) -> None:
             )
     remaining = resp.headers.get("x-ratelimit-remaining", "")
     if remaining and remaining.isdigit() and int(remaining) < 10:
-        logger.warning("GitHub API rate limit low: %s remaining", remaining)
+        log.warning("GitHub API rate limit low: %s remaining", remaining)
 
 
 _FETCH_CONCURRENCY = 5
@@ -301,7 +301,7 @@ async def fetch_skill_from_github(url: str) -> SkillPackage:
                 rf = _find_resource_files(tree_data.get("tree", []), skill_md_dir)
                 resources = await _fetch_resource_contents(client, raw_base, rf)
         except httpx.HTTPError:
-            logger.debug("Failed to fetch resource tree for %s/%s", owner, repo)
+            log.debug("Failed to fetch resource tree for %s/%s", owner, repo)
 
     # Build a per-skill source URL pointing to the specific subdirectory
     if skill_md_dir:
@@ -418,7 +418,7 @@ async def fetch_skills_from_github_repo(url: str) -> list[SkillPackage]:
             try:
                 parsed = parse_skill_md(content)
             except ValueError:
-                logger.debug("Skipping invalid SKILL.md at %s", skill_md_path)
+                log.debug("Skipping invalid SKILL.md at %s", skill_md_path)
                 continue
 
             # Collect resources for this skill (concurrent via helper)

--- a/turnstone/core/storage/_migrate.py
+++ b/turnstone/core/storage/_migrate.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any
 
-log = logging.getLogger(__name__)
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
 
 _MIGRATIONS_DIR = str(Path(__file__).parent / "migrations")
 

--- a/turnstone/core/storage/_registry.py
+++ b/turnstone/core/storage/_registry.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from typing import TYPE_CHECKING
+
+from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _storage: StorageBackend | None = None
 

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import json
-import logging
 from typing import Any
 
-log = logging.getLogger(__name__)
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Row helper

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -10,19 +10,19 @@ from __future__ import annotations
 
 import contextlib
 import json
-import logging
 import re
 import subprocess
 import threading
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core.log import get_logger
 from turnstone.core.safety import is_command_blocked, sanitize_command
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -16,7 +16,6 @@ import asyncio
 import contextlib
 import functools
 import json
-import logging
 import os
 import queue
 import socket
@@ -42,6 +41,7 @@ from turnstone import __version__
 from turnstone.api.docs import make_docs_handler, make_openapi_handler
 from turnstone.api.server_spec import build_server_spec
 from turnstone.core.auth import JWT_AUD_SERVER, AuthMiddleware
+from turnstone.core.log import get_logger
 from turnstone.core.metrics import metrics as _metrics
 from turnstone.core.ratelimit import resolve_client_ip
 from turnstone.core.session import ChatSession, GenerationCancelled, SessionUI  # noqa: F401
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 # Static assets — loaded once at startup from turnstone/ui/static/
 # ---------------------------------------------------------------------------
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _STATIC_DIR = Path(__file__).parent / "ui" / "static"
 _SHARED_DIR = Path(__file__).parent / "shared_static"


### PR DESCRIPTION
## Summary
- Replace `logging.getLogger(__name__)` with `get_logger(__name__)` from `turnstone.core.log` across 19 modules
- Enables structured context injection (node_id, ws_id, request_id) in all core modules
- Adds `_ensure_stdlib_factory()` to `log.py` for pytest caplog compatibility
- Renames `logger` → `log` in `skill_sources.py` for naming consistency

## Test plan
- [x] All 2862 tests pass
- [x] ruff clean
- [x] Mechanical change — only import line and logger creation modified, no call site changes