### PR TITLE
fix: prevent 100% CPU spin from unreachable HTTP MCP servers

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1368,3 +1368,130 @@ class TestShutdownCleanup:
         assert mgr.get_prompts() == []
         assert mgr._resource_map == {}
         assert mgr._prompt_map == {}
+
+
+# ---------------------------------------------------------------------------
+# TCP probe and unreachable server handling
+# ---------------------------------------------------------------------------
+
+
+class TestTCPProbe:
+    """MCPClientManager._tcp_probe should fail fast on unreachable servers."""
+
+    def test_tcp_probe_unreachable_raises_connection_error(self):
+        """Unreachable host raises ConnectionError, not TimeoutError."""
+        mgr = MCPClientManager({})
+
+        async def _run():
+            with pytest.raises(ConnectionError, match="unreachable"):
+                await mgr._tcp_probe("test-server", "http://127.0.0.1:1")
+
+        asyncio.run(_run())
+
+    def test_tcp_probe_parses_url_correctly(self):
+        """Port and host are extracted from the URL."""
+        mgr = MCPClientManager({})
+
+        async def _run():
+            # Non-routable port — should fail with ConnectionError
+            with pytest.raises(ConnectionError):
+                await mgr._tcp_probe("srv", "https://127.0.0.1:1/mcp")
+
+        asyncio.run(_run())
+
+    def test_tcp_probe_default_port_http(self):
+        """Default port 80 used for http:// URLs without explicit port."""
+        mgr = MCPClientManager({})
+
+        async def _run():
+            # Will fail (nothing on port 80), but should not crash on parsing
+            with pytest.raises(ConnectionError):
+                await mgr._tcp_probe("srv", "http://127.0.0.1")
+
+        asyncio.run(_run())
+
+    def test_tcp_probe_dns_failure(self):
+        """Unresolvable hostname raises ConnectionError."""
+        mgr = MCPClientManager({})
+
+        async def _run():
+            with pytest.raises(ConnectionError):
+                await mgr._tcp_probe("srv", "http://this.host.does.not.exist.invalid:8080/mcp")
+
+        asyncio.run(_run())
+
+
+class TestConnectOneUnreachable:
+    """_connect_one should handle unreachable HTTP servers gracefully."""
+
+    def test_unreachable_http_server_raises_connection_error(self):
+        """Unreachable HTTP MCP server raises ConnectionError without spinning."""
+        mgr = MCPClientManager({})
+        mgr._loop = asyncio.new_event_loop()
+
+        async def _run():
+            with pytest.raises(ConnectionError, match="unreachable"):
+                await mgr._connect_one(
+                    "bad-server",
+                    {
+                        "type": "http",
+                        "url": "http://127.0.0.1:1/mcp",
+                    },
+                )
+
+        mgr._loop.run_until_complete(_run())
+        mgr._loop.close()
+
+        # Server should NOT be in sessions (connection failed)
+        assert "bad-server" not in mgr._sessions
+
+    def test_connect_all_continues_after_unreachable_server(self):
+        """_connect_all logs error and continues to next server."""
+        mgr = MCPClientManager(
+            {
+                "bad": {"type": "http", "url": "http://127.0.0.1:1/mcp"},
+            }
+        )
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(mgr._connect_all())
+        loop.close()
+
+        assert "bad" not in mgr._sessions
+        assert "bad" in mgr._last_error
+
+
+class TestSafeCloseStack:
+    """_safe_close_stack should suppress errors from broken anyio scopes."""
+
+    def test_suppresses_runtime_error(self):
+        """RuntimeError from broken cancel scope is suppressed."""
+
+        async def _run():
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+
+            # Simulate a broken close that raises RuntimeError
+            async def _broken_close():
+                raise RuntimeError("Attempted to exit cancel scope in a different task")
+
+            stack.aclose = _broken_close
+            # Should not raise
+            await MCPClientManager._safe_close_stack(stack)
+
+        asyncio.run(_run())
+
+    def test_suppresses_cancelled_error(self):
+        """CancelledError during close is suppressed."""
+
+        async def _run():
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+
+            async def _cancel_close():
+                raise asyncio.CancelledError()
+
+            stack.aclose = _cancel_close
+            await MCPClientManager._safe_close_stack(stack)
+
+        asyncio.run(_run())

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -176,6 +176,8 @@ class MCPClientManager:
         for name, cfg in self._server_configs.items():
             try:
                 await self._connect_one(name, cfg)
+            except asyncio.CancelledError:
+                raise  # propagate so the background task can be cleanly stopped
             except Exception as exc:
                 log.warning("Failed to connect MCP server '%s'", name, exc_info=True)
                 self._set_error(name, f"{type(exc).__name__}: {exc}")
@@ -199,6 +201,49 @@ class MCPClientManager:
             self._refresh_task = asyncio.get_running_loop().create_task(self._periodic_refresh())
 
     _CONNECT_TIMEOUT = 30  # seconds — prevents hung connections on broken remotes
+    _TCP_PROBE_TIMEOUT = 5  # seconds — fast TCP pre-flight for HTTP transports
+
+    async def _tcp_probe(self, name: str, url: str) -> None:
+        """Fast TCP connect check before entering the MCP transport context.
+
+        Fails fast when the server is unreachable, avoiding the anyio
+        cancel-scope orphan bug that causes 100% CPU spin.
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if not host:
+            raise ConnectionError(f"MCP server '{name}' has invalid URL (no hostname): {url}")
+        try:
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        except ValueError:
+            raise ConnectionError(f"MCP server '{name}' has invalid port in URL: {url}") from None
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port),
+                timeout=self._TCP_PROBE_TIMEOUT,
+            )
+            writer.close()
+            await writer.wait_closed()
+        except (TimeoutError, OSError) as exc:
+            raise ConnectionError(
+                f"MCP server '{name}' unreachable at {host}:{port}: {exc}"
+            ) from None
+
+    @staticmethod
+    async def _safe_close_stack(stack: AsyncExitStack) -> None:
+        """Close an AsyncExitStack, suppressing errors from broken anyio scopes.
+
+        Called from exception handlers — must not raise, otherwise cleanup
+        errors could mask the original exception.  CancelledError is caught
+        explicitly because it is the primary failure mode (stray cancel from
+        broken anyio scope) and is BaseException, not Exception.
+        """
+        try:
+            await asyncio.wait_for(stack.aclose(), timeout=5)
+        except (Exception, asyncio.CancelledError):
+            log.debug("Error closing AsyncExitStack; ignoring", exc_info=True)
 
     async def _connect_one(self, name: str, cfg: dict[str, Any]) -> None:
         """Connect to a single MCP server and discover its tools."""
@@ -213,6 +258,13 @@ class MCPClientManager:
         transport = cfg.get("type", "stdio")
         try:
             if transport in ("http", "streamable-http") or "url" in cfg:
+                # Pre-flight TCP check: fail fast before entering the anyio
+                # task group in streamablehttp_client.  An immediate connect
+                # failure (ECONNREFUSED) inside the anyio context causes a
+                # CancelledError that escapes asyncio.wait_for and leaves
+                # orphaned cancel-scope tasks spinning at 100% CPU.
+                await self._tcp_probe(name, cfg["url"])
+
                 read, write, _ = await asyncio.wait_for(
                     stack.enter_async_context(
                         streamablehttp_client(url=cfg["url"], headers=cfg.get("headers"))
@@ -235,15 +287,25 @@ class MCPClientManager:
                     env=env,
                 )
                 read, write = await stack.enter_async_context(stdio_client(params))
+        except asyncio.CancelledError:
+            # Stray CancelledError from broken anyio cancel scope — treat as
+            # connection failure.  But if the task is genuinely being cancelled
+            # (shutdown), re-raise so we don't block teardown.
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                await self._safe_close_stack(stack)
+                raise
+            log.warning("MCP server '%s' connection failed (anyio cancel)", name)
+            await self._safe_close_stack(stack)
+            raise TimeoutError(f"Connection failed for '{name}'") from None
         except TimeoutError:
             log.warning(
                 "MCP server '%s' connection timed out after %ds", name, self._CONNECT_TIMEOUT
             )
-            with contextlib.suppress(Exception):
-                await stack.aclose()
+            await self._safe_close_stack(stack)
             raise TimeoutError(f"Connection timed out after {self._CONNECT_TIMEOUT}s") from None
         except Exception:
-            await stack.aclose()
+            await self._safe_close_stack(stack)
             raise
 
         # Register notification handler — dispatches tool, resource, and
@@ -274,21 +336,27 @@ class MCPClientManager:
                 ClientSession(read, write, message_handler=_on_notification)  # type: ignore[arg-type]
             )
         except Exception:
-            await stack.aclose()
+            await self._safe_close_stack(stack)
             raise
 
         self._per_server_stacks[name] = stack
         try:
             await asyncio.wait_for(session.initialize(), timeout=self._CONNECT_TIMEOUT)
+        except asyncio.CancelledError:
+            self._per_server_stacks.pop(name, None)
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                await self._safe_close_stack(stack)
+                raise
+            await self._safe_close_stack(stack)
+            raise TimeoutError(f"MCP handshake failed for '{name}'") from None
         except TimeoutError:
             self._per_server_stacks.pop(name, None)
-            with contextlib.suppress(Exception):
-                await stack.aclose()
+            await self._safe_close_stack(stack)
             raise TimeoutError(f"MCP handshake timed out after {self._CONNECT_TIMEOUT}s") from None
         except Exception:
             self._per_server_stacks.pop(name, None)
-            with contextlib.suppress(Exception):
-                await stack.aclose()
+            await self._safe_close_stack(stack)
             raise
         self._sessions[name] = session
 
@@ -873,8 +941,7 @@ class MCPClientManager:
 
             async def _close_all_stacks() -> None:
                 for stack in self._per_server_stacks.values():
-                    with contextlib.suppress(Exception):
-                        await stack.aclose()
+                    await self._safe_close_stack(stack)
 
             future = asyncio.run_coroutine_threadsafe(_close_all_stacks(), self._loop)
             try:
@@ -984,10 +1051,7 @@ class MCPClientManager:
                 self._sessions.pop(name, None)
                 stack = self._per_server_stacks.pop(name, None)
                 if stack is not None:
-                    try:
-                        await asyncio.wait_for(stack.aclose(), timeout=10)
-                    except (TimeoutError, Exception):
-                        log.warning("Timed out closing MCP server '%s', forcing cleanup", name)
+                    await self._safe_close_stack(stack)
                 # Clean up per-server state (on the event loop thread)
                 self._per_server_tools.pop(name, None)
                 self._per_server_resources.pop(name, None)


### PR DESCRIPTION
When an HTTP MCP server is unreachable and TCP connect fails immediately (ECONNREFUSED, DNS failure), the anyio task group inside streamablehttp_client produces a CancelledError that escapes asyncio.wait_for and leaves orphaned cancel-scope tasks in an infinite _deliver_cancellation loop (~800K callbacks/sec).

Three-part fix:
- TCP pre-flight probe (5s timeout) before entering the anyio transport context — fails fast on unreachable servers, avoiding the bug entirely
- Catch CancelledError alongside TimeoutError in _connect_one so broken anyio states are handled cleanly
- _safe_close_stack helper with bounded timeout and targeted exception suppression for broken anyio scope cleanup