### PR TITLE
feat: split plan_model and task_model, configurable agent reasoning e…

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -188,6 +188,59 @@ class TestModelRegistry:
         reg = self._make_registry(agent_model="cheap")
         assert reg.agent_model == "cheap"
 
+    def test_plan_task_models_default_none(self) -> None:
+        reg = self._make_registry()
+        assert reg.plan_model is None
+        assert reg.task_model is None
+        assert reg.plan_effort is None
+        assert reg.task_effort is None
+
+    def test_resolve_agent_alias_falls_back_to_agent_model(self) -> None:
+        reg = self._make_registry(agent_model="cheap")
+        assert reg.resolve_agent_alias("plan") == "cheap"
+        assert reg.resolve_agent_alias("task") == "cheap"
+
+    def test_resolve_agent_alias_per_kind_overrides(self) -> None:
+        models = {
+            "default": ModelConfig("default", "http://x/v1", "k", "m"),
+            "smart": ModelConfig("smart", "http://x/v1", "k", "m"),
+            "fast": ModelConfig("fast", "http://x/v1", "k", "m"),
+            "shared": ModelConfig("shared", "http://x/v1", "k", "m"),
+        }
+        reg = ModelRegistry(
+            models=models,
+            default="default",
+            agent_model="shared",
+            plan_model="smart",
+            task_model="fast",
+        )
+        assert reg.resolve_agent_alias("plan") == "smart"
+        assert reg.resolve_agent_alias("task") == "fast"
+
+    def test_resolve_agent_alias_returns_none_when_unconfigured(self) -> None:
+        reg = self._make_registry()
+        assert reg.resolve_agent_alias("plan") is None
+        assert reg.resolve_agent_alias("task") is None
+
+    def test_resolve_agent_effort_plan_back_compat_default(self) -> None:
+        reg = self._make_registry()
+        assert reg.resolve_agent_effort("plan") == ModelRegistry.PLAN_DEFAULT_EFFORT
+        assert reg.resolve_agent_effort("plan") == "high"
+
+    def test_resolve_agent_effort_plan_override(self) -> None:
+        models = {"a": ModelConfig("a", "x", "x", "x")}
+        reg = ModelRegistry(models=models, default="a", plan_effort="max")
+        assert reg.resolve_agent_effort("plan") == "max"
+
+    def test_resolve_agent_effort_task_returns_none_to_inherit(self) -> None:
+        reg = self._make_registry()
+        assert reg.resolve_agent_effort("task") is None
+
+    def test_resolve_agent_effort_task_override(self) -> None:
+        models = {"a": ModelConfig("a", "x", "x", "x")}
+        reg = ModelRegistry(models=models, default="a", task_effort="low")
+        assert reg.resolve_agent_effort("task") == "low"
+
 
 class TestModelRegistryValidation:
     def test_empty_models_raises(self) -> None:
@@ -208,6 +261,16 @@ class TestModelRegistryValidation:
         models = {"a": ModelConfig("a", "x", "x", "x")}
         with pytest.raises(ValueError, match="Agent model 'bad'"):
             ModelRegistry(models=models, default="a", agent_model="bad")
+
+    def test_invalid_plan_model_raises(self) -> None:
+        models = {"a": ModelConfig("a", "x", "x", "x")}
+        with pytest.raises(ValueError, match="Plan model 'bad'"):
+            ModelRegistry(models=models, default="a", plan_model="bad")
+
+    def test_invalid_task_model_raises(self) -> None:
+        models = {"a": ModelConfig("a", "x", "x", "x")}
+        with pytest.raises(ValueError, match="Task model 'bad'"):
+            ModelRegistry(models=models, default="a", task_model="bad")
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +359,52 @@ class TestLoadModelRegistry:
         with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
             reg = load_model_registry("http://x/v1", "x", "x")
         assert reg.agent_model is None
+
+    def test_plan_task_models_from_config(self) -> None:
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "smart": {"base_url": "http://s/v1", "model": "s"},
+                "fast": {"base_url": "http://f/v1", "model": "f"},
+            },
+            "model": {
+                "plan_model": "smart",
+                "task_model": "fast",
+                "plan_effort": "max",
+                "task_effort": "low",
+            },
+        }
+        with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+            reg = load_model_registry("http://x/v1", "x", "x")
+        assert reg.plan_model == "smart"
+        assert reg.task_model == "fast"
+        assert reg.plan_effort == "max"
+        assert reg.task_effort == "low"
+
+    def test_invalid_plan_task_models_ignored(self) -> None:
+        fake_cfg: dict[str, Any] = {
+            "model": {"plan_model": "nope", "task_model": "alsonope"},
+        }
+        with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+            reg = load_model_registry("http://x/v1", "x", "x")
+        assert reg.plan_model is None
+        assert reg.task_model is None
+
+    def test_invalid_effort_values_dropped_with_warning(self) -> None:
+        """Typos in plan_effort/task_effort shouldn't silently flow to providers."""
+        fake_cfg: dict[str, Any] = {
+            "model": {"plan_effort": "hihg", "task_effort": "extreme"},
+        }
+        with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+            reg = load_model_registry("http://x/v1", "x", "x")
+        assert reg.plan_effort is None
+        assert reg.task_effort is None
+
+    def test_valid_effort_values_accepted(self) -> None:
+        for level in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
+            fake_cfg: dict[str, Any] = {"model": {"plan_effort": level}}
+            with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+                reg = load_model_registry("http://x/v1", "x", "x")
+            assert reg.plan_effort == level, f"level={level} not accepted"
 
     def test_invalid_default_falls_back(self) -> None:
         fake_cfg: dict[str, Any] = {
@@ -711,6 +820,7 @@ class _FakeUI:
 def _make_session(
     registry: ModelRegistry | None = None,
     model_alias: str | None = None,
+    reasoning_effort: str = "medium",
 ) -> Any:
     """Create a ChatSession with a mock client and optional registry."""
     from turnstone.core.session import ChatSession
@@ -726,6 +836,7 @@ def _make_session(
         tool_timeout=30,
         registry=registry,
         model_alias=model_alias,
+        reasoning_effort=reasoning_effort,
     )
 
 
@@ -913,6 +1024,134 @@ class TestSessionAgentModel:
         ]
         session._run_agent(agent_msgs)
         assert captured_model == "agent-model"
+
+    @staticmethod
+    def _capture_on(client: Any) -> dict[str, Any]:
+        """Patch *client* (registry-resolved or session.client) to capture kwargs."""
+        captured: dict[str, Any] = {}
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "done"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].finish_reason = "stop"
+
+        def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return mock_response
+
+        client.chat.completions.create = fake_create
+        return captured
+
+    def _capture(self, reg: ModelRegistry, alias: str) -> dict[str, Any]:
+        return self._capture_on(reg.get_client(alias))
+
+    @staticmethod
+    def _captured_effort(captured: dict[str, Any]) -> str | None:
+        """Pull reasoning_effort out of provider-specific shapes.
+
+        openai-compatible servers receive it via extra_body.chat_template_kwargs;
+        commercial providers receive it as a top-level kwarg.
+        """
+        eb = captured.get("extra_body") or {}
+        ctk = eb.get("chat_template_kwargs") or {}
+        return ctk.get("reasoning_effort") or captured.get("reasoning_effort")
+
+    def _three_model_registry(self, **kwargs: Any) -> ModelRegistry:
+        return ModelRegistry(
+            models={
+                "main": ModelConfig(
+                    "main", "http://m/v1", "k", "main-model", provider="openai-compatible"
+                ),
+                "smart": ModelConfig(
+                    "smart", "http://s/v1", "k", "smart-model", provider="openai-compatible"
+                ),
+                "fast": ModelConfig(
+                    "fast", "http://f/v1", "k", "fast-model", provider="openai-compatible"
+                ),
+            },
+            default="main",
+            **kwargs,
+        )
+
+    def test_plan_model_overrides_agent_model(self) -> None:
+        reg = self._three_model_registry(agent_model="fast", plan_model="smart")
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture(reg, "smart")
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert captured["model"] == "smart-model"
+
+    def test_task_model_overrides_agent_model(self) -> None:
+        reg = self._three_model_registry(agent_model="smart", task_model="fast")
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "x"}], label="task")
+        assert captured["model"] == "fast-model"
+
+    def test_plan_falls_back_to_agent_model(self) -> None:
+        reg = self._three_model_registry(agent_model="fast")
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert captured["model"] == "fast-model"
+
+    def test_plan_uses_session_model_when_no_overrides(self) -> None:
+        # No agent_model/plan_model configured — _run_agent falls through to
+        # session.client (the test's MagicMock) and session.model ("test-model").
+        reg = self._three_model_registry()
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture_on(session.client)
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert captured["model"] == "test-model"
+
+    def test_plan_default_reasoning_effort_is_high(self) -> None:
+        """Back-compat: plan_agent always got "high" before; the default must
+        survive the migration even when no plan_effort is configured."""
+        reg = self._three_model_registry()
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture_on(session.client)
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert self._captured_effort(captured) == "high"
+
+    def test_plan_effort_from_registry_overrides_default(self) -> None:
+        reg = self._three_model_registry(plan_effort="max")
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture_on(session.client)
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert self._captured_effort(captured) == "max"
+
+    def test_task_effort_inherits_session_when_unset(self) -> None:
+        # Task with no task_effort override must inherit whatever the SESSION
+        # is configured for — assert against an explicit value rather than
+        # the constructor default so the invariant is unambiguous if someone
+        # changes ChatSession's default later.
+        reg = self._three_model_registry()
+        session = _make_session(registry=reg, model_alias="main", reasoning_effort="low")
+        captured = self._capture_on(session.client)
+        session._run_agent([{"role": "user", "content": "x"}], label="task")
+        assert self._captured_effort(captured) == "low"
+
+    def test_agent_model_routes_both_plan_and_task(self) -> None:
+        """Back-compat invariant via _run_agent: with only the legacy
+        agent_model knob set, both plan and task labels must route through it."""
+        reg = self._three_model_registry(agent_model="fast")
+        session = _make_session(registry=reg, model_alias="main")
+
+        plan_captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        assert plan_captured["model"] == "fast-model"
+
+        task_captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "y"}], label="task")
+        assert task_captured["model"] == "fast-model"
+
+    def test_explicit_effort_wins_over_registry(self) -> None:
+        reg = self._three_model_registry(plan_effort="low")
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture_on(session.client)
+        session._run_agent(
+            [{"role": "user", "content": "x"}], label="plan", reasoning_effort="minimal"
+        )
+        assert self._captured_effort(captured) == "minimal"
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -20,9 +20,19 @@
 [model]
 # name = ""                    # Model ID; empty = provider default (gpt-5 / claude-sonnet-4)
 # temperature = 0.0            # 0 = provider default
-# reasoning_effort = ""        # "low", "medium", "high", "max"
+# reasoning_effort = ""        # "low", "medium", "high", "xhigh", "max"
 # context_window = 0           # 0 = auto-detect from provider capabilities
 # max_tokens = 0               # 0 = provider default
+#
+# Sub-agent routing (plan_agent, task_agent tools).  Each falls back to
+# agent_model when unset, then to the session model.  Use this to point
+# the rare-but-expensive plan agent at a stronger model than the
+# frequent task agent.
+# agent_model = ""             # legacy single-knob: both plan and task share this
+# plan_model = ""              # plan_agent override (e.g. "claude" for a smart planner)
+# task_model = ""              # task_agent override (e.g. "local" for cheap subtasks)
+# plan_effort = ""             # reasoning effort for plan_agent (default: "high")
+# task_effort = ""             # reasoning effort for task_agent (default: inherit session)
 
 # --- Named Models (turnstone, node, eval) ---
 # Define model aliases with per-model overrides. Useful for local model

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -56,7 +56,16 @@ class ModelRegistry:
         models: Mapping of alias → ModelConfig.
         default: Alias of the default model.
         fallback: Ordered list of aliases to try when the primary model fails.
-        agent_model: Optional alias for plan/task sub-agents.
+        agent_model: Optional alias for plan/task sub-agents (single-knob
+            fallback used when ``plan_model``/``task_model`` are unset).
+        plan_model: Optional alias for the plan_agent sub-agent.  Overrides
+            ``agent_model`` for plan calls; falls back to it when unset.
+        task_model: Optional alias for the task_agent sub-agent.  Overrides
+            ``agent_model`` for task calls; falls back to it when unset.
+        plan_effort: Reasoning effort for plan_agent.  ``None`` means use the
+            built-in default of ``"high"`` (preserves prior behaviour).
+        task_effort: Reasoning effort for task_agent.  ``None`` means inherit
+            the parent session's reasoning effort.
     """
 
     def __init__(
@@ -65,6 +74,10 @@ class ModelRegistry:
         default: str,
         fallback: list[str] | None = None,
         agent_model: str | None = None,
+        plan_model: str | None = None,
+        task_model: str | None = None,
+        plan_effort: str | None = None,
+        task_effort: str | None = None,
     ) -> None:
         if not models:
             raise ValueError("ModelRegistry requires at least one model config")
@@ -76,11 +89,19 @@ class ModelRegistry:
                     raise ValueError(f"Fallback model '{alias}' not found in registry")
         if agent_model and agent_model not in models:
             raise ValueError(f"Agent model '{agent_model}' not found in registry")
+        if plan_model and plan_model not in models:
+            raise ValueError(f"Plan model '{plan_model}' not found in registry")
+        if task_model and task_model not in models:
+            raise ValueError(f"Task model '{task_model}' not found in registry")
 
         self._models = dict(models)
         self.default = default
         self.fallback = list(fallback) if fallback else []
         self.agent_model = agent_model
+        self.plan_model = plan_model
+        self.task_model = task_model
+        self.plan_effort = plan_effort
+        self.task_effort = task_effort
         self._clients: dict[str, Any] = {}
         self._providers: dict[str, LLMProvider] = {}
         self._client_lock = threading.Lock()
@@ -132,6 +153,40 @@ class ModelRegistry:
         cfg = self.get_config(alias)
         return self.get_client(alias), cfg.model, cfg
 
+    def resolve_agent_alias(self, kind: str) -> str | None:
+        """Return the configured alias for a sub-agent ``kind``.
+
+        Per-kind overrides (``plan_model``/``task_model``) win over the
+        legacy single-knob ``agent_model``.  Returns ``None`` when nothing
+        is configured (caller should fall back to the session model).
+
+        Recognised kinds: ``"plan"``, ``"task"``.  Any other value (e.g.
+        ``"agent"``, eval/utility paths) returns the legacy ``agent_model``
+        as-is — preserves prior behaviour for non-plan/task callers.
+        """
+        if kind == "plan":
+            return self.plan_model or self.agent_model
+        if kind == "task":
+            return self.task_model or self.agent_model
+        return self.agent_model
+
+    # Built-in default effort for plan_agent — preserves the value the three
+    # plan call sites used to pass explicitly before the split.
+    PLAN_DEFAULT_EFFORT = "high"
+
+    def resolve_agent_effort(self, kind: str) -> str | None:
+        """Return the reasoning effort for a sub-agent ``kind``.
+
+        Plan defaults to :attr:`PLAN_DEFAULT_EFFORT` (back-compat with the
+        previously hardcoded ``"high"``).  Task returns ``None`` to indicate
+        the caller should fall through to the session default.
+        """
+        if kind == "plan":
+            return self.plan_effort or self.PLAN_DEFAULT_EFFORT
+        if kind == "task":
+            return self.task_effort
+        return None
+
     @property
     def count(self) -> int:
         """Number of registered models."""
@@ -150,6 +205,10 @@ class ModelRegistry:
         default: str,
         fallback: list[str] | None = None,
         agent_model: str | None = None,
+        plan_model: str | None = None,
+        task_model: str | None = None,
+        plan_effort: str | None = None,
+        task_effort: str | None = None,
     ) -> None:
         """Hot-reload all model configs. Thread-safe; clears cached clients.
 
@@ -166,11 +225,19 @@ class ModelRegistry:
                     raise ValueError(f"Fallback model '{alias}' not found in registry")
         if agent_model and agent_model not in models:
             raise ValueError(f"Agent model '{agent_model}' not found in registry")
+        if plan_model and plan_model not in models:
+            raise ValueError(f"Plan model '{plan_model}' not found in registry")
+        if task_model and task_model not in models:
+            raise ValueError(f"Task model '{task_model}' not found in registry")
         with self._client_lock:
             self._models = dict(models)
             self.default = default
             self.fallback = list(fallback) if fallback else []
             self.agent_model = agent_model
+            self.plan_model = plan_model
+            self.task_model = task_model
+            self.plan_effort = plan_effort
+            self.task_effort = task_effort
             for client in self._clients.values():
                 if hasattr(client, "close"):
                     client.close()
@@ -245,8 +312,11 @@ def load_model_registry(
        *storage* is provided.
     3. CLI ``--base-url`` / ``--api-key`` / ``--model`` always create a
        ``"default"`` entry.
-    4. ``[model].default``, ``[model].fallback``, ``[model].agent_model``
-       control routing.
+    4. ``[model].default``, ``[model].fallback``, ``[model].agent_model``,
+       ``[model].plan_model``, ``[model].task_model``,
+       ``[model].plan_effort``, ``[model].task_effort`` control routing.
+       ``plan_model``/``task_model`` override ``agent_model`` per sub-agent
+       role; both fall back to it when unset.
     """
     import json as _json
 
@@ -406,17 +476,55 @@ def load_model_registry(
             else:
                 log.warning("Fallback alias '%s' not found in models, ignoring", alias)
 
-    # Agent model
+    # Agent model (legacy single-knob shared between plan_agent and task_agent)
     agent_model = model_section.get("agent_model")
     if agent_model and agent_model not in configs:
         log.warning("Configured agent_model '%s' not found, ignoring", agent_model)
         agent_model = None
+
+    # Per-kind sub-agent models — override agent_model for each role
+    plan_model = model_section.get("plan_model")
+    if plan_model and plan_model not in configs:
+        log.warning("Configured plan_model '%s' not found, ignoring", plan_model)
+        plan_model = None
+    task_model = model_section.get("task_model")
+    if task_model and task_model not in configs:
+        log.warning("Configured task_model '%s' not found, ignoring", task_model)
+        task_model = None
+
+    # Per-kind reasoning effort.  None means: plan defaults to "high" (back-
+    # compat with the previous hardcoded value); task inherits the session.
+    # Typos in config.toml shouldn't silently flow to the provider — log and
+    # drop unknown values, mirroring the model-not-found warning above.
+    valid_efforts = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+
+    def _validate_effort(value: Any, key: str) -> str | None:
+        if value is None:
+            return None
+        coerced = str(value)
+        if coerced not in valid_efforts:
+            log.warning(
+                "Configured %s '%s' is not a recognised effort level "
+                "(expected one of %s), ignoring",
+                key,
+                coerced,
+                sorted(valid_efforts),
+            )
+            return None
+        return coerced
+
+    plan_effort = _validate_effort(model_section.get("plan_effort"), "plan_effort")
+    task_effort = _validate_effort(model_section.get("task_effort"), "task_effort")
 
     return ModelRegistry(
         models=configs,
         default=default_alias,
         fallback=fallback,
         agent_model=agent_model,
+        plan_model=plan_model,
+        task_model=task_model,
+        plan_effort=plan_effort,
+        task_effort=task_effort,
     )
 
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5670,16 +5670,32 @@ class ChatSession:
             auto_tools = AGENT_AUTO_TOOLS
         max_tool_turns = self.agent_max_turns
 
-        # Resolve agent model and provider: use registry.agent_model if configured
-        agent_client = self.client
-        agent_model = self.model
-        agent_provider = self._provider
-        if self._registry and self._registry.agent_model:
-            agent_client, agent_model, _ = self._registry.resolve(self._registry.agent_model)
-            agent_provider = self._registry.get_provider(self._registry.agent_model)
+        # Resolve agent model: per-kind override (plan_model/task_model) wins
+        # over the legacy single-knob agent_model, which falls back to the
+        # session's primary model when unset.
+        agent_alias = self._registry.resolve_agent_alias(label) if self._registry else None
+        if self._registry and agent_alias:
+            agent_client, agent_model, _ = self._registry.resolve(agent_alias)
+            agent_provider = self._registry.get_provider(agent_alias)
+        else:
+            agent_client = self.client
+            agent_model = self.model
+            agent_provider = self._provider
+
+        # Per-kind reasoning effort.  Explicit caller arg wins; otherwise
+        # delegate to the registry which knows the per-kind default (plan
+        # gets the back-compat "high", task returns None to inherit the
+        # session).  When no registry exists, apply the plan back-compat
+        # default directly so single-process callers keep prior behaviour.
+        if reasoning_effort is None:
+            if self._registry:
+                reasoning_effort = self._registry.resolve_agent_effort(label)
+            elif label == "plan":
+                from turnstone.core.model_registry import ModelRegistry
+
+                reasoning_effort = ModelRegistry.PLAN_DEFAULT_EFFORT
 
         # Gate web_search: remove when no backend exists for the agent model
-        agent_alias = self._registry.agent_model if self._registry else None
         agent_caps = self._resolve_capabilities(agent_provider, agent_model, agent_alias)
         if not agent_caps.supports_web_search and not self._resolve_search_client():
             tools = _without_tool(tools, "web_search")
@@ -5999,7 +6015,6 @@ class ChatSession:
             content = self._run_agent(
                 agent_messages,
                 label="plan",
-                reasoning_effort="high",
             )
         except (KeyboardInterrupt, GenerationCancelled):
             return call_id, "(plan interrupted by user)"
@@ -6029,7 +6044,6 @@ class ChatSession:
                 content = self._run_agent(
                     agent_messages,
                     label="plan",
-                    reasoning_effort="high",
                 )
             except (KeyboardInterrupt, GenerationCancelled):
                 return call_id, "(plan interrupted by user)"
@@ -6097,7 +6111,6 @@ class ChatSession:
         content = self._run_agent(
             agent_messages,
             label="plan",
-            reasoning_effort="high",
         )
 
         valid, issues = self._validate_plan(content, original_goal)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3321,6 +3321,10 @@ def internal_model_reload(request: Request) -> JSONResponse:
             effective_default,
             new_registry.fallback,
             new_registry.agent_model,
+            plan_model=new_registry.plan_model,
+            task_model=new_registry.task_model,
+            plan_effort=new_registry.plan_effort,
+            task_effort=new_registry.task_effort,
         )
     except ValueError as exc:
         return JSONResponse({"status": "error", "reason": str(exc)}, status_code=422)
@@ -4045,7 +4049,16 @@ def main() -> None:
     # Apply runtime default alias override from ConfigStore (if set)
     cs_default_alias = config_store.get("model.default_alias")
     if cs_default_alias and registry.has_alias(cs_default_alias):
-        registry.reload(registry.models, cs_default_alias, registry.fallback, registry.agent_model)
+        registry.reload(
+            registry.models,
+            cs_default_alias,
+            registry.fallback,
+            registry.agent_model,
+            plan_model=registry.plan_model,
+            task_model=registry.task_model,
+            plan_effort=registry.plan_effort,
+            task_effort=registry.task_effort,
+        )
 
     # Initialize MCP client (connects to configured MCP servers, if any)
     from turnstone.core.mcp_client import create_mcp_client


### PR DESCRIPTION
…ffort

plan_agent and task_agent previously shared a single agent_model knob and plan_agent hardcoded reasoning_effort="high" in three call sites. They have different cost/latency profiles — plan is rare and benefits from a stronger model, task is frequent and benefits from a cheaper one — so sharing the knob undertunes both.

ModelRegistry gains plan_model, task_model, plan_effort, task_effort. Per-kind overrides win over the legacy agent_model, which still works as the single-knob fallback for both. resolve_agent_alias(kind) and resolve_agent_effort(kind) centralise the resolution; PLAN_DEFAULT_EFFORT captures the back-compat "high" default in one place rather than at every call site.

session._run_agent delegates resolution by label ("plan" vs "task"). The three hardcoded reasoning_effort="high" arguments are removed — behaviour is identical when no plan_effort is configured.

Loader validates effort against {none,minimal,low,medium,high,xhigh,max} and warns + drops typos rather than passing them to the provider.

ConfigStore parity and admin UI for the new knobs are deferred to a follow-up — config.toml-only is enough for the backend split.