### PR TITLE
fix(sdk): add token_factory param to sync TurnstoneServer and Turnsto…

### DIFF
--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -974,6 +974,7 @@ class TurnstoneConsole:
         ca_cert: str | None = None,
         client_cert: str | None = None,
         client_key: str | None = None,
+        token_factory: Callable[[], str] | None = None,
     ) -> None:
         self._runner = _SyncRunner()
         self._async = AsyncTurnstoneConsole(
@@ -983,6 +984,7 @@ class TurnstoneConsole:
             ca_cert=ca_cert,
             client_cert=client_cert,
             client_key=client_key,
+            token_factory=token_factory,
         )
 
     # -- cluster overview ----------------------------------------------------

--- a/turnstone/sdk/server.py
+++ b/turnstone/sdk/server.py
@@ -446,6 +446,7 @@ class TurnstoneServer:
         ca_cert: str | None = None,
         client_cert: str | None = None,
         client_key: str | None = None,
+        token_factory: Callable[[], str] | None = None,
     ) -> None:
         self._runner = _SyncRunner()
         self._async = AsyncTurnstoneServer(
@@ -455,6 +456,7 @@ class TurnstoneServer:
             ca_cert=ca_cert,
             client_cert=client_cert,
             client_key=client_key,
+            token_factory=token_factory,
         )
 
     # -- workstream management -----------------------------------------------


### PR DESCRIPTION
…neConsole

The async variants accepted token_factory for auto-rotating JWTs via ServiceTokenManager, but the sync wrappers did not expose or forward the parameter. External SDK users calling the sync clients with token_factory got a TypeError.