### PR TITLE
ci: suppress CVE-2026-25210 (libexpat1, no fix available)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# libexpat integer overflow — no fix available in Debian repos yet
+# https://avd.aquasec.com/nvd/cve-2026-25210
+# Review: remove this entry once a patched libexpat1 is published
+CVE-2026-25210


### PR DESCRIPTION
Integer overflow in libexpat1 2.7.1-2 with no patched version in Debian repos yet.  Suppress in Trivy until a fix is published.