### PR TITLE
fix: bootstrap DATABASE_URL scheme, Docker fd exhaustion, proxy error…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN uv sync --frozen --no-dev \
     --no-compile --extra all
 
 # Compile bytecode in a separate step (avoids fd exhaustion during install)
-RUN python -m compileall -q .venv/lib/ turnstone/
+RUN python -m compileall -q .venv turnstone/
 
 # Add venv to PATH so entry points are found
 ENV PATH="/app/.venv/bin:$PATH"

--- a/turnstone/bootstrap.py
+++ b/turnstone/bootstrap.py
@@ -669,7 +669,7 @@ class _BootstrapLLM:
         if getattr(message, "tool_calls", None):
             tool_calls = [
                 {
-                    "id": getattr(tc, "id", f"call_{i}"),
+                    "id": getattr(tc, "id", None) or f"call_{secrets.token_hex(4)}",
                     "type": "function",
                     "function": {
                         "name": tc.function.name,


### PR DESCRIPTION
… handling

- Bootstrap system prompt now generates postgresql+psycopg:// URLs (required by SQLAlchemy 2.0 + psycopg3)
- Dockerfile splits bytecode compilation into a separate step to avoid exhausting file descriptors during uv sync (os error 24)
- Bootstrap OpenAI completion path guards against non-spec responses from proxies (Open WebUI, LiteLLM) with actionable error messages