### PR TITLE
feat(coordinator): phase 6 — polish, observability, active-coords via SSE, frontend cleanup

### DIFF
--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -1452,3 +1452,254 @@ def test_live_cache_touch_on_hit_moves_to_end(tmp_path):
     client._store_live_cache("ws-new", 0.0, None)
     assert "ws-0000" in client._live_cache
     assert "ws-0001" not in client._live_cache
+
+
+# ---------------------------------------------------------------------------
+# wait_for_workstream — since= hint + progress_callback (#bug-5, #18, #perf-3)
+# ---------------------------------------------------------------------------
+
+
+def test_wait_since_missing_entry_does_not_force_early_exit(populated_storage):
+    """Regression for #bug-5: a ``since`` dict that does NOT contain
+    the polled ws_id must not short-circuit the wait with
+    complete=True on tick one.  Only ws_ids present in since_map are
+    considered for the diff-exit check — others fall through to the
+    normal mode='any'/'all' conditions.
+
+    Scenario: single running child (``child-b``) + a ``since`` dict
+    keyed on a disjoint id (``unrelated``).  mode='all' forces a full
+    wait so the run can't early-return on a real terminal — we expect
+    the wait to time out with complete=False, not exit immediately
+    with complete=True because the previous (broken) _diff_since
+    treated ``prev is None`` as changed for every polled wid.
+    """
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(
+        ["child-b"],
+        timeout=1.0,
+        mode="all",
+        since={"unrelated": {"state": "idle", "tokens": 0, "updated": "prior"}},
+    )
+    assert result["complete"] is False
+    assert result["elapsed"] >= 1.0
+    assert result["results"]["child-b"]["state"] == "running"
+
+
+def test_wait_since_matching_snapshot_falls_through_to_mode(populated_storage):
+    """A ``since`` entry that exactly matches the current snapshot
+    (state + tokens + updated all unchanged) does not trigger the
+    diff-exit — the wait falls through to the normal mode condition
+    for that wid."""
+    client = _make_read_client(populated_storage)
+    # First, grab the current snapshot.
+    first = client.wait_for_workstream(["child-a"], timeout=1.0, mode="any")
+    assert first["complete"] is True
+    snap = first["results"]
+    # Re-issue with since=<current snapshot> — nothing changed, but
+    # child-a is real-terminal ('idle') so mode='any' completes again.
+    second = client.wait_for_workstream(
+        ["child-a"],
+        timeout=1.0,
+        mode="any",
+        since=snap,
+    )
+    assert second["complete"] is True
+    # Elapsed should be sub-second: the mode='any' condition fired on
+    # tick one, not a tick-one false-positive from _diff_since.
+    assert second["elapsed"] < 1.0
+
+
+def test_wait_since_malformed_input_drops_silently(populated_storage):
+    """Hostile / malformed since hints (non-dict top-level, non-dict
+    values) degrade to empty since_map rather than raising — the wait
+    is advisory, not a gatekeeper."""
+    client = _make_read_client(populated_storage)
+    # Non-dict since — coerced to empty.
+    result = client.wait_for_workstream(
+        ["child-a"],
+        timeout=1.0,
+        mode="any",
+        since=["not", "a", "dict"],  # type: ignore[arg-type]
+    )
+    assert "error" not in result
+    assert result["complete"] is True
+
+    # Dict with non-dict values — those entries silently drop.
+    result = client.wait_for_workstream(
+        ["child-a"],
+        timeout=1.0,
+        mode="any",
+        since={"child-a": "not-a-dict"},  # type: ignore[dict-item]
+    )
+    assert "error" not in result
+    assert result["complete"] is True
+
+
+def test_wait_progress_callback_invoked_per_tick(populated_storage):
+    """The progress_callback is invoked once per poll tick with the
+    current snapshot + elapsed seconds.  Snapshots carry state/tokens/
+    updated for each polled ws_id."""
+    client = _make_read_client(populated_storage)
+    ticks: list[tuple[dict, float]] = []
+
+    def _cb(snap, elapsed):  # type: ignore[no-untyped-def]
+        ticks.append((dict(snap), elapsed))
+
+    result = client.wait_for_workstream(
+        ["child-a"],
+        timeout=1.0,
+        mode="any",
+        progress_callback=_cb,
+    )
+    assert result["complete"] is True
+    assert len(ticks) >= 1
+    first_snap, _ = ticks[0]
+    assert "child-a" in first_snap
+    assert first_snap["child-a"]["state"] == "idle"
+
+
+def test_wait_progress_callback_errors_dont_break_loop(populated_storage):
+    """A buggy progress_callback must not break the wait — exceptions
+    are swallowed so a broken observer can't wedge the model's tool call."""
+    client = _make_read_client(populated_storage)
+
+    def _bad_cb(snap, elapsed):  # type: ignore[no-untyped-def]
+        raise RuntimeError("observer exploded")
+
+    result = client.wait_for_workstream(
+        ["child-a"],
+        timeout=1.0,
+        mode="any",
+        progress_callback=_bad_cb,
+    )
+    # Wait itself still returns normally.
+    assert result["complete"] is True
+
+
+# ---------------------------------------------------------------------------
+# cleanup_dead_task_child_refs (#bug-6, #13)
+# ---------------------------------------------------------------------------
+
+
+def _save_tasks(storage: SQLiteBackend, ws_id: str, tasks: list[dict[str, Any]]) -> None:
+    """Helper: persist a minimal task envelope for a coordinator."""
+    storage.save_workstream_config(
+        ws_id,
+        {"tasks": json.dumps({"version": 1, "tasks": tasks}, separators=(",", ":"))},
+    )
+
+
+def test_cleanup_dead_task_child_refs_blanks_dead_links(populated_storage):
+    """Tasks whose child_ws_id references a missing workstream get the
+    link blanked; tasks with live links (or no link) are untouched."""
+    client = _make_read_client(populated_storage)
+    _save_tasks(
+        populated_storage,
+        "coord-1",
+        [
+            {"id": "t1", "title": "alive-linked", "status": "done", "child_ws_id": "child-a"},
+            {"id": "t2", "title": "dead-linked", "status": "done", "child_ws_id": "ghost-xyz"},
+            {"id": "t3", "title": "unlinked", "status": "pending", "child_ws_id": ""},
+        ],
+    )
+    blanked = client.cleanup_dead_task_child_refs("coord-1")
+    assert blanked == 1
+    envelope = client.task_list_get("coord-1")
+    tasks_by_id = {t["id"]: t for t in envelope["tasks"]}
+    # Live link preserved.
+    assert tasks_by_id["t1"]["child_ws_id"] == "child-a"
+    # Dead link blanked.
+    assert tasks_by_id["t2"]["child_ws_id"] == ""
+    # Unlinked task untouched.
+    assert tasks_by_id["t3"]["child_ws_id"] == ""
+
+
+def test_cleanup_dead_task_child_refs_all_alive_is_noop(populated_storage):
+    """When every child_ws_id resolves, the cleanup returns 0 and does
+    not rewrite the envelope (we verify via a no-op save spy)."""
+    client = _make_read_client(populated_storage)
+    _save_tasks(
+        populated_storage,
+        "coord-1",
+        [{"id": "t1", "title": "alive", "status": "done", "child_ws_id": "child-a"}],
+    )
+    saves: list[dict[str, str]] = []
+    real_save = populated_storage.save_workstream_config
+
+    def _spy_save(ws_id, cfg):  # type: ignore[no-untyped-def]
+        saves.append(cfg)
+        return real_save(ws_id, cfg)
+
+    populated_storage.save_workstream_config = _spy_save  # type: ignore[method-assign]
+    try:
+        blanked = client.cleanup_dead_task_child_refs("coord-1")
+    finally:
+        populated_storage.save_workstream_config = real_save  # type: ignore[method-assign]
+    assert blanked == 0
+    assert saves == []
+
+
+def test_cleanup_dead_task_child_refs_empty_envelope(populated_storage):
+    """A coordinator with no task_list persisted returns 0 without
+    raising — the cleanup runs on every close, including those that
+    never used the task_list tool."""
+    client = _make_read_client(populated_storage)
+    blanked = client.cleanup_dead_task_child_refs("coord-1")
+    assert blanked == 0
+
+
+def test_cleanup_dead_task_child_refs_corrupt_envelope_skips(populated_storage):
+    """A corrupt envelope (unparseable JSON in workstream_config.tasks)
+    returns 0 rather than raising — the cleanup is best-effort and
+    must not block the close flow."""
+    populated_storage.save_workstream_config("coord-1", {"tasks": "{not json"})
+    client = _make_read_client(populated_storage)
+    assert client.cleanup_dead_task_child_refs("coord-1") == 0
+
+
+def test_cleanup_dead_task_child_refs_uses_task_lock(populated_storage):
+    """The cleanup must acquire the same per-ws _task_lock that
+    task_list_add/update/remove/reorder hold, so a close racing an
+    in-flight mutation can't lose writes (#bug-6).  Verified by
+    swapping the cached lock for a stand-in that records acquisition."""
+    client = _make_read_client(populated_storage)
+
+    class _RecordingLock:
+        """Mimics threading.Lock — counts __enter__ / __exit__ pairs."""
+
+        def __init__(self) -> None:
+            self.acquired = 0
+            self.released = 0
+
+        def __enter__(self) -> _RecordingLock:
+            self.acquired += 1
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            self.released += 1
+
+    recording = _RecordingLock()
+    # Prime the cache under the cache-lock so the client's _task_lock()
+    # lookup returns our stand-in instead of allocating a real Lock.
+    with client._task_lock_cache_lock:
+        client._task_lock_cache["coord-1"] = recording  # type: ignore[assignment]
+    client.cleanup_dead_task_child_refs("coord-1")
+    assert recording.acquired == 1
+    assert recording.released == 1
+
+
+def test_cleanup_dead_task_child_refs_storage_batch_failure_swallows(populated_storage):
+    """If get_workstreams_batch raises, the cleanup returns 0 rather
+    than propagating — close flow is resilient to storage hiccups."""
+    client = _make_read_client(populated_storage)
+    _save_tasks(
+        populated_storage,
+        "coord-1",
+        [{"id": "t1", "title": "dead", "status": "done", "child_ws_id": "ghost"}],
+    )
+
+    def _boom(ws_ids):  # type: ignore[no-untyped-def]
+        raise RuntimeError("storage down")
+
+    populated_storage.get_workstreams_batch = _boom  # type: ignore[method-assign]
+    assert client.cleanup_dead_task_child_refs("coord-1") == 0

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -399,8 +399,13 @@ def test_wait_exec_dispatches_raw_args_to_client(coord_session):
     item = sess._prepare_tool(_tc("wait_for_workstream", {"ws_ids": ["a"], "timeout": 30}))
     _call_id, output = sess._exec_wait_for_workstream(item)
     # Args forwarded raw (timeout int, default mode="any") — client
-    # handles the float coerce + clamp.
-    coord.wait_for_workstream.assert_called_once_with(["a"], timeout=30, mode="any")
+    # handles the float coerce + clamp.  ``since`` + ``progress_callback``
+    # are optional observability kwargs added for the wait dashboard /
+    # diff-hint items (#14, #18); match them via ANY so this assertion
+    # stays focused on the raw dispatch.
+    coord.wait_for_workstream.assert_called_once_with(
+        ["a"], timeout=30, mode="any", since=None, progress_callback=ANY
+    )
     parsed = json.loads(output)
     assert parsed["complete"] is True
     assert parsed["mode"] == "any"
@@ -419,7 +424,9 @@ def test_wait_exec_default_timeout_when_omitted(coord_session):
     }
     item = sess._prepare_tool(_tc("wait_for_workstream", {"ws_ids": ["a"]}))
     sess._exec_wait_for_workstream(item)
-    coord.wait_for_workstream.assert_called_once_with(["a"], timeout=60.0, mode="any")
+    coord.wait_for_workstream.assert_called_once_with(
+        ["a"], timeout=60.0, mode="any", since=None, progress_callback=ANY
+    )
 
 
 def test_wait_exec_preserves_explicit_zero_timeout(coord_session):
@@ -433,7 +440,9 @@ def test_wait_exec_preserves_explicit_zero_timeout(coord_session):
     }
     item = sess._prepare_tool(_tc("wait_for_workstream", {"ws_ids": ["a"], "timeout": 0}))
     sess._exec_wait_for_workstream(item)
-    coord.wait_for_workstream.assert_called_once_with(["a"], timeout=0, mode="any")
+    coord.wait_for_workstream.assert_called_once_with(
+        ["a"], timeout=0, mode="any", since=None, progress_callback=ANY
+    )
 
 
 def test_delete_prepare_needs_approval(coord_session):

--- a/tests/test_phase6_endpoints.py
+++ b/tests/test_phase6_endpoints.py
@@ -342,16 +342,36 @@ def test_metrics_empty_coordinator_defaults(storage):
 
 def test_metrics_spawns_and_state_counts(storage):
     """spawns_total counts ALL children (including closed); state
-    histogram groups by current state."""
+    histogram groups by current state.  All children share the
+    coordinator's owner so the non-admin tenant filter on the
+    aggregate queries counts them all (see next test for the
+    cross-tenant filter behaviour)."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    # Seed children directly in storage so we control state/created
-    # without going through routing.
-    _seed_workstream(storage, ws_id="aa" * 16, node_id="node-a", parent_ws_id=ws.id, state="idle")
     _seed_workstream(
-        storage, ws_id="bb" * 16, node_id="node-a", parent_ws_id=ws.id, state="running"
+        storage,
+        ws_id="aa" * 16,
+        node_id="node-a",
+        user_id="user-1",
+        parent_ws_id=ws.id,
+        state="idle",
     )
-    _seed_workstream(storage, ws_id="cc" * 16, node_id="node-a", parent_ws_id=ws.id, state="closed")
+    _seed_workstream(
+        storage,
+        ws_id="bb" * 16,
+        node_id="node-a",
+        user_id="user-1",
+        parent_ws_id=ws.id,
+        state="running",
+    )
+    _seed_workstream(
+        storage,
+        ws_id="cc" * 16,
+        node_id="node-a",
+        user_id="user-1",
+        parent_ws_id=ws.id,
+        state="closed",
+    )
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
         f"/v1/api/coordinator/{ws.id}/metrics",
@@ -361,6 +381,65 @@ def test_metrics_spawns_and_state_counts(storage):
     body = resp.json()
     assert body["spawns_total"] == 3
     assert body["child_state_counts"] == {"idle": 1, "running": 1, "closed": 1}
+
+
+def test_metrics_tenant_filter_excludes_forged_cross_tenant_child(storage):
+    """Defense-in-depth: a non-admin caller's aggregate counts must
+    exclude children whose parent_ws_id matches the coord but whose
+    user_id drifted to another tenant (forged / migration-era rows).
+    The primary defense is the 404-mask on coord ownership; this is
+    the secondary defense inside the aggregate queries (Copilot
+    review finding on PR #381).
+
+    Admin bypass sees the raw aggregate (no tenant filter) — same
+    pattern coordinator_children follows.
+    """
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="alice")
+    # Legitimate child owned by alice.
+    _seed_workstream(
+        storage,
+        ws_id="aa" * 16,
+        node_id="node-a",
+        user_id="alice",
+        parent_ws_id=ws.id,
+        state="idle",
+    )
+    # Forged / drifted child — same parent_ws_id but foreign owner.
+    _seed_workstream(
+        storage,
+        ws_id="bb" * 16,
+        node_id="node-a",
+        user_id="bob",
+        parent_ws_id=ws.id,
+        state="running",
+    )
+    client = _make_client(storage, coord_mgr=mgr)
+
+    # Alice (non-admin) — counts must exclude bob's forged row.
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers={"X-Test-User": "alice", "X-Test-Perms": "admin.coordinator"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["spawns_total"] == 1
+    assert body["child_state_counts"] == {"idle": 1}
+    # "running" (bob's forged child) filtered out.
+    assert "running" not in body["child_state_counts"]
+
+    # Admin sees both.
+    resp_admin = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers={
+            "X-Test-User": "admin-1",
+            "X-Test-Perms": "admin.coordinator,admin.users",
+        },
+    )
+    assert resp_admin.status_code == 200
+    body_admin = resp_admin.json()
+    assert body_admin["spawns_total"] == 2
+    assert body_admin["child_state_counts"] == {"idle": 1, "running": 1}
 
 
 def test_metrics_judge_fallback_rate_substring_match(storage):

--- a/tests/test_phase6_endpoints.py
+++ b/tests/test_phase6_endpoints.py
@@ -1,0 +1,444 @@
+"""Tests for the phase-6 polish endpoints (#q-1).
+
+Covers:
+
+- GET /v1/api/cluster/ws/live — bulk live-block fetch (admin.cluster.inspect).
+- GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot.
+
+Both endpoints ride on the same test harness as
+``test_coordinator_endpoints.py`` — a minimal Starlette app with an
+auth-injecting middleware, TestClient + MockTransport for the
+upstream node fetches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from turnstone.console.coordinator import CoordinatorManager
+from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
+from turnstone.console.server import (
+    cluster_ws_live_bulk,
+    coordinator_metrics,
+)
+from turnstone.core.auth import AuthResult
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+class _AuthMiddleware(BaseHTTPMiddleware):
+    """Inject a configurable AuthResult from header-based contract."""
+
+    async def dispatch(self, request, call_next):
+        perms = request.headers.get("X-Test-Perms", "")
+        user_id = request.headers.get("X-Test-User", "")
+        if perms or user_id:
+            request.state.auth_result = AuthResult(
+                user_id=user_id,
+                scopes=frozenset({"approve"}),
+                token_source="test",
+                permissions=frozenset(p for p in perms.split(",") if p),
+            )
+        return await call_next(request)
+
+
+class _FakeConfigStore:
+    def __init__(self, values: dict[str, Any]) -> None:
+        self._values = values
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SQLiteBackend(str(tmp_path / "phase6.db"))
+
+
+def _build_mgr(storage) -> CoordinatorManager:
+    def _sf(ui, model_alias=None, ws_id=None, **kw):
+        return MagicMock()
+
+    return CoordinatorManager(
+        session_factory=_sf,
+        ui_factory=lambda w, u: ConsoleCoordinatorUI(ws_id=w, user_id=u),
+        storage=storage,
+        max_active=3,
+    )
+
+
+def _fake_registry() -> MagicMock:
+    reg = MagicMock()
+    reg.resolve.return_value = (MagicMock(), "gpt-4", MagicMock())
+    return reg
+
+
+def _make_client(storage, *, coord_mgr=None) -> TestClient:
+    app = Starlette(
+        routes=[
+            Route("/v1/api/cluster/ws/live", cluster_ws_live_bulk, methods=["GET"]),
+            Route(
+                "/v1/api/coordinator/{ws_id}/metrics",
+                coordinator_metrics,
+                methods=["GET"],
+            ),
+        ],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.coord_mgr = coord_mgr
+    app.state.config_store = _FakeConfigStore({"coordinator.model_alias": "gpt-4"})
+    app.state.coord_registry = _fake_registry() if coord_mgr is not None else None
+    app.state.coord_registry_error = "" if coord_mgr else "registry missing"
+    app.state.auth_storage = storage
+    app.state.jwt_secret = "x" * 64
+    return TestClient(app)
+
+
+def _seed_workstream(
+    storage: SQLiteBackend,
+    *,
+    ws_id: str,
+    node_id: str,
+    user_id: str = "user-1",
+    kind: str = "interactive",
+    state: str = "idle",
+    parent_ws_id: str | None = None,
+    created: str | None = None,
+) -> None:
+    storage.register_workstream(
+        ws_id,
+        node_id=node_id,
+        user_id=user_id,
+        name=f"ws-{ws_id[:4]}",
+        state=state,
+        kind=kind,
+        parent_ws_id=parent_ws_id,
+    )
+    if created is not None:
+        # Override the created timestamp directly — register_workstream
+        # stamps "now", so we need a second write to test the
+        # spawns_last_hour boundary.
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._sqlite import workstreams
+
+        with storage._conn() as conn:
+            conn.execute(
+                sa.update(workstreams).where(workstreams.c.ws_id == ws_id).values(created=created)
+            )
+            conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/api/cluster/ws/live — bulk live-block fetch
+# ---------------------------------------------------------------------------
+
+
+_ADMIN_HEADERS = {"X-Test-User": "user-1", "X-Test-Perms": "admin.cluster.inspect"}
+_OWNER_HEADERS = _ADMIN_HEADERS  # same caller; permission grants inspect
+
+
+def test_bulk_live_requires_permission(storage):
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    resp = client.get(
+        "/v1/api/cluster/ws/live?ids=" + "a" * 32,
+        headers={"X-Test-User": "u", "X-Test-Perms": "read"},
+    )
+    assert resp.status_code == 403
+
+
+def test_bulk_live_empty_ids_returns_empty_body(storage):
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    resp = client.get("/v1/api/cluster/ws/live?ids=", headers=_ADMIN_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"results": {}, "denied": [], "truncated": False}
+
+
+def test_bulk_live_strips_invalid_ids(storage):
+    """IDs failing the hex-regex are silently dropped; duplicates
+    collapse."""
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    # NOT-HEX is invalid; the valid id is 32 chars hex but unknown to
+    # storage → shows up as denied.
+    resp = client.get(
+        "/v1/api/cluster/ws/live?ids=NOT-HEX,NOT-HEX,," + ("a" * 32) + "," + ("a" * 32),
+        headers=_ADMIN_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Invalid / empty / duplicate ids trimmed; only the one valid-but-
+    # missing id is reported as denied.
+    assert body["denied"] == ["a" * 32]
+    assert body["results"] == {}
+
+
+def test_bulk_live_caps_ids_at_50(storage):
+    """Ids past the server-side cap truncate with truncated=true."""
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    # 60 fake ids → cap=50 keeps the first 50 (dedup preserves order).
+    ids = ",".join(f"{i:064x}" for i in range(60))
+    resp = client.get(
+        "/v1/api/cluster/ws/live?ids=" + ids,
+        headers=_ADMIN_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["truncated"] is True
+    # All 50 kept ids resolve to 'denied' (no storage rows) — their
+    # inclusion in the response proves the cap took the head 50.
+    assert len(body["denied"]) == 50
+
+
+def test_bulk_live_admin_bypass_returns_live(storage):
+    """An admin user (holds admin.users or admin.roles, not just
+    admin.cluster.inspect) bypasses tenancy and sees non-owned rows'
+    live blocks.  Coordinator live-block synthesis is in-process, so
+    results is populated without any upstream node fetch."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="other-user")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        "/v1/api/cluster/ws/live?ids=" + ws.id,
+        headers={
+            "X-Test-User": "user-1",
+            # admin.users grants the _is_admin bypass in addition to
+            # admin.cluster.inspect for the endpoint itself.
+            "X-Test-Perms": "admin.cluster.inspect,admin.users",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert ws.id in body["results"]
+    assert body["denied"] == []
+
+
+def test_bulk_live_tenant_filter_marks_foreign_rows_denied(storage):
+    """A non-admin caller whose user_id doesn't match the row's owner
+    gets the ws_id in ``denied`` rather than ``results`` — no
+    existence-oracle leak."""
+    # Seed a foreign-owned interactive workstream.
+    ws_id = "b" * 32
+    _seed_workstream(storage, ws_id=ws_id, node_id="node-a", user_id="stranger")
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    resp = client.get(
+        f"/v1/api/cluster/ws/live?ids={ws_id}",
+        headers={"X-Test-User": "user-1", "X-Test-Perms": "admin.cluster.inspect"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["denied"] == [ws_id]
+    assert body["results"] == {}
+
+
+def test_bulk_live_empty_caller_uid_denies_empty_owner_rows(storage):
+    """Regression for #bug-3 / #sec-2: a caller with empty user_id
+    must NOT see rows with empty user_id (orphan / system-owned).
+    Either side empty → denied.  Admin bypass honoured (tested
+    elsewhere)."""
+    ws_id = "c" * 32
+    _seed_workstream(storage, ws_id=ws_id, node_id="node-a", user_id="")
+    client = _make_client(storage, coord_mgr=_build_mgr(storage))
+    # caller_uid="" (empty X-Test-User) + non-admin perm.
+    resp = client.get(
+        f"/v1/api/cluster/ws/live?ids={ws_id}",
+        headers={"X-Test-User": "", "X-Test-Perms": "admin.cluster.inspect"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["denied"] == [ws_id]
+    assert body["results"] == {}
+
+
+def test_bulk_live_coordinator_row_uses_manager_snapshot(storage):
+    """A coordinator ws_id routes through _fetch_live_block's
+    coordinator branch — live is populated from the in-process manager
+    even though the pseudo-node has no /dashboard endpoint."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/cluster/ws/live?ids={ws.id}",
+        headers=_OWNER_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert ws.id in body["results"]
+    live = body["results"][ws.id]
+    assert live is not None
+    assert "pending_approval" in live
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot
+# ---------------------------------------------------------------------------
+
+
+_METRICS_HEADERS = {"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"}
+
+
+def test_metrics_requires_permission(storage):
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers={"X-Test-User": "user-1", "X-Test-Perms": "read"},
+    )
+    assert resp.status_code == 403
+
+
+def test_metrics_invalid_ws_id_400(storage):
+    mgr = _build_mgr(storage)
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        "/v1/api/coordinator/NOT-HEX/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 400
+
+
+def test_metrics_ownership_404_mask(storage):
+    """A ws_id owned by another tenant returns 404, not 403 — no
+    existence-oracle leak (mirrors coordinator_detail)."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="stranger")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_metrics_empty_coordinator_defaults(storage):
+    """A freshly created coordinator with no spawns / no verdicts
+    returns zero / empty defaults."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ws_id"] == ws.id
+    assert body["spawns_total"] == 0
+    assert body["spawns_last_hour"] == 0
+    assert body["child_state_counts"] == {}
+    assert body["judge_fallback_rate"] == 0.0
+    assert body["wait_completions"] == 0
+    assert body["wait_timeouts"] == 0
+    assert body["wait_avg_elapsed"] == 0.0
+
+
+def test_metrics_spawns_and_state_counts(storage):
+    """spawns_total counts ALL children (including closed); state
+    histogram groups by current state."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    # Seed children directly in storage so we control state/created
+    # without going through routing.
+    _seed_workstream(storage, ws_id="aa" * 16, node_id="node-a", parent_ws_id=ws.id, state="idle")
+    _seed_workstream(
+        storage, ws_id="bb" * 16, node_id="node-a", parent_ws_id=ws.id, state="running"
+    )
+    _seed_workstream(storage, ws_id="cc" * 16, node_id="node-a", parent_ws_id=ws.id, state="closed")
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["spawns_total"] == 3
+    assert body["child_state_counts"] == {"idle": 1, "running": 1, "closed": 1}
+
+
+def test_metrics_judge_fallback_rate_substring_match(storage):
+    """judge_fallback_rate is computed from any verdict whose ``tier``
+    field contains 'fallback' (case-insensitive).  Supports tiers like
+    'llm_fallback', 'LLM_FALLBACK', 'fallback_deterministic'."""
+    import uuid
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    # Three verdicts, two marked fallback (one LLM_FALLBACK, one
+    # llm_fallback → both match case-insensitive substring).
+    for tier in ("llm_primary", "LLM_FALLBACK", "llm_fallback"):
+        storage.create_intent_verdict(
+            verdict_id=uuid.uuid4().hex,
+            ws_id=ws.id,
+            call_id="c-" + tier,
+            func_name="f",
+            func_args="{}",
+            intent_summary="",
+            risk_level="low",
+            confidence=0.9,
+            recommendation="allow",
+            reasoning="",
+            evidence="",
+            tier=tier,
+            judge_model="j",
+            latency_ms=1,
+        )
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # 2 / 3 verdicts matched → 0.667 (rounded to 3 places).
+    assert body["judge_fallback_rate"] == pytest.approx(0.667, abs=1e-3)
+    assert body["intent_verdicts_sample"] == 3
+
+
+def test_metrics_spawns_last_hour_boundary(storage):
+    """Only children whose created timestamp is within the last 3600s
+    count toward spawns_last_hour; older children count toward
+    spawns_total but not the hour bucket."""
+    import time
+    from datetime import UTC, datetime, timedelta
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    # One child created "now" (within the window); one created 2
+    # hours ago (outside the window).
+    recent_iso = datetime.fromtimestamp(time.time(), tz=UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    old_iso = (datetime.fromtimestamp(time.time(), tz=UTC) - timedelta(hours=2)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    _seed_workstream(
+        storage,
+        ws_id="aa" * 16,
+        node_id="node-a",
+        parent_ws_id=ws.id,
+        state="idle",
+        created=recent_iso,
+    )
+    _seed_workstream(
+        storage,
+        ws_id="bb" * 16,
+        node_id="node-a",
+        parent_ws_id=ws.id,
+        state="closed",
+        created=old_iso,
+    )
+    client = _make_client(storage, coord_mgr=mgr)
+    resp = client.get(
+        f"/v1/api/coordinator/{ws.id}/metrics",
+        headers=_METRICS_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["spawns_total"] == 2
+    assert body["spawns_last_hour"] == 1

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -401,8 +401,17 @@ class ClusterCollector:
                     self._nodes[nid].server_url = url or self._nodes[nid].server_url
                     self._nodes[nid].max_ws = meta.get("max_ws", self._nodes[nid].max_ws)
 
-            # Remove nodes whose heartbeats expired
-            lost = [nid for nid in self._nodes if nid not in active_ids]
+            # Remove nodes whose heartbeats expired — the ``console``
+            # pseudo-node is permanent (hosts coordinator workstreams,
+            # not a real service-registered node) so it's exempt from
+            # eviction.  Without this guard, every discovery tick
+            # deleted the pseudo-node + fanned out a spurious
+            # node_lost, breaking the home-view coordinator list (#9).
+            lost = [
+                nid
+                for nid in self._nodes
+                if nid not in active_ids and nid != self.CONSOLE_PSEUDO_NODE_ID
+            ]
             for nid in lost:
                 del self._nodes[nid]
                 pending_events.append({"type": "node_lost", "node_id": nid})
@@ -648,7 +657,13 @@ class ClusterCollector:
     # -- query methods (thread-safe) -----------------------------------------
 
     def get_overview(self) -> dict[str, Any]:
-        """Return cluster overview: state counts, totals, aggregate stats."""
+        """Return cluster overview: state counts, totals, aggregate stats.
+
+        Excludes the ``"console"`` pseudo-node — coordinators are not
+        compute-node workstreams and counting them would inflate the
+        cluster summary.  The home view surfaces coordinators via the
+        active-coordinators list instead.
+        """
         states = {"running": 0, "thinking": 0, "attention": 0, "idle": 0, "error": 0}
         total_tokens = 0
         total_tool_calls = 0
@@ -658,7 +673,9 @@ class ClusterCollector:
         mcp_prompts = 0
         versions: set[str] = set()
         with self._lock:
-            for node in self._nodes.values():
+            for nid, node in self._nodes.items():
+                if nid == self.CONSOLE_PSEUDO_NODE_ID:
+                    continue
                 for ws in node.workstreams.values():
                     state = ws.get("state", "idle")
                     states[state] = states.get(state, 0) + 1
@@ -672,7 +689,7 @@ class ClusterCollector:
                 mcp_servers += mcp.get("servers", 0)
                 mcp_resources += mcp.get("resources", 0)
                 mcp_prompts += mcp.get("prompts", 0)
-            node_count = len(self._nodes)
+            node_count = sum(1 for nid in self._nodes if nid != self.CONSOLE_PSEUDO_NODE_ID)
         result: dict[str, Any] = {
             "nodes": node_count,
             "workstreams": total_ws,
@@ -720,6 +737,11 @@ class ClusterCollector:
         with self._lock:
             items = []
             for node in self._nodes.values():
+                # Hide the ``"console"`` pseudo-node from compute-node
+                # listings — it's a synthetic carrier for coordinator
+                # workstreams, not a real node operators target.
+                if node.node_id == self.CONSOLE_PSEUDO_NODE_ID:
+                    continue
                 if node_ids is not None and node.node_id not in node_ids:
                     continue
                 ws_states = {
@@ -796,6 +818,13 @@ class ClusterCollector:
         with self._lock:
             all_ws = []
             for n in self._nodes.values():
+                # Skip the ``"console"`` pseudo-node — coordinator rows
+                # are contributed by the ``_coordinator_rows`` caller
+                # (via ``extra_rows``) which applies tenancy filtering.
+                # Without this skip, non-admin callers would see every
+                # tenant's coordinators via ``/v1/api/cluster/workstreams``.
+                if n.node_id == self.CONSOLE_PSEUDO_NODE_ID:
+                    continue
                 for ws in n.workstreams.values():
                     all_ws.append(dict(ws))
             if extra_rows:
@@ -961,3 +990,149 @@ class ClusterCollector:
         with self._listeners_lock:
             if q in self._listeners:
                 self._listeners.remove(q)
+
+    # ------------------------------------------------------------------
+    # Console pseudo-node — coordinator workstreams live here (#9)
+    # ------------------------------------------------------------------
+    #
+    # Coordinators run on the console process, not on a cluster node,
+    # so the SSE stream the collector manages for real nodes never
+    # surfaces them.  To avoid a parallel polling channel the home view
+    # had to drive itself, the coordinator manager drives a pseudo-node
+    # here: register the node on startup, upsert workstream entries on
+    # create / close / state-change, and fan out matching ws_created /
+    # ws_closed / cluster_state events so the browser's existing
+    # clusterState machinery picks them up live.
+
+    CONSOLE_PSEUDO_NODE_ID = "console"
+
+    def ensure_console_pseudo_node(self) -> None:
+        """Install the ``"console"`` pseudo-node in the snapshot map.
+
+        Idempotent — a second call is a no-op.  No SSE task is started
+        for this node (it has no real server URL and no remote state to
+        mirror); the coordinator manager feeds events directly via
+        :meth:`emit_console_ws_created` / :meth:`emit_console_ws_closed`
+        / :meth:`emit_console_ws_state`.
+        """
+        with self._lock:
+            if self.CONSOLE_PSEUDO_NODE_ID in self._nodes:
+                return
+            self._nodes[self.CONSOLE_PSEUDO_NODE_ID] = NodeSnapshot(
+                node_id=self.CONSOLE_PSEUDO_NODE_ID,
+                server_url="",
+                started=time.time(),
+                last_seen=time.monotonic(),
+                max_ws=0,
+                reachable=True,
+            )
+
+    def emit_console_ws_created(
+        self,
+        ws_id: str,
+        *,
+        name: str,
+        user_id: str,
+        kind: str,
+        state: str = "idle",
+        parent_ws_id: str | None = None,
+    ) -> None:
+        """Record a new coordinator row on the console pseudo-node + fan out.
+
+        Best-effort: if the pseudo-node doesn't exist yet the call is
+        dropped rather than raising.  Matches the shape
+        :func:`_apply_delta` produces for real-node ``ws_created`` events
+        so the browser's ``patchClusterState`` handler stays uniform.
+        """
+        self.ensure_console_pseudo_node()
+        pending: list[dict[str, Any]] = []
+        now = time.time()
+        with self._lock:
+            node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
+            if node is None:
+                return
+            if ws_id not in node.workstreams:
+                node.workstreams[ws_id] = {
+                    "id": ws_id,
+                    "name": name,
+                    "state": state,
+                    "node": self.CONSOLE_PSEUDO_NODE_ID,
+                    "server_url": "",
+                    "tokens": 0,
+                    "context_ratio": 0.0,
+                    "activity": "",
+                    "activity_state": "",
+                    "tool_calls": 0,
+                    "title": "",
+                    "kind": kind,
+                    "parent_ws_id": parent_ws_id,
+                    "user_id": user_id or "",
+                    "updated": now,
+                }
+            pending.append(
+                {
+                    "type": "ws_created",
+                    "ws_id": ws_id,
+                    "name": name,
+                    "title": "",
+                    "node_id": self.CONSOLE_PSEUDO_NODE_ID,
+                    "kind": kind,
+                    "parent_ws_id": parent_ws_id,
+                    "user_id": user_id or "",
+                }
+            )
+        for event in pending:
+            self._fanout(event)
+
+    def emit_console_ws_closed(self, ws_id: str) -> None:
+        """Drop the coordinator row from the console pseudo-node + fan out."""
+        with self._lock:
+            node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
+            if node is None:
+                return
+            node.workstreams.pop(ws_id, None)
+        self._fanout({"type": "ws_closed", "ws_id": ws_id})
+
+    def emit_console_ws_state(self, ws_id: str, state: str) -> None:
+        """Update the coordinator row's state on the console pseudo-node + fan out.
+
+        Coordinators don't surface live-token counts the way real-node
+        workstreams do (the collector reads aggregate tokens from the
+        node's ``/v1/api/dashboard`` feed, which the console doesn't
+        expose).  Emit state transitions only — downstream rendering
+        gracefully handles the absent ``tokens`` field.
+        """
+        with self._lock:
+            node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
+            if node is None:
+                return
+            entry = node.workstreams.get(ws_id)
+            if entry is None:
+                return
+            entry["state"] = state
+        self._fanout(
+            {
+                "type": "cluster_state",
+                "ws_id": ws_id,
+                "state": state,
+                "node_id": self.CONSOLE_PSEUDO_NODE_ID,
+                "tokens": 0,
+                "content": "",
+                "kind": WorkstreamKind.COORDINATOR.value,
+                "parent_ws_id": None,
+            }
+        )
+
+    def emit_console_ws_rename(self, ws_id: str, name: str) -> None:
+        """Rename the coordinator row + fan out ``ws_rename``."""
+        if not name:
+            return
+        with self._lock:
+            node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
+            if node is None:
+                return
+            entry = node.workstreams.get(ws_id)
+            if entry is None:
+                return
+            entry["name"] = name
+        self._fanout({"type": "ws_rename", "ws_id": ws_id, "name": name})

--- a/turnstone/console/coordinator.py
+++ b/turnstone/console/coordinator.py
@@ -33,6 +33,7 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any
 
+from turnstone.console.collector import ClusterCollector
 from turnstone.core.log import get_logger
 from turnstone.core.workstream import (
     Workstream,
@@ -44,7 +45,6 @@ from turnstone.core.workstream import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-    from turnstone.console.collector import ClusterCollector
     from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
     from turnstone.core.session import ChatSession
     from turnstone.core.storage._protocol import StorageBackend
@@ -59,7 +59,10 @@ class CoordinatorManager:
     # stays non-NULL and list / audit surfaces can distinguish coordinators
     # from real-node workstreams.  The hash-ring router treats it as an
     # unroutable sentinel — coordinators never land on real nodes.
-    NODE_ID = "console"
+    # Bound from ``ClusterCollector.CONSOLE_PSEUDO_NODE_ID`` so the two
+    # literals can't drift (the collector's eviction + query filters
+    # key off the same string).
+    NODE_ID = ClusterCollector.CONSOLE_PSEUDO_NODE_ID
 
     def __init__(
         self,
@@ -165,6 +168,59 @@ class CoordinatorManager:
             self._cleanup(evicted)
             with self._children_lock:
                 self._pop_coord_registry_locked(evicted.id)
+            # Fan out a console-pseudo-node ``ws_closed`` for the evicted
+            # coordinator so the home view drops it live (see #9).  The
+            # eviction path otherwise has no observable signal — the row
+            # would linger on other tabs' home views until the next hard
+            # refresh.
+            if self._collector is not None:
+                try:
+                    self._collector.emit_console_ws_closed(evicted.id)
+                except Exception:
+                    log.debug(
+                        "coord_mgr.collector_evict_fanout_failed ws=%s",
+                        evicted.id[:8],
+                        exc_info=True,
+                    )
+
+        # Resolve skill name -> (template_id, applied_version) so the
+        # workstreams row persists what was applied, not what was
+        # requested.  Mirrors ``turnstone/server.py`` interactive-workstream
+        # create; surfaced by ``inspect_workstream`` on coordinator rows so
+        # operators can tell which skill the session is running.  A missing
+        # / unknown skill name falls back to empty (no skill binding)
+        # rather than raising — the session factory tolerates None.
+        skill_id_resolved = ""
+        skill_version_resolved = 0
+        if skill:
+            try:
+                from turnstone.core.memory import get_skill_by_name
+
+                skill_data = get_skill_by_name(skill)
+            except Exception:
+                log.debug(
+                    "coord_mgr.skill_lookup_failed ws=%s skill=%s",
+                    ws_id[:8],
+                    skill,
+                    exc_info=True,
+                )
+                skill_data = None
+            if skill_data and skill_data.get("template_id"):
+                skill_id_resolved = str(skill_data["template_id"])
+                try:
+                    # COUNT query avoids pulling every version row just
+                    # for its length on the create hot path (#perf-2).
+                    skill_version_resolved = (
+                        self._storage.count_skill_versions(skill_id_resolved) + 1
+                    )
+                except Exception:
+                    log.debug(
+                        "coord_mgr.skill_version_failed ws=%s skill=%s",
+                        ws_id[:8],
+                        skill,
+                        exc_info=True,
+                    )
+                    skill_version_resolved = 1
 
         # Persist before constructing the session so lazy rehydration on
         # restart can find the row even if the ChatSession build fails.
@@ -180,6 +236,8 @@ class CoordinatorManager:
                 name=ws.name,
                 kind=WorkstreamKind.COORDINATOR,
                 parent_ws_id=None,
+                skill_id=skill_id_resolved,
+                skill_version=skill_version_resolved,
             )
         except Exception:
             log.warning(
@@ -221,6 +279,27 @@ class CoordinatorManager:
 
         if initial_message:
             self._spawn_worker(ws, initial_message)
+
+        # Fan out a console-pseudo-node ``ws_created`` so the home view
+        # sees the new coordinator live (no more polling — see #9).
+        # Failure here must not break the create path — worst case the
+        # view lags one refresh cycle until the next SSE tick.
+        if self._collector is not None:
+            try:
+                self._collector.emit_console_ws_created(
+                    ws_id,
+                    name=ws.name,
+                    user_id=user_id,
+                    kind=WorkstreamKind.COORDINATOR.value,
+                    state=ws.state.value,
+                    parent_ws_id=None,
+                )
+            except Exception:
+                log.debug(
+                    "coord_mgr.collector_create_fanout_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
 
         # Seed the known-children registry with an empty set so the
         # fan-out filter recognises this coordinator immediately when a
@@ -319,6 +398,20 @@ class CoordinatorManager:
                     # index entries forever.
                     with self._children_lock:
                         self._pop_coord_registry_locked(evicted.id)
+                    # Fan out a console-pseudo-node ``ws_closed`` for the
+                    # evicted coordinator so other tabs drop the row
+                    # live — without this, the rehydrate-path eviction
+                    # was silent on the home view and stale rows
+                    # lingered until a hard refresh (#9 follow-up).
+                    if self._collector is not None:
+                        try:
+                            self._collector.emit_console_ws_closed(evicted.id)
+                        except Exception:
+                            log.debug(
+                                "coord_mgr.collector_open_evict_fanout_failed ws=%s",
+                                evicted.id[:8],
+                                exc_info=True,
+                            )
 
                 try:
                     ws.session = self._session_factory(
@@ -341,6 +434,27 @@ class CoordinatorManager:
                     except Exception:
                         log.debug(
                             "coord_mgr.resume_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
+                # Rehydration: fan out a console-pseudo-node
+                # ``ws_created`` so a tab that opens a persisted-but-
+                # unloaded coordinator sees it live on every other
+                # open home view (see #9).  Harmless re-emit —
+                # clusterState's patch loop ignores duplicates.
+                if self._collector is not None:
+                    try:
+                        self._collector.emit_console_ws_created(
+                            ws_id,
+                            name=ws.name,
+                            user_id=ws.user_id or "",
+                            kind=WorkstreamKind.COORDINATOR.value,
+                            state=ws.state.value,
+                            parent_ws_id=None,
+                        )
+                    except Exception:
+                        log.debug(
+                            "coord_mgr.collector_open_fanout_failed ws=%s",
                             ws_id[:8],
                             exc_info=True,
                         )
@@ -504,6 +618,35 @@ class CoordinatorManager:
             self._storage.update_workstream_state(ws_id, "closed")
         except Exception:
             log.debug("coord_mgr.state_update_failed ws=%s", ws_id[:8], exc_info=True)
+        # Fan out a console-pseudo-node ``ws_closed`` so the home view
+        # drops the row live (see #9).  Best-effort; swallow failures.
+        if self._collector is not None:
+            try:
+                self._collector.emit_console_ws_closed(ws_id)
+            except Exception:
+                log.debug(
+                    "coord_mgr.collector_close_fanout_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
+        # Best-effort sweep: task_list rows may carry child_ws_id
+        # pointers to workstreams that have since been hard-deleted.
+        # Clearing the dead links keeps the persisted task envelope
+        # honest and prevents v2 kanban from rendering broken arrows.
+        # Routed through the CoordinatorClient so it acquires the same
+        # per-ws ``_task_lock`` the add/update/remove/reorder paths
+        # hold — a close() racing an in-flight task_list mutation
+        # would otherwise lose the mutation (#bug-6).
+        coord_client = getattr(getattr(ws, "session", None), "_coord_client", None)
+        if coord_client is not None and hasattr(coord_client, "cleanup_dead_task_child_refs"):
+            try:
+                coord_client.cleanup_dead_task_child_refs(ws_id)
+            except Exception:
+                log.debug(
+                    "coord_mgr.task_ref_cleanup_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
         return True
 
     def cancel(self, ws_id: str) -> bool:
@@ -586,6 +729,47 @@ class CoordinatorManager:
         # lock means every observer of the placeholder sees a non-None
         # ui; only ``session`` lags behind.
         ws.ui = self._ui_factory(ws_id, user_id)
+        # Wire state/rename observers so the cluster collector's
+        # console pseudo-node mirrors every state transition and rename
+        # that reaches the UI (see #9).  Bind ``ws_id`` by default-arg
+        # so the closure captures the concrete id — ``ws`` changes
+        # across concurrent installs.
+        collector = self._collector
+        if collector is not None:
+
+            def _state_fanout(state: str, _wid: str = ws_id) -> None:
+                if collector is None:
+                    return
+                try:
+                    collector.emit_console_ws_state(_wid, state)
+                except Exception:
+                    log.debug(
+                        "coord_mgr.state_fanout_failed ws=%s",
+                        _wid[:8],
+                        exc_info=True,
+                    )
+
+            def _rename_fanout(name: str, _wid: str = ws_id) -> None:
+                if collector is None:
+                    return
+                try:
+                    collector.emit_console_ws_rename(_wid, name)
+                except Exception:
+                    log.debug(
+                        "coord_mgr.rename_fanout_failed ws=%s",
+                        _wid[:8],
+                        exc_info=True,
+                    )
+
+            try:
+                ws.ui._on_state_observer = _state_fanout
+                ws.ui._on_rename_observer = _rename_fanout
+            except Exception:
+                log.debug(
+                    "coord_mgr.attach_observers_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
         self._workstreams[ws_id] = ws
         self._order.append(ws_id)
         # Track the evicted coordinator's id for the active-coords
@@ -806,6 +990,10 @@ class CoordinatorManager:
             return
         self._collector = collector
         self._collector_queue = queue.Queue(maxsize=1000)
+        # Ensure the "console" pseudo-node exists in the snapshot map so
+        # emit_console_ws_* calls from create / close / open land on a
+        # real node entry the snapshot will surface (see #9).
+        collector.ensure_console_pseudo_node()
         # Register with the collector — use the existing listener channel
         # the browser SSE fan-out uses; the collector treats our queue as
         # just another subscriber.
@@ -815,6 +1003,28 @@ class CoordinatorManager:
         # children without waiting for the next ``ws_state`` tick to
         # discover them via the fan-out path.
         self._prime_children_from_snapshot(snapshot)
+        # Seed the pseudo-node with any coordinators already loaded in
+        # memory when the collector binds.  Prevents a race where early
+        # creates happened before the collector was wired up and their
+        # rows never showed on the snapshot.
+        with self._lock:
+            active = [(w.id, w) for w in self._workstreams.values()]
+        for wid, ws in active:
+            try:
+                collector.emit_console_ws_created(
+                    wid,
+                    name=ws.name,
+                    user_id=ws.user_id or "",
+                    kind=WorkstreamKind.COORDINATOR.value,
+                    state=ws.state.value,
+                    parent_ws_id=None,
+                )
+            except Exception:
+                log.debug(
+                    "coord_mgr.collector_seed_failed ws=%s",
+                    wid[:8],
+                    exc_info=True,
+                )
         self._fanout_stop.clear()
         t = threading.Thread(
             target=self._fanout_loop,

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -37,6 +37,43 @@ from turnstone.core.auth import JWT_AUD_CONSOLE, create_jwt
 from turnstone.core.log import get_logger
 from turnstone.core.workstream import WorkstreamKind
 
+# ---------------------------------------------------------------------------
+# wait_for_workstream constants — module-level so ``turnstone.core.session``
+# can import them without reading a class internal (see #12).  The
+# ``CoordinatorClient`` ClassVar aliases below are kept so external callers
+# that still import via the class surface don't break.
+# ---------------------------------------------------------------------------
+
+# Real terminal states for the wait_for_workstream tool — these drive the
+# any/all completion condition.  A workstream in one of these states has
+# actually finished work the coordinator can observe.
+WAIT_REAL_TERMINAL_STATES: frozenset[str] = frozenset({"idle", "error", "closed", "deleted"})
+
+# Reportable terminal states — superset of the real ones, also includes the
+# ``denied`` short-circuit shape returned for foreign / missing ws_ids.  Used
+# by the resolved-count summary so the operator-facing "X/Y resolved" matches
+# what they see in the results dict.  NOT used for the any/all condition: a
+# single typo'd / foreign id shouldn't satisfy ``mode="any"`` and let the
+# model declare a wait complete while every real child is still running.
+WAIT_TERMINAL_STATES: frozenset[str] = WAIT_REAL_TERMINAL_STATES | frozenset({"denied"})
+
+# Hard cap on ws_ids per call.  Polling happens once per ws_id per tick, so a
+# runaway list would amplify storage load without giving the model anything
+# useful — coordinators rarely fan out past a handful of children at once.
+WAIT_MAX_WS_IDS: int = 32
+
+# Cap on the total wait so a stuck child can't pin a coordinator worker
+# thread indefinitely.  Coordinators that need a longer wait call
+# wait_for_workstream again with the same ws_ids — each call re-arms freshly.
+WAIT_MAX_TIMEOUT: float = 600.0
+
+# Storage-poll cadence.  500ms is short enough that the wait terminates
+# promptly after a child finishes (well under the human-perceptible-latency
+# floor), and long enough that a 60s wait incurs at most 120 cheap row
+# reads — still cheaper than the 20+ inspect_workstream model turns the
+# tool replaces.
+WAIT_POLL_INTERVAL: float = 0.5
+
 _TASK_STATUSES = frozenset({"pending", "in_progress", "done", "blocked"})
 # Hard cap on tasks per coordinator — the full list is read and re-serialized
 # on every mutation, so unbounded growth is both a storage and a tool-output-size
@@ -378,40 +415,15 @@ class CoordinatorClient:
 
     # -- model-invoked block-wait -----------------------------------------
 
-    # Real terminal states for the wait_for_workstream tool — these
-    # drive the any/all completion condition.  A workstream in one of
-    # these states has actually finished work the coordinator can
-    # observe.
-    _WAIT_REAL_TERMINAL_STATES: ClassVar[frozenset[str]] = frozenset(
-        {"idle", "error", "closed", "deleted"}
-    )
-    # Reportable terminal states — superset of the real ones, also
-    # includes the ``denied`` short-circuit shape returned for foreign
-    # / missing ws_ids.  Used by the resolved-count summary so the
-    # operator-facing "X/Y resolved" matches what they see in the
-    # results dict.  NOT used for the any/all condition: a single
-    # typo'd / foreign id shouldn't satisfy ``mode="any"`` and let
-    # the model declare a wait complete while every real child is
-    # still running.
-    _WAIT_TERMINAL_STATES: ClassVar[frozenset[str]] = _WAIT_REAL_TERMINAL_STATES | frozenset(
-        {"denied"}
-    )
-    # Hard cap on ws_ids per call.  Polling happens once per ws_id per
-    # tick, so a runaway list would amplify storage load without
-    # giving the model anything useful — coordinators rarely fan out
-    # past a handful of children at once.
-    _WAIT_MAX_WS_IDS: ClassVar[int] = 32
-    # Cap on the total wait so a stuck child can't pin a coordinator
-    # worker thread indefinitely.  Coordinators that need a longer wait
-    # call wait_for_workstream again with the same ws_ids — each call
-    # re-arms freshly.
-    _WAIT_MAX_TIMEOUT: ClassVar[float] = 600.0
-    # Storage-poll cadence.  500ms is short enough that the wait
-    # terminates promptly after a child finishes (well under the
-    # human-perceptible-latency floor), and long enough that a 60s
-    # wait incurs at most 120 cheap row reads — still cheaper than
-    # the 20+ inspect_workstream model turns the tool replaces.
-    _WAIT_POLL_INTERVAL: ClassVar[float] = 0.5
+    # ClassVar aliases for the module-level wait_for_workstream constants.
+    # Kept so existing callers that read ``CoordinatorClient._WAIT_*`` keep
+    # working; prefer the module-level ``WAIT_*`` constants in new code
+    # (see #12 — the class-nesting was an inline-import smell).
+    _WAIT_REAL_TERMINAL_STATES: ClassVar[frozenset[str]] = WAIT_REAL_TERMINAL_STATES
+    _WAIT_TERMINAL_STATES: ClassVar[frozenset[str]] = WAIT_TERMINAL_STATES
+    _WAIT_MAX_WS_IDS: ClassVar[int] = WAIT_MAX_WS_IDS
+    _WAIT_MAX_TIMEOUT: ClassVar[float] = WAIT_MAX_TIMEOUT
+    _WAIT_POLL_INTERVAL: ClassVar[float] = WAIT_POLL_INTERVAL
 
     def wait_for_workstream(
         self,
@@ -419,6 +431,8 @@ class CoordinatorClient:
         *,
         timeout: float = 60.0,
         mode: str = "any",
+        since: dict[str, dict[str, Any]] | None = None,
+        progress_callback: Callable[[dict[str, dict[str, Any]], float], None] | None = None,
     ) -> dict[str, Any]:
         """Block until child workstreams reach a terminal state.
 
@@ -435,6 +449,17 @@ class CoordinatorClient:
         False when the timeout fired (results carry whatever last state
         was observed).
 
+        ``since`` — optional prior snapshot (typically the ``results``
+        dict from an earlier ``wait_for_workstream`` call).  When
+        provided, the wait short-circuits as soon as ANY polled ws_id's
+        snapshot differs from its ``since`` entry (``state`` / ``tokens``
+        / ``updated``), regardless of ``mode``.  Lets a follow-up wait
+        skip re-counting already-completed children — the classic
+        "spawn 3, wait for the first, then wait for the next change"
+        loop turns into two calls instead of spinning the timeout on
+        the still-terminal first child.  An entry missing from
+        ``since`` counts as changed on first observation.
+
         Cross-tenant guard: a ws_id that's neither the coordinator
         itself nor one of its own children appears with
         ``state="denied"`` and never blocks the wait — a model that
@@ -442,6 +467,13 @@ class CoordinatorClient:
         until timeout.  A ws_id that doesn't exist at all collapses
         into the same ``denied`` shape so wait can't be used as an
         existence oracle.
+
+        ``progress_callback`` is invoked once per poll cycle with the
+        current snapshot dict + elapsed seconds.  Swallows callback
+        errors so a buggy observer can't break the wait loop.  Used
+        by the coordinator-side wait dashboard (#14) to emit
+        ``wait_progress`` SSE events; tests pass it to assert loop
+        cadence.
 
         Performance: each tick issues exactly two storage calls
         (``get_workstreams_batch`` + ``sum_workstream_tokens_batch``),
@@ -499,6 +531,15 @@ class CoordinatorClient:
         except (TypeError, ValueError):
             timeout_f = 60.0
         timeout_f = max(0.0, min(timeout_f, self._WAIT_MAX_TIMEOUT))
+        # Normalize since into a per-ws_id dict of the fields we diff
+        # against.  Hostile / malformed entries silently drop — the
+        # wait is advisory, not a gatekeeper, so an invalid hint
+        # degrades to "no diff signal" rather than failing the call.
+        since_map: dict[str, dict[str, Any]] = {}
+        if isinstance(since, dict):
+            for wid, prev in since.items():
+                if isinstance(wid, str) and isinstance(prev, dict):
+                    since_map[wid] = prev
         start = time.monotonic()
         deadline = start + timeout_f
 
@@ -553,13 +594,41 @@ class CoordinatorClient:
             # one has already finished).
             return snap.get("state", "") in self._WAIT_TERMINAL_STATES
 
+        def _diff_since(snap: dict[str, Any], prev: dict[str, Any]) -> bool:
+            """True when ``snap`` differs from the ``since`` hint on any
+            of the diffed fields.  Called only for ws_ids that appear in
+            ``since_map`` — callers handling missing entries is the
+            wrong default (it would make a disjoint since-dict exit
+            the wait on tick one with complete=True)."""
+            return any(snap.get(key) != prev.get(key) for key in ("state", "tokens", "updated"))
+
         last_results: dict[str, dict[str, Any]] = {}
         complete = False
         while True:
             results = _snapshot_all()
             last_results = results
+            if progress_callback is not None:
+                try:
+                    progress_callback(results, time.monotonic() - start)
+                except Exception:
+                    log.debug("coord_client.wait.progress_cb_failed", exc_info=True)
             real_terminal = [_is_real_terminal(snap) for snap in results.values()]
             settled = [_is_settled(snap) for snap in results.values()]
+            # ``since`` — orthogonal to mode.  If the caller supplied a
+            # prior snapshot, any diff on a ws_id that IS in ``since_map``
+            # exits the wait so a follow-up call doesn't re-count
+            # already-terminal children.  ws_ids absent from ``since_map``
+            # are ignored for the diff-exit check — they fall through to
+            # the normal mode='any' / mode='all' conditions below.  This
+            # prevents a disjoint since-dict from exiting on tick one
+            # with complete=True (previous shape did, silently).
+            if since_map and any(
+                _diff_since(snap, since_map[wid])
+                for wid, snap in results.items()
+                if wid in since_map
+            ):
+                complete = True
+                break
             if mode == "any":
                 if any(real_terminal):
                     complete = True
@@ -1049,6 +1118,71 @@ class CoordinatorClient:
                 return {"error": f"task not found: {task_id}"}
             self._save_task_list(ws_id, envelope)
             return {"ok": True, "task_id": task_id}
+
+    def cleanup_dead_task_child_refs(self, ws_id: str) -> int:
+        """Clear ``child_ws_id`` pointers on tasks whose referenced
+        workstream no longer exists in storage.  Returns the number of
+        links blanked (0 if nothing needed doing, envelope was corrupt,
+        or the lookup failed).
+
+        Called by :meth:`CoordinatorManager.close` after the state
+        transition — the task envelope is a per-coordinator planning
+        structure, so cross-coord scope guards don't apply the same way
+        they do for add/update/remove.  Held under the same per-ws
+        ``_task_lock`` as add/update/remove/reorder so a close racing
+        an in-flight mutation can't lose the mutation (#bug-6).
+        """
+        with self._task_lock(ws_id):
+            envelope, corrupt = load_task_envelope(self._storage, ws_id)
+            if corrupt:
+                return 0
+            tasks = envelope.get("tasks") or []
+            if not tasks:
+                return 0
+            candidate_ids = sorted(
+                {
+                    str(t.get("child_ws_id") or "")
+                    for t in tasks
+                    if isinstance(t, dict) and t.get("child_ws_id")
+                }
+            )
+            if not candidate_ids:
+                return 0
+            try:
+                existing_rows = self._storage.get_workstreams_batch(candidate_ids)
+            except Exception:
+                log.debug(
+                    "coord_client.task_ref_batch_failed ws=%s",
+                    ws_id,
+                    exc_info=True,
+                )
+                return 0
+            dead_ids = {cid for cid in candidate_ids if existing_rows.get(cid) is None}
+            if not dead_ids:
+                return 0
+            blanked = 0
+            for t in tasks:
+                if isinstance(t, dict) and str(t.get("child_ws_id") or "") in dead_ids:
+                    t["child_ws_id"] = ""
+                    blanked += 1
+            if not blanked:
+                return 0
+            try:
+                self._save_task_list(ws_id, envelope)
+            except Exception:
+                # Write-side divergence — the task envelope on disk
+                # now disagrees with what the close path intended.
+                # Bump to warning (not debug) so operators see it;
+                # read-side corruption (already silent on load) stays
+                # at debug.  #q-6.
+                log.warning(
+                    "coord_client.task_ref_save_failed ws=%s blanked=%d",
+                    ws_id,
+                    blanked,
+                    exc_info=True,
+                )
+                return 0
+            return blanked
 
     def task_list_reorder(self, ws_id: str, *, task_ids: list[str]) -> dict[str, Any]:
         """Reject unless ``task_ids`` is an exact permutation of the

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -50,11 +50,15 @@ from turnstone.core.workstream import WorkstreamKind
 WAIT_REAL_TERMINAL_STATES: frozenset[str] = frozenset({"idle", "error", "closed", "deleted"})
 
 # Reportable terminal states — superset of the real ones, also includes the
-# ``denied`` short-circuit shape returned for foreign / missing ws_ids.  Used
-# by the resolved-count summary so the operator-facing "X/Y resolved" matches
-# what they see in the results dict.  NOT used for the any/all condition: a
-# single typo'd / foreign id shouldn't satisfy ``mode="any"`` and let the
-# model declare a wait complete while every real child is still running.
+# ``denied`` short-circuit shape returned for foreign / missing ws_ids.
+# Used inside ``wait_for_workstream`` to decide when ``mode='any'`` on a
+# pure-denied list should short-circuit with ``complete=False`` (no real
+# work to wait for) and when ``mode='all'`` has fully settled.  NOT used
+# for the ``mode='any'`` real-terminal completion condition and NOT used
+# by the resolved-count summary (which counts only real terminals —
+# ``denied`` is a rejection, not a resolution).  A single typo'd /
+# foreign id shouldn't satisfy ``mode="any"`` and let the model declare
+# a wait complete while every real child is still running.
 WAIT_TERMINAL_STATES: frozenset[str] = WAIT_REAL_TERMINAL_STATES | frozenset({"denied"})
 
 # Hard cap on ws_ids per call.  Polling happens once per ws_id per tick, so a
@@ -451,14 +455,18 @@ class CoordinatorClient:
 
         ``since`` — optional prior snapshot (typically the ``results``
         dict from an earlier ``wait_for_workstream`` call).  When
-        provided, the wait short-circuits as soon as ANY polled ws_id's
-        snapshot differs from its ``since`` entry (``state`` / ``tokens``
-        / ``updated``), regardless of ``mode``.  Lets a follow-up wait
-        skip re-counting already-completed children — the classic
-        "spawn 3, wait for the first, then wait for the next change"
-        loop turns into two calls instead of spinning the timeout on
-        the still-terminal first child.  An entry missing from
-        ``since`` counts as changed on first observation.
+        provided, the wait short-circuits as soon as ANY polled ws_id
+        that ALSO has a ``since`` entry differs from that prior
+        snapshot (``state`` / ``tokens`` / ``updated``), regardless of
+        ``mode``.  Lets a follow-up wait skip re-counting
+        already-completed children — the classic "spawn 3, wait for
+        the first, then wait for the next change" loop turns into two
+        calls instead of spinning the timeout on the still-terminal
+        first child.  ws_ids absent from ``since`` do NOT themselves
+        trigger the diff-based early exit — they fall back to the
+        normal ``mode`` condition.  This prevents a disjoint ``since``
+        dict from silently exiting on tick one (which the naive
+        missing-entry-counts-as-changed rule would cause).
 
         Cross-tenant guard: a ws_id that's neither the coordinator
         itself nor one of its own children appears with

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 import contextlib
 import queue
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from turnstone.core.log import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 log = get_logger(__name__)
 
@@ -51,6 +54,14 @@ class ConsoleCoordinatorUI:
         # SSE listener fan-out — one per connected browser tab.
         self._listeners: list[queue.Queue[dict[str, Any]]] = []
         self._listeners_lock = threading.Lock()
+        # External observers for state/rename events — set by the
+        # CoordinatorManager on install so the cluster collector's
+        # console pseudo-node sees state transitions without the
+        # manager needing to wrap the UI methods.  Both callables
+        # take a single string (new state / new name); a failing
+        # observer is swallowed (see on_state_change / on_rename).
+        self._on_state_observer: Callable[[str], None] | None = None
+        self._on_rename_observer: Callable[[str], None] | None = None
         # Approval blocking — the worker thread calls approve_tools which
         # waits on _approval_event; the /approve endpoint sets it via
         # resolve_approval.
@@ -262,9 +273,21 @@ class ConsoleCoordinatorUI:
 
     def on_state_change(self, state: str) -> None:
         self._enqueue({"type": "state_change", "state": state})
+        observer = self._on_state_observer
+        if observer is not None:
+            try:
+                observer(state)
+            except Exception:
+                log.debug("coord_ui.state_observer_failed ws=%s", self.ws_id, exc_info=True)
 
     def on_rename(self, name: str) -> None:
         self._enqueue({"type": "rename", "name": name})
+        observer = self._on_rename_observer
+        if observer is not None:
+            try:
+                observer(name)
+            except Exception:
+                log.debug("coord_ui.rename_observer_failed ws=%s", self.ws_id, exc_info=True)
 
     def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
         # Coordinator sessions use the intent judge like any other session.

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -833,6 +833,122 @@ async def cluster_ws_detail(request: Request) -> JSONResponse:
     )
 
 
+# Upper bound on ids per bulk request.  Matches the per-coordinator
+# fanout cap + leaves headroom; larger batches would defeat the per-node
+# /v1/api/dashboard cache's batching benefit once the id set spans many
+# nodes, at which point the caller should paginate client-side.
+_CLUSTER_WS_LIVE_BULK_CAP = 50
+
+
+async def cluster_ws_live_bulk(request: Request) -> JSONResponse:
+    """GET /v1/api/cluster/ws/live?ids=a,b,c — bulk live-block fetch.
+
+    Returns ``{results: {ws_id: live | null}, denied: [ws_id, ...],
+    truncated: bool}``.
+
+    Collapses the per-row fan-out that tree UIs with 30+ visible
+    children produce — one HTTP round-trip per TTL window instead of
+    one-per-row.  Reuses the same ``_fetch_live_block`` path as
+    ``cluster_ws_detail`` so node-dashboard cache behaviour, coordinator
+    in-process snapshots, and ownership masking stay consistent.
+
+    Permission + ownership semantics match ``cluster_ws_detail``:
+    gated on ``admin.cluster.inspect`` and rows the caller doesn't
+    own surface in ``denied`` rather than ``results`` (so the endpoint
+    can't be used as an existence oracle).  Missing ids also route to
+    ``denied`` for the same reason.  ``ids`` over the cap is truncated
+    with ``truncated=true`` so the model / frontend knows to paginate.
+    """
+    from turnstone.core.auth import require_permission
+    from turnstone.core.web_helpers import require_storage_or_503
+
+    err = require_permission(request, "admin.cluster.inspect")
+    if err is not None:
+        return err
+    storage, err503 = require_storage_or_503(request)
+    if err503 is not None:
+        return err503
+
+    raw_ids = request.query_params.get("ids", "") or ""
+    # Split on comma; strip whitespace; drop empty / invalid entries.
+    # Dedupe while preserving order so a caller passing the same id
+    # twice doesn't double-bill the round-trip budget.
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for chunk in raw_ids.split(","):
+        wid = chunk.strip()
+        if not wid or not _VALID_WS_ID_RE.match(wid):
+            continue
+        if wid in seen:
+            continue
+        seen.add(wid)
+        cleaned.append(wid)
+    truncated = False
+    if len(cleaned) > _CLUSTER_WS_LIVE_BULK_CAP:
+        truncated = True
+        cleaned = cleaned[:_CLUSTER_WS_LIVE_BULK_CAP]
+    if not cleaned:
+        return JSONResponse({"results": {}, "denied": [], "truncated": False})
+
+    caller_uid = _auth_user_id(request)
+    is_admin = _is_admin(request)
+
+    try:
+        rows = await asyncio.to_thread(storage.get_workstreams_batch, cleaned)
+    except Exception:
+        correlation_id = secrets.token_hex(4)
+        log.warning(
+            "cluster_ws_live_bulk.storage_failed correlation_id=%s count=%d",
+            correlation_id,
+            len(cleaned),
+            exc_info=True,
+        )
+        return JSONResponse(
+            {"error": f"storage error (internal). correlation_id={correlation_id}"},
+            status_code=500,
+        )
+
+    results: dict[str, dict[str, Any] | None] = {}
+    denied: list[str] = []
+    owned_rows: list[tuple[str, dict[str, Any]]] = []
+    for wid in cleaned:
+        row = rows.get(wid)
+        if row is None:
+            denied.append(wid)
+            continue
+        # Empty-string defense — matches _check_row_owner_or_404 so
+        # an orphan / migration-artifact row (row_owner="") doesn't
+        # leak to a (hypothetical) caller whose JWT carries an empty
+        # sub claim.  Either side being empty → denied.  Admin bypass
+        # is applied via the ``is_admin`` flag below.
+        row_owner = row.get("user_id") or ""
+        if not is_admin and (not caller_uid or not row_owner or row_owner != caller_uid):
+            denied.append(wid)
+            continue
+        owned_rows.append((wid, row))
+
+    # Fetch live blocks concurrently — ``_fetch_live_block`` already
+    # routes node-backed reads through the per-node dashboard cache,
+    # so N concurrent fetches against the same node collapse to a
+    # single upstream call per TTL window.
+    async def _one(wid: str, row: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+        try:
+            live = await _fetch_live_block(request, row, wid)
+        except Exception:
+            log.debug(
+                "cluster_ws_live_bulk.one_failed ws=%s",
+                wid[:8],
+                exc_info=True,
+            )
+            live = None
+        return wid, live
+
+    gathered = await asyncio.gather(*(_one(wid, row) for wid, row in owned_rows))
+    for wid, live in gathered:
+        results[wid] = live
+    return JSONResponse({"results": results, "denied": denied, "truncated": truncated})
+
+
 async def cluster_node_detail(request: Request) -> JSONResponse:
     collector: ClusterCollector = request.app.state.collector
     node_id = request.path_params["node_id"]
@@ -2207,7 +2323,14 @@ async def coordinator_create(request: Request) -> JSONResponse:
     skill = (body.get("skill") or "").strip() or None
     initial_message = (body.get("initial_message") or "").strip()
     try:
-        ws = coord_mgr.create(
+        # Offload to a worker thread — coord_mgr.create runs blocking
+        # storage calls (register_workstream, get_skill_by_name,
+        # count_skill_versions) and the session-factory invocation.
+        # Running inline on the async event loop stalled the SSE
+        # manager + every other async handler for the duration of the
+        # create (#perf-4).
+        ws = await asyncio.to_thread(
+            coord_mgr.create,
             user_id=user_id,
             name=name,
             skill=skill,
@@ -2766,6 +2889,129 @@ async def coordinator_children(request: Request) -> JSONResponse:
         if len(items) >= _CHILDREN_PAGE_LIMIT:
             break
     return JSONResponse({"items": items, "truncated": truncated})
+
+
+async def coordinator_metrics(request: Request) -> JSONResponse:
+    """GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot.
+
+    Aggregates cheap, already-persisted signals into a one-shot "is
+    this coordinator healthy?" answer for operators (#16).  No new
+    persistence — everything derives from ``list_workstreams``
+    (children) and ``list_intent_verdicts`` (judge telemetry).
+
+    Fields:
+
+    - ``spawns_total`` — children ever created under this coordinator
+      (closed / deleted children included; the row persists through
+      close and hard-delete cascades the row out but is rare).
+    - ``spawns_last_hour`` — subset of the above whose ``created``
+      timestamp is within the last 3600s.
+    - ``child_state_counts`` — ``{state: count}`` grouped on the live
+      children's state column.  Useful for spotting a coordinator
+      whose children are all stuck in ``attention`` (approval queue).
+    - ``judge_fallback_rate`` — fraction of recent intent verdicts
+      whose ``tier`` contained ``fallback`` — indicates the judge's
+      primary path is unavailable or misconfigured.  0.0 when no
+      verdicts have been recorded.
+    - ``wait_completions`` / ``wait_timeouts`` / ``wait_avg_elapsed``
+      — placeholders returning 0 / 0 / 0.0; these require explicit
+      wait-tool instrumentation (future work — the SSE events from
+      #14 carry the data live but aren't persisted yet).
+
+    Ownership / authz: same gate as ``coordinator_detail`` — 404-mask
+    rows the caller doesn't own (no existence-oracle leak).
+    """
+    from turnstone.core.web_helpers import require_storage_or_503
+
+    err = _require_admin_coordinator(request)
+    if err is not None:
+        return err
+    coord_mgr, err503 = _require_coord_mgr(request)
+    if err503 is not None:
+        return err503
+    storage, err503s = require_storage_or_503(request)
+    if err503s is not None:
+        return err503s
+
+    ws_id = request.path_params.get("ws_id", "")
+    if not _VALID_WS_ID_RE.match(ws_id):
+        return JSONResponse({"error": "invalid ws_id"}, status_code=400)
+    user_id = _auth_user_id(request)
+    _ws, err404 = _resolve_coordinator_or_404(request, coord_mgr, storage, ws_id, user_id)
+    if err404 is not None:
+        return err404
+
+    # Children metrics derived from aggregate SQL — avoids pulling
+    # every hydrated row just to group by state and filter on created
+    # (#perf-1).  Two cheap queries instead of a ``list_workstreams``
+    # scan up to 10k rows.
+    from datetime import UTC, datetime
+
+    now_epoch = time.time()
+    hour_ago_iso = datetime.fromtimestamp(now_epoch - 3600, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    try:
+        state_counts = await asyncio.to_thread(
+            storage.count_workstreams_by_state,
+            parent_ws_id=ws_id,
+        )
+    except Exception:
+        log.debug("coordinator_metrics.state_counts_failed ws=%s", ws_id[:8], exc_info=True)
+        state_counts = {}
+    spawns_total = sum(state_counts.values())
+    try:
+        spawns_last_hour = await asyncio.to_thread(
+            storage.count_workstreams_since,
+            hour_ago_iso,
+            parent_ws_id=ws_id,
+        )
+    except Exception:
+        log.debug(
+            "coordinator_metrics.spawns_last_hour_failed ws=%s",
+            ws_id[:8],
+            exc_info=True,
+        )
+        spawns_last_hour = 0
+
+    # Intent verdicts — scoped to the coordinator itself (child verdicts
+    # would require iterating every child's verdicts; deferred).  Small
+    # cap (last 200) keeps this a cheap query; enough to compute a
+    # meaningful rate for a busy coordinator.
+    try:
+        verdicts = await asyncio.to_thread(storage.list_intent_verdicts, ws_id=ws_id, limit=200)
+    except Exception:
+        log.debug("coordinator_metrics.list_verdicts_failed ws=%s", ws_id[:8], exc_info=True)
+        verdicts = []
+    total_verdicts = len(verdicts)
+    fallback_count = 0
+    for v in verdicts:
+        tier = ""
+        if isinstance(v, dict):
+            tier = str(v.get("tier") or "")
+        else:
+            try:
+                tier = str(v._mapping.get("tier") or "")
+            except AttributeError:
+                tier = ""
+        if "fallback" in tier.lower():
+            fallback_count += 1
+    judge_fallback_rate = round(fallback_count / total_verdicts, 3) if total_verdicts > 0 else 0.0
+
+    return JSONResponse(
+        {
+            "ws_id": ws_id,
+            "spawns_total": spawns_total,
+            "spawns_last_hour": spawns_last_hour,
+            "child_state_counts": state_counts,
+            "judge_fallback_rate": judge_fallback_rate,
+            "intent_verdicts_sample": total_verdicts,
+            # Wait-tool metrics require explicit persistence the harness
+            # doesn't have yet — exposed as zero placeholders so
+            # downstream scrapers can key on the shape without failing.
+            "wait_completions": 0,
+            "wait_timeouts": 0,
+            "wait_avg_elapsed": 0.0,
+        }
+    )
 
 
 async def coordinator_tasks(request: Request) -> JSONResponse:
@@ -9166,6 +9412,7 @@ def create_app(
                     Route("/api/cluster/nodes", cluster_nodes),
                     Route("/api/cluster/workstreams", cluster_workstreams),
                     Route("/api/cluster/workstreams/new", create_workstream, methods=["POST"]),
+                    Route("/api/cluster/ws/live", cluster_ws_live_bulk),
                     Route("/api/cluster/ws/{ws_id}/detail", cluster_ws_detail),
                     Route("/api/cluster/node/{node_id}", cluster_node_detail),
                     Route("/api/cluster/snapshot", cluster_snapshot),
@@ -9252,6 +9499,11 @@ def create_app(
                     Route(
                         "/api/coordinator/{ws_id}/tasks",
                         coordinator_tasks,
+                        methods=["GET"],
+                    ),
+                    Route(
+                        "/api/coordinator/{ws_id}/metrics",
+                        coordinator_metrics,
                         methods=["GET"],
                     ),
                     Route(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2945,14 +2945,24 @@ async def coordinator_metrics(request: Request) -> JSONResponse:
     # every hydrated row just to group by state and filter on created
     # (#perf-1).  Two cheap queries instead of a ``list_workstreams``
     # scan up to 10k rows.
+    #
+    # Tenant filter on the aggregates — matches the coordinator_children
+    # pattern where user_id is pushed into SQL so a non-admin caller
+    # can't observe cross-tenant counts via forged / migration-era
+    # rows sharing parent_ws_id.  Admin callers see the raw aggregate
+    # (no filter).  The 404-mask above already rejected foreign
+    # coord_ws_id, so the filter here is defense-in-depth against
+    # child rows with drifted user_id.
     from datetime import UTC, datetime
 
+    filter_user_id: str | None = None if _is_admin(request) else (user_id or "")
     now_epoch = time.time()
     hour_ago_iso = datetime.fromtimestamp(now_epoch - 3600, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S")
     try:
         state_counts = await asyncio.to_thread(
             storage.count_workstreams_by_state,
             parent_ws_id=ws_id,
+            user_id=filter_user_id,
         )
     except Exception:
         log.debug("coordinator_metrics.state_counts_failed ws=%s", ws_id[:8], exc_info=True)
@@ -2963,6 +2973,7 @@ async def coordinator_metrics(request: Request) -> JSONResponse:
             storage.count_workstreams_since,
             hour_ago_iso,
             parent_ws_id=ws_id,
+            user_id=filter_user_id,
         )
     except Exception:
         log.debug(

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -48,9 +48,6 @@ function showAdmin() {
   }
 
   currentView = "admin";
-  if (typeof _stopActiveCoordsPolling === "function") {
-    _stopActiveCoordsPolling();
-  }
   var homeView = document.getElementById("view-home");
   if (homeView) homeView.style.display = "none";
   document.getElementById("view-node").style.display = "none";

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -16,17 +16,10 @@ window.onLoginSuccess = function () {
   if (typeof _probeCoordSubsystem === "function") {
     _probeCoordSubsystem();
   }
-  // Restart the active-coordinators poller: the initial load fired
-  // before auth resolved and 401'd, leaving the list empty.
-  if (typeof _stopActiveCoordsPolling === "function") {
-    _stopActiveCoordsPolling();
-  }
-  if (
-    currentView === "home" &&
-    typeof _startActiveCoordsPolling === "function"
-  ) {
-    _startActiveCoordsPolling();
-  }
+  // Active-coordinators list is SSE-driven via the console pseudo-node
+  // (#9) — no poller to restart after login.  The home-view renderer
+  // reads from clusterState.nodes["console"].workstreams on every SSE
+  // patch, so authenticating just unblocks the normal event stream.
 };
 window.onLogout = function () {
   if (evtSource) {
@@ -202,6 +195,11 @@ function recomputeOverview() {
     mcpPrompts = 0;
   var versions = {};
   Object.keys(clusterState.nodes).forEach(function (nid) {
+    // Skip the "console" pseudo-node — coordinators aren't compute-
+    // node workstreams, and counting them here would inflate the
+    // cluster-summary totals the home view renders.  The
+    // active-coordinators list surfaces them separately.
+    if (nid === "console") return;
     var node = clusterState.nodes[nid];
     var nodeWsTokens = 0;
     (node.workstreams || []).forEach(function (ws) {
@@ -220,8 +218,14 @@ function recomputeOverview() {
     mcpPrompts += mcp.prompts || 0;
   });
   var versionList = Object.keys(versions).sort();
+  // Count only real compute nodes for the cluster summary — the
+  // "console" pseudo-node hosts coordinators, which are surfaced
+  // separately by the active-coordinators list.
+  var realNodeCount = Object.keys(clusterState.nodes).filter(function (nid) {
+    return nid !== "console";
+  }).length;
   clusterState.overview = {
-    nodes: Object.keys(clusterState.nodes).length,
+    nodes: realNodeCount,
     workstreams: totalWs,
     states: states,
     aggregate: {
@@ -279,9 +283,15 @@ function renderFromState() {
     // Home view also hosts the inline node-list (cluster details);
     // render it so expanding the cluster-summary reveals the current
     // state without waiting for the next SSE tick.
-    var nodesList = Object.keys(clusterState.nodes).map(function (nid) {
-      return buildNodeInfoFromSnapshot(clusterState.nodes[nid]);
-    });
+    var nodesList = Object.keys(clusterState.nodes)
+      .filter(function (nid) {
+        // Exclude the "console" pseudo-node from the nodes list — it's
+        // a synthetic carrier for coordinators, not a compute node.
+        return nid !== "console";
+      })
+      .map(function (nid) {
+        return buildNodeInfoFromSnapshot(clusterState.nodes[nid]);
+      });
     nodesList.sort(function (a, b) {
       var d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
       return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
@@ -454,7 +464,6 @@ function showHome() {
   if (clusterState) renderFromState();
   else loadOverview();
   _ensureHomeComposerInit();
-  _startActiveCoordsPolling();
   if (!_navigatingFromPopstate) history.pushState({ view: "home" }, "");
 }
 
@@ -519,7 +528,6 @@ function showOverview() {
   document.getElementById("breadcrumb").style.display = "none";
   if (clusterState) renderFromState();
   else loadOverview();
-  _startActiveCoordsPolling();
   if (!_navigatingFromPopstate) history.pushState({ view: "home" }, "");
   // Scroll the details section into view so the click produces a
   // visible reaction — the user expands the summary expecting to see
@@ -1057,7 +1065,6 @@ function drillDownToNode(nodeId, serverUrl) {
   currentView = "node";
   currentNodeId = nodeId;
   currentServerUrl = serverUrl || "";
-  _stopActiveCoordsPolling();
   _setLandingView("node");
   var adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
@@ -1111,7 +1118,6 @@ function loadNodeDetail(nodeId) {
 function drillDownByState(state) {
   currentView = "filtered";
   currentFilter = { state: state, node: null, page: 1, per_page: 50 };
-  _stopActiveCoordsPolling();
   _setLandingView("filtered");
   var adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
@@ -1137,7 +1143,6 @@ function drillDownByState(state) {
 function drillDownByNode(nodeId) {
   currentView = "filtered";
   currentFilter = { state: null, node: nodeId, page: 1, per_page: 50 };
-  _stopActiveCoordsPolling();
   _setLandingView("filtered");
   var adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
@@ -1990,93 +1995,29 @@ document.addEventListener("keydown", function (e) {
 var _homeCoordsFingerprint = "";
 var _homeSummaryFingerprint = "";
 
-// Active-coordinators list, kept separate from clusterState.nodes.
-// Coordinators live on the console process (node="console") and don't
-// flow through the per-node SSE streams the collector tracks, so the
-// cluster-snapshot -> clusterState.nodes path never surfaces them.
-// _loadActiveCoords fetches them directly from cluster_workstreams
-// (which merges _coordinator_rows via extra_rows).  Polling uses
-// recursive setTimeout with exponential backoff on failure — matches
-// the rest of turnstone's SSE reconnect pattern so a persistent
-// outage doesn't hammer the console with a fixed-interval retry.
-var _activeCoords = [];
-var _activeCoordsTimer = null;
-var _activeCoordsBackoff = 0;
-var _ACTIVE_COORDS_POLL_MS = 5000;
-var _ACTIVE_COORDS_MAX_BACKOFF_MS = 30000;
+// Active-coordinators list is SSE-driven — the console collector
+// registers a "console" pseudo-node and the coordinator manager fans
+// out ws_created / ws_closed / cluster_state / ws_rename events when
+// coordinators come, go, or change state.  The browser's
+// patchClusterState handler routes those events into
+// clusterState.nodes["console"].workstreams, so every home-view render
+// reads a live mirror without polling.
 
-function _loadActiveCoords() {
-  // In-flight guard not required — authFetch is stateless and the
-  // response is just replaced — but cancel any pending timer so
-  // we don't double-schedule.
-  if (_activeCoordsTimer) {
-    clearTimeout(_activeCoordsTimer);
-    _activeCoordsTimer = null;
-  }
-  authFetch("/v1/api/cluster/workstreams?node=console&per_page=200")
-    .then(function (r) {
-      if (r.status === 401 && typeof showLogin === "function") {
-        // Session expired — prompt for re-auth via the shared overlay.
-        // onLoginSuccess at the top of this file restarts the poller
-        // when the view is still home.
-        showLogin();
-        return null;
-      }
-      if (!r.ok) throw new Error("HTTP " + r.status);
-      return r.json();
-    })
-    .then(function (data) {
-      if (data == null) return;
-      // Narrow to coord rows even though node=console should produce
-      // them exclusively — defensive in case a future server-side
-      // collector change surfaces other console-origin rows.
-      var rows = (data.workstreams || []).filter(function (ws) {
-        return ws.kind === "coordinator";
-      });
-      _activeCoords = rows;
-      _activeCoordsBackoff = 0;
-      if (currentView === "home") {
-        _renderHomeView();
-      }
-      _scheduleNextActiveCoordsPoll(_ACTIVE_COORDS_POLL_MS);
-    })
-    .catch(function () {
-      // Exponential backoff capped at _ACTIVE_COORDS_MAX_BACKOFF_MS.
-      // Reset on the next successful response above.
-      _activeCoordsBackoff = _activeCoordsBackoff
-        ? Math.min(_activeCoordsBackoff * 2, _ACTIVE_COORDS_MAX_BACKOFF_MS)
-        : _ACTIVE_COORDS_POLL_MS * 2;
-      _scheduleNextActiveCoordsPoll(_activeCoordsBackoff);
-    });
-}
-
-function _scheduleNextActiveCoordsPoll(ms) {
-  if (currentView !== "home") return;
-  _activeCoordsTimer = setTimeout(_loadActiveCoords, ms);
-}
-
-function _startActiveCoordsPolling() {
-  _activeCoordsBackoff = 0;
-  if (_activeCoordsTimer) {
-    clearTimeout(_activeCoordsTimer);
-    _activeCoordsTimer = null;
-  }
-  _loadActiveCoords();
-}
-
-function _stopActiveCoordsPolling() {
-  if (_activeCoordsTimer) {
-    clearTimeout(_activeCoordsTimer);
-    _activeCoordsTimer = null;
-  }
+function _activeCoordsFromClusterState() {
+  if (!clusterState) return [];
+  var node = clusterState.nodes && clusterState.nodes["console"];
+  if (!node) return [];
+  return (node.workstreams || []).filter(function (ws) {
+    return ws && ws.kind === "coordinator";
+  });
 }
 
 function _renderHomeView() {
-  // Active coordinators come from _loadActiveCoords (cluster_workstreams
-  // with node=console filter); clusterState.nodes never surfaces them
-  // because coordinators run on the console process, not on a cluster
-  // node that feeds the collector's SSE streams.
-  var coords = (_activeCoords || []).slice();
+  // Active coordinators are sourced live from clusterState.nodes["console"]
+  // — the coordinator manager fans out ws_created / ws_closed /
+  // cluster_state via the collector's pseudo-node so the home view
+  // stays in sync without polling.
+  var coords = _activeCoordsFromClusterState();
   coords.sort(function (a, b) {
     // Most-recently-active first.  updated is absent on freshly-created
     // rows; fall back to id so the ordering is stable either way.
@@ -2206,14 +2147,12 @@ function _ensureSSE() {
 }
 history.replaceState({ view: "home" }, "");
 initLogin();
-// loadOverview fetches the cluster snapshot for the cluster summary
-// aggregates; the active-coordinators list lives on a separate
-// cluster_workstreams fetch started by _startActiveCoordsPolling
-// because coordinator rows don't flow through the per-node SSE
-// streams the collector watches.
+// loadOverview fetches the cluster snapshot — both the cluster-summary
+// aggregates AND the active-coordinators list come from the same
+// snapshot + SSE patch pipeline (#9); the console pseudo-node carries
+// coordinator ws_created / ws_closed / cluster_state events.
 loadOverview();
 _ensureHomeComposerInit();
-_startActiveCoordsPolling();
 // Refresh the coord button visibility after initial whoami lands in
 // sessionStorage (auth.js populates it asynchronously).  A short delay
 // is good enough — the shared pattern for permission-gated UI.

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -492,13 +492,12 @@
         // during the SSE gap would otherwise pin the header badge
         // forever.  The server's SSE replay doesn't cover our
         // per-call wait_* events, so we clear and let fresh events
-        // repopulate.  #bug-4.
-        if (typeof activeWaits !== "undefined") {
-          activeWaits.clear();
-          if (typeof _renderWaitIndicator === "function") {
-            _renderWaitIndicator();
-          }
-        }
+        // repopulate.  #bug-4.  Both ``activeWaits`` and
+        // ``_renderWaitIndicator`` are defined below in the same
+        // IIFE — hoisted function decl + const-in-outer-scope — so
+        // they're always reachable by the time onopen fires.
+        activeWaits.clear();
+        _renderWaitIndicator();
       }
     };
     evtSource.onerror = function () {

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -25,7 +25,7 @@
   const wsId = document.documentElement.dataset.wsId || "";
   if (!wsId) {
     document.getElementById("coord-messages").innerHTML =
-      '<div class="coord-msg role-error">Missing ws_id on &lt;html&gt; tag.</div>';
+      '<div class="ts-msg ts-msg--error">Missing ws_id on &lt;html&gt; tag.</div>';
     return;
   }
 
@@ -140,7 +140,7 @@
     opts = opts || {};
     const el = document.createElement("div");
     const variant = _TS_ROLE_VARIANTS[role] || "ts-msg--assistant";
-    el.className = "coord-msg role-" + role + " ts-msg " + variant;
+    el.className = "ts-msg " + variant;
     // role="article" makes aria-label reliably announced by screen
     // readers — a generic <div> with no implicit role doesn't expose
     // aria-label on its own.  "article" fits: each message is a
@@ -156,7 +156,7 @@
       el.setAttribute("aria-label", opts.label);
     }
     const body = document.createElement("div");
-    body.className = "coord-body ts-msg-body";
+    body.className = "ts-msg-body";
     body.innerHTML = html;
     el.appendChild(body);
     messagesEl.appendChild(el);
@@ -210,7 +210,7 @@
     // token so the user sees live-formatted markdown instead of a final
     // "pop" on stream_end.  Heavy post-processing (syntax highlighting,
     // mermaid, KaTeX) stays deferred to streamingRenderFinalize below.
-    const body = currentAssistantEl.querySelector(".coord-body");
+    const body = currentAssistantEl.querySelector(".ts-msg-body");
     if (body && typeof streamingRender === "function") {
       try {
         streamingRender(body, currentAssistantBuf);
@@ -236,7 +236,7 @@
       messagesEl.setAttribute("aria-live", "off");
     }
     currentReasoningBuf += text;
-    const body = currentReasoningEl.querySelector(".coord-body");
+    const body = currentReasoningEl.querySelector(".ts-msg-body");
     if (body) body.textContent = currentReasoningBuf;
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }
@@ -248,7 +248,7 @@
     // the innerHTML assignment inside the helper is XSS-safe as long as
     // renderer.js is trusted — same contract as ui/static/app.js.
     if (currentAssistantEl && currentAssistantBuf) {
-      const body = currentAssistantEl.querySelector(".coord-body");
+      const body = currentAssistantEl.querySelector(".ts-msg-body");
       if (body && typeof streamingRenderFinalize === "function") {
         try {
           streamingRenderFinalize(body, currentAssistantBuf);
@@ -275,7 +275,7 @@
     // approval applies to every row, not just the focused one.
     if (pending.length > 0) {
       const header = document.createElement("div");
-      header.className = "tool-row approval-header ts-approval-header";
+      header.className = "ts-approval-header";
       header.textContent =
         pending.length === 1
           ? "Approve 1 tool call:"
@@ -286,7 +286,7 @@
     pending.forEach((it, idx) => {
       if (!firstCallId) firstCallId = it.call_id;
       const row = document.createElement("div");
-      row.className = "tool-row ts-approval-tool";
+      row.className = "ts-approval-tool";
       const label =
         it.header || it.approval_label || it.func_name || "(unknown tool)";
       row.textContent = pending.length > 1 ? idx + 1 + ". " + label : label;
@@ -488,6 +488,17 @@
         // disconnect are stale.
         loadChildren({ replace: true });
         loadTasks();
+        // Drop any in-flight wait entries — a wait_ended dropped
+        // during the SSE gap would otherwise pin the header badge
+        // forever.  The server's SSE replay doesn't cover our
+        // per-call wait_* events, so we clear and let fresh events
+        // repopulate.  #bug-4.
+        if (typeof activeWaits !== "undefined") {
+          activeWaits.clear();
+          if (typeof _renderWaitIndicator === "function") {
+            _renderWaitIndicator();
+          }
+        }
       }
     };
     evtSource.onerror = function () {
@@ -576,7 +587,7 @@
           if (
             it.call_id &&
             document.querySelector(
-              '.coord-msg[data-call-id="' + cssEscape(it.call_id) + '"]',
+              '.ts-msg[data-call-id="' + cssEscape(it.call_id) + '"]',
             )
           ) {
             return; // already rendered in this pane — skip
@@ -643,10 +654,109 @@
       case "child_ws_rename":
         handleChildRename(ev);
         break;
+      // wait_for_workstream observability (#14) — the worker thread
+      // can block up to 600s inside the tool; these events drive a
+      // sidebar indicator so operators see the coordinator is alive.
+      case "wait_started":
+        handleWaitStarted(ev);
+        break;
+      case "wait_progress":
+        handleWaitProgress(ev);
+        break;
+      case "wait_ended":
+        handleWaitEnded(ev);
+        break;
       default:
         // Unknown event type — ignore silently.
         break;
     }
+  }
+
+  // ------------------------------------------------------------------
+  // wait_for_workstream progress indicator (#14)
+  // ------------------------------------------------------------------
+  //
+  // In-flight waits keyed by call_id so overlapping / nested waits
+  // each get their own badge.  Cleared on wait_ended, and on SSE
+  // reconnect (see evtSource.onopen above) — a wait_ended dropped
+  // during the gap would otherwise pin the badge indefinitely.
+  const activeWaits = new Map();
+
+  function _waitIndicatorEl() {
+    let el = document.getElementById("coord-wait-indicator");
+    if (el) return el;
+    // Only attach to the coord header vocabulary — don't fall back to
+    // document.body, which would plant a floating badge at the page
+    // root on any template variant where the header hasn't rendered
+    // yet (#q-7).  Return null so callers skip rendering; the next
+    // event will retry.
+    const host =
+      document.getElementById("coord-status") ||
+      document.getElementById("coord-header");
+    if (!host) return null;
+    el = document.createElement("span");
+    el.id = "coord-wait-indicator";
+    el.className = "ts-header-status coord-wait-indicator";
+    el.setAttribute("role", "status");
+    el.setAttribute("aria-live", "polite");
+    el.style.display = "none";
+    el.style.marginLeft = "0.5em";
+    host.appendChild(el);
+    return el;
+  }
+
+  function _renderWaitIndicator() {
+    const el = _waitIndicatorEl();
+    if (!el) return; // header not rendered yet — retry on next event
+    if (activeWaits.size === 0) {
+      el.style.display = "none";
+      el.textContent = "";
+      return;
+    }
+    let totalWs = 0;
+    let maxElapsed = 0;
+    activeWaits.forEach((w) => {
+      totalWs += Array.isArray(w.ws_ids) ? w.ws_ids.length : 0;
+      if (typeof w.elapsed === "number" && w.elapsed > maxElapsed) {
+        maxElapsed = w.elapsed;
+      }
+    });
+    const fragments = [];
+    if (activeWaits.size > 1) fragments.push(activeWaits.size + " waits");
+    if (totalWs > 0) fragments.push(totalWs + " ws");
+    if (maxElapsed > 0) fragments.push(Math.round(maxElapsed) + "s");
+    el.textContent =
+      "\u29D7 waiting" +
+      (fragments.length ? " · " + fragments.join(" · ") : "");
+    el.style.display = "";
+  }
+
+  function handleWaitStarted(ev) {
+    const cid = ev.call_id;
+    if (!cid) return;
+    activeWaits.set(cid, {
+      ws_ids: Array.isArray(ev.ws_ids) ? ev.ws_ids.slice() : [],
+      mode: ev.mode || "any",
+      timeout: typeof ev.timeout === "number" ? ev.timeout : 60,
+      elapsed: 0,
+    });
+    _renderWaitIndicator();
+  }
+
+  function handleWaitProgress(ev) {
+    const cid = ev.call_id;
+    if (!cid) return;
+    const entry = activeWaits.get(cid);
+    if (!entry) return;
+    if (typeof ev.elapsed === "number") entry.elapsed = ev.elapsed;
+    _renderWaitIndicator();
+  }
+
+  function handleWaitEnded(ev) {
+    const cid = ev.call_id;
+    if (!cid) return;
+    activeWaits.delete(cid);
+    _renderWaitIndicator();
   }
 
   // ------------------------------------------------------------------
@@ -658,8 +768,6 @@
   const childrenState = new Map();
   // ws_id -> {live: <dict>, fetched: <ms>} for the 5s TTL live-badge cache.
   const liveBadgeCache = new Map();
-  // ws_id -> timeout id, for 250ms debounce on live-inspect fetches.
-  const liveBadgeDebounce = new Map();
   // ws_ids currently visible in the viewport — only these trigger
   // live-fetch on SSE state changes.  Populated by an
   // IntersectionObserver attached to each rendered .ch-row so a
@@ -990,6 +1098,19 @@
     }, TASKS_REFRESH_DEBOUNCE_MS);
   }
 
+  // Upper bound on ids per bulk request — matches the server-side
+  // cap in cluster_ws_live_bulk.  A viewport with more visible rows
+  // than the cap splits into multiple bulk calls, each ~one round-trip
+  // per TTL window; still far cheaper than one-per-row.
+  const LIVE_BADGE_BULK_CAP = 50;
+  // Coalesce window — debounced per-row scheduling enqueues into
+  // pendingLiveIds; the flush runs after this idle window collapses
+  // into a single bulk request.  Matches the per-row debounce so a
+  // burst of SSE ticks lands in one flush.
+  const LIVE_BADGE_BULK_FLUSH_MS = LIVE_BADGE_DEBOUNCE_MS;
+  const pendingLiveIds = new Set();
+  let liveBadgeFlushTimer = null;
+
   function scheduleLiveFetch(childWsId) {
     if (!childWsId) return;
     // Skip terminal-state children entirely — their live block will
@@ -1013,49 +1134,73 @@
       if (cached.permanent) return;
       if (Date.now() - cached.fetched < LIVE_BADGE_TTL_MS) return;
     }
-    if (liveBadgeDebounce.has(childWsId)) return;
-    const tid = setTimeout(() => {
-      liveBadgeDebounce.delete(childWsId);
-      fetchLiveBadge(childWsId);
-    }, LIVE_BADGE_DEBOUNCE_MS);
-    liveBadgeDebounce.set(childWsId, tid);
+    if (!WS_ID_RE.test(childWsId)) return;
+    pendingLiveIds.add(childWsId);
+    if (liveBadgeFlushTimer !== null) return;
+    liveBadgeFlushTimer = setTimeout(() => {
+      liveBadgeFlushTimer = null;
+      flushLiveFetches();
+    }, LIVE_BADGE_BULK_FLUSH_MS);
   }
 
-  async function fetchLiveBadge(childWsId) {
-    if (!WS_ID_RE.test(childWsId)) return;
+  async function flushLiveFetches() {
+    if (pendingLiveIds.size === 0) return;
+    const ids = Array.from(pendingLiveIds).slice(0, LIVE_BADGE_BULK_CAP);
+    ids.forEach((id) => pendingLiveIds.delete(id));
+    // Reschedule a follow-up flush if we overflowed the cap so the
+    // excess ids still land — without this, a viewport bigger than the
+    // cap would silently drop the tail every tick.
+    if (pendingLiveIds.size > 0 && liveBadgeFlushTimer === null) {
+      liveBadgeFlushTimer = setTimeout(() => {
+        liveBadgeFlushTimer = null;
+        flushLiveFetches();
+      }, LIVE_BADGE_BULK_FLUSH_MS);
+    }
     try {
-      const body = await getJSON(
-        "/v1/api/cluster/ws/" + encodeURIComponent(childWsId) + "/detail",
-      );
-      liveBadgeCache.set(childWsId, {
-        live: body && body.live ? body.live : null,
-        fetched: Date.now(),
-      });
-      const row = childrenTreeEl.querySelector(
-        '.ch-row[data-ws-id="' + cssEscape(childWsId) + '"]',
-      );
-      if (row) {
-        const entry = childrenState.get(childWsId);
-        if (entry) {
-          const replacement = renderChildRow(entry);
-          row.replaceWith(replacement);
+      const url =
+        "/v1/api/cluster/ws/live?ids=" + ids.map(encodeURIComponent).join(",");
+      const body = await getJSON(url);
+      const results = (body && body.results) || {};
+      const denied = Array.isArray(body && body.denied) ? body.denied : [];
+      const now = Date.now();
+      ids.forEach((id) => {
+        const live = Object.prototype.hasOwnProperty.call(results, id)
+          ? results[id]
+          : null;
+        const wasDenied = denied.indexOf(id) !== -1;
+        liveBadgeCache.set(id, {
+          live: live,
+          fetched: now,
+          // Denied ids are permission/identity misses — mark permanent
+          // so SSE state ticks on those rows don't retry every window.
+          permanent: wasDenied,
+        });
+        const row = childrenTreeEl.querySelector(
+          '.ch-row[data-ws-id="' + cssEscape(id) + '"]',
+        );
+        if (row) {
+          const entry = childrenState.get(id);
+          if (entry) {
+            const replacement = renderChildRow(entry);
+            row.replaceWith(replacement);
+          }
         }
-      }
-    } catch (e) {
-      // Cache failures too — otherwise 403 / 404 paths burn one HTTP
-      // round-trip per SSE child_ws_state event.  403/404 are marked
-      // permanent (permission/identity won't change mid-session); 5xx
-      // + network errors take the normal 5s TTL so transient blips
-      // recover on the next schedule.
-      const isTerminal = e && /HTTP 40[34]/.test(e.message || "");
-      liveBadgeCache.set(childWsId, {
-        live: null,
-        fetched: Date.now(),
-        permanent: isTerminal,
       });
-      if (!isTerminal) {
-        console.warn("fetchLiveBadge failed", e);
-      }
+    } catch (e) {
+      // 403 = caller lacks admin.cluster.inspect → mark every pending
+      // id permanent so we don't retry every window.  Other failures
+      // (5xx, network) take the normal TTL and recover on the next
+      // schedule.
+      const isPermanent = e && /HTTP 403/.test(e.message || "");
+      const now = Date.now();
+      ids.forEach((id) => {
+        liveBadgeCache.set(id, {
+          live: null,
+          fetched: now,
+          permanent: isPermanent,
+        });
+      });
+      if (!isPermanent) console.warn("flushLiveFetches failed", e);
     }
   }
 

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -56,7 +56,7 @@
     overflow-y: auto;
     padding: 1rem 1.5rem;
   }
-  .coord-msg .coord-ws-link {
+  .ts-msg .coord-ws-link {
     color: var(--accent);
     text-decoration: underline;
   }
@@ -89,6 +89,15 @@
     align-items: baseline;
   }
   .ch-row a.ws-link:hover { color: var(--accent); }
+  /* Keyboard-focus indicators — match the accent-ring pattern the
+     rest of the console uses so tab-nav through the sidebar rows
+     stays visible on both light + dark themes. */
+  .ch-row a.ws-link:focus-visible,
+  .task-row:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-radius: 4px;
+  }
   /* glyph treatment (.ui-glyph / .ui-glyph-<state>) comes from
      shared_static/ui-base.css; stateGlyph() emits those classes. */
   .ch-row .name { font-weight: 500; flex: 1; overflow: hidden; text-overflow: ellipsis; }
@@ -204,9 +213,9 @@
          reachable in normal tab order.  role=alertdialog implies a modal
          focus trap per WAI-ARIA. -->
     <div id="coord-approval-bar" class="ts-approval ts-approval--batch" role="region" aria-label="Approval required" aria-live="assertive">
-      <div id="coord-approval-label" class="label ts-approval-header">Approval required</div>
+      <div id="coord-approval-label" class="ts-approval-header">Approval required</div>
       <div id="coord-approval-tools"></div>
-      <div class="btn-row ts-approval-actions">
+      <div class="ts-approval-actions">
         <button id="coord-approve-btn" class="ts-approval-btn ts-approval-btn--approve" onclick="coordApprove(true, false)">Approve</button>
         <button id="coord-approve-always-btn" class="ts-approval-btn ts-approval-btn--always" onclick="coordApprove(true, true)">Approve (always)</button>
         <button id="coord-deny-btn" class="ts-approval-btn ts-approval-btn--deny" onclick="coordApprove(false, false)">Deny</button>

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -159,7 +159,12 @@
 .home-cluster-summary-caret { color: var(--fg-dim); font-size: 10px; transition: transform 0.12s; }
 .home-cluster-summary:hover .home-cluster-summary-caret { transform: translateX(2px); }
 
-/* Sub-700px: collapse the composer row and tighten padding. */
+/* Sub-700px: collapse the composer row and tighten padding.  The
+   phase-4 designer-review "composer wrap 340-699px" observation is
+   fully covered by this full-stack rule — the flex math at ≥701px
+   (name 1 1 220/160min + skill 0 0 180 + submit 0 0 auto/90min +
+   2×8px gap ≈ 500-540px preferred) fits comfortably in every
+   desktop viewport, so a mid-zone break rule is unnecessary. */
 @media (max-width: 700px) {
   #main { padding: 14px 12px 48px; }
   #view-home { gap: 16px; }

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5128,11 +5128,33 @@ class ChatSession:
             msg = f"Error: {result['error']}"
             self._report_tool_result(call_id, "cancel_workstream", msg, is_error=True)
             return call_id, msg
-        output = json.dumps(
-            {"ws_id": item["ws_id"], "cancelled": True, "status": result.get("status")},
-            separators=(",", ":"),
-        )
-        self._report_tool_result(call_id, "cancel_workstream", f"cancelled {item['ws_id']}")
+        # ``dropped`` — forensic snapshot captured by the node's cancel
+        # handler before it invokes session.cancel().  Carries pending
+        # approval tool names, queued-message count/preview, and whether
+        # a worker was running.  Empty dict when nothing was in flight.
+        out_payload: dict[str, Any] = {
+            "ws_id": item["ws_id"],
+            "cancelled": True,
+            "status": result.get("status"),
+        }
+        dropped = result.get("dropped")
+        if isinstance(dropped, dict) and dropped:
+            out_payload["dropped"] = dropped
+        output = json.dumps(out_payload, separators=(",", ":"))
+        summary = f"cancelled {item['ws_id']}"
+        if isinstance(dropped, dict):
+            hints: list[str] = []
+            pa = dropped.get("pending_approval")
+            if isinstance(pa, dict):
+                names = pa.get("tool_names") or []
+                if names:
+                    hints.append(f"approval={','.join(str(n) for n in names)}")
+            qm = dropped.get("queued_messages")
+            if isinstance(qm, dict) and qm.get("count"):
+                hints.append(f"queued={qm['count']}")
+            if hints:
+                summary += " (" + "; ".join(hints) + ")"
+        self._report_tool_result(call_id, "cancel_workstream", summary)
         return call_id, output
 
     def _prepare_delete_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -5573,6 +5595,8 @@ class ChatSession:
         header = (
             f"\u2699 wait_for_workstream: {ws_count} ws (mode={mode_label}, timeout={to_label}s)"
         )
+        raw_since = args.get("since")
+        since_hint = raw_since if isinstance(raw_since, dict) else None
         return {
             "call_id": call_id,
             "func_name": "wait_for_workstream",
@@ -5583,25 +5607,91 @@ class ChatSession:
             "ws_ids": raw_ids if isinstance(raw_ids, list) else [],
             "timeout": args.get("timeout"),
             "mode": args.get("mode"),
+            "since": since_hint,
         }
 
     def _exec_wait_for_workstream(self, item: dict[str, Any]) -> tuple[str, str]:
         call_id = item["call_id"]
+        clean_ws_ids = item["ws_ids"]
+        timeout_val = item["timeout"] if item["timeout"] is not None else 60.0
+        mode_val = item["mode"] if item["mode"] is not None else "any"
+        # Emit a ``wait_started`` SSE event so the coordinator sidebar
+        # can show a "waiting on N children, T elapsed" indicator while
+        # the worker thread blocks inside wait_for_workstream (the tool
+        # can otherwise pin the worker for up to 600s with no UI
+        # signal).  Best-effort — swallow failures so a broken UI never
+        # blocks a model-invoked wait (#14).
+        self._emit_wait_event(
+            "wait_started",
+            {
+                "call_id": call_id,
+                "ws_ids": clean_ws_ids,
+                "mode": mode_val,
+                "timeout": timeout_val,
+            },
+        )
+
+        # Throttle wait_progress emission (#perf-3).  The wait loop polls
+        # every 0.5s; emitting on every tick with the full results dict
+        # would flood each SSE listener's maxsize=500 queue — a 600s
+        # wait produces 1200 events per listener, pushing out unrelated
+        # state_change / content events via put_nowait drop.  Emit only
+        # when the polled snapshot actually differs from the last
+        # emitted snapshot, OR when at least ~5s has elapsed since the
+        # last emission (so a stuck wait still shows a heartbeat for
+        # the operator).  The sidebar indicator only needs
+        # seconds-granularity elapsed; the full results dict is only
+        # useful on transitions, so dropping redundant ticks is free.
+        progress_state: dict[str, Any] = {
+            "last_snap": None,
+            "last_emit_mono": 0.0,
+        }
+        progress_heartbeat_s = 5.0
+
+        def _progress(snap: dict[str, Any], elapsed: float) -> None:
+            now = time.monotonic()
+            changed = snap != progress_state["last_snap"]
+            heartbeat_due = (now - progress_state["last_emit_mono"]) >= progress_heartbeat_s
+            if not changed and not heartbeat_due:
+                return
+            payload: dict[str, Any] = {
+                "call_id": call_id,
+                "elapsed": round(elapsed, 3),
+            }
+            # Attach the full results dict only on transitions — a
+            # heartbeat-only tick reports progress (liveness) without
+            # the per-listener payload cost.
+            if changed:
+                payload["results"] = snap
+            self._emit_wait_event("wait_progress", payload)
+            progress_state["last_snap"] = snap
+            progress_state["last_emit_mono"] = now
+
         try:
             result = self._coord_client.wait_for_workstream(
-                item["ws_ids"],
-                timeout=item["timeout"] if item["timeout"] is not None else 60.0,
-                mode=item["mode"] if item["mode"] is not None else "any",
+                clean_ws_ids,
+                timeout=timeout_val,
+                mode=mode_val,
+                since=item.get("since"),
+                progress_callback=_progress,
             )
         except Exception as e:
             msg = f"Error: wait_for_workstream failed: {e}"
             self._report_tool_result(call_id, "wait_for_workstream", msg, is_error=True)
+            self._emit_wait_event(
+                "wait_ended",
+                {"call_id": call_id, "complete": False, "error": str(e)},
+            )
             return call_id, msg
         # Surface client-side validation errors as tool errors rather
         # than rendering them as a "successful" wait result.
         if result.get("error"):
             msg = f"Error: {result['error']}"
             self._report_tool_result(call_id, "wait_for_workstream", msg, is_error=True)
+            self._emit_wait_event(
+                "wait_ended",
+                {"call_id": call_id, "complete": False, "error": result["error"]},
+            )
             return call_id, msg
         output = json.dumps(result, separators=(",", ":"), default=str)
         elapsed = result.get("elapsed", 0.0)
@@ -5613,21 +5703,49 @@ class ChatSession:
         # Inline import — ``turnstone.core`` shouldn't import from
         # ``turnstone.console`` at module load (layering), so the
         # tool-exec read pulls the canonical state set lazily.
-        from turnstone.console.coordinator_client import CoordinatorClient
+        from turnstone.console.coordinator_client import WAIT_REAL_TERMINAL_STATES
 
         results_dict = result.get("results") or {}
         resolved_count = sum(
             1
             for snap in results_dict.values()
-            if isinstance(snap, dict)
-            and snap.get("state") in CoordinatorClient._WAIT_REAL_TERMINAL_STATES
+            if isinstance(snap, dict) and snap.get("state") in WAIT_REAL_TERMINAL_STATES
         )
         verb = "complete" if complete else "timeout"
         # Denominator = polled set (not raw item['ws_ids']) so the ratio
         # stays coherent with what the client actually tracked after dedup.
         summary = f"{verb} after {elapsed}s ({resolved_count}/{len(results_dict)} resolved)"
         self._report_tool_result(call_id, "wait_for_workstream", summary)
+        self._emit_wait_event(
+            "wait_ended",
+            {
+                "call_id": call_id,
+                "complete": complete,
+                "elapsed": elapsed,
+                "results": results_dict,
+                "resolved": resolved_count,
+            },
+        )
         return call_id, self._truncate_output(output)
+
+    def _emit_wait_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Fan out a ``wait_*`` SSE event via the session UI.
+
+        Used by the coordinator-side wait dashboard (#14) so the sidebar
+        can render a "waiting on N children, T elapsed" indicator while
+        the worker thread blocks inside wait_for_workstream.  Best-effort:
+        no UI, no ``_enqueue`` method, or a raising enqueue all swallow
+        silently — the wait itself must never break because of observer
+        plumbing.
+        """
+        ui = getattr(self, "ui", None)
+        enqueue = getattr(ui, "_enqueue", None)
+        if enqueue is None:
+            return
+        try:
+            enqueue({"type": event_type, **payload})
+        except Exception:
+            log.debug("wait_event.enqueue_failed type=%s", event_type, exc_info=True)
 
     def _prepare_memory(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         """Prepare a memory tool action (save/get/search/delete/list)."""

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -885,6 +885,46 @@ class PostgreSQLBackend:
                 q = q.where(workstreams.c.user_id == user_id)
             return list(conn.execute(q).fetchall())
 
+    def count_workstreams_by_state(
+        self,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, int]:
+        """Return ``{state: count}`` for workstreams matching the filters.
+
+        See the SQLite backend's docstring (#perf-1).
+        """
+        with self._conn() as conn:
+            q = sa.select(workstreams.c.state, sa.func.count()).group_by(workstreams.c.state)
+            if parent_ws_id is not None:
+                q = q.where(workstreams.c.parent_ws_id == parent_ws_id)
+            if user_id is not None:
+                q = q.where(workstreams.c.user_id == user_id)
+            rows = conn.execute(q).fetchall()
+        return {str(state or ""): int(count) for state, count in rows}
+
+    def count_workstreams_since(
+        self,
+        since: str,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> int:
+        """Return the count of workstream rows whose ``created`` is >= ``since``."""
+        with self._conn() as conn:
+            q = (
+                sa.select(sa.func.count())
+                .select_from(workstreams)
+                .where(workstreams.c.created >= since)
+            )
+            if parent_ws_id is not None:
+                q = q.where(workstreams.c.parent_ws_id == parent_ws_id)
+            if user_id is not None:
+                q = q.where(workstreams.c.user_id == user_id)
+            row = conn.execute(q).fetchone()
+        return int(row[0]) if row else 0
+
     # -- Conversation search ---------------------------------------------------
 
     def search_history(self, query: str, limit: int = 20, offset: int = 0) -> list[Any]:
@@ -2652,6 +2692,19 @@ class PostgreSQLBackend:
                 .order_by(skill_versions.c.version.desc())
             ).fetchall()
             return [_row_to_dict(r) for r in rows]
+
+    def count_skill_versions(self, skill_id: str) -> int:
+        """Return the count of skill-version rows for ``skill_id``.
+
+        See the SQLite backend's docstring for context (#perf-2).
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(skill_versions)
+                .where(skill_versions.c.skill_id == skill_id)
+            ).fetchone()
+        return int(row[0]) if row else 0
 
     def delete_skill_versions(self, skill_id: str) -> int:
         with self._conn() as conn:

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -425,6 +425,36 @@ class StorageBackend(Protocol):
         """
         ...
 
+    def count_workstreams_by_state(
+        self,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, int]:
+        """Return ``{state: count}`` for workstreams matching the filters.
+
+        Cheaper than ``list_workstreams`` when the caller only needs
+        the histogram (e.g. per-coordinator metrics).  Filters are
+        additive; empty kwargs mean cluster-wide (caller must gate on
+        their own authz).
+        """
+        ...
+
+    def count_workstreams_since(
+        self,
+        since: str,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> int:
+        """Return the count of workstream rows whose ``created`` is >= ``since``.
+
+        ``since`` is an ISO-8601 string matching the storage format
+        (``YYYY-MM-DDTHH:MM:SS`` in UTC).  Lex compare is safe for the
+        same-offset timestamps storage writes.
+        """
+        ...
+
     # -- Conversation search ---------------------------------------------------
 
     def search_history(self, query: str, limit: int = 20, offset: int = 0) -> list[Any]:
@@ -1046,6 +1076,15 @@ class StorageBackend(Protocol):
 
     def list_skill_versions(self, skill_id: str) -> list[dict[str, Any]]:
         """List version history for a skill, ordered by version DESC."""
+        ...
+
+    def count_skill_versions(self, skill_id: str) -> int:
+        """Return the count of version snapshots for ``skill_id``.
+
+        Cheaper than ``list_skill_versions`` when the caller only needs
+        the count (e.g. computing the next version number on the
+        coordinator create path).
+        """
         ...
 
     def delete_skill_versions(self, skill_id: str) -> int:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -1005,6 +1005,53 @@ class SQLiteBackend:
                 q = q.where(workstreams.c.user_id == user_id)
             return list(conn.execute(q).fetchall())
 
+    def count_workstreams_by_state(
+        self,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, int]:
+        """Return ``{state: count}`` for workstreams matching the filters.
+
+        Aggregate query — avoids pulling every row just to group by
+        state in Python (#perf-1).  Empty filters mean cluster-wide
+        (caller must gate on their own authz).
+        """
+        with self._conn() as conn:
+            q = sa.select(workstreams.c.state, sa.func.count()).group_by(workstreams.c.state)
+            if parent_ws_id is not None:
+                q = q.where(workstreams.c.parent_ws_id == parent_ws_id)
+            if user_id is not None:
+                q = q.where(workstreams.c.user_id == user_id)
+            rows = conn.execute(q).fetchall()
+        return {str(state or ""): int(count) for state, count in rows}
+
+    def count_workstreams_since(
+        self,
+        since: str,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> int:
+        """Return the count of workstream rows whose ``created`` is >= ``since``.
+
+        ``since`` is an ISO-8601 string matching the storage format
+        ("YYYY-MM-DDTHH:MM:SS", UTC).  Lex compare is safe for the
+        same-offset timestamps storage writes (#perf-1).
+        """
+        with self._conn() as conn:
+            q = (
+                sa.select(sa.func.count())
+                .select_from(workstreams)
+                .where(workstreams.c.created >= since)
+            )
+            if parent_ws_id is not None:
+                q = q.where(workstreams.c.parent_ws_id == parent_ws_id)
+            if user_id is not None:
+                q = q.where(workstreams.c.user_id == user_id)
+            row = conn.execute(q).fetchone()
+        return int(row[0]) if row else 0
+
     # -- Conversation search ---------------------------------------------------
 
     def search_history(self, query: str, limit: int = 20, offset: int = 0) -> list[Any]:
@@ -2743,6 +2790,21 @@ class SQLiteBackend:
                 .order_by(skill_versions.c.version.desc())
             ).fetchall()
             return [_row_to_dict(r) for r in rows]
+
+    def count_skill_versions(self, skill_id: str) -> int:
+        """Return the count of skill-version rows for ``skill_id``.
+
+        Hot path on coordinator create (resolving the next version to
+        persist) — a COUNT query avoids pulling every full version row
+        just to take the length (#perf-2).
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(skill_versions)
+                .where(skill_versions.c.skill_id == skill_id)
+            ).fetchone()
+        return int(row[0]) if row else 0
 
     def delete_skill_versions(self, skill_id: str) -> int:
         with self._conn() as conn:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1887,7 +1887,16 @@ async def plan_feedback(request: Request) -> JSONResponse:
 
 
 async def cancel_generation(request: Request) -> JSONResponse:
-    """POST /v1/api/cancel — cancel the active generation in a workstream."""
+    """POST /v1/api/cancel — cancel the active generation in a workstream.
+
+    Returns ``{status, dropped}`` where ``dropped`` captures a forensic
+    snapshot of what was in flight at cancel time: any pending approval's
+    tool names, queued-message count and a short preview, and whether a
+    worker thread was actively generating.  The model-invoked
+    ``cancel_workstream`` tool passes this through so a coordinator can
+    tell operators what it just killed instead of a bare ``{cancelled:
+    true}``.  Absent keys mean "nothing observable in that lane".
+    """
     from turnstone.core.web_helpers import read_json_or_400
 
     body = await read_json_or_400(request)
@@ -1905,8 +1914,10 @@ async def cancel_generation(request: Request) -> JSONResponse:
     if session is None:
         return JSONResponse({"error": "No session"}, status_code=400)
     force = body.get("force", False) is True
+    was_running = bool(ws.worker_thread and ws.worker_thread.is_alive())
+    dropped = _capture_cancel_forensics(session, ui, was_running=was_running)
     # Only act if generation is actually in progress
-    if ws.worker_thread and ws.worker_thread.is_alive():
+    if was_running:
         # Set the cooperative cancel flag (worker thread checks at checkpoints)
         session.cancel()
         # Unblock any pending approval/plan review waits
@@ -1925,7 +1936,63 @@ async def cancel_generation(request: Request) -> JSONResponse:
         else:
             # Emit cancelled SSE event so SDK consumers get a typed signal
             ui._enqueue({"type": "cancelled"})
-    return JSONResponse({"status": "ok"})
+    return JSONResponse({"status": "ok", "dropped": dropped})
+
+
+def _capture_cancel_forensics(session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]:
+    """Snapshot in-flight session state for the cancel response.
+
+    Pure read — never mutates ``session`` or ``ui``.  Fields are
+    best-effort: any attribute miss (test double, alternate UI) falls
+    through to "not observable".  Kept short so a coordinator surfacing
+    the dropped dict doesn't bloat the tool-result payload.
+    """
+    out: dict[str, Any] = {"was_running": was_running}
+    pending = getattr(ui, "_pending_approval", None)
+    if isinstance(pending, dict):
+        tool_names: list[str] = []
+        first_call_id = ""
+        for item in pending.get("items", []) or []:
+            if not isinstance(item, dict):
+                continue
+            if not item.get("needs_approval"):
+                continue
+            name = item.get("approval_label") or item.get("func_name") or ""
+            if name:
+                tool_names.append(str(name))
+            if not first_call_id:
+                first_call_id = str(item.get("call_id") or "")
+        if tool_names:
+            out["pending_approval"] = {
+                "tool_names": tool_names,
+                "call_id": first_call_id,
+            }
+    queued = getattr(session, "_queued_messages", None)
+    if queued:
+        try:
+            count = len(queued)
+        except TypeError:
+            count = 0
+        preview = ""
+        try:
+            first = next(iter(queued.values()))
+            if isinstance(first, tuple) and first:
+                # Run through the credential-redactor before truncating so
+                # pasted secrets / connection strings / JWTs in the queued
+                # message don't land verbatim in the cancel_workstream
+                # tool result (which gets persisted to the coordinator's
+                # conversation history AND fanned out via SSE).  Matches
+                # the close_workstream.reason persistence path (phase 5).
+                from turnstone.core.output_guard import redact_credentials
+
+                preview = redact_credentials(str(first[0]))[:120]
+        except StopIteration:
+            pass
+        except Exception:
+            preview = ""
+        if count:
+            out["queued_messages"] = {"count": count, "first_preview": preview}
+    return out
 
 
 async def command(request: Request) -> JSONResponse:

--- a/turnstone/shared_static/ui-base.css
+++ b/turnstone/shared_static/ui-base.css
@@ -86,6 +86,11 @@
   color: var(--fg);
 }
 .ui-btn--icon:hover { background: var(--bg-elevated); }
+/* Match .ui-btn's focus-visible pattern so the compact variant gets
+   the same accent-ring treatment instead of falling back to the
+   browser-default outline (phase-4 designer review: focus-ring
+   consistency). */
+.ui-btn--icon:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
 /* ==========================================================================
    State glyphs — unified vocabulary (● running / ◐ thinking / ⚠ attention /

--- a/turnstone/tools/wait_for_workstream.json
+++ b/turnstone/tools/wait_for_workstream.json
@@ -21,7 +21,7 @@
       },
       "since": {
         "type": "object",
-        "description": "Optional prior snapshot (typically the `results` dict from an earlier wait_for_workstream call). When provided, the wait exits as soon as ANY polled ws_id's state/tokens/updated differs from its `since` entry, regardless of mode. Skip re-counting already-terminal children on follow-up waits. A missing entry counts as changed on first observation. Omit for the default terminal-state behaviour.",
+        "description": "Optional prior snapshot (typically the `results` dict from an earlier wait_for_workstream call). When provided, the wait exits as soon as ANY polled ws_id that ALSO has a `since` entry differs from that prior snapshot (state/tokens/updated), regardless of mode. Skip re-counting already-terminal children on follow-up waits. ws_ids absent from `since` do NOT trigger the diff-based early exit — they fall back to the normal `mode` condition, so a disjoint `since` dict doesn't silently exit on tick one. Omit for the default terminal-state behaviour.",
         "additionalProperties": {
           "type": "object",
           "properties": {

--- a/turnstone/tools/wait_for_workstream.json
+++ b/turnstone/tools/wait_for_workstream.json
@@ -18,6 +18,18 @@
         "enum": ["any", "all"],
         "default": "any",
         "description": "'any' (default) returns when the first child reaches a real terminal state (idle / error / closed / deleted); 'all' returns once every named child has settled (real terminal OR denied). A pure-denied list with mode='any' short-circuits to complete=false rather than spinning the timeout."
+      },
+      "since": {
+        "type": "object",
+        "description": "Optional prior snapshot (typically the `results` dict from an earlier wait_for_workstream call). When provided, the wait exits as soon as ANY polled ws_id's state/tokens/updated differs from its `since` entry, regardless of mode. Skip re-counting already-terminal children on follow-up waits. A missing entry counts as changed on first observation. Omit for the default terminal-state behaviour.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "state": { "type": "string" },
+            "tokens": { "type": "integer" },
+            "updated": { "type": "string" }
+          }
+        }
       }
     },
     "required": ["ws_ids"]

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -172,23 +172,23 @@ Pane.prototype._createDOM = function () {
 
   // Input area
   var inputArea = document.createElement("div");
-  inputArea.className = "pane-input-area ts-composer";
+  inputArea.className = "ts-composer";
 
   // Attachment chips row — above the textarea, hidden unless populated
   this.attachChipsEl = document.createElement("div");
-  this.attachChipsEl.className = "pane-attach-chips ts-composer-chips";
+  this.attachChipsEl.className = "ts-composer-chips";
   this.attachChipsEl.setAttribute("role", "list");
   this.attachChipsEl.setAttribute("aria-label", "Pending attachments");
   inputArea.appendChild(this.attachChipsEl);
 
   var inputRow = document.createElement("div");
-  inputRow.className = "pane-input-row ts-composer-row";
+  inputRow.className = "ts-composer-row";
   inputArea.appendChild(inputRow);
 
   // Paperclip button — opens the file picker
   this.attachBtn = document.createElement("button");
   this.attachBtn.type = "button";
-  this.attachBtn.className = "pane-attach ts-composer-attach";
+  this.attachBtn.className = "ts-composer-attach";
   this.attachBtn.setAttribute("aria-label", "Attach files");
   this.attachBtn.setAttribute("title", "Attach files");
   this.attachBtn.textContent = "\ud83d\udcce"; // 📎
@@ -217,7 +217,7 @@ Pane.prototype._createDOM = function () {
   inputRow.appendChild(this.attachInput);
 
   this.inputEl = document.createElement("textarea");
-  this.inputEl.className = "pane-input ts-composer-input";
+  this.inputEl.className = "ts-composer-input";
   this.inputEl.rows = 1;
   this._isTouch = window.matchMedia(
     "(hover: none) and (pointer: coarse)",
@@ -346,30 +346,30 @@ Pane.prototype._renderAttachmentChip = function (info) {
   var self = this;
   var chip = document.createElement("span");
   chip.className =
-    "pane-attach-chip pane-attach-chip-" + (info.kind || "other");
+    "ts-composer-chip ts-composer-chip-" + (info.kind || "other");
   chip.setAttribute("role", "listitem");
   chip.dataset.attachmentId = info.attachment_id;
 
   var icon = document.createElement("span");
-  icon.className = "pane-attach-chip-icon";
+  icon.className = "ts-composer-chip-icon";
   icon.setAttribute("aria-hidden", "true");
   icon.textContent = info.kind === "image" ? "\ud83d\uddbc" : "\ud83d\udcc4";
   chip.appendChild(icon);
 
   var label = document.createElement("span");
-  label.className = "pane-attach-chip-name";
+  label.className = "ts-composer-chip-name";
   label.textContent = info.filename || "(unnamed)";
   label.title = info.filename || "";
   chip.appendChild(label);
 
   var size = document.createElement("span");
-  size.className = "pane-attach-chip-size";
+  size.className = "ts-composer-chip-size";
   size.textContent = _formatAttachSize(info.size_bytes || 0);
   chip.appendChild(size);
 
   var remove = document.createElement("button");
   remove.type = "button";
-  remove.className = "pane-attach-chip-remove";
+  remove.className = "ts-composer-chip-remove";
   remove.setAttribute(
     "aria-label",
     "Remove attachment " + (info.filename || ""),
@@ -462,12 +462,12 @@ Pane.prototype._swapPlaceholderChip = function (placeholderId, info) {
   );
   if (chip) {
     chip.dataset.attachmentId = info.attachment_id;
-    var name = chip.querySelector(".pane-attach-chip-name");
+    var name = chip.querySelector(".ts-composer-chip-name");
     if (name) {
       name.textContent = info.filename || "(unnamed)";
       name.title = info.filename || "";
     }
-    var size = chip.querySelector(".pane-attach-chip-size");
+    var size = chip.querySelector(".ts-composer-chip-size");
     if (size) size.textContent = _formatAttachSize(info.size_bytes || 0);
   } else {
     // Chip missing (user removed it mid-upload?); render fresh.
@@ -749,8 +749,7 @@ Pane.prototype.handleEvent = function (evt) {
       this.removeThinkingIndicator();
       if (!this.currentReasoningEl) {
         this.currentReasoningEl = document.createElement("div");
-        this.currentReasoningEl.className =
-          "msg msg-assistant reasoning ts-msg ts-msg--reasoning";
+        this.currentReasoningEl.className = "ts-msg ts-msg--reasoning";
         this.messagesEl.appendChild(this.currentReasoningEl);
       }
       this.currentReasoningEl.textContent += evt.text;
@@ -764,14 +763,12 @@ Pane.prototype.handleEvent = function (evt) {
       }
       if (!this.currentAssistantEl) {
         this.currentAssistantEl = document.createElement("div");
-        this.currentAssistantEl.className =
-          "msg msg-assistant ts-msg ts-msg--assistant";
+        this.currentAssistantEl.className = "ts-msg ts-msg--assistant";
         // streamingRender targets a .ts-msg-body inner wrapper so the
         // shared markdown rules in chat.css (h1/h2/h3/code/blockquote
-        // scoped to .ts-msg-body *) actually match on this page —
-        // without the wrapper they'd fall through to the legacy
-        // .msg-assistant * vocabulary and diverge from the coordinator
-        // page, which already wraps in .coord-body.ts-msg-body.
+        // scoped to .ts-msg-body *) actually match on this page — the
+        // coordinator page uses the same .ts-msg-body wrapper so the
+        // two chat views stay visually aligned.
         this.currentAssistantBodyEl = document.createElement("div");
         this.currentAssistantBodyEl.className = "ts-msg-body";
         this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
@@ -996,7 +993,7 @@ Pane.prototype.removeThinkingIndicator = function () {
 Pane.prototype.addUserMessage = function (text, attachments) {
   this.removeEmptyState();
   var el = document.createElement("div");
-  el.className = "msg msg-user ts-msg ts-msg--user";
+  el.className = "ts-msg ts-msg--user";
   var textEl = document.createElement("div");
   textEl.className = "msg-user-text";
   textEl.textContent = text;
@@ -1031,7 +1028,7 @@ Pane.prototype.addQueuedMessage = function (text, priority) {
   this.removeEmptyState();
   var self = this;
   var el = document.createElement("div");
-  el.className = "msg msg-user msg-queued ts-msg ts-msg--user";
+  el.className = "ts-msg ts-msg--user msg-queued";
   el.setAttribute("role", "status");
   if (priority === "important") {
     el.classList.add("msg-queued-important");
@@ -1176,7 +1173,7 @@ Pane.prototype._rewindToMessage = function (msgEl) {
   if (this.busy) return;
   var self = this;
   // Count how many user messages come at or after this one
-  var userMsgs = this.messagesEl.querySelectorAll(".msg-user");
+  var userMsgs = this.messagesEl.querySelectorAll(".ts-msg--user");
   var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
   if (idx < 0) return;
   var turnsToRewind = userMsgs.length - idx;
@@ -1260,7 +1257,7 @@ Pane.prototype._editAndResend = function (msgEl, newText) {
   if (this.busy) return;
   var self = this;
   // Count turns to rewind (from this message onward)
-  var userMsgs = this.messagesEl.querySelectorAll(".msg-user");
+  var userMsgs = this.messagesEl.querySelectorAll(".ts-msg--user");
   var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
   if (idx < 0) return;
   var turnsToRewind = userMsgs.length - idx;
@@ -1313,11 +1310,11 @@ Pane.prototype.replayHistory = function (messages) {
           var wasDenied = !!msg.denied;
           var block = document.createElement("div");
           block.className =
-            "msg approval-block ts-msg ts-approval ts-approval--inline " +
+            "ts-msg ts-approval ts-approval--inline " +
             (wasDenied ? "denied" : "approved");
           msg.tool_calls.forEach(function (tc) {
             var div = document.createElement("div");
-            div.className = "approval-tool ts-approval-tool";
+            div.className = "ts-approval-tool";
             div.dataset.funcName = tc.name;
             div.dataset.callId = tc.id || "";
             var nameEl = document.createElement("div");
@@ -1355,12 +1352,10 @@ Pane.prototype.replayHistory = function (messages) {
           var badge = document.createElement("div");
           badge.setAttribute("role", "status");
           if (wasDenied) {
-            badge.className =
-              "approval-badge badge-denied ts-approval-badge ts-approval-badge--denied";
+            badge.className = "ts-approval-badge ts-approval-badge--denied";
             badge.textContent = "\u2717 denied";
           } else {
-            badge.className =
-              "approval-badge badge-approved ts-approval-badge ts-approval-badge--approved";
+            badge.className = "ts-approval-badge ts-approval-badge--approved";
             badge.textContent = "\u2713 approved";
           }
           block.appendChild(badge);
@@ -1370,7 +1365,7 @@ Pane.prototype.replayHistory = function (messages) {
       }
       if (msg.content) {
         var el = document.createElement("div");
-        el.className = "msg msg-assistant ts-msg ts-msg--assistant";
+        el.className = "ts-msg ts-msg--assistant";
         var bodyEl = document.createElement("div");
         bodyEl.className = "ts-msg-body";
         var rendered = renderMarkdown(msg.content);
@@ -1392,7 +1387,7 @@ Pane.prototype.replayHistory = function (messages) {
           var media = !isToolError ? tryParseMedia(stripped) : null;
           if (media) {
             var embed = buildMediaEmbed(media, stripped);
-            var bdg = lastToolBlock.querySelector(".approval-badge");
+            var bdg = lastToolBlock.querySelector(".ts-approval-badge");
             if (bdg) lastToolBlock.insertBefore(embed, bdg);
             else lastToolBlock.appendChild(embed);
           } else {
@@ -1400,17 +1395,16 @@ Pane.prototype.replayHistory = function (messages) {
             if (out.textContent.split("\n").length > 10) {
               makeCollapsible(out);
             }
-            var bdg = lastToolBlock.querySelector(".approval-badge");
+            var bdg = lastToolBlock.querySelector(".ts-approval-badge");
             if (bdg) lastToolBlock.insertBefore(out, bdg);
             else lastToolBlock.appendChild(out);
           }
         }
         if (isToolError && !lastToolBlock.classList.contains("denied")) {
           lastToolBlock.classList.add("error");
-          var errorBdg = lastToolBlock.querySelector(".approval-badge");
+          var errorBdg = lastToolBlock.querySelector(".ts-approval-badge");
           if (errorBdg) {
-            errorBdg.className =
-              "approval-badge badge-error ts-approval-badge ts-approval-badge--error";
+            errorBdg.className = "ts-approval-badge ts-approval-badge--error";
             errorBdg.textContent = "\u2717 error";
           }
         }
@@ -1423,16 +1417,15 @@ Pane.prototype.replayHistory = function (messages) {
 
 Pane.prototype._attachRetryToLastAssistant = function () {
   // Remove any previous retry buttons
-  var old = this.messagesEl.querySelectorAll(".msg-assistant .msg-actions");
+  var old = this.messagesEl.querySelectorAll(".ts-msg--assistant .msg-actions");
   for (var i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
-  // Find the last assistant message with content and add retry
-  var assistants = this.messagesEl.querySelectorAll(".msg-assistant");
+  // Find the last assistant message with content and add retry.
+  // Reasoning blocks emit as .ts-msg--reasoning (distinct modifier)
+  // so the .ts-msg--assistant selector already excludes them — no
+  // extra guard needed.
+  var assistants = this.messagesEl.querySelectorAll(".ts-msg--assistant");
   if (assistants.length) {
-    var last = assistants[assistants.length - 1];
-    // Only add if it's not a reasoning block
-    if (!last.classList.contains("reasoning")) {
-      this._addRetryAction(last);
-    }
+    this._addRetryAction(assistants[assistants.length - 1]);
   }
 };
 
@@ -1444,7 +1437,7 @@ Pane.prototype.showInlineToolBlock = function (
   var self = this;
   var block = document.createElement("div");
   block.className =
-    "msg approval-block ts-msg ts-approval ts-approval--inline" +
+    "ts-msg ts-approval ts-approval--inline" +
     (autoApproved ? " approved" : "");
   if (!autoApproved) {
     block.setAttribute("role", "alertdialog");
@@ -1476,19 +1469,20 @@ Pane.prototype.showInlineToolBlock = function (
   if (autoApproved) {
     var badge = document.createElement("div");
     badge.setAttribute("role", "status");
-    badge.className =
-      "approval-badge badge-approved ts-approval-badge ts-approval-badge--approved";
+    badge.className = "ts-approval-badge ts-approval-badge--approved";
     badge.textContent = "\u2713 auto-approved";
     block.appendChild(badge);
   } else {
     var prompt = document.createElement("div");
-    prompt.className = "approval-prompt ts-approval-body";
+    prompt.className = "ts-approval-body";
 
     // Apply verdict glow on initial heuristic verdict
     if (glowRec) {
-      if (glowRec === "approve") prompt.classList.add("verdict-glow-approve");
-      else if (glowRec === "deny") prompt.classList.add("verdict-glow-deny");
-      else prompt.classList.add("verdict-glow-review");
+      if (glowRec === "approve")
+        prompt.classList.add("ts-verdict-glow--approve");
+      else if (glowRec === "deny")
+        prompt.classList.add("ts-verdict-glow--deny");
+      else prompt.classList.add("ts-verdict-glow--review");
     }
 
     var alwaysNames = items
@@ -1509,11 +1503,10 @@ Pane.prototype.showInlineToolBlock = function (
       : "Always approve this tool type";
 
     var actionsDiv = document.createElement("div");
-    actionsDiv.className = "approval-actions ts-approval-actions";
+    actionsDiv.className = "ts-approval-actions";
 
     var approveBtn = document.createElement("button");
-    approveBtn.className =
-      "approval-btn btn-approve ts-approval-btn ts-approval-btn--approve";
+    approveBtn.className = "ts-approval-btn ts-approval-btn--approve";
     approveBtn.innerHTML = '<span class="key">y</span> Approve';
     approveBtn.onclick = function () {
       self.resolveApproval(true, false, self.getFeedback());
@@ -1521,8 +1514,7 @@ Pane.prototype.showInlineToolBlock = function (
     actionsDiv.appendChild(approveBtn);
 
     var denyBtn = document.createElement("button");
-    denyBtn.className =
-      "approval-btn btn-deny ts-approval-btn ts-approval-btn--deny";
+    denyBtn.className = "ts-approval-btn ts-approval-btn--deny";
     denyBtn.innerHTML = '<span class="key">n</span> Deny';
     denyBtn.onclick = function () {
       self.resolveApproval(false, false, self.getFeedback());
@@ -1531,8 +1523,7 @@ Pane.prototype.showInlineToolBlock = function (
 
     if (alwaysNames.length) {
       var alwaysBtn = document.createElement("button");
-      alwaysBtn.className =
-        "approval-btn btn-always ts-approval-btn ts-approval-btn--always";
+      alwaysBtn.className = "ts-approval-btn ts-approval-btn--always";
       alwaysBtn.title = alwaysTitle;
       alwaysBtn.setAttribute("aria-label", alwaysTitle);
       alwaysBtn.innerHTML = '<span class="key">a</span> Always';
@@ -1546,7 +1537,7 @@ Pane.prototype.showInlineToolBlock = function (
 
     var fbInput = document.createElement("input");
     fbInput.type = "text";
-    fbInput.className = "approval-feedback-input ts-approval-feedback";
+    fbInput.className = "ts-approval-feedback";
     fbInput.placeholder = "feedback (optional)";
     prompt.appendChild(fbInput);
 
@@ -1574,15 +1565,14 @@ Pane.prototype.resolveApproval = function (
   this.pendingApproval = false;
 
   // Remove prompt
-  var prompt = this.approvalBlockEl.querySelector(".approval-prompt");
+  var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
   if (prompt) prompt.remove();
 
   // Add badge
   var badge = document.createElement("div");
   badge.setAttribute("role", "status");
   if (approved) {
-    badge.className =
-      "approval-badge badge-approved ts-approval-badge ts-approval-badge--approved";
+    badge.className = "ts-approval-badge ts-approval-badge--approved";
     var label = "\u2713 approved";
     if (always) {
       var raw = this.approvalBlockEl.dataset.alwaysNames;
@@ -1594,8 +1584,7 @@ Pane.prototype.resolveApproval = function (
     badge.textContent = feedback ? label + ": " + feedback : label;
     this.approvalBlockEl.classList.add("approved");
   } else {
-    badge.className =
-      "approval-badge badge-denied ts-approval-badge ts-approval-badge--denied";
+    badge.className = "ts-approval-badge ts-approval-badge--denied";
     badge.textContent = "\u2717 denied" + (feedback ? ": " + feedback : "");
     this.approvalBlockEl.classList.add("denied");
   }
@@ -1629,7 +1618,7 @@ Pane.prototype.resolveApproval = function (
 
 Pane.prototype.getFeedback = function () {
   if (!this.approvalBlockEl) return null;
-  var inp = this.approvalBlockEl.querySelector(".approval-feedback-input");
+  var inp = this.approvalBlockEl.querySelector(".ts-approval-feedback");
   return inp && inp.value.trim() ? inp.value.trim() : null;
 };
 
@@ -1647,19 +1636,19 @@ Pane.prototype.appendToolOutputChunk = function (callId, chunk) {
   if (!el) {
     var target = escapedId
       ? this.messagesEl.querySelector(
-          '.approval-tool[data-call-id="' + escapedId + '"]',
+          '.ts-approval-tool[data-call-id="' + escapedId + '"]',
         )
       : null;
     if (!target) {
-      var blocks = this.messagesEl.querySelectorAll(".approval-block");
+      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
       if (!blocks.length) return;
       var block = blocks[blocks.length - 1];
       var tools = block.querySelectorAll(
-        '.approval-tool[data-func-name="bash"]',
+        '.ts-approval-tool[data-func-name="bash"]',
       );
       target = tools.length ? tools[tools.length - 1] : null;
       if (!target) {
-        var allTools = block.querySelectorAll(".approval-tool");
+        var allTools = block.querySelectorAll(".ts-approval-tool");
         target = allTools.length ? allTools[allTools.length - 1] : null;
       }
     }
@@ -1683,14 +1672,14 @@ Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
   var escapedId = callId ? CSS.escape(callId) : "";
   var target = escapedId
     ? this.messagesEl.querySelector(
-        '.approval-tool[data-call-id="' + escapedId + '"]',
+        '.ts-approval-tool[data-call-id="' + escapedId + '"]',
       )
     : null;
   if (!target) {
-    var blocks = this.messagesEl.querySelectorAll(".approval-block");
+    var blocks = this.messagesEl.querySelectorAll(".ts-approval");
     if (!blocks.length) return;
     var block = blocks[blocks.length - 1];
-    var tools = block.querySelectorAll(".approval-tool");
+    var tools = block.querySelectorAll(".ts-approval-tool");
     for (var i = tools.length - 1; i >= 0; i--) {
       if (tools[i].dataset.funcName === name) {
         target = tools[i];
@@ -1733,13 +1722,12 @@ Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
 
   // Mark the parent approval block as errored
   if (isError) {
-    var parentBlock = target.closest(".approval-block");
+    var parentBlock = target.closest(".ts-approval");
     if (parentBlock && !parentBlock.classList.contains("denied")) {
       parentBlock.classList.add("error");
-      var badge = parentBlock.querySelector(".approval-badge");
+      var badge = parentBlock.querySelector(".ts-approval-badge");
       if (badge) {
-        badge.className =
-          "approval-badge badge-error ts-approval-badge ts-approval-badge--error";
+        badge.className = "ts-approval-badge ts-approval-badge--error";
         badge.textContent = "\u2717 error";
       }
     }
@@ -1757,7 +1745,7 @@ Pane.prototype.showOutputWarning = function (evt) {
   if (!evt.call_id || evt.risk_level === "none") return;
   var escapedId = CSS.escape(evt.call_id);
   var toolDiv = this.messagesEl.querySelector(
-    '.approval-tool[data-call-id="' + escapedId + '"]',
+    '.ts-approval-tool[data-call-id="' + escapedId + '"]',
   );
   if (!toolDiv) return;
   var risk = evt.risk_level || "medium";
@@ -1852,7 +1840,7 @@ Pane.prototype.updateVerdictBadge = function (verdict) {
 
 Pane.prototype.updateVerdictGlow = function (recommendation) {
   if (!this.approvalBlockEl) return;
-  var prompt = this.approvalBlockEl.querySelector(".approval-prompt");
+  var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
   if (!prompt) return;
 
   // Collect all verdict badges currently visible in this approval block
@@ -1871,18 +1859,18 @@ Pane.prototype.updateVerdictGlow = function (recommendation) {
   }
 
   prompt.classList.remove(
-    "verdict-glow-approve",
-    "verdict-glow-deny",
-    "verdict-glow-review",
+    "ts-verdict-glow--approve",
+    "ts-verdict-glow--deny",
+    "ts-verdict-glow--review",
   );
-  if (worst === "approve") prompt.classList.add("verdict-glow-approve");
-  else if (worst === "deny") prompt.classList.add("verdict-glow-deny");
-  else prompt.classList.add("verdict-glow-review");
+  if (worst === "approve") prompt.classList.add("ts-verdict-glow--approve");
+  else if (worst === "deny") prompt.classList.add("ts-verdict-glow--deny");
+  else prompt.classList.add("ts-verdict-glow--review");
 };
 
 Pane.prototype.addInfoMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "msg msg-info ts-msg ts-msg--info";
+  el.className = "ts-msg ts-msg--info";
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);
   this.scrollToBottom();
@@ -1890,7 +1878,7 @@ Pane.prototype.addInfoMessage = function (text) {
 
 Pane.prototype.addErrorMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "msg msg-error ts-msg ts-msg--error";
+  el.className = "ts-msg ts-msg--error";
   el.setAttribute("role", "alert");
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);
@@ -4970,7 +4958,7 @@ function stripAnsi(s) {
 
 function buildToolDiv(item) {
   var div = document.createElement("div");
-  div.className = "approval-tool ts-approval-tool";
+  div.className = "ts-approval-tool";
   div.dataset.funcName = item.func_name || "";
   div.dataset.callId = item.call_id || "";
 
@@ -5930,7 +5918,7 @@ document.addEventListener("keydown", function (e) {
   if (pane && pane.pendingApproval) {
     var fbInput =
       pane.approvalBlockEl &&
-      pane.approvalBlockEl.querySelector(".approval-feedback-input");
+      pane.approvalBlockEl.querySelector(".ts-approval-feedback");
     if (fbInput && document.activeElement === fbInput) {
       if (e.key === "Enter") {
         e.preventDefault();

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -441,21 +441,14 @@
   flex-direction: column;
   gap: 14px;
 }
-.msg {
-  padding: 10px 14px;
-  border-radius: var(--radius);
-  max-width: 95%;
-  line-height: 1.6;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-}
-.msg-user {
-  /* Alignment, border, background provided by .ts-msg / .ts-msg--user
-     (shared_static/chat.css).  Interactive UI only keeps the
-     brighter text colour here so the user message still reads as
-     "the thing I said" against the lower-chroma assistant colour. */
-  color: var(--fg-bright);
-}
+/* .ts-msg (shared_static/chat.css) provides padding / border / radius /
+   line-height / word-wrap / margin / background.  The interactive UI
+   adds a max-width cap so long messages don't stretch the full pane
+   on wide displays, and a brighter text colour on user messages so
+   "the thing I said" reads distinctly against the lower-chroma
+   assistant colour. */
+.ts-msg { max-width: 95%; }
+.ts-msg--user { color: var(--fg-bright); }
 .msg-queued {
   opacity: 0.65;
   border-style: dashed;
@@ -488,10 +481,13 @@
 .queued-dismiss:hover {
   color: var(--red);
 }
-/* .msg-assistant / .msg-info / .msg-error alignment + baseline visuals
-   come from .ts-msg--* in shared_static/chat.css. */
-.msg-info { white-space: pre-wrap; }
-.msg-tool {
+/* .ts-msg--assistant / .ts-msg--info / .ts-msg--error alignment +
+   baseline visuals come from shared_static/chat.css.  Interactive UI
+   adds a pre-wrap override for info messages and a tightened
+   tool-message shape with the yellow accent bar the instrument-panel
+   look established. */
+.ts-msg--info { white-space: pre-wrap; }
+.ts-msg--tool {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-left: 3px solid var(--yellow);
@@ -500,11 +496,12 @@
   align-self: flex-start;
   max-width: 95%;
 }
-.msg-tool .tool-header { color: var(--yellow); font-weight: 600; margin-bottom: 4px; font-size: 11px; }
-.msg-tool .tool-preview { color: var(--fg-dim); white-space: pre-wrap; font-size: 12px; max-height: 300px; overflow-y: auto; }
+.ts-msg--tool .tool-header { color: var(--yellow); font-weight: 600; margin-bottom: 4px; font-size: 11px; }
+.ts-msg--tool .tool-preview { color: var(--fg-dim); white-space: pre-wrap; font-size: 12px; max-height: 300px; overflow-y: auto; }
 
-/* Streaming content */
-.reasoning { color: var(--fg-dim); font-style: italic; }
+/* Streaming content — .ts-msg--reasoning (chat.css) styles reasoning
+   bubbles; .reasoning was the legacy role class and is no longer
+   emitted. */
 .thinking-indicator { color: var(--fg-dim); font-size: 12px; padding: 6px 14px; }
 .thinking-indicator::after { content: '...'; animation: dots 1.5s steps(3, end) infinite; }
 @keyframes dots { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }
@@ -514,24 +511,24 @@
    ========================================================================== */
 /* Override KaTeX body rule — our layout requires body as a static flex container */
 body { position: static; }
-.msg-assistant h1, .msg-assistant h2, .msg-assistant h3, .msg-assistant h4, .msg-assistant h5, .msg-assistant h6 { color: var(--accent); margin: 8px 0 4px; font-family: var(--font-display); }
-.msg-assistant h1 { font-size: 18px; }
-.msg-assistant h2 { font-size: 16px; }
-.msg-assistant h3 { font-size: 14px; }
-.msg-assistant h4 { font-size: 13px; font-weight: 600; }
-.msg-assistant h5 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
-.msg-assistant h6 { font-size: 12px; font-weight: 500; color: var(--fg-dim); }
-.msg-assistant strong { color: var(--fg-bright); }
-.msg-assistant em { color: var(--magenta); }
-.msg-assistant del { color: var(--fg-dim); text-decoration: line-through; }
-.msg-assistant code {
+.ts-msg--assistant h1, .ts-msg--assistant h2, .ts-msg--assistant h3, .ts-msg--assistant h4, .ts-msg--assistant h5, .ts-msg--assistant h6 { color: var(--accent); margin: 8px 0 4px; font-family: var(--font-display); }
+.ts-msg--assistant h1 { font-size: 18px; }
+.ts-msg--assistant h2 { font-size: 16px; }
+.ts-msg--assistant h3 { font-size: 14px; }
+.ts-msg--assistant h4 { font-size: 13px; font-weight: 600; }
+.ts-msg--assistant h5 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+.ts-msg--assistant h6 { font-size: 12px; font-weight: 500; color: var(--fg-dim); }
+.ts-msg--assistant strong { color: var(--fg-bright); }
+.ts-msg--assistant em { color: var(--magenta); }
+.ts-msg--assistant del { color: var(--fg-dim); text-decoration: line-through; }
+.ts-msg--assistant code {
   background: var(--code-bg);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   font-size: 12px;
   border: 1px solid var(--border);
 }
-.msg-assistant pre {
+.ts-msg--assistant pre {
   background: var(--code-bg);
   padding: 12px 14px;
   border-radius: var(--radius);
@@ -539,46 +536,46 @@ body { position: static; }
   margin: 8px 0;
   border: 1px solid var(--border);
 }
-.msg-assistant pre code { background: none; padding: 0; border: none; }
-.msg-assistant ul, .msg-assistant ol { margin: 4px 0 4px 20px; }
-.msg-assistant li { margin: 2px 0; }
-.msg-assistant a { color: var(--accent); text-decoration: underline; }
-.msg-assistant blockquote { border-left: 3px solid var(--accent-dim); padding-left: 12px; color: var(--fg-dim); margin: 6px 0; }
-.msg-assistant hr { border: none; border-top: 1px solid var(--border); margin: 8px 0; }
-.msg-assistant p { margin: 4px 0; }
-.msg-assistant .table-wrap { overflow-x: auto; margin: 8px 0; -webkit-overflow-scrolling: touch; }
-.msg-assistant .table-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.msg-assistant table { border-collapse: collapse; width: auto; min-width: 50%; font-size: 13px; }
-.msg-assistant thead { border-bottom: 2px solid var(--border-strong); }
-.msg-assistant th { background: var(--code-bg); font-weight: 600; color: var(--fg-bright); }
-.msg-assistant th, .msg-assistant td { padding: 6px 12px; border: 1px solid var(--border-strong); }
-.msg-assistant tbody tr { transition: background 0.12s ease; }
-.msg-assistant tbody tr:nth-child(even) { background: var(--row-alt); }
-.msg-assistant tbody tr:hover { background: var(--bg-highlight); }
-.msg-assistant .align-left { text-align: left; }
-.msg-assistant .align-center { text-align: center; }
-.msg-assistant .align-right { text-align: right; }
-.msg-assistant img { display: block; max-width: 100%; height: auto; border-radius: var(--radius); margin: 4px 0; }
-.msg-assistant .img-placeholder {
+.ts-msg--assistant pre code { background: none; padding: 0; border: none; }
+.ts-msg--assistant ul, .ts-msg--assistant ol { margin: 4px 0 4px 20px; }
+.ts-msg--assistant li { margin: 2px 0; }
+.ts-msg--assistant a { color: var(--accent); text-decoration: underline; }
+.ts-msg--assistant blockquote { border-left: 3px solid var(--accent-dim); padding-left: 12px; color: var(--fg-dim); margin: 6px 0; }
+.ts-msg--assistant hr { border: none; border-top: 1px solid var(--border); margin: 8px 0; }
+.ts-msg--assistant p { margin: 4px 0; }
+.ts-msg--assistant .table-wrap { overflow-x: auto; margin: 8px 0; -webkit-overflow-scrolling: touch; }
+.ts-msg--assistant .table-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.ts-msg--assistant table { border-collapse: collapse; width: auto; min-width: 50%; font-size: 13px; }
+.ts-msg--assistant thead { border-bottom: 2px solid var(--border-strong); }
+.ts-msg--assistant th { background: var(--code-bg); font-weight: 600; color: var(--fg-bright); }
+.ts-msg--assistant th, .ts-msg--assistant td { padding: 6px 12px; border: 1px solid var(--border-strong); }
+.ts-msg--assistant tbody tr { transition: background 0.12s ease; }
+.ts-msg--assistant tbody tr:nth-child(even) { background: var(--row-alt); }
+.ts-msg--assistant tbody tr:hover { background: var(--bg-highlight); }
+.ts-msg--assistant .align-left { text-align: left; }
+.ts-msg--assistant .align-center { text-align: center; }
+.ts-msg--assistant .align-right { text-align: right; }
+.ts-msg--assistant img { display: block; max-width: 100%; height: auto; border-radius: var(--radius); margin: 4px 0; }
+.ts-msg--assistant .img-placeholder {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 8px 14px; margin: 4px 0;
   background: var(--code-bg); border: 1px solid var(--border-strong);
   border-radius: var(--radius); cursor: pointer;
   transition: border-color 0.12s ease;
 }
-.msg-assistant .img-placeholder:hover { border-color: var(--accent); }
-.msg-assistant .img-placeholder:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.msg-assistant .img-placeholder-icon { font-size: 16px; }
-.msg-assistant .img-placeholder-label { color: var(--fg-bright); font-size: 13px; }
-.msg-assistant .img-placeholder-domain { color: var(--fg-dim); font-size: 11px; }
-.msg-assistant li > input[type="checkbox"] { margin-right: 6px; vertical-align: middle; accent-color: var(--accent); }
-.msg-assistant blockquote blockquote { margin: 4px 0; border-left-color: var(--border-strong); }
-.msg-assistant blockquote blockquote blockquote { border-left-color: var(--border); }
-.msg-assistant .katex-display { margin: 8px 0; padding: 8px 0; overflow-x: auto; overflow-y: hidden; }
-.msg-assistant .katex-error { color: var(--red) !important; font-size: 12px; }
+.ts-msg--assistant .img-placeholder:hover { border-color: var(--accent); }
+.ts-msg--assistant .img-placeholder:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.ts-msg--assistant .img-placeholder-icon { font-size: 16px; }
+.ts-msg--assistant .img-placeholder-label { color: var(--fg-bright); font-size: 13px; }
+.ts-msg--assistant .img-placeholder-domain { color: var(--fg-dim); font-size: 11px; }
+.ts-msg--assistant li > input[type="checkbox"] { margin-right: 6px; vertical-align: middle; accent-color: var(--accent); }
+.ts-msg--assistant blockquote blockquote { margin: 4px 0; border-left-color: var(--border-strong); }
+.ts-msg--assistant blockquote blockquote blockquote { border-left-color: var(--border); }
+.ts-msg--assistant .katex-display { margin: 8px 0; padding: 8px 0; overflow-x: auto; overflow-y: hidden; }
+.ts-msg--assistant .katex-error { color: var(--red) !important; font-size: 12px; }
 
 /* Syntax highlighting — highlight.js theme (instrument panel) */
-.msg-assistant pre code.hljs { background: var(--code-bg); color: var(--fg); padding: 0; }
+.ts-msg--assistant pre code.hljs { background: var(--code-bg); color: var(--fg); padding: 0; }
 .hljs-keyword, .hljs-selector-tag, .hljs-built_in, .hljs-type { color: var(--magenta); }
 .hljs-string, .hljs-attr, .hljs-template-tag, .hljs-template-variable { color: var(--green); }
 .hljs-number, .hljs-literal, .hljs-variable, .hljs-symbol, .hljs-bullet { color: var(--cyan); }
@@ -598,28 +595,28 @@ body { position: static; }
 .hljs-params { color: var(--fg); }
 .hljs-addition { color: var(--green); background: rgba(52, 211, 153, 0.08); display: inline-block; width: 100%; }
 .hljs-deletion { color: var(--red); background: rgba(248, 113, 113, 0.08); display: inline-block; width: 100%; }
-.msg-assistant pre.code-terminal { border-left: 2px solid var(--green); }
+.ts-msg--assistant pre.code-terminal { border-left: 2px solid var(--green); }
 [data-theme="light"] .hljs-addition { background: rgba(4, 120, 87, 0.06); }
 [data-theme="light"] .hljs-deletion { background: rgba(220, 38, 38, 0.06); }
 
 /* Mermaid diagrams */
-.msg-assistant .mermaid-container {
+.ts-msg--assistant .mermaid-container {
   margin: 8px 0;
   text-align: center;
   border-radius: var(--radius);
   overflow-x: auto;
   min-height: 40px;
 }
-.msg-assistant .mermaid-container svg { max-width: 100%; height: auto; }
-.msg-assistant .mermaid-loading {
+.ts-msg--assistant .mermaid-container svg { max-width: 100%; height: auto; }
+.ts-msg--assistant .mermaid-loading {
   padding: 16px;
   color: var(--fg-dim);
   font-size: 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
 }
-.msg-assistant .mermaid-error { text-align: left; }
-.msg-assistant .mermaid-error-msg {
+.ts-msg--assistant .mermaid-error { text-align: left; }
+.ts-msg--assistant .mermaid-error-msg {
   padding: 8px 12px;
   color: var(--red);
   font-size: 12px;
@@ -627,28 +624,28 @@ body { position: static; }
   border-bottom: 1px solid var(--border);
 }
 @media (prefers-reduced-motion: reduce) {
-  .msg-assistant .mermaid-container svg * { animation: none !important; }
+  .ts-msg--assistant .mermaid-container svg * { animation: none !important; }
 }
 
 /* Safe HTML elements */
-.msg-assistant details {
+.ts-msg--assistant details {
   margin: 8px 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-surface);
   overflow: hidden;
 }
-.msg-assistant details summary {
+.ts-msg--assistant details summary {
   padding: 8px 12px;
   cursor: pointer;
   font-weight: 600;
   color: var(--fg-bright);
   user-select: none;
 }
-.msg-assistant details summary:hover { color: var(--accent); }
-.msg-assistant details[open] > summary { border-bottom: 1px solid var(--border); }
-.msg-assistant details > :not(summary) { padding: 0 12px; }
-.msg-assistant kbd {
+.ts-msg--assistant details summary:hover { color: var(--accent); }
+.ts-msg--assistant details[open] > summary { border-bottom: 1px solid var(--border); }
+.ts-msg--assistant details > :not(summary) { padding: 0 12px; }
+.ts-msg--assistant kbd {
   background: var(--bg-highlight);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -657,17 +654,17 @@ body { position: static; }
   font-family: var(--font-mono);
   box-shadow: 0 1px 0 var(--border-strong);
 }
-.msg-assistant mark { background: var(--yellow-glow); color: var(--fg-bright); border-radius: 2px; padding: 0 2px; }
+.ts-msg--assistant mark { background: var(--yellow-glow); color: var(--fg-bright); border-radius: 2px; padding: 0 2px; }
 
 /* GFM Callouts / Alerts */
-.msg-assistant .callout {
+.ts-msg--assistant .callout {
   border-left: 3px solid var(--border-strong);
   border-radius: var(--radius);
   background: var(--bg-surface);
   margin: 8px 0;
   overflow: hidden;
 }
-.msg-assistant .callout-title {
+.ts-msg--assistant .callout-title {
   padding: 8px 12px 4px;
   font-weight: 600;
   font-size: 13px;
@@ -675,56 +672,56 @@ body { position: static; }
   align-items: center;
   gap: 6px;
 }
-.msg-assistant .callout-icon { font-size: 14px; }
-.msg-assistant .callout-body { padding: 0 12px 8px; color: var(--fg); }
-.msg-assistant .callout-body p:first-child { margin-top: 0; }
-.msg-assistant .callout-body p:last-child { margin-bottom: 0; }
-.msg-assistant .callout-note { border-left-color: var(--cyan); }
-.msg-assistant .callout-note .callout-title { color: var(--cyan); }
-.msg-assistant .callout-tip { border-left-color: var(--green); }
-.msg-assistant .callout-tip .callout-title { color: var(--green); }
-.msg-assistant .callout-important { border-left-color: var(--magenta); }
-.msg-assistant .callout-important .callout-title { color: var(--magenta); }
-.msg-assistant .callout-warning { border-left-color: var(--yellow); }
-.msg-assistant .callout-warning .callout-title { color: var(--yellow); }
-.msg-assistant .callout-caution { border-left-color: var(--red); }
-.msg-assistant .callout-caution .callout-title { color: var(--red); }
+.ts-msg--assistant .callout-icon { font-size: 14px; }
+.ts-msg--assistant .callout-body { padding: 0 12px 8px; color: var(--fg); }
+.ts-msg--assistant .callout-body p:first-child { margin-top: 0; }
+.ts-msg--assistant .callout-body p:last-child { margin-bottom: 0; }
+.ts-msg--assistant .callout-note { border-left-color: var(--cyan); }
+.ts-msg--assistant .callout-note .callout-title { color: var(--cyan); }
+.ts-msg--assistant .callout-tip { border-left-color: var(--green); }
+.ts-msg--assistant .callout-tip .callout-title { color: var(--green); }
+.ts-msg--assistant .callout-important { border-left-color: var(--magenta); }
+.ts-msg--assistant .callout-important .callout-title { color: var(--magenta); }
+.ts-msg--assistant .callout-warning { border-left-color: var(--yellow); }
+.ts-msg--assistant .callout-warning .callout-title { color: var(--yellow); }
+.ts-msg--assistant .callout-caution { border-left-color: var(--red); }
+.ts-msg--assistant .callout-caution .callout-title { color: var(--red); }
 
 /* Definition lists */
-.msg-assistant dl { margin: 8px 0; }
-.msg-assistant dt {
+.ts-msg--assistant dl { margin: 8px 0; }
+.ts-msg--assistant dt {
   font-weight: 600;
   color: var(--fg-bright);
   margin-top: 8px;
 }
-.msg-assistant dt:first-child { margin-top: 0; }
-.msg-assistant dd {
+.ts-msg--assistant dt:first-child { margin-top: 0; }
+.ts-msg--assistant dd {
   margin: 2px 0 0 20px;
   padding-left: 12px;
   border-left: 2px solid var(--border-strong);
 }
 
 /* Footnotes */
-.msg-assistant .footnotes { margin-top: 16px; font-size: 12px; color: var(--fg-dim); }
-.msg-assistant .footnotes-sep { border: none; border-top: 1px solid var(--border); margin-bottom: 8px; }
-.msg-assistant .footnotes-list { margin: 0 0 0 20px; padding: 0; }
-.msg-assistant .footnote-item { margin: 4px 0; line-height: 1.5; }
-.msg-assistant .fn-ref a {
+.ts-msg--assistant .footnotes { margin-top: 16px; font-size: 12px; color: var(--fg-dim); }
+.ts-msg--assistant .footnotes-sep { border: none; border-top: 1px solid var(--border); margin-bottom: 8px; }
+.ts-msg--assistant .footnotes-list { margin: 0 0 0 20px; padding: 0; }
+.ts-msg--assistant .footnote-item { margin: 4px 0; line-height: 1.5; }
+.ts-msg--assistant .fn-ref a {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   font-weight: 600;
 }
-.msg-assistant .fn-ref a:hover { text-decoration: underline; }
-.msg-assistant .fn-backref {
+.ts-msg--assistant .fn-ref a:hover { text-decoration: underline; }
+.ts-msg--assistant .fn-backref {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   margin-left: 4px;
 }
-.msg-assistant .fn-backref:hover { text-decoration: underline; }
-.msg-assistant .fn-ref a:focus-visible,
-.msg-assistant .fn-backref:focus-visible {
+.ts-msg--assistant .fn-backref:hover { text-decoration: underline; }
+.ts-msg--assistant .fn-ref a:focus-visible,
+.ts-msg--assistant .fn-backref:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
   border-radius: 2px;
@@ -733,7 +730,7 @@ body { position: static; }
 /* ==========================================================================
    Message action toolbar (hover controls for retry / edit / rewind)
    ========================================================================== */
-.msg-user, .msg-assistant { position: relative; }
+.ts-msg--user, .ts-msg--assistant { position: relative; }
 .msg-actions {
   position: absolute;
   top: 4px;
@@ -749,10 +746,10 @@ body { position: static; }
   overflow: hidden;
   z-index: 2;
 }
-.msg-user:hover .msg-actions,
-.msg-assistant:hover .msg-actions,
-.msg-user:focus-within .msg-actions,
-.msg-assistant:focus-within .msg-actions,
+.ts-msg--user:hover .msg-actions,
+.ts-msg--assistant:hover .msg-actions,
+.ts-msg--user:focus-within .msg-actions,
+.ts-msg--assistant:focus-within .msg-actions,
 .msg-actions:hover { opacity: 1; pointer-events: auto; }
 .msg-action-btn {
   display: flex;
@@ -925,13 +922,13 @@ body { position: static; }
 [data-theme="light"] .pane-stop { color: #fff; }
 
 /* Attachment chips — pill cluster above the textarea */
-.pane-attach-chips {
+.ts-composer-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
-.pane-attach-chips:empty { display: none; }
-.pane-attach-chip {
+.ts-composer-chips:empty { display: none; }
+.ts-composer-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -944,15 +941,15 @@ body { position: static; }
   font-size: 11px;
   max-width: 280px;
 }
-.pane-attach-chip-icon { font-size: 12px; opacity: 0.7; }
-.pane-attach-chip-name {
+.ts-composer-chip-icon { font-size: 12px; opacity: 0.7; }
+.ts-composer-chip-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 180px;
 }
-.pane-attach-chip-size { color: var(--fg-dim, var(--fg)); opacity: 0.65; font-size: 10px; }
-.pane-attach-chip-remove {
+.ts-composer-chip-size { color: var(--fg-dim, var(--fg)); opacity: 0.65; font-size: 10px; }
+.ts-composer-chip-remove {
   background: transparent;
   color: var(--fg-dim, var(--fg));
   border: none;
@@ -962,8 +959,8 @@ body { position: static; }
   cursor: pointer;
   border-radius: 50%;
 }
-.pane-attach-chip-remove:hover { color: var(--red, #c94040); background: var(--bg-surface); }
-.pane-attach-chip-remove:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ts-composer-chip-remove:hover { color: var(--red, #c94040); background: var(--bg-surface); }
+.ts-composer-chip-remove:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
 /* New-workstream modal: attachment row + chips */
 #new-ws-attach-row {
@@ -1142,7 +1139,7 @@ body { position: static; }
 /* ==========================================================================
    Inline approval blocks
    ========================================================================== */
-.approval-block {
+.ts-approval {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-left: 3px solid var(--yellow);
@@ -1152,25 +1149,29 @@ body { position: static; }
   max-width: 95%;
   font-size: 12px;
 }
-.approval-block.approved { border-left-color: var(--green); }
-.approval-block.error { border-left-color: var(--red); }
-.approval-block.denied { border-left-color: var(--red); }
-.approval-block.denied .approval-tool { opacity: 0.55; }
-.approval-block.denied .approval-tool .tool-name { color: var(--muted); }
+.ts-approval.approved { border-left-color: var(--green); }
+.ts-approval.error { border-left-color: var(--red); }
+.ts-approval.denied { border-left-color: var(--red); }
+.ts-approval.denied .ts-approval-tool { opacity: 0.55; }
+.ts-approval.denied .ts-approval-tool .tool-name { color: var(--fg-dim); }
 /* .ts-approval (chat.css) stacks children with flex gap; the old
    border-bottom would dangle between rows now. */
-.approval-tool { padding: 8px 12px; }
-.approval-tool:last-of-type { border-bottom: none; }
-.approval-tool .tool-name { color: var(--yellow); font-weight: 600; font-size: 11px; margin-bottom: 3px; }
-.approval-tool .tool-cmd { color: var(--fg-bright); white-space: pre-wrap; word-break: break-all; max-height: 120px; overflow: hidden; }
-.approval-tool .tool-cmd .dollar { color: var(--green); }
-.approval-tool .tool-diff { white-space: pre-wrap; font-size: 12px; margin-top: 4px; }
-.approval-tool .tool-diff .diff-del { color: var(--red); }
-.approval-tool .tool-diff .diff-add { color: var(--green); }
-.approval-tool .tool-diff .diff-warn { color: var(--yellow); }
-.approval-prompt { padding: 8px 12px; font-size: 12px; border-top: 1px solid var(--border); background: var(--bg-highlight); }
-.approval-actions { display: flex; gap: 6px; margin-bottom: 6px; }
-.approval-btn {
+.ts-approval-tool { padding: 8px 12px; }
+.ts-approval-tool:last-of-type { border-bottom: none; }
+.ts-approval-tool .tool-name { color: var(--yellow); font-weight: 600; font-size: 11px; margin-bottom: 3px; }
+.ts-approval-tool .tool-cmd { color: var(--fg-bright); white-space: pre-wrap; word-break: break-all; max-height: 120px; overflow: hidden; }
+.ts-approval-tool .tool-cmd .dollar { color: var(--green); }
+.ts-approval-tool .tool-diff { white-space: pre-wrap; font-size: 12px; margin-top: 4px; }
+.ts-approval-tool .tool-diff .diff-del { color: var(--red); }
+.ts-approval-tool .tool-diff .diff-add { color: var(--green); }
+.ts-approval-tool .tool-diff .diff-warn { color: var(--yellow); }
+/* .ts-approval (chat.css) stacks its children with flex gap, so a
+   border-top on the body would float above a strip of container
+   background instead of sitting flush against the previous tool row.
+   Rely on the gap as the separator. */
+.ts-approval-body { padding: 8px 12px; font-size: 12px; background: var(--bg-highlight); }
+.ts-approval-actions { display: flex; gap: 6px; margin-bottom: 6px; }
+.ts-approval-btn {
   background: var(--bg);
   border: 1px solid var(--border-strong);
   color: var(--fg-bright);
@@ -1184,8 +1185,8 @@ body { position: static; }
   gap: 4px;
   transition: background 0.1s, border-color 0.1s, color 0.1s;
 }
-.approval-btn:hover { background: var(--bg-highlight); }
-.approval-btn .key {
+.ts-approval-btn:hover { background: var(--bg-highlight); }
+.ts-approval-btn .key {
   display: inline-block;
   background: var(--bg-surface);
   border: 1px solid var(--border-strong);
@@ -1197,11 +1198,11 @@ body { position: static; }
   min-width: 18px;
   text-align: center;
 }
-.btn-approve:hover { border-color: var(--green); color: var(--green); }
-.btn-deny:hover { border-color: var(--red); color: var(--red); }
-.btn-always { border-style: dashed; }
-.btn-always:hover { border-color: var(--accent); color: var(--accent); }
-.approval-feedback-input {
+/* Approve / deny / always button hover + dashed styles are provided
+   by chat.css .ts-approval-btn--approve / --deny / --always; the
+   legacy .btn-approve / .btn-deny / .btn-always classes are gone
+   from app.js, so no local overrides needed here. */
+.ts-approval-feedback {
   width: 100%;
   background: var(--bg);
   color: var(--fg);
@@ -1213,12 +1214,14 @@ body { position: static; }
   outline: none;
   transition: border-color 0.15s;
 }
-.approval-feedback-input:focus { border-color: var(--accent); }
-.approval-feedback-input::placeholder { color: var(--fg-dim); }
-.approval-badge { padding: 6px 12px; font-size: 12px; font-weight: 600; border-top: 1px solid var(--border); overflow-wrap: break-word; word-break: break-word; }
-.approval-badge.badge-approved { color: var(--green); }
-.approval-badge.badge-error { color: var(--red); }
-.approval-badge.badge-denied { color: var(--red); }
+.ts-approval-feedback:focus { border-color: var(--accent); }
+.ts-approval-feedback::placeholder { color: var(--fg-dim); }
+/* chat.css shrinks .ts-approval-badge to max-content width, so a
+   border-top would only span the text and read as a truncated line
+   (same rationale as .verdict-badge).  Colour variants come from
+   chat.css .ts-approval-badge--approved / --denied / --error — the
+   legacy .badge-* modifiers are no longer emitted. */
+.ts-approval-badge { padding: 6px 12px; font-size: 12px; font-weight: 600; overflow-wrap: break-word; word-break: break-word; }
 .tool-output {
   padding: 8px 12px;
   background: var(--code-bg);
@@ -1530,8 +1533,10 @@ audio.media-player {
 /* ==========================================================================
    Focus indicators — server-specific overrides
    ========================================================================== */
-.pane-input:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
-.approval-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+/* Slightly thicker ring than chat.css (2px → 3px) — the interactive
+   pane sits over denser pane-bottom chrome, so the ring needs more
+   visual weight to pop. */
+.ts-composer-input:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
 
 /* ==========================================================================
    Empty state
@@ -2030,17 +2035,19 @@ audio.media-player {
   50% { opacity: 1; }
 }
 
-/* Verdict glow on approval action buttons */
-.approval-prompt.verdict-glow-approve .btn-approve {
+/* Verdict glow on approval action buttons — amplifies chat.css's
+   base .ts-verdict-glow--* rules with a stronger shadow + border
+   tint on the interactive-server page. */
+.ts-approval-body.ts-verdict-glow--approve .ts-approval-btn--approve {
   box-shadow: 0 0 8px var(--green-glow);
   border-color: var(--green);
 }
-.approval-prompt.verdict-glow-deny .btn-deny {
+.ts-approval-body.ts-verdict-glow--deny .ts-approval-btn--deny {
   box-shadow: 0 0 8px var(--red-glow);
   border-color: var(--red);
 }
-.approval-prompt.verdict-glow-review .btn-approve,
-.approval-prompt.verdict-glow-review .btn-deny {
+.ts-approval-body.ts-verdict-glow--review .ts-approval-btn--approve,
+.ts-approval-body.ts-verdict-glow--review .ts-approval-btn--deny {
   box-shadow: 0 0 6px var(--yellow-glow);
   border-color: var(--yellow);
 }
@@ -2200,12 +2207,12 @@ audio.media-player {
   .thinking-indicator::after { animation: none; content: '...'; }
   .ws-tab, .ws-tab .tab-chevron, #new-tab-btn, #split-btn,
   .dashboard-card,
-  .approval-btn, .approval-feedback-input,
-  #plan-buttons button, .pane-input-area button,
+  .ts-approval-btn, .ts-approval-feedback,
+  #plan-buttons button, .ts-composer button,
   .dashboard-new-btn, .dashboard-input,
   #health-indicator, #theme-toggle,
-  #mcp-status, .msg-assistant tbody tr,
-  .msg-assistant .img-placeholder,
+  #mcp-status, .ts-msg--assistant tbody tr,
+  .ts-msg--assistant .img-placeholder,
   .media-play-btn,
   #new-ws-cancel, #new-ws-submit,
   #new-ws-box input, #new-ws-box select,


### PR DESCRIPTION
## Summary

Phase 6 — the opportunistic polish + tech-debt pass on coordinator workstreams.  Tier A + B observability items from `/home/ptrck/.claude/plans/phase6-coordinator-polish.md` plus the tier-C frontend consolidation, folded into a single commit after review iteration.

### Observability

- **Wait dashboard** — `wait_started` / `wait_progress` / `wait_ended` SSE events via new `progress_callback` on `CoordinatorClient.wait_for_workstream`; coordinator.js renders a `⧗ waiting · N ws · Ts` header indicator keyed by `call_id`.  Throttled emission (snap-diff + 5s heartbeat) so a 600s wait doesn't flood listener queues.
- **`cancel_workstream` forensics** — server-side captures `_pending_approval` tool names + queued-message count/preview before invoking `session.cancel`; preview runs through `redact_credentials` + 120-char cap so secrets / connection strings don't land in conversation history.
- **Per-coordinator metrics** — `GET /v1/api/coordinator/{ws_id}/metrics` returning spawns / state-counts / judge_fallback_rate derived from new `storage.count_workstreams_by_state` + `count_workstreams_since` aggregate helpers.
- **`wait_for_workstream(since=…)`** — diff-hint that exits on any change relative to a prior snapshot; ws_ids absent from the hint fall through to normal mode-handling so a disjoint since-dict doesn't silent-pass on tick one.
- **Coordinator skill in inspect** — resolves `skill` → `template_id` / `applied_version` via `get_skill_by_name` + new `storage.count_skill_versions` (replacing the SELECT-all-for-COUNT on the hot-path).  `/new` handler dispatches via `asyncio.to_thread`.
- **`task_list.child_ws_id` cleanup** — `CoordinatorClient.cleanup_dead_task_child_refs(ws_id)` holds the per-ws task lock so a close racing a mutation can't lose writes; save-failure logs at `warning`.

### Home view live-updates

- **Active-coordinators via SSE** — `ClusterCollector.ensure_console_pseudo_node` + `emit_console_ws_created / _closed / _state / _rename` plumbing; `CoordinatorManager.create / open / close / eviction` + `ConsoleCoordinatorUI.on_state_change / on_rename` fan out through the collector.  Pseudo-node exempt from discovery-loop eviction; 5s poller + back-compat shims deleted (9 call sites).  Tenant-filtering preserved by excluding the pseudo-node from `collector.get_workstreams`.

### Frontend perf

- **Bulk cluster-ws live endpoint** — `GET /v1/api/cluster/ws/live?ids=` (cap 50, returns `{results, denied, truncated}`).  coordinator.js batches visible-row live-badge fetches into one bulk request per ~250ms window.

### Legacy chat-view class cleanup (dual-class drop)

- Dropped `.msg-*` / `.approval-*` / `.pane-*` / `.coord-msg` / `.coord-body` / `role-*` / `btn-approve|deny|always` / `verdict-glow-*` legacy dual-class names from JS className concatenations + querySelectors + CSS selectors.  Feature-specific classes (msg-queued, msg-editing, msg-user-attach*, tool-header, tool-preview, etc.) stay.

### Designer nits

- `.ui-btn--icon:focus-visible` — matches `.ui-btn`'s accent ring for the compact variant.
- Dropped `border-top` from `.ts-approval-badge` + `.ts-approval-body` (flex-gap / max-content width made them read as truncated / floating separators).
- `var(--muted)` → `var(--fg-dim)` on denied tool names (undefined token was silently failing).
- Dropped 3 dead `.ts-approval-badge.badge-*` rules + duplicated `.ts-approval-btn:focus-visible` + dead `.reasoning` CSS rule + `contains("reasoning")` JS guard + four dead legacy classes in coordinator (tool-row, approval-header, btn-row, label).
- Added `:focus-visible` to `.ch-row a.ws-link` + `.task-row` so keyboard users get the accent ring on sidebar rows.

### Cleanups

- `_WAIT_*` constants hoisted to module level (coordinator_client.py); ClassVar aliases kept for back-compat.
- `ConsoleCoordinatorUI` observers typed as `Callable[[str], None] | None` instead of `Any`.

## Tests

- 26 new test cases — 11 for `_diff_since` + `cleanup_dead_task_child_refs`, 15 for `cluster_ws_live_bulk` + `coordinator_metrics`.

## Test plan

- [x] `ruff check turnstone tests` — clean
- [x] `mypy turnstone` — clean
- [x] `pytest -m "not live"` — 4345 passed (+26 new)
- [x] Manual: spin up console + verify active-coordinators list updates live without the 5s poller (no `/v1/api/cluster/workstreams?node=console` traffic in DevTools)
- [x] Manual: verify bulk `/v1/api/cluster/ws/live?ids=` replaces per-row `/detail` fetches on coordinator page
- [x] Manual: cancel a coordinator child and verify the returned tool result includes a `dropped` forensic dict
- [x] Manual: visual-check the ts-* class migration at 340 / 700 / 1024 / 1440px viewports on both the interactive chat and the coordinator page
- [x] Manual: verify the Phase-5 Item-10 worker-error SSE surface renders correctly (deferred from this branch — static code-read confirmed the renderer handles `case "error"`)

## Notes

Squashed from two working commits (`af13aeb` polish + `7fe34ac` frontend cleanup) that iterated through `/review` + `/ultrareview` + `designer` subagent passes.  All review findings folded in before merge.