### PR TITLE
fix: display tool errors inline in CLI

### DIFF
--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -260,7 +260,9 @@ class TerminalUI(SessionUI):
         is_error: bool = False,
     ) -> None:
         if is_error:
-            sys.stderr.write(f"{RED}\u2717 {name}: {output}{RESET}\n")
+            with self._print_lock:
+                sys.stderr.write(f"{RED}\u2717 {name}: {output}{RESET}\n")
+                sys.stderr.flush()
 
     def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
         pass  # Terminal shows spinner during tool execution


### PR DESCRIPTION
## Summary
- CLI `on_tool_result` was a no-op — tool errors were only visible when the LLM acknowledged them in its next response
- Now renders errors inline in red (`✗ name: output`) to stderr using the `is_error` flag from PR #207

## Test plan
- [ ] Run CLI, trigger a tool error (e.g. edit_file with bad old_string), verify red error appears immediately
- [ ] Verify non-error tool results produce no extra output (preserves current behavior)