### PR TITLE
fix: harden tool call handling for local model servers

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -435,31 +435,30 @@ class TestSessionIntegration:
         session.ui.on_error.assert_called_once()
         assert "Malformed tool call" in session.ui.on_error.call_args[0][0]
 
-    def test_synthetic_tool_call_ids_for_empty_ids(self, tmp_db):
-        """When a local server returns empty tool call IDs, synthetic IDs
-        are generated so subsequent turns don't break."""
-        import uuid
+    def test_ensure_tool_call_ids_dict(self, tmp_db):
+        """_ensure_tool_call_ids fills empty IDs on streaming-style dict."""
+        from turnstone.core.session import ChatSession
 
         tool_calls_acc = {
-            0: {
-                "id": "",
-                "type": "function",
-                "function": {"name": "bash", "arguments": '{"command": "ls"}'},
-            },
-            1: {
-                "id": "",
-                "type": "function",
-                "function": {"name": "read_file", "arguments": '{"path": "/tmp/x"}'},
-            },
+            0: {"id": "", "function": {"name": "bash", "arguments": "{}"}},
+            1: {"id": "", "function": {"name": "read_file", "arguments": "{}"}},
         }
-        # Apply the same fixup that _stream_response does
-        for tc in tool_calls_acc.values():
-            if not tc.get("id"):
-                tc["id"] = f"call_{uuid.uuid4().hex}"
-        # All IDs should now be populated and unique
+        ChatSession._ensure_tool_call_ids(tool_calls_acc)
         ids = [tc["id"] for tc in tool_calls_acc.values()]
         assert all(id_.startswith("call_") for id_ in ids)
         assert len(set(ids)) == 2  # unique
+
+    def test_ensure_tool_call_ids_list(self, tmp_db):
+        """_ensure_tool_call_ids fills empty IDs on list (agent path)."""
+        from turnstone.core.session import ChatSession
+
+        tool_calls = [
+            {"id": None, "function": {"name": "bash", "arguments": "{}"}},
+            {"id": "call_existing", "function": {"name": "bash", "arguments": "{}"}},
+        ]
+        ChatSession._ensure_tool_call_ids(tool_calls)
+        assert tool_calls[0]["id"].startswith("call_")
+        assert tool_calls[1]["id"] == "call_existing"  # preserved
 
     def test_mcp_command_no_client(self, tmp_db):
         session = self._make_session(mcp_client=None)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1718,13 +1718,7 @@ class ChatSession:
         msg["content"] = content or ""
 
         if tool_calls_acc:
-            # Ensure every tool call has a non-empty ID.  Some local
-            # servers (llama.cpp, older vLLM) omit or leave the id blank;
-            # an empty tool_call_id corrupts subsequent turns because the
-            # matching tool-result message can't reference the call.
-            for tc in tool_calls_acc.values():
-                if not tc.get("id"):
-                    tc["id"] = f"call_{uuid.uuid4().hex}"
+            self._ensure_tool_call_ids(tool_calls_acc)
             msg["tool_calls"] = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
 
         # Store raw provider content blocks for multi-turn preservation
@@ -2346,6 +2340,19 @@ class ChatSession:
 
         return results, user_feedback
 
+    @staticmethod
+    def _ensure_tool_call_ids(tool_calls: list[dict[str, Any]] | dict[int, dict[str, Any]]) -> None:
+        """Fill in missing tool call IDs with synthetic UUIDs.
+
+        Some local servers (llama.cpp, older vLLM) omit or leave the id
+        blank; an empty tool_call_id corrupts subsequent turns because
+        the matching tool-result message can't reference the call.
+        """
+        items = tool_calls.values() if isinstance(tool_calls, dict) else tool_calls
+        for tc in items:
+            if not tc.get("id"):
+                tc["id"] = f"call_{uuid.uuid4().hex}"
+
     def _prepare_tool(self, tc: dict[str, Any]) -> dict[str, Any]:
         """Parse a tool call and prepare preview info for display."""
         call_id = tc["id"]
@@ -2440,7 +2447,9 @@ class ChatSession:
             if self._mcp_client and self._mcp_client.is_mcp_tool(func_name):
                 return self._prepare_mcp_tool(call_id, func_name, args)
             self.ui.on_error(f"Model called unknown tool: {func_name!r}")
-            available = ", ".join(preparers)
+            available = list(preparers)
+            if self._mcp_client:
+                available.extend(sorted(self._mcp_client._tool_map))
             return {
                 "call_id": call_id,
                 "func_name": func_name,
@@ -2449,7 +2458,7 @@ class ChatSession:
                 "needs_approval": False,
                 "error": (
                     f"Unknown tool: {func_name!r}. "
-                    f"Available tools: {available}. "
+                    f"Available tools: {', '.join(available)}. "
                     f"Use one of the listed tool names exactly."
                 ),
             }
@@ -4005,11 +4014,7 @@ class ChatSession:
                 "content": result.content or "",
             }
             if result.tool_calls:
-                # Ensure every tool call has a non-empty ID (same
-                # fixup as _stream_response for local servers).
-                for tc in result.tool_calls:
-                    if not tc.get("id"):
-                        tc["id"] = f"call_{uuid.uuid4().hex}"
+                self._ensure_tool_call_ids(result.tool_calls)
                 msg_dict["tool_calls"] = result.tool_calls
             agent_messages.append(msg_dict)
 


### PR DESCRIPTION
Local models (Qwen 3.5 9B, etc.) via llama.cpp produce tool calls with empty IDs, whitespace-padded names, and malformed JSON arguments. These defensive gaps caused cascading conversation corruption and silent failures.

- Strip whitespace from tool names in both main and agent paths
- Generate synthetic UUIDs when tool call IDs are empty/null
- Surface malformed tool call errors to the user via on_error
- Give the model actionable hints (expected JSON format, available tools) so it can self-correct on retry
- Surface metacognition nudge types to UI via on_info

Ref: #186, #117