### PR TITLE
fix: Anthropic sub-agent streaming timeout (#218)

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -627,7 +627,11 @@ class TestAnthropicProvider:
         response.usage.output_tokens = 5
 
         client = MagicMock()
-        client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        client.messages.stream.return_value = stream_ctx
 
         result = self.provider.create_completion(
             client=client,
@@ -659,7 +663,11 @@ class TestAnthropicProvider:
         response.usage.output_tokens = 20
 
         client = MagicMock()
-        client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        client.messages.stream.return_value = stream_ctx
 
         result = self.provider.create_completion(
             client=client,
@@ -690,7 +698,11 @@ class TestAnthropicProvider:
         response.usage.output_tokens = 50
 
         client = MagicMock()
-        client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        client.messages.stream.return_value = stream_ctx
 
         result = self.provider.create_completion(
             client=client,
@@ -1412,7 +1424,11 @@ class TestAnthropicWebSearch:
         response.usage.output_tokens = 50
 
         client = MagicMock()
-        client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        client.messages.stream.return_value = stream_ctx
 
         with patch("turnstone.core.providers._anthropic._ensure_anthropic"):
             result = self.provider.create_completion(
@@ -2434,7 +2450,11 @@ class TestAnthropicPromptCaching:
         response.usage = usage
 
         client = MagicMock()
-        client.messages.create.return_value = response
+        stream_ctx = MagicMock()
+        stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+        stream_ctx.__exit__ = MagicMock(return_value=False)
+        stream_ctx.get_final_message.return_value = response
+        client.messages.stream.return_value = stream_ctx
 
         result = self.provider.create_completion(
             client=client,

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -672,7 +672,24 @@ class AnthropicProvider:
             deferred_names,
         )
 
-        response = client.messages.create(**kwargs)
+        # Use streaming internally to avoid the Anthropic SDK's 10-minute
+        # timeout on non-streaming requests.  get_final_message() returns the
+        # same Message object as messages.create() would.
+        # Mirror create_streaming's defensive __enter__/__exit__ pattern so
+        # resources are cleaned up even if __enter__ fails.
+        manager = client.messages.stream(**kwargs)
+        try:
+            stream = manager.__enter__()
+        except BaseException:
+            manager.__exit__(*sys.exc_info())
+            raise
+        try:
+            response = stream.get_final_message()
+        except BaseException:
+            manager.__exit__(*sys.exc_info())
+            raise
+        else:
+            manager.__exit__(None, None, None)
 
         # Extract content and tool_calls from content blocks.
         # Skip server-side blocks (server_tool_use, web_search_tool_result)


### PR DESCRIPTION
## Summary
- `plan_agent` and `task_agent` are completely broken on Anthropic models — every invocation fails with `Streaming is required for operations that may take longer than 10 minutes` from the SDK.
- Root cause: `AnthropicProvider.create_completion()` used `client.messages.create()` (non-streaming). The SDK rejects this for thinking-enabled models (all current Claude models).
- Fix: use `client.messages.stream()` internally and call `get_final_message()` to get the same `Message` object. Transparent to all callers — also fixes title generation, summarization, web fetch, and judge `create_completion` calls.
- 3-line provider change + test mock updates.

## Test plan
- [ ] Run `plan_agent` with an Anthropic model — should complete instead of erroring
- [ ] Run `task_agent` with an Anthropic model — should complete instead of erroring
- [ ] Verify title generation still works (uses `create_completion`)
- [ ] Verify context summarization still works
- [ ] Verify 147 provider unit tests pass