### PR TITLE
fix: judge double tool conversion on Anthropic

### DIFF
--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -1031,10 +1031,11 @@ class IntentJudge:
         # Prepare context
         judge_messages = self._prepare_context(item, messages)
 
-        # Prepare tools (only if read_only_tools enabled)
+        # Prepare tools (only if read_only_tools enabled).
+        # Pass raw OpenAI-format schemas — create_completion handles conversion.
         tools: list[dict[str, Any]] | None = None
         if self._config.read_only_tools:
-            tools = self._provider.convert_tools(_JUDGE_TOOL_SCHEMAS)
+            tools = _JUDGE_TOOL_SCHEMAS
 
         # Multi-turn judge loop
         timeout_budget = self._config.timeout


### PR DESCRIPTION
## Summary
- The intent validation LLM judge never returns a verdict on Anthropic models — shows "judge analyzing" spinner forever.
- Root cause: the judge pre-converted tool schemas via `convert_tools()` before passing them to `create_completion()`, which internally calls `convert_tools()` again. The second conversion stripped the `function` wrapper, producing tools with empty names (`""`) that the Anthropic API rejected.
- Error from logs: `tools.0.custom.name: String should have at least 1 character`
- Fix: pass raw OpenAI-format schemas directly — `create_completion` handles provider-specific conversion.
- 1 line changed. 76 judge tests pass.

## Test plan
- [ ] Trigger a tool approval on an Anthropic workstream — judge spinner should resolve to a verdict
- [ ] Verify judge still works on OpenAI models (no regression)