### PR TITLE
fix: prevent cross-workstream SSE event contamination in WebUI

### DIFF
--- a/tests/test_workstream.py
+++ b/tests/test_workstream.py
@@ -730,13 +730,23 @@ class TestWebUIFanOut:
         ui._enqueue({"type": "content", "text": "hello"})  # should not raise
 
     def test_enqueue_single_listener(self):
-        """Single listener receives the event."""
+        """Single listener receives the event with ws_id stamped."""
         from turnstone.server import WebUI
 
         ui = WebUI(ws_id="test")
         q = ui._register_listener()
         ui._enqueue({"type": "content", "text": "hello"})
-        assert q.get_nowait() == {"type": "content", "text": "hello"}
+        assert q.get_nowait() == {"type": "content", "text": "hello", "ws_id": "test"}
+
+    def test_enqueue_does_not_mutate_input(self):
+        """_enqueue must not mutate the caller's dict."""
+        from turnstone.server import WebUI
+
+        ui = WebUI(ws_id="test")
+        ui._register_listener()
+        original = {"type": "content", "text": "hello"}
+        ui._enqueue(original)
+        assert "ws_id" not in original
 
     def test_enqueue_multiple_listeners(self):
         """All registered listeners receive an identical copy."""
@@ -747,12 +757,12 @@ class TestWebUIFanOut:
         q2 = ui._register_listener()
         q3 = ui._register_listener()
 
-        event = {"type": "content", "text": "world"}
-        ui._enqueue(event)
+        ui._enqueue({"type": "content", "text": "world"})
 
-        assert q1.get_nowait() == event
-        assert q2.get_nowait() == event
-        assert q3.get_nowait() == event
+        expected = {"type": "content", "text": "world", "ws_id": "test"}
+        assert q1.get_nowait() == expected
+        assert q2.get_nowait() == expected
+        assert q3.get_nowait() == expected
 
     def test_unregister_stops_delivery(self):
         """After unregister, the queue receives no further events."""
@@ -784,11 +794,10 @@ class TestWebUIFanOut:
         assert fast.qsize() == 0
 
         # Enqueue via fan-out — slow drops (full), fast receives
-        event = {"type": "content", "text": "overflow"}
-        ui._enqueue(event)
+        ui._enqueue({"type": "content", "text": "overflow"})
         assert slow.qsize() == 500  # still full, overflow dropped
         assert fast.qsize() == 1
-        assert fast.get_nowait() == event
+        assert fast.get_nowait() == {"type": "content", "text": "overflow", "ws_id": "test"}
 
     def test_unregister_idempotent(self):
         """Double unregister does not raise."""

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -119,6 +119,11 @@ class WebUI:
         self._ws_turn_content_size: int = 0
 
     def _enqueue(self, data: dict[str, Any]) -> None:
+        # Stamp ws_id on every per-workstream event so the client can
+        # validate it belongs to the pane's current workstream.
+        # Shallow copy to avoid mutating caller's dict (e.g. _pending_approval).
+        if "ws_id" not in data:
+            data = {**data, "ws_id": self.ws_id}
         with self._listeners_lock:
             snapshot = list(self._listeners)
         for lq in snapshot:

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -310,29 +310,53 @@ Pane.prototype.connectSSE = function (wsId) {
               workstreams[ws.id] = { name: ws.name, state: ws.state };
             });
             renderTabBar();
-            // Reconnect all disconnected panes, reassigning stale ws_ids
+            // Reconnect all disconnected panes, reassigning stale ws_ids.
+            // Two passes: (1) reassign stale panes, (2) reconnect all.
+            // Track assigned ws_ids to avoid multiple panes on the same ws.
+            var remaining = Object.keys(workstreams);
+            if (!remaining.length) {
+              showDashboard();
+              return;
+            }
+            var usedWsIds = {};
             for (var pid in panes) {
-              var p = panes[pid];
-              if (p.wsId && !workstreams[p.wsId]) {
-                var ids = Object.keys(workstreams);
-                if (ids.length) {
-                  p.wsId = ids[0];
-                  p.messagesEl.innerHTML = "";
-                  p.showEmptyState();
-                  p.updateWsName();
-                } else {
-                  showDashboard();
-                  return;
+              if (panes[pid].wsId && workstreams[panes[pid].wsId])
+                usedWsIds[panes[pid].wsId] = true;
+            }
+            for (var pid2 in panes) {
+              var p2 = panes[pid2];
+              if (p2.wsId && !workstreams[p2.wsId]) {
+                var newWsId = null;
+                for (var ri = 0; ri < remaining.length; ri++) {
+                  if (!usedWsIds[remaining[ri]]) {
+                    newWsId = remaining[ri];
+                    break;
+                  }
                 }
+                if (newWsId) {
+                  p2.disconnectSSE();
+                  p2.wsId = newWsId;
+                  usedWsIds[newWsId] = true;
+                  while (p2.messagesEl.firstChild)
+                    p2.messagesEl.removeChild(p2.messagesEl.firstChild);
+                  p2.showEmptyState();
+                  p2.updateWsName();
+                }
+                // else: more panes than workstreams — leave pane stale,
+                // connectSSE below will pick it up or it stays disconnected.
               }
-              if (pid === focusedPaneId) currentWsId = p.wsId;
-              if (!p.evtSource) {
+            }
+            // Pass 2: reconnect all panes and sync focused pane
+            for (var pid3 in panes) {
+              var p3 = panes[pid3];
+              if (pid3 === focusedPaneId) currentWsId = p3.wsId;
+              if (!p3.evtSource && p3.wsId && workstreams[p3.wsId]) {
                 setTimeout(
                   (function (pp) {
                     return function () {
                       pp.connectSSE(pp.wsId);
                     };
-                  })(p),
+                  })(p3),
                   self.retryDelay,
                 );
               }
@@ -357,6 +381,9 @@ Pane.prototype.connectSSE = function (wsId) {
 };
 
 Pane.prototype.handleEvent = function (evt) {
+  // Guard: drop events that belong to a different workstream.
+  // This prevents cross-contamination during tab switches and reconnects.
+  if (evt.ws_id && evt.ws_id !== this.wsId) return;
   var self = this;
   switch (evt.type) {
     case "thinking_start":
@@ -2304,10 +2331,12 @@ function switchTab(wsId) {
     }
   }
 
+  pane.disconnectSSE();
   pane.reset();
   pane.wsId = wsId;
   currentWsId = wsId;
-  pane.messagesEl.innerHTML = "";
+  while (pane.messagesEl.firstChild)
+    pane.messagesEl.removeChild(pane.messagesEl.firstChild);
   pane.showEmptyState();
   pane.updateWsName();
   renderTabBar();
@@ -2957,8 +2986,18 @@ function connectGlobalSSE() {
       for (var id in panes) {
         if (panes[id].wsId === data.ws_id) panes[id].updateWsName();
       }
+    } else if (data.type === "ws_created") {
+      workstreams[data.ws_id] = workstreams[data.ws_id] || {};
+      workstreams[data.ws_id].name = data.name || data.ws_id.slice(0, 6);
+      workstreams[data.ws_id].state = "idle";
+      renderTabBar();
     } else if (data.type === "ws_closed") {
       var wsId = data.ws_id;
+      // Disconnect per-ws SSE on affected panes immediately so stale
+      // events from the dying workstream don't leak into reassigned panes.
+      for (var cid in panes) {
+        if (panes[cid].wsId === wsId) panes[cid].disconnectSSE();
+      }
       delete workstreams[wsId];
       renderTabBar();
       if (data.reason === "evicted") {
@@ -3137,10 +3176,13 @@ function makeCollapsible(el) {
 
 var _planContent = "";
 var _planPaneId = null;
+var _planWsId = null;
 
 function showPlanDialog(content) {
   _planContent = content;
   _planPaneId = focusedPaneId;
+  var paneNow = panes[_planPaneId];
+  _planWsId = paneNow ? paneNow.wsId : currentWsId;
   document.getElementById("plan-content").textContent = content;
   var feedbackEl = document.getElementById("plan-feedback");
   feedbackEl.value = "";
@@ -3186,7 +3228,10 @@ function resolvePlan(defaultFeedback) {
   }
 
   // Critical: fire the API call first — this unblocks the server.
-  var wsId = pane ? pane.wsId : currentWsId;
+  // Use the ws_id captured when the dialog opened, not the current pane
+  // (user may have switched tabs while the dialog was open).
+  var wsId = _planWsId || (pane ? pane.wsId : currentWsId);
+  _planWsId = null;
   authFetch("/v1/api/plan", {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Multiple browser tabs open to the same server could see workstream names, states, and content mixed up between workstreams when creating, closing, and switching tabs rapidly.

Root causes and fixes:
- Global SSE ws_created events were never handled — other tabs never learned about new workstreams, causing blank names and stale tab bars
- SSE reconnection assigned all stale panes to the first workstream instead of deduplicating; now uses two-pass assignment with tracking
- switchTab left the old EventSource open while reassigning pane.wsId, creating a window for events to leak; now disconnects SSE first
- Per-workstream events carried no ws_id — server now stamps ws_id on all events via _enqueue (shallow copy); client handleEvent drops events with mismatched ws_id as defense-in-depth
- Plan dialog used pane.wsId at resolve time (could drift after tab switch); now captures ws_id when the dialog opens
- Global ws_closed could reassign panes before per-ws SSE finished draining; now disconnects per-ws SSE immediately on close