### PR TITLE
fix: health monitor probe loop transitions OPEN → HALF_OPEN autonomously

### DIFF
--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -221,6 +221,63 @@ class TestBackendHealthMonitor:
         mon.record_failure()
         assert mon.circuit_state == CircuitState.OPEN  # type: ignore[comparison-overlap]
 
+    def test_probe_loop_autonomous_recovery(
+        self, mock_client: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        """_probe_loop transitions OPEN → HALF_OPEN → CLOSED without user requests."""
+        # Use very short intervals so the test is fast
+        mon = BackendHealthMonitor(
+            client=mock_client,
+            probe_interval=0.05,
+            probe_timeout=1.0,
+            failure_threshold=1,
+            cooldown=0.1,
+        )
+        # Trip the circuit
+        mon.record_failure()
+        assert mon.circuit_state == CircuitState.OPEN
+
+        # Backend is healthy — probe_once will succeed
+        mock_client.with_options.return_value.models.list.return_value = MagicMock()
+
+        # Start the probe loop and wait for autonomous recovery
+        mon.start()
+        try:
+            import time
+
+            deadline = time.monotonic() + 5.0
+            while mon.circuit_state != CircuitState.CLOSED and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert mon.circuit_state == CircuitState.CLOSED
+            # User requests should flow again without anyone calling acquire_request_permit
+            assert mon.acquire_request_permit() is True
+        finally:
+            mon.stop()
+            if mon._thread:
+                mon._thread.join(timeout=2.0)
+
+    def test_probe_loop_no_user_permit_during_probe(
+        self, mock_client: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        """While background probe is in HALF_OPEN, user requests are blocked."""
+        mon = BackendHealthMonitor(
+            client=mock_client,
+            probe_interval=0.05,
+            probe_timeout=1.0,
+            failure_threshold=1,
+            cooldown=0.1,
+        )
+        mon.record_failure()
+        assert mon.circuit_state == CircuitState.OPEN
+
+        # Force into HALF_OPEN as the probe loop would
+        with mon._lock:
+            mon._state = CircuitState.HALF_OPEN
+            mon._half_open_permit = False  # probe consumes it
+
+        # User requests should be blocked — only the probe gets through
+        assert mon.acquire_request_permit() is False
+
     def test_stop_thread(self, mock_client: MagicMock) -> None:
         """stop() signals the probe loop to exit."""
         mon = _make_monitor(mock_client)

--- a/turnstone/core/healthcheck.py
+++ b/turnstone/core/healthcheck.py
@@ -164,6 +164,30 @@ class BackendHealthMonitor:
             self._stop_event.wait(self._probe_interval)
             if self._stop_event.is_set():
                 break
+            # When circuit is OPEN, only probe after cooldown expires.
+            with self._lock:
+                if self._state == CircuitState.OPEN:
+                    elapsed = time.monotonic() - self._last_state_change
+                    remaining = self._cooldown - elapsed
+                    if remaining > 0:
+                        # Wait precisely for cooldown rather than skipping
+                        # a full probe_interval (which could overshoot).
+                        self._lock.release()
+                        try:
+                            self._stop_event.wait(remaining)
+                        finally:
+                            self._lock.acquire()
+                        if self._stop_event.is_set():
+                            break
+                    # Transition to HALF_OPEN for the probe.  The background
+                    # probe itself is the single HALF_OPEN request — keep
+                    # _half_open_permit False so concurrent user requests
+                    # are blocked until the probe completes.
+                    self._state = CircuitState.HALF_OPEN
+                    self._half_open_permit = False
+                    self._last_state_change = time.monotonic()
+                    log.info("Circuit breaker HALF_OPEN: cooldown elapsed, probing")
+                    self._update_metrics()
             success = self._probe_once()
             if success:
                 self.record_success()


### PR DESCRIPTION
## Summary
The circuit breaker probe loop never transitioned from OPEN → HALF_OPEN on its own. The transition only happened inside `acquire_request_permit()`, which requires a user request. If no user sends a message during the cooldown period, the circuit stays OPEN forever — even when the backend has recovered.

This caused the "Connection error" regression: llama-server was running but the circuit breaker was stuck open because no user message triggered the recovery path.

Now the probe loop checks cooldown expiry and transitions to HALF_OPEN before probing, so recovery happens automatically.

## Test plan
- [x] All 17 healthcheck tests pass
- [x] ruff clean
- [ ] Manual: start server with no backend, start backend after 60s, verify circuit recovers without user interaction