### PR TITLE
fix: exclude build/vendor/VCS directories from search tool

### DIFF
--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4258,10 +4258,11 @@ class ChatSession:
                     "--exclude-dir=.pytest_cache",
                     "--exclude-dir=dist",
                     "--exclude-dir=build",
-                    "--exclude-dir=.egg-info",
+                    "--exclude-dir=*.egg-info",
                     "--exclude-dir=.tox",
                     "--exclude-dir=.venv",
                     "--exclude-dir=venv",
+                    "--exclude-dir=vendor",
                     "--",
                     pattern,
                     path,  # -- prevents pattern as flag


### PR DESCRIPTION
grep -rn recursed into .git, node_modules, target, __pycache__, etc. producing hundreds of noise hits from generated content.  Add --exclude-dir flags for common directories that should never appear in search results.