### PR TITLE
fix: block math sandbox escape via getattr/setattr/type reflection

### DIFF
--- a/turnstone/core/sandbox.py
+++ b/turnstone/core/sandbox.py
@@ -143,7 +143,7 @@ def _math_exec_in_process(code: str, result_queue: multiprocessing.Queue[tuple[s
             # (covers operator.attrgetter('__builtins__') and similar).
             if hasattr(mod, "__builtins__"):
                 with contextlib.suppress(AttributeError, TypeError):
-                    mod.__builtins__ = {}
+                    mod.__builtins__ = {}  # type: ignore[attr-defined]
             return mod
 
         original_import = (


### PR DESCRIPTION
getattr() with runtime-constructed strings bypassed the AST validator, allowing full os/subprocess access from the sandboxed math tool via module.__builtins__['__import__']('os').

Three-layer fix:
- Block getattr, setattr, delattr, type, __import__ in _MATH_BLOCKED_BUILTINS (prevents direct calls)
- Add AST validation for getattr/setattr/delattr call nodes (catches them even if builtins dict is bypassed)
- Strip __builtins__ from all pre-imported modules in the execution namespace (runtime defense — even if AST is somehow bypassed, module.__builtins__ returns empty dict)

Normal math, sympy, numpy, scipy operations unaffected.