### PR TITLE
feat(ui): dashboard composer polish from PR #362 designer review

### DIFF
--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -3721,6 +3721,8 @@ function showDashboard() {
   document.getElementById("split-root").inert = true;
   loadDashboard();
   _loadDashboardOptionsLists();
+  _restoreDashboardOptionsState();
+  _refreshDashboardOptionsSummary();
   _refreshDashboardSubmitLabel();
   setTimeout(function () {
     document.getElementById("dashboard-input").focus();
@@ -4667,18 +4669,69 @@ function _loadDashboardOptionsLists() {
   }
 }
 
-function _toggleDashboardOptions() {
+// localStorage key for the dashboard composer's Options-panel disclosure
+// state — power users who set non-default model/skill repeatedly want the
+// panel to stay open across reloads instead of clicking it every time.
+var _DASH_OPTIONS_LS_KEY = "turnstone.dashboard.options_open";
+
+function _setDashboardOptionsOpen(open) {
   var panel = document.getElementById("dashboard-options");
   var btn = document.getElementById("dashboard-options-btn");
   if (!panel || !btn) return;
-  var open = !panel.hasAttribute("hidden");
   if (open) {
-    panel.setAttribute("hidden", "");
-    btn.setAttribute("aria-expanded", "false");
-  } else {
     panel.removeAttribute("hidden");
     btn.setAttribute("aria-expanded", "true");
+  } else {
+    panel.setAttribute("hidden", "");
+    btn.setAttribute("aria-expanded", "false");
   }
+}
+
+function _toggleDashboardOptions() {
+  var panel = document.getElementById("dashboard-options");
+  if (!panel) return;
+  var nextOpen = panel.hasAttribute("hidden");
+  _setDashboardOptionsOpen(nextOpen);
+  try {
+    localStorage.setItem(_DASH_OPTIONS_LS_KEY, nextOpen ? "1" : "0");
+  } catch (_) {
+    /* localStorage may be unavailable (private mode, quota) — fall back to
+       per-session state, which is what we already have. */
+  }
+}
+
+function _restoreDashboardOptionsState() {
+  // Default closed when never set; non-power users get the cleaner first view.
+  var saved = null;
+  try {
+    saved = localStorage.getItem(_DASH_OPTIONS_LS_KEY);
+  } catch (_) {
+    /* unavailable */
+  }
+  _setDashboardOptionsOpen(saved === "1");
+}
+
+// Update the inline summary chip beside the Options button when any of
+// model / judge_model / skill is non-default.  Helps users see at a
+// glance that they've overridden defaults — without having to expand
+// the panel.  Hidden when everything is default.
+function _refreshDashboardOptionsSummary() {
+  var summary = document.getElementById("dashboard-options-summary");
+  if (!summary) return;
+  var bits = [];
+  var modelSel = document.getElementById("dashboard-model");
+  var judgeSel = document.getElementById("dashboard-judge-model");
+  var skillSel = document.getElementById("dashboard-skill");
+  if (modelSel && modelSel.value) bits.push(modelSel.value);
+  if (judgeSel && judgeSel.value) bits.push("judge: " + judgeSel.value);
+  if (skillSel && skillSel.value) bits.push(skillSel.value);
+  if (bits.length === 0) {
+    summary.textContent = "";
+    summary.setAttribute("hidden", "");
+    return;
+  }
+  summary.textContent = bits.join(" · ");
+  summary.removeAttribute("hidden");
 }
 
 // Unified dashboard submit. Replaces the old "click button → modal" +
@@ -5655,6 +5708,13 @@ document
   }
   if (optionsBtn) {
     optionsBtn.addEventListener("click", _toggleDashboardOptions);
+  }
+  // Keep the inline summary chip in sync with whichever non-default
+  // model / judge / skill is selected.  Listening on the options panel
+  // catches all three selects with one handler.
+  var optionsPanel = document.getElementById("dashboard-options");
+  if (optionsPanel) {
+    optionsPanel.addEventListener("change", _refreshDashboardOptionsSummary);
   }
   if (composer) {
     composer.addEventListener("dragover", function (e) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -4673,6 +4673,10 @@ function _loadDashboardOptionsLists() {
 // state — power users who set non-default model/skill repeatedly want the
 // panel to stay open across reloads instead of clicking it every time.
 var _DASH_OPTIONS_LS_KEY = "turnstone.dashboard.options_open";
+// In-memory fallback for environments where localStorage throws (private
+// mode, storage quota, embedded WebViews).  null means "no preference
+// recorded this session yet — use the closed default".
+var _dashOptionsOpenSession = null;
 
 function _setDashboardOptionsOpen(open) {
   var panel = document.getElementById("dashboard-options");
@@ -4692,23 +4696,36 @@ function _toggleDashboardOptions() {
   if (!panel) return;
   var nextOpen = panel.hasAttribute("hidden");
   _setDashboardOptionsOpen(nextOpen);
+  _dashOptionsOpenSession = nextOpen;
   try {
     localStorage.setItem(_DASH_OPTIONS_LS_KEY, nextOpen ? "1" : "0");
   } catch (_) {
-    /* localStorage may be unavailable (private mode, quota) — fall back to
-       per-session state, which is what we already have. */
+    /* localStorage unavailable — _dashOptionsOpenSession above keeps the
+       state for this session so a hide/show cycle preserves the choice. */
   }
 }
 
 function _restoreDashboardOptionsState() {
-  // Default closed when never set; non-power users get the cleaner first view.
+  // Read order: localStorage (cross-session) → in-memory session value
+  // → closed default.  Only override based on a genuinely-successful
+  // localStorage read; on throw, fall back to the session value so the
+  // panel stays where the user last put it within the same tab.
   var saved = null;
+  var lsAvailable = true;
   try {
     saved = localStorage.getItem(_DASH_OPTIONS_LS_KEY);
   } catch (_) {
-    /* unavailable */
+    lsAvailable = false;
   }
-  _setDashboardOptionsOpen(saved === "1");
+  var open;
+  if (lsAvailable && saved !== null) {
+    open = saved === "1";
+  } else if (_dashOptionsOpenSession !== null) {
+    open = _dashOptionsOpenSession;
+  } else {
+    open = false;
+  }
+  _setDashboardOptionsOpen(open);
 }
 
 // Update the inline summary chip beside the Options button when any of

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -45,6 +45,7 @@
                   aria-controls="dashboard-options">
             Options <span aria-hidden="true" class="dashboard-options-caret">&#9662;</span>
           </button>
+          <span id="dashboard-options-summary" class="dashboard-options-summary" aria-live="polite" hidden></span>
         </div>
         <button id="dashboard-submit-btn" class="dashboard-new-btn" type="button"
                 onclick="dashboardSubmit()" aria-label="Create workstream">Create</button>

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -1619,14 +1619,13 @@ audio.media-player {
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
   padding: 10px;
+  /* position context for the .dashboard-composer-drop::before overlay */
+  position: relative;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .dashboard-composer:focus-within {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
-}
-.dashboard-composer {
-  position: relative;
 }
 .dashboard-composer-drop {
   border-style: dashed;

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -1625,11 +1625,35 @@ audio.media-player {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
+.dashboard-composer {
+  position: relative;
+}
 .dashboard-composer-drop {
   border-style: dashed;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-glow-strong);
   background: var(--accent-glow);
+}
+/* Drag-over affordance — make the action explicit so users know what
+   dropping does.  Pseudo-element so the markup stays clean; the inner
+   composer controls remain interactive. */
+.dashboard-composer-drop::before {
+  content: "Drop to attach";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: var(--bg-surface);
+  opacity: 0.92;
+  border-radius: var(--radius);
+  pointer-events: none;
+  z-index: 1;
 }
 .dashboard-input {
   background: transparent;
@@ -1667,6 +1691,27 @@ audio.media-player {
 .dashboard-options-btn[aria-expanded="true"] .dashboard-options-caret {
   transform: rotate(180deg);
   display: inline-block;
+}
+/* Inline summary of non-default options so users see at a glance which
+   defaults they've overridden, without having to expand the panel.
+   Hidden via [hidden] when everything is default. */
+.dashboard-options-summary {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+  padding: 2px 6px;
+  border-left: 1px solid var(--border-strong);
+  margin-left: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
+}
+.dashboard-options-summary[hidden] { display: none; }
+@media (max-width: 600px) {
+  /* On phones the action row stacks; the summary hides to keep the
+     row compact — power users on mobile can expand the panel itself. */
+  .dashboard-options-summary { display: none; }
 }
 .dashboard-composer-row {
   display: flex;


### PR DESCRIPTION
Three deferred items from the prior designer pass on the unified dashboard composer.  Pure UX affordances; no server change.

- **Persist Options open/closed in localStorage.**  Power users who routinely set non-default model/skill don't have to click "Options" on every page load.  Key: `turnstone.dashboard.options_open`. Defaults closed for first-time users.  Falls back gracefully when localStorage is unavailable (private mode, quota).

- **Active-options summary chip.**  Renders the non-default model / judge / skill values inline next to the Options button (mono, dim, separated by middots).  Hidden via `[hidden]` when everything is at default — no chrome cost in the common case.  Updates on any select change via a single delegated handler on the panel.  Hidden on narrow viewports (the action row stacks vertically there and the chip would push the layout further).

- **"Drop to attach" overlay during drag.**  CSS pseudo-element on `.dashboard-composer-drop` overlays a centered "Drop to attach" label so dragging a file makes the action explicit instead of just showing the dashed-border highlight.  pointer-events: none keeps the underlying composer controls reachable; visual only.