### PR TITLE
feat: console CA + ACME server via lacme

### DIFF
--- a/tests/test_tls_manager.py
+++ b/tests/test_tls_manager.py
@@ -1,0 +1,226 @@
+"""Tests for TLSManager — console CA and ACME server."""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.storage import get_storage, init_storage, reset_storage
+
+lacme = pytest.importorskip("lacme")
+
+
+@pytest.fixture(autouse=True)
+def _storage(tmp_path):
+    """Initialize ephemeral SQLite storage for each test."""
+    reset_storage()
+    db = str(tmp_path / "test.db")
+    init_storage("sqlite", path=db)
+    yield
+    reset_storage()
+
+
+@pytest.fixture
+def tls_manager():
+    """Create a TLSManager backed by test storage."""
+    from turnstone.console.tls import TLSManager
+
+    return TLSManager(get_storage())
+
+
+# ── CA initialization ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_init_ca(tls_manager):
+    await tls_manager.init_ca()
+    assert tls_manager.ca_initialized
+    root_pem = tls_manager.get_root_cert_pem()
+    assert b"BEGIN CERTIFICATE" in root_pem
+
+
+@pytest.mark.anyio
+async def test_init_ca_persists(tls_manager):
+    """CA root survives re-initialization (loaded from storage)."""
+    await tls_manager.init_ca()
+    pem1 = tls_manager.get_root_cert_pem()
+
+    # Create a new manager on the same storage
+    from turnstone.console.tls import TLSManager
+
+    mgr2 = TLSManager(get_storage())
+    await mgr2.init_ca()
+    pem2 = mgr2.get_root_cert_pem()
+
+    assert pem1 == pem2  # Same CA loaded from DB
+
+
+@pytest.mark.anyio
+async def test_get_responder_before_init(tls_manager):
+    with pytest.raises(RuntimeError, match="CA not initialized"):
+        tls_manager.get_responder()
+
+
+@pytest.mark.anyio
+async def test_get_responder(tls_manager):
+    await tls_manager.init_ca()
+    responder = tls_manager.get_responder()
+    assert responder is not None
+    # Should be an ASGI app (callable)
+    assert callable(responder)
+
+
+# ── Cert issuance ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_issue_console_certs_internal(tls_manager):
+    """Console certs issued from internal CA when no external directory."""
+    await tls_manager.init_ca()
+    await tls_manager.issue_console_certs(["console.internal", "localhost"])
+    assert tls_manager.internal_bundle is not None
+    assert tls_manager.frontend_bundle is not None
+    assert tls_manager.internal_bundle.domain == "console.internal"
+    assert b"BEGIN CERTIFICATE" in tls_manager.internal_bundle.cert_pem
+
+
+@pytest.mark.anyio
+async def test_issue_console_certs_persists(tls_manager):
+    """Certs loaded from storage on re-issue."""
+    await tls_manager.init_ca()
+    await tls_manager.issue_console_certs(["console.internal"])
+    bundle1 = tls_manager.internal_bundle
+
+    # New manager, same storage
+    from turnstone.console.tls import TLSManager
+
+    mgr2 = TLSManager(get_storage())
+    await mgr2.init_ca()
+    await mgr2.issue_console_certs(["console.internal"])
+    bundle2 = mgr2.internal_bundle
+
+    assert bundle1.cert_pem == bundle2.cert_pem
+
+
+# ── SSL contexts ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_ssl_contexts_none_before_certs(tls_manager):
+    await tls_manager.init_ca()
+    assert tls_manager.get_server_ssl_context() is None
+    assert tls_manager.get_client_ssl_context() is None
+
+
+@pytest.mark.anyio
+async def test_ssl_contexts_after_certs(tls_manager):
+    await tls_manager.init_ca()
+    await tls_manager.issue_console_certs(["console.internal"])
+    server_ctx = tls_manager.get_server_ssl_context()
+    client_ctx = tls_manager.get_client_ssl_context()
+    assert server_ctx is not None
+    assert client_ctx is not None
+    import ssl
+
+    assert isinstance(server_ctx, ssl.SSLContext)
+    assert isinstance(client_ctx, ssl.SSLContext)
+
+
+# ── Root cert endpoint ────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_tls_ca_cert_endpoint(tls_manager):
+    """Test the CA cert download endpoint via test client."""
+    await tls_manager.init_ca()
+
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.console.server import tls_ca_cert, tls_ca_status
+
+    # Middleware that grants full access (config-token style: no user_id)
+    from turnstone.core.auth import AuthResult
+
+    async def _grant_access(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.auth_result = AuthResult(
+            user_id="", scopes=frozenset({"approve"}), token_source="config"
+        )
+        return await call_next(request)
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    app = Starlette(
+        routes=[
+            Route("/ca.pem", tls_ca_cert),
+            Route("/ca", tls_ca_status),
+        ],
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=_grant_access)],
+    )
+    app.state.tls_manager = tls_manager
+
+    client = TestClient(app)
+
+    # CA cert download
+    resp = client.get("/ca.pem")
+    assert resp.status_code == 200
+    assert b"BEGIN CERTIFICATE" in resp.content
+    assert resp.headers["content-type"] == "application/x-pem-file"
+
+    # CA status
+    resp = client.get("/ca")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["enabled"] is True
+    assert data["ca_cn"] == "Turnstone CA"
+
+
+@pytest.mark.anyio
+async def test_tls_endpoints_disabled():
+    """Endpoints return 404/disabled when TLS not enabled."""
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.console.server import tls_ca_cert, tls_ca_status
+    from turnstone.core.auth import AuthResult
+
+    async def _grant_access(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.auth_result = AuthResult(
+            user_id="", scopes=frozenset({"approve"}), token_source="config"
+        )
+        return await call_next(request)
+
+    app = Starlette(
+        routes=[
+            Route("/ca.pem", tls_ca_cert),
+            Route("/ca", tls_ca_status),
+        ],
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=_grant_access)],
+    )
+    # No tls_manager on state
+
+    client = TestClient(app)
+
+    resp = client.get("/ca.pem")
+    assert resp.status_code == 404
+
+    resp = client.get("/ca")
+    data = resp.json()
+    assert data["enabled"] is False
+
+
+# ── Events ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_event_dispatcher_wired(tls_manager):
+    """Verify the event dispatcher has subscribers."""
+    assert tls_manager._event_dispatcher is not None
+    # Should have at least 4 subscriptions (issued, renewed, expiring, failed)
+    # The exact check depends on lacme's EventDispatcher internals,
+    # so just verify the dispatcher exists and the manager initializes cleanly
+    await tls_manager.init_ca()

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -769,8 +769,25 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     "OIDC JWKS prefetch failed — will retry on first login",
                     exc_info=True,
                 )
+    # TLS: init CA, issue console certs, start renewal
+    tls_mgr = getattr(app.state, "tls_manager", None)
+    if tls_mgr is not None:
+        import socket
+
+        try:
+            if not tls_mgr.ca_initialized:
+                await tls_mgr.init_ca()
+            hostname = socket.getfqdn()
+            await tls_mgr.issue_console_certs([hostname, "localhost", "127.0.0.1"])
+            tls_mgr.start_renewal()
+        except Exception:
+            log.warning("TLS initialization failed — continuing without TLS", exc_info=True)
+
     yield
     # Shutdown
+    tls_mgr = getattr(app.state, "tls_manager", None)
+    if tls_mgr is not None:
+        await tls_mgr.stop_renewal()
     if scheduler is not None:
         scheduler.stop()
     await app.state.proxy_sse_client.aclose()
@@ -4581,6 +4598,58 @@ async def admin_import_mcp_config(request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# TLS endpoints
+# ---------------------------------------------------------------------------
+
+
+async def tls_ca_cert(request: Request) -> Response:
+    """GET /v1/api/admin/tls/ca.pem — Download CA root certificate."""
+    from turnstone.core.auth import require_permission
+
+    err = require_permission(request, "admin.settings")
+    if err:
+        return err
+    mgr = getattr(request.app.state, "tls_manager", None)
+    if mgr is None or not mgr.ca_initialized:
+        return JSONResponse({"error": "TLS not enabled"}, status_code=404)
+    return Response(
+        content=mgr.get_root_cert_pem(),
+        media_type="application/x-pem-file",
+        headers={"Content-Disposition": "attachment; filename=turnstone-ca.pem"},
+    )
+
+
+async def tls_ca_status(request: Request) -> JSONResponse:
+    """GET /v1/api/admin/tls/ca — CA status."""
+    from turnstone.core.auth import require_permission
+
+    err = require_permission(request, "admin.settings")
+    if err:
+        return err
+    mgr = getattr(request.app.state, "tls_manager", None)
+    if mgr is None or not mgr.ca_initialized:
+        return JSONResponse({"enabled": False})
+    from turnstone.console.tls import _CA_CN
+
+    certs = mgr.list_certs()
+    return JSONResponse(
+        {
+            "enabled": True,
+            "ca_cn": _CA_CN,
+            "cert_count": len(certs),
+            "certs": [
+                {
+                    "domain": c.domain,
+                    "issued_at": c.issued_at.isoformat(),
+                    "expires_at": c.expires_at.isoformat(),
+                }
+                for c in certs
+            ],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
 
@@ -4595,6 +4664,7 @@ def create_app(
     proxy_auth_token: str = "",
     proxy_token_mgr: Any = None,
     cors_origins: list[str] | None = None,
+    tls_manager: Any = None,
 ) -> Starlette:
     """Build the Starlette ASGI application for the console dashboard."""
     _spec = build_console_spec()
@@ -4817,6 +4887,9 @@ def create_app(
                         admin_rescan_skill,
                         methods=["POST"],
                     ),
+                    # TLS / ACME
+                    Route("/api/admin/tls/ca", tls_ca_status),
+                    Route("/api/admin/tls/ca.pem", tls_ca_cert),
                 ],
             ),
             Route("/health", health),
@@ -4842,6 +4915,13 @@ def create_app(
     app.state.auth_storage = auth_storage
     app.state.proxy_auth_token = proxy_auth_token
     app.state.proxy_token_mgr = proxy_token_mgr
+    app.state.tls_manager = tls_manager
+
+    # Mount ACME responder if TLS is enabled
+    if tls_manager is not None and tls_manager.ca_initialized:
+        from starlette.routing import Mount as RouteMount
+
+        app.routes.insert(0, RouteMount("/acme", app=tls_manager.get_responder()))
 
     from turnstone.core.auth import LoginRateLimiter
 

--- a/turnstone/console/tls.py
+++ b/turnstone/console/tls.py
@@ -1,0 +1,322 @@
+"""TLS Manager — Certificate Authority and ACME server for the console.
+
+Owns the lacme CertificateAuthority, ACMEResponder, and RenewalManager
+lifecycle. When TLS is enabled, the console acts as the cluster's internal
+CA and ACME server, issuing short-lived mTLS certificates to all services.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    import ssl
+
+    from starlette.types import ASGIApp
+
+    from turnstone.core.config_store import ConfigStore
+    from turnstone.core.storage._protocol import StorageBackend
+
+log = structlog.get_logger(__name__)
+
+# Hardcoded defaults — no operator config needed
+_CA_CN = "Turnstone CA"
+_CA_VALIDITY_DAYS = 3650  # 10 years
+_CERT_VALIDITY_HOURS = 48
+_RENEW_INTERVAL_HOURS = 24
+_RENEW_BEFORE_EXPIRY_DAYS = 1
+
+
+def _require_lacme() -> Any:
+    try:
+        import lacme
+    except ImportError:
+        raise ImportError(
+            "lacme is required for TLS support. Install with: pip install turnstone[tls]",
+        ) from None
+    return lacme
+
+
+class TLSManager:
+    """Manages the internal CA, ACME responder, and certificate lifecycle.
+
+    Typical usage::
+
+        mgr = TLSManager(storage, config_store)
+        await mgr.init_ca()
+        responder = mgr.get_responder()       # Mount at /acme
+        await mgr.issue_console_certs()        # Self-issue for this node
+        mgr.start_renewal()                    # Background auto-renewal
+    """
+
+    def __init__(
+        self,
+        storage: StorageBackend,
+        config_store: ConfigStore | None = None,
+    ) -> None:
+        lacme = _require_lacme()
+
+        from turnstone.core.tls_store import StorageStore
+
+        self._store = StorageStore(storage)
+        self._config_store = config_store
+        self._event_dispatcher = lacme.EventDispatcher()
+        self._ca: Any | None = None
+        self._responder: Any | None = None
+        self._renewal_task: Any | None = None
+        self._internal_bundle: Any | None = None
+        self._frontend_bundle: Any | None = None
+
+        # Wire structlog to lacme events
+        self._subscribe_events()
+
+        # Wire Prometheus metrics (if prometheus_client available)
+        try:
+            from lacme.metrics import setup_metrics
+
+            setup_metrics(self._event_dispatcher)
+        except ImportError:
+            pass  # prometheus_client not installed
+
+    def _subscribe_events(self) -> None:
+        """Subscribe structlog handlers to lacme lifecycle events."""
+        _require_lacme()
+        from lacme.events import (
+            CertificateExpiring,
+            CertificateIssued,
+            CertificateRenewed,
+            ChallengeFailed,
+        )
+
+        def _on_issued(event: Any) -> None:
+            if isinstance(event, CertificateIssued):
+                log.info("tls.cert.issued", domain=event.domain)
+
+        def _on_renewed(event: Any) -> None:
+            if isinstance(event, CertificateRenewed):
+                log.info("tls.cert.renewed", domain=event.domain)
+
+        def _on_expiring(event: Any) -> None:
+            if isinstance(event, CertificateExpiring):
+                log.warning("tls.cert.expiring", domain=event.domain)
+
+        def _on_failed(event: Any) -> None:
+            if isinstance(event, ChallengeFailed):
+                log.error("tls.challenge.failed", domain=getattr(event, "domain", "unknown"))
+
+        self._event_dispatcher.subscribe(_on_issued, event_type=CertificateIssued)
+        self._event_dispatcher.subscribe(_on_renewed, event_type=CertificateRenewed)
+        self._event_dispatcher.subscribe(_on_expiring, event_type=CertificateExpiring)
+        self._event_dispatcher.subscribe(_on_failed, event_type=ChallengeFailed)
+
+    # -- CA lifecycle ----------------------------------------------------------
+
+    async def init_ca(self) -> None:
+        """Initialize the internal Certificate Authority.
+
+        Loads an existing CA from storage or generates a new root key+cert.
+        """
+        lacme = _require_lacme()
+        self._ca = lacme.CertificateAuthority(
+            self._store,
+            event_dispatcher=self._event_dispatcher,
+        )
+        self._ca.init(cn=_CA_CN, validity_days=_CA_VALIDITY_DAYS)
+        log.info("tls.ca.initialized", cn=_CA_CN)
+
+    def get_responder(self) -> ASGIApp:
+        """Return the ACME responder ASGI app for mounting."""
+        if self._ca is None:
+            raise RuntimeError("CA not initialized — call init_ca() first")
+        lacme = _require_lacme()
+        if self._responder is None:
+            self._responder = lacme.ACMEResponder(
+                ca=self._ca,
+                auto_approve=True,
+            )
+        return self._responder  # type: ignore[no-any-return]
+
+    def get_root_cert_pem(self) -> bytes:
+        """Return the CA root certificate in PEM format."""
+        if self._ca is None:
+            raise RuntimeError("CA not initialized — call init_ca() first")
+        return self._ca.root_cert_pem  # type: ignore[no-any-return]
+
+    # -- Cert issuance ---------------------------------------------------------
+
+    async def issue_console_certs(self, hostnames: list[str]) -> None:
+        """Issue certificates for the console node.
+
+        Raises ValueError if hostnames is empty.
+
+        Issues two certificates:
+        - Internal cert: always from the internal CA (for mTLS with cluster)
+        - Frontend cert: from external ACME CA if configured, else internal CA
+        """
+        if not hostnames:
+            raise ValueError("issue_console_certs requires at least one hostname")
+
+        # Internal cert — always from our own CA
+        await self._issue_internal_cert(hostnames)
+
+        # Frontend cert — external CA if configured
+        acme_directory = ""
+        if self._config_store:
+            acme_directory = self._config_store.get("tls.acme_directory") or ""
+
+        if acme_directory:
+            await self._issue_frontend_cert(hostnames, acme_directory)
+        else:
+            # Self-issue from internal CA (behind reverse proxy or internal only)
+            self._frontend_bundle = self._internal_bundle
+            log.info("tls.frontend.self_issued", hostnames=hostnames)
+
+    async def _issue_internal_cert(self, hostnames: list[str]) -> None:
+        """Issue an internal mTLS cert from the internal CA."""
+        if self._ca is None:
+            raise RuntimeError("CA not initialized")
+
+        # Check for existing cert in store (skip if expired)
+        existing = self._store.load_cert(hostnames[0])
+        if existing is not None:
+            from datetime import UTC, datetime
+
+            if existing.expires_at > datetime.now(UTC):
+                self._internal_bundle = existing
+                log.info("tls.internal.loaded", domain=hostnames[0])
+                return
+            log.info("tls.internal.expired", domain=hostnames[0])
+            self._store.delete_cert(hostnames[0])
+
+        # Issue new cert
+        bundle = self._ca.issue(
+            hostnames,
+            validity_hours=_CERT_VALIDITY_HOURS,
+        )
+        self._store.save_cert(bundle)
+        self._internal_bundle = bundle
+        log.info("tls.internal.issued", domain=hostnames[0])
+
+    async def _issue_frontend_cert(
+        self,
+        hostnames: list[str],
+        acme_directory: str,
+    ) -> None:
+        """Issue a frontend cert from an external ACME CA."""
+        lacme = _require_lacme()
+        from lacme.challenges.http01 import HTTP01Handler
+
+        handler = HTTP01Handler()
+
+        async with lacme.Client(
+            directory_url=acme_directory,
+            store=self._store,
+            challenge_handler=handler,
+            event_dispatcher=self._event_dispatcher,
+        ) as client:
+            self._frontend_bundle = await client.issue(hostnames)
+            self._store.save_cert(self._frontend_bundle)
+            log.info(
+                "tls.frontend.issued",
+                domain=hostnames[0],
+                ca=acme_directory,
+            )
+
+    # -- Auto-renewal ----------------------------------------------------------
+
+    def start_renewal(self) -> None:
+        """Start background auto-renewal for all stored certificates."""
+        if self._ca is None:
+            raise RuntimeError("CA not initialized")
+        lacme = _require_lacme()
+
+        def _on_renewed(bundle: Any) -> None:
+            # Update our cached bundles if the renewed domain matches
+            if self._internal_bundle and bundle.domain == self._internal_bundle.domain:
+                self._internal_bundle = bundle
+            if self._frontend_bundle and bundle.domain == self._frontend_bundle.domain:
+                self._frontend_bundle = bundle
+
+        manager = lacme.RenewalManager(
+            client=None,  # Uses CA directly for internal certs
+            store=self._store,
+            interval_hours=_RENEW_INTERVAL_HOURS,
+            days_before_expiry=_RENEW_BEFORE_EXPIRY_DAYS,
+            on_renewed=_on_renewed,
+            event_dispatcher=self._event_dispatcher,
+        )
+        self._renewal_task = manager.start()
+        log.info(
+            "tls.renewal.started",
+            interval_hours=_RENEW_INTERVAL_HOURS,
+        )
+
+    async def stop_renewal(self) -> None:
+        """Stop the background renewal task."""
+        if self._renewal_task is not None:
+            import asyncio
+            import contextlib
+
+            self._renewal_task.cancel()
+            try:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._renewal_task
+            except Exception:
+                log.exception("tls.renewal.stop_error")
+            self._renewal_task = None
+
+    # -- SSL contexts ----------------------------------------------------------
+
+    def get_server_ssl_context(self) -> ssl.SSLContext | None:
+        """Build an SSL context for the uvicorn HTTPS listener.
+
+        Uses the frontend cert (external CA or self-issued).
+        Returns None if no certs are available.
+        """
+        if self._frontend_bundle is None:
+            return None
+        _require_lacme()
+        from lacme.mtls import server_ssl_context
+
+        return server_ssl_context(  # type: ignore[no-any-return]
+            cert_pem=self._frontend_bundle.fullchain_pem,
+            key_pem=self._frontend_bundle.key_pem,
+            ca_cert_pem=self.get_root_cert_pem(),
+        )
+
+    def get_client_ssl_context(self) -> ssl.SSLContext | None:
+        """Build an mTLS client context for connecting to cluster services.
+
+        Uses the internal cert for mutual authentication.
+        Returns None if no certs are available.
+        """
+        if self._internal_bundle is None:
+            return None
+        _require_lacme()
+        from lacme.mtls import client_ssl_context
+
+        return client_ssl_context(  # type: ignore[no-any-return]
+            cert_pem=self._internal_bundle.cert_pem,
+            key_pem=self._internal_bundle.key_pem,
+            ca_cert_pem=self.get_root_cert_pem(),
+        )
+
+    # -- Properties ------------------------------------------------------------
+
+    def list_certs(self) -> list[Any]:
+        """List all stored certificate bundles."""
+        return self._store.list_certs()
+
+    @property
+    def ca_initialized(self) -> bool:
+        return self._ca is not None
+
+    @property
+    def internal_bundle(self) -> Any | None:
+        return self._internal_bundle
+
+    @property
+    def frontend_bundle(self) -> Any | None:
+        return self._frontend_bundle

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -157,7 +157,7 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         "/api/auth/oidc/callback",
     }
 )
-PUBLIC_PREFIXES: tuple[str, ...] = ("/static/", "/shared/")
+PUBLIC_PREFIXES: tuple[str, ...] = ("/static/", "/shared/", "/acme/")
 
 WRITE_PATHS: frozenset[str] = frozenset(
     {


### PR DESCRIPTION
## Summary
- `TLSManager` class (`turnstone/console/tls.py`) — owns CA, ACME responder, cert lifecycle
- `ACMEResponder` mounted at `/acme` when `tls.enabled = true`
- Dual cert issuance: internal CA for mTLS mesh, optional external ACME for frontend HTTPS
- Auto-renewal with clean async shutdown (awaits cancelled task)
- Expired cert detection on reload — re-issues instead of loading stale certs
- EventDispatcher → structlog + lacme Prometheus metrics (shared registry)
- `GET /v1/api/admin/tls/ca.pem` — root cert download
- `GET /v1/api/admin/tls/ca` — CA status + cert inventory
- Console lifespan wiring: init CA → issue certs → start renewal → stop on shutdown

Phase 2 of mTLS + ACME integration. Builds on Phase 1 storage (#178).

## Test plan
- [x] 11 async tests pass (`tests/test_tls_manager.py`)
- [x] 20 storage tests still pass (`tests/test_tls_storage.py`)
- [x] Ruff + format clean
- [ ] CI: full test suite, lint, typecheck, postgres tests