### PR TITLE
feat: ConfigStore + admin UI for plan/task agent model and effort

### DIFF
--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -90,6 +90,18 @@ class TestSetGetRoundTrip:
         store.set("model.default_alias", "gpt5-prod")
         assert store.get("model.default_alias") == "gpt5-prod"
 
+    def test_plan_task_alias(self, store):
+        store.set("model.plan_alias", "smart")
+        store.set("model.task_alias", "fast")
+        assert store.get("model.plan_alias") == "smart"
+        assert store.get("model.task_alias") == "fast"
+
+    def test_plan_task_effort(self, store):
+        store.set("model.plan_effort", "max")
+        store.set("model.task_effort", "low")
+        assert store.get("model.plan_effort") == "max"
+        assert store.get("model.task_effort") == "low"
+
 
 # ---------------------------------------------------------------------------
 # delete()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -406,6 +406,23 @@ class TestLoadModelRegistry:
                 reg = load_model_registry("http://x/v1", "x", "x")
             assert reg.plan_effort == level, f"level={level} not accepted"
 
+    def test_empty_or_whitespace_effort_treated_as_unset(self) -> None:
+        """Operators write `plan_effort = ""` to make "unset" explicit;
+        warning on benign empty values would be noise."""
+        for value in ("", "  ", "\t"):
+            fake_cfg: dict[str, Any] = {"model": {"plan_effort": value, "task_effort": value}}
+            with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+                reg = load_model_registry("http://x/v1", "x", "x")
+            assert reg.plan_effort is None, f"empty value {value!r} not treated as unset"
+            assert reg.task_effort is None
+
+    def test_effort_normalised_to_lowercase(self) -> None:
+        fake_cfg: dict[str, Any] = {"model": {"plan_effort": "HIGH", "task_effort": " Low "}}
+        with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+            reg = load_model_registry("http://x/v1", "x", "x")
+        assert reg.plan_effort == "high"
+        assert reg.task_effort == "low"
+
     def test_invalid_default_falls_back(self) -> None:
         fake_cfg: dict[str, Any] = {
             "model": {"default": "nonexistent"},

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1434,3 +1434,127 @@ class TestLoadModelRegistryDBOnly:
         with patch("turnstone.core.model_registry.load_config", return_value={}):
             reg = load_model_registry(model="", storage=storage)
         assert not reg.has_alias("default")
+
+
+# ---------------------------------------------------------------------------
+# server._effective_routing / _apply_routing_overrides
+# ---------------------------------------------------------------------------
+
+
+class _FakeCS:
+    """Minimal ConfigStore stand-in: dict-backed get()."""
+
+    def __init__(self, **values: str) -> None:
+        self._values = values
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default if default is not None else "")
+
+
+class TestEffectiveRouting:
+    """Pure-function helper that overlays ConfigStore values on a base."""
+
+    def _models(self) -> dict[str, ModelConfig]:
+        return {
+            "default": ModelConfig("default", "x", "x", "m"),
+            "smart": ModelConfig("smart", "x", "x", "m"),
+            "fast": ModelConfig("fast", "x", "x", "m"),
+        }
+
+    def test_returns_base_when_cs_is_none(self) -> None:
+        from turnstone.server import _effective_routing
+
+        result = _effective_routing(None, self._models(), "default", "smart", "fast", "high", "low")
+        assert result == ("default", "smart", "fast", "high", "low")
+
+    def test_cs_alias_overrides_base(self) -> None:
+        from turnstone.server import _effective_routing
+
+        cs = _FakeCS(**{"model.plan_alias": "fast", "model.task_alias": "smart"})
+        result = _effective_routing(cs, self._models(), "default", "smart", "fast", "high", "low")
+        assert result == ("default", "fast", "smart", "high", "low")
+
+    def test_cs_alias_silently_dropped_when_unknown(self) -> None:
+        from turnstone.server import _effective_routing
+
+        cs = _FakeCS(**{"model.plan_alias": "nonexistent"})
+        result = _effective_routing(cs, self._models(), "default", "smart", None, None, None)
+        assert result == ("default", "smart", None, None, None)  # falls back to base
+
+    def test_cs_empty_string_treated_as_unset(self) -> None:
+        from turnstone.server import _effective_routing
+
+        cs = _FakeCS(
+            **{
+                "model.default_alias": "",
+                "model.plan_alias": "",
+                "model.task_alias": "",
+                "model.plan_effort": "",
+                "model.task_effort": "",
+            }
+        )
+        result = _effective_routing(cs, self._models(), "default", "smart", "fast", "high", "low")
+        assert result == ("default", "smart", "fast", "high", "low")
+
+    def test_cs_effort_overrides_base(self) -> None:
+        from turnstone.server import _effective_routing
+
+        cs = _FakeCS(**{"model.plan_effort": "max", "model.task_effort": "minimal"})
+        result = _effective_routing(cs, self._models(), "default", None, None, "high", None)
+        assert result == ("default", None, None, "max", "minimal")
+
+
+class TestApplyRoutingOverrides:
+    """Decides whether to call registry.reload based on effective vs current."""
+
+    def _registry(self, **kwargs: Any) -> ModelRegistry:
+        return ModelRegistry(
+            models={
+                "default": ModelConfig("default", "x", "x", "m"),
+                "smart": ModelConfig("smart", "x", "x", "m"),
+                "fast": ModelConfig("fast", "x", "x", "m"),
+            },
+            default="default",
+            **kwargs,
+        )
+
+    def test_no_reload_when_cs_matches_registry(self) -> None:
+        from turnstone.server import _apply_routing_overrides
+
+        reg = self._registry(plan_model="smart", task_model="fast")
+        cs = _FakeCS(**{"model.plan_alias": "smart", "model.task_alias": "fast"})
+        # Patch reload to detect calls
+        called = {"count": 0}
+        original_reload = reg.reload
+        reg.reload = lambda *a, **kw: (
+            called.update(count=called["count"] + 1)
+            or original_reload(  # type: ignore[method-assign]
+                *a, **kw
+            )
+        )
+
+        assert _apply_routing_overrides(reg, cs) is False
+        assert called["count"] == 0
+
+    def test_reload_when_cs_differs(self) -> None:
+        from turnstone.server import _apply_routing_overrides
+
+        reg = self._registry()  # plan_model=None
+        cs = _FakeCS(**{"model.plan_alias": "smart"})
+        assert _apply_routing_overrides(reg, cs) is True
+        assert reg.plan_model == "smart"
+
+    def test_no_reload_when_cs_is_none(self) -> None:
+        from turnstone.server import _apply_routing_overrides
+
+        reg = self._registry()
+        assert _apply_routing_overrides(reg, None) is False
+
+    def test_unknown_alias_does_not_trigger_reload(self) -> None:
+        """Invalid CS aliases are silently dropped — no spurious reload."""
+        from turnstone.server import _apply_routing_overrides
+
+        reg = self._registry()
+        cs = _FakeCS(**{"model.plan_alias": "nonexistent"})
+        assert _apply_routing_overrides(reg, cs) is False
+        assert reg.plan_model is None  # unchanged

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -122,6 +122,26 @@ class TestValidateValueChoices:
         for ch in ("", "none", "low", "medium", "high", "max"):
             assert validate_value("model.reasoning_effort", ch) == ch
 
+    def test_plan_task_alias_accept_any_string(self):
+        # plan/task aliases are validated dynamically against live registry
+        # at apply time; here we just confirm the static validator accepts
+        # arbitrary strings (including "" for "use server default").
+        assert validate_value("model.plan_alias", "") == ""
+        assert validate_value("model.task_alias", "") == ""
+        assert validate_value("model.plan_alias", "smart") == "smart"
+        assert validate_value("model.task_alias", "fast") == "fast"
+
+    def test_plan_task_effort_choices(self):
+        for ch in ("", "none", "minimal", "low", "medium", "high", "xhigh", "max"):
+            assert validate_value("model.plan_effort", ch) == ch
+            assert validate_value("model.task_effort", ch) == ch
+
+    def test_plan_task_effort_invalid(self):
+        with pytest.raises(ValueError, match="not in"):
+            validate_value("model.plan_effort", "extreme")
+        with pytest.raises(ValueError, match="not in"):
+            validate_value("model.task_effort", "supercharged")
+
 
 # ---------------------------------------------------------------------------
 # serialize / deserialize round-trip
@@ -147,6 +167,16 @@ class TestSerializeDeserialize:
 
     def test_str_round_trip_empty(self):
         assert deserialize_value("model.default_alias", serialize_value("")) == ""
+
+    def test_plan_task_round_trip(self):
+        for k in (
+            "model.plan_alias",
+            "model.task_alias",
+            "model.plan_effort",
+            "model.task_effort",
+        ):
+            assert deserialize_value(k, serialize_value("")) == ""
+            assert deserialize_value(k, serialize_value("high")) == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -20,7 +20,7 @@
 [model]
 # name = ""                    # Model ID; empty = provider default (gpt-5 / claude-sonnet-4)
 # temperature = 0.0            # 0 = provider default
-# reasoning_effort = ""        # "low", "medium", "high", "xhigh", "max"
+# reasoning_effort = ""        # "none", "minimal", "low", "medium", "high", "xhigh", "max"
 # context_window = 0           # 0 = auto-detect from provider capabilities
 # max_tokens = 0               # 0 = provider default
 #

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -15,6 +15,21 @@ var _confirmCallbackFn = null;
 var _confirmTriggerEl = null;
 var _mobileSidebarOpen = false;
 
+// Settings whose choices are populated dynamically from the live model
+// alias list, and whose empty-string option renders as "(server default)".
+var ALIAS_SETTING_KEYS = [
+  "model.default_alias",
+  "model.plan_alias",
+  "model.task_alias",
+  "channels.default_model_alias",
+];
+
+// Settings whose empty option means "inherit from a fallback chain", as
+// opposed to "no value" — distinct from the literal "none" choice (e.g.
+// reasoning_effort="none" actually disables reasoning, very different
+// from leaving it unset).
+var INHERIT_EMPTY_LABEL_KEYS = ["model.plan_effort", "model.task_effort"];
+
 // ---------------------------------------------------------------------------
 // View switching (called from app.js showOverview/drillDown pattern)
 // ---------------------------------------------------------------------------
@@ -2577,11 +2592,9 @@ function loadSettings() {
         if (modelDefs[m].enabled) enabledAliases.push(modelDefs[m].alias);
       }
       if (enabledAliases.length > 1) {
-        if (merged["model.default_alias"]) {
-          merged["model.default_alias"].choices = enabledAliases;
-        }
-        if (merged["channels.default_model_alias"]) {
-          merged["channels.default_model_alias"].choices = enabledAliases;
+        for (var ak = 0; ak < ALIAS_SETTING_KEYS.length; ak++) {
+          var aliasKey = ALIAS_SETTING_KEYS[ak];
+          if (merged[aliasKey]) merged[aliasKey].choices = enabledAliases;
         }
       }
 
@@ -2757,11 +2770,10 @@ function _renderSettingRow(item) {
       var label;
       if (item.choices[c] !== "") {
         label = escapeHtml(item.choices[c]);
-      } else if (
-        item.key === "model.default_alias" ||
-        item.key === "channels.default_model_alias"
-      ) {
+      } else if (ALIAS_SETTING_KEYS.indexOf(item.key) !== -1) {
         label = "(server default)";
+      } else if (INHERIT_EMPTY_LABEL_KEYS.indexOf(item.key) !== -1) {
+        label = "(inherit)";
       } else {
         label = "(none)";
       }

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -501,7 +501,12 @@ def load_model_registry(
     def _validate_effort(value: Any, key: str) -> str | None:
         if value is None:
             return None
-        coerced = str(value)
+        # Treat empty / whitespace as unset.  Operators commonly write
+        # `plan_effort = ""` to make "leave it default" explicit; warning
+        # on that benign case would just be noise.
+        coerced = str(value).strip().lower()
+        if not coerced:
+            return None
         if coerced not in valid_efforts:
             log.warning(
                 "Configured %s '%s' is not a recognised effort level "

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -83,6 +83,54 @@ def _build_registry() -> dict[str, SettingDef]:
             "Higher effort improves quality on complex tasks but is slower and uses more "
             "tokens. Per-model overrides can be set in the Models tab.",
         ),
+        SettingDef(
+            "model.plan_alias",
+            "str",
+            "",
+            "Model alias for plan_agent (empty = inherit from config / session)",
+            "model",
+            help="Which model the plan_agent sub-agent uses. When empty, falls back to "
+            "[model].plan_model in config.toml, then [model].agent_model, then the session "
+            "model. Plan_agent runs rarely but benefits from a stronger model for "
+            "high-quality plans \u2014 point this at your strongest reasoner.",
+        ),
+        SettingDef(
+            "model.task_alias",
+            "str",
+            "",
+            "Model alias for task_agent (empty = inherit from config / session)",
+            "model",
+            help="Which model the task_agent sub-agent uses. When empty, falls back to "
+            "[model].task_model in config.toml, then [model].agent_model, then the session "
+            "model. Task_agent fires frequently for autonomous subtasks \u2014 point this "
+            "at a cheaper/faster model than your plan_agent.",
+        ),
+        SettingDef(
+            "model.plan_effort",
+            "str",
+            "",
+            "Reasoning effort for plan_agent (empty = inherit from config; default \u2018high\u2019)",
+            "model",
+            choices=["", "none", "minimal", "low", "medium", "high", "xhigh", "max"],
+            help="Reasoning effort for plan_agent specifically. When empty, falls back to "
+            "[model].plan_effort in config.toml, then to the built-in default \u2018high\u2019. "
+            "Use \u2018xhigh\u2019 or \u2018max\u2019 with models that support deeper reasoning "
+            "for higher-quality plans. (Empty here means \u201cinherit\u201d \u2014 use "
+            "\u2018none\u2019 to actually disable reasoning.)",
+        ),
+        SettingDef(
+            "model.task_effort",
+            "str",
+            "",
+            "Reasoning effort for task_agent (empty = inherit from config / session)",
+            "model",
+            choices=["", "none", "minimal", "low", "medium", "high", "xhigh", "max"],
+            help="Reasoning effort for task_agent specifically. When empty, falls back to "
+            "[model].task_effort in config.toml, then inherits the session\u2019s effort. "
+            "Set to \u2018low\u2019 or \u2018minimal\u2019 if your task_agent runs many "
+            "fast subtasks where deep reasoning is wasteful. (Empty here means \u201cinherit\u201d "
+            "\u2014 use \u2018none\u2019 to actually disable reasoning.)",
+        ),
         # -- session --------------------------------------------------------
         SettingDef(
             "session.instructions",

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3238,6 +3238,12 @@ def config_reload(request: Request) -> JSONResponse:
     if not cs:
         return JSONResponse({"status": "noop"})
     cs.reload()
+    # Apply routing overrides to the live registry — admin settings updates
+    # fan out via this endpoint and would otherwise not affect plan/task
+    # routing until a model-reload or restart.
+    registry = getattr(request.app.state, "registry", None)
+    if registry is not None:
+        _apply_routing_overrides(registry, cs)
     # Broadcast settings_changed event to all connected clients
     if gq is not None:
         with contextlib.suppress(queue.Full):
@@ -3283,6 +3289,85 @@ def internal_mcp_status(request: Request) -> JSONResponse:
 # -- internal model management -----------------------------------------------
 
 
+def _effective_routing(
+    cs: Any,
+    base_models: dict[str, Any],
+    base_default: str,
+    base_plan_model: str | None,
+    base_task_model: str | None,
+    base_plan_effort: str | None,
+    base_task_effort: str | None,
+) -> tuple[str, str | None, str | None, str | None, str | None]:
+    """Compute (default, plan_model, task_model, plan_effort, task_effort)
+    after layering ConfigStore overrides on top of the supplied base values.
+
+    Aliases require existence in *base_models* (silently dropped otherwise);
+    effort values were validated against SettingDef choices on write, so a
+    truthiness check is sufficient at apply time.
+
+    Returns the base values unchanged when *cs* is None.
+    """
+    eff_default = base_default
+    eff_plan_model = base_plan_model
+    eff_task_model = base_task_model
+    eff_plan_effort = base_plan_effort
+    eff_task_effort = base_task_effort
+    if cs is not None:
+        cs_default = cs.get("model.default_alias")
+        if cs_default and cs_default in base_models:
+            eff_default = cs_default
+        cs_plan_alias = cs.get("model.plan_alias")
+        if cs_plan_alias and cs_plan_alias in base_models:
+            eff_plan_model = cs_plan_alias
+        cs_task_alias = cs.get("model.task_alias")
+        if cs_task_alias and cs_task_alias in base_models:
+            eff_task_model = cs_task_alias
+        cs_plan_effort = cs.get("model.plan_effort")
+        if cs_plan_effort:
+            eff_plan_effort = cs_plan_effort
+        cs_task_effort = cs.get("model.task_effort")
+        if cs_task_effort:
+            eff_task_effort = cs_task_effort
+    return eff_default, eff_plan_model, eff_task_model, eff_plan_effort, eff_task_effort
+
+
+def _apply_routing_overrides(registry: Any, cs: Any) -> bool:
+    """Apply ConfigStore routing overrides to a live *registry* in place.
+
+    Used by the startup path and by ``config_reload`` (admin settings
+    update fan-out) — both keep the existing model definitions and only
+    rewrite routing fields.  Returns True when a reload happened.
+    """
+    eff = _effective_routing(
+        cs,
+        registry.models,
+        registry.default,
+        registry.plan_model,
+        registry.task_model,
+        registry.plan_effort,
+        registry.task_effort,
+    )
+    if (
+        eff[0] != registry.default
+        or eff[1] != registry.plan_model
+        or eff[2] != registry.task_model
+        or eff[3] != registry.plan_effort
+        or eff[4] != registry.task_effort
+    ):
+        registry.reload(
+            registry.models,
+            eff[0],
+            registry.fallback,
+            registry.agent_model,
+            plan_model=eff[1],
+            task_model=eff[2],
+            plan_effort=eff[3],
+            task_effort=eff[4],
+        )
+        return True
+    return False
+
+
 def internal_model_reload(request: Request) -> JSONResponse:
     """POST /v1/api/_internal/model-reload — rebuild registry from DB + config."""
     from turnstone.core.model_registry import load_model_registry
@@ -3301,51 +3386,53 @@ def internal_model_reload(request: Request) -> JSONResponse:
         provider=cli_args["provider"],
         storage=get_storage(),
     )
-    # Allow runtime override of routing fields via ConfigStore.  Per-kind
-    # values (plan/task) override the legacy single-knob agent_model when
-    # set; effort values override the per-kind defaults from config.toml.
-    effective_default = new_registry.default
-    effective_plan_model = new_registry.plan_model
-    effective_task_model = new_registry.task_model
-    effective_plan_effort = new_registry.plan_effort
-    effective_task_effort = new_registry.task_effort
     cs = getattr(request.app.state, "config_store", None)
-    if cs:
+    if cs is not None:
         cs.reload()  # Ensure latest settings from DB
-        cs_alias = cs.get("model.default_alias")
-        if cs_alias and cs_alias in new_registry.models:
-            effective_default = cs_alias
-            log.info(
-                "ConfigStore override: using '%s' as default model (registry had '%s')",
-                effective_default,
-                new_registry.default,
-            )
-        # Aliases are validated against the live registry here (must exist);
-        # effort values were validated against the SettingDef choices on
-        # write, so a truthiness check is sufficient at apply time.
-        cs_plan_alias = cs.get("model.plan_alias")
-        if cs_plan_alias and cs_plan_alias in new_registry.models:
-            effective_plan_model = cs_plan_alias
-        cs_task_alias = cs.get("model.task_alias")
-        if cs_task_alias and cs_task_alias in new_registry.models:
-            effective_task_model = cs_task_alias
-        cs_plan_effort = cs.get("model.plan_effort")
-        if cs_plan_effort:
-            effective_plan_effort = cs_plan_effort
-        cs_task_effort = cs.get("model.task_effort")
-        if cs_task_effort:
-            effective_task_effort = cs_task_effort
+    eff_default, eff_plan_model, eff_task_model, eff_plan_effort, eff_task_effort = (
+        _effective_routing(
+            cs,
+            new_registry.models,
+            new_registry.default,
+            new_registry.plan_model,
+            new_registry.task_model,
+            new_registry.plan_effort,
+            new_registry.task_effort,
+        )
+    )
+    if eff_default != new_registry.default:
+        log.info(
+            "ConfigStore override: using '%s' as default model (registry had '%s')",
+            eff_default,
+            new_registry.default,
+        )
+
+    # No-op fast path: skip reload when nothing changed (avoids client churn
+    # on broadcast model-reloads where this node has no pending changes).
+    unchanged = (
+        new_registry.models == registry.models
+        and new_registry.fallback == registry.fallback
+        and new_registry.agent_model == registry.agent_model
+        and eff_default == registry.default
+        and eff_plan_model == registry.plan_model
+        and eff_task_model == registry.task_model
+        and eff_plan_effort == registry.plan_effort
+        and eff_task_effort == registry.task_effort
+    )
+    if unchanged:
+        new_registry.shutdown()
+        return JSONResponse({"status": "ok", "aliases": registry.list_aliases(), "noop": True})
 
     try:
         registry.reload(
             new_registry.models,
-            effective_default,
+            eff_default,
             new_registry.fallback,
             new_registry.agent_model,
-            plan_model=effective_plan_model,
-            task_model=effective_task_model,
-            plan_effort=effective_plan_effort,
-            task_effort=effective_task_effort,
+            plan_model=eff_plan_model,
+            task_model=eff_task_model,
+            plan_effort=eff_plan_effort,
+            task_effort=eff_task_effort,
         )
     except ValueError as exc:
         return JSONResponse({"status": "error", "reason": str(exc)}, status_code=422)
@@ -4073,47 +4160,7 @@ def main() -> None:
     # ConfigStore returns the SettingDef default ("" for these keys) when
     # unset — distinct from the registry's None for unconfigured fields.
     config_store.reload()  # symmetry with internal_model_reload's cs.reload()
-    cs_default_alias = config_store.get("model.default_alias")
-    cs_plan_alias = config_store.get("model.plan_alias")
-    cs_task_alias = config_store.get("model.task_alias")
-    cs_plan_effort = config_store.get("model.plan_effort")
-    cs_task_effort = config_store.get("model.task_effort")
-
-    eff_default = (
-        cs_default_alias
-        if cs_default_alias and registry.has_alias(cs_default_alias)
-        else registry.default
-    )
-    eff_plan_model = (
-        cs_plan_alias
-        if cs_plan_alias and registry.has_alias(cs_plan_alias)
-        else registry.plan_model
-    )
-    eff_task_model = (
-        cs_task_alias
-        if cs_task_alias and registry.has_alias(cs_task_alias)
-        else registry.task_model
-    )
-    eff_plan_effort = cs_plan_effort or registry.plan_effort
-    eff_task_effort = cs_task_effort or registry.task_effort
-
-    if (
-        eff_default != registry.default
-        or eff_plan_model != registry.plan_model
-        or eff_task_model != registry.task_model
-        or eff_plan_effort != registry.plan_effort
-        or eff_task_effort != registry.task_effort
-    ):
-        registry.reload(
-            registry.models,
-            eff_default,
-            registry.fallback,
-            registry.agent_model,
-            plan_model=eff_plan_model,
-            task_model=eff_task_model,
-            plan_effort=eff_plan_effort,
-            task_effort=eff_task_effort,
-        )
+    _apply_routing_overrides(registry, config_store)
 
     # Initialize MCP client (connects to configured MCP servers, if any)
     from turnstone.core.mcp_client import create_mcp_client

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3301,8 +3301,14 @@ def internal_model_reload(request: Request) -> JSONResponse:
         provider=cli_args["provider"],
         storage=get_storage(),
     )
-    # Allow runtime override of the default alias via ConfigStore
+    # Allow runtime override of routing fields via ConfigStore.  Per-kind
+    # values (plan/task) override the legacy single-knob agent_model when
+    # set; effort values override the per-kind defaults from config.toml.
     effective_default = new_registry.default
+    effective_plan_model = new_registry.plan_model
+    effective_task_model = new_registry.task_model
+    effective_plan_effort = new_registry.plan_effort
+    effective_task_effort = new_registry.task_effort
     cs = getattr(request.app.state, "config_store", None)
     if cs:
         cs.reload()  # Ensure latest settings from DB
@@ -3314,6 +3320,21 @@ def internal_model_reload(request: Request) -> JSONResponse:
                 effective_default,
                 new_registry.default,
             )
+        # Aliases are validated against the live registry here (must exist);
+        # effort values were validated against the SettingDef choices on
+        # write, so a truthiness check is sufficient at apply time.
+        cs_plan_alias = cs.get("model.plan_alias")
+        if cs_plan_alias and cs_plan_alias in new_registry.models:
+            effective_plan_model = cs_plan_alias
+        cs_task_alias = cs.get("model.task_alias")
+        if cs_task_alias and cs_task_alias in new_registry.models:
+            effective_task_model = cs_task_alias
+        cs_plan_effort = cs.get("model.plan_effort")
+        if cs_plan_effort:
+            effective_plan_effort = cs_plan_effort
+        cs_task_effort = cs.get("model.task_effort")
+        if cs_task_effort:
+            effective_task_effort = cs_task_effort
 
     try:
         registry.reload(
@@ -3321,10 +3342,10 @@ def internal_model_reload(request: Request) -> JSONResponse:
             effective_default,
             new_registry.fallback,
             new_registry.agent_model,
-            plan_model=new_registry.plan_model,
-            task_model=new_registry.task_model,
-            plan_effort=new_registry.plan_effort,
-            task_effort=new_registry.task_effort,
+            plan_model=effective_plan_model,
+            task_model=effective_task_model,
+            plan_effort=effective_plan_effort,
+            task_effort=effective_task_effort,
         )
     except ValueError as exc:
         return JSONResponse({"status": "error", "reason": str(exc)}, status_code=422)
@@ -4046,18 +4067,52 @@ def main() -> None:
         storage=_get_storage(),
     )
 
-    # Apply runtime default alias override from ConfigStore (if set)
+    # Apply runtime overrides from ConfigStore for default alias plus the
+    # per-kind sub-agent routing.  Only triggers a reload when at least one
+    # ConfigStore value differs from what the registry loaded from disk.
+    # ConfigStore returns the SettingDef default ("" for these keys) when
+    # unset — distinct from the registry's None for unconfigured fields.
+    config_store.reload()  # symmetry with internal_model_reload's cs.reload()
     cs_default_alias = config_store.get("model.default_alias")
-    if cs_default_alias and registry.has_alias(cs_default_alias):
+    cs_plan_alias = config_store.get("model.plan_alias")
+    cs_task_alias = config_store.get("model.task_alias")
+    cs_plan_effort = config_store.get("model.plan_effort")
+    cs_task_effort = config_store.get("model.task_effort")
+
+    eff_default = (
+        cs_default_alias
+        if cs_default_alias and registry.has_alias(cs_default_alias)
+        else registry.default
+    )
+    eff_plan_model = (
+        cs_plan_alias
+        if cs_plan_alias and registry.has_alias(cs_plan_alias)
+        else registry.plan_model
+    )
+    eff_task_model = (
+        cs_task_alias
+        if cs_task_alias and registry.has_alias(cs_task_alias)
+        else registry.task_model
+    )
+    eff_plan_effort = cs_plan_effort or registry.plan_effort
+    eff_task_effort = cs_task_effort or registry.task_effort
+
+    if (
+        eff_default != registry.default
+        or eff_plan_model != registry.plan_model
+        or eff_task_model != registry.task_model
+        or eff_plan_effort != registry.plan_effort
+        or eff_task_effort != registry.task_effort
+    ):
         registry.reload(
             registry.models,
-            cs_default_alias,
+            eff_default,
             registry.fallback,
             registry.agent_model,
-            plan_model=registry.plan_model,
-            task_model=registry.task_model,
-            plan_effort=registry.plan_effort,
-            task_effort=registry.task_effort,
+            plan_model=eff_plan_model,
+            task_model=eff_task_model,
+            plan_effort=eff_plan_effort,
+            task_effort=eff_task_effort,
         )
 
     # Initialize MCP client (connects to configured MCP servers, if any)


### PR DESCRIPTION
Per-kind sub-agent routing was added in #359 but only via config.toml. Operators can now switch the plan_agent / task_agent model and reasoning effort at runtime from the admin Model tab without restarting.

Adds four ConfigStore-backed settings:
  model.plan_alias    — alias for plan_agent
  model.task_alias    — alias for task_agent
  model.plan_effort   — reasoning effort for plan_agent
  model.task_effort   — reasoning effort for task_agent

Server startup and internal_model_reload both apply these as overrides on top of the registry's config.toml-loaded values; the new logic computes "effective" values for all five model-routing fields and only calls registry.reload() when at least one differs.

Admin UI: extracts ALIAS_SETTING_KEYS to a const used by both the dynamic-alias-choice injection and the empty-option label rendering. Adds INHERIT_EMPTY_LABEL_KEYS so plan_effort / task_effort show "(inherit)" for empty — distinct from the literal "none" choice (which actually disables reasoning, very different from leaving unset).

Also fixes Copilot review feedback from #359:
  - _validate_effort treats empty / whitespace as unset rather than warning on benign explicit-empty configs (with .strip().lower() normalisation; "HIGH" and " low " now parse correctly)
  - turnstone.example.toml's reasoning_effort comment lists the full set of accepted values (none, minimal, low, medium, high, xhigh, max)