### PR TITLE
fix: distinguish user cancel from crash in bash tool results

### DIFF
--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4274,8 +4274,9 @@ class ChatSession:
             if timed_out.is_set():
                 raise subprocess.TimeoutExpired(cmd="bash", timeout=timeout)
 
-            # Distinguish user cancel from unexpected SIGKILL
-            if cancel.is_set() and proc.returncode == -9:
+            # Distinguish user cancel from unexpected SIGKILL.
+            # Popen.returncode is negative of the signal number when killed.
+            if cancel.is_set() and proc.returncode == -signal.SIGKILL:
                 msg = "Cancelled by user."
                 self._report_tool_result(call_id, "bash", msg)
                 return call_id, msg


### PR DESCRIPTION
When a user cancels a running bash command, the process is killed with SIGKILL (exit code -9).  Previously this showed as an error, causing the model to retry.  Now checks cancel.is_set() after proc exit and returns "Cancelled by user." as a non-error result so the model knows to stop rather than retry.