### PR TITLE
fix: UnboundLocalError on TLS advertise URL upgrade

### DIFF
--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2911,7 +2911,10 @@ def main() -> None:
                 # Store client on app state for lifespan renewal
                 app.state.tls_client = tls_client
                 # Update advertise URL to HTTPS now that TLS is active
-                app.state.advertise_url = f"https://{_advertise_host}:{args.port}"
+                if _advertise_url.startswith("http://"):
+                    app.state.advertise_url = _advertise_url.replace("http://", "https://", 1)
+                else:
+                    app.state.advertise_url = _advertise_url
                 log.info("TLS enabled — serving HTTPS")
             else:
                 log.warning("TLS enabled but no cert available")


### PR DESCRIPTION
When TURNSTONE_ADVERTISE_URL is set (Docker deployments), the _advertise_host variable was never assigned. The TLS upgrade path tried to use it to construct the https:// URL, causing an UnboundLocalError that made TLS init fail silently.

Fix: derive the TLS URL from _advertise_url (replace http → https) instead of reconstructing from _advertise_host.