### PR TITLE
feat: TLS admin UI, CLI cert management, Redis/PG TLS

### DIFF
--- a/tests/test_tls_admin.py
+++ b/tests/test_tls_admin.py
@@ -1,0 +1,186 @@
+"""Tests for TLS admin API endpoints and CLI commands."""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.storage import get_storage, init_storage, reset_storage
+
+lacme = pytest.importorskip("lacme")
+
+
+@pytest.fixture(autouse=True)
+def _storage(tmp_path):
+    """Initialize ephemeral SQLite storage for each test."""
+    reset_storage()
+    db = str(tmp_path / "test.db")
+    init_storage("sqlite", path=db)
+    yield
+    reset_storage()
+
+
+@pytest.fixture
+def tls_manager():
+    """Create an initialized TLSManager."""
+    import asyncio
+
+    from turnstone.console.tls import TLSManager
+
+    mgr = TLSManager(get_storage())
+    asyncio.run(mgr.init_ca())
+    # Issue a test cert
+    asyncio.run(mgr.issue_console_certs(["test.internal", "localhost"]))
+    return mgr
+
+
+# ── Admin API endpoints ───────────────────────────────────────────────────────
+
+
+def _make_app(tls_manager):
+    """Create a minimal Starlette app with TLS endpoints."""
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.routing import Route
+
+    from turnstone.console.server import (
+        tls_ca_cert,
+        tls_ca_status,
+        tls_delete_cert,
+        tls_list_certs,
+        tls_renew_cert,
+    )
+    from turnstone.core.auth import AuthResult
+
+    async def _grant_access(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.auth_result = AuthResult(
+            user_id="",
+            scopes=frozenset({"approve"}),
+            token_source="config",
+        )
+        return await call_next(request)
+
+    app = Starlette(
+        routes=[
+            Route("/ca", tls_ca_status),
+            Route("/ca.pem", tls_ca_cert),
+            Route("/certs", tls_list_certs),
+            Route("/certs/{domain}/renew", tls_renew_cert, methods=["POST"]),
+            Route("/certs/{domain}", tls_delete_cert, methods=["DELETE"]),
+        ],
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=_grant_access)],
+    )
+    app.state.tls_manager = tls_manager
+    return app
+
+
+def test_list_certs(tls_manager):
+    from starlette.testclient import TestClient
+
+    client = TestClient(_make_app(tls_manager))
+    resp = client.get("/certs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["certs"]) >= 1
+    assert data["certs"][0]["domain"] == "test.internal"
+
+
+def test_renew_cert(tls_manager):
+    from starlette.testclient import TestClient
+
+    client = TestClient(_make_app(tls_manager))
+    resp = client.post("/certs/test.internal/renew")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["domain"] == "test.internal"
+
+
+def test_renew_cert_not_found(tls_manager):
+    from starlette.testclient import TestClient
+
+    client = TestClient(_make_app(tls_manager))
+    resp = client.post("/certs/nonexistent.internal/renew")
+    assert resp.status_code == 404
+
+
+def test_delete_cert(tls_manager):
+    from starlette.testclient import TestClient
+
+    client = TestClient(_make_app(tls_manager))
+    resp = client.delete("/certs/test.internal")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == "test.internal"
+    # Verify it's gone
+    resp = client.get("/certs")
+    domains = [c["domain"] for c in resp.json()["certs"]]
+    assert "test.internal" not in domains
+
+
+def test_delete_cert_not_found(tls_manager):
+    from starlette.testclient import TestClient
+
+    client = TestClient(_make_app(tls_manager))
+    resp = client.delete("/certs/nonexistent.internal")
+    assert resp.status_code == 404
+
+
+# ── CLI bootstrap ─────────────────────────────────────────────────────────────
+
+
+def test_cli_bootstrap(tmp_path):
+    """Test offline CA bootstrap."""
+    import argparse
+
+    from turnstone.admin import _cmd_tls_bootstrap
+
+    out = tmp_path / "certs"
+    args = argparse.Namespace(out=str(out), issue=["redis.internal", "pg.internal"])
+    _cmd_tls_bootstrap(args)
+
+    assert (out / "ca.pem").exists()
+    assert b"BEGIN CERTIFICATE" in (out / "ca.pem").read_bytes()
+    # Check certs were issued
+    assert (out / "certs" / "redis.internal").exists()
+    assert (out / "certs" / "pg.internal").exists()
+
+
+def test_cli_bootstrap_no_issue(tmp_path):
+    """Bootstrap with no --issue creates CA only."""
+    import argparse
+
+    from turnstone.admin import _cmd_tls_bootstrap
+
+    out = tmp_path / "certs"
+    args = argparse.Namespace(out=str(out), issue=[])
+    _cmd_tls_bootstrap(args)
+
+    assert (out / "ca.pem").exists()
+    # No certs dir
+    certs_dir = out / "certs"
+    if certs_dir.exists():
+        assert len(list(certs_dir.iterdir())) == 0
+
+
+# ── Config parsing ────────────────────────────────────────────────────────────
+
+
+def test_redis_tls_config_map():
+    """Redis TLS keys are in the config map."""
+    from turnstone.core.config import _CONFIG_MAP
+
+    redis_map = _CONFIG_MAP["redis"]
+    assert "tls" in redis_map
+    assert "tls_ca" in redis_map
+    assert "tls_cert" in redis_map
+    assert "tls_key" in redis_map
+
+
+def test_database_ssl_config_map():
+    """Database SSL keys are in the config map."""
+    from turnstone.core.config import _CONFIG_MAP
+
+    db_map = _CONFIG_MAP["database"]
+    assert "sslmode" in db_map
+    assert "sslrootcert" in db_map
+    assert "sslcert" in db_map
+    assert "sslkey" in db_map

--- a/turnstone/admin.py
+++ b/turnstone/admin.py
@@ -142,6 +142,186 @@ def _cmd_revoke_token(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+# ---------------------------------------------------------------------------
+# TLS commands
+# ---------------------------------------------------------------------------
+
+
+def _cmd_tls_bootstrap(args: argparse.Namespace) -> None:
+    """Initialize CA and issue certs offline."""
+    try:
+        from lacme import CertificateAuthority, FileStore
+    except ImportError:
+        print("lacme not installed. Run: pip install turnstone[tls]", file=sys.stderr)
+        sys.exit(1)
+
+    import os
+    from pathlib import Path
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(out_dir, 0o700)  # Restrict access — contains CA private key
+
+    store = FileStore(str(out_dir))
+    ca = CertificateAuthority(store)
+    ca.init(cn="Turnstone CA", validity_days=3650)
+    print(f"CA initialized in {out_dir} (permissions: 0700)")
+
+    # Write CA cert to a well-known location
+    ca_cert_path = out_dir / "ca.pem"
+    ca_cert_path.write_bytes(ca.root_cert_pem)
+    os.chmod(ca_cert_path, 0o644)
+    print(f"CA cert: {ca_cert_path}")
+
+    # Issue certs for requested domains
+    for domain in args.issue:
+        bundle = ca.issue([domain], validity_hours=48)
+        store.save_cert(bundle)
+        cert_dir = out_dir / "certs" / domain
+        print(f"Issued: {domain} -> {cert_dir}")
+
+    print(f"\nBootstrap complete. {len(args.issue)} cert(s) issued.")
+    print(f"CA and certs written to: {out_dir}")
+
+
+def _cmd_tls_issue(args: argparse.Namespace) -> None:
+    """Request a cert from the console's ACME endpoint."""
+    try:
+        from lacme import SyncClient
+    except ImportError:
+        print("lacme not installed. Run: pip install turnstone[tls]", file=sys.stderr)
+        sys.exit(1)
+
+    import os
+    from pathlib import Path
+
+    console_url = args.console_url
+    if not console_url:
+        console_url = _discover_console_url()
+
+    domains = [args.domain] + args.san
+    directory_url = f"{console_url}/acme/directory"
+    print(f"Requesting cert for {domains} from {directory_url}")
+
+    client = SyncClient(
+        directory_url=directory_url,
+        allow_insecure=True,
+    )
+    bundle = client.issue(domains)
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "cert.pem").write_bytes(bundle.cert_pem)
+    (out_dir / "fullchain.pem").write_bytes(bundle.fullchain_pem)
+    (out_dir / "key.pem").write_bytes(bundle.key_pem)
+    os.chmod(out_dir / "key.pem", 0o600)
+
+    print(f"Certificate written to {out_dir}/")
+    print("  cert.pem      (leaf certificate)")
+    print("  fullchain.pem (cert + chain)")
+    print("  key.pem       (private key, 0600)")
+
+
+def _cmd_tls_ca_cert(args: argparse.Namespace) -> None:
+    """Download the CA root certificate from the console."""
+    import httpx
+
+    console_url = args.console_url
+    if not console_url:
+        console_url = _discover_console_url()
+
+    # Use plain HTTP for bootstrap (node may not have CA cert yet)
+    # WARNING: This is trust-on-first-use (TOFU) — verify the fingerprint
+    base = console_url.replace("https://", "http://")
+    url = f"{base}/acme/ca.pem"
+    print(f"Fetching CA cert from {url}")
+    print("WARNING: Fetching over plain HTTP — verify the fingerprint below")
+
+    resp = httpx.get(url)
+    resp.raise_for_status()
+
+    # Show fingerprint for out-of-band verification
+    import hashlib
+
+    fingerprint = hashlib.sha256(resp.content).hexdigest()
+    print(f"CA cert SHA-256: {fingerprint}")
+
+    from pathlib import Path
+
+    Path(args.out).write_bytes(resp.content)
+    print(f"CA cert written to {args.out}")
+
+
+def _cmd_tls_list(args: argparse.Namespace) -> None:
+    """List certificates from the console."""
+    import httpx
+
+    console_url = args.console_url
+    if not console_url:
+        console_url = _discover_console_url()
+
+    url = f"{console_url}/v1/api/admin/tls/certs"
+    headers = {}
+    token = getattr(args, "auth_token", "") or _get_config_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = httpx.get(url, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
+
+    certs = data.get("certs", [])
+    if not certs:
+        print("No certificates issued.")
+        return
+
+    print(f"{'DOMAIN':<30s} {'ISSUED':<22s} {'EXPIRES':<22s}")
+    print("-" * 74)
+    for c in certs:
+        print(f"{c['domain']:<30s} {c['issued_at']:<22s} {c['expires_at']:<22s}")
+
+
+def _get_config_token() -> str:
+    """Try to load auth token from config.toml or environment."""
+    token = os.environ.get("TURNSTONE_AUTH_TOKEN", "")
+    if token:
+        return token
+    try:
+        from turnstone.core.config import load_config
+
+        cfg = load_config("auth")
+        return str(cfg.get("token", ""))
+    except Exception:
+        return ""
+
+
+def _discover_console_url() -> str:
+    """Discover console URL from the services table."""
+    from turnstone.core.storage import get_storage
+
+    try:
+        storage = get_storage()
+    except Exception:
+        print(
+            "No storage configured. Use --console-url or run from a "
+            "directory with a turnstone database.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    consoles = storage.list_services("console", max_age_seconds=3600)
+    if not consoles:
+        print(
+            "No console found in services table. Use --console-url explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return consoles[0]["url"]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
 def main() -> None:
     """Entry point for turnstone-admin CLI."""
     parser = argparse.ArgumentParser(
@@ -171,6 +351,35 @@ def main() -> None:
     p_rt = sub.add_parser("revoke-token", help="Revoke an API token")
     p_rt.add_argument("--token-id", required=True, help="Token ID to revoke")
 
+    # TLS subcommands
+    p_bootstrap = sub.add_parser(
+        "tls-bootstrap",
+        help="Initialize CA and issue certs offline (no running console needed)",
+    )
+    p_bootstrap.add_argument("--out", required=True, help="Output directory for PEM files")
+    p_bootstrap.add_argument(
+        "--issue",
+        action="append",
+        default=[],
+        help="Domain to issue cert for (repeatable)",
+    )
+
+    p_issue = sub.add_parser("tls-issue", help="Request cert from console ACME")
+    p_issue.add_argument("domain", help="Primary domain for the certificate")
+    p_issue.add_argument("--san", action="append", default=[], help="Additional SAN (repeatable)")
+    p_issue.add_argument("--out", default=".", help="Output directory for PEM files")
+    p_issue.add_argument(
+        "--console-url", default="", help="Console URL (discovered from DB if empty)"
+    )
+
+    p_cacert = sub.add_parser("tls-ca-cert", help="Download CA root certificate")
+    p_cacert.add_argument("--out", default="ca.pem", help="Output file path")
+    p_cacert.add_argument("--console-url", default="", help="Console URL")
+
+    p_tlslist = sub.add_parser("tls-list", help="List issued certificates")
+    p_tlslist.add_argument("--console-url", default="", help="Console URL")
+    p_tlslist.add_argument("--auth-token", default="", help="Auth token for admin API")
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -182,5 +391,9 @@ def main() -> None:
         "list-users": _cmd_list_users,
         "list-tokens": _cmd_list_tokens,
         "revoke-token": _cmd_revoke_token,
+        "tls-bootstrap": _cmd_tls_bootstrap,
+        "tls-issue": _cmd_tls_issue,
+        "tls-ca-cert": _cmd_tls_ca_cert,
+        "tls-list": _cmd_tls_list,
     }
     dispatch[args.command](args)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4680,6 +4680,74 @@ async def tls_ca_status(request: Request) -> JSONResponse:
     )
 
 
+async def tls_list_certs(request: Request) -> JSONResponse:
+    """GET /v1/api/admin/tls/certs — List issued certificates."""
+    from turnstone.core.auth import require_permission
+
+    err = require_permission(request, "admin.settings")
+    if err:
+        return err
+    mgr = getattr(request.app.state, "tls_manager", None)
+    if mgr is None or not mgr.ca_initialized:
+        return JSONResponse({"certs": []})
+    certs = mgr.list_certs()
+    return JSONResponse(
+        {
+            "certs": [
+                {
+                    "domain": c.domain,
+                    "domains": list(c.domains),
+                    "issued_at": c.issued_at.isoformat(),
+                    "expires_at": c.expires_at.isoformat(),
+                }
+                for c in certs
+            ],
+        },
+    )
+
+
+async def tls_renew_cert(request: Request) -> JSONResponse:
+    """POST /v1/api/admin/tls/certs/{domain}/renew — Force cert renewal."""
+    from turnstone.core.auth import require_permission
+
+    err = require_permission(request, "admin.settings")
+    if err:
+        return err
+    mgr = getattr(request.app.state, "tls_manager", None)
+    if mgr is None or not mgr.ca_initialized:
+        return JSONResponse({"error": "TLS not enabled"}, status_code=404)
+    domain = request.path_params["domain"]
+    try:
+        bundle = mgr.renew_cert(domain)
+        return JSONResponse(
+            {
+                "domain": bundle.domain,
+                "issued_at": bundle.issued_at.isoformat(),
+                "expires_at": bundle.expires_at.isoformat(),
+            },
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=404)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def tls_delete_cert(request: Request) -> JSONResponse:
+    """DELETE /v1/api/admin/tls/certs/{domain} — Delete a certificate."""
+    from turnstone.core.auth import require_permission
+
+    err = require_permission(request, "admin.settings")
+    if err:
+        return err
+    mgr = getattr(request.app.state, "tls_manager", None)
+    if mgr is None or not mgr.ca_initialized:
+        return JSONResponse({"error": "TLS not enabled"}, status_code=404)
+    domain = request.path_params["domain"]
+    if not mgr.delete_cert(domain):
+        return JSONResponse({"error": f"No cert for {domain}"}, status_code=404)
+    return JSONResponse({"deleted": domain})
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -4922,6 +4990,17 @@ def create_app(
                     # TLS / ACME
                     Route("/api/admin/tls/ca", tls_ca_status),
                     Route("/api/admin/tls/ca.pem", tls_ca_cert),
+                    Route("/api/admin/tls/certs", tls_list_certs),
+                    Route(
+                        "/api/admin/tls/certs/{domain}/renew",
+                        tls_renew_cert,
+                        methods=["POST"],
+                    ),
+                    Route(
+                        "/api/admin/tls/certs/{domain}",
+                        tls_delete_cert,
+                        methods=["DELETE"],
+                    ),
                 ],
             ),
             Route("/health", health),

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -64,6 +64,7 @@ function showAdmin() {
     audit: "admin.audit",
     memories: "admin.memories",
     settings: "admin.settings",
+    tls: "admin.settings",
     mcp: "admin.mcp",
   };
   if (perms) {
@@ -193,6 +194,7 @@ function switchAdminTab(tab) {
     "audit",
     "memories",
     "settings",
+    "tls",
     "mcp",
   ];
   for (var p = 0; p < panels.length; p++) {
@@ -215,6 +217,7 @@ function switchAdminTab(tab) {
   }
   if (tab === "memories") loadAdminMemories();
   if (tab === "settings") loadSettings();
+  if (tab === "tls") loadTlsCerts();
   if (tab === "mcp") loadAdminMcp();
 
   // Update breadcrumb with active tab label
@@ -2082,6 +2085,180 @@ function _settingsSectionLabel(section) {
   };
   return labels[section] || section;
 }
+
+// ---------------------------------------------------------------------------
+// TLS tab
+// ---------------------------------------------------------------------------
+
+function loadTlsCerts() {
+  var statusEl = document.getElementById("tls-ca-status");
+  var listEl = document.getElementById("tls-cert-list");
+  if (!statusEl || !listEl) return;
+
+  // Fetch CA status and cert list in parallel
+  Promise.all([
+    authFetch("/v1/api/admin/tls/ca").then(function (r) {
+      if (!r.ok) throw new Error("Failed");
+      return r.json();
+    }),
+    authFetch("/v1/api/admin/tls/certs").then(function (r) {
+      if (!r.ok) return { certs: [] };
+      return r.json();
+    }),
+  ])
+    .then(function (results) {
+      var data = results[0];
+      var certData = results[1];
+      while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
+      while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+
+      if (!data.enabled) {
+        var msg = document.createElement("div");
+        msg.className = "dashboard-empty";
+        msg.textContent =
+          "TLS is not enabled. Set tls.enabled = true in Settings.";
+        statusEl.appendChild(msg);
+        return;
+      }
+
+      // CA status bar
+      var bar = document.createElement("div");
+      bar.className = "tls-ca-bar";
+      var caLabel = document.createElement("span");
+      caLabel.textContent = "CA: " + data.ca_cn;
+      var countLabel = document.createElement("span");
+      countLabel.textContent = "Certificates: " + data.cert_count;
+      bar.appendChild(caLabel);
+      bar.appendChild(countLabel);
+      statusEl.appendChild(bar);
+
+      var certs = certData.certs || [];
+      if (certs.length === 0) {
+        var empty = document.createElement("div");
+        empty.className = "dashboard-empty";
+        empty.textContent = "No certificates issued yet.";
+        listEl.appendChild(empty);
+        return;
+      }
+
+      // Cert rows
+      certs.forEach(function (c) {
+        var row = document.createElement("div");
+        row.className = "admin-row";
+        row.setAttribute("role", "listitem");
+
+        var colDomain = document.createElement("span");
+        colDomain.className = "admin-col";
+        colDomain.textContent = c.domain;
+
+        var colSans = document.createElement("span");
+        colSans.className = "admin-col";
+        colSans.textContent = (c.domains || [c.domain]).join(", ");
+
+        var colIssued = document.createElement("span");
+        colIssued.className = "admin-col";
+        colIssued.textContent = (c.issued_at || "")
+          .slice(0, 16)
+          .replace("T", " ");
+
+        var colExpires = document.createElement("span");
+        colExpires.className = "admin-col";
+        var expires = new Date(c.expires_at);
+        var isExpired = expires < new Date();
+        colExpires.textContent =
+          (isExpired ? "EXPIRED " : "") +
+          (c.expires_at || "").slice(0, 16).replace("T", " ");
+        if (isExpired) colExpires.style.color = "var(--red)";
+
+        var colActions = document.createElement("span");
+        colActions.className = "admin-col admin-col-actions";
+        var renewBtn = document.createElement("button");
+        renewBtn.className = "admin-btn-action";
+        renewBtn.textContent = "Renew";
+        renewBtn.setAttribute(
+          "aria-label",
+          "Renew certificate for " + c.domain,
+        );
+        renewBtn.onclick = function () {
+          tlsRenewCert(c.domain);
+        };
+        var deleteBtn = document.createElement("button");
+        deleteBtn.className = "admin-btn-danger";
+        deleteBtn.textContent = "Delete";
+        deleteBtn.setAttribute(
+          "aria-label",
+          "Delete certificate for " + c.domain,
+        );
+        deleteBtn.onclick = function () {
+          tlsDeleteCert(c.domain);
+        };
+        colActions.appendChild(renewBtn);
+        colActions.appendChild(deleteBtn);
+
+        row.appendChild(colDomain);
+        row.appendChild(colSans);
+        row.appendChild(colIssued);
+        row.appendChild(colExpires);
+        row.appendChild(colActions);
+        listEl.appendChild(row);
+      });
+    })
+    .catch(function () {
+      while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
+      while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+      var errMsg = document.createElement("div");
+      errMsg.className = "dashboard-empty";
+      errMsg.textContent = "Failed to load TLS status";
+      statusEl.appendChild(errMsg);
+    });
+}
+
+function tlsRenewCert(domain) {
+  showConfirmModal(
+    "Renew Certificate",
+    "Force renew certificate for \u2018" + domain + "\u2019?",
+    "Renew",
+    function () {
+      authFetch(
+        "/v1/api/admin/tls/certs/" + encodeURIComponent(domain) + "/renew",
+        { method: "POST" },
+      )
+        .then(function (r) {
+          if (!r.ok) throw new Error("Renew failed");
+          showToast("Certificate renewed for " + domain);
+          loadTlsCerts();
+        })
+        .catch(function () {
+          showToast("Failed to renew certificate", "error");
+        });
+    },
+  );
+}
+
+function tlsDeleteCert(domain) {
+  showConfirmModal(
+    "Delete Certificate",
+    "Delete certificate for \u2018" + domain + "\u2019? This cannot be undone.",
+    "Delete",
+    function () {
+      authFetch("/v1/api/admin/tls/certs/" + encodeURIComponent(domain), {
+        method: "DELETE",
+      })
+        .then(function (r) {
+          if (!r.ok) throw new Error("Delete failed");
+          showToast("Certificate deleted for " + domain);
+          loadTlsCerts();
+        })
+        .catch(function () {
+          showToast("Failed to delete certificate", "error");
+        });
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Settings tab
+// ---------------------------------------------------------------------------
 
 function loadSettings() {
   var el = document.getElementById("admin-settings-content");

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -110,6 +110,7 @@
         <div class="admin-sidebar-group" data-group="system" role="group" aria-label="System">
           <div class="admin-sidebar-group-label" aria-hidden="true">System</div>
           <button id="tab-settings" class="admin-nav" data-tab="settings" role="tab" aria-selected="false" aria-controls="admin-settings" tabindex="-1" onclick="switchAdminTab('settings')">Settings</button>
+          <button id="tab-tls" class="admin-nav" data-tab="tls" role="tab" aria-selected="false" aria-controls="admin-tls" tabindex="-1" onclick="switchAdminTab('tls')">TLS</button>
         </div>
       </nav>
       <div id="admin-sidebar-backdrop" class="admin-sidebar-backdrop" aria-hidden="true"></div>
@@ -400,6 +401,24 @@
         <a href="/docs#/System:%20Settings" target="_blank" rel="noopener" class="settings-docs-link" title="Settings API reference">docs</a>
       </div>
       <div id="admin-settings-content">
+        <div class="dashboard-empty">Loading&hellip;</div>
+      </div>
+    </div>
+
+    <!-- TLS Tab -->
+    <div id="admin-tls" class="admin-panel" role="tabpanel" aria-labelledby="tab-tls" style="display:none">
+      <div class="admin-toolbar">
+        <span class="section-header" style="margin:0">TLS / CERTIFICATES</span>
+      </div>
+      <div id="tls-ca-status"></div>
+      <div class="admin-colheaders admin-colheaders-tls" aria-hidden="true">
+        <span class="admin-col">DOMAIN</span>
+        <span class="admin-col">SANS</span>
+        <span class="admin-col">ISSUED</span>
+        <span class="admin-col">EXPIRES</span>
+        <span class="admin-col admin-col-actions">ACTIONS</span>
+      </div>
+      <div id="tls-cert-list" role="list" aria-label="TLS certificates" aria-live="polite">
         <div class="dashboard-empty">Loading&hellip;</div>
       </div>
     </div>

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -948,6 +948,19 @@
   grid-template-columns: 100px 1fr 100px 80px;
 }
 
+/* TLS grid: DOMAIN | SANS | ISSUED | EXPIRES | ACTIONS */
+#admin-tls .admin-colheaders,
+#admin-tls .admin-row {
+  grid-template-columns: 160px 1fr 130px 150px 120px;
+}
+.tls-ca-bar {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+
 /* Scope badges */
 .scope-badge {
   display: inline-block;

--- a/turnstone/console/tls.py
+++ b/turnstone/console/tls.py
@@ -315,6 +315,28 @@ class TLSManager:
         """List all stored certificate bundles."""
         return self._store.list_certs()
 
+    def renew_cert(self, domain: str) -> Any:
+        """Force-renew a certificate by domain. Returns the new bundle."""
+        if self._ca is None:
+            raise RuntimeError("CA not initialized")
+        existing = self._store.load_cert(domain)
+        if existing is None:
+            raise ValueError(f"No certificate for {domain}")
+        # Issue new cert first, then delete old (safe if issuance fails)
+        bundle = self._ca.issue(list(existing.domains))
+        self._store.delete_cert(domain)
+        self._store.save_cert(bundle)
+        # Update in-memory bundles if this is the console's own cert
+        if self._internal_bundle and bundle.domain == self._internal_bundle.domain:
+            self._internal_bundle = bundle
+        if self._frontend_bundle and bundle.domain == self._frontend_bundle.domain:
+            self._frontend_bundle = bundle
+        return bundle
+
+    def delete_cert(self, domain: str) -> bool:
+        """Delete a certificate by domain."""
+        return self._store.delete_cert(domain)
+
     @property
     def ca_initialized(self) -> bool:
         return self._ca is not None

--- a/turnstone/core/config.py
+++ b/turnstone/core/config.py
@@ -125,6 +125,10 @@ _CONFIG_MAP: dict[str, dict[str, str]] = {
         "port": "redis_port",
         "password": "redis_password",
         "db": "redis_db",
+        "tls": "redis_tls",
+        "tls_ca": "redis_tls_ca",
+        "tls_cert": "redis_tls_cert",
+        "tls_key": "redis_tls_key",
     },
     "console": {
         "host": "host",
@@ -157,6 +161,10 @@ _CONFIG_MAP: dict[str, dict[str, str]] = {
         "url": "db_url",
         "path": "db_path",
         "pool_size": "db_pool_size",
+        "sslmode": "db_sslmode",
+        "sslrootcert": "db_sslrootcert",
+        "sslcert": "db_sslcert",
+        "sslkey": "db_sslkey",
     },
     "judge": {
         "enabled": "judge_enabled",

--- a/turnstone/core/tls_store.py
+++ b/turnstone/core/tls_store.py
@@ -107,9 +107,9 @@ class StorageStore:
         rows = self._storage.list_tls_certs()
         return [self._row_to_bundle(r) for r in rows]
 
-    def delete_cert(self, domain: str) -> None:
+    def delete_cert(self, domain: str) -> bool:
         """Delete a stored certificate bundle by domain."""
-        self._storage.delete_tls_cert(domain)
+        return self._storage.delete_tls_cert(domain)
 
     def _row_to_bundle(self, row: dict[str, Any]) -> Any:
         """Convert a storage row dict to a lacme CertBundle."""

--- a/turnstone/mq/async_broker.py
+++ b/turnstone/mq/async_broker.py
@@ -47,6 +47,10 @@ class AsyncRedisBroker:
         prefix: str = "turnstone",
         password: str | None = None,
         response_ttl: int = 600,
+        ssl: bool = False,
+        ssl_ca_certs: str | None = None,
+        ssl_certfile: str | None = None,
+        ssl_keyfile: str | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -54,6 +58,15 @@ class AsyncRedisBroker:
         self._password = password
         self._prefix = prefix
         self._response_ttl = response_ttl
+        self._ssl_kwargs: dict[str, Any] = {}
+        if ssl:
+            self._ssl_kwargs["ssl"] = True
+            if ssl_ca_certs:
+                self._ssl_kwargs["ssl_ca_certs"] = ssl_ca_certs
+            if ssl_certfile:
+                self._ssl_kwargs["ssl_certfile"] = ssl_certfile
+            if ssl_keyfile:
+                self._ssl_kwargs["ssl_keyfile"] = ssl_keyfile
         self._redis: _aredis_t.Redis[str] | None = None
         self._pubsub: _aredis_t.client.PubSub | None = None
         self._tasks: dict[str, asyncio.Task[None]] = {}
@@ -82,6 +95,7 @@ class AsyncRedisBroker:
             password=self._password,
             decode_responses=True,
             retry_on_timeout=True,
+            **self._ssl_kwargs,
             max_connections=200,
         )
         self._pubsub = self._redis.pubsub(ignore_subscribe_messages=True)

--- a/turnstone/mq/broker.py
+++ b/turnstone/mq/broker.py
@@ -122,11 +122,24 @@ class RedisBroker:
         prefix: str = "turnstone",
         password: str | None = None,
         response_ttl: int = 600,
+        ssl: bool = False,
+        ssl_ca_certs: str | None = None,
+        ssl_certfile: str | None = None,
+        ssl_keyfile: str | None = None,
     ) -> None:
         import redis
 
         self._prefix = prefix
         self._response_ttl = response_ttl
+        ssl_kwargs: dict[str, Any] = {}
+        if ssl:
+            ssl_kwargs["ssl"] = True
+            if ssl_ca_certs:
+                ssl_kwargs["ssl_ca_certs"] = ssl_ca_certs
+            if ssl_certfile:
+                ssl_kwargs["ssl_certfile"] = ssl_certfile
+            if ssl_keyfile:
+                ssl_kwargs["ssl_keyfile"] = ssl_keyfile
         self._pool: _redis_t.ConnectionPool = redis.ConnectionPool(
             host=host,
             port=port,
@@ -135,6 +148,7 @@ class RedisBroker:
             decode_responses=True,
             retry_on_timeout=True,
             max_connections=200,
+            **ssl_kwargs,
         )
         self._redis: _redis_t.Redis[str] = cast(
             "_redis_t.Redis[str]",
@@ -256,7 +270,7 @@ class RedisBroker:
 
 
 def add_redis_args(parser: Any) -> None:
-    """Add ``--redis-host``, ``--redis-port``, ``--redis-password``, ``--redis-db``."""
+    """Add Redis CLI arguments including TLS options."""
     import os
 
     parser.add_argument(
@@ -281,6 +295,27 @@ def add_redis_args(parser: Any) -> None:
         default=0,
         help="Redis DB number (default: %(default)s)",
     )
+    parser.add_argument("--redis-tls", action="store_true", help="Enable Redis TLS")
+    parser.add_argument("--redis-tls-ca", default=None, help="Redis CA cert path")
+    parser.add_argument("--redis-tls-cert", default=None, help="Redis client cert path")
+    parser.add_argument("--redis-tls-key", default=None, help="Redis client key path")
+
+
+def _redis_tls_kwargs(args: Any) -> dict[str, Any]:
+    """Extract Redis TLS kwargs from parsed args."""
+    kwargs: dict[str, Any] = {}
+    if getattr(args, "redis_tls", False):
+        kwargs["ssl"] = True
+        ca = getattr(args, "redis_tls_ca", None)
+        if ca:
+            kwargs["ssl_ca_certs"] = ca
+        cert = getattr(args, "redis_tls_cert", None)
+        if cert:
+            kwargs["ssl_certfile"] = cert
+        key = getattr(args, "redis_tls_key", None)
+        if key:
+            kwargs["ssl_keyfile"] = key
+    return kwargs
 
 
 def broker_from_args(args: Any) -> RedisBroker:
@@ -290,6 +325,7 @@ def broker_from_args(args: Any) -> RedisBroker:
         port=args.redis_port,
         db=args.redis_db,
         password=args.redis_password,
+        **_redis_tls_kwargs(args),
     )
 
 
@@ -302,4 +338,5 @@ def async_broker_from_args(args: Any) -> Any:
         port=args.redis_port,
         db=args.redis_db,
         password=args.redis_password,
+        **_redis_tls_kwargs(args),
     )


### PR DESCRIPTION
## Summary
Phase 4 of mTLS + ACME integration.

- **Admin API**: list/renew/delete certs (admin.settings permission)
- **Admin UI**: TLS tab with grid layout, CA status, cert table, renew/delete with confirm modal
- **CLI**: tls-bootstrap (offline), tls-issue (ACME), tls-ca-cert (TOFU fingerprint), tls-list (authenticated)
- **Redis TLS**: wired through RedisBroker + AsyncRedisBroker + broker_from_args
- **Database SSL**: config map passthrough for sslmode/sslrootcert/sslcert/sslkey

## Review fixes applied
- Fixed _fmtTime crash (used .slice(0,16) pattern)
- Fixed button classes (admin-btn-action/admin-btn-danger)
- Added r.ok check before JSON parse
- Replaced confirm() with showConfirmModal()
- Grid layout instead of raw table
- ARIA labels, aria-live, loading/empty states
- Expired cert text prefix (WCAG 1.4.1)
- broker_from_args forwards TLS params (was dead code)
- AsyncRedisBroker gets TLS support
- CLI tls-list sends auth token
- Bootstrap dir chmod 0700
- CA cert fetch shows SHA-256 fingerprint
- renew_cert updates in-memory bundles
- StorageStore.delete_cert returns bool

## Test plan
- [x] 46 TLS tests pass
- [x] Ruff + mypy clean
- [ ] CI: full suite