### PR TITLE
fix: chunk IN clauses to stay within DB parameter limits

### DIFF
--- a/tests/test_hash_ring_storage.py
+++ b/tests/test_hash_ring_storage.py
@@ -41,6 +41,21 @@ class TestHashRingBuckets:
         # Empty list returns 0
         assert storage.assign_buckets([], "node-x") == 0
 
+    def test_assign_large_list_exceeds_chunk_size(self, storage):
+        """Regression: lists larger than chunk_size must not hit param limits."""
+        n = 1200  # exceeds SQLite chunk_size (500) and exercises multi-chunk path
+        storage.seed_ring_buckets([(i, "node-a") for i in range(n)])
+        count = storage.assign_buckets(list(range(n)), "node-b")
+        assert count == n
+        rows = storage.list_ring_buckets()
+        assert all(r["node_id"] == "node-b" for r in rows)
+
+    def test_assign_deduplicates_input(self, storage):
+        """Duplicates in the input list should not inflate rowcount."""
+        storage.seed_ring_buckets([(0, "node-a"), (1, "node-a")])
+        count = storage.assign_buckets([0, 1, 0, 1, 0], "node-b")
+        assert count == 2
+
 
 class TestBucketStats:
     def test_increment_creates_row(self, storage):

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -1260,6 +1260,8 @@ class PostgreSQLBackend:
     def assign_buckets(self, buckets: list[int], node_id: str) -> int:
         if not buckets:
             return 0
+        # De-duplicate so rowcount stays accurate across chunks.
+        buckets = list(dict.fromkeys(buckets))
         # psycopg limits query parameters to 65 535; chunk to stay well under.
         chunk_size = 10_000
         total = 0

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -1337,6 +1337,8 @@ class SQLiteBackend:
     def assign_buckets(self, buckets: list[int], node_id: str) -> int:
         if not buckets:
             return 0
+        # De-duplicate so rowcount stays accurate across chunks.
+        buckets = list(dict.fromkeys(buckets))
         # SQLite default SQLITE_MAX_VARIABLE_NUMBER is 999; chunk conservatively.
         chunk_size = 500
         total = 0


### PR DESCRIPTION
psycopg caps query parameters at 65 535 and SQLite defaults to 999. assign_buckets, prune_workstreams, and count_skill_resources_bulk were passing unbounded lists into single IN(...) clauses, causing OperationalError during rebalancer runs on full-size hash rings.

Chunk sizes: 10 000 (PostgreSQL), 500 (SQLite).