### PR TITLE
fix: use gethostname() instead of getfqdn() for advertise URLs

### DIFF
--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1318,8 +1318,11 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         try:
             if not tls_mgr.ca_initialized:
                 await tls_mgr.init_ca()
-            hostname = socket.getfqdn()
+            hostname = socket.gethostname()
+            fqdn = socket.getfqdn()
             cert_hostnames = [hostname, "localhost", "127.0.0.1"]
+            if fqdn != hostname:
+                cert_hostnames.append(fqdn)
             extra_sans = os.environ.get("TURNSTONE_TLS_SANS", "")
             if extra_sans:
                 cert_hostnames.extend(s.strip() for s in extra_sans.split(",") if s.strip())
@@ -7933,7 +7936,7 @@ def main() -> None:
     else:
         _advertise_host = args.host
         if _advertise_host in ("0.0.0.0", "::", ""):
-            _advertise_host = _socket.getfqdn()
+            _advertise_host = _socket.gethostname()
         console_url = f"http://{_advertise_host}:{args.port}"
     if auth_storage:
         try:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3720,10 +3720,10 @@ def main() -> None:
     # isn't DNS-resolvable by other containers.  Priority:
     # 1. TURNSTONE_ADVERTISE_URL env var (explicit override)
     # 2. Explicit --host (not a wildcard bind address)
-    # 3. socket.getfqdn() (may work in k8s with proper DNS)
+    # 3. socket.gethostname() (getfqdn does reverse DNS which often truncates)
     _advertise_url = os.environ.get("TURNSTONE_ADVERTISE_URL", "")
     if not _advertise_url:
-        _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.getfqdn()
+        _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.gethostname()
         _advertise_url = f"http://{_advertise_host}:{args.port}"
 
     _skip_perms = config_store.get("tools.skip_permissions")
@@ -3793,8 +3793,11 @@ def main() -> None:
 
             from turnstone.core.tls import TLSClient
 
-            hostname = socket.getfqdn()
+            hostname = socket.gethostname()
+            fqdn = socket.getfqdn()
             hostnames = [hostname, "localhost", "127.0.0.1"]
+            if fqdn != hostname:
+                hostnames.append(fqdn)
             # Only add bind host if it's a concrete address
             if args.host not in ("0.0.0.0", "::", ""):
                 hostnames.append(args.host)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3715,12 +3715,12 @@ def main() -> None:
 
     cors_origins = parse_cors_origins()
 
-    # Construct advertise URL for service registration.
-    # In Docker/k8s, socket.gethostname() returns the container ID which
-    # isn't DNS-resolvable by other containers.  Priority:
-    # 1. TURNSTONE_ADVERTISE_URL env var (explicit override)
+    # Construct advertise URL for service registration.  Priority:
+    # 1. TURNSTONE_ADVERTISE_URL env var (required in Docker/k8s where
+    #    gethostname() returns a container ID that peers can't resolve)
     # 2. Explicit --host (not a wildcard bind address)
-    # 3. socket.gethostname() (getfqdn does reverse DNS which often truncates)
+    # 3. socket.gethostname() (bare-metal fallback; getfqdn() does
+    #    reverse DNS which often truncates the hostname)
     _advertise_url = os.environ.get("TURNSTONE_ADVERTISE_URL", "")
     if not _advertise_url:
         _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.gethostname()


### PR DESCRIPTION
socket.getfqdn() does a reverse DNS lookup that often returns a truncated hostname (e.g. "flat" instead of "flat-blck-io"). Use gethostname() for advertise URLs in both server and console. For TLS SANs, include both names so certs cover all variations.