### PR TITLE
fix: UI busy state during multi-tool-call turns

### DIFF
--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -485,6 +485,9 @@ class WebUI:
             else:
                 WebUI._workstream_mgr.set_state(self.ws_id, ws_state)
         self._broadcast_state(state)
+        # Also send to per-workstream listeners so the browser UI can track
+        # busy/idle transitions (stream_end fires per-segment, not per-turn).
+        self._enqueue({"type": "state_change", "state": state})
 
     def on_rename(self, name: str) -> None:
         """Update the workstream's display name and broadcast to all clients."""

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -378,18 +378,33 @@ Pane.prototype.handleEvent = function (evt) {
         clearTimeout(this._forceTimeout);
         this._forceTimeout = null;
       }
-      // Render final markdown for the assistant message (existing code).
-      // Note: renderMarkdown is the project's sanitizing markdown renderer.
+      // Finalize the current streaming segment's markdown.  This fires
+      // per-segment (between tool calls), NOT per-turn.  Busy state is
+      // managed by state_change events instead.
       if (this.currentAssistantEl && this.contentBuffer) {
-        this.currentAssistantEl.innerHTML = renderMarkdown(this.contentBuffer); // sanitized by renderMarkdown
+        this.currentAssistantEl.innerHTML = renderMarkdown(this.contentBuffer); // sanitized by renderMarkdown — see renderer.js
         postRenderMarkdown(this.currentAssistantEl);
       }
       this.currentAssistantEl = null;
       this.currentReasoningEl = null;
       this.contentBuffer = "";
-      this.setBusy(false);
-      this.inputEl.focus();
       this.scrollToBottom(true);
+      break;
+
+    case "state_change":
+      if (evt.state === "idle" || evt.state === "error") {
+        this.setBusy(false);
+        // Only steal focus if this is the active pane and no approval pending.
+        if (this.id === focusedPaneId && !this.pendingApproval) {
+          this.inputEl.focus();
+        }
+      } else if (
+        evt.state === "thinking" ||
+        evt.state === "running" ||
+        evt.state === "attention"
+      ) {
+        this.setBusy(true);
+      }
       break;
 
     case "tool_info":
@@ -438,8 +453,10 @@ Pane.prototype.handleEvent = function (evt) {
       break;
 
     case "error":
+      // Show the error but don't change busy state — state_change
+      // handles idle/error transitions.  on_error fires for non-terminal
+      // errors (tool parse failures, truncation) mid-turn too.
       this.addErrorMessage(evt.message);
-      this.setBusy(false);
       break;
 
     case "busy_error":
@@ -454,8 +471,8 @@ Pane.prototype.handleEvent = function (evt) {
 
     case "cancelled":
       // Cancel requested but worker thread may still be finishing.
-      // Show "Cancelling..." state; stream_end will transition to ready.
-      // If stream_end already arrived (busy is false), the cancel is
+      // Show "Cancelling..." state; state_change will transition to ready.
+      // If state_change already arrived (busy is false), the cancel is
       // already handled — don't re-enter the cancelling state.
       if (!this.busy) break;
       // Clear any prior timeouts first (duplicate cancelled events).
@@ -470,7 +487,7 @@ Pane.prototype.handleEvent = function (evt) {
       this.scrollToBottom(true);
       // After 2s, offer "Force Stop" for a harder cancel that abandons
       // the stuck worker thread.  Safety timeout at 10s auto-recovers
-      // if stream_end never arrives (connection drop).
+      // if state_change never arrives (connection drop).
       var self = this;
       this._cancelTimeout = setTimeout(function () {
         if (self.busy) {


### PR DESCRIPTION
## Summary
- `stream_end` fires per-streaming-segment (between tool calls), not per-turn. The UI used it to transition to idle, causing a window where Send appeared but the worker thread was still alive. User messages were silently dropped and no Stop button was visible — the user had no cancel path.
- Root cause: `state_change` events (idle/thinking/running/error) were only broadcast to the global SSE stream (console dashboard), never to the per-workstream SSE that the browser UI listens to.
- Fix: `on_state_change` now also enqueues to per-workstream listeners. `stream_end` only finalizes markdown rendering. New `state_change` handler manages busy transitions.

## Test plan
- [ ] Run a workstream with sequential bash tool calls (`time sleep 5 && echo OK` x3) — Stop button should stay visible throughout
- [ ] Verify cancel works mid-tool-execution during multi-tool turns
- [ ] Verify single-tool-call turns still transition to idle correctly
- [ ] Verify cancel timeout and force-cancel still work
- [ ] Verify markdown rendering still finalizes between tool calls