### PR TITLE
refactor: adopt lacme 1.0.2 — eliminate loopback client + temp file boilerplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ anthropic = ["anthropic>=0.39"]
 postgres = ["psycopg[binary]>=3.2"]
 ddg = ["ddgs>=9.0"]
 discord = ["discord.py>=2.4", "redis>=7.2"]
-tls = ["lacme>=1.0.1"]
+tls = ["lacme>=1.0.2"]
 all = ["turnstone[mq,console,sim,anthropic,postgres,discord,ddg,tls]"]
 
 [project.scripts]

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4950,20 +4950,12 @@ def create_app(
     app.state.console_url = console_url
     app.state.tls_manager = tls_manager
 
-    # Mount ACME responder and CA cert endpoint if TLS is enabled
-    if tls_manager is not None and tls_manager.ca_initialized:
+    # Mount ACME responder whenever a TLS manager is configured.
+    # ACMEResponder (lacme 1.0.2+) serves /ca.pem natively.
+    if tls_manager is not None:
         from starlette.routing import Mount as RouteMount
-        from starlette.routing import Route as RouteRoute
 
-        # CA cert endpoint BEFORE mount so it's matched first
-        async def _acme_ca_pem(request: Request) -> Response:
-            mgr = getattr(request.app.state, "tls_manager", None)
-            if mgr is None or not mgr.ca_initialized:
-                return JSONResponse({"error": "TLS not enabled"}, status_code=404)
-            return Response(content=mgr.get_root_cert_pem(), media_type="application/x-pem-file")
-
-        app.routes.insert(0, RouteRoute("/acme/ca.pem", _acme_ca_pem))
-        app.routes.insert(1, RouteMount("/acme", app=tls_manager.get_responder()))
+        app.routes.insert(0, RouteMount("/acme", app=tls_manager.get_responder()))
 
     from turnstone.core.auth import LoginRateLimiter
 
@@ -5147,7 +5139,11 @@ def main() -> None:
             if _cs.get("tls.enabled"):
                 from turnstone.console.tls import TLSManager
 
-                tls_mgr = TLSManager(auth_storage, config_store=_cs, port=args.port)
+                tls_mgr = TLSManager(auth_storage, config_store=_cs)
+                # Init CA before create_app so ACME responder can be mounted
+                import asyncio
+
+                asyncio.run(tls_mgr.init_ca())
                 console_url = f"https://{args.host}:{args.port}"
                 log.info("TLS enabled")
         except ImportError:

--- a/turnstone/console/tls.py
+++ b/turnstone/console/tls.py
@@ -55,7 +55,6 @@ class TLSManager:
         self,
         storage: StorageBackend,
         config_store: ConfigStore | None = None,
-        port: int = 8080,
     ) -> None:
         lacme = _require_lacme()
 
@@ -63,13 +62,11 @@ class TLSManager:
 
         self._store = StorageStore(storage)
         self._config_store = config_store
-        self._port = port
         self._event_dispatcher = lacme.EventDispatcher()
         self._ca: Any | None = None
         self._responder: Any | None = None
         self._renewal_task: Any | None = None
         self._renewal_manager: Any | None = None
-        self._renewal_client: Any | None = None
         self._internal_bundle: Any | None = None
         self._frontend_bundle: Any | None = None
 
@@ -233,8 +230,9 @@ class TLSManager:
     async def start_renewal(self) -> None:
         """Start background auto-renewal for all stored certificates.
 
-        Creates a lacme Client pointed at the console's own ACME endpoint
-        (localhost loopback) for cert renewal requests.
+        Uses CA-direct mode (lacme 1.0.2+) — signs directly via the CA
+        without going through ACME. No loopback client, no network,
+        no startup ordering dependency.
         """
         if self._ca is None:
             raise RuntimeError("CA not initialized")
@@ -247,18 +245,8 @@ class TLSManager:
             if self._frontend_bundle and bundle.domain == self._frontend_bundle.domain:
                 self._frontend_bundle = bundle
 
-        # Create a client pointed at our own ACME endpoint for renewal
-        directory_url = f"http://localhost:{self._port}/acme/directory"
-        client = lacme.Client(
-            directory_url=directory_url,
-            store=self._store,
-            event_dispatcher=self._event_dispatcher,
-            allow_insecure=True,  # localhost loopback
-        )
-        await client.__aenter__()
-
         self._renewal_manager = lacme.RenewalManager(
-            client=client,
+            ca=self._ca,
             store=self._store,
             interval_hours=_RENEW_INTERVAL_HOURS,
             days_before_expiry=_RENEW_BEFORE_EXPIRY_DAYS,
@@ -266,19 +254,17 @@ class TLSManager:
             event_dispatcher=self._event_dispatcher,
         )
         self._renewal_task = self._renewal_manager.start()
-        self._renewal_client = client
         log.info(
             "tls.renewal.started",
             interval_hours=_RENEW_INTERVAL_HOURS,
-            directory=directory_url,
         )
 
     async def stop_renewal(self) -> None:
-        """Stop the background renewal task and close the ACME client."""
-        import asyncio
-        import contextlib
-
+        """Stop the background renewal task."""
         if self._renewal_task is not None:
+            import asyncio
+            import contextlib
+
             self._renewal_task.cancel()
             try:
                 with contextlib.suppress(asyncio.CancelledError):
@@ -286,11 +272,6 @@ class TLSManager:
             except Exception:
                 log.exception("tls.renewal.stop_error")
             self._renewal_task = None
-        # Close the loopback ACME client
-        if self._renewal_client is not None:
-            with contextlib.suppress(Exception):
-                await self._renewal_client.__aexit__(None, None, None)
-            self._renewal_client = None
 
     # -- SSL contexts ----------------------------------------------------------
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2445,7 +2445,6 @@ def main() -> None:
         try:
             import asyncio
             import socket
-            import tempfile
 
             from turnstone.core.tls import TLSClient
 
@@ -2461,39 +2460,20 @@ def main() -> None:
             asyncio.run(tls_client.init())
             bundle = tls_client.bundle
             if bundle:
-                # Write PEM to temp files for uvicorn (restricted permissions)
-                _tls_temp_files: list[str] = []
+                from lacme.mtls import write_pem_files_persistent
 
-                def _write_pem(data: bytes, suffix: str = ".pem") -> str:
-                    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
-                        f.write(data)
-                        name = f.name
-                    os.chmod(name, 0o600)
-                    _tls_temp_files.append(name)
-                    return name
-
-                ssl_kwargs["ssl_certfile"] = _write_pem(bundle.fullchain_pem)
-                ssl_kwargs["ssl_keyfile"] = _write_pem(bundle.key_pem)
+                pem_paths = write_pem_files_persistent(
+                    bundle,
+                    ca_pem=tls_client.ca_pem,
+                )
+                ssl_kwargs.update(pem_paths.as_uvicorn_kwargs())
                 if tls_client.ca_pem:
-                    ssl_kwargs["ssl_ca_certs"] = _write_pem(tls_client.ca_pem)
                     import ssl as _ssl
 
                     ssl_kwargs["ssl_cert_reqs"] = _ssl.CERT_REQUIRED
 
                 # Store client on app state for lifespan renewal
                 app.state.tls_client = tls_client
-
-                # Clean up temp files on exit
-                import atexit
-
-                def _cleanup_tls_files() -> None:
-                    import contextlib
-
-                    for path in _tls_temp_files:
-                        with contextlib.suppress(OSError):
-                            os.unlink(path)
-
-                atexit.register(_cleanup_tls_files)
                 log.info("TLS enabled — serving HTTPS")
             else:
                 log.warning("TLS enabled but no cert available")

--- a/uv.lock
+++ b/uv.lock
@@ -984,15 +984,15 @@ wheels = [
 
 [[package]]
 name = "lacme"
-version = "1.0.1"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/3f/0371df0b8c5d92697234893ec90168983d86a6608cadae01f287b9093aa9/lacme-1.0.1.tar.gz", hash = "sha256:d90f919f7eb98e6569d05acc9e8e86006540356d9c1321cb7dd868352965201f", size = 196508, upload-time = "2026-03-25T21:42:25.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/b7/aadbf032c95e61d83242b8e27a25853fdc19685747f4bd78968962271c8a/lacme-1.0.2.tar.gz", hash = "sha256:3059a39cee454f612869bf9e419d4e6f279a35e8ce9e6c130cc1b7721704ea4a", size = 199743, upload-time = "2026-03-26T00:42:02.581Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/e4/fe7d02c95f20c4212683456da605125a28463d3838a77cbcab4234c63015/lacme-1.0.1-py3-none-any.whl", hash = "sha256:3ceb598c4044378d55f91ca661d5fab1366739711ca05f8e3f8143904a04a1a9", size = 70062, upload-time = "2026-03-25T21:42:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a3/8e9495ee920e4c4a945ef2f0e4266dd4968a1511e630184990499f12025d/lacme-1.0.2-py3-none-any.whl", hash = "sha256:5bf7b859deddc8aab47619c8e165b85f4ff730bf0c0b9463789b5b01c51d9177", size = 71836, upload-time = "2026-03-26T00:42:00.797Z" },
 ]
 
 [[package]]
@@ -2412,7 +2412,7 @@ requires-dist = [
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.4" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx-sse", specifier = ">=0.4" },
-    { name = "lacme", marker = "extra == 'tls'", specifier = ">=1.0.1" },
+    { name = "lacme", marker = "extra == 'tls'", specifier = ">=1.0.2" },
     { name = "mcp", specifier = ">=1.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "openai", specifier = ">=2.24" },


### PR DESCRIPTION
## Summary
Adopts lacme 1.0.2 features to simplify turnstone's TLS code:

- **CA-direct renewal**: `RenewalManager(ca=ca)` replaces loopback ACME client — no network, no startup ordering dependency
- **Built-in /ca.pem**: ACMEResponder serves CA cert natively — removed custom route + ordering workaround
- **PEM file helper**: `write_pem_files_persistent()` replaces manual temp file creation, chmod, and atexit cleanup
- **Cleanup**: removed `port` param from TLSManager, `_renewal_client` lifecycle

Net: ~50 lines removed, two tech debt items resolved.

## Test plan
- [x] 37 TLS tests pass
- [x] Ruff + mypy clean
- [ ] CI: full suite