### PR TITLE
feat: per-call model selection on plan_agent / task_agent

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1170,6 +1170,35 @@ class TestSessionAgentModel:
         )
         assert self._captured_effort(captured) == "minimal"
 
+    # -- per-call agent_alias override (LLM passes model="<alias>") ----------
+
+    def test_run_agent_uses_explicit_alias_override(self) -> None:
+        """agent_alias kwarg routes the agent call to the chosen client/model."""
+        reg = self._three_model_registry()
+        session = _make_session(registry=reg, model_alias="main")
+        captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "x"}], label="task", agent_alias="fast")
+        assert captured["model"] == "fast-model"
+
+    def test_explicit_alias_overrides_registry_plan_model(self) -> None:
+        """Per-call alias wins over the configured per-kind plan_model."""
+        reg = self._three_model_registry(plan_model="smart")
+        session = _make_session(registry=reg, model_alias="main")
+        # Without override the call would route to "smart"; we ask for "fast".
+        captured = self._capture(reg, "fast")
+        session._run_agent([{"role": "user", "content": "x"}], label="plan", agent_alias="fast")
+        assert captured["model"] == "fast-model"
+
+    def test_invalid_alias_raises_in_run_agent(self) -> None:
+        """Defence-in-depth: _prepare_* validates first, but _run_agent
+        rejects unknown aliases too rather than silently falling back."""
+        reg = self._three_model_registry()
+        session = _make_session(registry=reg, model_alias="main")
+        with pytest.raises(ValueError, match="Unknown agent_alias"):
+            session._run_agent(
+                [{"role": "user", "content": "x"}], label="plan", agent_alias="bogus"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Workstream integration

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -367,6 +367,142 @@ class TestPlanExec:
 
 
 # ---------------------------------------------------------------------------
+# Per-call model override on plan_agent / task_agent
+# ---------------------------------------------------------------------------
+
+
+class TestAgentModelOverride:
+    """Tests for the optional `model` arg on plan_agent / task_agent tools."""
+
+    @staticmethod
+    def _registry():
+        from turnstone.core.model_registry import ModelConfig, ModelRegistry
+
+        return ModelRegistry(
+            models={
+                "default": ModelConfig("default", "x", "x", "m"),
+                "smart": ModelConfig("smart", "x", "x", "m"),
+                "fast": ModelConfig("fast", "x", "x", "m"),
+            },
+            default="default",
+        )
+
+    # ---- _prepare_plan ----
+
+    def test_prepare_plan_extracts_model_override(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_plan("c1", {"goal": "do x", "model": "smart"})
+        assert item["model_override"] == "smart"
+        assert "error" not in item
+
+    def test_prepare_plan_missing_model_arg_means_no_override(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_plan("c1", {"goal": "do x"})
+        assert item["model_override"] is None
+
+    def test_prepare_plan_empty_string_model_means_no_override(self, tmp_db) -> None:
+        # LLMs sometimes echo "" rather than omit the field; treat as unset.
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_plan("c1", {"goal": "do x", "model": ""})
+        assert item["model_override"] is None
+
+    def test_prepare_plan_unknown_model_returns_error(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_plan("c1", {"goal": "do x", "model": "bogus"})
+        assert item.get("needs_approval") is False
+        assert "error" in item
+        assert "unknown model alias 'bogus'" in item["error"]
+        # The error guidance must list the available aliases so the LLM can retry.
+        for alias in ("default", "smart", "fast"):
+            assert alias in item["error"]
+
+    # ---- _prepare_task ----
+
+    def test_prepare_task_extracts_model_override(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_task("c1", {"prompt": "do x", "model": "fast"})
+        assert item["model_override"] == "fast"
+
+    def test_prepare_task_missing_model_arg_means_no_override(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_task("c1", {"prompt": "do x"})
+        assert item["model_override"] is None
+
+    def test_prepare_task_unknown_model_returns_error(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        item = session._prepare_task("c1", {"prompt": "do x", "model": "bogus"})
+        assert item.get("needs_approval") is False
+        assert "error" in item
+        assert "unknown model alias 'bogus'" in item["error"]
+
+    # ---- tool description rendering ----
+
+    @staticmethod
+    def _agent_tool(session, name):
+        """Return the plan_agent / task_agent dict from the main tool set."""
+        for t in session._tools:
+            fn = t.get("function") or {}
+            if fn.get("name") == name:
+                return t
+        return None
+
+    def test_render_injects_alias_list_into_descriptions(self, tmp_db) -> None:
+        session = _make_session(registry=self._registry(), model_alias="default")
+        for name in ("plan_agent", "task_agent"):
+            tool = self._agent_tool(session, name)
+            assert tool is not None, f"{name} missing from session tools"
+            desc = tool["function"]["parameters"]["properties"]["model"]["description"]
+            for alias in ("default", "smart", "fast"):
+                assert f"`{alias}`" in desc, f"alias {alias} missing from {desc!r}"
+
+    def test_render_no_op_without_registry(self, tmp_db) -> None:
+        """No registry → leave the placeholder description untouched."""
+        session = _make_session()  # no registry
+        plan_tool = self._agent_tool(session, "plan_agent")
+        assert plan_tool is not None
+        desc = plan_tool["function"]["parameters"]["properties"]["model"]["description"]
+        assert "No alternative aliases configured" in desc
+
+    def test_refresh_picks_up_new_aliases(self, tmp_db) -> None:
+        """Adding a new model and calling refresh_agent_tool_schemas updates
+        the description without requiring a fresh session."""
+        from turnstone.core.model_registry import ModelConfig
+
+        reg = self._registry()
+        session = _make_session(registry=reg, model_alias="default")
+
+        # Mutate the registry to add a new alias (simulates admin model add
+        # followed by sync-to-nodes / internal_model_reload).
+        new_models = dict(reg.models)
+        new_models["bigboi"] = ModelConfig("bigboi", "x", "x", "m")
+        reg.reload(new_models, reg.default, reg.fallback, reg.agent_model)
+
+        session.refresh_agent_tool_schemas()
+
+        plan_tool = self._agent_tool(session, "plan_agent")
+        assert plan_tool is not None
+        desc = plan_tool["function"]["parameters"]["properties"]["model"]["description"]
+        assert "`bigboi`" in desc
+
+    def test_module_level_constants_not_mutated(self, tmp_db) -> None:
+        """Rendering must not pollute the module-level TOOLS list shared
+        across all sessions."""
+        from turnstone.core.tools import TOOLS
+
+        # Construct purely for the side effect of rendering on init.
+        _make_session(registry=self._registry(), model_alias="default")
+
+        for t in TOOLS:
+            fn = t.get("function") or {}
+            if fn.get("name") not in ("plan_agent", "task_agent"):
+                continue
+            desc = fn["parameters"]["properties"]["model"]["description"]
+            assert "No alternative aliases configured" in desc, (
+                f"module-level {fn['name']} description was mutated to: {desc!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Plan validation
 # ---------------------------------------------------------------------------
 

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -33,6 +33,11 @@
 # task_model = ""              # task_agent override (e.g. "local" for cheap subtasks)
 # plan_effort = ""             # reasoning effort for plan_agent (default: "high")
 # task_effort = ""             # reasoning effort for task_agent (default: inherit session)
+#
+# At call time, the calling LLM may also pass `model="<alias>"` to
+# plan_agent / task_agent to override these per-invocation.  Tool
+# descriptions list available aliases dynamically; bad aliases return
+# an error so the model retries with a valid choice.
 
 # --- Named Models (turnstone, node, eval) ---
 # Define model aliases with per-model overrides. Useful for local model

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -831,22 +831,23 @@ class ChatSession:
                 )
             new_tools.append(new_tool)
         self._tools = new_tools
-        # The BM25 tool-search index (when active) holds the OLD plan/task
-        # dicts; rebuild so its description text matches what the LLM sees.
-        # getattr guard: this method also runs from __init__ before
-        # _tool_search is assigned, in which case there's nothing to rebuild.
-        if getattr(self, "_tool_search", None) is not None:
-            self._rebuild_tool_search()
 
     def refresh_agent_tool_schemas(self) -> None:
         """Public entry point: re-render plan_agent / task_agent tool
-        descriptions to reflect the current ModelRegistry state.
+        descriptions to reflect the current ModelRegistry state, and
+        rebuild the BM25 tool-search index so its text matches.
 
         Called by the server after a registry reload (sync-to-nodes /
         admin model edits) so active sessions pick up the new alias
         list on their next LLM turn.
+
+        ``_on_mcp_tools_changed`` calls ``_render_agent_tool_descriptions``
+        directly (not this) because it already rebuilds the tool-search
+        index right after — calling this wrapper would do that twice.
         """
         self._render_agent_tool_descriptions()
+        if getattr(self, "_tool_search", None) is not None:
+            self._rebuild_tool_search()
 
     def _on_mcp_resources_changed(self) -> None:
         """Callback from MCPClientManager when the resource list changes.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -12,6 +12,7 @@ import base64
 import collections
 import concurrent.futures
 import contextlib
+import copy
 import dataclasses
 import difflib
 import hashlib
@@ -456,6 +457,11 @@ class ChatSession:
             self._tools = TOOLS
             self._task_tools = TASK_AGENT_TOOLS
             self._agent_tools = AGENT_TOOLS
+        # Inject the live alias list into plan_agent / task_agent tool
+        # descriptions so the calling LLM sees its `model` parameter options.
+        # Replaces affected tool dicts with deep copies — module-level
+        # constants are not mutated.
+        self._render_agent_tool_descriptions()
         # Web search backend (pluggable: auto/tavily/ddg/mcp:server:tool)
         self._web_search_backend = web_search_backend
         # Dynamic tool search: defer MCP tools when tool count is high
@@ -780,7 +786,67 @@ class ChatSession:
         self._tools = merge_mcp_tools(TOOLS, mcp_tools)
         self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
         self._agent_tools = merge_mcp_tools(AGENT_TOOLS, mcp_tools)
+        self._render_agent_tool_descriptions()
         self._rebuild_tool_search()
+
+    def _render_agent_tool_descriptions(self) -> None:
+        """Inject the live alias list into the ``model`` parameter description
+        on plan_agent / task_agent tools.
+
+        Lets the calling LLM see which aliases are valid right now.
+        Called on session init and on registry reload (via
+        ``refresh_agent_tool_schemas``).  No-op when no registry is
+        configured (CLI single-model case).
+
+        Replaces affected tool dicts with deep copies so the module-level
+        ``TOOLS`` constant stays untouched across sessions.
+
+        plan_agent and task_agent live in ``self._tools`` (the main session's
+        tool set) — not in ``self._agent_tools`` / ``self._task_tools``,
+        which are what *sub-agents* see (sub-agents don't get delegation
+        tools to avoid infinite recursion).
+        """
+        if self._registry is None:
+            return
+        aliases = sorted(self._registry.list_aliases())
+        if not aliases:
+            return
+        aliases_str = ", ".join(f"`{a}`" for a in aliases)
+
+        new_tools: list[dict[str, Any]] = []
+        for tool in self._tools:
+            fn = tool.get("function") or {}
+            name = fn.get("name", "")
+            if name not in ("plan_agent", "task_agent"):
+                new_tools.append(tool)
+                continue
+            kind = "plan model" if name == "plan_agent" else "task model"
+            new_tool = copy.deepcopy(tool)
+            props = new_tool.get("function", {}).get("parameters", {}).get("properties", {})
+            if "model" in props:
+                props["model"]["description"] = (
+                    f"Optional model alias to run this {name} on. "
+                    f"Omit to use the operator-configured {kind}. "
+                    f"Available aliases: {aliases_str}."
+                )
+            new_tools.append(new_tool)
+        self._tools = new_tools
+        # The BM25 tool-search index (when active) holds the OLD plan/task
+        # dicts; rebuild so its description text matches what the LLM sees.
+        # getattr guard: this method also runs from __init__ before
+        # _tool_search is assigned, in which case there's nothing to rebuild.
+        if getattr(self, "_tool_search", None) is not None:
+            self._rebuild_tool_search()
+
+    def refresh_agent_tool_schemas(self) -> None:
+        """Public entry point: re-render plan_agent / task_agent tool
+        descriptions to reflect the current ModelRegistry state.
+
+        Called by the server after a registry reload (sync-to-nodes /
+        admin model edits) so active sessions pick up the new alias
+        list on their next LLM turn.
+        """
+        self._render_agent_tool_descriptions()
 
     def _on_mcp_resources_changed(self) -> None:
         """Callback from MCPClientManager when the resource list changes.
@@ -4476,6 +4542,35 @@ class ChatSession:
         output = self._tool_search.format_search_results(results)
         return item["call_id"], output
 
+    def _validate_agent_model_override(
+        self, call_id: str, func_name: str, args: dict[str, Any]
+    ) -> tuple[str | None, dict[str, Any] | None]:
+        """Pull and validate the optional `model` arg for plan/task agents.
+
+        Returns (alias, error_item).  When the caller passed a `model` and
+        it isn't in the registry, returns an error_item shaped like the
+        existing _prepare_* error dicts so the LLM gets corrective guidance
+        and retries.  When no override was passed, returns (None, None).
+        """
+        raw = args.get("model")
+        if raw is None or raw == "":
+            return None, None
+        alias = str(raw).strip()
+        if not alias:
+            return None, None
+        if self._registry is None or not self._registry.has_alias(alias):
+            available = sorted(self._registry.list_aliases()) if self._registry is not None else []
+            available_str = ", ".join(available) if available else "(no registry configured)"
+            return None, {
+                "call_id": call_id,
+                "func_name": func_name,
+                "header": f"\u2717 {func_name}: unknown model alias",
+                "preview": "",
+                "needs_approval": False,
+                "error": f"Error: unknown model alias '{alias}'. Available: {available_str}",
+            }
+        return alias, None
+
     def _prepare_task(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         """Prepare a general-purpose sub-agent task for approval."""
         prompt = (args.get("prompt") or "").strip()
@@ -4488,6 +4583,9 @@ class ChatSession:
                 "needs_approval": False,
                 "error": "Error: empty prompt",
             }
+        model_override, err = self._validate_agent_model_override(call_id, "task_agent", args)
+        if err is not None:
+            return err
         preview_text = prompt[:300] + ("..." if len(prompt) > 300 else "")
         return {
             "call_id": call_id,
@@ -4498,6 +4596,7 @@ class ChatSession:
             "approval_label": "task_agent",
             "execute": self._exec_task,
             "prompt": prompt,
+            "model_override": model_override,
         }
 
     def _prepare_plan(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -4512,6 +4611,9 @@ class ChatSession:
                 "needs_approval": False,
                 "error": "Error: empty goal",
             }
+        model_override, err = self._validate_agent_model_override(call_id, "plan_agent", args)
+        if err is not None:
+            return err
         preview_text = goal[:300] + ("..." if len(goal) > 300 else "")
         return {
             "call_id": call_id,
@@ -4522,6 +4624,7 @@ class ChatSession:
             "approval_label": "plan_agent",
             "execute": self._exec_plan,
             "prompt": goal,
+            "model_override": model_override,
         }
 
     def _resolve_scope_id(self, scope: str) -> str:
@@ -5651,6 +5754,7 @@ class ChatSession:
         tools: list[dict[str, Any]] | None = None,
         auto_tools: set[str] | None = None,
         reasoning_effort: str | None = None,
+        agent_alias: str | None = None,
     ) -> str:
         """Run an autonomous agent loop.
 
@@ -5660,6 +5764,11 @@ class ChatSession:
             tools: Tool definitions to send to the API. Defaults to AGENT_TOOLS (read-only).
             auto_tools: Set of tool names the agent may execute. Defaults to AGENT_AUTO_TOOLS.
             reasoning_effort: Override reasoning effort for this agent.
+            agent_alias: Per-call model alias override (the LLM passed
+                ``model="<alias>"`` to plan_agent/task_agent).  Wins over
+                the registry's per-kind resolution when set.  Caller is
+                expected to have validated the alias against the registry;
+                an unknown alias here raises ``ValueError``.
 
         Returns:
             Final content string from the agent.
@@ -5670,10 +5779,14 @@ class ChatSession:
             auto_tools = AGENT_AUTO_TOOLS
         max_tool_turns = self.agent_max_turns
 
-        # Resolve agent model: per-kind override (plan_model/task_model) wins
-        # over the legacy single-knob agent_model, which falls back to the
-        # session's primary model when unset.
-        agent_alias = self._registry.resolve_agent_alias(label) if self._registry else None
+        # Resolve agent model: explicit per-call override wins, then per-kind
+        # registry override (plan_model/task_model), then the legacy single-
+        # knob agent_model, then the session's primary model.
+        if agent_alias is not None:
+            if self._registry is None or not self._registry.has_alias(agent_alias):
+                raise ValueError(f"Unknown agent_alias '{agent_alias}'")
+        else:
+            agent_alias = self._registry.resolve_agent_alias(label) if self._registry else None
         if self._registry and agent_alias:
             agent_client, agent_model, _ = self._registry.resolve(agent_alias)
             agent_provider = self._registry.get_provider(agent_alias)
@@ -5897,6 +6010,7 @@ class ChatSession:
                 label="task",
                 tools=self._task_tools,
                 auto_tools=TASK_AUTO_TOOLS,
+                agent_alias=item.get("model_override"),
             )
         except (KeyboardInterrupt, GenerationCancelled):
             return call_id, "(task interrupted by user)"
@@ -6011,10 +6125,12 @@ class ChatSession:
         agent_messages.extend(prior_plan_msgs)
         agent_messages.append({"role": "user", "content": prompt})
 
+        plan_alias = item.get("model_override")
         try:
             content = self._run_agent(
                 agent_messages,
                 label="plan",
+                agent_alias=plan_alias,
             )
         except (KeyboardInterrupt, GenerationCancelled):
             return call_id, "(plan interrupted by user)"
@@ -6044,6 +6160,7 @@ class ChatSession:
                 content = self._run_agent(
                     agent_messages,
                     label="plan",
+                    agent_alias=plan_alias,
                 )
             except (KeyboardInterrupt, GenerationCancelled):
                 return call_id, "(plan interrupted by user)"

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3331,6 +3331,31 @@ def _effective_routing(
     return eff_default, eff_plan_model, eff_task_model, eff_plan_effort, eff_task_effort
 
 
+def _broadcast_agent_tool_schema_refresh(app_state: Any) -> None:
+    """Tell every active session on this node to re-render its plan_agent /
+    task_agent tool descriptions.  Best-effort: a session that lacks the
+    method (older code path or test stub) is skipped silently.
+
+    Called after a registry reload that may have added/removed model
+    aliases, so the calling LLMs see an updated `model` parameter
+    description on their next turn.
+    """
+    mgr = getattr(app_state, "workstreams", None)
+    if mgr is None:
+        return
+    try:
+        workstreams = mgr.list_all()
+    except Exception:
+        return
+    for ws in workstreams:
+        session = getattr(ws, "session", None)
+        refresh = getattr(session, "refresh_agent_tool_schemas", None)
+        if refresh is None:
+            continue
+        with contextlib.suppress(Exception):
+            refresh()
+
+
 def _apply_routing_overrides(registry: Any, cs: Any) -> bool:
     """Apply ConfigStore routing overrides to a live *registry* in place.
 
@@ -3445,6 +3470,10 @@ def internal_model_reload(request: Request) -> JSONResponse:
         for alias in registry.list_aliases():
             cfg = registry.get_config(alias)
             health_reg.get_tracker(provider=cfg.provider, base_url=cfg.base_url)
+
+    # Push the new alias list into active sessions so plan_agent/task_agent
+    # `model` parameter descriptions reflect the current registry.
+    _broadcast_agent_tool_schema_refresh(request.app.state)
 
     return JSONResponse({"status": "ok", "aliases": registry.list_aliases()})
 

--- a/turnstone/tools/plan_agent.json
+++ b/turnstone/tools/plan_agent.json
@@ -10,7 +10,7 @@
       },
       "model": {
         "type": "string",
-        "description": "Optional model alias to run this plan agent on. Omit to use the operator-configured plan model. (No alternative aliases configured in this session.)"
+        "description": "Optional model alias to run this plan agent on. Omit to use the current session model. (No alternative aliases configured in this session.)"
       }
     },
     "required": ["goal"]

--- a/turnstone/tools/plan_agent.json
+++ b/turnstone/tools/plan_agent.json
@@ -7,6 +7,10 @@
       "goal": {
         "type": "string",
         "description": "The goal and scope of the plan, including any constraints."
+      },
+      "model": {
+        "type": "string",
+        "description": "Optional model alias to run this plan agent on. Omit to use the operator-configured plan model. (No alternative aliases configured in this session.)"
       }
     },
     "required": ["goal"]

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -7,6 +7,10 @@
       "prompt": {
         "type": "string",
         "description": "Complete task description for the sub-agent."
+      },
+      "model": {
+        "type": "string",
+        "description": "Optional model alias to run this task agent on. Omit to use the operator-configured task model. (No alternative aliases configured in this session.)"
       }
     },
     "required": ["prompt"]

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -10,7 +10,7 @@
       },
       "model": {
         "type": "string",
-        "description": "Optional model alias to run this task agent on. Omit to use the operator-configured task model. (No alternative aliases configured in this session.)"
+        "description": "Optional model alias to run this task agent on. Omit to use the current session model. (No alternative aliases configured in this session.)"
       }
     },
     "required": ["prompt"]


### PR DESCRIPTION
The calling LLM can now pass `model="<alias>"` to plan_agent or task_agent to override the operator-configured per-kind model for that one invocation.  Useful when subtask difficulty varies within a session: the model can downgrade to a cheap alias for trivial work and reach for a stronger one when the problem is hard.

Tool descriptions list the live registered aliases (refreshed when the operator hits "sync to nodes" / internal_model_reload), so the calling LLM always sees the current options.  Bad aliases return a corrective error dict with the available choices so the LLM retries cleanly rather than failing silently.

No whitelist — any alias the registry knows is acceptable; cost control is intentionally ceded to the model.  No per-call effort override (out of scope; effort stays operator-configured).

Resolution precedence in _run_agent: explicit per-call agent_alias override > registry per-kind (plan_model/task_model) > legacy agent_model > session model.  The plan retry path (when _validate_plan fails) reuses the same alias so coaching reflects real model behaviour rather than a different model masking the signal.

Implementation:
- plan_agent.json / task_agent.json: optional `model` parameter.
- ChatSession._validate_agent_model_override extracts and validates the arg; mirrors the existing empty-prompt error pattern.
- _prepare_plan / _prepare_task stash the override in item["model_override"]; _exec_* pass it through.
- _run_agent gains agent_alias kwarg with defence-in-depth ValueError on unknown alias.
- _render_agent_tool_descriptions deep-copies plan/task entries before mutating description so the module-level TOOLS constant stays untouched across sessions; rebuilds the BM25 tool-search index when active so its text matches what the LLM sees.
- server._broadcast_agent_tool_schema_refresh walks active workstreams on internal_model_reload so descriptions update without restart.