### PR TITLE
fix: clear dedup sigs after write tools to avoid false repeat warnings

### DIFF
--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1454,26 +1454,33 @@ class ChatSession:
                 if self._generation != my_generation:
                     return
 
-                # Clear dedup sigs when a write tool executed — the state has
-                # changed so re-running a read tool (e.g. read→edit→read) is valid.
-                _write_tools = frozenset({"write_file", "edit_file", "bash"})
-                if any(
-                    tc["function"]["name"] in _write_tools
-                    for tc in tool_calls
-                    if not any(
-                        r[0] == tc["id"] and isinstance(r[1], str) and r[1].startswith("Error")
-                        for r in results
-                    )
-                ):
-                    self._recent_tool_sigs.clear()
-
                 # Repeat detection: warn when a tool is called with identical args.
                 # Skip error outputs — retrying a failed tool is valid.
                 # Skip JSON outputs (MCP structured results) — appending
                 # text would corrupt the payload.
                 _tc_by_id = {c["id"]: c for c in tool_calls}
                 _repeat_detected = False
-                _error_prefixes = ("Error", "JSON parse error", "Unknown tool", "Command timed out")
+                _error_prefixes = (
+                    "Error",
+                    "JSON parse error",
+                    "Unknown tool",
+                    "Command timed out",
+                    "Blocked:",
+                    "Denied",
+                )
+
+                # Clear dedup sigs when a write tool executed successfully —
+                # the state has changed so re-running a read tool is valid.
+                _write_tools = frozenset({"write_file", "edit_file", "bash"})
+                if any(
+                    tc["function"]["name"] in _write_tools
+                    and not any(
+                        cid == tc["id"] and isinstance(out, str) and out.startswith(_error_prefixes)
+                        for cid, out in results
+                    )
+                    for tc in tool_calls
+                ):
+                    self._recent_tool_sigs.clear()
                 for i, (tc_id, output) in enumerate(results):
                     tc = _tc_by_id.get(tc_id)
                     if tc and isinstance(output, str) and not output.startswith(_error_prefixes):


### PR DESCRIPTION
## Summary
- The read→edit→read workflow triggered "identical repeat" warnings because the dedup tracker compared (tool_name, args) without considering intervening state changes
- Now clears the signature set when write_file, edit_file, or bash executes successfully, so subsequent reads are not flagged

## Test plan
- [ ] Verify read→edit→read workflow no longer produces warning
- [ ] Verify genuine duplicates (no intervening write) still warn
- [ ] Full test suite passes (2980 tests)