### PR TITLE
fix: universal tool_call/tool_result orphan detection for OpenAI-comp…

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -353,6 +353,42 @@ class TestOpenAIProvider:
         assert tc["id"] == ""  # original dict untouched
         assert msg["tool_calls"][0]["id"] == ""
 
+    def test_sanitize_repeated_ids_across_turns(self) -> None:
+        """Reused tool_call IDs across turns are handled per-turn, not globally."""
+        msgs = [
+            # Turn 1: call_1 fully paired
+            {"role": "user", "content": "do A"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            # Turn 2: reuses call_1 but has no result → must be synthesized
+            {"role": "user", "content": "do B"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            },
+        ]
+        result = sanitize_messages(msgs)
+        # Turn 2's orphaned call_1 should get a synthetic result
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 2  # one real from turn 1, one synthetic from turn 2
+
     # -- convert_tools --------------------------------------------------------
 
     def test_convert_tools_passthrough(self) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -178,6 +178,181 @@ class TestOpenAIProvider:
         sanitize_messages([original])
         assert original["content"] is None
 
+    # -- sanitize_messages: orphan detection -----------------------------------
+
+    def test_sanitize_orphaned_tool_call_synthesized(self) -> None:
+        """Tool_call with no matching tool result gets a synthetic error result."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        result = sanitize_messages(msgs)
+        assert len(result) == 3
+        assert result[1]["role"] == "tool"
+        assert result[1]["tool_call_id"] == "call_1"
+        assert "cancelled" in result[1]["content"]
+        assert result[2]["role"] == "user"
+
+    def test_sanitize_partial_results(self) -> None:
+        """Only the missing tool_call gets a synthetic result."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        result = sanitize_messages(msgs)
+        assert len(result) == 3
+        assert result[1]["tool_call_id"] == "call_1"
+        assert result[1]["content"] == "ok"
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_2"
+        assert "cancelled" in result[2]["content"]
+
+    def test_sanitize_complete_results_unchanged(self) -> None:
+        """All tool_calls paired → no changes."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "user", "content": "thanks"},
+        ]
+        result = sanitize_messages(msgs)
+        assert len(result) == 3
+        assert result[0]["tool_calls"][0]["id"] == "call_1"
+        assert result[1]["content"] == "ok"
+        assert result[2]["role"] == "user"
+
+    def test_sanitize_trailing_orphan(self) -> None:
+        """Orphaned tool_call at end of conversation (no following messages)."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                ],
+            },
+        ]
+        result = sanitize_messages(msgs)
+        assert len(result) == 2
+        assert result[1]["role"] == "tool"
+        assert result[1]["tool_call_id"] == "call_1"
+
+    def test_sanitize_orphaned_tool_result_dropped(self) -> None:
+        """Tool result with no matching tool_call in preceding assistant → dropped."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "tool", "tool_call_id": "call_ORPHAN", "content": "stale"},
+        ]
+        result = sanitize_messages(msgs)
+        assert len(result) == 2
+        assert result[1]["tool_call_id"] == "call_1"
+
+    def test_sanitize_empty_tool_call_id_filled(self) -> None:
+        """Empty tool_call IDs get synthetic values; tool results are remapped to match."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "", "content": "ok"},
+        ]
+        result = sanitize_messages(msgs)
+        new_id = result[0]["tool_calls"][0]["id"]
+        assert new_id.startswith("call_")
+        assert len(new_id) > 10
+        # Tool result must have been remapped to match
+        assert result[1]["tool_call_id"] == new_id
+        # No synthetic result needed — the pairing is complete
+        assert len(result) == 2
+
+    def test_sanitize_stale_result_with_orphan(self) -> None:
+        """Stale tool results are dropped even when orphaned calls are present."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "tool", "tool_call_id": "call_STALE", "content": "stale"},
+        ]
+        result = sanitize_messages(msgs)
+        result_tc_ids = [m["tool_call_id"] for m in result if m.get("role") == "tool"]
+        assert "call_STALE" not in result_tc_ids
+        assert "call_1" in result_tc_ids
+        assert "call_2" in result_tc_ids  # synthesized
+
+    def test_sanitize_orphan_no_mutation(self) -> None:
+        """Original messages and dicts are not mutated by orphan detection."""
+        tc = {"id": "", "type": "function", "function": {"name": "a", "arguments": "{}"}}
+        msg = {"role": "assistant", "content": None, "tool_calls": [tc]}
+        sanitize_messages([msg])
+        assert tc["id"] == ""  # original dict untouched
+        assert msg["tool_calls"][0]["id"] == ""
+
     # -- convert_tools --------------------------------------------------------
 
     def test_convert_tools_passthrough(self) -> None:
@@ -3235,11 +3410,14 @@ class TestResponsesMessageConversion:
             },
         ]
         _, items = self.provider._convert_messages(messages)
-        assert len(items) == 1
+        # sanitize_messages synthesizes a missing tool result for the orphaned call
+        assert len(items) == 2
         assert items[0]["type"] == "function_call"
         assert items[0]["call_id"] == "call_1"
         assert items[0]["name"] == "read_file"
         assert items[0]["arguments"] == '{"path": "/tmp"}'
+        assert items[1]["type"] == "function_call_output"
+        assert items[1]["call_id"] == "call_1"
 
     def test_tool_result(self) -> None:
         messages = [
@@ -3290,11 +3468,14 @@ class TestResponsesMessageConversion:
             },
         ]
         _, items = self.provider._convert_messages(messages)
-        assert len(items) == 2
+        # sanitize_messages synthesizes a missing tool result for the orphaned call
+        assert len(items) == 3
         assert items[0]["type"] == "message"
         assert items[0]["content"] == "I'll read that file"
         assert items[1]["type"] == "function_call"
         assert items[1]["name"] == "read_file"
+        assert items[2]["type"] == "function_call_output"
+        assert items[2]["call_id"] == "call_1"
 
 
 class TestResponsesToolConversion:

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -366,30 +366,29 @@ def sanitize_messages(
             tc_ids = [tc["id"] for tc in tool_calls if tc.get("id")]
             tc_id_set = set(tc_ids)
 
-            # Peek ahead: collect tool_call_ids from consecutive tool messages
-            j = i + 1
-            result_ids: set[str] = set()
-            while j < len(messages) and messages[j].get("role") == "tool":
-                tc_id = messages[j].get("tool_call_id", "")
-                if tc_id:
-                    result_ids.add(tc_id)
-                j += 1
-
             out.append(msg)
             i += 1
 
             # Copy through existing tool messages, applying ID remap and
             # filtering out stale results that don't match any tool_call.
+            local_answered: set[str] = set()
             empty_result_idx = 0
             while i < len(messages) and messages[i].get("role") == "tool":
                 tool_msg = messages[i]
                 result_tc_id = tool_msg.get("tool_call_id", "")
                 if not result_tc_id and empty_result_idx in id_remap:
                     # Positional remap: empty result → matching new ID
-                    tool_msg = {**tool_msg, "tool_call_id": id_remap[empty_result_idx]}
+                    new_id = id_remap[empty_result_idx]
+                    tool_msg = {**tool_msg, "tool_call_id": new_id}
+                    local_answered.add(new_id)
                     empty_result_idx += 1
                     out.append(tool_msg)
-                elif result_tc_id in tc_id_set or not result_tc_id:
+                elif not result_tc_id:
+                    # Empty ID with no remap available — drop it
+                    log.debug("sanitize_messages: dropping tool result with empty ID")
+                    empty_result_idx += 1
+                elif result_tc_id in tc_id_set:
+                    local_answered.add(result_tc_id)
                     out.append(tool_msg)
                 else:
                     log.debug(
@@ -398,10 +397,10 @@ def sanitize_messages(
                     )
                 i += 1
 
-            # Synthesize error results for orphaned tool_calls
-            # (recompute after remap may have resolved some)
-            answered = {m.get("tool_call_id", "") for m in out if m.get("role") == "tool"}
-            still_orphaned = [uid for uid in tc_ids if uid not in answered]
+            # Synthesize error results for tool_calls not answered in
+            # THIS turn (not all of `out`, to avoid false matches from
+            # reused IDs across turns).
+            still_orphaned = [uid for uid in tc_ids if uid not in local_answered]
             if still_orphaned:
                 log.debug(
                     "sanitize_messages: synthesizing %d tool result(s) for orphaned tool_calls",

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -7,13 +7,18 @@ formatting, and message sanitisation live here so both
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
+
+import structlog
 
 from turnstone.core.providers._protocol import (
     ModelCapabilities,
     UsageInfo,
     _lookup_capabilities,
 )
+
+log = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Model capability table
@@ -304,21 +309,133 @@ def format_citations(content: str, annotations: list[Any]) -> str:
 def sanitize_messages(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Ensure assistant messages always have ``content`` or ``tool_calls``.
+    """Sanitize messages for OpenAI-compatible APIs.
 
-    OpenAI-compatible APIs reject assistant messages that have neither.
-    This is a defensive catch-all; the upstream layers should already
-    guarantee well-formed messages.
+    Performs three repairs:
+
+    1. Ensures assistant messages always have ``content`` or ``tool_calls``
+       (APIs reject messages with neither).
+    2. Fills empty tool_call IDs with synthetic ``call_{uuid}`` values
+       (local servers sometimes omit them).
+    3. Detects and repairs orphaned tool_call / tool_result pairs:
+
+       - Synthesizes error tool messages for tool_calls with no matching
+         tool result.
+       - Drops tool messages whose ``tool_call_id`` has no matching
+         tool_call in the preceding assistant message.
+
+    Returns a new list; the original messages are not mutated.
     """
     out: list[dict[str, Any]] = []
-    for msg in messages:
-        if (
-            msg.get("role") == "assistant"
-            and msg.get("content") is None
-            and not msg.get("tool_calls")
-        ):
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        role = msg.get("role", "")
+
+        # (1) Fix empty-content assistant messages
+        if role == "assistant" and msg.get("content") is None and not msg.get("tool_calls"):
             msg = {**msg, "content": ""}
+            out.append(msg)
+            i += 1
+            continue
+
+        # (2+3) Assistant with tool_calls: fix IDs and detect orphans
+        if role == "assistant" and msg.get("tool_calls"):
+            tool_calls = msg["tool_calls"]
+
+            # Back-fill empty IDs and build positional remap for tool results.
+            # Local servers (vLLM, llama.cpp) sometimes omit IDs entirely;
+            # positional pairing is the best heuristic in that case.
+            needs_id_fix = any(not tc.get("id") for tc in tool_calls)
+            id_remap: dict[int, str] = {}  # positional index → new ID
+            if needs_id_fix:
+                new_tcs = []
+                empty_idx = 0
+                for tc in tool_calls:
+                    if not tc.get("id"):
+                        new_id = f"call_{uuid.uuid4().hex}"
+                        id_remap[empty_idx] = new_id
+                        empty_idx += 1
+                        new_tcs.append({**tc, "id": new_id})
+                    else:
+                        new_tcs.append(tc)
+                msg = {**msg, "tool_calls": new_tcs}
+                tool_calls = msg["tool_calls"]
+
+            # Collect IDs from this assistant message
+            tc_ids = [tc["id"] for tc in tool_calls if tc.get("id")]
+            tc_id_set = set(tc_ids)
+
+            # Peek ahead: collect tool_call_ids from consecutive tool messages
+            j = i + 1
+            result_ids: set[str] = set()
+            while j < len(messages) and messages[j].get("role") == "tool":
+                tc_id = messages[j].get("tool_call_id", "")
+                if tc_id:
+                    result_ids.add(tc_id)
+                j += 1
+
+            out.append(msg)
+            i += 1
+
+            # Copy through existing tool messages, applying ID remap and
+            # filtering out stale results that don't match any tool_call.
+            empty_result_idx = 0
+            while i < len(messages) and messages[i].get("role") == "tool":
+                tool_msg = messages[i]
+                result_tc_id = tool_msg.get("tool_call_id", "")
+                if not result_tc_id and empty_result_idx in id_remap:
+                    # Positional remap: empty result → matching new ID
+                    tool_msg = {**tool_msg, "tool_call_id": id_remap[empty_result_idx]}
+                    empty_result_idx += 1
+                    out.append(tool_msg)
+                elif result_tc_id in tc_id_set or not result_tc_id:
+                    out.append(tool_msg)
+                else:
+                    log.debug(
+                        "sanitize_messages: dropping stale tool result: %s",
+                        result_tc_id,
+                    )
+                i += 1
+
+            # Synthesize error results for orphaned tool_calls
+            # (recompute after remap may have resolved some)
+            answered = {m.get("tool_call_id", "") for m in out if m.get("role") == "tool"}
+            still_orphaned = [uid for uid in tc_ids if uid not in answered]
+            if still_orphaned:
+                log.debug(
+                    "sanitize_messages: synthesizing %d tool result(s) for orphaned tool_calls",
+                    len(still_orphaned),
+                )
+                for uid in still_orphaned:
+                    out.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": uid,
+                            "content": "Tool execution was cancelled.",
+                        }
+                    )
+            continue
+
+        # (3d) Drop orphaned tool results
+        if role == "tool":
+            tc_id = msg.get("tool_call_id", "")
+            # Find the preceding assistant message's tool_call IDs
+            prev_tc_ids: set[str] = set()
+            for k in range(len(out) - 1, -1, -1):
+                if out[k].get("role") == "assistant" and out[k].get("tool_calls"):
+                    prev_tc_ids = {tc.get("id", "") for tc in out[k]["tool_calls"] if tc.get("id")}
+                    break
+            if prev_tc_ids and tc_id and tc_id not in prev_tc_ids:
+                log.debug(
+                    "sanitize_messages: dropping orphaned tool result (no matching tool_call): %s",
+                    tc_id,
+                )
+                i += 1
+                continue
+
         out.append(msg)
+        i += 1
     return out
 
 

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -24,6 +24,7 @@ from turnstone.core.providers._openai_common import (
     format_citations,
     lookup_openai_capabilities,
     resolve_reasoning_effort,
+    sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
     CompletionResult,
@@ -83,6 +84,7 @@ class OpenAIResponsesProvider:
         concatenated system/developer messages (or ``None``) and *input_items*
         is the Responses API ``input`` array.
         """
+        messages = sanitize_messages(messages)
         instructions_parts: list[str] = []
         items: list[dict[str, Any]] = []
 


### PR DESCRIPTION
…at providers

The Anthropic provider had orphan detection for mismatched tool_call ↔ tool_result pairs, but OpenAI-compatible providers (Chat Completions, Google, Responses API) had none. When an Anthropic model runs behind an OpenAI-compat API (e.g. Azure) or cancellation creates orphans, the API rejects the malformed request.

- Rewrite sanitize_messages() with orphan detection: synthesize error tool results for unmatched tool_calls, drop tool results with no matching tool_call, fill empty tool_call IDs with positional remap
- Call sanitize_messages() from Responses API _convert_messages()