### PR TITLE
feat: Add Claude Opus 4.7 support

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1246,6 +1246,31 @@ class TestAnthropicHelpers:
         assert caps.token_param == "max_tokens"
         assert caps.thinking_mode == "adaptive"
 
+    def test_capabilities_opus_4_7(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-opus-4-7")
+        assert caps.context_window == 1000000
+        assert caps.max_output_tokens == 128000
+        assert caps.thinking_mode == "adaptive"
+        assert caps.supports_effort is True
+        assert "xhigh" in caps.effort_levels
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.supports_web_search is True
+        assert caps.supports_tool_search is True
+        assert caps.supports_vision is True
+
+    def test_capabilities_opus_4_7_dated(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-opus-4-7-20260416")
+        assert caps.context_window == 1000000
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+
     def test_capabilities_lookup_unknown(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
 
@@ -1955,6 +1980,18 @@ class TestAnthropicReasoningNone:
         result = self.provider._reasoning_params("low", None, max_tokens=4096)
         assert "thinking" in result
         assert result["thinking"]["budget_tokens"] == 1024
+
+    def test_map_xhigh_effort(self) -> None:
+        from turnstone.core.providers._anthropic import _map_reasoning_to_effort
+
+        result = _map_reasoning_to_effort("xhigh", ("low", "medium", "high", "xhigh", "max"))
+        assert result == "xhigh"
+
+    def test_map_xhigh_rejected_by_model_without_it(self) -> None:
+        from turnstone.core.providers._anthropic import _map_reasoning_to_effort
+
+        result = _map_reasoning_to_effort("xhigh", ("low", "medium", "high", "max"))
+        assert result is None
 
 
 # ===========================================================================
@@ -3113,6 +3150,103 @@ class TestAnthropicPromptCaching:
         )
         assert "cache_control" in kwargs
         assert kwargs["cache_control"] == {"type": "ephemeral"}
+
+    def test_opus_4_7_no_temperature_in_kwargs(self) -> None:
+        """Opus 4.7 rejects temperature — must not appear in kwargs."""
+        caps = self.provider.get_capabilities("claude-opus-4-7")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="high",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-7",
+            tools=None,
+        )
+        assert "temperature" not in kwargs
+
+    def test_opus_4_6_still_has_temperature(self) -> None:
+        """Opus 4.6 must still send temperature (regression guard)."""
+        caps = self.provider.get_capabilities("claude-opus-4-6")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="high",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-6",
+            tools=None,
+        )
+        assert "temperature" in kwargs
+        assert kwargs["temperature"] == 1.0  # forced for adaptive thinking
+
+    def test_opus_4_7_thinking_display_summarized(self) -> None:
+        """Opus 4.7 must opt in to thinking display with 'summarized'."""
+        caps = self.provider.get_capabilities("claude-opus-4-7")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="high",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-7",
+            tools=None,
+        )
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+    def test_opus_4_6_thinking_no_display(self) -> None:
+        """Opus 4.6 adaptive thinking should not include display key."""
+        caps = self.provider.get_capabilities("claude-opus-4-6")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="high",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-6",
+            tools=None,
+        )
+        assert kwargs["thinking"] == {"type": "adaptive"}
+
+    def test_opus_4_7_xhigh_effort(self) -> None:
+        """Opus 4.7 xhigh effort passes through to output_config."""
+        caps = self.provider.get_capabilities("claude-opus-4-7")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="xhigh",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-7",
+            tools=None,
+        )
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+
+    def test_xhigh_effort_not_applied_to_opus_4_6(self) -> None:
+        """xhigh is not a valid effort level for Opus 4.6 — should be ignored."""
+        caps = self.provider.get_capabilities("claude-opus-4-6")
+        kwargs = self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="xhigh",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=0.5,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model="claude-opus-4-6",
+            tools=None,
+        )
+        assert "output_config" not in kwargs
 
     @patch("turnstone.core.providers._anthropic._ensure_anthropic")
     def test_streaming_message_start_cache_metrics(self, mock_ensure: MagicMock) -> None:

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -39,7 +39,7 @@
 # supports_web_search = false
 #
 # [models.claude]
-# name = "claude-opus-4-6"
+# name = "claude-opus-4-7"
 # provider = "anthropic"
 
 # --- Database (turnstone, node, console) ---

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1280,6 +1280,8 @@ window.TURNSTONE_KB_SHORTCUTS = [
             <option value="low">Low</option>
             <option value="medium">Medium</option>
             <option value="high">High</option>
+            <option value="xhigh">Extra High</option>
+            <option value="max">Max</option>
           </select>
         </div>
         <div><label for="csk-max-tokens">Max Tokens</label><input id="csk-max-tokens" type="number" min="1" placeholder="System default"></div>
@@ -1399,6 +1401,8 @@ window.TURNSTONE_KB_SHORTCUTS = [
             <option value="low">Low</option>
             <option value="medium">Medium</option>
             <option value="high">High</option>
+            <option value="xhigh">Extra High</option>
+            <option value="max">Max</option>
           </select>
         </div>
         <div><label for="esk-max-tokens">Max Tokens</label><input id="esk-max-tokens" type="number" min="1" placeholder="System default"></div>
@@ -1559,13 +1563,13 @@ window.TURNSTONE_KB_SHORTCUTS = [
     <label for="model-reasoning-effort">Reasoning Effort <span style="font-weight:400;text-transform:none">(empty = use global default)</span></label>
     <select id="model-reasoning-effort">
       <option value="">Global default</option>
-      <option value="none">none</option>
-      <option value="minimal">minimal</option>
-      <option value="low">low</option>
-      <option value="medium">medium</option>
-      <option value="high">high</option>
-      <option value="xhigh">xhigh</option>
-      <option value="max">max</option>
+      <option value="none">None</option>
+      <option value="minimal">Minimal</option>
+      <option value="low">Low</option>
+      <option value="medium">Medium</option>
+      <option value="high">High</option>
+      <option value="xhigh">Extra High</option>
+      <option value="max">Max</option>
     </select>
     <div id="model-server-compat-section" style="display:none">
     <div class="modal-section-divider" role="separator">Server Compatibility</div>

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -83,6 +83,19 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 )
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
+    "claude-opus-4-7": ModelCapabilities(
+        context_window=1000000,
+        max_output_tokens=128000,
+        token_param="max_tokens",
+        thinking_mode="adaptive",
+        supports_effort=True,
+        effort_levels=("low", "medium", "high", "xhigh", "max"),
+        supports_web_search=True,
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_temperature=False,
+        thinking_display="summarized",
+    ),
     "claude-opus-4-6": ModelCapabilities(
         context_window=1000000,
         max_output_tokens=128000,
@@ -139,7 +152,7 @@ def _map_reasoning_to_effort(
     valid_levels: tuple[str, ...],
 ) -> str | None:
     """Map turnstone reasoning_effort to Anthropic effort parameter."""
-    mapping = {"low": "low", "medium": "medium", "high": "high", "max": "max"}
+    mapping = {"low": "low", "medium": "medium", "high": "high", "xhigh": "xhigh", "max": "max"}
     effort = mapping.get(reasoning_effort)
     if effort and effort in valid_levels:
         return effort
@@ -226,8 +239,12 @@ class AnthropicProvider:
         """Build the full kwargs dict with thinking mode and effort params."""
         thinking_params: dict[str, Any] = {}
         if caps.thinking_mode == "adaptive":
-            thinking_params = {"thinking": {"type": "adaptive"}}
-            temperature = 1.0  # Required with thinking
+            thinking_dict: dict[str, Any] = {"type": "adaptive"}
+            if caps.thinking_display:
+                thinking_dict["display"] = caps.thinking_display
+            thinking_params = {"thinking": thinking_dict}
+            if caps.supports_temperature:
+                temperature = 1.0  # Required with thinking
         elif caps.thinking_mode == "manual":
             thinking_params = self._reasoning_params(reasoning_effort, extra_params, max_tokens)
             if thinking_params:
@@ -237,12 +254,13 @@ class AnthropicProvider:
             "model": model,
             "messages": converted_msgs,
             caps.token_param: max_tokens,
-            "temperature": temperature,
             # Automatic prompt caching — the API places the cache breakpoint
             # on the last cacheable block and advances it as conversation grows.
             # 90% input cost reduction on cache hits; 1.25x write on first turn.
             "cache_control": {"type": "ephemeral"},
         }
+        if caps.supports_temperature:
+            kwargs["temperature"] = temperature
         if system_prompt:
             kwargs["system"] = system_prompt
         if tools:
@@ -252,7 +270,7 @@ class AnthropicProvider:
             kwargs["tools"] = anthropic_tools
         kwargs.update(thinking_params)
 
-        # Effort param for models that support it (Opus 4.6, Sonnet 4.6, Opus 4.5)
+        # Effort param for models that support it (Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5)
         if caps.supports_effort and reasoning_effort:
             effort = _map_reasoning_to_effort(reasoning_effort, caps.effort_levels)
             if effort:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -87,6 +87,7 @@ class ModelCapabilities:
     supports_tool_search: bool = False
     supports_vision: bool = False
     supports_tool_advisories: bool = True
+    thinking_display: str = ""  # "summarized" for models that omit thinking by default
 
 
 def _lookup_capabilities(


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.7, released April 16, 2026. Handles all four breaking API changes from Opus 4.6 → 4.7.

## Breaking changes handled

| Change | Fix |
|---|---|
| `temperature`/`top_p`/`top_k` params removed (400 error) | Suppress `temperature` in kwargs when `caps.supports_temperature is False` |
| `{"type": "enabled", "budget_tokens": N}` thinking removed (400 error) | Opus 4.7 uses `thinking_mode="adaptive"` - manual path never hit |
| Thinking content omitted by default | Always send `"display": "summarized"` via new `thinking_display` field |
| New `xhigh` effort level | Added to mapping + Opus 4.7 effort_levels tuple |

## Changes

- **`_protocol.py`** - Add `thinking_display: str = ""` field to `ModelCapabilities`
- **`_anthropic.py`** - Add `claude-opus-4-7` capability entry, `xhigh` effort mapping, conditional temperature suppression, thinking display opt-in
- **`index.html`** - Add `xhigh`/`max` to skill template dropdowns, align label capitalization
- **`turnstone.example.toml`** - Update example model to `claude-opus-4-7`
- **`test_providers.py`** - 10 new tests with regression guards for Opus 4.6

## Verification

- 308 provider + model registry tests pass
- 2808 total tests pass (1 pre-existing infra failure in `test_server_live.py`)
- Live API verification: streaming and completion calls to `claude-opus-4-7` succeed with correct kwargs (no temperature, `display: summarized`, xhigh effort)

## Backward compatibility

Opus 4.6, Sonnet 4.6, and all older models are unaffected - regression tests confirm temperature is still sent and thinking dict has no display key for 4.6.