### PR TITLE
fix: synthesize cancelled tool results instead of stripping turns

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -241,6 +241,7 @@ class TestCancelDuringToolExecution:
         assert len(tool_msgs) == 1
         assert tool_msgs[0]["tool_call_id"] == "tc_1"
         assert "Cancelled by user" in tool_msgs[0]["content"]
+        assert tool_msgs[0].get("is_error") is True
         # The assistant message with tool_calls should still be present
         assistant_msgs = [m for m in session.messages if m.get("tool_calls")]
         assert len(assistant_msgs) == 1

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1672,6 +1672,7 @@ class ChatSession:
         # Synthesize results for unanswered tool_calls
         for tc in self.messages[assistant_idx].get("tool_calls", []):
             tc_id = tc.get("id", "")
+            func_name = tc.get("function", {}).get("name", "")
             if tc_id and tc_id not in answered_ids:
                 self.messages.append(
                     {
@@ -1682,6 +1683,7 @@ class ChatSession:
                     }
                 )
                 self._msg_tokens.append(1)
+                save_message(self._ws_id, "tool", reason, func_name, tool_call_id=tc_id)
 
     # -- Rewind / retry -------------------------------------------------------
 


### PR DESCRIPTION
When a user cancels during tool execution, the model previously lost all context about what was attempted (assistant message + tool_calls stripped entirely).  Now synthesizes tool_result messages with is_error=true and "Cancelled by user." content for any tool_calls that lack matching results.  This keeps the conversation valid for both providers while preserving the full tool call structure so the model knows what was tried.

Also applies to KeyboardInterrupt with "Interrupted by user." text.