### PR TITLE
fix(server): close cross-tenant authz gaps on interactive-ws handlers

### DIFF
--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -1,0 +1,462 @@
+"""HTTP-boundary authorization tests for turnstone-server.
+
+Covers the ownership gates added in PR #2 (sec-1 through sec-9 +
+sec-11) and the kind-validation branches that PR #1 tightened but
+never had Starlette-level regression coverage.  Each test crosses
+the middleware → handler boundary via ``TestClient`` so the JWT
+decoding, scope extraction, and audit-context wiring are all exercised.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+_TEST_JWT_SECRET = "test-jwt-secret-minimum-32-chars!"
+
+
+def _make_jwt(user_id: str, *, scopes: frozenset[str] | None = None) -> str:
+    from turnstone.core.auth import JWT_AUD_SERVER, create_jwt
+
+    return create_jwt(
+        user_id=user_id,
+        scopes=scopes or frozenset({"read", "write", "approve"}),
+        source="test",
+        secret=_TEST_JWT_SECRET,
+        audience=JWT_AUD_SERVER,
+    )
+
+
+def _auth(user: str, *, scopes: frozenset[str] | None = None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_make_jwt(user, scopes=scopes)}"}
+
+
+# ---------------------------------------------------------------------------
+# FakeUI / FakeSession doubles — match the shape the create handler expects
+# ---------------------------------------------------------------------------
+
+
+class _FakeUI:
+    def __init__(self, ws_id: str = "", user_id: str = "", **_kw: Any) -> None:
+        self.ws_id = ws_id
+        self._user_id = user_id
+        self.auto_approve = False
+        self.auto_approve_tools: set[str] = set()
+        self._enqueued: list[dict[str, Any]] = []
+        self._listeners: list[queue.Queue[dict[str, Any]]] = []
+        self._listeners_lock = threading.Lock()
+        self._pending_approval: dict[str, Any] | None = None
+        self._pending_plan_review: dict[str, Any] | None = None
+        self._approval_event = threading.Event()
+        self._plan_event = threading.Event()
+        self._fg_event = threading.Event()
+        self._ws_lock = threading.Lock()
+        # Dashboard handler reads these fields under _ws_lock to build
+        # per-ws summary rows; keep them zero/empty for the fake so the
+        # handler doesn't need to special-case.
+        self._ws_prompt_tokens = 0
+        self._ws_completion_tokens = 0
+        self._ws_tool_calls: dict[str, int] = {}
+        self._ws_context_ratio = 0.0
+        self._ws_current_activity = ""
+        self._ws_activity_state = ""
+        self._ws_messages = 0
+        self._ws_turn_tool_calls = 0
+
+    def _register_listener(self) -> queue.Queue[dict[str, Any]]:
+        q: queue.Queue[dict[str, Any]] = queue.Queue()
+        with self._listeners_lock:
+            self._listeners.append(q)
+        return q
+
+    def _enqueue(self, ev: dict[str, Any]) -> None:
+        self._enqueued.append(ev)
+
+    def on_stream_end(self) -> None:
+        pass
+
+    def on_state_change(self, _state: str) -> None:
+        pass
+
+    def on_error(self, _msg: str) -> None:
+        pass
+
+    def resolve_approval(self, *_a: Any, **_kw: Any) -> None:
+        self._approval_event.set()
+
+    def resolve_plan(self, *_a: Any, **_kw: Any) -> None:
+        self._plan_event.set()
+
+
+class _FakeSession:
+    def __init__(self, ws_id: str = "", user_id: str = "") -> None:
+        self.ws_id = ws_id
+        self.user_id = user_id
+        self.model = "test-model"
+        self.model_alias = ""
+        self.reasoning_effort = ""
+        self.context_window = 100000
+        self.messages: list[dict[str, Any]] = []
+        self._last_usage: dict[str, int] | None = None
+        self._pending_retry: str | None = None
+        self.sends: list[tuple[str, Any, Any]] = []
+
+    def send(self, text: str, *, attachments: Any = None, send_id: Any = None) -> None:
+        self.sends.append((text, attachments, send_id))
+
+    def set_watch_runner(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    def resume(self, _ws_id: str, *, fork: bool = False) -> bool:
+        return False
+
+    def cancel(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def handle_command(self, _cmd: str) -> bool:
+        return False
+
+    def request_title_refresh(self, _title: str) -> None:
+        pass
+
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+    """Full turnstone-server app with in-memory workstreams + fake sessions."""
+    from turnstone.core.metrics import MetricsCollector
+    from turnstone.core.storage import get_storage, init_storage, reset_storage
+    from turnstone.core.workstream import WorkstreamManager
+    from turnstone.server import create_app
+
+    reset_storage()
+    init_storage("sqlite", path=str(tmp_path / "t.db"), run_migrations=False)
+
+    metrics = MetricsCollector()
+    metrics.model = "test-model"
+    monkeypatch.setattr("turnstone.server._metrics", metrics)
+    monkeypatch.setattr("turnstone.server.WebUI", _FakeUI)
+
+    def _factory(ui: Any, _model: Any, ws_id: str, **_kw: Any) -> _FakeSession:
+        uid = getattr(ui, "_user_id", "")
+        return _FakeSession(ws_id=ws_id, user_id=uid)
+
+    mgr = WorkstreamManager(_factory, max_workstreams=10, node_id="node-test")
+    gq: queue.Queue[dict[str, Any]] = queue.Queue()
+    app = create_app(
+        workstreams=mgr,
+        global_queue=gq,
+        global_listeners=[],
+        global_listeners_lock=threading.Lock(),
+        skip_permissions=False,
+        jwt_secret=_TEST_JWT_SECRET,
+        auth_storage=get_storage(),
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        yield client, mgr
+    finally:
+        client.close()
+        reset_storage()
+
+
+# ---------------------------------------------------------------------------
+# PR #1 HTTP-boundary kind validation (q-4) — previously untested
+# ---------------------------------------------------------------------------
+
+
+class TestKindValidationOnCreate:
+    """POST /v1/api/workstreams/new — kind field validation at the HTTP edge."""
+
+    def test_rejects_kind_coordinator(self, app_client):
+        client, _mgr = app_client
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"kind": "coordinator", "name": "x"},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 400
+        assert "coordinator" in resp.json()["error"].lower()
+
+    def test_rejects_unknown_kind(self, app_client):
+        client, _mgr = app_client
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"kind": "interative", "name": "x"},  # typo
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 400
+        assert "unknown" in resp.json()["error"].lower()
+
+    def test_accepts_default_kind(self, app_client):
+        client, _mgr = app_client
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "x"},  # kind omitted
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+
+    def test_rejects_cross_tenant_parent_ws_id(self, app_client, tmp_path):
+        """parent_ws_id pointing at another user's coordinator → 403."""
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        # Victim creates a coordinator directly in storage (console path).
+        storage.register_workstream(
+            "victim-coord",
+            node_id="console",
+            name="victim",
+            kind="coordinator",
+            user_id="victim-user",
+        )
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "attacker", "parent_ws_id": "victim-coord"},
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 403
+        assert "coordinator you own" in resp.json()["error"]
+
+
+class TestOpenKindGate:
+    """POST /v1/api/workstreams/{ws_id}/open refuses coordinator rows."""
+
+    def test_refuses_to_open_coordinator(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        storage.register_workstream(
+            "coord-1",
+            node_id="console",
+            name="c",
+            kind="coordinator",
+            user_id="user-1",
+        )
+        resp = client.post(
+            "/v1/api/workstreams/coord-1/open",
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 400
+        assert "interactive" in resp.json()["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# PR #2 authz cluster — cross-tenant gates on interactive-ws mutations
+# ---------------------------------------------------------------------------
+
+
+def _register_ws(storage: Any, ws_id: str, owner: str) -> None:
+    storage.register_workstream(ws_id, node_id="node-test", name=ws_id, user_id=owner)
+
+
+class TestCrossTenantDelete:
+    def test_non_owner_cannot_delete(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/workstreams/ws-victim/delete",
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+        # Victim's workstream still present in storage.
+        assert storage.get_workstream("ws-victim") is not None
+
+    def test_owner_delete_records_audit(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-own", "user-1")
+        resp = client.post(
+            "/v1/api/workstreams/ws-own/delete",
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        events = storage.list_audit_events(action="workstream.deleted")
+        assert any(e["resource_id"] == "ws-own" for e in events)
+
+
+class TestCrossTenantApprove:
+    def test_non_owner_cannot_approve(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/approve",
+            json={"ws_id": "ws-victim", "approved": True},
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+
+class TestCrossTenantClose:
+    def test_non_owner_cannot_close(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/workstreams/close",
+            json={"ws_id": "ws-victim"},
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+
+class TestCrossTenantTitle:
+    def test_non_owner_cannot_refresh_title(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/workstreams/ws-victim/refresh-title",
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+    def test_non_owner_cannot_set_title(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/workstreams/ws-victim/title",
+            json={"title": "phishing title"},
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+
+class TestCrossTenantOpen:
+    def test_non_owner_cannot_open_persisted(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.post(
+            "/v1/api/workstreams/ws-victim/open",
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+
+class TestListWorkstreamsFiltered:
+    def test_list_excludes_other_tenants(self, app_client):
+        client, mgr = app_client
+        # Seed two workstreams in the in-memory manager — one per tenant.
+        resp_a = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "a"},
+            headers=_auth("user-a"),
+        )
+        resp_b = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "b"},
+            headers=_auth("user-b"),
+        )
+        assert resp_a.status_code == 200 and resp_b.status_code == 200
+        ws_a, ws_b = resp_a.json()["ws_id"], resp_b.json()["ws_id"]
+
+        # user-a sees only ws_a.
+        resp = client.get("/v1/api/workstreams", headers=_auth("user-a"))
+        assert resp.status_code == 200
+        ids = {w["id"] for w in resp.json()["workstreams"]}
+        assert ws_a in ids
+        assert ws_b not in ids
+
+
+class TestDashboardFiltered:
+    def test_dashboard_aggregate_scoped_to_caller(self, app_client):
+        client, _mgr = app_client
+        client.post("/v1/api/workstreams/new", json={"name": "a"}, headers=_auth("user-a"))
+        client.post("/v1/api/workstreams/new", json={"name": "b"}, headers=_auth("user-b"))
+        client.post("/v1/api/workstreams/new", json={"name": "b2"}, headers=_auth("user-b"))
+
+        resp = client.get("/v1/api/dashboard", headers=_auth("user-b"))
+        assert resp.status_code == 200
+        data = resp.json()
+        # user-b owns 2; aggregate total_count reflects filtered set.
+        assert data["aggregate"]["total_count"] == 2
+        owners = {w["user_id"] for w in data["workstreams"]}
+        assert owners == {"user-b"}
+
+
+class TestGlobalEventsServiceGate:
+    def test_non_service_rejected(self, app_client):
+        client, _mgr = app_client
+        resp = client.get(
+            "/v1/api/events/global",
+            headers=_auth("user-a"),  # no service scope
+        )
+        assert resp.status_code == 403
+        assert "service" in resp.json()["error"].lower()
+
+
+class TestPerWsSseGate:
+    def test_non_owner_rejected(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        _register_ws(storage, "ws-victim", "victim-user")
+        resp = client.get(
+            "/v1/api/events?ws_id=ws-victim",
+            headers=_auth("attacker-user"),
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Audit events on successful mutations (sec-11)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEventsOnMutations:
+    def test_workstream_created_emits_audit(self, app_client):
+        from turnstone.core.storage import get_storage
+
+        client, _mgr = app_client
+        storage = get_storage()
+        assert storage is not None
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "auditme"},
+            headers=_auth("user-audit"),
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["ws_id"]
+        events = storage.list_audit_events(action="workstream.created")
+        matching = [e for e in events if e["resource_id"] == ws_id]
+        assert matching, "audit row absent for newly created workstream"
+        detail = json.loads(matching[0]["detail"])
+        assert detail["kind"] == "interactive"

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -176,8 +176,9 @@ class TestDeleteWorkstream:
         assert r.status_code == 404
         assert "not found" in r.json()["error"].lower()
 
-    def test_delete_error_redacted(self, delete_client):
+    def test_delete_error_redacted(self, delete_client, storage):
         """500 response should not leak exception internals."""
+        storage.register_workstream("ws-abc", "node-1", name="test", user_id="test-user")
         with patch(
             "turnstone.core.memory.delete_workstream",
             side_effect=RuntimeError("secret internal detail"),
@@ -206,8 +207,9 @@ class TestSetWorkstreamTitle:
         assert r.status_code == 200
         assert r.json()["title"] == "New Title"
 
-    def test_set_title_empty(self, title_client):
+    def test_set_title_empty(self, title_client, storage):
         client, _ = title_client
+        storage.register_workstream("ws-abc", "node-1", name="test", user_id="test-user")
         r = client.post(
             "/v1/api/workstreams/ws-abc/title",
             json={"title": ""},
@@ -215,8 +217,9 @@ class TestSetWorkstreamTitle:
         assert r.status_code == 400
         assert "required" in r.json()["error"].lower()
 
-    def test_set_title_missing_body(self, title_client):
+    def test_set_title_missing_body(self, title_client, storage):
         client, _ = title_client
+        storage.register_workstream("ws-abc", "node-1", name="test", user_id="test-user")
         r = client.post(
             "/v1/api/workstreams/ws-abc/title",
             json={},
@@ -253,8 +256,9 @@ class TestSetWorkstreamTitle:
 
 
 class TestRefreshWorkstreamTitle:
-    def test_refresh_success(self, title_client):
+    def test_refresh_success(self, title_client, storage):
         client, mock_mgr = title_client
+        storage.register_workstream("ws-abc", "node-1", name="test", user_id="test-user")
         mock_ws = MagicMock()
         mock_ws.session = MagicMock()
         mock_mgr.get.return_value = mock_ws

--- a/tests/test_workstream_kind.py
+++ b/tests/test_workstream_kind.py
@@ -13,15 +13,12 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-
-from turnstone.core.storage._sqlite import SQLiteBackend
 from turnstone.core.workstream import Workstream
 
-
-@pytest.fixture
-def storage(tmp_path):
-    return SQLiteBackend(str(tmp_path / "test.db"))
+# ``storage`` comes from tests/conftest.py — backend-parametrized fixture that
+# respects the ``--storage-backend`` flag so the same assertions run against
+# both SQLite (default) and PostgreSQL (CI), closing the q-3 drift risk that
+# sqlite↔postgres register/list/normalize semantics could diverge silently.
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +64,40 @@ def test_register_normalizes_empty_parent_to_null(storage):
     row = storage.get_workstream("ws-a")
     assert row is not None
     assert row["parent_ws_id"] is None
+
+
+def test_register_rejects_unknown_kind(storage):
+    """Storage edge validates kind via WorkstreamKind(kind).value —
+    SDK / restore / direct callers can't silently corrupt the NOT NULL column
+    with typos or unknown values the way pre-PR #1 they could."""
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError):
+        storage.register_workstream("ws-bogus", kind="interative")  # typo
+    # Row was never inserted — no side effects on failure.
+    assert storage.get_workstream("ws-bogus") is None
+
+
+def test_list_workstreams_filter_by_user_id(storage):
+    """The user_id kwarg pushes tenant scoping into SQL so callers
+    can't forget to filter client-side."""
+    storage.register_workstream("ws-a", user_id="user-1")
+    storage.register_workstream("ws-b", user_id="user-1")
+    storage.register_workstream("ws-c", user_id="user-2")
+    storage.register_workstream("ws-ownerless")  # no user_id
+
+    mine = storage.list_workstreams(user_id="user-1")
+    theirs = storage.list_workstreams(user_id="user-2")
+    ownerless = storage.list_workstreams(user_id="")
+    unfiltered = storage.list_workstreams()
+
+    assert {r[0] for r in mine} == {"ws-a", "ws-b"}
+    assert {r[0] for r in theirs} == {"ws-c"}
+    # Empty string is a real filter value (matches rows with stored "" owner).
+    # Rows with NULL owner are distinct and not matched.
+    assert "ws-ownerless" not in {r[0] for r in ownerless}
+    # No filter → all rows.
+    assert {r[0] for r in unfiltered} == {"ws-a", "ws-b", "ws-c", "ws-ownerless"}
 
 
 def test_get_workstream_missing_returns_none(storage):

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -975,6 +975,12 @@ async def events_sse(request: Request) -> Response:
     """GET /v1/api/events — per-workstream SSE event stream."""
     mgr = request.app.state.workstreams
     ws_id = request.query_params.get("ws_id")
+    # Subscribing to another tenant's stream would leak their messages,
+    # tool calls, and pending approvals in real time.  Gate before
+    # _register_listener so non-owners get a flat 404 (no enumeration).
+    _owner, err = _require_ws_access(request, ws_id or "")
+    if err:
+        return err
     ws, ui = _get_ws(mgr, ws_id)
     if not ws or not ui:
         return JSONResponse({"error": "Unknown workstream"}, status_code=404)
@@ -1135,6 +1141,15 @@ async def global_events_sse(request: Request) -> Response:
     (workstreams, health, aggregate) followed by real-time delta events.
     The snapshot and listener registration are atomic — no events are lost.
     """
+    # -- Service-scope gate ---------------------------------------------------
+    # The global stream carries cluster-wide workstream inventory across
+    # every tenant (user_id, kind, parent_ws_id, token counts) — intended
+    # for the console's ClusterCollector, not end-user browsers.  Require
+    # a service-scoped token so an authenticated end-user can't subscribe
+    # and observe cluster state for other tenants.
+    if "service" not in _auth_scopes(request):
+        return JSONResponse({"error": "service scope required"}, status_code=403)
+
     # -- Node identity check --------------------------------------------------
     expected = request.query_params.get("expected_node_id")
     actual_node_id = getattr(request.app.state, "node_id", "")
@@ -1185,13 +1200,29 @@ async def global_events_sse(request: Request) -> Response:
     return EventSourceResponse(event_generator(), ping=5)
 
 
+def _visible_workstreams(request: Request, wss: list[Workstream]) -> list[Workstream]:
+    """Filter an in-memory workstream list to the caller's tenant view.
+
+    Service-scoped tokens see everything (internal cluster callers,
+    console routing proxy).  End-user tokens see only workstreams they
+    own — a blank ``ws.user_id`` (legacy / pre-migration rows) is
+    hidden from non-service callers to prevent orphan leakage.
+    """
+    if "service" in _auth_scopes(request):
+        return wss
+    caller = _auth_user_id(request)
+    if not caller:
+        return []
+    return [ws for ws in wss if ws.user_id and ws.user_id == caller]
+
+
 async def list_workstreams(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams — list all workstreams."""
+    """GET /v1/api/workstreams — list workstreams visible to the caller."""
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: WorkstreamManager = request.app.state.workstreams
     result = []
-    for ws in mgr.list_all():
+    for ws in _visible_workstreams(request, mgr.list_all()):
         title = get_workstream_display_name(ws.id) or ws.name
         result.append(
             {
@@ -1208,7 +1239,7 @@ async def dashboard(request: Request) -> JSONResponse:
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: WorkstreamManager = request.app.state.workstreams
-    wss = mgr.list_all()
+    wss = _visible_workstreams(request, mgr.list_all())
     total_tokens = 0
     total_tool_calls = 0
     active_count = 0
@@ -1772,6 +1803,12 @@ async def approve(request: Request) -> JSONResponse:
     feedback = body.get("feedback")
     always = body.get("always", False)
     ws_id = body.get("ws_id")
+    # Cross-tenant guard: resolving a pending tool approval on another
+    # tenant's workstream is RCE-adjacent (the victim queued a command
+    # expecting to decide themselves).  Gate before touching the UI.
+    _owner, err = _require_ws_access(request, str(ws_id or ""))
+    if err:
+        return err
     mgr = request.app.state.workstreams
     ws, ui = _get_ws(mgr, ws_id)
     if not ws or not ui:
@@ -1799,6 +1836,9 @@ async def plan_feedback(request: Request) -> JSONResponse:
         return body
     feedback = body.get("feedback", "")
     ws_id = body.get("ws_id")
+    _owner, err = _require_ws_access(request, str(ws_id or ""))
+    if err:
+        return err
     mgr = request.app.state.workstreams
     ws, ui = _get_ws(mgr, ws_id)
     if not ws or not ui:
@@ -1815,6 +1855,9 @@ async def cancel_generation(request: Request) -> JSONResponse:
     if isinstance(body, JSONResponse):
         return body
     ws_id = body.get("ws_id")
+    _owner, err = _require_ws_access(request, str(ws_id or ""))
+    if err:
+        return err
     mgr = request.app.state.workstreams
     ws, ui = _get_ws(mgr, ws_id)
     if not ws or not ui:
@@ -1857,6 +1900,9 @@ async def command(request: Request) -> JSONResponse:
     ws_id = body.get("ws_id")
     if not cmd:
         return JSONResponse({"error": "Empty command"}, status_code=400)
+    _owner, err = _require_ws_access(request, str(ws_id or ""))
+    if err:
+        return err
 
     mgr = request.app.state.workstreams
     ws, ui = _get_ws(mgr, ws_id)
@@ -2295,6 +2341,7 @@ async def create_workstream(request: Request) -> JSONResponse:
       ``initial_message`` turn (if provided) before the worker dispatches.
     """
     from turnstone.core.attachments import IMAGE_SIZE_CAP
+    from turnstone.core.audit import record_audit
     from turnstone.core.memory import get_workstream_display_name
     from turnstone.core.web_helpers import (
         read_json_or_400,
@@ -2492,6 +2539,21 @@ async def create_workstream(request: Request) -> JSONResponse:
                     "user_id": ws.user_id,
                 }
             )
+        # Tamper-evident audit trail.  Lives alongside the broadcast
+        # event (not replacing it — the broadcast is ephemeral UI
+        # signalling, the audit row survives for forensic review).
+        _audit_storage = getattr(request.app.state, "auth_storage", None)
+        if _audit_storage is not None:
+            _, _audit_ip = _audit_context(request)
+            record_audit(
+                _audit_storage,
+                uid,
+                "workstream.created",
+                "workstream",
+                ws.id,
+                {"kind": str(ws.kind), "parent_ws_id": ws.parent_ws_id},
+                _audit_ip,
+            )
         # Emit eviction event if a workstream was evicted to make room
         evicted = mgr.last_evicted
         if evicted is not None:
@@ -2663,29 +2725,50 @@ async def create_workstream(request: Request) -> JSONResponse:
 
 async def close_workstream(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/close — close a workstream."""
+    from turnstone.core.audit import record_audit
     from turnstone.core.web_helpers import read_json_or_400
 
     body = await read_json_or_400(request)
     if isinstance(body, JSONResponse):
         return body
     ws_id = str(body.get("ws_id", ""))
+    # Cross-tenant close would abort another tenant's running generation.
+    # _require_ws_access returns 404 on non-owner — same shape as the
+    # "last workstream" (400) / "not found" (404) branches below.
+    owner_uid, err = _require_ws_access(request, ws_id)
+    if err:
+        return err
     mgr = request.app.state.workstreams
     # Distinguish "last workstream" (400) from "not found" (404).
     # Note: get() and close() acquire the manager lock independently, so a
     # concurrent close between the two could produce a wrong error code.
     # The failure mode is cosmetic (400 instead of 404), not data corruption.
-    if not mgr.get(ws_id):
+    ws_before = mgr.get(ws_id)
+    if not ws_before:
         return JSONResponse({"error": "Workstream not found"}, status_code=404)
     if mgr.close(ws_id):
         gq: queue.Queue[dict[str, Any]] = request.app.state.global_queue
         with contextlib.suppress(queue.Full):
             gq.put_nowait({"type": "ws_closed", "ws_id": ws_id, "reason": "closed"})
+        storage = getattr(request.app.state, "auth_storage", None)
+        if storage is not None:
+            _, ip = _audit_context(request)
+            record_audit(
+                storage,
+                owner_uid,
+                "workstream.closed",
+                "workstream",
+                ws_id,
+                {"kind": str(ws_before.kind), "parent_ws_id": ws_before.parent_ws_id},
+                ip,
+            )
         return JSONResponse({"status": "ok"})
     return JSONResponse({"error": "Cannot close last workstream"}, status_code=400)
 
 
 async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/{ws_id}/delete — permanently delete a saved workstream."""
+    from turnstone.core.audit import record_audit
     from turnstone.core.log import get_logger
     from turnstone.core.memory import delete_workstream
 
@@ -2694,9 +2777,33 @@ async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     if not ws_id:
         log.warning("ws.delete.failed", reason="empty_ws_id")
         return JSONResponse({"error": "ws_id is required"}, status_code=400)
+    # Cross-tenant delete would destroy another tenant's workstream,
+    # conversations, and attachments in one call.  _require_ws_access
+    # returns 404 on mismatch so existence isn't enumerable.
+    owner_uid, err = _require_ws_access(request, ws_id)
+    if err:
+        return err
+    # Snapshot kind/parent for the audit record before deletion wipes the row.
+    storage = getattr(request.app.state, "auth_storage", None)
+    row: dict[str, Any] = {}
+    if storage is not None:
+        row = storage.get_workstream(ws_id) or {}
+    kind = row.get("kind", "")
+    parent_ws_id = row.get("parent_ws_id")
+    _, ip = _audit_context(request)
     try:
         if delete_workstream(ws_id):
             log.info("ws.deleted", ws_id=ws_id[:8])
+            if storage is not None:
+                record_audit(
+                    storage,
+                    owner_uid,
+                    "workstream.deleted",
+                    "workstream",
+                    ws_id,
+                    {"kind": str(kind), "parent_ws_id": parent_ws_id},
+                    ip,
+                )
             return JSONResponse({"deleted": ws_id})
         log.warning("ws.delete.failed", reason="not_found", ws_id=ws_id[:8])
         return JSONResponse({"error": "Workstream not found"}, status_code=404)
@@ -2713,6 +2820,12 @@ async def refresh_workstream_title(request: Request, ws_id: str = "") -> JSONRes
     log = get_logger(__name__)
     ws_id = request.path_params.get("ws_id", "")
     log.info("ws.title.refresh_requested", ws_id=ws_id[:8] if ws_id else "empty")
+    # Cross-tenant rename is a phishing / denial-of-use vector — a
+    # malicious caller could push the victim's title to a misleading
+    # string visible in list/dashboard responses.
+    _owner, err = _require_ws_access(request, ws_id)
+    if err:
+        return err
     mgr = request.app.state.workstreams
     ws = mgr.get(ws_id)
     if not ws or not ws.session:
@@ -2745,6 +2858,10 @@ async def set_workstream_title(request: Request, ws_id: str = "") -> JSONRespons
     log.info("ws.title.set_requested", ws_id=ws_id[:8] if ws_id else "empty")
     if not ws_id:
         return JSONResponse({"error": "ws_id is required"}, status_code=400)
+    # Cross-tenant rename gate — same rationale as refresh-title above.
+    _owner, err = _require_ws_access(request, ws_id)
+    if err:
+        return err
     body = await read_json_or_400(request)
     if isinstance(body, JSONResponse):
         return body
@@ -3171,15 +3288,21 @@ async def open_workstream(request: Request) -> JSONResponse:
             status_code=400,
         )
 
-    auth = getattr(getattr(request, "state", None), "auth_result", None)
-    uid: str = getattr(auth, "user_id", "") or ""
+    uid: str = _auth_user_id(request)
+    scopes = _auth_scopes(request)
+
+    # Ownership gate: the stored owner must match the caller (or the
+    # caller must hold the service scope, which covers the console
+    # routing proxy and cluster rehydration paths).  A legacy row with
+    # a blank owner is claimable by the authenticated caller — same
+    # semantics as _require_ws_access for the interactive handlers.
+    # 404 (not 403) so existence isn't enumerable by non-owners.
+    stored_owner = (ws_row.get("user_id") or "").strip()
+    if stored_owner and "service" not in scopes and stored_owner != uid:
+        return JSONResponse({"error": "Workstream not found"}, status_code=404)
+    owner_uid = stored_owner or uid
 
     try:
-        # Prefer the persisted owner (this workstream may have been created
-        # by a trusted-service forwarder) and only fall back to the
-        # authenticated caller if the stored row has no owner recorded.
-        stored_owner = (ws_row.get("user_id") or "").strip()
-        owner_uid = stored_owner or uid
         ws = mgr.create(
             name=ws_row.get("name", ""),
             ui_factory=lambda wid, **kw: WebUI(ws_id=wid, user_id=owner_uid, **kw),
@@ -3217,6 +3340,24 @@ async def open_workstream(request: Request) -> JSONResponse:
                 "parent_ws_id": ws.parent_ws_id,
                 "user_id": ws.user_id,
             }
+        )
+
+    # Audit the rehydration so console-side forensic review can distinguish
+    # rehydrated workstreams from fresh creates (same broadcast shape; the
+    # audit action name is the disambiguator).
+    _audit_storage = getattr(request.app.state, "auth_storage", None)
+    if _audit_storage is not None:
+        from turnstone.core.audit import record_audit as _record_audit
+
+        _, _audit_ip = _audit_context(request)
+        _record_audit(
+            _audit_storage,
+            owner_uid,
+            "workstream.opened",
+            "workstream",
+            ws.id,
+            {"kind": str(ws.kind), "parent_ws_id": ws.parent_ws_id},
+            _audit_ip,
         )
 
     log.info("ws.opened", ws_id=resolved_id[:8])


### PR DESCRIPTION
Second of three PRs addressing the retrospective review of the turnstone-server interactive-kind feature.  The first (PR #374) put the structural pieces in place — WorkstreamKind enum + user_id kwarg on the storage protocol.  This PR uses them to close the handler-level ownership gaps that shipped under the prior design.

- sec-1: approve / plan_feedback / cancel_generation / command now call _require_ws_access before touching the target UI.  Previously any authenticated user could resolve pending tool-approvals on another tenant's workstream — RCE-adjacent because the attacker could approve destructive operations the victim would have denied.
- sec-2: /v1/api/workstreams/{ws_id}/delete now gates on ownership AND writes a workstream.deleted audit event.  Previously any authenticated user could destroy any other tenant's workstream, conversations, and attachments in one call with no tamper-evident trail.
- sec-3: /v1/api/events (per-ws SSE) gates before _register_listener so non-owners can't subscribe to another tenant's message / tool / approval stream.
- sec-4 / sec-5: /v1/api/workstreams and /v1/api/dashboard filter to the caller's tenant view via a new _visible_workstreams helper; service-scoped tokens (cluster / routing proxy) keep the full view.
- sec-6: /v1/api/events/global requires service scope.  The global snapshot carries cross-tenant workstream inventory and was never intended for end-user browsers.
- sec-7: /v1/api/workstreams/{ws_id}/open verifies the caller is the stored owner (or holds service scope) before rehydrating. Returns 404 on mismatch — existence isn't enumerable by response code.
- sec-8 / sec-9: /workstreams/close, /refresh-title, /title all gate on ownership.  Cross-tenant close aborts the victim's running generation; cross-tenant rename is a phishing / denial-of-use vector in list / dashboard responses.
- sec-11: workstream.created / .deleted / .closed / .opened now land in the audit_events table with kind + parent_ws_id detail, so forensic review can reconstruct lifecycle even after the row is gone.
- q-4: new tests/test_server_authz.py covers every gate above via TestClient, plus the PR #1 HTTP-boundary kind-validation branches that had no regression coverage (coordinator / unknown-kind / 400, cross-tenant parent_ws_id / 403, non-interactive open / 400).
- q-3: test_workstream_kind.py now uses the conftest storage fixture so it runs against both SQLite and PostgreSQL under --storage-backend=postgresql, closing the sqlite↔postgres drift risk the prior review flagged.  Added storage-edge ValueError and user_id SQL filter tests alongside.

Tests, lint (ruff), typecheck (strict mypy) all green.  Stacked on PR #374 — merges after that lands.