### PR TITLE
fix: prevent assistant messages with content=None from reaching OpenAI API

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -140,6 +140,34 @@ class TestOpenAIProvider:
     def test_provider_name(self) -> None:
         assert self.provider.provider_name == "openai"
 
+    # -- _sanitize_messages ---------------------------------------------------
+
+    def test_sanitize_messages_none_content_no_tool_calls(self) -> None:
+        msgs = [{"role": "assistant", "content": None}]
+        assert self.provider._sanitize_messages(msgs) == [{"role": "assistant", "content": ""}]
+
+    def test_sanitize_messages_none_content_with_tool_calls(self) -> None:
+        msgs = [{"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]}]
+        result = self.provider._sanitize_messages(msgs)
+        assert result[0]["content"] is None
+        assert result[0]["tool_calls"] == [{"id": "1"}]
+
+    def test_sanitize_messages_empty_string_passthrough(self) -> None:
+        msgs = [{"role": "assistant", "content": ""}]
+        assert self.provider._sanitize_messages(msgs) == msgs
+
+    def test_sanitize_messages_non_assistant_unchanged(self) -> None:
+        msgs = [{"role": "user", "content": None}]
+        result = self.provider._sanitize_messages(msgs)
+        assert result[0]["content"] is None
+
+    def test_sanitize_messages_does_not_mutate_original(self) -> None:
+        original = {"role": "assistant", "content": None}
+        self.provider._sanitize_messages([original])
+        assert original["content"] is None
+
+    # -- convert_tools --------------------------------------------------------
+
     def test_convert_tools_passthrough(self) -> None:
         tools = [
             {

--- a/turnstone/core/providers/_openai.py
+++ b/turnstone/core/providers/_openai.py
@@ -273,6 +273,29 @@ class OpenAIProvider:
                 result.append(tool)
         return result
 
+    # -- message sanitisation ------------------------------------------------
+
+    @staticmethod
+    def _sanitize_messages(
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Ensure assistant messages always have ``content`` or ``tool_calls``.
+
+        OpenAI-compatible APIs reject assistant messages that have neither.
+        This is a defensive catch-all; the upstream layers should already
+        guarantee well-formed messages.
+        """
+        out: list[dict[str, Any]] = []
+        for msg in messages:
+            if (
+                msg.get("role") == "assistant"
+                and msg.get("content") is None
+                and not msg.get("tool_calls")
+            ):
+                msg = {**msg, "content": ""}
+            out.append(msg)
+        return out
+
     # -- streaming -----------------------------------------------------------
 
     def create_streaming(
@@ -289,6 +312,7 @@ class OpenAIProvider:
         deferred_names: frozenset[str] | None = None,
     ) -> Iterator[StreamChunk]:
         caps = self.get_capabilities(model)
+        messages = self._sanitize_messages(messages)
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -402,6 +426,7 @@ class OpenAIProvider:
         deferred_names: frozenset[str] | None = None,
     ) -> CompletionResult:
         caps = self.get_capabilities(model)
+        messages = self._sanitize_messages(messages)
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1670,7 +1670,7 @@ class ChatSession:
             self.ui.on_stream_end()
             partial: dict[str, Any] = {"role": "assistant"}
             partial_content = "".join(content_parts)
-            partial["content"] = partial_content or None
+            partial["content"] = partial_content or ""
             # Deliberately omit tool_calls — they are incomplete
             if provider_blocks:
                 partial["_provider_content"] = provider_blocks
@@ -1701,10 +1701,7 @@ class ChatSession:
         msg: dict[str, Any] = {"role": "assistant"}
 
         content = "".join(content_parts)
-        if content:
-            msg["content"] = content
-        else:
-            msg["content"] = None
+        msg["content"] = content or ""
 
         if tool_calls_acc:
             msg["tool_calls"] = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
@@ -4251,7 +4248,7 @@ class ChatSession:
             {"role": "system", "content": self._plan_system_content()},
             {
                 "role": "assistant",
-                "content": None,
+                "content": "",
                 "tool_calls": [
                     {
                         "id": tc_id,

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -152,7 +152,7 @@ def reconstruct_messages(rows: list[Any], ws_id: str) -> list[dict[str, Any]]:
             messages.append({"role": "user", "content": content or ""})
 
         elif role == "assistant":
-            msg: dict[str, Any] = {"role": "assistant", "content": content}
+            msg: dict[str, Any] = {"role": "assistant", "content": content or ""}
             if provider_data:
                 with contextlib.suppress(json.JSONDecodeError, TypeError):
                     msg["_provider_content"] = json.loads(provider_data)


### PR DESCRIPTION
## Summary

- Replayed or cancelled conversations could produce assistant messages with `content=None` and no `tool_calls`, which OpenAI-compatible APIs reject with a 400
- Fix at three layers for defense in depth:
  - **session.py**: use empty string instead of `None` when building assistant messages (streaming + cancellation paths)
  - **_utils.py**: normalise content on DB load in `reconstruct_messages()`
  - **_openai.py**: add `_sanitize_messages()` catch-all at provider boundary

Thanks to @sillyWillieBilly for identifying this bug in #194 — the root cause analysis there was spot on. This PR applies the fix at the source (where `content=None` is created) and at the persistence layer, in addition to the provider-boundary guard, for defense in depth.

## Test plan

- [x] New unit tests for `_sanitize_messages` (5 cases: None without tool_calls, None with tool_calls, empty string passthrough, non-assistant unchanged, no mutation of original)
- [x] Existing storage + provider test suites pass (591 tests)
- [x] ruff + mypy clean