### PR TITLE
fix: channel gateway SSE connectivity and multi-turn messaging

### DIFF
--- a/turnstone/channels/discord/bot.py
+++ b/turnstone/channels/discord/bot.py
@@ -310,6 +310,24 @@ class TurnstoneBot:
             del self._notify_ws_map[mid]
         log.info("discord.unsubscribed", ws_id=ws_id)
 
+    async def _cleanup_stale_route(self, ws_id: str) -> None:
+        """Remove a channel route whose workstream no longer exists."""
+        route = await asyncio.to_thread(self.storage.get_channel_route_by_ws, ws_id)
+        if route:
+            await asyncio.to_thread(
+                self.storage.delete_channel_route, route["channel_type"], route["channel_id"]
+            )
+            log.info("discord.stale_route_removed", ws_id=ws_id)
+        # Clear same per-ws state that unsubscribe_ws() clears.
+        self._subscribed_ws.discard(ws_id)
+        self._sse_tasks.pop(ws_id, None)
+        self._streaming.pop(ws_id, None)
+        self._pending_approval_msgs.pop(ws_id, None)
+        self._notify_reply_channels.pop(ws_id, None)
+        stale = [mid for mid, entry in self._notify_ws_map.items() if entry[0] == ws_id]
+        for mid in stale:
+            del self._notify_ws_map[mid]
+
     # -- SSE listener --------------------------------------------------------
 
     async def _sse_listener(self, ws_id: str, thread: discord.abc.Messageable) -> None:
@@ -325,7 +343,7 @@ class TurnstoneBot:
         # When routing through the console, connect SSE directly to the
         # assigned server node (node_url from the create response).
         node_base = await self.router.get_node_url(ws_id)
-        url = f"{node_base}/api/events"
+        url = f"{node_base}/v1/api/events"
         delay = _SSE_RECONNECT_DELAY
 
         while True:
@@ -341,6 +359,19 @@ class TurnstoneBot:
                     params={"ws_id": ws_id},
                     headers=sse_headers,
                 ) as event_source:
+                    # Bail on non-retryable responses (404 = workstream gone).
+                    status = event_source.response.status_code
+                    if status == 404:
+                        log.info("discord.sse_ws_gone", ws_id=ws_id)
+                        await self._cleanup_stale_route(ws_id)
+                        return
+                    if status >= 400:
+                        log.warning(
+                            "discord.sse_upstream_error",
+                            ws_id=ws_id,
+                            status=status,
+                        )
+                        # Fall through to backoff/retry for transient errors.
                     delay = _SSE_RECONNECT_DELAY  # reset on successful connect
                     async for sse in event_source.aiter_sse():
                         if sse.event == "message" or not sse.event:
@@ -355,8 +386,6 @@ class TurnstoneBot:
                                 continue
                             event = ServerEvent.from_dict(data)
                             await self._on_ws_event(ws_id, thread, event)
-                            if isinstance(event, StreamEndEvent):
-                                return  # clean end, do not reconnect
             except httpx.RemoteProtocolError:
                 # Server closed connection (normal on stream_end or shutdown).
                 log.debug("discord.sse_remote_closed", ws_id=ws_id)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -528,17 +528,26 @@ async def route_create(request: Request) -> Response:
     """POST /v1/api/route/workstreams/new — create via hash-ring routing."""
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    if router is None or not router.is_ready():
-        return _record_route(
-            request,
-            "create",
-            503,
-            t0,
-            JSONResponse(
-                {"error": "Cluster routing not initialized"},
-                status_code=503,
-            ),
-        )
+    ring_ready = router is not None and router.is_ready()
+    if not ring_ready:
+        # Ring not yet populated (rebalancer hasn't run or is disabled).
+        # Try a one-shot refresh before giving up — the rebalancer may
+        # have written buckets since the last collector poll.
+        if router is not None:
+            await asyncio.to_thread(router.refresh_cache)
+            ring_ready = router.is_ready()
+        if not ring_ready:
+            return _record_route(
+                request,
+                "create",
+                503,
+                t0,
+                JSONResponse(
+                    {"error": "Cluster routing not initialized"},
+                    status_code=503,
+                ),
+            )
+    assert router is not None
 
     try:
         body = await request.json()
@@ -664,17 +673,23 @@ async def route_proxy(request: Request) -> Response:
     if method == "close":
         method = "close"  # /route/workstreams/close
     router: ConsoleRouter | None = request.app.state.router
-    if router is None or not router.is_ready():
-        return _record_route(
-            request,
-            method,
-            503,
-            t0,
-            JSONResponse(
-                {"error": "Cluster routing not initialized"},
-                status_code=503,
-            ),
-        )
+    ring_ready = router is not None and router.is_ready()
+    if not ring_ready:
+        if router is not None:
+            await asyncio.to_thread(router.refresh_cache)
+            ring_ready = router.is_ready()
+        if not ring_ready:
+            return _record_route(
+                request,
+                method,
+                503,
+                t0,
+                JSONResponse(
+                    {"error": "Cluster routing not initialized"},
+                    status_code=503,
+                ),
+            )
+    assert router is not None
 
     try:
         body = await request.json()
@@ -789,17 +804,23 @@ async def route_lookup(request: Request) -> JSONResponse:
     """GET /v1/api/route — look up which node owns a workstream."""
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    if router is None or not router.is_ready():
-        return _record_route(
-            request,
-            "route",
-            503,
-            t0,
-            JSONResponse(
-                {"error": "Cluster routing not initialized"},
-                status_code=503,
-            ),
-        )  # type: ignore[return-value]
+    ring_ready = router is not None and router.is_ready()
+    if not ring_ready:
+        if router is not None:
+            await asyncio.to_thread(router.refresh_cache)
+            ring_ready = router.is_ready()
+        if not ring_ready:
+            return _record_route(
+                request,
+                "route",
+                503,
+                t0,
+                JSONResponse(
+                    {"error": "Cluster routing not initialized"},
+                    status_code=503,
+                ),
+            )  # type: ignore[return-value]
+    assert router is not None
 
     ws_id = request.query_params.get("ws_id", "")
     if not ws_id:

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -568,12 +568,12 @@ def _build_registry() -> dict[str, SettingDef]:
         SettingDef(
             "rebalancer.enabled",
             "bool",
-            False,
+            True,
             "Enable the hash ring rebalancer daemon",
             "rebalancer",
             help="When enabled, the console runs a background thread that monitors cluster "
             "membership and automatically redistributes hash ring buckets when nodes join "
-            "or leave. Required for multi-node deployments.",
+            "or leave. Required for the channel gateway and multi-node routing.",
         ),
         SettingDef(
             "rebalancer.interval",


### PR DESCRIPTION
- Fix missing /v1 prefix on SSE endpoint URL (caused all SSE connections to get text/plain 404 responses instead of event streams)
- Stop treating StreamEndEvent as session-terminal (it fires per-segment, not per-workstream) so multi-turn conversations work in Discord
- Bail on 404 instead of retrying forever for gone workstreams, and clean up stale routes from storage
- Check response status before iterating SSE events to avoid retrying non-retryable upstream errors
- Default rebalancer.enabled to True so hash ring routing works without manual ConfigStore setup
- Add one-shot cache refresh fallback on route endpoints to handle the startup race between rebalancer and first routed request