### PR TITLE
fix: broadcast plan_resolved SSE so other clients dismiss in sync

### DIFF
--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -92,6 +92,11 @@ export interface PlanReviewEvent {
   content: string;
 }
 
+export interface PlanResolvedEvent {
+  type: "plan_resolved";
+  feedback: string;
+}
+
 export interface InfoEvent {
   type: "info";
   message: string;
@@ -165,6 +170,7 @@ export type ServerEvent =
   | ToolOutputChunkEvent
   | StatusEvent
   | PlanReviewEvent
+  | PlanResolvedEvent
   | InfoEvent
   | ErrorEvent
   | BusyErrorEvent
@@ -281,6 +287,10 @@ export function isApprovalResolvedEvent(
 
 export function isPlanReviewEvent(e: ServerEvent): e is PlanReviewEvent {
   return e.type === "plan_review";
+}
+
+export function isPlanResolvedEvent(e: ServerEvent): e is PlanResolvedEvent {
+  return e.type === "plan_resolved";
 }
 
 export function isCancelledEvent(e: ServerEvent): e is CancelledEvent {

--- a/sdk/typescript/tests/events.test.ts
+++ b/sdk/typescript/tests/events.test.ts
@@ -8,6 +8,7 @@ import {
   isApproveRequestEvent,
   isApprovalResolvedEvent,
   isPlanReviewEvent,
+  isPlanResolvedEvent,
   isReasoningEvent,
 } from "../src/events.js";
 import type { ServerEvent } from "../src/events.js";
@@ -75,5 +76,10 @@ describe("event type guards", () => {
   it("isPlanReviewEvent", () => {
     const e: ServerEvent = { type: "plan_review", content: "## Plan" };
     expect(isPlanReviewEvent(e)).toBe(true);
+  });
+
+  it("isPlanResolvedEvent", () => {
+    const e: ServerEvent = { type: "plan_resolved", feedback: "approved" };
+    expect(isPlanResolvedEvent(e)).toBe(true);
   });
 });

--- a/tests/test_sdk_events.py
+++ b/tests/test_sdk_events.py
@@ -17,6 +17,7 @@ from turnstone.sdk.events import (
     InfoEvent,
     NodeJoinedEvent,
     NodeLostEvent,
+    PlanResolvedEvent,
     PlanReviewEvent,
     ReasoningEvent,
     ServerEvent,
@@ -141,6 +142,12 @@ def test_plan_review_event():
     e = ServerEvent.from_dict({"type": "plan_review", "content": "## Plan\n1. Do X"})
     assert isinstance(e, PlanReviewEvent)
     assert "Plan" in e.content
+
+
+def test_plan_resolved_event():
+    e = ServerEvent.from_dict({"type": "plan_resolved", "feedback": "approved"})
+    assert isinstance(e, PlanResolvedEvent)
+    assert e.feedback == "approved"
 
 
 def test_info_event():

--- a/tests/test_workstream.py
+++ b/tests/test_workstream.py
@@ -751,6 +751,53 @@ class TestWebUI:
         ui.resolve_plan("ok")
         assert ui._pending_plan_review is None
 
+    def test_resolve_plan_broadcasts_plan_resolved(self):
+        """resolve_plan emits a plan_resolved SSE so other clients dismiss.
+
+        Also verifies _pending_plan_review is cleared BEFORE the event is
+        enqueued, so a reconnecting client cannot get both the replayed
+        plan_review and the live plan_resolved.
+        """
+        from turnstone.server import WebUI
+
+        ui = WebUI(ws_id="test")
+        ui._pending_plan_review = {"type": "plan_review", "content": "x"}
+        listener = ui._register_listener()
+        try:
+            ui.resolve_plan("approved")
+            events = []
+            while not listener.empty():
+                events.append(listener.get_nowait())
+        finally:
+            ui._unregister_listener(listener)
+
+        resolved = [e for e in events if e.get("type") == "plan_resolved"]
+        assert len(resolved) == 1
+        assert resolved[0]["feedback"] == "approved"
+        # Critical ordering invariant: pending cleared before broadcast.
+        assert ui._pending_plan_review is None
+
+    def test_resolve_plan_skips_broadcast_when_no_plan_pending(self):
+        """cancel_generation calls resolve_plan unconditionally — don't
+        emit a stray plan_resolved frame when no modal was ever shown."""
+        from turnstone.server import WebUI
+
+        ui = WebUI(ws_id="test")
+        assert ui._pending_plan_review is None
+        listener = ui._register_listener()
+        try:
+            ui.resolve_plan("reject")  # cancel path with no pending plan
+            events = []
+            while not listener.empty():
+                events.append(listener.get_nowait())
+        finally:
+            ui._unregister_listener(listener)
+
+        assert not [e for e in events if e.get("type") == "plan_resolved"]
+        # Wait must still unblock so the worker thread can return.
+        assert ui._plan_event.is_set()
+        assert ui._plan_result == "reject"
+
 
 # ---------------------------------------------------------------------------
 # WebUI SSE fan-out

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -138,6 +138,12 @@ class PlanReviewEvent(ServerEvent):
 
 
 @dataclass
+class PlanResolvedEvent(ServerEvent):
+    type: str = "plan_resolved"
+    feedback: str = ""
+
+
+@dataclass
 class InfoEvent(ServerEvent):
     type: str = "info"
     message: str = ""
@@ -360,6 +366,7 @@ _SERVER_REGISTRY: dict[str, type[ServerEvent]] = {
         ToolOutputChunkEvent,
         StatusEvent,
         PlanReviewEvent,
+        PlanResolvedEvent,
         InfoEvent,
         ErrorEvent,
         BusyErrorEvent,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -642,8 +642,20 @@ class WebUI:
 
     def resolve_plan(self, feedback: str) -> None:
         """Called by the HTTP handler when the user responds to a plan."""
-        self._pending_plan_review = None
         self._plan_result = feedback
+        if self._pending_plan_review is None:
+            # cancel_generation calls us unconditionally to unblock any wait.
+            # No plan pending — just signal and skip the broadcast frame.
+            self._plan_event.set()
+            return
+        # Clear pending BEFORE broadcasting so a client reconnecting in the
+        # window between enqueue and clear cannot receive both the replayed
+        # plan_review (SSE re-injection at the connect handler) AND the live
+        # plan_resolved.  Broadcast lets other clients (e.g. desktop while
+        # phone approved) dismiss their plan modals in sync — mirrors the
+        # approval_resolved pattern used by resolve_approval().
+        self._pending_plan_review = None
+        self._enqueue({"type": "plan_resolved", "feedback": feedback})
         self._plan_event.set()
 
 

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -851,6 +851,14 @@ Pane.prototype.handleEvent = function (evt) {
       showPlanDialog(evt.content);
       break;
 
+    case "plan_resolved":
+      // Plan was resolved on another client (or by server-initiated cancel).
+      // Only act if our modal is for this pane's workstream.
+      if (_planWsId === this.wsId) {
+        dismissPlanDialog(evt.feedback);
+      }
+      break;
+
     case "info":
       this.addInfoMessage(evt.message);
       break;
@@ -5056,6 +5064,8 @@ function _updatePlanRejectBtn() {
 function resolvePlan(defaultFeedback) {
   var feedback = document.getElementById("plan-feedback").value.trim();
   if (!feedback && defaultFeedback) feedback = defaultFeedback;
+  // Removing 'active' synchronously is what lets dismissPlanDialog's
+  // early-return guard treat the server's echoed plan_resolved as a no-op.
   document.getElementById("plan-overlay").classList.remove("active");
 
   var pane = panes[_planPaneId];
@@ -5095,7 +5105,70 @@ function resolvePlan(defaultFeedback) {
   }
 }
 
-function _addInlinePlan(content, action, feedback) {
+function dismissPlanDialog(feedback) {
+  // Sync-dismiss: another client (or the server) already resolved the plan.
+  // Do NOT call /v1/api/plan — the server has already moved on.  The early
+  // return also handles self-receipt: the client that called resolvePlan()
+  // already removed the active class, so this is a no-op for that client.
+  var overlay = document.getElementById("plan-overlay");
+  if (!overlay.classList.contains("active")) return;
+  overlay.classList.remove("active");
+
+  var pane = panes[_planPaneId];
+  if (pane) {
+    pane.inputEl.disabled = false;
+    pane.sendBtn.disabled = false;
+    // Restore keyboard context — but skip on touch so we don't surprise the
+    // mobile user with a soft-keyboard pop after a remote approval.
+    if (!matchMedia("(pointer: coarse)").matches) pane.inputEl.focus();
+  }
+
+  var fb = feedback || "";
+  var isReject = fb === "reject";
+  var isAmend = fb && !isReject;
+  var action = isReject ? "rejected" : isAmend ? "amending" : "approved";
+
+  // Race fallback: if plan_resolved arrives before plan_review (e.g. SSE
+  // reconnect ordering), _planContent is empty and _addInlinePlan early-
+  // returns silently.  Surface a one-line info message so the user sees
+  // what happened.
+  if (_planContent) {
+    try {
+      _addInlinePlan(_planContent, action, fb, "remote");
+    } catch (err) {
+      console.error("Failed to render inline plan:", err);
+      if (pane) pane.addInfoMessage("Plan " + action + " on another device");
+    }
+  } else if (pane) {
+    pane.addInfoMessage("Plan " + action + " on another device");
+  }
+
+  // SR announcement (visible toast styling deferred — #toast already has
+  // aria-live="polite" in markup, this just gives screen-reader parity).
+  _announce("Plan " + action + " on another device");
+
+  if (pane) {
+    pane.setBusy(true);
+    pane.addThinkingIndicator();
+  }
+
+  _planContent = "";
+  _planPaneId = null;
+  _planWsId = null;
+}
+
+function _announce(text) {
+  var el = document.getElementById("toast");
+  if (!el) return;
+  // Re-set textContent in two ticks so screen readers re-announce even
+  // when the message is identical to the previous one.
+  el.textContent = "";
+  setTimeout(function () {
+    el.textContent = text;
+  }, 50);
+}
+
+function _addInlinePlan(content, action, feedback, origin) {
   if (!content) return;
   var pane = panes[_planPaneId];
   if (!pane) return;
@@ -5111,8 +5184,13 @@ function _addInlinePlan(content, action, feedback) {
       : action === "amending"
         ? "Plan \u2014 amending"
         : "Plan approved";
-  header.innerHTML =
-    '<span class="plan-inline-label plan-' + action + '">' + label + "</span>";
+  // Disambiguate remote dismissal — otherwise the desktop user sees "Plan
+  // approved" with no attribution and may wonder if the agent self-approved.
+  if (origin === "remote") label += " (synced)";
+  var labelEl = document.createElement("span");
+  labelEl.className = "plan-inline-label plan-" + action;
+  labelEl.textContent = label;
+  header.appendChild(labelEl);
   wrapper.appendChild(header);
 
   var body = document.createElement("div");


### PR DESCRIPTION
Previously, resolving a plan on one client (e.g. phone) cleared the server's pending state and unblocked the worker, but emitted no event to other connected clients. Their plan-approval modal stayed stuck.

resolve_plan() now enqueues a plan_resolved frame (mirroring the approval_resolved pattern in resolve_approval) before clearing _pending_plan_review, so a reconnecting client cannot receive both the replayed plan_review and the live plan_resolved. Skips the frame on the cancel-with-no-plan path.

Client adds a plan_resolved handler that dismisses the modal without re-firing /v1/api/plan, restores keyboard context (skipped on touch to avoid soft-keyboard pop on mobile), labels the inline plan summary "(synced)" so remote dismissal is unambiguous, announces via the existing aria-live #toast for screen-reader parity, and falls back to an info message if plan_resolved races ahead of plan_review.

Adds PlanResolvedEvent to the Python and TypeScript SDKs with deserialization and type-guard tests.