### PR TITLE
feat: mTLS service clients with ACME auto-provisioning

### DIFF
--- a/tests/test_tls_client.py
+++ b/tests/test_tls_client.py
@@ -1,0 +1,98 @@
+"""Tests for TLSClient — service node certificate provisioning."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from turnstone.core.storage import get_storage, init_storage, reset_storage
+
+lacme = pytest.importorskip("lacme")
+
+
+@pytest.fixture(autouse=True)
+def _storage(tmp_path):
+    """Initialize ephemeral SQLite storage for each test."""
+    reset_storage()
+    db = str(tmp_path / "test.db")
+    init_storage("sqlite", path=db)
+    yield
+    reset_storage()
+
+
+# ── Console URL discovery ─────────────────────────────────────────────────────
+
+
+def test_discover_console_url():
+    """TLSClient discovers console URL from services table."""
+    from turnstone.core.tls import TLSClient
+
+    storage = get_storage()
+    storage.register_service("console", "console", "http://console:8080")
+
+    client = TLSClient(storage=storage, hostnames=["node-1"])
+    url = client._discover_console_url()
+    assert url == "http://console:8080"
+
+
+def test_discover_console_url_missing():
+    """TLSClient raises if no console registered."""
+    from turnstone.core.tls import TLSClient
+
+    client = TLSClient(storage=get_storage(), hostnames=["node-1"])
+    with pytest.raises(RuntimeError, match="No console service found"):
+        client._discover_console_url()
+
+
+def test_explicit_console_url_skips_discovery():
+    """When console_url is provided, discovery is skipped."""
+    from turnstone.core.tls import TLSClient
+
+    client = TLSClient(
+        storage=get_storage(),
+        console_url="http://explicit:9090",
+        hostnames=["node-1"],
+    )
+    assert client._console_url == "http://explicit:9090"
+
+
+# ── SSL context construction ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_ssl_contexts_none_before_init():
+    """SSL contexts are None before init()."""
+    from turnstone.core.tls import TLSClient
+
+    client = TLSClient(
+        storage=get_storage(),
+        console_url="http://localhost:8080",
+        hostnames=["node-1"],
+    )
+    assert client.get_server_ssl_context() is None
+    assert client.get_client_ssl_context() is None
+    assert not client.initialized
+
+
+# ── Backward compatibility ───────────────────────────────────────────────────
+
+
+def test_bridge_tls_defaults():
+    """Bridge with default TLS params works without changes."""
+    from turnstone.mq.bridge import Bridge
+
+    # Default: tls_verify=True, tls_cert=None — no mTLS
+    bridge = Bridge(server_url="http://localhost:8080")
+    assert bridge._tls_verify is True
+    assert bridge._tls_cert is None
+
+
+def test_collector_tls_defaults():
+    """Collector with default TLS params works without changes."""
+    from turnstone.console.collector import ClusterCollector
+
+    broker_mock = MagicMock()
+    collector = ClusterCollector(broker=broker_mock)
+    # Should create httpx client without errors
+    assert collector._http_client is not None

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -209,11 +209,19 @@ def main() -> None:
                     except Exception:
                         log.exception("channel.heartbeat_failed")
 
+            # TLS: use cert files if available (from bootstrap or TLSClient)
+            ssl_certfile = getattr(args, "ssl_certfile", None)
+            ssl_keyfile = getattr(args, "ssl_keyfile", None)
+            ssl_ca_certs = getattr(args, "ssl_ca_certs", None)
+
             uv_config = uvicorn.Config(
                 channel_app,
                 host=args.http_host,
                 port=args.http_port,
                 log_level="warning",
+                ssl_certfile=ssl_certfile,
+                ssl_keyfile=ssl_keyfile,
+                ssl_ca_certs=ssl_ca_certs,
             )
             server = uvicorn.Server(uv_config)
 

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -60,6 +60,8 @@ class ClusterCollector:
         http_timeout: float = 30.0,
         auth_token: str = "",
         token_manager: ServiceTokenManager | None = None,
+        tls_verify: Any = True,
+        tls_cert: tuple[str, str] | None = None,
     ):
         self._broker = broker
         self._prefix = prefix
@@ -86,6 +88,8 @@ class ClusterCollector:
                 max_connections=max_poll_workers + 10,
                 max_keepalive_connections=min(max_poll_workers, 200),
             ),
+            verify=tls_verify,
+            cert=tls_cert,
         )
 
         # SSE fan-out to browser clients

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -727,18 +727,25 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         config_store.get("cluster.node_fan_out_limit") if config_store else _NODE_FAN_OUT_LIMIT
     )
     app.state.fan_out_limit = fan_out
+    # Build mTLS context for proxy clients if TLS is enabled
+    _tls_mgr = getattr(app.state, "tls_manager", None)
+    _proxy_ssl = _tls_mgr.get_client_ssl_context() if _tls_mgr and _tls_mgr.ca_initialized else None
+    _proxy_verify: Any = _proxy_ssl if _proxy_ssl else True
+
     app.state.proxy_client = httpx.AsyncClient(
         timeout=30,
         limits=httpx.Limits(
             max_connections=fan_out + 50,
             max_keepalive_connections=min(fan_out // 4, 100),
         ),
+        verify=_proxy_verify,
     )
     app.state.proxy_sse_client = httpx.AsyncClient(
         timeout=httpx.Timeout(connect=5, read=30, write=5, pool=5),
         limits=httpx.Limits(
             max_connections=1100, max_keepalive_connections=100, keepalive_expiry=30
         ),
+        verify=_proxy_verify,
     )
     # Start scheduler if configured
     scheduler = getattr(app.state, "scheduler", None)
@@ -769,6 +776,28 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     "OIDC JWKS prefetch failed — will retry on first login",
                     exc_info=True,
                 )
+    # Register console in service registry so other services can discover it
+    console_url = getattr(app.state, "console_url", "")
+    _console_heartbeat_task: Any = None
+    if console_url and storage:
+        try:
+            storage.register_service("console", "console", console_url)
+
+            # Periodic heartbeat to keep the registration alive
+            import asyncio
+
+            async def _console_heartbeat() -> None:
+                while True:
+                    await asyncio.sleep(30)
+                    try:
+                        storage.heartbeat_service("console", "console")
+                    except Exception:
+                        log.warning("console.heartbeat_failed", exc_info=True)
+
+            _console_heartbeat_task = asyncio.create_task(_console_heartbeat())
+        except Exception:
+            log.warning("Failed to register console service", exc_info=True)
+
     # TLS: init CA, issue console certs, start renewal
     tls_mgr = getattr(app.state, "tls_manager", None)
     if tls_mgr is not None:
@@ -779,12 +808,14 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 await tls_mgr.init_ca()
             hostname = socket.getfqdn()
             await tls_mgr.issue_console_certs([hostname, "localhost", "127.0.0.1"])
-            tls_mgr.start_renewal()
+            await tls_mgr.start_renewal()
         except Exception:
             log.warning("TLS initialization failed — continuing without TLS", exc_info=True)
 
     yield
     # Shutdown
+    if _console_heartbeat_task is not None:
+        _console_heartbeat_task.cancel()
     tls_mgr = getattr(app.state, "tls_manager", None)
     if tls_mgr is not None:
         await tls_mgr.stop_renewal()
@@ -4665,6 +4696,7 @@ def create_app(
     proxy_token_mgr: Any = None,
     cors_origins: list[str] | None = None,
     tls_manager: Any = None,
+    console_url: str = "",
 ) -> Starlette:
     """Build the Starlette ASGI application for the console dashboard."""
     _spec = build_console_spec()
@@ -4915,13 +4947,23 @@ def create_app(
     app.state.auth_storage = auth_storage
     app.state.proxy_auth_token = proxy_auth_token
     app.state.proxy_token_mgr = proxy_token_mgr
+    app.state.console_url = console_url
     app.state.tls_manager = tls_manager
 
-    # Mount ACME responder if TLS is enabled
+    # Mount ACME responder and CA cert endpoint if TLS is enabled
     if tls_manager is not None and tls_manager.ca_initialized:
         from starlette.routing import Mount as RouteMount
+        from starlette.routing import Route as RouteRoute
 
-        app.routes.insert(0, RouteMount("/acme", app=tls_manager.get_responder()))
+        # CA cert endpoint BEFORE mount so it's matched first
+        async def _acme_ca_pem(request: Request) -> Response:
+            mgr = getattr(request.app.state, "tls_manager", None)
+            if mgr is None or not mgr.ca_initialized:
+                return JSONResponse({"error": "TLS not enabled"}, status_code=404)
+            return Response(content=mgr.get_root_cert_pem(), media_type="application/x-pem-file")
+
+        app.routes.insert(0, RouteRoute("/acme/ca.pem", _acme_ca_pem))
+        app.routes.insert(1, RouteMount("/acme", app=tls_manager.get_responder()))
 
     from turnstone.core.auth import LoginRateLimiter
 
@@ -5094,6 +5136,25 @@ def main() -> None:
 
     cors_origins = parse_cors_origins()
 
+    # TLS: initialize manager if enabled
+    tls_mgr = None
+    console_url = f"http://{args.host}:{args.port}"
+    if auth_storage:
+        try:
+            from turnstone.core.config_store import ConfigStore
+
+            _cs = ConfigStore(auth_storage)
+            if _cs.get("tls.enabled"):
+                from turnstone.console.tls import TLSManager
+
+                tls_mgr = TLSManager(auth_storage, config_store=_cs, port=args.port)
+                console_url = f"https://{args.host}:{args.port}"
+                log.info("TLS enabled")
+        except ImportError:
+            log.warning("TLS enabled but lacme not installed — pip install turnstone[tls]")
+        except Exception:
+            log.warning("TLS initialization failed", exc_info=True)
+
     app = create_app(
         collector=collector,
         broker=broker,
@@ -5103,9 +5164,11 @@ def main() -> None:
         proxy_auth_token=proxy_token if proxy_token_mgr is None else "",
         proxy_token_mgr=proxy_token_mgr,
         cors_origins=cors_origins,
+        tls_manager=tls_mgr,
+        console_url=console_url,
     )
 
-    log.info("Console starting on http://%s:%s", args.host, args.port)
+    log.info("Console starting on %s", console_url)
     if auth_config.enabled:
         log.info("Auth: enabled (%d config token(s))", len(auth_config.tokens))
     print("Press Ctrl+C to stop.")

--- a/turnstone/console/tls.py
+++ b/turnstone/console/tls.py
@@ -55,6 +55,7 @@ class TLSManager:
         self,
         storage: StorageBackend,
         config_store: ConfigStore | None = None,
+        port: int = 8080,
     ) -> None:
         lacme = _require_lacme()
 
@@ -62,10 +63,13 @@ class TLSManager:
 
         self._store = StorageStore(storage)
         self._config_store = config_store
+        self._port = port
         self._event_dispatcher = lacme.EventDispatcher()
         self._ca: Any | None = None
         self._responder: Any | None = None
         self._renewal_task: Any | None = None
+        self._renewal_manager: Any | None = None
+        self._renewal_client: Any | None = None
         self._internal_bundle: Any | None = None
         self._frontend_bundle: Any | None = None
 
@@ -226,8 +230,12 @@ class TLSManager:
 
     # -- Auto-renewal ----------------------------------------------------------
 
-    def start_renewal(self) -> None:
-        """Start background auto-renewal for all stored certificates."""
+    async def start_renewal(self) -> None:
+        """Start background auto-renewal for all stored certificates.
+
+        Creates a lacme Client pointed at the console's own ACME endpoint
+        (localhost loopback) for cert renewal requests.
+        """
         if self._ca is None:
             raise RuntimeError("CA not initialized")
         lacme = _require_lacme()
@@ -239,26 +247,38 @@ class TLSManager:
             if self._frontend_bundle and bundle.domain == self._frontend_bundle.domain:
                 self._frontend_bundle = bundle
 
-        manager = lacme.RenewalManager(
-            client=None,  # Uses CA directly for internal certs
+        # Create a client pointed at our own ACME endpoint for renewal
+        directory_url = f"http://localhost:{self._port}/acme/directory"
+        client = lacme.Client(
+            directory_url=directory_url,
+            store=self._store,
+            event_dispatcher=self._event_dispatcher,
+            allow_insecure=True,  # localhost loopback
+        )
+        await client.__aenter__()
+
+        self._renewal_manager = lacme.RenewalManager(
+            client=client,
             store=self._store,
             interval_hours=_RENEW_INTERVAL_HOURS,
             days_before_expiry=_RENEW_BEFORE_EXPIRY_DAYS,
             on_renewed=_on_renewed,
             event_dispatcher=self._event_dispatcher,
         )
-        self._renewal_task = manager.start()
+        self._renewal_task = self._renewal_manager.start()
+        self._renewal_client = client
         log.info(
             "tls.renewal.started",
             interval_hours=_RENEW_INTERVAL_HOURS,
+            directory=directory_url,
         )
 
     async def stop_renewal(self) -> None:
-        """Stop the background renewal task."""
-        if self._renewal_task is not None:
-            import asyncio
-            import contextlib
+        """Stop the background renewal task and close the ACME client."""
+        import asyncio
+        import contextlib
 
+        if self._renewal_task is not None:
             self._renewal_task.cancel()
             try:
                 with contextlib.suppress(asyncio.CancelledError):
@@ -266,6 +286,11 @@ class TLSManager:
             except Exception:
                 log.exception("tls.renewal.stop_error")
             self._renewal_task = None
+        # Close the loopback ACME client
+        if self._renewal_client is not None:
+            with contextlib.suppress(Exception):
+                await self._renewal_client.__aexit__(None, None, None)
+            self._renewal_client = None
 
     # -- SSL contexts ----------------------------------------------------------
 

--- a/turnstone/core/tls.py
+++ b/turnstone/core/tls.py
@@ -1,0 +1,248 @@
+"""TLS Client — certificate provisioning for service nodes.
+
+Non-console services (server, bridge, channel gateway) use this to
+request certificates from the console's ACME endpoint and build
+SSL contexts for mTLS communication.
+
+Flow:
+1. Fetch CA root cert from console (plain HTTP, first boot)
+2. Request service cert via ACME (plain HTTP, first boot)
+3. Build SSL contexts for uvicorn (server) and httpx (client)
+4. Start auto-renewal (uses existing cert for mTLS to console)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import ssl
+
+    from turnstone.core.storage._protocol import StorageBackend
+
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
+
+_RENEW_INTERVAL_HOURS = 24
+_RENEW_BEFORE_EXPIRY_DAYS = 1
+
+
+def _require_lacme() -> Any:
+    try:
+        import lacme
+    except ImportError:
+        raise ImportError(
+            "lacme is required for TLS support. Install with: pip install turnstone[tls]",
+        ) from None
+    return lacme
+
+
+class TLSClient:
+    """TLS client for service nodes.
+
+    Requests certificates from the console's ACME endpoint and provides
+    SSL contexts for server (uvicorn) and client (httpx) use.
+
+    Typical usage::
+
+        client = TLSClient(storage, console_url="http://console:8080")
+        await client.init()             # Fetch CA, request cert
+        server_ctx = client.get_server_ssl_context()  # For uvicorn
+        client_ctx = client.get_client_ssl_context()  # For httpx
+        await client.start_renewal()    # Background auto-renewal
+    """
+
+    def __init__(
+        self,
+        storage: StorageBackend,
+        console_url: str = "",
+        hostnames: list[str] | None = None,
+    ) -> None:
+        lacme = _require_lacme()
+
+        from turnstone.core.tls_store import StorageStore
+
+        self._storage = storage
+        self._store = StorageStore(storage)
+        self._console_url = console_url.rstrip("/") if console_url else ""
+        self._hostnames = hostnames or []
+        self._event_dispatcher = lacme.EventDispatcher()
+        self._ca_pem: bytes | None = None
+        self._bundle: Any | None = None
+        self._renewal_task: Any | None = None
+        self._renewal_client: Any | None = None
+
+        # Wire Prometheus metrics
+        try:
+            from lacme.metrics import setup_metrics
+
+            setup_metrics(self._event_dispatcher)
+        except ImportError:
+            pass
+
+    async def init(self) -> None:
+        """Fetch CA root cert and request a service certificate.
+
+        If no console_url was provided, discovers it from the services
+        table. Performs initial cert provisioning over plain HTTP (ACME
+        protocol provides integrity via JWS).
+        """
+        if not self._console_url:
+            self._console_url = self._discover_console_url()
+        await self._fetch_ca_cert()
+        await self._request_cert()
+
+    def _discover_console_url(self) -> str:
+        """Look up the console URL from the services table."""
+        consoles = self._storage.list_services("console", max_age_seconds=3600)
+        if not consoles:
+            raise RuntimeError(
+                "No console service found in services table. "
+                "Ensure the console is running and has registered, "
+                "or provide console_url explicitly."
+            )
+        url = consoles[0]["url"]
+        log.info("tls.console.discovered", url=url)
+        return url
+
+    async def _fetch_ca_cert(self) -> None:
+        """Fetch the CA root cert from the console.
+
+        Always uses plain HTTP for bootstrapping — the node doesn't have
+        the CA cert yet, so it can't verify HTTPS.
+        """
+        import httpx
+
+        # Force HTTP for bootstrap (can't verify HTTPS without CA cert)
+        base = self._console_url.replace("https://", "http://")
+        url = f"{base}/acme/ca.pem"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                self._ca_pem = resp.content
+                log.info("tls.ca.fetched", url=url)
+        except Exception:
+            log.error("tls.ca.fetch_failed", url=url, exc_info=True)
+            raise
+
+    async def _request_cert(self) -> None:
+        """Request a certificate from the console's ACME endpoint."""
+        if not self._hostnames:
+            raise ValueError("No hostnames configured for TLS cert request")
+
+        # Check for existing valid cert
+        from datetime import UTC, datetime
+
+        existing = self._store.load_cert(self._hostnames[0])
+        if existing is not None and existing.expires_at > datetime.now(UTC):
+            self._bundle = existing
+            log.info("tls.cert.loaded", domain=self._hostnames[0])
+            return
+
+        # Request new cert via ACME (plain HTTP for initial request)
+        lacme = _require_lacme()
+        directory_url = f"{self._console_url}/acme/directory"
+
+        async with lacme.Client(
+            directory_url=directory_url,
+            store=self._store,
+            event_dispatcher=self._event_dispatcher,
+            allow_insecure=True,
+        ) as client:
+            self._bundle = await client.issue(self._hostnames)
+            self._store.save_cert(self._bundle)
+            log.info("tls.cert.issued", domain=self._hostnames[0])
+
+    # -- Auto-renewal ----------------------------------------------------------
+
+    async def start_renewal(self) -> None:
+        """Start background auto-renewal via the console's ACME endpoint."""
+        lacme = _require_lacme()
+
+        def _on_renewed(bundle: Any) -> None:
+            self._bundle = bundle
+            log.info("tls.cert.renewed", domain=bundle.domain)
+
+        directory_url = f"{self._console_url}/acme/directory"
+        client = lacme.Client(
+            directory_url=directory_url,
+            store=self._store,
+            event_dispatcher=self._event_dispatcher,
+            allow_insecure=True,
+        )
+        await client.__aenter__()
+
+        manager = lacme.RenewalManager(
+            client=client,
+            store=self._store,
+            interval_hours=_RENEW_INTERVAL_HOURS,
+            days_before_expiry=_RENEW_BEFORE_EXPIRY_DAYS,
+            on_renewed=_on_renewed,
+            event_dispatcher=self._event_dispatcher,
+        )
+        self._renewal_task = manager.start()
+        self._renewal_client = client
+        log.info("tls.renewal.started", directory=directory_url)
+
+    async def stop_renewal(self) -> None:
+        """Stop background renewal and close the ACME client."""
+        import contextlib
+
+        if self._renewal_task is not None:
+            import asyncio
+
+            self._renewal_task.cancel()
+            try:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._renewal_task
+            except Exception:
+                log.exception("tls.renewal.stop_error")
+            self._renewal_task = None
+        if self._renewal_client is not None:
+            with contextlib.suppress(Exception):
+                await self._renewal_client.__aexit__(None, None, None)
+            self._renewal_client = None
+
+    # -- SSL contexts ----------------------------------------------------------
+
+    def get_server_ssl_context(self) -> ssl.SSLContext | None:
+        """Build SSL context for uvicorn HTTPS listener."""
+        if self._bundle is None or self._ca_pem is None:
+            return None
+        _require_lacme()
+        from lacme.mtls import server_ssl_context
+
+        return server_ssl_context(  # type: ignore[no-any-return]
+            cert_pem=self._bundle.fullchain_pem,
+            key_pem=self._bundle.key_pem,
+            ca_cert_pem=self._ca_pem,
+        )
+
+    def get_client_ssl_context(self) -> ssl.SSLContext | None:
+        """Build mTLS client context for httpx connections."""
+        if self._bundle is None or self._ca_pem is None:
+            return None
+        _require_lacme()
+        from lacme.mtls import client_ssl_context
+
+        return client_ssl_context(  # type: ignore[no-any-return]
+            cert_pem=self._bundle.cert_pem,
+            key_pem=self._bundle.key_pem,
+            ca_cert_pem=self._ca_pem,
+        )
+
+    # -- Properties ------------------------------------------------------------
+
+    @property
+    def ca_pem(self) -> bytes | None:
+        return self._ca_pem
+
+    @property
+    def bundle(self) -> Any | None:
+        return self._bundle
+
+    @property
+    def initialized(self) -> bool:
+        return self._bundle is not None and self._ca_pem is not None

--- a/turnstone/mq/bridge.py
+++ b/turnstone/mq/bridge.py
@@ -78,6 +78,8 @@ class Bridge:
         heartbeat_ttl: int = 60,
         auth_token: str = "",
         token_manager: Any = None,
+        tls_verify: Any = True,
+        tls_cert: tuple[str, str] | None = None,
     ) -> None:
         self._server_url = server_url.rstrip("/")
         self._broker = broker or RedisBroker()
@@ -89,6 +91,8 @@ class Bridge:
         self._started_at = time.time()
         self._auth_token = auth_token
         self._token_manager = token_manager  # ServiceTokenManager (auto-rotating)
+        self._tls_verify = tls_verify  # CA cert path or ssl.SSLContext or True
+        self._tls_cert = tls_cert  # (cert_path, key_path) for mTLS
 
         # Shared httpx client for short-lived POST requests (main thread only).
         # Auth headers refreshed per-request via event hook so auto-rotating
@@ -97,6 +101,8 @@ class Bridge:
             base_url=self._server_url,
             timeout=30,
             event_hooks={"request": [self._inject_auth]},
+            verify=self._tls_verify,
+            cert=self._tls_cert,
         )
 
         # Protected by _lock — accessed from main, global SSE, and per-ws SSE threads
@@ -592,6 +598,8 @@ class Bridge:
             base_url=self._server_url,
             timeout=None,
             event_hooks={"request": [self._inject_auth]},
+            verify=self._tls_verify,
+            cert=self._tls_cert,
         ) as sse_client:
             while self._running:
                 # Stop if workstream was closed (thread removed from registry)
@@ -903,6 +911,8 @@ class Bridge:
             base_url=self._server_url,
             timeout=None,
             event_hooks={"request": [self._inject_auth]},
+            verify=self._tls_verify,
+            cert=self._tls_cert,
         ) as sse_client:
             while self._running:
                 try:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -18,7 +18,6 @@ import functools
 import json
 import os
 import queue
-import socket
 import sys
 import textwrap
 import threading
@@ -1851,8 +1850,19 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     "OIDC JWKS prefetch failed — will retry on first login",
                     exc_info=True,
                 )
+    # TLS: start auto-renewal if client was initialized
+    tls_client = getattr(app.state, "tls_client", None)
+    if tls_client is not None:
+        try:
+            await tls_client.start_renewal()
+        except Exception:
+            log.warning("TLS auto-renewal startup failed", exc_info=True)
+
     yield
     # Shutdown
+    tls_client = getattr(app.state, "tls_client", None)
+    if tls_client is not None:
+        await tls_client.stop_renewal()
     if app.state.watch_runner:
         app.state.watch_runner.stop()
     if app.state.health_monitor:
@@ -2428,11 +2438,73 @@ def main() -> None:
         )
     log.info("Max workstreams: %s", config_store.get("server.max_workstreams"))
     log.info("Node ID: %s", _node_id)
+
+    # TLS: request cert from console ACME if enabled
+    ssl_kwargs: dict[str, Any] = {}
+    if config_store.get("tls.enabled"):
+        try:
+            import asyncio
+            import socket
+            import tempfile
+
+            from turnstone.core.tls import TLSClient
+
+            hostname = socket.getfqdn()
+            hostnames = [hostname, "localhost", "127.0.0.1"]
+            # Only add bind host if it's a concrete address
+            if args.host not in ("0.0.0.0", "::", ""):
+                hostnames.append(args.host)
+            tls_client = TLSClient(
+                storage=get_storage(),
+                hostnames=hostnames,
+            )
+            asyncio.run(tls_client.init())
+            bundle = tls_client.bundle
+            if bundle:
+                # Write PEM to temp files for uvicorn (restricted permissions)
+                _tls_temp_files: list[str] = []
+
+                def _write_pem(data: bytes, suffix: str = ".pem") -> str:
+                    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+                        f.write(data)
+                        name = f.name
+                    os.chmod(name, 0o600)
+                    _tls_temp_files.append(name)
+                    return name
+
+                ssl_kwargs["ssl_certfile"] = _write_pem(bundle.fullchain_pem)
+                ssl_kwargs["ssl_keyfile"] = _write_pem(bundle.key_pem)
+                if tls_client.ca_pem:
+                    ssl_kwargs["ssl_ca_certs"] = _write_pem(tls_client.ca_pem)
+                    import ssl as _ssl
+
+                    ssl_kwargs["ssl_cert_reqs"] = _ssl.CERT_REQUIRED
+
+                # Store client on app state for lifespan renewal
+                app.state.tls_client = tls_client
+
+                # Clean up temp files on exit
+                import atexit
+
+                def _cleanup_tls_files() -> None:
+                    import contextlib
+
+                    for path in _tls_temp_files:
+                        with contextlib.suppress(OSError):
+                            os.unlink(path)
+
+                atexit.register(_cleanup_tls_files)
+                log.info("TLS enabled — serving HTTPS")
+            else:
+                log.warning("TLS enabled but no cert available")
+        except Exception:
+            log.warning("TLS initialization failed — serving plain HTTP", exc_info=True)
+
     print("Press Ctrl+C to stop.")
 
     import uvicorn
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning", **ssl_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `TLSClient` class for service nodes — discovers console, fetches CA, requests certs via ACME
- Console self-registers in services table for discovery (no extra config needed)
- RenewalManager fix: console creates loopback ACME client (was passing client=None)
- Unauthenticated `/acme/ca.pem` endpoint for node bootstrapping
- Server: TLS init, temp PEM files (0o600 + atexit), auto-renewal in lifespan
- Bridge: `tls_verify`/`tls_cert` on all 3 httpx clients
- Console collector/proxy: mTLS context params
- Channel gateway: optional SSL params on uvicorn.Config
- Console `main()` wired: reads `tls.enabled`, creates TLSManager, passes to create_app

Phase 3 of mTLS + ACME integration. Builds on Phase 2 (#179).

## Test plan
- [x] 37 TLS tests pass (20 storage + 11 manager + 6 client)
- [x] Ruff + mypy clean on new files
- [x] Backward compat: default params preserve non-TLS behavior
- [ ] CI: full test suite, lint, typecheck, postgres tests

## Known gaps (tracked in PROGRESS.md)
- Temp PEM files for uvicorn (lacme feature request filed)
- RenewalManager should support CA-direct mode (lacme feature request filed)
- Channel CLI TLS args not yet added to argparser (Phase 4)
- Proxy mTLS context stale on first boot (resolved on restart after TLS init)