### PR TITLE
fix: orphaned tool_use followup — ordering, empty IDs, universal repair

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1273,11 +1273,13 @@ class TestAnthropicOrphanedToolUse:
                 for block in msg["content"]:
                     if isinstance(block, dict) and block.get("type") == "tool_result":
                         tool_results.append(block)
-        result_map = {r["tool_use_id"]: r for r in tool_results}
-        assert "c1" in result_map
-        assert result_map["c1"]["content"] == "file1.txt"  # real result
-        assert "c2" in result_map
-        assert result_map["c2"]["is_error"] is True  # synthetic
+        # Real result should come before synthetic (ordering matters for Anthropic)
+        assert len(tool_results) == 2
+        assert tool_results[0]["tool_use_id"] == "c1"
+        assert tool_results[0]["content"] == "file1.txt"  # real result
+        assert tool_results[0].get("is_error") is not True
+        assert tool_results[1]["tool_use_id"] == "c2"
+        assert tool_results[1]["is_error"] is True  # synthetic
 
     def test_complete_results_no_synthesis(self) -> None:
         """All tool_calls have results — no synthesis needed."""
@@ -1294,12 +1296,16 @@ class TestAnthropicOrphanedToolUse:
             {"role": "user", "content": "thanks"},
         ]
         _, converted = self.provider._convert_messages(messages)
-        # No synthetic results — only the real one
+        # No synthetic results — only the real one (no is_error flag)
+        tool_results = []
         for msg in converted:
             if msg["role"] == "user" and isinstance(msg["content"], list):
                 for block in msg["content"]:
                     if isinstance(block, dict) and block.get("type") == "tool_result":
-                        assert "cancelled" not in block.get("content", "").lower()
+                        tool_results.append(block)
+        assert len(tool_results) == 1
+        assert tool_results[0]["tool_use_id"] == "c1"
+        assert tool_results[0].get("is_error") is not True
 
     def test_trailing_orphan(self) -> None:
         """Orphaned tool_use at end of conversation (no following messages)."""
@@ -1322,6 +1328,43 @@ class TestAnthropicOrphanedToolUse:
                         tool_results.append(block)
         assert len(tool_results) == 1
         assert tool_results[0]["tool_use_id"] == "c1"
+        assert tool_results[0]["is_error"] is True
+
+    def test_provider_content_orphan(self) -> None:
+        """Orphaned tool_use inside _provider_content (Anthropic raw blocks)."""
+        messages = [
+            {"role": "user", "content": "run something"},
+            {
+                "role": "assistant",
+                "content": "Running...",
+                "_provider_content": [
+                    {"type": "text", "text": "Running..."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_abc",
+                        "name": "bash",
+                        "input": {"command": "sleep 30"},
+                    },
+                ],
+                "tool_calls": [
+                    {
+                        "id": "toolu_abc",
+                        "function": {"name": "bash", "arguments": '{"command": "sleep 30"}'},
+                    },
+                ],
+            },
+            {"role": "user", "content": "never mind"},
+        ]
+        _, converted = self.provider._convert_messages(messages)
+        # Should synthesize a tool_result for the orphaned tool_use in provider_content
+        tool_results = []
+        for msg in converted:
+            if msg["role"] == "user" and isinstance(msg["content"], list):
+                for block in msg["content"]:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        tool_results.append(block)
+        assert len(tool_results) == 1
+        assert tool_results[0]["tool_use_id"] == "toolu_abc"
         assert tool_results[0]["is_error"] is True
 
 

--- a/tests/test_reconstruct_messages.py
+++ b/tests/test_reconstruct_messages.py
@@ -226,3 +226,91 @@ class TestEdgeCases:
         assert len(msgs) == 2
         assert msgs[0]["role"] == "user"
         assert msgs[1]["role"] == "assistant"
+
+
+class TestMidConversationOrphanRepair:
+    """Mid-conversation orphaned tool_calls get synthetic tool results."""
+
+    def test_all_orphaned_mid_conversation(self):
+        """Assistant has 2 tool_calls, no tool results, then user message."""
+        tc = json.dumps(
+            [
+                {"id": "c1", "function": {"name": "bash", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "write_file", "arguments": "{}"}},
+            ]
+        )
+        rows = [
+            _row("user", "do stuff"),
+            _row("assistant", "Running...", tool_calls=tc),
+            _row("user", "never mind"),
+        ]
+        msgs = reconstruct_messages(rows, "ws1")
+        # Should have: user, assistant, tool(c1), tool(c2), user
+        assert len(msgs) == 5
+        assert msgs[2]["role"] == "tool"
+        assert msgs[2]["tool_call_id"] == "c1"
+        assert msgs[2]["is_error"] is True
+        assert msgs[3]["role"] == "tool"
+        assert msgs[3]["tool_call_id"] == "c2"
+        assert msgs[4]["role"] == "user"
+
+    def test_partial_results_mid_conversation(self):
+        """2 tool_calls, 1 result present, 1 missing — synthesize only the missing one."""
+        tc = json.dumps(
+            [
+                {"id": "c1", "function": {"name": "bash", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "write_file", "arguments": "{}"}},
+            ]
+        )
+        rows = [
+            _row("user", "do stuff"),
+            _row("assistant", "", tool_calls=tc),
+            _row("tool", "file1.txt", tool_name="bash", tc_id="c1"),
+            _row("user", "skip the write"),
+        ]
+        msgs = reconstruct_messages(rows, "ws1")
+        # Should have: user, assistant, tool(c1 real), tool(c2 synthetic), user
+        assert len(msgs) == 5
+        assert msgs[2]["role"] == "tool"
+        assert msgs[2]["tool_call_id"] == "c1"
+        assert msgs[2]["content"] == "file1.txt"
+        assert msgs[2].get("is_error") is not True
+        assert msgs[3]["role"] == "tool"
+        assert msgs[3]["tool_call_id"] == "c2"
+        assert msgs[3]["is_error"] is True
+        assert msgs[4]["role"] == "user"
+
+    def test_complete_results_no_synthesis(self):
+        """All tool_calls have results — no synthesis needed."""
+        tc = json.dumps(
+            [
+                {"id": "c1", "function": {"name": "bash", "arguments": "{}"}},
+            ]
+        )
+        rows = [
+            _row("user", "do it"),
+            _row("assistant", "", tool_calls=tc),
+            _row("tool", "done", tool_name="bash", tc_id="c1"),
+            _row("user", "thanks"),
+        ]
+        msgs = reconstruct_messages(rows, "ws1")
+        assert len(msgs) == 4
+        tool_msgs = [m for m in msgs if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].get("is_error") is not True
+
+    def test_trailing_orphan_stripped_not_synthesized(self):
+        """Trailing orphan is handled by the existing strip repair, not synthesis."""
+        tc = json.dumps(
+            [
+                {"id": "c1", "function": {"name": "bash", "arguments": "{}"}},
+            ]
+        )
+        rows = [
+            _row("user", "do it"),
+            _row("assistant", "Running...", tool_calls=tc),
+        ]
+        msgs = reconstruct_messages(rows, "ws1")
+        # Trailing strip removes the assistant message entirely
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -290,6 +290,7 @@ class AnthropicProvider:
         """
         system_parts: list[str] = []
         converted: list[dict[str, Any]] = []
+        pending_orphan_results: list[dict[str, Any]] = []
 
         i = 0
         while i < len(messages):
@@ -303,11 +304,50 @@ class AnthropicProvider:
                 continue
 
             if role == "assistant":
+                # Safety: flush any unconsumed synthetic results from a prior
+                # assistant message (should not happen with well-formed data).
+                if pending_orphan_results:
+                    converted.append({"role": "user", "content": pending_orphan_results})
+                    pending_orphan_results = []
                 # If raw provider content was preserved, pass it through verbatim
                 # so encrypted_content/encrypted_index from web search are retained
                 provider_content = msg.get("_provider_content")
                 if provider_content:
                     converted.append({"role": "assistant", "content": provider_content})
+                    # Check for orphaned tool_use in provider content too
+                    if isinstance(provider_content, list):
+                        pc_tool_ids = [
+                            b["id"]
+                            for b in provider_content
+                            if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id")
+                        ]
+                        if pc_tool_ids:
+                            j = i + 1
+                            result_ids_pc: set[str] = set()
+                            while j < len(messages) and messages[j]["role"] == "tool":
+                                tc_id = messages[j].get("tool_call_id", "")
+                                if tc_id:
+                                    result_ids_pc.add(tc_id)
+                                j += 1
+                            orphaned_pc = [uid for uid in pc_tool_ids if uid not in result_ids_pc]
+                            if orphaned_pc:
+                                log.debug(
+                                    "Synthesizing %d tool_result(s) for orphaned provider_content tool_use IDs",
+                                    len(orphaned_pc),
+                                )
+                                synthetic_pc = [
+                                    {
+                                        "type": "tool_result",
+                                        "tool_use_id": uid,
+                                        "content": "Tool execution was cancelled.",
+                                        "is_error": True,
+                                    }
+                                    for uid in orphaned_pc
+                                ]
+                                if j == i + 1:
+                                    converted.append({"role": "user", "content": synthetic_pc})
+                                else:
+                                    pending_orphan_results = synthetic_pc
                     i += 1
                     continue
 
@@ -339,20 +379,28 @@ class AnthropicProvider:
                 # happens when a cancel interrupts tool execution — the
                 # assistant message is saved to DB before tools run, but
                 # GenerationCancelled prevents tool results from being created.
-                tool_use_ids = {b["id"] for b in content_blocks if b.get("type") == "tool_use"}
+                # Collect IDs in order, skip empty IDs (from malformed tool calls).
+                tool_use_ids = [
+                    b["id"] for b in content_blocks if b.get("type") == "tool_use" and b.get("id")
+                ]
                 if tool_use_ids:
                     # Peek ahead to collect tool_result IDs
                     j = i + 1
                     result_ids: set[str] = set()
                     while j < len(messages) and messages[j]["role"] == "tool":
-                        result_ids.add(messages[j].get("tool_call_id", ""))
+                        tc_id = messages[j].get("tool_call_id", "")
+                        if tc_id:
+                            result_ids.add(tc_id)
                         j += 1
-                    orphaned = tool_use_ids - result_ids
+                    orphaned = [uid for uid in tool_use_ids if uid not in result_ids]
                     if orphaned:
                         log.debug(
                             "Synthesizing %d tool_result(s) for orphaned tool_use IDs",
                             len(orphaned),
                         )
+                        # Store for deferred injection — synthetic results are
+                        # appended after any real tool results so
+                        # _merge_consecutive produces them in tool_use order.
                         synthetic = [
                             {
                                 "type": "tool_result",
@@ -362,7 +410,14 @@ class AnthropicProvider:
                             }
                             for uid in orphaned
                         ]
-                        converted.append({"role": "user", "content": synthetic})
+                        if j == i + 1:
+                            # No real tool messages follow — inject immediately
+                            converted.append({"role": "user", "content": synthetic})
+                        else:
+                            # Real tool messages follow — they'll be converted
+                            # next iteration.  Stash synthetic results to append
+                            # after them.
+                            pending_orphan_results = synthetic
 
                 i += 1
                 continue
@@ -376,14 +431,19 @@ class AnthropicProvider:
                     # Convert image_url parts to Anthropic image format
                     if isinstance(content, list):
                         content = self._convert_content_parts(content)
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": tool_msg.get("tool_call_id", ""),
-                            "content": content,
-                        }
-                    )
+                    result_block: dict[str, Any] = {
+                        "type": "tool_result",
+                        "tool_use_id": tool_msg.get("tool_call_id", ""),
+                        "content": content,
+                    }
+                    if tool_msg.get("is_error"):
+                        result_block["is_error"] = True
+                    tool_results.append(result_block)
                     i += 1
+                # Append any deferred synthetic results after real ones
+                if pending_orphan_results:
+                    tool_results.extend(pending_orphan_results)
+                    pending_orphan_results = []
                 converted.append({"role": "user", "content": tool_results})
                 continue
 

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -200,4 +200,45 @@ def reconstruct_messages(rows: list[Any], ws_id: str) -> list[dict[str, Any]]:
             break
         del messages[asst_idx:]
 
+    # Repair: synthesize tool results for mid-conversation orphaned tool calls.
+    # This happens when a cancel interrupts tool execution — the assistant
+    # message with tool_calls is saved to DB but GenerationCancelled prevents
+    # tool results from being created.  Both Anthropic (strict) and OpenAI
+    # (lenient today, may tighten) benefit from well-formed histories.
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            expected_ids = [tc.get("id", "") for tc in msg["tool_calls"] if tc.get("id")]
+            # Collect tool result IDs that follow
+            j = i + 1
+            result_ids: set[str] = set()
+            while j < len(messages) and messages[j].get("role") == "tool":
+                tc_id = messages[j].get("tool_call_id", "")
+                if tc_id:
+                    result_ids.add(tc_id)
+                j += 1
+            # Synthesize results for any missing IDs
+            orphaned = [uid for uid in expected_ids if uid not in result_ids]
+            if orphaned:
+                synthetic = [
+                    {
+                        "role": "tool",
+                        "tool_call_id": uid,
+                        "content": "Tool execution was cancelled.",
+                        "is_error": True,
+                    }
+                    for uid in orphaned
+                ]
+                # Insert after the last existing tool result (or after assistant)
+                messages[j:j] = synthetic
+            if orphaned:
+                i = j + len(orphaned)  # skip past spliced synthetics
+            elif j > i + 1:
+                i = j  # skip past existing tool block
+            else:
+                i += 1  # no tools followed; just advance
+        else:
+            i += 1
+
     return messages


### PR DESCRIPTION
## Summary
Followup to #219 addressing Copilot review feedback:

- Anthropic `_convert_messages`: ordered list instead of set for tool_use IDs, filter empty IDs, defer synthetic result injection until after real tool results for correct ordering after `_merge_consecutive`. Flush stale pending results on assistant message entry.
- Universal repair in `reconstruct_messages` (`_utils.py`): synthesize tool results for mid-conversation orphaned tool calls on DB load. Benefits all providers — OpenAI is lenient today but may tighten.
- Test improvements: assert on `is_error` flag instead of "cancelled" substring, verify real-before-synthetic ordering.

## Test plan
- [ ] 152 provider tests pass
- [ ] Partial results test verifies real result before synthetic in order
- [ ] Verify resumed workstream with mid-conversation orphan loads cleanly on both providers