### PR TITLE
docs(tools): clarify node_id snapshot vs current-binding semantics

### DIFF
--- a/turnstone/tools/inspect_workstream.json
+++ b/turnstone/tools/inspect_workstream.json
@@ -1,6 +1,6 @@
 {
   "name": "inspect_workstream",
-  "description": "Read the persisted state of a workstream you previously spawned: state, title, skill, timestamps, and the last N messages. Auto-approved — safe, read-only. A `live` block from the owning node is merged when available (current tokens, activity, pending_approval). Provider-native content blocks are stripped by default to keep the response compact; pass include_provider_content=true if you need the full fidelity payload for replay tooling.",
+  "description": "Read the persisted state of a workstream you previously spawned: state, title, skill, timestamps, and the last N messages. Auto-approved — safe, read-only. A `live` block from the owning node is merged when available (current tokens, activity, pending_approval). The `node_id` here is the CURRENT binding (storage-authoritative) — if the rebalancer migrated the workstream after a prior spawn_workstream call, this read reflects the new node. Provider-native content blocks are stripped by default to keep the response compact; pass include_provider_content=true if you need the full fidelity payload for replay tooling.",
   "parameters": {
     "type": "object",
     "properties": {

--- a/turnstone/tools/spawn_workstream.json
+++ b/turnstone/tools/spawn_workstream.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn_workstream",
-  "description": "Create a new child workstream and optionally dispatch an initial message. Use this to kick off a focused sub-task on a separate workstream (different skill, model, or node) while your coordinator remains in charge of orchestration. The child runs independently; use send_to_workstream / inspect_workstream / close_workstream to drive and observe it.",
+  "description": "Create a new child workstream and optionally dispatch an initial message. Use this to kick off a focused sub-task on a separate workstream (different skill, model, or node) while your coordinator remains in charge of orchestration. The child runs independently; use send_to_workstream / inspect_workstream / close_workstream to drive and observe it. The returned `node_id` is a POINT-IN-TIME snapshot of the binding at spawn — the cluster rebalancer can migrate a workstream to a different node later, so don't cache the value for long-running callbacks; re-read with inspect_workstream when you need the current binding.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
Phase 3 fixed spawn_workstream's response to return the storage- authoritative node_id at spawn time, but neither tool description mentioned that the cluster rebalancer can migrate the workstream to a different node afterwards.  A coordinator that cached the spawn-time node_id for a long-running callback would silently dispatch to a node that no longer owns the workstream.

- spawn_workstream: ``node_id`` is a POINT-IN-TIME snapshot at spawn; re-read with inspect_workstream when you need the current binding.
- inspect_workstream: ``node_id`` is the CURRENT (storage-authoritative) binding; reflects any rebalancer migration that happened since spawn.

Pure description edit — no schema or runtime change.