### PR TITLE
Add Slack channel adapter with Socket Mode support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ ddg = ["ddgs>=9.0"]
 discord = ["discord.py>=2.4"]
 tls = ["lacme>=1.0.5"]
 sandbox = ["sympy>=1.13", "numpy>=2.0", "scipy>=1.14", "pytest>=9.0"]
-all = ["turnstone[console,anthropic,postgres,discord,ddg,tls,sandbox]"]
+slack = ["slack-bolt>=1.18", "aiohttp>=3.9"]
+all = ["turnstone[console,anthropic,postgres,discord,ddg,tls,sandbox,slack]"]
 
 [project.scripts]
 turnstone = "turnstone.cli:main"
@@ -183,3 +184,8 @@ warn_unused_ignores = false
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["slack_bolt", "slack_bolt.*", "slack_sdk", "slack_sdk.*"]
+ignore_missing_imports = true
+disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Repository = "https://github.com/turnstonelabs/turnstone"
 Issues = "https://github.com/turnstonelabs/turnstone/issues"
 
 [project.optional-dependencies]
-test = ["pytest>=9.0", "pytest-cov>=6.0", "croniter>=3.0"]
+test = ["pytest>=9.0", "pytest-cov>=6.0", "croniter>=3.0", "slack-bolt>=1.18", "aiohttp>=3.9"]
 dev = ["ruff>=0.9", "mypy>=1.14"]
 console = ["croniter>=3.0"]
 anthropic = ["anthropic>=0.39"]

--- a/tests/test_channel_slack.py
+++ b/tests/test_channel_slack.py
@@ -146,7 +146,7 @@ class TestStreamingMessage:
         client = AsyncMock()
         client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
         client.chat_update = AsyncMock(return_value={"ok": True})
-        
+
         sm = StreamingMessage(client=client, channel="C1", edit_interval=999.0)
 
         _run(sm.append("hello "))

--- a/tests/test_channel_slack.py
+++ b/tests/test_channel_slack.py
@@ -1,0 +1,552 @@
+"""Tests for the Slack channel adapter (bot, config, CLI)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+slack_bolt = pytest.importorskip("slack_bolt")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    """Run an async coroutine in a fresh event loop (no pytest-asyncio needed)."""
+    return asyncio.run(coro)
+
+
+def _make_slack_event(
+    *,
+    bot_id: str | None = None,
+    subtype: str | None = None,
+    channel: str = "C01SAPU5414",
+    channel_type: str = "channel",
+    thread_ts: str = "1234567890.000100",
+    user: str = "U12345",
+    text: str = "hello",
+    ts: str = "1234567890.000200",
+) -> dict[str, object]:
+    event: dict[str, object] = {
+        "channel": channel,
+        "channel_type": channel_type,
+        "user": user,
+        "text": text,
+        "ts": ts,
+        "thread_ts": thread_ts,
+    }
+    if bot_id is not None:
+        event["bot_id"] = bot_id
+    if subtype is not None:
+        event["subtype"] = subtype
+    return event
+
+
+def _make_bot() -> tuple[object, MagicMock, MagicMock]:
+    """Build a TurnstoneSlackBot with fully mocked dependencies."""
+    from turnstone.channels.slack.bot import TurnstoneSlackBot
+    from turnstone.channels.slack.config import SlackConfig
+
+    config = SlackConfig(
+        bot_token="xoxb-test",
+        app_token="xapp-test",
+        allowed_channels=["C01SAPU5414"],
+        auto_approve=False,
+    )
+
+    storage = MagicMock()
+    storage.list_channel_routes_by_type = MagicMock(return_value=[])
+
+    router = MagicMock()
+    router.get_or_create_workstream = AsyncMock(return_value=("ws-1", True))
+    router.send_message = AsyncMock()
+    router.send_approval = AsyncMock()
+    router.get_node_url = AsyncMock(return_value="http://localhost:8080")
+    router.aclose = AsyncMock()
+
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1234567890.000100"})
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    client.chat_postEphemeral = AsyncMock(return_value={"ok": True})
+    client.conversations_history = AsyncMock(return_value={"ok": True, "messages": []})
+
+    with (
+        patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
+        patch("turnstone.channels.slack.bot.AsyncWebClient", return_value=client),
+    ):
+        bot = TurnstoneSlackBot(
+            config,
+            server_url="http://localhost:8080",
+            storage=storage,
+        )
+
+    bot.router = router  # type: ignore[attr-defined]
+    bot._client = client  # type: ignore[attr-defined]
+
+    return bot, router, client
+
+
+# ---------------------------------------------------------------------------
+# SlackConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSlackConfig:
+    """Tests for SlackConfig default and custom values."""
+
+    def test_defaults(self) -> None:
+        from turnstone.channels.slack.config import SlackConfig
+
+        cfg = SlackConfig()
+        assert cfg.bot_token == ""
+        assert cfg.app_token == ""
+        assert cfg.allowed_channels == []
+        assert cfg.max_message_length == 3000
+        assert cfg.streaming_edit_interval == 1.5
+        # Inherited from ChannelConfig
+        assert cfg.model == ""
+        assert cfg.auto_approve is False
+
+    def test_custom_values(self) -> None:
+        from turnstone.channels.slack.config import SlackConfig
+
+        cfg = SlackConfig(
+            bot_token="xoxb-123",
+            app_token="xapp-456",
+            allowed_channels=["C1", "C2"],
+            max_message_length=4000,
+            streaming_edit_interval=0.5,
+            model="gpt-4.1",
+            auto_approve=True,
+        )
+        assert cfg.bot_token == "xoxb-123"
+        assert cfg.app_token == "xapp-456"
+        assert cfg.allowed_channels == ["C1", "C2"]
+        assert cfg.max_message_length == 4000
+        assert cfg.streaming_edit_interval == 0.5
+        assert cfg.model == "gpt-4.1"
+        assert cfg.auto_approve is True
+
+
+# ---------------------------------------------------------------------------
+# StreamingMessage
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingMessage:
+    """Tests for the StreamingMessage helper."""
+
+    def test_append_accumulates(self) -> None:
+        from turnstone.channels.slack.bot import StreamingMessage
+
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+        client.chat_update = AsyncMock(return_value={"ok": True})
+        
+        sm = StreamingMessage(client=client, channel="C1", edit_interval=999.0)
+
+        _run(sm.append("hello "))
+        _run(sm.append("world"))
+
+        assert "".join(sm._buffer) == "hello world"
+
+    def test_finalize_sends_when_no_prior_message(self) -> None:
+        from turnstone.channels.slack.bot import StreamingMessage
+
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+        sm = StreamingMessage(client=client, channel="C1", edit_interval=999.0)
+
+        _run(sm.append("hello"))
+        _run(sm.finalize())
+
+        client.chat_postMessage.assert_awaited_once()
+
+    def test_finalize_edits_existing_message(self) -> None:
+        from turnstone.channels.slack.bot import StreamingMessage
+
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+        client.chat_update = AsyncMock(return_value={"ok": True})
+        sm = StreamingMessage(client=client, channel="C1", edit_interval=0.0)
+
+        _run(sm.append("hi"))
+        assert sm._ts == "123"
+
+        _run(sm.finalize())
+        client.chat_update.assert_awaited()
+
+    def test_finalize_chunks_long_content(self) -> None:
+        from turnstone.channels.slack.bot import StreamingMessage
+
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+        sm = StreamingMessage(client=client, channel="C1", max_length=10, edit_interval=999.0)
+
+        _run(sm.append("a" * 25))
+        _run(sm.finalize())
+
+        assert client.chat_postMessage.await_count >= 2
+
+    def test_finalize_empty_is_noop(self) -> None:
+        from turnstone.channels.slack.bot import StreamingMessage
+
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock()
+        sm = StreamingMessage(client=client, channel="C1")
+
+        _run(sm.finalize())
+        client.chat_postMessage.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _on_message filtering
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessage:
+    """Tests for the _on_message handler filtering logic."""
+
+    def test_ignores_bot_messages(self) -> None:
+        bot, router, _ = _make_bot()
+        event = _make_slack_event(bot_id="B12345")
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_not_awaited()
+
+    def test_ignores_subtype_messages(self) -> None:
+        bot, router, _ = _make_bot()
+        event = _make_slack_event(subtype="message_changed")
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_not_awaited()
+
+    def test_ignores_non_allowed_channel(self) -> None:
+        bot, router, _ = _make_bot()
+        event = _make_slack_event(channel="C_NOT_ALLOWED")
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_not_awaited()
+
+    def test_ignores_message_outside_session_thread(self) -> None:
+        bot, router, _ = _make_bot()
+        # Set up a session with a different thread_ts
+        bot._channel_sessions[("C01SAPU5414", "U12345")] = ("ws-1", "9999999.000001")  # type: ignore[attr-defined]
+
+        event = _make_slack_event(thread_ts="1234567890.000100")  # different thread
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_not_awaited()
+
+    def test_routes_message_in_active_session_thread(self) -> None:
+        bot, router, _ = _make_bot()
+        bot._channel_sessions[("C01SAPU5414", "U12345")] = ("ws-1", "1234567890.000100")  # type: ignore[attr-defined]
+
+        event = _make_slack_event(thread_ts="1234567890.000100")
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_awaited_once_with("ws-1", "hello")
+
+    def test_dm_routes_freely(self) -> None:
+        bot, router, _ = _make_bot()
+        router.get_or_create_workstream = AsyncMock(return_value=("ws-dm", True))
+
+        event = _make_slack_event(channel_type="im", thread_ts="")
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Per-user session isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPerUserSessionIsolation:
+    """User1 session must not be closed when user2 starts a session."""
+
+    def test_user2_session_does_not_archive_user1(self) -> None:
+        bot, router, client = _make_bot()
+
+        # User1 has an existing session
+        bot._channel_sessions[("C01SAPU5414", "U111")] = ("ws-user1", "1000000.000001")  # type: ignore[attr-defined]
+        bot._subscribed_ws.add("ws-user1")  # type: ignore[attr-defined]
+
+        # User2 starts a new session
+        body = {"channel_id": "C01SAPU5414", "user_id": "U222"}
+        ack = AsyncMock()
+
+        router.get_or_create_workstream = AsyncMock(return_value=("ws-user2", True))
+
+        _run(bot._on_slash_command(ack, body))  # type: ignore[attr-defined]
+
+        # User1 session should still exist
+        assert ("C01SAPU5414", "U111") in bot._channel_sessions  # type: ignore[attr-defined]
+        assert bot._channel_sessions[("C01SAPU5414", "U111")] == ("ws-user1", "1000000.000001")  # type: ignore[attr-defined]
+
+    def test_same_user_second_session_archives_first(self) -> None:
+        bot, router, client = _make_bot()
+
+        # User1 has an existing session
+        bot._channel_sessions[("C01SAPU5414", "U111")] = ("ws-old", "1000000.000001")  # type: ignore[attr-defined]
+        bot._subscribed_ws.add("ws-old")  # type: ignore[attr-defined]
+
+        # Same user starts a new session
+        body = {"channel_id": "C01SAPU5414", "user_id": "U111"}
+        ack = AsyncMock()
+
+        router.get_or_create_workstream = AsyncMock(return_value=("ws-new", True))
+
+        _run(bot._on_slash_command(ack, body))  # type: ignore[attr-defined]
+
+        # Old session should be gone, new one in its place
+        assert bot._channel_sessions.get(("C01SAPU5414", "U111")) is not None  # type: ignore[attr-defined]
+        ws_id, _ = bot._channel_sessions[("C01SAPU5414", "U111")]  # type: ignore[attr-defined]
+        assert ws_id == "ws-new"
+
+        # Archive message should have been sent
+        client.chat_postMessage.assert_awaited()
+        calls = [str(c) for c in client.chat_postMessage.call_args_list]
+        assert any("archived" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# _on_ws_event dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestWsEventDispatch:
+    """Tests for SSE event handling in the Slack bot."""
+
+    def _make_ws_bot(self) -> tuple[object, MagicMock]:
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        config = SlackConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            auto_approve=False,
+        )
+        storage = MagicMock()
+        router = MagicMock()
+        router.send_approval = AsyncMock()
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+        client.chat_update = AsyncMock(return_value={"ok": True})
+        client.conversations_history = AsyncMock(return_value={"ok": True, "messages": []})
+
+        with (
+            patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
+            patch("turnstone.channels.slack.bot.AsyncWebClient", return_value=client),
+        ):
+            bot = TurnstoneSlackBot(
+                config,
+                server_url="http://localhost:8080",
+                storage=storage,
+            )
+        bot.router = router  # type: ignore[attr-defined]
+        bot._client = client  # type: ignore[attr-defined]
+        bot.storage = None  # type: ignore[attr-defined]
+        return bot, client
+
+    def test_content_event_creates_streaming_message(self) -> None:
+        from turnstone.sdk.events import ContentEvent
+
+        bot, client = self._make_ws_bot()
+
+        event = ContentEvent(ws_id="ws-1", text="Hello")
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        assert "ws-1" in bot._streaming  # type: ignore[attr-defined]
+
+    def test_stream_end_finalizes_streaming(self) -> None:
+        from turnstone.sdk.events import ContentEvent, StreamEndEvent
+
+        bot, client = self._make_ws_bot()
+
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", ContentEvent(ws_id="ws-1", text="Hi")))  # type: ignore[attr-defined]
+        assert "ws-1" in bot._streaming  # type: ignore[attr-defined]
+
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
+        assert "ws-1" not in bot._streaming  # type: ignore[attr-defined]
+
+    def test_stream_end_no_streaming_is_noop(self) -> None:
+        from turnstone.sdk.events import StreamEndEvent
+
+        bot, client = self._make_ws_bot()
+
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
+        assert "ws-1" not in bot._streaming  # type: ignore[attr-defined]
+
+    def test_error_event_posts_message(self) -> None:
+        from turnstone.sdk.events import ErrorEvent
+
+        bot, client = self._make_ws_bot()
+
+        event = ErrorEvent(ws_id="ws-1", message="Something went wrong")
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        client.chat_postMessage.assert_awaited_once()
+        text = client.chat_postMessage.call_args[1]["text"]
+        assert "Something went wrong" in text
+
+    def test_approve_request_auto_approve(self) -> None:
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+        from turnstone.sdk.events import ApproveRequestEvent
+
+        config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test", auto_approve=True)
+        storage = MagicMock()
+        router = MagicMock()
+        router.send_approval = AsyncMock()
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
+
+        with (
+            patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
+            patch("turnstone.channels.slack.bot.AsyncWebClient", return_value=client),
+        ):
+            bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
+        bot.router = router  # type: ignore[attr-defined]
+        bot._client = client  # type: ignore[attr-defined]
+        bot.storage = None  # type: ignore[attr-defined]
+
+        event = ApproveRequestEvent(ws_id="ws-1", items=[{"func_name": "bash", "needs_approval": True}])
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        router.send_approval.assert_awaited_once_with("ws-1", "", approved=True)
+
+    def test_approve_request_sends_approval_buttons(self) -> None:
+        from turnstone.sdk.events import ApproveRequestEvent
+
+        bot, client = self._make_ws_bot()
+
+        event = ApproveRequestEvent(ws_id="ws-1", items=[{"func_name": "bash", "needs_approval": True}])
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        client.chat_postMessage.assert_awaited_once()
+        call_kwargs = client.chat_postMessage.call_args[1]
+        assert "blocks" in call_kwargs
+        assert "ws-1" in bot._pending_approval_ts  # type: ignore[attr-defined]
+
+    def test_intent_verdict_updates_approval_message(self) -> None:
+        from turnstone.sdk.events import IntentVerdictEvent
+
+        bot, client = self._make_ws_bot()
+        client.conversations_history = AsyncMock(return_value={
+            "ok": True,
+            "messages": [{"blocks": []}],
+        })
+
+        bot._pending_approval_ts["ws-1"] = ("C1", "999.000")  # type: ignore[attr-defined]
+
+        event = IntentVerdictEvent(
+            ws_id="ws-1",
+            func_name="bash",
+            risk_level="high",
+            confidence=0.9,
+            intent_summary="Dangerous",
+        )
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        client.chat_update.assert_awaited_once()
+
+    def test_approval_resolved_clears_pending(self) -> None:
+        from turnstone.sdk.events import ApprovalResolvedEvent
+
+        bot, client = self._make_ws_bot()
+        bot._pending_approval_ts["ws-1"] = ("C1", "999.000")  # type: ignore[attr-defined]
+
+        event = ApprovalResolvedEvent(ws_id="ws-1", approved=True)
+        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+
+        assert "ws-1" not in bot._pending_approval_ts  # type: ignore[attr-defined]
+        client.chat_update.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Notification tracking
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationTracking:
+    """Tests for notification message tracking."""
+
+    def test_track_notification_stores_entry(self) -> None:
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test")
+        storage = MagicMock()
+        with (
+            patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
+            patch("turnstone.channels.slack.bot.AsyncWebClient"),
+        ):
+            bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
+
+        bot._track_notification("ts-123", "ws-1", "C01SAPU5414", "U12345")
+        assert bot._notify_ws_map["ts-123"] == ("ws-1", "C01SAPU5414", "U12345")
+
+    def test_track_notification_evicts_oldest(self) -> None:
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test")
+        storage = MagicMock()
+        with (
+            patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
+            patch("turnstone.channels.slack.bot.AsyncWebClient"),
+        ):
+            bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
+
+        bot._MAX_NOTIFY_TRACKING = 3  # type: ignore[attr-defined]
+        bot._notify_ws_map = {
+            "ts-1": ("ws-1", "C1", "U1"),
+            "ts-2": ("ws-2", "C1", "U2"),
+            "ts-3": ("ws-3", "C1", "U3"),
+        }
+
+        bot._track_notification("ts-4", "ws-4", "C1", "U4")  # type: ignore[attr-defined]
+
+        assert "ts-4" in bot._notify_ws_map  # type: ignore[attr-defined]
+        assert "ts-1" not in bot._notify_ws_map  # type: ignore[attr-defined]
+        assert len(bot._notify_ws_map) <= 3  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestChannelCLI:
+    """Tests for the channel CLI entry point with Slack args."""
+
+    def test_exits_without_adapter_token(self) -> None:
+        import sys
+
+        from turnstone.channels.cli import main
+
+        with (
+            patch.object(sys, "argv", ["turnstone-channel"]),
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 1

--- a/tests/test_channel_slack.py
+++ b/tests/test_channel_slack.py
@@ -56,6 +56,7 @@ def _make_bot() -> tuple[object, MagicMock, MagicMock]:
         app_token="xapp-test",
         allowed_channels=["C01SAPU5414"],
         auto_approve=False,
+        slash_command="/network-help",
     )
 
     storage = MagicMock()
@@ -65,6 +66,7 @@ def _make_bot() -> tuple[object, MagicMock, MagicMock]:
     router.get_or_create_workstream = AsyncMock(return_value=("ws-1", True))
     router.send_message = AsyncMock()
     router.send_approval = AsyncMock()
+    router.send_plan_feedback = AsyncMock()
     router.get_node_url = AsyncMock(return_value="http://localhost:8080")
     router.aclose = AsyncMock()
 
@@ -73,6 +75,7 @@ def _make_bot() -> tuple[object, MagicMock, MagicMock]:
     client.chat_update = AsyncMock(return_value={"ok": True})
     client.chat_postEphemeral = AsyncMock(return_value={"ok": True})
     client.conversations_history = AsyncMock(return_value={"ok": True, "messages": []})
+    client.views_open = AsyncMock(return_value={"ok": True})
 
     with (
         patch("turnstone.channels.slack.bot.AsyncApp", MagicMock()),
@@ -107,6 +110,7 @@ class TestSlackConfig:
         assert cfg.allowed_channels == []
         assert cfg.max_message_length == 3000
         assert cfg.streaming_edit_interval == 1.5
+        assert cfg.slash_command == "/turnstone"
         # Inherited from ChannelConfig
         assert cfg.model == ""
         assert cfg.auto_approve is False
@@ -122,6 +126,7 @@ class TestSlackConfig:
             streaming_edit_interval=0.5,
             model="gpt-4.1",
             auto_approve=True,
+            slash_command="/network-help",
         )
         assert cfg.bot_token == "xoxb-123"
         assert cfg.app_token == "xapp-456"
@@ -130,6 +135,68 @@ class TestSlackConfig:
         assert cfg.streaming_edit_interval == 0.5
         assert cfg.model == "gpt-4.1"
         assert cfg.auto_approve is True
+        assert cfg.slash_command == "/network-help"
+
+
+# ---------------------------------------------------------------------------
+# SlackRoute
+# ---------------------------------------------------------------------------
+
+
+class TestSlackRoute:
+    """Tests for canonical Slack route parsing/formatting."""
+
+    def test_parse_channel_only(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        route = SlackRoute.parse("C123")
+        assert route.channel == "C123"
+        assert route.user_id is None
+        assert route.thread_ts is None
+
+    def test_parse_channel_and_user(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        route = SlackRoute.parse("C123:U456")
+        assert route.channel == "C123"
+        assert route.user_id == "U456"
+        assert route.thread_ts is None
+
+    def test_parse_full(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        route = SlackRoute.parse("C123:U456:111.222")
+        assert route.channel == "C123"
+        assert route.user_id == "U456"
+        assert route.thread_ts == "111.222"
+
+    def test_to_channel_id(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        assert SlackRoute(channel="C123").to_channel_id() == "C123"
+        assert SlackRoute(channel="C123", user_id="U456").to_channel_id() == "C123:U456"
+        assert (
+            SlackRoute(channel="C123", user_id="U456", thread_ts="111.222").to_channel_id()
+            == "C123:U456:111.222"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preview sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewSanitization:
+    def test_sanitize_slack_preview_escapes_and_truncates(self) -> None:
+        from turnstone.channels.slack.bot import _sanitize_slack_preview
+
+        text = "<@U123>`abc`" + ("x" * 2000)
+        out = _sanitize_slack_preview(text, max_length=50)
+
+        assert "&lt;@U123&gt;" in out
+        assert "`abc`" not in out
+        assert "\\`abc\\`" in out
+        assert len(out) <= 50
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +271,7 @@ class TestStreamingMessage:
 
 
 # ---------------------------------------------------------------------------
-# _on_message filtering
+# _on_message filtering and routing
 # ---------------------------------------------------------------------------
 
 
@@ -240,10 +307,9 @@ class TestOnMessage:
 
     def test_ignores_message_outside_session_thread(self) -> None:
         bot, router, _ = _make_bot()
-        # Set up a session with a different thread_ts
         bot._channel_sessions[("C01SAPU5414", "U12345")] = ("ws-1", "9999999.000001")  # type: ignore[attr-defined]
 
-        event = _make_slack_event(thread_ts="1234567890.000100")  # different thread
+        event = _make_slack_event(thread_ts="1234567890.000100")
         say = AsyncMock()
 
         _run(bot._on_message(event, say))  # type: ignore[attr-defined]
@@ -265,12 +331,71 @@ class TestOnMessage:
         bot, router, _ = _make_bot()
         router.get_or_create_workstream = AsyncMock(return_value=("ws-dm", True))
 
-        event = _make_slack_event(channel_type="im", thread_ts="")
+        event = _make_slack_event(channel="D12345", channel_type="im", thread_ts="")
         say = AsyncMock()
 
         _run(bot._on_message(event, say))  # type: ignore[attr-defined]
 
         router.send_message.assert_awaited_once()
+
+    def test_notification_reply_routes_to_origin_workstream(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        bot, router, _ = _make_bot()
+        ws_id = "ws-123"
+        thread_ts = "1776321000.563629"
+        bot._notify_ws_map[thread_ts] = (  # type: ignore[attr-defined]
+            ws_id,
+            SlackRoute(channel="C01SAPU5414", user_id="U12345", thread_ts=thread_ts),
+        )
+
+        event = _make_slack_event(
+            channel="C01SAPU5414",
+            channel_type="channel",
+            thread_ts=thread_ts,
+            user="U12345",
+            text="reply text",
+            ts="1776321000.999999",
+        )
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        router.send_message.assert_awaited_once_with(ws_id, "reply text")
+        assert bot._notify_reply_routes[ws_id] == SlackRoute(  # type: ignore[attr-defined]
+            channel="C01SAPU5414",
+            user_id="U12345",
+            thread_ts=thread_ts,
+        )
+
+    def test_notification_reply_dead_ws_clears_tracking(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+        from turnstone.sdk._types import TurnstoneAPIError
+
+        bot, router, client = _make_bot()
+        ws_id = "ws-dead"
+        thread_ts = "1776321102.784939"
+        bot._notify_ws_map[thread_ts] = (  # type: ignore[attr-defined]
+            ws_id,
+            SlackRoute(channel="C01SAPU5414", user_id="U12345", thread_ts=thread_ts),
+        )
+        router.send_message.side_effect = TurnstoneAPIError(404, "Unknown workstream")
+
+        event = _make_slack_event(
+            channel="C01SAPU5414",
+            channel_type="channel",
+            thread_ts=thread_ts,
+            user="U12345",
+            text="reply text",
+            ts="1776321103.000000",
+        )
+        say = AsyncMock()
+
+        _run(bot._on_message(event, say))  # type: ignore[attr-defined]
+
+        assert ws_id not in bot._notify_reply_routes  # type: ignore[attr-defined]
+        assert thread_ts not in bot._notify_ws_map  # type: ignore[attr-defined]
+        client.chat_postEphemeral.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -282,13 +407,11 @@ class TestPerUserSessionIsolation:
     """User1 session must not be closed when user2 starts a session."""
 
     def test_user2_session_does_not_archive_user1(self) -> None:
-        bot, router, client = _make_bot()
+        bot, router, _client = _make_bot()
 
-        # User1 has an existing session
         bot._channel_sessions[("C01SAPU5414", "U111")] = ("ws-user1", "1000000.000001")  # type: ignore[attr-defined]
         bot._subscribed_ws.add("ws-user1")  # type: ignore[attr-defined]
 
-        # User2 starts a new session
         body = {"channel_id": "C01SAPU5414", "user_id": "U222"}
         ack = AsyncMock()
 
@@ -296,18 +419,15 @@ class TestPerUserSessionIsolation:
 
         _run(bot._on_slash_command(ack, body))  # type: ignore[attr-defined]
 
-        # User1 session should still exist
         assert ("C01SAPU5414", "U111") in bot._channel_sessions  # type: ignore[attr-defined]
         assert bot._channel_sessions[("C01SAPU5414", "U111")] == ("ws-user1", "1000000.000001")  # type: ignore[attr-defined]
 
     def test_same_user_second_session_archives_first(self) -> None:
         bot, router, client = _make_bot()
 
-        # User1 has an existing session
         bot._channel_sessions[("C01SAPU5414", "U111")] = ("ws-old", "1000000.000001")  # type: ignore[attr-defined]
         bot._subscribed_ws.add("ws-old")  # type: ignore[attr-defined]
 
-        # Same user starts a new session
         body = {"channel_id": "C01SAPU5414", "user_id": "U111"}
         ack = AsyncMock()
 
@@ -315,15 +435,86 @@ class TestPerUserSessionIsolation:
 
         _run(bot._on_slash_command(ack, body))  # type: ignore[attr-defined]
 
-        # Old session should be gone, new one in its place
         assert bot._channel_sessions.get(("C01SAPU5414", "U111")) is not None  # type: ignore[attr-defined]
         ws_id, _ = bot._channel_sessions[("C01SAPU5414", "U111")]  # type: ignore[attr-defined]
         assert ws_id == "ws-new"
 
-        # Archive message should have been sent
         client.chat_postMessage.assert_awaited()
         calls = [str(c) for c in client.chat_postMessage.call_args_list]
         assert any("archived" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# Approval ownership
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalOwnership:
+    def test_non_owner_cannot_approve(self) -> None:
+        from turnstone.channels.slack.bot import PendingApproval
+
+        bot, router, client = _make_bot()
+        ws_id = "ws-1"
+        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+            channel="C01SAPU5414",
+            message_ts="111.222",
+            owner_user_id="U_OWNER",
+        )
+
+        body = {
+            "actions": [{"value": f"{ws_id}|corr-1"}],
+            "user": {"id": "U_OTHER"},
+            "container": {"channel_id": "C01SAPU5414", "message_ts": "111.222"},
+        }
+
+        _run(bot._on_approve(AsyncMock(), body))  # type: ignore[attr-defined]
+
+        client.chat_postEphemeral.assert_awaited_once()
+        router.send_approval.assert_not_awaited()
+
+    def test_non_owner_cannot_deny(self) -> None:
+        from turnstone.channels.slack.bot import PendingApproval
+
+        bot, router, client = _make_bot()
+        ws_id = "ws-1"
+        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+            channel="C01SAPU5414",
+            message_ts="111.222",
+            owner_user_id="U_OWNER",
+        )
+
+        body = {
+            "actions": [{"value": f"{ws_id}|corr-1"}],
+            "user": {"id": "U_OTHER"},
+            "container": {"channel_id": "C01SAPU5414", "message_ts": "111.222"},
+        }
+
+        _run(bot._on_deny(AsyncMock(), body))  # type: ignore[attr-defined]
+
+        client.chat_postEphemeral.assert_awaited_once()
+        router.send_approval.assert_not_awaited()
+
+    def test_owner_can_approve(self) -> None:
+        from turnstone.channels.slack.bot import PendingApproval
+
+        bot, router, client = _make_bot()
+        ws_id = "ws-1"
+        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+            channel="C01SAPU5414",
+            message_ts="111.222",
+            owner_user_id="U_OWNER",
+        )
+
+        body = {
+            "actions": [{"value": f"{ws_id}|corr-1"}],
+            "user": {"id": "U_OWNER"},
+            "container": {"channel_id": "C01SAPU5414", "message_ts": "111.222"},
+        }
+
+        _run(bot._on_approve(AsyncMock(), body))  # type: ignore[attr-defined]
+
+        router.send_approval.assert_awaited_once_with(ws_id, "corr-1", approved=True)
+        client.chat_update.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +537,7 @@ class TestWsEventDispatch:
         storage = MagicMock()
         router = MagicMock()
         router.send_approval = AsyncMock()
+        router.send_plan_feedback = AsyncMock()
         client = AsyncMock()
         client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "123"})
         client.chat_update = AsyncMock(return_value={"ok": True})
@@ -366,41 +558,49 @@ class TestWsEventDispatch:
         return bot, client
 
     def test_content_event_creates_streaming_message(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ContentEvent
 
-        bot, client = self._make_ws_bot()
+        bot, _client = self._make_ws_bot()
 
         event = ContentEvent(ws_id="ws-1", text="Hello")
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        route = SlackRoute(channel="C1", user_id="U1", thread_ts="123.456")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
         assert "ws-1" in bot._streaming  # type: ignore[attr-defined]
 
     def test_stream_end_finalizes_streaming(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ContentEvent, StreamEndEvent
 
-        bot, client = self._make_ws_bot()
+        bot, _client = self._make_ws_bot()
+        route = SlackRoute(channel="C1", user_id="U1", thread_ts="123.456")
 
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", ContentEvent(ws_id="ws-1", text="Hi")))  # type: ignore[attr-defined]
+        _run(bot._on_ws_event("ws-1", route, ContentEvent(ws_id="ws-1", text="Hi")))  # type: ignore[attr-defined]
         assert "ws-1" in bot._streaming  # type: ignore[attr-defined]
 
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
+        _run(bot._on_ws_event("ws-1", route, StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
         assert "ws-1" not in bot._streaming  # type: ignore[attr-defined]
 
     def test_stream_end_no_streaming_is_noop(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import StreamEndEvent
 
-        bot, client = self._make_ws_bot()
+        bot, _client = self._make_ws_bot()
+        route = SlackRoute(channel="C1", user_id="U1", thread_ts="123.456")
 
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
+        _run(bot._on_ws_event("ws-1", route, StreamEndEvent(ws_id="ws-1")))  # type: ignore[attr-defined]
         assert "ws-1" not in bot._streaming  # type: ignore[attr-defined]
 
     def test_error_event_posts_message(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ErrorEvent
 
         bot, client = self._make_ws_bot()
+        route = SlackRoute(channel="C1", user_id="U1", thread_ts="123.456")
 
         event = ErrorEvent(ws_id="ws-1", message="Something went wrong")
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
         client.chat_postMessage.assert_awaited_once()
         text = client.chat_postMessage.call_args[1]["text"]
@@ -409,6 +609,7 @@ class TestWsEventDispatch:
     def test_approve_request_auto_approve(self) -> None:
         from turnstone.channels.slack.bot import TurnstoneSlackBot
         from turnstone.channels.slack.config import SlackConfig
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ApproveRequestEvent
 
         config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test", auto_approve=True)
@@ -428,33 +629,42 @@ class TestWsEventDispatch:
         bot.storage = None  # type: ignore[attr-defined]
 
         event = ApproveRequestEvent(ws_id="ws-1", items=[{"func_name": "bash", "needs_approval": True}])
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        route = SlackRoute(channel="C1", user_id="U1", thread_ts="123.456")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
         router.send_approval.assert_awaited_once_with("ws-1", "", approved=True)
 
     def test_approve_request_sends_approval_buttons(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ApproveRequestEvent
 
         bot, client = self._make_ws_bot()
 
         event = ApproveRequestEvent(ws_id="ws-1", items=[{"func_name": "bash", "needs_approval": True}])
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
         client.chat_postMessage.assert_awaited_once()
         call_kwargs = client.chat_postMessage.call_args[1]
         assert "blocks" in call_kwargs
-        assert "ws-1" in bot._pending_approval_ts  # type: ignore[attr-defined]
+        assert "ws-1" in bot._pending_approval  # type: ignore[attr-defined]
+        assert bot._pending_approval["ws-1"].owner_user_id == "U12345"  # type: ignore[attr-defined]
 
     def test_intent_verdict_updates_approval_message(self) -> None:
+        from turnstone.channels.slack.bot import PendingApproval
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import IntentVerdictEvent
 
         bot, client = self._make_ws_bot()
-        client.conversations_history = AsyncMock(return_value={
-            "ok": True,
-            "messages": [{"blocks": []}],
-        })
+        client.conversations_history = AsyncMock(
+            return_value={"ok": True, "messages": [{"blocks": []}]}
+        )
 
-        bot._pending_approval_ts["ws-1"] = ("C1", "999.000")  # type: ignore[attr-defined]
+        bot._pending_approval["ws-1"] = PendingApproval(  # type: ignore[attr-defined]
+            channel="C1",
+            message_ts="999.000",
+            owner_user_id="U12345",
+        )
 
         event = IntentVerdictEvent(
             ws_id="ws-1",
@@ -463,20 +673,80 @@ class TestWsEventDispatch:
             confidence=0.9,
             intent_summary="Dangerous",
         )
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
         client.chat_update.assert_awaited_once()
 
     def test_approval_resolved_clears_pending(self) -> None:
+        from turnstone.channels.slack.bot import PendingApproval
+        from turnstone.channels.slack.routes import SlackRoute
         from turnstone.sdk.events import ApprovalResolvedEvent
 
         bot, client = self._make_ws_bot()
-        bot._pending_approval_ts["ws-1"] = ("C1", "999.000")  # type: ignore[attr-defined]
+        bot._pending_approval["ws-1"] = PendingApproval(  # type: ignore[attr-defined]
+            channel="C1",
+            message_ts="999.000",
+            owner_user_id="U12345",
+        )
 
         event = ApprovalResolvedEvent(ws_id="ws-1", approved=True)
-        _run(bot._on_ws_event("ws-1", "C1", "123.456", event))  # type: ignore[attr-defined]
+        route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
-        assert "ws-1" not in bot._pending_approval_ts  # type: ignore[attr-defined]
+        assert "ws-1" not in bot._pending_approval  # type: ignore[attr-defined]
+        client.chat_update.assert_awaited_once()
+
+    def test_plan_review_event_posts_buttons(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+        from turnstone.sdk.events import PlanReviewEvent
+
+        bot, client = self._make_ws_bot()
+        route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
+
+        event = PlanReviewEvent(ws_id="ws-1", content="1. do thing\n2. do next thing")
+        _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
+
+        client.chat_postMessage.assert_awaited_once()
+        kwargs = client.chat_postMessage.call_args[1]
+        assert kwargs["text"] == "Plan review required"
+        assert "blocks" in kwargs
+        assert "ws-1" in bot._pending_plan_review_ts  # type: ignore[attr-defined]
+
+    def test_plan_approve_sends_feedback_and_updates_message(self) -> None:
+        bot, client = self._make_ws_bot()
+        body = {
+            "actions": [{"value": "ws-1"}],
+            "container": {"channel_id": "C1", "message_ts": "111.222"},
+        }
+
+        _run(bot._on_plan_approve(AsyncMock(), body))  # type: ignore[attr-defined]
+
+        bot.router.send_plan_feedback.assert_awaited_once_with("ws-1", "", "")  # type: ignore[attr-defined]
+        client.chat_update.assert_awaited_once()
+
+    def test_plan_feedback_modal_sends_feedback_and_updates_message(self) -> None:
+        bot, client = self._make_ws_bot()
+        bot._pending_plan_review_ts["ws-1"] = ("C1", "111.222")  # type: ignore[attr-defined]
+
+        view = {
+            "private_metadata": "ws-1",
+            "state": {
+                "values": {
+                    "feedback_block": {
+                        "feedback_input": {"value": "please revise step 2"}
+                    }
+                }
+            },
+        }
+
+        _run(bot._on_plan_feedback_modal(AsyncMock(), {}, view))  # type: ignore[attr-defined]
+
+        bot.router.send_plan_feedback.assert_awaited_once_with(  # type: ignore[attr-defined]
+            "ws-1",
+            "",
+            "please revise step 2",
+        )
         client.chat_update.assert_awaited_once()
 
 
@@ -491,6 +761,7 @@ class TestNotificationTracking:
     def test_track_notification_stores_entry(self) -> None:
         from turnstone.channels.slack.bot import TurnstoneSlackBot
         from turnstone.channels.slack.config import SlackConfig
+        from turnstone.channels.slack.routes import SlackRoute
 
         config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test")
         storage = MagicMock()
@@ -500,12 +771,14 @@ class TestNotificationTracking:
         ):
             bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
 
-        bot._track_notification("ts-123", "ws-1", "C01SAPU5414", "U12345")
-        assert bot._notify_ws_map["ts-123"] == ("ws-1", "C01SAPU5414", "U12345")
+        route = SlackRoute(channel="C01SAPU5414", user_id="U12345", thread_ts="ts-123")
+        bot._track_notification("ts-123", "ws-1", route)  # type: ignore[attr-defined]
+        assert bot._notify_ws_map["ts-123"] == ("ws-1", route)  # type: ignore[attr-defined]
 
     def test_track_notification_evicts_oldest(self) -> None:
         from turnstone.channels.slack.bot import TurnstoneSlackBot
         from turnstone.channels.slack.config import SlackConfig
+        from turnstone.channels.slack.routes import SlackRoute
 
         config = SlackConfig(bot_token="xoxb-test", app_token="xapp-test")
         storage = MagicMock()
@@ -516,17 +789,84 @@ class TestNotificationTracking:
             bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
 
         bot._MAX_NOTIFY_TRACKING = 3  # type: ignore[attr-defined]
-        bot._notify_ws_map = {
-            "ts-1": ("ws-1", "C1", "U1"),
-            "ts-2": ("ws-2", "C1", "U2"),
-            "ts-3": ("ws-3", "C1", "U3"),
+        bot._notify_ws_map = {  # type: ignore[attr-defined]
+            "ts-1": ("ws-1", SlackRoute(channel="C1", user_id="U1", thread_ts="ts-1")),
+            "ts-2": ("ws-2", SlackRoute(channel="C1", user_id="U2", thread_ts="ts-2")),
+            "ts-3": ("ws-3", SlackRoute(channel="C1", user_id="U3", thread_ts="ts-3")),
         }
 
-        bot._track_notification("ts-4", "ws-4", "C1", "U4")  # type: ignore[attr-defined]
+        bot._track_notification(  # type: ignore[attr-defined]
+            "ts-4",
+            "ws-4",
+            SlackRoute(channel="C1", user_id="U4", thread_ts="ts-4"),
+        )
 
         assert "ts-4" in bot._notify_ws_map  # type: ignore[attr-defined]
         assert "ts-1" not in bot._notify_ws_map  # type: ignore[attr-defined]
         assert len(bot._notify_ws_map) <= 3  # type: ignore[attr-defined]
+
+    def test_send_notification_tracks_root_thread_ts(self) -> None:
+        from turnstone.channels.slack.routes import SlackRoute
+
+        bot, _router, client = _make_bot()
+        client.chat_postMessage = AsyncMock(
+            side_effect=[
+                {"ok": True, "ts": "111.222"},
+                {"ok": True, "ts": "111.333"},
+            ]
+        )
+
+        msg_id = _run(
+            bot.send_notification(  # type: ignore[attr-defined]
+                "C01SAPU5414:U12345",
+                "x" * 5000,
+                "ws-1",
+            )
+        )
+
+        assert msg_id == "111.222"
+        assert "111.222" in bot._notify_ws_map  # type: ignore[attr-defined]
+        stored_ws, stored_route = bot._notify_ws_map["111.222"]  # type: ignore[attr-defined]
+        assert stored_ws == "ws-1"
+        assert stored_route == SlackRoute(
+            channel="C01SAPU5414",
+            user_id="U12345",
+            thread_ts="111.222",
+        )
+
+
+# ---------------------------------------------------------------------------
+# DM continuity
+# ---------------------------------------------------------------------------
+
+
+class TestDmContinuity:
+    def test_dm_messages_reuse_same_workstream(self) -> None:
+        bot, router, _client = _make_bot()
+        router.get_or_create_workstream = AsyncMock(
+            side_effect=[("ws-dm", True), ("ws-dm", False)]
+        )
+
+        event1 = _make_slack_event(
+            channel="D12345",
+            channel_type="im",
+            thread_ts="",
+            ts="1.000",
+            text="hello",
+        )
+        event2 = _make_slack_event(
+            channel="D12345",
+            channel_type="im",
+            thread_ts="1.000",
+            ts="1.111",
+            text="again",
+        )
+
+        _run(bot._handle_dm(event1, AsyncMock()))  # type: ignore[attr-defined]
+        _run(bot._handle_dm(event2, AsyncMock()))  # type: ignore[attr-defined]
+
+        assert router.get_or_create_workstream.await_count == 2
+        assert router.send_message.await_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -550,3 +890,163 @@ class TestChannelCLI:
             main()
 
         assert exc_info.value.code == 1
+
+    def test_slack_requires_both_tokens(self) -> None:
+        import sys
+
+        from turnstone.channels.cli import main
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["turnstone-channel", "--slack-token", "xoxb-test", "--server-url", "http://localhost:8080"],
+            ),
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert "--slack-token and --slack-app-token must be provided together" in str(
+            exc_info.value
+        )
+
+    def test_slack_only_startup_creates_channel_app(self) -> None:
+        import sys
+
+        from turnstone.channels.cli import main
+
+        created_adapters: dict[str, object] = {}
+
+        class FakeSlackBot:
+            channel_type = "slack"
+
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def start(self) -> None:
+                return None
+
+        class FakeServer:
+            def __init__(self, _config) -> None:
+                pass
+
+            async def serve(self) -> None:
+                return None
+
+        def _fake_create_channel_app(adapters, storage, *, jwt_secret=""):  # type: ignore[no-untyped-def]
+            created_adapters.update(adapters)
+            return MagicMock()
+
+        async def _fake_gather(*aws):  # type: ignore[no-untyped-def]
+            for aw in aws:
+                await aw
+            return []
+        storage = MagicMock()
+        storage.register_service = MagicMock()
+        storage.deregister_service = MagicMock()
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "turnstone-channel",
+                    "--slack-token",
+                    "xoxb-test",
+                    "--slack-app-token",
+                    "xapp-test",
+                    "--server-url",
+                    "http://localhost:8080",
+                ],
+            ),
+            patch("turnstone.core.storage._registry.init_storage"),
+            patch("turnstone.core.storage._registry.get_storage", return_value=storage),
+            patch("turnstone.channels._http.create_channel_app", side_effect=_fake_create_channel_app),
+            patch("turnstone.channels._http._get_service_id", return_value="channel-test"),
+            patch("asyncio.gather", side_effect=_fake_gather),
+            patch("uvicorn.Config", return_value=MagicMock()),
+            patch("uvicorn.Server", FakeServer),
+            patch("turnstone.channels.slack.bot.TurnstoneSlackBot", FakeSlackBot),
+        ):
+            main()
+
+        assert "slack" in created_adapters
+        assert len(created_adapters) == 1
+
+    def test_discord_and_slack_startup_creates_both_adapters(self) -> None:
+        import sys
+
+        from turnstone.channels.cli import main
+
+        created_adapters: dict[str, object] = {}
+
+        class FakeSlackBot:
+            channel_type = "slack"
+
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def start(self) -> None:
+                return None
+
+        class FakeDiscordBot:
+            channel_type = "discord"
+
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            async def start(self) -> None:
+                return None
+
+        class FakeServer:
+            def __init__(self, _config) -> None:
+                pass
+
+            async def serve(self) -> None:
+                return None
+
+        def _fake_create_channel_app(adapters, storage, *, jwt_secret=""):  # type: ignore[no-untyped-def]
+            created_adapters.update(adapters)
+            return MagicMock()
+
+        async def _fake_gather(*aws):  # type: ignore[no-untyped-def]
+            for aw in aws:
+                await aw
+            return []
+
+        storage = MagicMock()
+        storage.register_service = MagicMock()
+        storage.deregister_service = MagicMock()
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "turnstone-channel",
+                    "--discord-token",
+                    "discord-test",
+                    "--slack-token",
+                    "xoxb-test",
+                    "--slack-app-token",
+                    "xapp-test",
+                    "--server-url",
+                    "http://localhost:8080",
+                ],
+            ),
+            patch("turnstone.core.storage._registry.init_storage"),
+            patch("turnstone.core.storage._registry.get_storage", return_value=storage),
+            patch("turnstone.channels._http.create_channel_app", side_effect=_fake_create_channel_app),
+            patch("turnstone.channels._http._get_service_id", return_value="channel-test"),
+            patch("asyncio.gather", side_effect=_fake_gather),
+            patch("uvicorn.Config", return_value=MagicMock()),
+            patch("uvicorn.Server", FakeServer),
+            patch("turnstone.channels.slack.bot.TurnstoneSlackBot", FakeSlackBot),
+            patch("turnstone.channels.discord.bot.TurnstoneBot", FakeDiscordBot),
+        ):
+            main()
+
+        assert "discord" in created_adapters
+        assert "slack" in created_adapters
+        assert len(created_adapters) == 2

--- a/turnstone/channels/_http.py
+++ b/turnstone/channels/_http.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from turnstone.channels._protocol import ChannelAdapter
     from turnstone.core.storage._protocol import StorageBackend
 
+from turnstone.channels.slack.routes import SlackRoute
+
 log = get_logger(__name__)
 
 _NOTIFY_ADAPTER_TIMEOUT: float = 30.0
@@ -112,9 +114,8 @@ async def _handle_notify(request: Request) -> JSONResponse:
         channel_id = target["channel_id"]
 
         if channel_type == "slack":
-            parts = channel_id.split(":", 2)
-            target_user_id = parts[1] if len(parts) >= 2 else ""
-            if ws_id and not target_user_id:
+            route = SlackRoute.parse(channel_id)
+            if ws_id and (not route.channel or not route.user_id):
                 return JSONResponse(
                     {
                         "error": (

--- a/turnstone/channels/_http.py
+++ b/turnstone/channels/_http.py
@@ -108,7 +108,25 @@ async def _handle_notify(request: Request) -> JSONResponse:
                 status_code=404,
             )
     elif "channel_type" in target and "channel_id" in target:
-        targets.append((target["channel_type"], target["channel_id"]))
+        channel_type = target["channel_type"]
+        channel_id = target["channel_id"]
+
+        if channel_type == "slack":
+            parts = channel_id.split(":", 2)
+            target_user_id = parts[1] if len(parts) >= 2 else ""
+            if ws_id and not target_user_id:
+                return JSONResponse(
+                    {
+                        "error": (
+                            "slack notification targets with ws_id must use "
+                            "channel_id in the form 'channel:user_id' or "
+                            "'channel:user_id:thread_ts'"
+                        )
+                    },
+                    status_code=400,
+                )
+
+        targets.append((channel_type, channel_id))
     else:
         return JSONResponse(
             {"error": "target must have username or channel_type+channel_id"},

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -222,6 +222,12 @@ def main() -> None:
         )
         sys.exit(1)
 
+    # Slack config validation (fail fast)
+    if bool(args.slack_token) != bool(args.slack_app_token):
+        raise SystemExit(
+            "--slack-token and --slack-app-token must be provided together"
+        )
+
     # -- Run -----------------------------------------------------------------
     import asyncio
     import contextlib

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -54,6 +54,28 @@ def main() -> None:
         help="Comma-separated list of allowed Discord channel IDs (default: all)",
     )
 
+    # -- Slack ---------------------------------------------------------------
+    parser.add_argument(
+        "--slack-token",
+        default=os.environ.get("TURNSTONE_SLACK_TOKEN", ""),
+        help="Slack bot token (default: $TURNSTONE_SLACK_TOKEN)",
+    )
+    parser.add_argument(
+        "--slack-app-token",
+        default=os.environ.get("TURNSTONE_SLACK_APP_TOKEN", ""),
+        help="Slack app-level token for Socket Mode (default: $TURNSTONE_SLACK_APP_TOKEN)",
+    )
+    parser.add_argument(
+        "--slack-channels",
+        default=os.environ.get("TURNSTONE_SLACK_CHANNELS", ""),
+        help="Comma-separated list of allowed Slack channel IDs (default: all)",
+    )
+    parser.add_argument(
+        "--slack-slash-command",
+        default=os.environ.get("TURNSTONE_SLACK_SLASH_COMMAND", "/turnstone"),
+        help="Slack slash command name (default: /turnstone)",
+    )
+
     # -- HTTP server ---------------------------------------------------------
     parser.add_argument(
         "--http-host",
@@ -101,7 +123,7 @@ def main() -> None:
     log = get_logger(__name__)
 
     # -- Storage -------------------------------------------------------------
-    from turnstone.core.storage._registry import init_storage
+    from turnstone.core.storage._registry import get_storage, init_storage
 
     db_backend = os.environ.get("TURNSTONE_DB_BACKEND", "sqlite")
     db_url = os.environ.get("TURNSTONE_DB_URL", "")
@@ -196,6 +218,9 @@ def main() -> None:
     if args.discord_token:
         adapters_configured = True
 
+    if args.slack_token:
+        adapters_configured = True
+
     if not adapters_configured:
         print(
             "Error: no channel adapters configured. "
@@ -205,6 +230,40 @@ def main() -> None:
         sys.exit(1)
 
     # -- Run -----------------------------------------------------------------
+    if args.slack_token and not args.discord_token:
+        import asyncio
+        import contextlib
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        _storage = get_storage()
+        config = SlackConfig(
+            model=args.model,
+            auto_approve=args.auto_approve,
+            bot_token=args.slack_token,
+            app_token=args.slack_app_token,
+            allowed_channels=[c.strip() for c in args.slack_channels.split(",") if c.strip()],
+            slash_command=args.slack_slash_command,
+        )
+        slack_bot = TurnstoneSlackBot(
+            config,
+            server_url=server_url,
+            storage=_storage,
+            console_url=console_url,
+            console_token_factory=_console_token_factory,
+            server_token_factory=_server_token_factory,
+        )
+
+        async def _run_slack() -> None:
+            try:
+                await slack_bot.start()
+            finally:
+                await slack_bot.stop()
+
+        with contextlib.suppress(KeyboardInterrupt):
+            asyncio.run(_run_slack())
+        return
+
     if args.discord_token:
         import asyncio
 
@@ -219,7 +278,7 @@ def main() -> None:
                 int(c.strip()) for c in args.discord_channels.split(",") if c.strip()
             ]
 
-        config = DiscordConfig(
+        discord_config = DiscordConfig(
             server_url=server_url,
             model=args.model,
             auto_approve=args.auto_approve,
@@ -230,7 +289,7 @@ def main() -> None:
 
         storage = get_storage()
         bot = TurnstoneBot(
-            config,
+            discord_config,
             server_url,
             storage,
             console_url=console_url,
@@ -249,7 +308,7 @@ def main() -> None:
         log.info(
             "channel.starting",
             adapter="discord",
-            guild_id=config.guild_id,
+            guild_id=discord_config.guild_id,
             http_port=args.http_port,
             server_url=server_url,
         )

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -213,65 +213,29 @@ def main() -> None:
         sys.exit(1)
 
     # -- Adapter selection ---------------------------------------------------
-    adapters_configured = False
-
-    if args.discord_token:
-        adapters_configured = True
-
-    if args.slack_token:
-        adapters_configured = True
-
-    if not adapters_configured:
+    if not args.discord_token and not args.slack_token:
         print(
             "Error: no channel adapters configured. "
-            "Set --discord-token or $TURNSTONE_DISCORD_TOKEN.",
+            "Set --discord-token / $TURNSTONE_DISCORD_TOKEN "
+            "or --slack-token / $TURNSTONE_SLACK_TOKEN.",
             file=sys.stderr,
         )
         sys.exit(1)
 
     # -- Run -----------------------------------------------------------------
-    if args.slack_token and not args.discord_token:
-        import asyncio
-        import contextlib
+    import asyncio
+    import contextlib
+    from typing import cast
 
-        from turnstone.channels.slack.bot import TurnstoneSlackBot
-        from turnstone.channels.slack.config import SlackConfig
+    from turnstone.channels._http import _get_service_id, create_channel_app
+    from turnstone.channels._protocol import ChannelAdapter
 
-        _storage = get_storage()
-        config = SlackConfig(
-            model=args.model,
-            auto_approve=args.auto_approve,
-            bot_token=args.slack_token,
-            app_token=args.slack_app_token,
-            allowed_channels=[c.strip() for c in args.slack_channels.split(",") if c.strip()],
-            slash_command=args.slack_slash_command,
-        )
-        slack_bot = TurnstoneSlackBot(
-            config,
-            server_url=server_url,
-            storage=_storage,
-            console_url=console_url,
-            console_token_factory=_console_token_factory,
-            server_token_factory=_server_token_factory,
-        )
-
-        async def _run_slack() -> None:
-            try:
-                await slack_bot.start()
-            finally:
-                await slack_bot.stop()
-
-        with contextlib.suppress(KeyboardInterrupt):
-            asyncio.run(_run_slack())
-        return
+    storage = get_storage()
+    adapters: dict[str, ChannelAdapter] = {}
 
     if args.discord_token:
-        import asyncio
-
-        from turnstone.channels._http import _get_service_id, create_channel_app
         from turnstone.channels.discord.bot import TurnstoneBot
         from turnstone.channels.discord.config import DiscordConfig
-        from turnstone.core.storage._registry import get_storage
 
         allowed_channels: list[int] = []
         if args.discord_channels:
@@ -287,9 +251,7 @@ def main() -> None:
             guild_id=args.discord_guild,
             allowed_channels=allowed_channels,
         )
-
-        storage = get_storage()
-        bot = TurnstoneBot(
+        discord_bot = TurnstoneBot(
             discord_config,
             server_url,
             storage,
@@ -297,99 +259,120 @@ def main() -> None:
             console_token_factory=_console_token_factory,
             server_token_factory=_server_token_factory,
         )
-        adapters = {"discord": bot}
+        adapters[discord_bot.channel_type] = cast(ChannelAdapter, discord_bot)
 
-        # Create HTTP app for notification delivery
-        channel_app = create_channel_app(
-            adapters,  # type: ignore[arg-type]
-            storage,
-            jwt_secret=jwt_secret,
+    if args.slack_token:
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        slack_config = SlackConfig(
+            model=args.model,
+            auto_approve=args.auto_approve,
+            bot_token=args.slack_token,
+            app_token=args.slack_app_token,
+            allowed_channels=[c.strip() for c in args.slack_channels.split(",") if c.strip()],
+            slash_command=args.slack_slash_command,
         )
-
-        log.info(
-            "channel.starting",
-            adapter="discord",
-            guild_id=discord_config.guild_id,
-            http_port=args.http_port,
+        slack_bot = TurnstoneSlackBot(
+            slack_config,
             server_url=server_url,
+            storage=storage,
+            console_url=console_url,
+            console_token_factory=_console_token_factory,
+            server_token_factory=_server_token_factory,
+        )
+        adapters[slack_bot.channel_type] = cast(ChannelAdapter, slack_bot)
+
+    channel_app = create_channel_app(
+        adapters,
+        storage,
+        jwt_secret=jwt_secret,
+    )
+
+    log.info(
+        "channel.starting",
+        adapters=list(adapters.keys()),
+        http_port=args.http_port,
+        server_url=server_url,
+    )
+
+    async def _run_all() -> None:
+        """Run all adapters + HTTP server + service heartbeat concurrently."""
+        import uvicorn
+
+        service_id = _get_service_id()
+
+        # Resolve advertise URL — env override for Docker/K8s,
+        # otherwise derive from bind address.
+        advertise_url = os.environ.get("TURNSTONE_CHANNEL_ADVERTISE_URL", "").strip()
+        if not advertise_url:
+            if args.http_host in ("0.0.0.0", "::"):
+                advertise_host = socket.gethostname()
+            else:
+                advertise_host = args.http_host
+            scheme = "https" if args.ssl_certfile else "http"
+            advertise_url = f"{scheme}://{advertise_host}:{args.http_port}"
+        service_url = advertise_url
+
+        # Register in service registry
+        storage.register_service("channel", service_id, service_url)
+        log.info(
+            "channel.service_registered",
+            service_id=service_id,
+            url=service_url,
         )
 
-        async def _run_all() -> None:
-            """Run Discord bot + HTTP server + service heartbeat concurrently."""
-            import uvicorn
+        async def _heartbeat_loop() -> None:
+            """Periodically update service heartbeat."""
+            from turnstone.core.storage._registry import StorageUnavailableError
 
-            service_id = _get_service_id()
+            while True:
+                await asyncio.sleep(30)
+                try:
+                    await asyncio.to_thread(storage.heartbeat_service, "channel", service_id)
+                except StorageUnavailableError:
+                    pass  # already logged by storage layer
+                except Exception:
+                    log.exception("channel.heartbeat_failed")
 
-            # Resolve advertise URL — env override for Docker/K8s,
-            # otherwise derive from bind address.
-            advertise_url = os.environ.get("TURNSTONE_CHANNEL_ADVERTISE_URL", "").strip()
-            if not advertise_url:
-                if args.http_host in ("0.0.0.0", "::"):
-                    advertise_host = socket.gethostname()
-                else:
-                    advertise_host = args.http_host
-                scheme = "https" if args.ssl_certfile else "http"
-                advertise_url = f"{scheme}://{advertise_host}:{args.http_port}"
-            service_url = advertise_url
-
-            # Register in service registry
-            storage.register_service("channel", service_id, service_url)
-            log.info(
-                "channel.service_registered",
-                service_id=service_id,
-                url=service_url,
+        # TLS: use cert files if available (from bootstrap or TLSClient)
+        ssl_certfile = getattr(args, "ssl_certfile", None)
+        ssl_keyfile = getattr(args, "ssl_keyfile", None)
+        ssl_ca_certs = getattr(args, "ssl_ca_certs", None)
+        if bool(ssl_certfile) != bool(ssl_keyfile):
+            print(
+                "Both --ssl-certfile and --ssl-keyfile are required for TLS",
+                file=sys.stderr,
             )
+            sys.exit(1)
 
-            async def _heartbeat_loop() -> None:
-                """Periodically update service heartbeat."""
-                from turnstone.core.storage._registry import StorageUnavailableError
+        uv_config = uvicorn.Config(
+            channel_app,
+            host=args.http_host,
+            port=args.http_port,
+            log_level="warning",
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
+            ssl_ca_certs=ssl_ca_certs,
+        )
+        server = uvicorn.Server(uv_config)
 
-                while True:
-                    await asyncio.sleep(30)
-                    try:
-                        await asyncio.to_thread(storage.heartbeat_service, "channel", service_id)
-                    except StorageUnavailableError:
-                        pass  # already logged by storage layer
-                    except Exception:
-                        log.exception("channel.heartbeat_failed")
-
-            # TLS: use cert files if available (from bootstrap or TLSClient)
-            ssl_certfile = getattr(args, "ssl_certfile", None)
-            ssl_keyfile = getattr(args, "ssl_keyfile", None)
-            ssl_ca_certs = getattr(args, "ssl_ca_certs", None)
-            if bool(ssl_certfile) != bool(ssl_keyfile):
-                print(
-                    "Both --ssl-certfile and --ssl-keyfile are required for TLS",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-            uv_config = uvicorn.Config(
-                channel_app,
-                host=args.http_host,
-                port=args.http_port,
-                log_level="warning",
-                ssl_certfile=ssl_certfile,
-                ssl_keyfile=ssl_keyfile,
-                ssl_ca_certs=ssl_ca_certs,
+        heartbeat_task = asyncio.create_task(_heartbeat_loop())
+        try:
+            await asyncio.gather(
+                *(adapter.start() for adapter in adapters.values()),
+                server.serve(),
             )
-            server = uvicorn.Server(uv_config)
+        finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
 
-            heartbeat_task = asyncio.create_task(_heartbeat_loop())
-            try:
-                await asyncio.gather(
-                    bot.start(),
-                    server.serve(),
-                )
-            finally:
-                heartbeat_task.cancel()
-                await asyncio.to_thread(storage.deregister_service, "channel", service_id)
-                log.info("channel.service_deregistered", service_id=service_id)
+            await asyncio.to_thread(storage.deregister_service, "channel", service_id)
+            log.info("channel.service_deregistered", service_id=service_id)
 
-        import contextlib
-
-        with contextlib.suppress(KeyboardInterrupt):
-            asyncio.run(_run_all())
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(_run_all())
 
 
 if __name__ == "__main__":

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -233,6 +233,7 @@ def main() -> None:
     if args.slack_token and not args.discord_token:
         import asyncio
         import contextlib
+
         from turnstone.channels.slack.bot import TurnstoneSlackBot
         from turnstone.channels.slack.config import SlackConfig
 

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -74,6 +74,12 @@ def _sanitize_slack_preview(text: str, max_length: int = 1200) -> str:
         return text[: max_length - 3] + "..."
     return text
 
+def _parse_ts(ts: str) -> tuple[int, int]:
+    parts = ts.split(".", 1)
+    seconds = int(parts[0])
+    micros = int(parts[1]) if len(parts) > 1 else 0
+    return (seconds, micros)
+
 @dataclass(frozen=True)
 class PendingApproval:
     channel: str
@@ -267,7 +273,7 @@ class TurnstoneSlackBot:
                 key = (slack_route.channel, slack_route.user_id)
                 existing = latest_sessions.get(key)
 
-                if existing is None or float(slack_route.thread_ts) > float(existing[1]):
+                if existing is None or _parse_ts(slack_route.thread_ts) > _parse_ts(existing[1]):
                     latest_sessions[key] = (ws_id, slack_route.thread_ts)
 
             log.info("slack.route_recovered", ws_id=ws_id, channel_id=channel_id)

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -183,7 +183,11 @@ class TurnstoneSlackBot:
         self._streaming: dict[str, StreamingMessage] = {}
 
         self._pending_approval_ts: dict[str, tuple[str, str]] = {}
+        self._pending_plan_review_ts: dict[str, tuple[str, str]] = {}
         self._notify_ws_map: dict[str, tuple[str, str, str]] = {}
+        # Temporary reply forwarding for notification conversations:
+        # maps ws_id -> canonical Slack route string
+        self._notify_reply_routes: dict[str, str] = {}
         self._channel_sessions: dict[tuple[str, str], tuple[str, str]] = {}
 
         headers: dict[str, str] = {}
@@ -204,6 +208,9 @@ class TurnstoneSlackBot:
         self._app.event("message")(self._on_message)
         self._app.action("ts_approve")(self._on_approve)
         self._app.action("ts_deny")(self._on_deny)
+        self._app.action("ts_plan_approve")(self._on_plan_approve)
+        self._app.action("ts_plan_request_changes")(self._on_plan_request_changes)
+        self._app.view("ts_plan_feedback_modal")(self._on_plan_feedback_modal)
 
     async def start(self) -> None:
         from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
@@ -211,7 +218,7 @@ class TurnstoneSlackBot:
         self._handler = AsyncSocketModeHandler(self._app, self._app_token)
         await self._recover_routes()
         log.info("slack.starting_socket_mode")
-        await self._handler.start_async()  # type: ignore[no-untyped-call]
+        await self._handler.start_async()
 
     async def stop(self) -> None:
         for ws_id in list(self._subscribed_ws):
@@ -219,7 +226,7 @@ class TurnstoneSlackBot:
         await self.router.aclose()
         await self._http_client.aclose()
         if self._handler is not None:
-            await self._handler.close_async()  # type: ignore[no-untyped-call]
+            await self._handler.close_async()
         log.info("slack.stopped")
 
     async def _recover_routes(self) -> None:
@@ -237,9 +244,8 @@ class TurnstoneSlackBot:
 
             await self.subscribe_ws(ws_id, channel_id)
 
-            parts = channel_id.split(":", 2)
-            if len(parts) == 3:
-                slack_channel, user_id, thread_ts = parts
+            slack_channel, user_id, thread_ts = self._parse_route(channel_id)
+            if slack_channel and user_id and thread_ts:
                 key = (slack_channel, user_id)
                 existing = latest_sessions.get(key)
 
@@ -266,10 +272,7 @@ class TurnstoneSlackBot:
         slack_channel = body["channel_id"]
         user_id = body["user_id"]
 
-        if (
-            self.config.allowed_channels
-            and slack_channel not in self.config.allowed_channels
-        ):
+        if self.config.allowed_channels and slack_channel not in self.config.allowed_channels:
             await self._client.chat_postEphemeral(
                 channel=slack_channel,
                 user=user_id,
@@ -377,22 +380,29 @@ class TurnstoneSlackBot:
         if not text or not channel_id or not user_id:
             return
 
+        if thread_ts and thread_ts in self._notify_ws_map:
+            origin_ws_id, notify_channel_id, target_user_id = self._notify_ws_map[thread_ts]
+            if channel_id == notify_channel_id and user_id == target_user_id:
+                try:
+                    reply_thread_ts = thread_ts or event.get("ts", "")
+                    self._notify_reply_routes[origin_ws_id] = self._format_route(
+                        channel_id,
+                        target_user_id,
+                        reply_thread_ts,
+                    )
+                    await self.router.send_message(origin_ws_id, text)
+                    log.info("slack.notification_reply_routed", ws_id=origin_ws_id)
+                except Exception:
+                    self._notify_reply_routes.pop(origin_ws_id, None)
+                    log.exception("slack.notification_reply_failed")
+                return
+
         if channel_id.startswith("D") or channel_type == "im":
             await self._handle_dm(event, say)
             return
 
         if self.config.allowed_channels and channel_id not in self.config.allowed_channels:
             return
-
-        if thread_ts and thread_ts in self._notify_ws_map:
-            origin_ws_id, notify_channel_id, target_user_id = self._notify_ws_map[thread_ts]
-            if channel_id == notify_channel_id and user_id == target_user_id:
-                try:
-                    await self.router.send_message(origin_ws_id, text)
-                    log.info("slack.notification_reply_routed", ws_id=origin_ws_id)
-                except Exception:
-                    log.exception("slack.notification_reply_failed")
-                return
 
         session = self._channel_sessions.get((channel_id, user_id))
         if session is None:
@@ -485,6 +495,97 @@ class TurnstoneSlackBot:
         except Exception:
             log.debug("slack.deny_message_update_failed")
 
+    async def _on_plan_approve(self, ack: Any, body: dict[str, Any]) -> None:
+        await ack()
+        ws_id = body["actions"][0].get("value", "")
+        if not ws_id:
+            return
+
+        await self.router.send_plan_feedback(ws_id, "", "")
+
+        channel = body["container"]["channel_id"]
+        ts = body["container"]["message_ts"]
+
+        self._pending_plan_review_ts.pop(ws_id, None)
+
+        try:
+            await self._client.chat_update(
+                channel=channel,
+                ts=ts,
+                text="Plan approved",
+                blocks=[],
+            )
+        except Exception:
+            log.debug("slack.plan_review_approve_update_failed")
+
+    async def _on_plan_request_changes(self, ack: Any, body: dict[str, Any], client: Any) -> None:
+        await ack()
+        ws_id = body["actions"][0].get("value", "")
+        if not ws_id:
+            return
+
+        trigger_id = body.get("trigger_id", "")
+        if not trigger_id:
+            return
+
+        await client.views_open(
+            trigger_id=trigger_id,
+            view={
+                "type": "modal",
+                "callback_id": "ts_plan_feedback_modal",
+                "private_metadata": ws_id,
+                "title": {"type": "plain_text", "text": "Plan feedback"},
+                "submit": {"type": "plain_text", "text": "Send"},
+                "close": {"type": "plain_text", "text": "Cancel"},
+                "blocks": [
+                    {
+                        "type": "input",
+                        "block_id": "feedback_block",
+                        "label": {"type": "plain_text", "text": "Requested changes"},
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": "feedback_input",
+                            "multiline": True,
+                        },
+                    }
+                ],
+            },
+        )
+
+    async def _on_plan_feedback_modal(self, ack: Any, body: dict[str, Any], view: dict[str, Any]) -> None:
+        await ack()
+
+        ws_id = view.get("private_metadata", "")
+        if not ws_id:
+            return
+
+        feedback = (
+            view.get("state", {})
+            .get("values", {})
+            .get("feedback_block", {})
+            .get("feedback_input", {})
+            .get("value", "")
+            .strip()
+        )
+
+        if not feedback:
+            feedback = "Please revise the plan."
+
+        await self.router.send_plan_feedback(ws_id, "", feedback)
+
+        entry = self._pending_plan_review_ts.pop(ws_id, None)
+        if entry is not None:
+            channel, ts = entry
+            try:
+                await self._client.chat_update(
+                    channel=channel,
+                    ts=ts,
+                    text="Plan changes requested",
+                    blocks=[],
+                )
+            except Exception:
+                log.debug("slack.plan_review_modal_update_failed")
+
     async def subscribe_ws(self, ws_id: str, channel_id: str) -> None:
         if ws_id in self._subscribed_ws:
             return
@@ -507,6 +608,8 @@ class TurnstoneSlackBot:
         self._subscribed_ws.discard(ws_id)
         self._streaming.pop(ws_id, None)
         self._pending_approval_ts.pop(ws_id, None)
+        self._pending_plan_review_ts.pop(ws_id, None)
+        self._notify_reply_routes.pop(ws_id, None)
 
         stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
         for ts in stale:
@@ -517,10 +620,6 @@ class TurnstoneSlackBot:
     async def _sse_listener(self, ws_id: str, channel_id: str) -> None:
         """Connect to the server SSE endpoint and dispatch events."""
         import httpx_sse
-
-        parts = channel_id.split(":", 2)
-        slack_channel = parts[0]
-        thread_ts = parts[2] if len(parts) == 3 else (parts[1] if len(parts) == 2 else "")
 
         delay = _SSE_RECONNECT_DELAY
         url = ""
@@ -570,6 +669,11 @@ class TurnstoneSlackBot:
 
                             event = ServerEvent.from_dict(data)
                             try:
+                                effective_route = self._notify_reply_routes.get(ws_id, channel_id)
+                                slack_channel, _target_user_id, thread_ts = self._parse_route(
+                                    effective_route
+                                )
+
                                 await self._on_ws_event(
                                     ws_id,
                                     slack_channel,
@@ -606,9 +710,8 @@ class TurnstoneSlackBot:
 
     async def _cleanup_stale_route(self, ws_id: str, channel_id: str) -> None:
         """Remove a channel route whose workstream no longer exists."""
-        parts = channel_id.split(":", 2)
-        if len(parts) == 3:
-            slack_channel, user_id, _ = parts
+        slack_channel, user_id, thread_ts = self._parse_route(channel_id)
+        if slack_channel and user_id and thread_ts:
             self._channel_sessions.pop((slack_channel, user_id), None)
 
         await self.router.delete_route("slack", channel_id)
@@ -616,6 +719,8 @@ class TurnstoneSlackBot:
         self._sse_tasks.pop(ws_id, None)
         self._streaming.pop(ws_id, None)
         self._pending_approval_ts.pop(ws_id, None)
+        self._pending_plan_review_ts.pop(ws_id, None)
+        self._notify_reply_routes.pop(ws_id, None)
 
         stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
         for ts in stale:
@@ -636,7 +741,7 @@ class TurnstoneSlackBot:
 
         elif isinstance(event, ContentEvent):
             sm = self._streaming.get(ws_id)
-            if sm is None:
+            if sm is None or sm.channel != slack_channel or sm.thread_ts != thread_ts:
                 sm = StreamingMessage(
                     client=self._client,
                     channel=slack_channel,
@@ -645,6 +750,7 @@ class TurnstoneSlackBot:
                     edit_interval=self.config.streaming_edit_interval,
                 )
                 self._streaming[ws_id] = sm
+
             await sm.append(event.text)
 
         elif isinstance(event, ApproveRequestEvent):
@@ -753,11 +859,44 @@ class TurnstoneSlackBot:
                     log.debug("slack.verdict_message_update_failed", ws_id=ws_id)
 
         elif isinstance(event, PlanReviewEvent):
-            await self._client.chat_postMessage(
+            log.info("slack.plan_review_received", ws_id=ws_id)
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Plan Review*\n```{event.content[:2000]}```",
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Approve"},
+                            "style": "primary",
+                            "action_id": "ts_plan_approve",
+                            "value": ws_id,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Request changes"},
+                            "style": "danger",
+                            "action_id": "ts_plan_request_changes",
+                            "value": ws_id,
+                        },
+                    ],
+                },
+            ]
+
+            resp = await self._client.chat_postMessage(
                 channel=slack_channel,
                 thread_ts=thread_ts or None,
-                text=f"*Plan Review*\n```{event.content[:2000]}```",
+                text="Plan review required",
+                blocks=cast("list[dict[str, Any]]", blocks),
             )
+            if resp.get("ok"):
+                self._pending_plan_review_ts[ws_id] = (slack_channel, resp["ts"])
 
         elif isinstance(event, ApprovalResolvedEvent):
             entry = self._pending_approval_ts.pop(ws_id, None)
@@ -776,8 +915,21 @@ class TurnstoneSlackBot:
 
         elif isinstance(event, StreamEndEvent):
             sm = self._streaming.pop(ws_id, None)
+
             if sm is not None:
                 await sm.finalize()
+
+            reply_route = self._notify_reply_routes.get(ws_id)
+            if reply_route is not None and sm is not None and sm._ts:
+                reply_channel, target_user_id, _reply_thread_ts = self._parse_route(reply_route)
+                if reply_channel and target_user_id:
+                    self._track_notification(
+                        sm._ts,
+                        ws_id,
+                        reply_channel,
+                        target_user_id,
+                    )
+
             self._pending_approval_ts.pop(ws_id, None)
 
         elif isinstance(event, ErrorEvent):
@@ -858,6 +1010,27 @@ class TurnstoneSlackBot:
 
         return True
 
+    def _parse_route(self, channel_id: str) -> tuple[str, str, str]:
+        """Parse canonical Slack route as (channel, user_id, thread_ts)."""
+        parts = channel_id.split(":", 2)
+        slack_channel = parts[0]
+        user_id = parts[1] if len(parts) >= 2 else ""
+        thread_ts = parts[2] if len(parts) == 3 else ""
+        return slack_channel, user_id, thread_ts
+
+    def _format_route(
+        self,
+        slack_channel: str,
+        user_id: str = "",
+        thread_ts: str = "",
+    ) -> str:
+        """Format canonical Slack route as channel[:user_id[:thread_ts]]."""
+        if thread_ts:
+            return f"{slack_channel}:{user_id}:{thread_ts}"
+        if user_id:
+            return f"{slack_channel}:{user_id}"
+        return slack_channel
+
     def _track_notification(
         self,
         msg_ts: str,
@@ -870,9 +1043,7 @@ class TurnstoneSlackBot:
         self._notify_ws_map[msg_ts] = (ws_id, slack_channel, target_user_id)
 
     async def send(self, channel_id: str, content: str) -> str:
-        parts = channel_id.split(":", 2)
-        slack_channel = parts[0]
-        thread_ts = parts[2] if len(parts) == 3 else (parts[1] if len(parts) == 2 else "")
+        slack_channel, _user_id, thread_ts = self._parse_route(channel_id)
 
         last_ts = ""
         for chunk in chunk_message(content, self.config.max_message_length):
@@ -889,9 +1060,7 @@ class TurnstoneSlackBot:
     async def send_notification(self, channel_id: str, content: str, ws_id: str) -> str:
         msg_ts = await self.send(channel_id, content)
         if msg_ts and ws_id:
-            parts = channel_id.split(":", 2)
-            slack_channel = parts[0]
-            target_user_id = parts[1] if len(parts) >= 2 else ""
+            slack_channel, target_user_id, _thread_ts = self._parse_route(channel_id)
             if slack_channel and target_user_id:
                 self._track_notification(
                     msg_ts,

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -1045,34 +1045,36 @@ class TurnstoneSlackBot:
     async def send(self, channel_id: str, content: str) -> str:
         slack_channel, _user_id, thread_ts = self._parse_route(channel_id)
 
-        last_ts = ""
-        for chunk in chunk_message(content, self.config.max_message_length):
+        root_ts = thread_ts or ""
+        first_post_ts = ""
+
+        for i, chunk in enumerate(chunk_message(content, self.config.max_message_length)):
             resp = await self._client.chat_postMessage(
                 channel=slack_channel,
-                thread_ts=thread_ts or None,
+                thread_ts=root_ts or None,
                 text=chunk,
             )
             if resp.get("ok"):
-                last_ts = resp["ts"]
+                ts = resp["ts"]
+                if i == 0:
+                    first_post_ts = ts
+                    if not root_ts:
+                        # If we started a new thread, all later chunks should go under it
+                        root_ts = ts
 
-        return last_ts
+        # If this was a new top-level notification, return the thread root ts
+        # If it was sent into an existing thread, return that existing thread ts
+        return root_ts or first_post_ts
 
     async def send_notification(self, channel_id: str, content: str, ws_id: str) -> str:
-        msg_ts = await self.send(channel_id, content)
-        if msg_ts and ws_id:
+        thread_root_ts = await self.send(channel_id, content)
+        if thread_root_ts and ws_id:
             slack_channel, target_user_id, _thread_ts = self._parse_route(channel_id)
             if slack_channel and target_user_id:
                 self._track_notification(
-                    msg_ts,
+                    thread_root_ts,
                     ws_id,
                     slack_channel,
                     target_user_id,
                 )
-                log.debug(
-                    "slack.notification_tracked",
-                    message_ts=msg_ts,
-                    ws_id=ws_id,
-                    channel=slack_channel,
-                    user=target_user_id,
-                )
-        return msg_ts
+        return thread_root_ts

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -242,7 +242,7 @@ class TurnstoneSlackBot:
         self._handler = AsyncSocketModeHandler(self._app, self._app_token)
         await self._recover_routes()
         log.info("slack.starting_socket_mode")
-        await self._handler.start_async()
+        await self._handler.start_async()  # type: ignore[no-untyped-call]
 
     async def stop(self) -> None:
         for ws_id in list(self._subscribed_ws):
@@ -250,7 +250,7 @@ class TurnstoneSlackBot:
         await self.router.aclose()
         await self._http_client.aclose()
         if self._handler is not None:
-            await self._handler.close_async()
+            await self._handler.close_async()  # type: ignore[no-untyped-call]
         log.info("slack.stopped")
 
     async def _recover_routes(self) -> None:

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -512,7 +512,28 @@ class TurnstoneSlackBot:
         actor_user_id = body.get("user", {}).get("id", "")
         channel = body["container"]["channel_id"]
 
-        if entry and entry.owner_user_id and actor_user_id != entry.owner_user_id:
+        log.info(
+            "slack.approval_actor_check",
+            ws_id=ws_id,
+            actor_user_id=actor_user_id,
+            owner_user_id=entry.owner_user_id if entry else None,
+            has_entry=entry is not None,
+        )
+
+        if entry is None or not entry.owner_user_id:
+            log.warning(
+                "slack.approval_missing_owner",
+                ws_id=ws_id,
+                actor_user_id=actor_user_id,
+            )
+            await self._client.chat_postEphemeral(
+                channel=channel,
+                user=actor_user_id,
+                text="This approval can no longer be verified. Please retry from the active session.",
+            )
+            return
+
+        if actor_user_id != entry.owner_user_id:
             await self._client.chat_postEphemeral(
                 channel=channel,
                 user=actor_user_id,
@@ -545,7 +566,28 @@ class TurnstoneSlackBot:
         actor_user_id = body.get("user", {}).get("id", "")
         channel = body["container"]["channel_id"]
 
-        if entry and entry.owner_user_id and actor_user_id != entry.owner_user_id:
+        log.info(
+            "slack.approval_actor_check",
+            ws_id=ws_id,
+            actor_user_id=actor_user_id,
+            owner_user_id=entry.owner_user_id if entry else None,
+            has_entry=entry is not None,
+        )
+
+        if entry is None or not entry.owner_user_id:
+            log.warning(
+                "slack.approval_missing_owner",
+                ws_id=ws_id,
+                actor_user_id=actor_user_id,
+            )
+            await self._client.chat_postEphemeral(
+                channel=channel,
+                user=actor_user_id,
+                text="This approval can no longer be verified. Please retry from the active session.",
+            )
+            return
+
+        if actor_user_id != entry.owner_user_id:
             await self._client.chat_postEphemeral(
                 channel=channel,
                 user=actor_user_id,
@@ -1060,6 +1102,13 @@ class TurnstoneSlackBot:
             self._pending_approval[ws_id] = PendingApproval(
                 channel=channel,
                 message_ts=resp["ts"],
+                owner_user_id=owner_user_id,
+            )
+            log.info(
+                "slack.pending_approval_stored",
+                ws_id=ws_id,
+                channel=channel,
+                thread_ts=thread_ts,
                 owner_user_id=owner_user_id,
             )
 

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -631,10 +631,7 @@ class TurnstoneSlackBot:
         event: ServerEvent,
     ) -> None:
         """Handle a typed server event for a subscribed workstream."""
-        if isinstance(event, ThinkingStartEvent):
-            pass
-
-        elif isinstance(event, ThinkingStopEvent):
+        if isinstance(event, (ThinkingStartEvent, ThinkingStopEvent)):
             pass
 
         elif isinstance(event, ContentEvent):
@@ -772,7 +769,7 @@ class TurnstoneSlackBot:
                         channel=pending_channel,
                         ts=pending_ts,
                         text=label,
-                        blocks=cast(list[dict[str, Any]], []),
+                        blocks=cast("list[dict[str, Any]]", []),
                     )
                 except Exception:
                     log.debug("slack.approval_resolved_edit_failed", ws_id=ws_id)
@@ -840,7 +837,7 @@ class TurnstoneSlackBot:
             channel=channel,
             thread_ts=thread_ts or None,
             text="Tool approval required",
-            blocks=cast(list[dict[str, Any]], blocks),
+            blocks=cast("list[dict[str, Any]]", blocks),
         )
         if resp.get("ok"):
             self._pending_approval_ts[ws_id] = (channel, resp["ts"])

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -35,6 +35,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from turnstone.channels._formatter import chunk_message
 from turnstone.channels._routing import ChannelRouter
+from turnstone.channels.slack.routes import SlackRoute
 from turnstone.core.log import get_logger
 from turnstone.sdk._types import TurnstoneAPIError
 from turnstone.sdk.events import (
@@ -58,14 +59,20 @@ if TYPE_CHECKING:
     from turnstone.channels.slack.config import SlackConfig
     from turnstone.core.storage._protocol import StorageBackend
 
-from turnstone.channels.slack.routes import SlackRoute
-
 log = get_logger(__name__)
 
 _GREETING = "Hey! Let me know what I can help with."
 
 _SSE_RECONNECT_DELAY: float = 2.0
 _SSE_MAX_RECONNECT_DELAY: float = 30.0
+
+
+@dataclass(frozen=True)
+class PendingApproval:
+    channel: str
+    message_ts: str
+    owner_user_id: str | None = None
+
 
 @dataclass
 class StreamingMessage:
@@ -185,7 +192,7 @@ class TurnstoneSlackBot:
         self._sse_tasks: dict[str, asyncio.Task[None]] = {}
         self._streaming: dict[str, StreamingMessage] = {}
 
-        self._pending_approval_ts: dict[str, tuple[str, str]] = {}
+        self._pending_approval: dict[str, PendingApproval] = {}
         self._pending_plan_review_ts: dict[str, tuple[str, str]] = {}
         self._notify_ws_map: dict[str, tuple[str, SlackRoute]] = {}
         # Per-workstream override used to route the next streamed assistant
@@ -422,9 +429,9 @@ class TurnstoneSlackBot:
                         )
                         try:
                             slash_cmd = self.config.slash_command or "/turnstone"
-                            await self._client.chat_postMessage(
+                            await self._client.chat_postEphemeral(
                                 channel=channel_id,
-                                thread_ts=thread_ts or None,
+                                user=user_id,
                                 text=(
                                     "This notification is no longer linked to an active session. "
                                     f"Please start a new one with `{slash_cmd}`."
@@ -501,8 +508,19 @@ class TurnstoneSlackBot:
             return
 
         ws_id, correlation_id = parts
-        await self.router.send_approval(ws_id, correlation_id, approved=True)
+        entry = self._pending_approval.get(ws_id)
+        actor_user_id = body.get("user", {}).get("id", "")
         channel = body["container"]["channel_id"]
+
+        if entry and entry.owner_user_id and actor_user_id != entry.owner_user_id:
+            await self._client.chat_postEphemeral(
+                channel=channel,
+                user=actor_user_id,
+                text="Only the session owner can approve this tool call.",
+            )
+            return
+
+        await self.router.send_approval(ws_id, correlation_id, approved=True)
         ts = body["container"]["message_ts"]
 
         try:
@@ -523,8 +541,19 @@ class TurnstoneSlackBot:
             return
 
         ws_id, correlation_id = parts
-        await self.router.send_approval(ws_id, correlation_id, approved=False)
+        entry = self._pending_approval.get(ws_id)
+        actor_user_id = body.get("user", {}).get("id", "")
         channel = body["container"]["channel_id"]
+
+        if entry and entry.owner_user_id and actor_user_id != entry.owner_user_id:
+            await self._client.chat_postEphemeral(
+                channel=channel,
+                user=actor_user_id,
+                text="Only the session owner can deny this tool call.",
+            )
+            return
+
+        await self.router.send_approval(ws_id, correlation_id, approved=False)
         ts = body["container"]["message_ts"]
 
         try:
@@ -656,7 +685,7 @@ class TurnstoneSlackBot:
 
         self._subscribed_ws.discard(ws_id)
         self._streaming.pop(ws_id, None)
-        self._pending_approval_ts.pop(ws_id, None)
+        self._pending_approval.pop(ws_id, None)
         self._pending_plan_review_ts.pop(ws_id, None)
         self._clear_notification_tracking_for_ws(ws_id)
 
@@ -718,12 +747,7 @@ class TurnstoneSlackBot:
                                     ws_id,
                                     SlackRoute.parse(channel_id),
                                 )
-                                await self._on_ws_event(
-                                    ws_id,
-                                    effective_route.channel,
-                                    effective_route.thread_ts or "",
-                                    event,
-                                )
+                                await self._on_ws_event(ws_id, effective_route, event)
                             except Exception:
                                 log.warning(
                                     "slack.event_dispatch_failed",
@@ -762,7 +786,7 @@ class TurnstoneSlackBot:
         self._subscribed_ws.discard(ws_id)
         self._sse_tasks.pop(ws_id, None)
         self._streaming.pop(ws_id, None)
-        self._pending_approval_ts.pop(ws_id, None)
+        self._pending_approval.pop(ws_id, None)
         self._pending_plan_review_ts.pop(ws_id, None)
         self._clear_notification_tracking_for_ws(ws_id)
 
@@ -771,11 +795,14 @@ class TurnstoneSlackBot:
     async def _on_ws_event(
         self,
         ws_id: str,
-        slack_channel: str,
-        thread_ts: str,
+        route: SlackRoute,
         event: ServerEvent,
     ) -> None:
         """Handle a typed server event for a subscribed workstream."""
+        slack_channel = route.channel
+        thread_ts = route.thread_ts or ""
+        owner_user_id = route.user_id
+
         if isinstance(event, (ThinkingStartEvent, ThinkingStopEvent)):
             pass
 
@@ -858,12 +885,14 @@ class TurnstoneSlackBot:
                     event.items,
                     slack_channel,
                     thread_ts,
+                    owner_user_id,
                 )
 
         elif isinstance(event, IntentVerdictEvent):
-            entry = self._pending_approval_ts.get(ws_id)
+            entry = self._pending_approval.get(ws_id)
             if entry is not None:
-                pending_channel, pending_ts = entry
+                pending_channel = entry.channel
+                pending_ts = entry.message_ts
                 risk = (event.risk_level or "medium").upper()
                 verdict_text = (
                     f"*Judge Verdict: {event.func_name or 'tool'}*\n"
@@ -939,9 +968,10 @@ class TurnstoneSlackBot:
                 self._pending_plan_review_ts[ws_id] = (slack_channel, resp["ts"])
 
         elif isinstance(event, ApprovalResolvedEvent):
-            entry = self._pending_approval_ts.pop(ws_id, None)
+            entry = self._pending_approval.pop(ws_id, None)
             if entry is not None:
-                pending_channel, pending_ts = entry
+                pending_channel = entry.channel
+                pending_ts = entry.message_ts
                 label = "Approved" if event.approved else "Denied"
                 try:
                     await self._client.chat_update(
@@ -964,7 +994,7 @@ class TurnstoneSlackBot:
                 if reply_route.channel and reply_route.user_id:
                     self._track_notification(sm._ts, ws_id, reply_route)
 
-            self._pending_approval_ts.pop(ws_id, None)
+            self._pending_approval.pop(ws_id, None)
 
         elif isinstance(event, ErrorEvent):
             safe_msg = event.message[:500] if event.message else "An error occurred"
@@ -981,6 +1011,7 @@ class TurnstoneSlackBot:
         items: list[dict[str, Any]],
         channel: str,
         thread_ts: str,
+        owner_user_id: str | None,
     ) -> None:
         tool_lines = []
         for item in items:
@@ -1026,7 +1057,11 @@ class TurnstoneSlackBot:
             blocks=cast("list[dict[str, Any]]", blocks),
         )
         if resp.get("ok"):
-            self._pending_approval_ts[ws_id] = (channel, resp["ts"])
+            self._pending_approval[ws_id] = PendingApproval(
+                channel=channel,
+                message_ts=resp["ts"],
+                owner_user_id=owner_user_id,
+            )
 
     def _should_auto_approve(self, event: ApproveRequestEvent) -> bool:
         allowed = self.config.auto_approve_tools

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -5,9 +5,10 @@ or API Gateway is required. Mirrors the Discord adapter pattern.
 
 Interaction model
 -----------------
-* **Channels**: invoke with ``/turnstone``. The bot replies in a thread and
-  waits for messages there. Messages outside a bot-created thread are ignored.
-  Running ``/turnstone`` again in the same channel (by the same user)
+* **Channels**: invoke with the configured Slack slash command. The bot replies
+  in a thread and waits for messages there. Messages outside a bot-created
+  thread are ignored.
+* Running the slash command again in the same channel (by the same user)
   archives the old workstream and starts a fresh thread.
 * **DMs**: every message is routed freely, no slash command needed.
 
@@ -35,6 +36,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 from turnstone.channels._formatter import chunk_message
 from turnstone.channels._routing import ChannelRouter
 from turnstone.core.log import get_logger
+from turnstone.sdk._types import TurnstoneAPIError
 from turnstone.sdk.events import (
     ApprovalResolvedEvent,
     ApproveRequestEvent,
@@ -56,13 +58,14 @@ if TYPE_CHECKING:
     from turnstone.channels.slack.config import SlackConfig
     from turnstone.core.storage._protocol import StorageBackend
 
+from turnstone.channels.slack.routes import SlackRoute
+
 log = get_logger(__name__)
 
 _GREETING = "Hey! Let me know what I can help with."
 
 _SSE_RECONNECT_DELAY: float = 2.0
 _SSE_MAX_RECONNECT_DELAY: float = 30.0
-
 
 @dataclass
 class StreamingMessage:
@@ -184,10 +187,11 @@ class TurnstoneSlackBot:
 
         self._pending_approval_ts: dict[str, tuple[str, str]] = {}
         self._pending_plan_review_ts: dict[str, tuple[str, str]] = {}
-        self._notify_ws_map: dict[str, tuple[str, str, str]] = {}
-        # Temporary reply forwarding for notification conversations:
-        # maps ws_id -> canonical Slack route string
-        self._notify_reply_routes: dict[str, str] = {}
+        self._notify_ws_map: dict[str, tuple[str, SlackRoute]] = {}
+        # Per-workstream override used to route the next streamed assistant
+        # response back into a Slack notification reply thread instead of the
+        # default session thread.
+        self._notify_reply_routes: dict[str, SlackRoute] = {}
         self._channel_sessions: dict[tuple[str, str], tuple[str, str]] = {}
 
         headers: dict[str, str] = {}
@@ -244,13 +248,13 @@ class TurnstoneSlackBot:
 
             await self.subscribe_ws(ws_id, channel_id)
 
-            slack_channel, user_id, thread_ts = self._parse_route(channel_id)
-            if slack_channel and user_id and thread_ts:
-                key = (slack_channel, user_id)
+            slack_route = SlackRoute.parse(channel_id)
+            if slack_route.channel and slack_route.user_id and slack_route.thread_ts:
+                key = (slack_route.channel, slack_route.user_id)
                 existing = latest_sessions.get(key)
 
-                if existing is None or float(thread_ts) > float(existing[1]):
-                    latest_sessions[key] = (ws_id, thread_ts)
+                if existing is None or float(slack_route.thread_ts) > float(existing[1]):
+                    latest_sessions[key] = (ws_id, slack_route.thread_ts)
 
             log.info("slack.route_recovered", ws_id=ws_id, channel_id=channel_id)
 
@@ -306,14 +310,18 @@ class TurnstoneSlackBot:
             text=_GREETING,
         )
 
-        route_key = f"{slack_channel}:{user_id}:{opener_ts}"
+        route = SlackRoute(
+            channel=slack_channel,
+            user_id=user_id,
+            thread_ts=opener_ts,
+        )
 
         ws_id, _ = await self.router.get_or_create_workstream(
             channel_type="slack",
-            channel_id=route_key,
+            channel_id=route.to_channel_id(),
             name=f"slack-{slack_channel[:8]}",
         )
-        await self.subscribe_ws(ws_id, route_key)
+        await self.subscribe_ws(ws_id, route.to_channel_id())
         self._channel_sessions[(slack_channel, user_id)] = (ws_id, opener_ts)
 
         log.info(
@@ -341,20 +349,24 @@ class TurnstoneSlackBot:
         except Exception:
             log.debug("slack.archive_session.notify_failed", ws_id=ws_id)
 
-        route_key = f"{slack_channel}:{user_id}:{thread_ts}"
+        route = SlackRoute(
+            channel=slack_channel,
+            user_id=user_id,
+            thread_ts=thread_ts,
+        )
 
         try:
-            await self.router.delete_route("slack", route_key)
+            await self.router.delete_route("slack", route.to_channel_id())
             log.info(
                 "slack.archived_route_deleted",
                 ws_id=ws_id,
-                channel_id=route_key,
+                channel_id=route.to_channel_id(),
             )
         except Exception:
             log.exception(
                 "slack.archived_route_delete_failed",
                 ws_id=ws_id,
-                channel_id=route_key,
+                channel_id=route.to_channel_id(),
             )
 
         await self.unsubscribe_ws(ws_id)
@@ -381,17 +393,47 @@ class TurnstoneSlackBot:
             return
 
         if thread_ts and thread_ts in self._notify_ws_map:
-            origin_ws_id, notify_channel_id, target_user_id = self._notify_ws_map[thread_ts]
-            if channel_id == notify_channel_id and user_id == target_user_id:
+            origin_ws_id, notify_route = self._notify_ws_map[thread_ts]
+            if channel_id == notify_route.channel and user_id == (notify_route.user_id or ""):
                 try:
-                    reply_thread_ts = thread_ts or event.get("ts", "")
-                    self._notify_reply_routes[origin_ws_id] = self._format_route(
-                        channel_id,
-                        target_user_id,
-                        reply_thread_ts,
+                    reply_route = SlackRoute(
+                        channel=channel_id,
+                        user_id=user_id or None,
+                        thread_ts=thread_ts or event.get("ts") or None,
+                    )
+                    self._notify_reply_routes[origin_ws_id] = reply_route
+                    log.info(
+                        "slack.notification_reply_attempt",
+                        thread_ts=thread_ts,
+                        ws_id=origin_ws_id,
+                        channel=channel_id,
+                        user=user_id,
                     )
                     await self.router.send_message(origin_ws_id, text)
                     log.info("slack.notification_reply_routed", ws_id=origin_ws_id)
+                except TurnstoneAPIError as exc:
+                    self._notify_reply_routes.pop(origin_ws_id, None)
+                    if exc.status_code == 404:
+                        self._clear_notification_tracking_for_ws(origin_ws_id)
+                        log.warning(
+                            "slack.notification_reply_dead_ws",
+                            ws_id=origin_ws_id,
+                            thread_ts=thread_ts,
+                        )
+                        try:
+                            slash_cmd = self.config.slash_command or "/turnstone"
+                            await self._client.chat_postMessage(
+                                channel=channel_id,
+                                thread_ts=thread_ts or None,
+                                text=(
+                                    "This notification is no longer linked to an active session. "
+                                    f"Please start a new one with `{slash_cmd}`."
+                                ),
+                            )
+                        except Exception:
+                            log.debug("slack.notification_reply_dead_ws_notice_failed")
+                    else:
+                        log.exception("slack.notification_reply_failed")
                 except Exception:
                     self._notify_reply_routes.pop(origin_ws_id, None)
                     log.exception("slack.notification_reply_failed")
@@ -430,20 +472,20 @@ class TurnstoneSlackBot:
         text = event.get("text", "").strip()
         msg_ts = event.get("ts", "")
         thread_key = thread_ts or msg_ts
-        route_key = (
-            f"{channel_id}:{user_id}:{thread_key}"
-            if thread_key
-            else f"{channel_id}:{user_id}"
+        route = SlackRoute(
+            channel=channel_id,
+            user_id=user_id or None,
+            thread_ts=thread_key or None,
         )
 
         try:
             ws_id, is_new = await self.router.get_or_create_workstream(
                 channel_type="slack",
-                channel_id=route_key,
+                channel_id=route.to_channel_id(),
                 name=f"slack-dm-{user_id[:8]}",
             )
             if is_new:
-                await self.subscribe_ws(ws_id, route_key)
+                await self.subscribe_ws(ws_id, route.to_channel_id())
 
             await self.router.send_message(ws_id, text)
             log.info("slack.dm_dispatched", ws_id=ws_id, user=user_id)
@@ -498,10 +540,13 @@ class TurnstoneSlackBot:
     async def _on_plan_approve(self, ack: Any, body: dict[str, Any]) -> None:
         await ack()
         ws_id = body["actions"][0].get("value", "")
+        log.info("slack.plan_approve_clicked", ws_id=ws_id)
         if not ws_id:
             return
 
+        self._streaming.pop(ws_id, None)
         await self.router.send_plan_feedback(ws_id, "", "")
+        log.info("slack.plan_feedback_sent", ws_id=ws_id, feedback="")
 
         channel = body["container"]["channel_id"]
         ts = body["container"]["message_ts"]
@@ -571,7 +616,11 @@ class TurnstoneSlackBot:
         if not feedback:
             feedback = "Please revise the plan."
 
+        log.info("slack.plan_feedback_modal_submitted", ws_id=ws_id, feedback=feedback)
+
+        self._streaming.pop(ws_id, None)
         await self.router.send_plan_feedback(ws_id, "", feedback)
+        log.info("slack.plan_feedback_sent", ws_id=ws_id, feedback=feedback)
 
         entry = self._pending_plan_review_ts.pop(ws_id, None)
         if entry is not None:
@@ -609,11 +658,7 @@ class TurnstoneSlackBot:
         self._streaming.pop(ws_id, None)
         self._pending_approval_ts.pop(ws_id, None)
         self._pending_plan_review_ts.pop(ws_id, None)
-        self._notify_reply_routes.pop(ws_id, None)
-
-        stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
-        for ts in stale:
-            del self._notify_ws_map[ts]
+        self._clear_notification_tracking_for_ws(ws_id)
 
         log.info("slack.unsubscribed", ws_id=ws_id)
 
@@ -669,15 +714,14 @@ class TurnstoneSlackBot:
 
                             event = ServerEvent.from_dict(data)
                             try:
-                                effective_route = self._notify_reply_routes.get(ws_id, channel_id)
-                                slack_channel, _target_user_id, thread_ts = self._parse_route(
-                                    effective_route
+                                effective_route = self._notify_reply_routes.get(
+                                    ws_id,
+                                    SlackRoute.parse(channel_id),
                                 )
-
                                 await self._on_ws_event(
                                     ws_id,
-                                    slack_channel,
-                                    thread_ts,
+                                    effective_route.channel,
+                                    effective_route.thread_ts or "",
                                     event,
                                 )
                             except Exception:
@@ -710,9 +754,9 @@ class TurnstoneSlackBot:
 
     async def _cleanup_stale_route(self, ws_id: str, channel_id: str) -> None:
         """Remove a channel route whose workstream no longer exists."""
-        slack_channel, user_id, thread_ts = self._parse_route(channel_id)
-        if slack_channel and user_id and thread_ts:
-            self._channel_sessions.pop((slack_channel, user_id), None)
+        route = SlackRoute.parse(channel_id)
+        if route.channel and route.user_id and route.thread_ts:
+            self._channel_sessions.pop((route.channel, route.user_id), None)
 
         await self.router.delete_route("slack", channel_id)
         self._subscribed_ws.discard(ws_id)
@@ -720,11 +764,7 @@ class TurnstoneSlackBot:
         self._streaming.pop(ws_id, None)
         self._pending_approval_ts.pop(ws_id, None)
         self._pending_plan_review_ts.pop(ws_id, None)
-        self._notify_reply_routes.pop(ws_id, None)
-
-        stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
-        for ts in stale:
-            del self._notify_ws_map[ts]
+        self._clear_notification_tracking_for_ws(ws_id)
 
         log.info("slack.stale_route_removed", ws_id=ws_id)
 
@@ -921,14 +961,8 @@ class TurnstoneSlackBot:
 
             reply_route = self._notify_reply_routes.get(ws_id)
             if reply_route is not None and sm is not None and sm._ts:
-                reply_channel, target_user_id, _reply_thread_ts = self._parse_route(reply_route)
-                if reply_channel and target_user_id:
-                    self._track_notification(
-                        sm._ts,
-                        ws_id,
-                        reply_channel,
-                        target_user_id,
-                    )
+                if reply_route.channel and reply_route.user_id:
+                    self._track_notification(sm._ts, ws_id, reply_route)
 
             self._pending_approval_ts.pop(ws_id, None)
 
@@ -1010,47 +1044,32 @@ class TurnstoneSlackBot:
 
         return True
 
-    def _parse_route(self, channel_id: str) -> tuple[str, str, str]:
-        """Parse canonical Slack route as (channel, user_id, thread_ts)."""
-        parts = channel_id.split(":", 2)
-        slack_channel = parts[0]
-        user_id = parts[1] if len(parts) >= 2 else ""
-        thread_ts = parts[2] if len(parts) == 3 else ""
-        return slack_channel, user_id, thread_ts
-
-    def _format_route(
-        self,
-        slack_channel: str,
-        user_id: str = "",
-        thread_ts: str = "",
-    ) -> str:
-        """Format canonical Slack route as channel[:user_id[:thread_ts]]."""
-        if thread_ts:
-            return f"{slack_channel}:{user_id}:{thread_ts}"
-        if user_id:
-            return f"{slack_channel}:{user_id}"
-        return slack_channel
-
     def _track_notification(
         self,
         msg_ts: str,
         ws_id: str,
-        slack_channel: str,
-        target_user_id: str,
+        route: SlackRoute,
     ) -> None:
         while len(self._notify_ws_map) >= self._MAX_NOTIFY_TRACKING:
             del self._notify_ws_map[next(iter(self._notify_ws_map))]
-        self._notify_ws_map[msg_ts] = (ws_id, slack_channel, target_user_id)
+        self._notify_ws_map[msg_ts] = (ws_id, route)
+        log.info(
+            "slack.notification_tracked",
+            message_ts=msg_ts,
+            ws_id=ws_id,
+            channel=route.channel,
+            user=route.user_id,
+        )
 
     async def send(self, channel_id: str, content: str) -> str:
-        slack_channel, _user_id, thread_ts = self._parse_route(channel_id)
+        route = SlackRoute.parse(channel_id)
 
-        root_ts = thread_ts or ""
+        root_ts = route.thread_ts or ""
         first_post_ts = ""
 
         for i, chunk in enumerate(chunk_message(content, self.config.max_message_length)):
             resp = await self._client.chat_postMessage(
-                channel=slack_channel,
+                channel=route.channel,
                 thread_ts=root_ts or None,
                 text=chunk,
             )
@@ -1059,22 +1078,27 @@ class TurnstoneSlackBot:
                 if i == 0:
                     first_post_ts = ts
                     if not root_ts:
-                        # If we started a new thread, all later chunks should go under it
                         root_ts = ts
 
-        # If this was a new top-level notification, return the thread root ts
-        # If it was sent into an existing thread, return that existing thread ts
         return root_ts or first_post_ts
 
     async def send_notification(self, channel_id: str, content: str, ws_id: str) -> str:
+        route = SlackRoute.parse(channel_id)
         thread_root_ts = await self.send(channel_id, content)
-        if thread_root_ts and ws_id:
-            slack_channel, target_user_id, _thread_ts = self._parse_route(channel_id)
-            if slack_channel and target_user_id:
-                self._track_notification(
-                    thread_root_ts,
-                    ws_id,
-                    slack_channel,
-                    target_user_id,
-                )
+        if thread_root_ts and ws_id and route.channel and route.user_id:
+            self._track_notification(
+                thread_root_ts,
+                ws_id,
+                SlackRoute(
+                    channel=route.channel,
+                    user_id=route.user_id,
+                    thread_ts=thread_root_ts,
+                ),
+            )
         return thread_root_ts
+
+    def _clear_notification_tracking_for_ws(self, ws_id: str) -> None:
+        self._notify_reply_routes.pop(ws_id, None)
+        stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
+        for ts in stale:
+            del self._notify_ws_map[ts]

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -66,6 +66,13 @@ _GREETING = "Hey! Let me know what I can help with."
 _SSE_RECONNECT_DELAY: float = 2.0
 _SSE_MAX_RECONNECT_DELAY: float = 30.0
 
+def _sanitize_slack_preview(text: str, max_length: int = 1200) -> str:
+    """Escape Slack mrkdwn-sensitive content for safe fenced display."""
+    text = text.replace("`", "\\`")
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text
 
 @dataclass(frozen=True)
 class PendingApproval:
@@ -1057,8 +1064,12 @@ class TurnstoneSlackBot:
     ) -> None:
         tool_lines = []
         for item in items:
-            name = item.get("approval_label") or item.get("func_name") or "tool"
-            preview = item.get("preview", "")
+            raw_name = item.get("approval_label") or item.get("func_name") or "tool"
+            name = raw_name.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+            raw_preview = item.get("preview", "")
+            preview = _sanitize_slack_preview(raw_preview) if raw_preview else ""
+
             tool_lines.append(
                 f"• *{name}*\n```{preview}```" if preview else f"• *{name}*"
             )

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -1,0 +1,912 @@
+"""Slack bot adapter — connects Slack channels/threads to turnstone workstreams.
+
+:class:`TurnstoneSlackBot` uses Slack Bolt with Socket Mode so no public URL
+or API Gateway is required. Mirrors the Discord adapter pattern.
+
+Interaction model
+-----------------
+* **Channels**: invoke with ``/turnstone``. The bot replies in a thread and
+  waits for messages there. Messages outside a bot-created thread are ignored.
+  Running ``/turnstone`` again in the same channel (by the same user)
+  archives the old workstream and starts a fresh thread.
+* **DMs**: every message is routed freely, no slash command needed.
+
+Events are consumed from the server's per-workstream SSE endpoint
+(``GET /v1/api/events?ws_id=X``) using httpx-sse. Inbound messages are
+sent directly to server nodes via HTTP (``POST /v1/api/send``).
+
+Install dependencies:
+    pip install slack-bolt httpx httpx-sse
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+from slack_bolt.async_app import AsyncApp
+from slack_sdk.web.async_client import AsyncWebClient
+
+from turnstone.channels._formatter import chunk_message
+from turnstone.channels._routing import ChannelRouter
+from turnstone.core.log import get_logger
+from turnstone.sdk.events import (
+    ApprovalResolvedEvent,
+    ApproveRequestEvent,
+    ContentEvent,
+    ErrorEvent,
+    IntentVerdictEvent,
+    PlanReviewEvent,
+    ServerEvent,
+    StreamEndEvent,
+    ThinkingStartEvent,
+    ThinkingStopEvent,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+
+    from turnstone.channels.slack.config import SlackConfig
+    from turnstone.core.storage._protocol import StorageBackend
+
+log = get_logger(__name__)
+
+_GREETING = "Hey! Let me know what I can help with."
+
+_SSE_RECONNECT_DELAY: float = 2.0
+_SSE_MAX_RECONNECT_DELAY: float = 30.0
+
+
+@dataclass
+class StreamingMessage:
+    """Accumulates streamed content and periodically edits a Slack message."""
+
+    client: Any
+    channel: str
+    thread_ts: str = ""
+    max_length: int = 3000
+    edit_interval: float = 1.5
+
+    _ts: str = field(default="", init=False, repr=False)
+    _buffer: list[str] = field(default_factory=list, init=False, repr=False)
+    _last_edit: float = field(default=0.0, init=False, repr=False)
+
+    async def append(self, text: str) -> None:
+        self._buffer.append(text)
+        if time.monotonic() - self._last_edit >= self.edit_interval:
+            await self._flush()
+
+    async def finalize(self) -> None:
+        content = "".join(self._buffer)
+        if not content:
+            return
+
+        chunks = chunk_message(content, self.max_length)
+        if self._ts:
+            try:
+                await self.client.chat_update(
+                    channel=self.channel,
+                    ts=self._ts,
+                    text=chunks[0],
+                )
+            except Exception:
+                log.debug("slack.streaming_message.finalize_edit_failed")
+
+            for chunk in chunks[1:]:
+                await self.client.chat_postMessage(
+                    channel=self.channel,
+                    thread_ts=self.thread_ts or self._ts,
+                    text=chunk,
+                )
+        else:
+            for chunk in chunks:
+                resp = await self.client.chat_postMessage(
+                    channel=self.channel,
+                    thread_ts=self.thread_ts or None,
+                    text=chunk,
+                )
+                if not self._ts and resp.get("ok"):
+                    self._ts = resp["ts"]
+
+    async def _flush(self) -> None:
+        content = "".join(self._buffer)
+        if not content:
+            return
+
+        display = content[: self.max_length]
+        try:
+            if not self._ts:
+                resp = await self.client.chat_postMessage(
+                    channel=self.channel,
+                    thread_ts=self.thread_ts or None,
+                    text=display,
+                )
+                if resp.get("ok"):
+                    self._ts = resp["ts"]
+            else:
+                await self.client.chat_update(
+                    channel=self.channel,
+                    ts=self._ts,
+                    text=display,
+                )
+        except Exception:
+            log.debug("slack.streaming_message.flush_failed")
+
+        self._last_edit = time.monotonic()
+
+
+class TurnstoneSlackBot:
+    """Slack bot bridging Slack channels/threads to turnstone workstreams."""
+
+    channel_type: str = "slack"
+    _MAX_NOTIFY_TRACKING: int = 100
+
+    def __init__(
+        self,
+        config: SlackConfig,
+        server_url: str,
+        storage: StorageBackend,
+        *,
+        api_token: str = "",
+        console_url: str = "",
+        console_token_factory: Callable[[], str] | None = None,
+        server_token_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.config = config
+        self._server_url = server_url.rstrip("/")
+        self._console_url = console_url.rstrip("/") if console_url else ""
+        self._api_token = api_token
+        self._token_factory = server_token_factory
+        self.storage = storage
+
+        self.router = ChannelRouter(
+            server_url,
+            storage,
+            auto_approve=config.auto_approve,
+            auto_approve_tools=list(config.auto_approve_tools),
+            skill=config.skill,
+            api_token=api_token,
+            console_url=console_url,
+            console_token_factory=console_token_factory,
+            server_token_factory=server_token_factory,
+        )
+
+        self._subscribed_ws: set[str] = set()
+        self._sse_tasks: dict[str, asyncio.Task[None]] = {}
+        self._streaming: dict[str, StreamingMessage] = {}
+
+        self._pending_approval_ts: dict[str, tuple[str, str]] = {}
+        self._notify_ws_map: dict[str, tuple[str, str, str]] = {}
+        self._channel_sessions: dict[tuple[str, str], tuple[str, str]] = {}
+
+        headers: dict[str, str] = {}
+        if api_token and not server_token_factory:
+            headers["Authorization"] = f"Bearer {api_token}"
+
+        self._http_client = httpx.AsyncClient(
+            headers=headers,
+            timeout=httpx.Timeout(connect=10.0, read=90.0, write=10.0, pool=10.0),
+        )
+
+        self._app = AsyncApp(token=config.bot_token)
+        self._client = AsyncWebClient(token=config.bot_token)
+        self._app_token = config.app_token
+        self._handler: AsyncSocketModeHandler | None = None
+
+        self._app.command(config.slash_command)(self._on_slash_command)
+        self._app.event("message")(self._on_message)
+        self._app.action("ts_approve")(self._on_approve)
+        self._app.action("ts_deny")(self._on_deny)
+
+    async def start(self) -> None:
+        from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+
+        self._handler = AsyncSocketModeHandler(self._app, self._app_token)
+        await self._recover_routes()
+        log.info("slack.starting_socket_mode")
+        await self._handler.start_async()  # type: ignore[no-untyped-call]
+
+    async def stop(self) -> None:
+        for ws_id in list(self._subscribed_ws):
+            await self.unsubscribe_ws(ws_id)
+        await self.router.aclose()
+        await self._http_client.aclose()
+        if self._handler is not None:
+            await self._handler.close_async()  # type: ignore[no-untyped-call]
+        log.info("slack.stopped")
+
+    async def _recover_routes(self) -> None:
+        """Re-subscribe to SSE streams for existing slack routes."""
+        routes = await asyncio.to_thread(
+            self.storage.list_channel_routes_by_type,
+            "slack",
+        )
+
+        latest_sessions: dict[tuple[str, str], tuple[str, str]] = {}
+
+        for route in routes:
+            ws_id = route["ws_id"]
+            channel_id = route["channel_id"]
+
+            await self.subscribe_ws(ws_id, channel_id)
+
+            parts = channel_id.split(":", 2)
+            if len(parts) == 3:
+                slack_channel, user_id, thread_ts = parts
+                key = (slack_channel, user_id)
+                existing = latest_sessions.get(key)
+
+                if existing is None or float(thread_ts) > float(existing[1]):
+                    latest_sessions[key] = (ws_id, thread_ts)
+
+            log.info("slack.route_recovered", ws_id=ws_id, channel_id=channel_id)
+
+        self._channel_sessions = latest_sessions
+
+        for (slack_channel, user_id), (ws_id, thread_ts) in self._channel_sessions.items():
+            log.info(
+                "slack.session_recovered",
+                slack_channel=slack_channel,
+                user_id=user_id,
+                ws_id=ws_id,
+                thread_ts=thread_ts,
+            )
+
+    async def _on_slash_command(self, ack: Any, body: dict[str, Any]) -> None:
+        """Start or restart a per-user session in this channel."""
+        await ack()
+
+        slack_channel = body["channel_id"]
+        user_id = body["user_id"]
+
+        if (
+            self.config.allowed_channels
+            and slack_channel not in self.config.allowed_channels
+        ):
+            await self._client.chat_postEphemeral(
+                channel=slack_channel,
+                user=user_id,
+                text="Sorry, turnstone isn't enabled in this channel.",
+            )
+            return
+
+        existing = self._channel_sessions.get((slack_channel, user_id))
+        if existing is not None:
+            old_ws_id, old_thread_ts = existing
+            await self._archive_session(
+                slack_channel,
+                user_id,
+                old_ws_id,
+                old_thread_ts,
+            )
+
+        opener = await self._client.chat_postMessage(
+            channel=slack_channel,
+            text=f"<@{user_id}> started a turnstone session.",
+        )
+        if not opener.get("ok"):
+            log.error("slack.slash_command.opener_failed", channel=slack_channel)
+            return
+
+        opener_ts = opener["ts"]
+
+        await self._client.chat_postMessage(
+            channel=slack_channel,
+            thread_ts=opener_ts,
+            text=_GREETING,
+        )
+
+        route_key = f"{slack_channel}:{user_id}:{opener_ts}"
+
+        ws_id, _ = await self.router.get_or_create_workstream(
+            channel_type="slack",
+            channel_id=route_key,
+            name=f"slack-{slack_channel[:8]}",
+        )
+        await self.subscribe_ws(ws_id, route_key)
+        self._channel_sessions[(slack_channel, user_id)] = (ws_id, opener_ts)
+
+        log.info(
+            "slack.session_started",
+            ws_id=ws_id,
+            channel=slack_channel,
+            user=user_id,
+            thread_ts=opener_ts,
+        )
+
+    async def _archive_session(
+        self,
+        slack_channel: str,
+        user_id: str,
+        ws_id: str,
+        thread_ts: str,
+    ) -> None:
+        """Mark the old session as archived and unsubscribe."""
+        try:
+            await self._client.chat_postMessage(
+                channel=slack_channel,
+                thread_ts=thread_ts,
+                text="_This session has been archived. A new one has started._",
+            )
+        except Exception:
+            log.debug("slack.archive_session.notify_failed", ws_id=ws_id)
+
+        route_key = f"{slack_channel}:{user_id}:{thread_ts}"
+
+        try:
+            await self.router.delete_route("slack", route_key)
+            log.info(
+                "slack.archived_route_deleted",
+                ws_id=ws_id,
+                channel_id=route_key,
+            )
+        except Exception:
+            log.exception(
+                "slack.archived_route_delete_failed",
+                ws_id=ws_id,
+                channel_id=route_key,
+            )
+
+        await self.unsubscribe_ws(ws_id)
+        self._channel_sessions.pop((slack_channel, user_id), None)
+        log.info(
+            "slack.session_archived",
+            ws_id=ws_id,
+            channel=slack_channel,
+            user=user_id,
+        )
+
+    async def _on_message(self, event: dict[str, Any], say: Any) -> None:
+        """Route messages — thread-only in channels, free in DMs."""
+        if event.get("bot_id") or event.get("subtype"):
+            return
+
+        channel_id = event.get("channel", "")
+        channel_type = event.get("channel_type", "")
+        thread_ts = event.get("thread_ts", "")
+        user_id = event.get("user", "")
+        text = event.get("text", "").strip()
+
+        if not text or not channel_id or not user_id:
+            return
+
+        if channel_id.startswith("D") or channel_type == "im":
+            await self._handle_dm(event, say)
+            return
+
+        if self.config.allowed_channels and channel_id not in self.config.allowed_channels:
+            return
+
+        if thread_ts and thread_ts in self._notify_ws_map:
+            origin_ws_id, notify_channel_id, target_user_id = self._notify_ws_map[thread_ts]
+            if channel_id == notify_channel_id and user_id == target_user_id:
+                try:
+                    await self.router.send_message(origin_ws_id, text)
+                    log.info("slack.notification_reply_routed", ws_id=origin_ws_id)
+                except Exception:
+                    log.exception("slack.notification_reply_failed")
+                return
+
+        session = self._channel_sessions.get((channel_id, user_id))
+        if session is None:
+            return
+
+        ws_id, session_thread_ts = session
+        if thread_ts != session_thread_ts:
+            return
+
+        try:
+            await self.router.send_message(ws_id, text)
+            log.info("slack.message_dispatched", ws_id=ws_id, channel=channel_id)
+        except Exception:
+            log.exception("slack.message_dispatch_failed", channel=channel_id)
+            await say(
+                text="Sorry, something went wrong routing your message.",
+                thread_ts=thread_ts,
+            )
+
+    async def _handle_dm(self, event: dict[str, Any], say: Any) -> None:
+        """Handle a direct message — no slash command required."""
+        channel_id = event.get("channel", "")
+        thread_ts = event.get("thread_ts", "")
+        user_id = event.get("user", "")
+        text = event.get("text", "").strip()
+        msg_ts = event.get("ts", "")
+        thread_key = thread_ts or msg_ts
+        route_key = (
+            f"{channel_id}:{user_id}:{thread_key}"
+            if thread_key
+            else f"{channel_id}:{user_id}"
+        )
+
+        try:
+            ws_id, is_new = await self.router.get_or_create_workstream(
+                channel_type="slack",
+                channel_id=route_key,
+                name=f"slack-dm-{user_id[:8]}",
+            )
+            if is_new:
+                await self.subscribe_ws(ws_id, route_key)
+
+            await self.router.send_message(ws_id, text)
+            log.info("slack.dm_dispatched", ws_id=ws_id, user=user_id)
+        except Exception:
+            log.exception("slack.dm_dispatch_failed", user=user_id)
+            await say(text="Sorry, something went wrong routing your message.")
+
+    async def _on_approve(self, ack: Any, body: dict[str, Any]) -> None:
+        await ack()
+        value = body["actions"][0].get("value", "")
+        parts = value.split("|", 1)
+        if len(parts) != 2:
+            return
+
+        ws_id, correlation_id = parts
+        await self.router.send_approval(ws_id, correlation_id, approved=True)
+        channel = body["container"]["channel_id"]
+        ts = body["container"]["message_ts"]
+
+        try:
+            await self._client.chat_update(
+                channel=channel,
+                ts=ts,
+                text="Tool approved",
+                blocks=[],
+            )
+        except Exception:
+            log.debug("slack.approve_message_update_failed")
+
+    async def _on_deny(self, ack: Any, body: dict[str, Any]) -> None:
+        await ack()
+        value = body["actions"][0].get("value", "")
+        parts = value.split("|", 1)
+        if len(parts) != 2:
+            return
+
+        ws_id, correlation_id = parts
+        await self.router.send_approval(ws_id, correlation_id, approved=False)
+        channel = body["container"]["channel_id"]
+        ts = body["container"]["message_ts"]
+
+        try:
+            await self._client.chat_update(
+                channel=channel,
+                ts=ts,
+                text="Tool denied",
+                blocks=[],
+            )
+        except Exception:
+            log.debug("slack.deny_message_update_failed")
+
+    async def subscribe_ws(self, ws_id: str, channel_id: str) -> None:
+        if ws_id in self._subscribed_ws:
+            return
+
+        task = asyncio.create_task(
+            self._sse_listener(ws_id, channel_id),
+            name=f"sse:{ws_id}",
+        )
+        self._sse_tasks[ws_id] = task
+        self._subscribed_ws.add(ws_id)
+        log.info("slack.subscribed", ws_id=ws_id, channel_id=channel_id)
+
+    async def unsubscribe_ws(self, ws_id: str) -> None:
+        task = self._sse_tasks.pop(ws_id, None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+        self._subscribed_ws.discard(ws_id)
+        self._streaming.pop(ws_id, None)
+        self._pending_approval_ts.pop(ws_id, None)
+
+        stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
+        for ts in stale:
+            del self._notify_ws_map[ts]
+
+        log.info("slack.unsubscribed", ws_id=ws_id)
+
+    async def _sse_listener(self, ws_id: str, channel_id: str) -> None:
+        """Connect to the server SSE endpoint and dispatch events."""
+        import httpx_sse
+
+        parts = channel_id.split(":", 2)
+        slack_channel = parts[0]
+        thread_ts = parts[2] if len(parts) == 3 else (parts[1] if len(parts) == 2 else "")
+
+        delay = _SSE_RECONNECT_DELAY
+        url = ""
+
+        while True:
+            try:
+                node_base = await self.router.get_node_url(ws_id)
+                url = f"{node_base}/v1/api/events"
+
+                sse_headers: dict[str, str] | None = None
+                if self._token_factory is not None:
+                    sse_headers = {"Authorization": f"Bearer {self._token_factory()}"}
+
+                async with httpx_sse.aconnect_sse(
+                    self._http_client,
+                    "GET",
+                    url,
+                    params={"ws_id": ws_id},
+                    headers=sse_headers,
+                ) as event_source:
+                    status = event_source.response.status_code
+                    if status == 404:
+                        log.info("slack.sse_ws_gone", ws_id=ws_id)
+                        await self._cleanup_stale_route(ws_id, channel_id)
+                        return
+
+                    if status >= 400:
+                        log.warning(
+                            "slack.sse_upstream_error",
+                            ws_id=ws_id,
+                            status=status,
+                        )
+                        raise httpx.HTTPStatusError(
+                            f"SSE upstream {status}",
+                            request=event_source.response.request,
+                            response=event_source.response,
+                        )
+
+                    delay = _SSE_RECONNECT_DELAY
+                    async for sse in event_source.aiter_sse():
+                        if sse.event == "message" or not sse.event:
+                            try:
+                                data = json.loads(sse.data)
+                            except json.JSONDecodeError:
+                                log.debug("slack.sse_invalid_json", ws_id=ws_id)
+                                continue
+
+                            event = ServerEvent.from_dict(data)
+                            try:
+                                await self._on_ws_event(
+                                    ws_id,
+                                    slack_channel,
+                                    thread_ts,
+                                    event,
+                                )
+                            except Exception:
+                                log.warning(
+                                    "slack.event_dispatch_failed",
+                                    ws_id=ws_id,
+                                    exc_info=True,
+                                )
+
+            except httpx.HTTPStatusError:
+                pass
+            except httpx.RemoteProtocolError:
+                log.debug("slack.sse_remote_closed", ws_id=ws_id)
+            except asyncio.CancelledError:
+                return
+            except httpx.ReadTimeout:
+                log.info("slack.sse_read_timeout", ws_id=ws_id)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                log.warning(
+                    "slack.sse_connect_failed",
+                    ws_id=ws_id,
+                    url=url,
+                    error=str(exc),
+                )
+            except Exception:
+                log.warning("slack.sse_error", ws_id=ws_id, exc_info=True)
+
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _SSE_MAX_RECONNECT_DELAY)
+
+    async def _cleanup_stale_route(self, ws_id: str, channel_id: str) -> None:
+        """Remove a channel route whose workstream no longer exists."""
+        parts = channel_id.split(":", 2)
+        if len(parts) == 3:
+            slack_channel, user_id, _ = parts
+            self._channel_sessions.pop((slack_channel, user_id), None)
+
+        await self.router.delete_route("slack", channel_id)
+        self._subscribed_ws.discard(ws_id)
+        self._sse_tasks.pop(ws_id, None)
+        self._streaming.pop(ws_id, None)
+        self._pending_approval_ts.pop(ws_id, None)
+
+        stale = [ts for ts, entry in self._notify_ws_map.items() if entry[0] == ws_id]
+        for ts in stale:
+            del self._notify_ws_map[ts]
+
+        log.info("slack.stale_route_removed", ws_id=ws_id)
+
+    async def _on_ws_event(
+        self,
+        ws_id: str,
+        slack_channel: str,
+        thread_ts: str,
+        event: ServerEvent,
+    ) -> None:
+        """Handle a typed server event for a subscribed workstream."""
+        if isinstance(event, ThinkingStartEvent):
+            pass
+
+        elif isinstance(event, ThinkingStopEvent):
+            pass
+
+        elif isinstance(event, ContentEvent):
+            sm = self._streaming.get(ws_id)
+            if sm is None:
+                sm = StreamingMessage(
+                    client=self._client,
+                    channel=slack_channel,
+                    thread_ts=thread_ts,
+                    max_length=self.config.max_message_length,
+                    edit_interval=self.config.streaming_edit_interval,
+                )
+                self._streaming[ws_id] = sm
+            await sm.append(event.text)
+
+        elif isinstance(event, ApproveRequestEvent):
+            _policy_handled = False
+            if self.storage is not None:
+                try:
+                    from turnstone.core.policy import evaluate_tool_policies_batch
+
+                    _tool_names = [
+                        it.get("approval_label", "") or it.get("func_name", "")
+                        for it in event.items
+                        if it.get("needs_approval")
+                        and it.get("func_name")
+                        and not it.get("error")
+                    ]
+                    _tool_names = [n for n in _tool_names if n]
+                    if _tool_names:
+                        verdicts = await asyncio.to_thread(
+                            evaluate_tool_policies_batch,
+                            self.storage,
+                            _tool_names,
+                        )
+                        if any(v == "deny" for v in verdicts.values()):
+                            denied = [n for n, v in verdicts.items() if v == "deny"]
+                            await self.router.send_approval(
+                                ws_id,
+                                "",
+                                approved=False,
+                                feedback=f"Blocked by tool policy: {', '.join(denied)}",
+                            )
+                            await self._client.chat_postMessage(
+                                channel=slack_channel,
+                                thread_ts=thread_ts or None,
+                                text=f"_Tool blocked by admin policy: {', '.join(denied)}_",
+                            )
+                            _policy_handled = True
+                        elif all(verdicts.get(n) == "allow" for n in _tool_names):
+                            await self.router.send_approval(ws_id, "", approved=True)
+                            await self._client.chat_postMessage(
+                                channel=slack_channel,
+                                thread_ts=thread_ts or None,
+                                text="_Tool approved by policy._",
+                            )
+                            _policy_handled = True
+                except Exception:
+                    log.debug(
+                        "Tool policy evaluation failed for ws %s",
+                        ws_id,
+                        exc_info=True,
+                    )
+
+            if not _policy_handled and (
+                self.config.auto_approve or self._should_auto_approve(event)
+            ):
+                await self.router.send_approval(ws_id, "", approved=True)
+                await self._client.chat_postMessage(
+                    channel=slack_channel,
+                    thread_ts=thread_ts or None,
+                    text="_Tool auto-approved._",
+                )
+            elif not _policy_handled:
+                await self._send_approval_request(
+                    ws_id,
+                    "",
+                    event.items,
+                    slack_channel,
+                    thread_ts,
+                )
+
+        elif isinstance(event, IntentVerdictEvent):
+            entry = self._pending_approval_ts.get(ws_id)
+            if entry is not None:
+                pending_channel, pending_ts = entry
+                risk = (event.risk_level or "medium").upper()
+                verdict_text = (
+                    f"*Judge Verdict: {event.func_name or 'tool'}*\n"
+                    f"Risk: {risk} | Confidence: {event.confidence or 'N/A'}\n"
+                    f"_{event.intent_summary or ''}_"
+                )
+                try:
+                    result = await self._client.conversations_history(
+                        channel=pending_channel,
+                        latest=pending_ts,
+                        limit=1,
+                        inclusive=True,
+                    )
+                    existing_blocks = []
+                    if result.get("ok") and result.get("messages"):
+                        existing_blocks = result["messages"][0].get("blocks", [])
+                    existing_blocks.append(
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": verdict_text,
+                            },
+                        }
+                    )
+                    await self._client.chat_update(
+                        channel=pending_channel,
+                        ts=pending_ts,
+                        blocks=existing_blocks,
+                        text="Tool approval required",
+                    )
+                except Exception:
+                    log.debug("slack.verdict_message_update_failed", ws_id=ws_id)
+
+        elif isinstance(event, PlanReviewEvent):
+            await self._client.chat_postMessage(
+                channel=slack_channel,
+                thread_ts=thread_ts or None,
+                text=f"*Plan Review*\n```{event.content[:2000]}```",
+            )
+
+        elif isinstance(event, ApprovalResolvedEvent):
+            entry = self._pending_approval_ts.pop(ws_id, None)
+            if entry is not None:
+                pending_channel, pending_ts = entry
+                label = "Approved" if event.approved else "Denied"
+                try:
+                    await self._client.chat_update(
+                        channel=pending_channel,
+                        ts=pending_ts,
+                        text=label,
+                        blocks=cast(list[dict[str, Any]], []),
+                    )
+                except Exception:
+                    log.debug("slack.approval_resolved_edit_failed", ws_id=ws_id)
+
+        elif isinstance(event, StreamEndEvent):
+            sm = self._streaming.pop(ws_id, None)
+            if sm is not None:
+                await sm.finalize()
+            self._pending_approval_ts.pop(ws_id, None)
+
+        elif isinstance(event, ErrorEvent):
+            safe_msg = event.message[:500] if event.message else "An error occurred"
+            await self._client.chat_postMessage(
+                channel=slack_channel,
+                thread_ts=thread_ts or None,
+                text=f"*Error:* {safe_msg}",
+            )
+
+    async def _send_approval_request(
+        self,
+        ws_id: str,
+        correlation_id: str,
+        items: list[dict[str, Any]],
+        channel: str,
+        thread_ts: str,
+    ) -> None:
+        tool_lines = []
+        for item in items:
+            name = item.get("approval_label") or item.get("func_name") or "tool"
+            preview = item.get("preview", "")
+            tool_lines.append(
+                f"• *{name}*\n```{preview}```" if preview else f"• *{name}*"
+            )
+
+        blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Tool Approval Required*\n" + "\n".join(tool_lines),
+                },
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Approve"},
+                        "style": "primary",
+                        "action_id": "ts_approve",
+                        "value": f"{ws_id}|{correlation_id}",
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Deny"},
+                        "style": "danger",
+                        "action_id": "ts_deny",
+                        "value": f"{ws_id}|{correlation_id}",
+                    },
+                ],
+            },
+        ]
+
+        resp = await self._client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts or None,
+            text="Tool approval required",
+            blocks=cast(list[dict[str, Any]], blocks),
+        )
+        if resp.get("ok"):
+            self._pending_approval_ts[ws_id] = (channel, resp["ts"])
+
+    def _should_auto_approve(self, event: ApproveRequestEvent) -> bool:
+        allowed = self.config.auto_approve_tools
+        if not allowed or not event.items:
+            return False
+
+        for item in event.items:
+            name = (
+                item.get("func_name")
+                or item.get("approval_label")
+                or item.get("function", {}).get("name", "")
+            )
+            if name not in allowed:
+                return False
+
+        return True
+
+    def _track_notification(
+        self,
+        msg_ts: str,
+        ws_id: str,
+        slack_channel: str,
+        target_user_id: str,
+    ) -> None:
+        while len(self._notify_ws_map) >= self._MAX_NOTIFY_TRACKING:
+            del self._notify_ws_map[next(iter(self._notify_ws_map))]
+        self._notify_ws_map[msg_ts] = (ws_id, slack_channel, target_user_id)
+
+    async def send(self, channel_id: str, content: str) -> str:
+        parts = channel_id.split(":", 2)
+        slack_channel = parts[0]
+        thread_ts = parts[2] if len(parts) == 3 else (parts[1] if len(parts) == 2 else "")
+
+        last_ts = ""
+        for chunk in chunk_message(content, self.config.max_message_length):
+            resp = await self._client.chat_postMessage(
+                channel=slack_channel,
+                thread_ts=thread_ts or None,
+                text=chunk,
+            )
+            if resp.get("ok"):
+                last_ts = resp["ts"]
+
+        return last_ts
+
+    async def send_notification(self, channel_id: str, content: str, ws_id: str) -> str:
+        msg_ts = await self.send(channel_id, content)
+        if msg_ts and ws_id:
+            parts = channel_id.split(":", 2)
+            slack_channel = parts[0]
+            target_user_id = parts[1] if len(parts) >= 2 else ""
+            if slack_channel and target_user_id:
+                self._track_notification(
+                    msg_ts,
+                    ws_id,
+                    slack_channel,
+                    target_user_id,
+                )
+                log.debug(
+                    "slack.notification_tracked",
+                    message_ts=msg_ts,
+                    ws_id=ws_id,
+                    channel=slack_channel,
+                    user=target_user_id,
+                )
+        return msg_ts

--- a/turnstone/channels/slack/config.py
+++ b/turnstone/channels/slack/config.py
@@ -1,0 +1,37 @@
+"""Slack-specific configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from turnstone.channels._config import ChannelConfig
+
+
+@dataclass
+class SlackConfig(ChannelConfig):
+    """Configuration for the Slack channel adapter.
+
+    Uses Socket Mode so no public URL or API Gateway is required —
+    Slack connects outbound to the instance via a WebSocket.
+
+    Requires two tokens:
+    - bot_token (xoxb-...): for posting messages via the Web API
+    - app_token (xapp-...): for Socket Mode WebSocket connection
+
+    To create these:
+    1. Go to https://api.slack.com/apps and create a new app
+    2. Enable Socket Mode under Settings > Socket Mode — this generates the app_token
+    3. Under OAuth & Permissions add bot scopes:
+       chat:write, chat:write.public, channels:history, im:history,
+       groups:history, mpim:history, reactions:write
+    4. Under Event Subscriptions (via Socket Mode) subscribe to:
+       message.channels, message.im, message.groups
+    5. Install the app to your workspace to get the bot_token
+    """
+
+    bot_token: str = ""           # xoxb-...  (Bot User OAuth Token)
+    app_token: str = ""           # xapp-...  (App-Level Token for Socket Mode)
+    allowed_channels: list[str] = field(default_factory=list)  # empty = all
+    max_message_length: int = 3000
+    streaming_edit_interval: float = 1.5  # seconds between message edits
+    slash_command: str = "/turnstone"

--- a/turnstone/channels/slack/routes.py
+++ b/turnstone/channels/slack/routes.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SlackRoute:
+    channel: str
+    user_id: str | None = None
+    thread_ts: str | None = None
+
+    @classmethod
+    def parse(cls, channel_id: str) -> "SlackRoute":
+        parts = channel_id.split(":", 2)
+        channel = parts[0] if parts else ""
+        user_id = parts[1] if len(parts) >= 2 and parts[1] else None
+        thread_ts = parts[2] if len(parts) == 3 and parts[2] else None
+        return cls(channel=channel, user_id=user_id, thread_ts=thread_ts)
+
+    def to_channel_id(self) -> str:
+        if self.thread_ts:
+            return f"{self.channel}:{self.user_id or ''}:{self.thread_ts}"
+        if self.user_id:
+            return f"{self.channel}:{self.user_id}"
+        return self.channel
+
+    @property
+    def has_user(self) -> bool:
+        return bool(self.user_id)
+
+    @property
+    def has_thread(self) -> bool:
+        return bool(self.thread_ts)

--- a/uv.lock
+++ b/uv.lock
@@ -754,9 +754,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
     { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
     { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
     { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
     { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
     { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
@@ -764,9 +762,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -774,9 +770,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -784,9 +778,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -794,9 +786,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -2330,6 +2320,27 @@ wheels = [
 ]
 
 [[package]]
+name = "slack-bolt"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "slack-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/97/a62dde97e84027b252807f2044bed2edcda2d063a5cb0c535fb2be8d9b5d/slack_bolt-1.28.0.tar.gz", hash = "sha256:bfe367d867e8fb157a057248ebd4ac2d7f43acac6d0700fa31381db1e10f3b0f", size = 130768, upload-time = "2026-04-06T23:24:59.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a9/697b6a92c728f09d5ef6b8e83dc6c8a87bc6d59499b2933ed067f11b7e30/slack_bolt-1.28.0-py2.py3-none-any.whl", hash = "sha256:738d1ca5e7c7039b6e18103d29267ced6e18c2517053eff18991fdd593acce5c", size = 234819, upload-time = "2026-04-06T23:24:58.278Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2527,6 +2538,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "aiohttp" },
     { name = "anthropic" },
     { name = "croniter" },
     { name = "ddgs" },
@@ -2536,6 +2548,7 @@ all = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "scipy" },
+    { name = "slack-bolt" },
     { name = "sympy" },
 ]
 anthropic = [
@@ -2563,6 +2576,10 @@ sandbox = [
     { name = "scipy" },
     { name = "sympy" },
 ]
+slack = [
+    { name = "aiohttp" },
+    { name = "slack-bolt" },
+]
 test = [
     { name = "croniter" },
     { name = "pytest" },
@@ -2574,6 +2591,7 @@ tls = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9" },
     { name = "alembic", specifier = ">=1.14" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.39" },
     { name = "bcrypt", specifier = ">=4.0" },
@@ -2597,15 +2615,16 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "scipy", marker = "extra == 'sandbox'", specifier = ">=1.14" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sse-starlette", specifier = ">=2.0" },
     { name = "starlette", specifier = ">=0.45" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "sympy", marker = "extra == 'sandbox'", specifier = ">=1.13" },
-    { name = "turnstone", extras = ["console", "anthropic", "postgres", "discord", "ddg", "tls", "sandbox"], marker = "extra == 'all'" },
+    { name = "turnstone", extras = ["console", "anthropic", "postgres", "discord", "ddg", "tls", "sandbox", "slack"], marker = "extra == 'all'" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
-provides-extras = ["test", "dev", "console", "anthropic", "postgres", "ddg", "discord", "tls", "sandbox", "all"]
+provides-extras = ["test", "dev", "console", "anthropic", "postgres", "ddg", "discord", "tls", "sandbox", "slack", "all"]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
Adds a Slack channel adapter mirroring the Discord adapter pattern:

- Socket Mode connection
- Per-user session management in channels via configurable slash command
- SSE-based event consumption from server nodes
- Tool approval buttons with policy evaluation support
- DM routing without slash command
- Session recovery after restart via recoverable route keys

New files:
- turnstone/channels/slack/bot.py
- turnstone/channels/slack/config.py
- turnstone/channels/slack/__init__.py
- tests/test_channel_slack.py

Updated:
- turnstone/channels/cli.py — adds Slack CLI arguments
- pyproject.toml — adds slack extra and mypy overrides

Usage:
- Install with Slack support: