### PR TITLE
fix: resolve symlinks before file I/O to prevent path-based bypass

### DIFF
--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -607,8 +607,9 @@ def _get_arg_text(func_name: str, func_args: dict[str, object]) -> str:
         return str(func_args.get("command", ""))
     if func_name in ("write_file", "edit_file"):
         path = str(func_args.get("path", ""))
-        resolved = os.path.realpath(os.path.expanduser(path)) if path else ""
-        return f"{path} {resolved}" if resolved != os.path.abspath(path) else path
+        expanded = os.path.expanduser(path) if path else ""
+        resolved = os.path.realpath(expanded) if expanded else ""
+        return f"{path} {resolved}" if resolved != os.path.abspath(expanded) else path
     try:
         return json.dumps(func_args, ensure_ascii=False, separators=(",", ":"))
     except (TypeError, ValueError):

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3041,7 +3041,7 @@ class ChatSession:
 
         # Pre-read to validate all edits and build diff preview
         try:
-            with open(path) as f:
+            with open(resolved) as f:
                 content = f.read()
 
             for i, edit in enumerate(edits):
@@ -4193,7 +4193,7 @@ class ChatSession:
         caps = self._get_capabilities()
         if not caps.supports_vision:
             try:
-                size = os.path.getsize(path)
+                size = os.path.getsize(resolved)
             except OSError as e:
                 self._read_files.discard(resolved)
                 msg = f"Error: {path}: {e}"
@@ -4208,7 +4208,7 @@ class ChatSession:
             )
 
         try:
-            with open(path, "rb") as f:
+            with open(resolved, "rb") as f:
                 raw = f.read()
         except FileNotFoundError:
             self._read_files.discard(resolved)
@@ -5379,7 +5379,7 @@ class ChatSession:
         self._check_cancelled()
         call_id = item["call_id"]
         path = item["path"]
-        resolved = item.get("resolved", os.path.realpath(path))
+        resolved = item.get("resolved", os.path.realpath(os.path.expanduser(path)))
         edits: list[dict[str, Any]] = item["edits"]
         try:
             with open(resolved) as f:


### PR DESCRIPTION
write_file and edit_file followed symlinks silently — a symlink at /data/link → /etc/passwd would show the /data path in the approval header while writing to the real target.  Three changes:

- open() calls in _exec_write_file, _exec_edit_file, _exec_read_file now use the resolved (realpath) path instead of the raw symlink
- Approval headers show both paths when a symlink is detected (e.g. "⚙ write_file: /data/link → /etc/passwd")
- Judge _get_arg_text includes the resolved path so heuristic rules like write-system-path fire even through symlinks