### PR TITLE
fix: add git, curl, jq to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ LABEL org.opencontainers.image.title="turnstone" \
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /usr/local/bin/uv
 
-# System dependencies for psycopg (PostgreSQL client library)
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends libpq5 \
+# System dependencies: psycopg (libpq5), developer tooling for agent workflows
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    libpq5 git curl jq man-db info \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user


### PR DESCRIPTION
Agent workflows need git for version control operations, curl for raw HTTP requests and file downloads, and jq for JSON processing.  All three were missing from the slim base image.