### PR TITLE
fix: update Claude 4.6 context windows to 1M, remove EOL 4.0 models

### DIFF
--- a/tests/test_model_probe.py
+++ b/tests/test_model_probe.py
@@ -138,7 +138,7 @@ class TestProbeModelEndpoint:
         )
         assert result["reachable"] is True
         assert result["server_type"] == "anthropic"
-        assert result["context_window"] == 200000
+        assert result["context_window"] == 1000000
 
     @patch("turnstone.core.providers.create_client")
     def test_connection_failure(self, mock_cc: MagicMock) -> None:
@@ -184,7 +184,7 @@ class TestLookupModelCapabilities:
     def test_known_anthropic_model(self) -> None:
         caps = lookup_model_capabilities("anthropic", "claude-opus-4-6")
         assert caps is not None
-        assert caps["context_window"] == 200000
+        assert caps["context_window"] == 1000000
         assert caps["thinking_mode"] == "adaptive"
 
     def test_unknown_model_returns_none(self) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -957,7 +957,7 @@ class TestAnthropicHelpers:
 
         provider = AnthropicProvider()
         caps = provider.get_capabilities("claude-opus-4-6")
-        assert caps.context_window == 200000
+        assert caps.context_window == 1000000
         assert caps.max_output_tokens == 128000
         assert caps.thinking_mode == "adaptive"
         assert caps.supports_effort is True
@@ -966,11 +966,11 @@ class TestAnthropicHelpers:
         from turnstone.core.providers._anthropic import AnthropicProvider
 
         provider = AnthropicProvider()
-        # Prefix match: "claude-sonnet-4" matches dated variants
-        caps = provider.get_capabilities("claude-sonnet-4-20260101")
-        assert caps.context_window == 200000
+        # Prefix match: "claude-sonnet-4-6" matches dated variants
+        caps = provider.get_capabilities("claude-sonnet-4-6-20260101")
+        assert caps.context_window == 1000000
         assert caps.token_param == "max_tokens"
-        assert caps.thinking_mode == "manual"
+        assert caps.thinking_mode == "adaptive"
 
     def test_capabilities_lookup_unknown(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
@@ -1407,7 +1407,7 @@ class TestAnthropicWebSearch:
         """All Anthropic models should support native web search."""
         caps = self.provider.get_capabilities("claude-opus-4-6")
         assert caps.supports_web_search is True
-        caps = self.provider.get_capabilities("claude-sonnet-4")
+        caps = self.provider.get_capabilities("claude-sonnet-4-6")
         assert caps.supports_web_search is True
         # Unknown models use default which also has web search
         caps = self.provider.get_capabilities("claude-unknown-99")

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -84,7 +84,7 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
     "claude-opus-4-6": ModelCapabilities(
-        context_window=200000,
+        context_window=1000000,
         max_output_tokens=128000,
         token_param="max_tokens",
         thinking_mode="adaptive",
@@ -95,7 +95,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_vision=True,
     ),
     "claude-sonnet-4-6": ModelCapabilities(
-        context_window=200000,
+        context_window=1000000,
         max_output_tokens=64000,
         token_param="max_tokens",
         thinking_mode="adaptive",
@@ -129,24 +129,6 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_effort=True,
         effort_levels=("low", "medium", "high"),
         supports_web_search=True,
-        supports_vision=True,
-    ),
-    "claude-opus-4": ModelCapabilities(
-        context_window=200000,
-        max_output_tokens=32000,
-        token_param="max_tokens",
-        thinking_mode="manual",
-        supports_web_search=True,
-        supports_tool_search=True,
-        supports_vision=True,
-    ),
-    "claude-sonnet-4": ModelCapabilities(
-        context_window=200000,
-        max_output_tokens=64000,
-        token_param="max_tokens",
-        thinking_mode="manual",
-        supports_web_search=True,
-        supports_tool_search=True,
         supports_vision=True,
     ),
 }


### PR DESCRIPTION
Claude 4.6 (Opus + Sonnet) unified on 1M token context windows. Update capabilities table from 200K to 1M for both models.  Remove claude-opus-4 and claude-sonnet-4 entries (end of life).  4.5 models remain at 200K.  Default fallback stays at 200K for unknown models.