### PR TITLE
fix: eager cancel_ref registration, SDK type drift, force-cancel tests

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,5 +1,6 @@
 """Tests for generation cancellation (cooperative cancel via threading.Event)."""
 
+import contextlib
 import threading
 import time
 from dataclasses import dataclass, field
@@ -698,3 +699,111 @@ class TestForceCancelGeneration:
         # (not the same object as before the call).
         assert session._cancel_event is not original_event
         assert not session._cancel_event.is_set()
+
+
+class TestForceCancelThreaded:
+    """Force cancel with actual threads — verifies orphaned thread behavior."""
+
+    def test_force_cancel_orphan_does_not_mutate_messages(self, tmp_db):
+        """After force cancel + new send(), the orphaned thread must not
+        append stale content to session.messages."""
+        ui = NullUI()
+        session = _make_session(ui=ui)
+
+        @dataclass
+        class FakeChunk:
+            content_delta: str = ""
+            reasoning_delta: str = ""
+            tool_call_deltas: list = field(default_factory=list)
+            usage: None = None
+            finish_reason: str = ""
+            info_delta: str = ""
+            provider_blocks: list = field(default_factory=list)
+
+        barrier = threading.Event()
+        old_done = threading.Event()
+
+        def slow_stream():
+            yield FakeChunk(content_delta="Old content")
+            barrier.set()  # signal: first chunk delivered
+            time.sleep(2)  # simulate stuck stream
+            yield FakeChunk(content_delta=" more", finish_reason="stop")
+
+        # Start generation 1 (will get stuck)
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=slow_stream()),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+
+            def run_old():
+                with contextlib.suppress(Exception):
+                    session.send("old message")
+                old_done.set()
+
+            t1 = threading.Thread(target=run_old, daemon=True)
+            t1.start()
+            assert barrier.wait(timeout=5), "stream did not start"
+
+        # Force cancel: simulate what the server does
+        session.cancel()
+        # Increment generation as new send() would
+        session._generation += 1
+        session._cancel_event = threading.Event()
+
+        # Wait for old thread to notice generation mismatch and exit
+        assert old_done.wait(timeout=10), "orphaned thread did not exit"
+
+        # The orphaned thread should NOT have appended its content
+        assistant_msgs = [m for m in session.messages if m["role"] == "assistant"]
+        # May have partial content from before cancel, but NOT the full
+        # "Old content more" that would appear without the generation guard
+        for msg in assistant_msgs:
+            assert "more" not in msg.get("content", "")
+
+    def test_force_cancel_then_new_send_succeeds(self, tmp_db):
+        """A new send() after force cancel works cleanly."""
+        ui = NullUI()
+        session = _make_session(ui=ui)
+
+        @dataclass
+        class FakeChunk:
+            content_delta: str = ""
+            reasoning_delta: str = ""
+            tool_call_deltas: list = field(default_factory=list)
+            usage: None = None
+            finish_reason: str = "stop"
+            info_delta: str = ""
+            provider_blocks: list = field(default_factory=list)
+
+        barrier = threading.Event()
+
+        def stuck_stream():
+            yield FakeChunk(content_delta="stuck")
+            barrier.set()
+            time.sleep(2)
+            yield FakeChunk(content_delta=" end", finish_reason="stop")
+
+        # Start stuck generation
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=stuck_stream()),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            t = threading.Thread(target=lambda: session.send("old"), daemon=True)
+            t.start()
+            assert barrier.wait(timeout=5), "stream did not start"
+
+        # Force cancel
+        session.cancel()
+
+        # New generation should work
+        fresh_stream = iter([FakeChunk(content_delta="Fresh response")])
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=fresh_stream),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("new message")
+
+        # The new generation should have completed successfully
+        assert "idle" in ui.states
+        assistant_msgs = [m for m in session.messages if m["role"] == "assistant"]
+        assert any("Fresh response" in m.get("content", "") for m in assistant_msgs)

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -7,6 +7,7 @@ The ``anthropic`` SDK is imported lazily so it remains an optional dependency.
 from __future__ import annotations
 
 import json
+import sys
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.providers._protocol import (
@@ -477,10 +478,25 @@ class AnthropicProvider:
             deferred_names,
         )
 
-        with client.messages.stream(**kwargs) as stream:
-            if cancel_ref is not None:
-                cancel_ref.append(stream)
+        manager = client.messages.stream(**kwargs)
+        try:
+            stream = manager.__enter__()
+        except BaseException:
+            manager.__exit__(*sys.exc_info())
+            raise
+        if cancel_ref is not None:
+            cancel_ref.append(stream)
+        return self._iter_with_cleanup(stream, manager)
+
+    def _iter_with_cleanup(self, stream: Any, manager: Any) -> Iterator[StreamChunk]:
+        """Iterate the Anthropic stream, ensuring the context manager exits."""
+        try:
             yield from self._iter_anthropic_stream(stream)
+        except BaseException:
+            manager.__exit__(*sys.exc_info())
+            raise
+        else:
+            manager.__exit__(None, None, None)
 
     def _iter_anthropic_stream(self, stream: Any) -> Iterator[StreamChunk]:
         """Convert Anthropic streaming events to normalized StreamChunks."""

--- a/turnstone/core/providers/_openai.py
+++ b/turnstone/core/providers/_openai.py
@@ -333,7 +333,7 @@ class OpenAIProvider:
         stream = client.chat.completions.create(**kwargs)
         if cancel_ref is not None:
             cancel_ref.append(stream)
-        yield from self._iter_stream(stream)
+        return self._iter_stream(stream)
 
     def _iter_stream(self, stream: Any) -> Iterator[StreamChunk]:
         """Convert OpenAI stream chunks to normalized StreamChunks."""

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -120,13 +120,12 @@ class GenerationCancelled(BaseException):
 class _CancelRef(list[Any]):
     """List proxy used for ``ChatSession._cancel_ref``.
 
-    Providers call ``cancel_ref.append(stream_handle)`` inside a generator
-    body — the generator body doesn't execute until the first ``next()`` call,
-    i.e. just before the first chunk is yielded.  By overriding ``append`` we
-    update ``ChatSession._cancel_stream`` eagerly at that moment.  If
-    cancellation was already requested before the first chunk arrived (e.g.
-    the model was slow to start responding), the stream is closed immediately
-    so the blocked ``for chunk in stream`` iteration is unblocked.
+    Providers call ``cancel_ref.append(stream_handle)`` eagerly — the HTTP
+    call and registration happen before the iterator is returned to the
+    caller.  By overriding ``append`` we update ``ChatSession._cancel_stream``
+    immediately.  If cancellation was already requested before the stream
+    was created (e.g. cancel during retry backoff), the stream is closed
+    on arrival so the blocked iteration is unblocked.
     """
 
     __slots__ = ("_session",)

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -50,6 +50,7 @@ from turnstone.api.schemas import (
     AuthLoginResponse,
     AuthSetupResponse,
     AuthStatusResponse,
+    DeleteSettingResponse,
     ListScheduleRunsResponse,
     ListSchedulesResponse,
     ScheduleInfo,
@@ -642,13 +643,16 @@ class AsyncTurnstoneConsole(_BaseClient):
             "PUT", f"/v1/api/admin/settings/{key}", json_body=body, response_model=SettingInfo
         )
 
-    async def delete_setting(self, key: str, *, node_id: str = "") -> StatusResponse:
+    async def delete_setting(self, key: str, *, node_id: str = "") -> DeleteSettingResponse:
         """Reset a setting to its default value."""
         params: dict[str, Any] = {}
         if node_id:
             params["node_id"] = node_id
         return await self._request(
-            "DELETE", f"/v1/api/admin/settings/{key}", params=params, response_model=StatusResponse
+            "DELETE",
+            f"/v1/api/admin/settings/{key}",
+            params=params,
+            response_model=DeleteSettingResponse,
         )
 
     # -- MCP servers -------------------------------------------------------
@@ -1205,7 +1209,7 @@ class TurnstoneConsole:
     def update_setting(self, key: str, value: Any, *, node_id: str = "") -> SettingInfo:
         return self._runner.run(self._async.update_setting(key, value, node_id=node_id))
 
-    def delete_setting(self, key: str, *, node_id: str = "") -> StatusResponse:
+    def delete_setting(self, key: str, *, node_id: str = "") -> DeleteSettingResponse:
         return self._runner.run(self._async.delete_setting(key, node_id=node_id))
 
     # -- MCP servers -------------------------------------------------------


### PR DESCRIPTION
Providers now register the SDK stream handle eagerly (before returning the iterator) instead of lazily inside a generator body. This closes the window where cancel() couldn't abort a blocked HTTP read because the stream handle wasn't populated yet.

- OpenAI: yield from → return (HTTP call + cancel_ref happen eagerly)
- Anthropic: split into eager __enter__ + _iter_with_cleanup generator with defensive __exit__ on __enter__ failure
- Console SDK: delete_setting() return type fixed from StatusResponse to DeleteSettingResponse (matching actual endpoint response)
- 2 new threaded force-cancel integration tests verifying orphaned threads don't mutate messages and new generations succeed
- Updated _CancelRef docstring, test robustness (assert on wait)