### PR TITLE
fix: strip NUL bytes in both storage backends via shared sanitize_text

### DIFF
--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -72,6 +72,7 @@ from turnstone.core.storage._utils import (
 from turnstone.core.storage._utils import (
     row_to_dict as _row_to_dict,
 )
+from turnstone.core.storage._utils import sanitize_text
 from turnstone.core.storage._utils import (
     scan_skill_content as _scan_skill_content,
 )
@@ -112,6 +113,8 @@ class PostgreSQLBackend:
         tool_calls: str | None = None,
     ) -> None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        content = sanitize_text(content)
+        provider_data = sanitize_text(provider_data)
         with self._engine.connect() as conn:
             conn.execute(
                 sa.insert(conversations),

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -72,6 +72,7 @@ from turnstone.core.storage._utils import (
 from turnstone.core.storage._utils import (
     row_to_dict as _row_to_dict,
 )
+from turnstone.core.storage._utils import sanitize_text
 from turnstone.core.storage._utils import (
     scan_skill_content as _scan_skill_content,
 )
@@ -163,6 +164,8 @@ class SQLiteBackend:
         tool_calls: str | None = None,
     ) -> None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        content = sanitize_text(content)
+        provider_data = sanitize_text(provider_data)
         with self._engine.connect() as conn:
             result = conn.execute(
                 sa.insert(conversations),

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -11,6 +11,22 @@ from turnstone.core.log import get_logger
 log = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
+# Text sanitization
+# ---------------------------------------------------------------------------
+
+
+def sanitize_text(value: str | None) -> str | None:
+    """Strip NUL bytes that PostgreSQL text fields cannot store.
+
+    SQLite tolerates NUL in TEXT but they cause downstream issues (API
+    payloads, web UI rendering), so both backends use this.
+    """
+    if value and "\x00" in value:
+        return value.replace("\x00", "")
+    return value
+
+
+# ---------------------------------------------------------------------------
 # Row helper
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PostgreSQL text fields cannot store NUL (0x00) bytes, and SQLite stores them but they cause downstream issues (API payloads, web UI). Add sanitize_text() to _utils.py and apply it in both backends' save_message to content and provider_data fields.