### PR TITLE
fix: materialize skill resources to disk for subprocess access

### DIFF
--- a/tests/test_skill_resource_materialization.py
+++ b/tests/test_skill_resource_materialization.py
@@ -247,8 +247,8 @@ class TestMaterializeResources:
 
         session = _make_session(skill="traversal-skill")
         base = session._skill_resources_dir
-        # The traversal path must not be written
-        assert not os.path.exists(os.path.join(base, "..", "etc", "passwd"))
+        # The traversal path must not be written inside the resources dir
+        assert not os.path.exists(os.path.join(base, "etc"))
         # The good resource should still be materialized
         assert os.path.isfile(os.path.join(base, "scripts", "good.py"))
         session.close()

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -690,7 +690,7 @@ class ChatSession:
         referenced = {os.path.normpath(p) for p in _RESOURCE_PATH_RE.findall(self._skill_content)}
         if not referenced:
             return
-        available = set(self._skill_resources.keys())
+        available = {os.path.normpath(p) for p in self._skill_resources}
         missing = sorted(referenced - available)
         if missing:
             log.warning("skill_resources.missing", skill=self._skill_name, paths=missing)


### PR DESCRIPTION
Skill-bundled scripts stored in skill_resources were loaded into memory but never written to disk, causing FileNotFoundError when the model tried to execute them. Write resources to a per-workstream temp directory on skill load, expose via SKILL_RESOURCES_DIR env var and PATH, clean up on skill change or session close.