### PR TITLE
feat(coordinator): phase 8 PR A — spawn_batch + close_all_children batch tools

### DIFF
--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -7096,7 +7096,8 @@
         "properties": {
           "reason": {
             "default": "",
-            "description": "Optional human-readable reason \u2014 propagated to every closed child's audit + workstream_config for postmortem.  Capped at 512 chars.",
+            "description": "Optional human-readable reason \u2014 propagated to every closed child's audit + workstream_config for postmortem.  Capped at 512 chars; the handler returns 400 on overflow.",
+            "maxLength": 512,
             "title": "Reason",
             "type": "string"
           }

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "turnstone Console API",
-    "version": "1.5.0a1",
+    "version": "1.5.0a2",
     "description": "Cluster-wide visibility and control across all turnstone nodes."
   },
   "paths": {
@@ -5650,6 +5650,88 @@
         }
       }
     },
+    "/v1/api/coordinator/{ws_id}/close_all_children": {
+      "post": {
+        "summary": "Soft-close every direct child of the coordinator",
+        "operationId": "v1_api_coordinator_{ws_id}_close_all_children_post",
+        "tags": [
+          "Coordinator"
+        ],
+        "description": "Reads the in-memory child registry and dispatches ``close_workstream`` via the routing proxy for every direct child under a bounded (16-concurrency) semaphore.  Unlike ``stop_cascade`` this does not touch grandchildren \u2014 the model-facing tool asks for a bounded teardown of its own fan-out.  Returns ``{closed, failed, skipped}`` where ``skipped`` distinguishes already-gone (404) from dispatch-broken (``failed``).  The optional ``reason`` propagates to every closed child's audit + workstream_config.  Writes ``coordinator.closed_all_children`` at the coord level.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CoordinatorCloseAllChildrenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinatorCloseAllChildrenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/api/cluster/ws/{ws_id}/detail": {
       "get": {
         "summary": "Cluster-wide live workstream detail (storage + live block + tail)",
@@ -7007,6 +7089,55 @@
           }
         },
         "title": "CoordinatorChildrenResponse",
+        "type": "object"
+      },
+      "CoordinatorCloseAllChildrenRequest": {
+        "description": "Body for POST /v1/api/coordinator/{ws_id}/close_all_children.",
+        "properties": {
+          "reason": {
+            "default": "",
+            "description": "Optional human-readable reason \u2014 propagated to every closed child's audit + workstream_config for postmortem.  Capped at 512 chars.",
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "title": "CoordinatorCloseAllChildrenRequest",
+        "type": "object"
+      },
+      "CoordinatorCloseAllChildrenResponse": {
+        "description": "Response body for POST /v1/api/coordinator/{ws_id}/close_all_children.",
+        "properties": {
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "closed": {
+            "description": "Child ws_ids that accepted the close dispatch.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Closed",
+            "type": "array"
+          },
+          "failed": {
+            "description": "Child ws_ids whose close dispatch returned an error other than an already-gone 404 \u2014 the cascade continues on per-child failure so a single unreachable node doesn't abort the whole batch.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Failed",
+            "type": "array"
+          },
+          "skipped": {
+            "description": "Child ws_ids that returned 404 on close (already gone).  Reported separately from ``failed`` so operators can distinguish already-done from dispatch-broken.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Skipped",
+            "type": "array"
+          }
+        },
+        "title": "CoordinatorCloseAllChildrenResponse",
         "type": "object"
       },
       "CoordinatorCreateRequest": {

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "turnstone Server API",
-    "version": "1.5.0a1",
+    "version": "1.5.0a2",
     "description": "Single-node workstream management, chat interaction, and real-time streaming."
   },
   "paths": {

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -176,6 +176,9 @@ def test_route_map_matches_console_routes():
     assert _ROUTE_PATHS["cancel"] == "/v1/api/route/cancel"
     assert _ROUTE_PATHS["close"] == "/v1/api/route/workstreams/close"
     assert _ROUTE_PATHS["delete"] == "/v1/api/route/workstreams/delete"
+    # Cascade endpoint lives on the console itself (not a node), so the
+    # path slots in the coord ws_id rather than routing through a proxy.
+    assert _ROUTE_PATHS["close_all_children"] == "/v1/api/coordinator/{ws_id}/close_all_children"
 
 
 def test_spawn_posts_to_routing_proxy_with_bearer_token():
@@ -235,6 +238,57 @@ def test_close_workstream_includes_reason_when_provided():
     client.close_workstream("ws-x", reason="done")
     body = json.loads(captured[0].content)
     assert body == {"ws_id": "ws-x", "reason": "done"}
+
+
+def test_close_all_children_posts_to_console_endpoint():
+    """Targets the console directly (not the routing proxy).  The URL
+    embeds the coord's own ws_id so the server can resolve the session.
+    """
+    client, captured = _mock_client(
+        _ok_json(
+            {
+                "status": "ok",
+                "closed": ["c-1", "c-2"],
+                "failed": [],
+                "skipped": [],
+            }
+        )
+    )
+    result = client.close_all_children(reason="batch done")
+    assert result["closed"] == ["c-1", "c-2"]
+    assert captured[0].url.path == "/v1/api/coordinator/coord-1/close_all_children"
+    assert captured[0].headers["Authorization"] == "Bearer test-token"
+    body = json.loads(captured[0].content)
+    assert body == {"reason": "batch done"}
+
+
+def test_close_all_children_omits_empty_reason():
+    client, captured = _mock_client(
+        _ok_json({"status": "ok", "closed": [], "failed": [], "skipped": []})
+    )
+    client.close_all_children()
+    body = json.loads(captured[0].content)
+    assert body == {}
+
+
+def test_close_all_children_surfaces_http_error():
+    def _boom(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "internal"})
+
+    client, _captured = _mock_client(_boom)
+    result = client.close_all_children()
+    assert result["status"] == 500
+    assert "error" in result
+
+
+def test_close_all_children_surfaces_transport_error():
+    def _raise(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    client, _captured = _mock_client(_raise)
+    result = client.close_all_children()
+    assert result["status"] == 0
+    assert "upstream unreachable" in result["error"]
 
 
 def test_delete_workstream_posts_to_delete_route():

--- a/tests/test_coordinator_close_all_children.py
+++ b/tests/test_coordinator_close_all_children.py
@@ -1,0 +1,234 @@
+"""Tests for the coordinator ``close_all_children`` endpoint.
+
+Near-twin of the ``stop_cascade`` tests in
+``test_coordinator_governance.py``.  Keeps the close-cascade surface in
+its own file so PR A's review surface stays tight.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tests._coord_test_helpers import (
+    _AuthMiddleware,
+    _build_mgr,
+    _fake_registry,
+    _FakeConfigStore,
+)
+from turnstone.console.server import coordinator_close_all_children
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SQLiteBackend(str(tmp_path / "coord.db"))
+
+
+_COORD_HEADERS = {"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"}
+
+
+def _make_client(storage, *, coord_mgr, alias="my-model", registry=None) -> TestClient:
+    app = Starlette(
+        routes=[
+            Route(
+                "/v1/api/coordinator/{ws_id}/close_all_children",
+                coordinator_close_all_children,
+                methods=["POST"],
+            ),
+        ],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.coord_mgr = coord_mgr
+    app.state.config_store = _FakeConfigStore({"coordinator.model_alias": alias})
+    app.state.coord_registry = registry
+    app.state.coord_registry_error = "" if coord_mgr else "registry missing"
+    app.state.auth_storage = storage
+    app.state.jwt_secret = "x" * 64
+    return TestClient(app)
+
+
+def test_close_all_children_closes_each_child_and_audits(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    mgr.register_children(coord.id, ["child-1", "child-2", "child-3"])
+
+    def _close(wid, reason):
+        if wid == "child-2":
+            return {"error": "gateway_timeout", "status": 502}
+        return {"status": "ok"}
+
+    coord_client = MagicMock()
+    coord_client.close_workstream.side_effect = _close
+    coord.session = MagicMock()
+    coord.session._coord_client = coord_client
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={"reason": "tests done"},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["closed"] + body["failed"] + body["skipped"]) == {
+        "child-1",
+        "child-2",
+        "child-3",
+    }
+    assert body["failed"] == ["child-2"]
+    assert set(body["closed"]) == {"child-1", "child-3"}
+    assert body["skipped"] == []
+    assert coord_client.close_workstream.call_count == 3
+    # Reason must propagate to each per-child close call.
+    for call in coord_client.close_workstream.call_args_list:
+        assert call.args[1] == "tests done"
+
+    events = [
+        e for e in storage.list_audit_events() if e["action"] == "coordinator.closed_all_children"
+    ]
+    assert len(events) == 1
+    detail = json.loads(events[0]["detail"])
+    assert detail["reason"] == "tests done"
+    assert set(detail["closed"] + detail["failed"] + detail["skipped"]) == {
+        "child-1",
+        "child-2",
+        "child-3",
+    }
+
+
+def test_close_all_children_routes_404_to_skipped_bucket(storage):
+    """An upstream 404 (child row already deleted, stale registry entry)
+    is 'already gone', not a dispatch failure.  Route to skipped."""
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    mgr.register_children(coord.id, ["stale-child"])
+
+    coord_client = MagicMock()
+    coord_client.close_workstream.return_value = {
+        "error": "workstream not in coordinator subtree: stale-child",
+        "status": 404,
+    }
+    coord.session = MagicMock()
+    coord.session._coord_client = coord_client
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["closed"] == []
+    assert body["failed"] == []
+    assert body["skipped"] == ["stale-child"]
+
+
+def test_close_all_children_empty_children_still_audits(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = MagicMock()
+    coord.session._coord_client = MagicMock()
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"status": "ok", "closed": [], "failed": [], "skipped": []}
+    assert [
+        e for e in storage.list_audit_events() if e["action"] == "coordinator.closed_all_children"
+    ]
+
+
+def test_close_all_children_without_coord_client_marks_all_failed(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    mgr.register_children(coord.id, ["child-a", "child-b"])
+    coord.session = MagicMock()
+    coord.session._coord_client = None
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["closed"] == []
+    assert body["skipped"] == []
+    assert set(body["failed"]) == {"child-a", "child-b"}
+
+
+def test_close_all_children_rejects_non_string_reason(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = MagicMock()
+    coord.session._coord_client = MagicMock()
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={"reason": 123},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 400
+
+
+def test_close_all_children_rejects_overlong_reason(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = MagicMock()
+    coord.session._coord_client = MagicMock()
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={"reason": "x" * 600},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 400
+
+
+def test_close_all_children_404_when_session_not_loaded(storage):
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = None
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_close_all_children_service_token_cannot_bypass_admin_coordinator(storage):
+    """Destructive endpoint — a service token matching the coord owner
+    still needs the explicit ``admin.coordinator`` grant.  Mirrors the
+    stop_cascade treatment."""
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = MagicMock()
+    coord.session._coord_client = MagicMock()
+
+    # Service token without admin.coordinator should be rejected.
+    headers = {"X-Test-User": "user-1", "X-Test-Perms": ""}
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code in (401, 403)

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -119,6 +119,8 @@ def test_coordinator_session_uses_coordinator_tools(coord_session):
     names = {t["function"]["name"] for t in sess._tools}
     assert names == {
         "spawn_workstream",
+        "spawn_batch",
+        "close_all_children",
         "inspect_workstream",
         "send_to_workstream",
         "close_workstream",
@@ -988,3 +990,267 @@ def test_inspect_workstream_include_provider_content_opt_in(coord_session):
     sess._exec_inspect_workstream(item)
     kwargs = coord.inspect.call_args.kwargs
     assert kwargs.get("include_provider_content") is True
+
+
+# ---------------------------------------------------------------------------
+# spawn_batch
+# ---------------------------------------------------------------------------
+
+
+def _three_children() -> list[dict[str, Any]]:
+    return [
+        {"initial_message": "benchmark A", "skill": "researcher"},
+        {"initial_message": "benchmark B", "skill": "researcher", "target_node": "n-1"},
+        {"initial_message": "", "name": "idle-child"},
+    ]
+
+
+def test_spawn_batch_prepare_rejects_non_list(coord_session):
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": "not-a-list"}))
+    assert "error" in item
+    assert "non-empty list" in item["error"]
+
+
+def test_spawn_batch_prepare_rejects_empty_list(coord_session):
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": []}))
+    assert "error" in item
+
+
+def test_spawn_batch_prepare_rejects_over_cap(coord_session):
+    sess, _coord, _ui = coord_session
+    too_many = [{"initial_message": f"msg-{i}"} for i in range(11)]
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": too_many}))
+    assert "error" in item
+    assert "cap" in item["error"].lower()
+
+
+def test_spawn_batch_prepare_builds_approval_card(coord_session):
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": _three_children()}))
+    assert "error" not in item
+    assert item["needs_approval"] is True
+    assert item["func_name"] == "spawn_batch"
+    assert "3 children" in item["header"]
+    # Each row shows up in the preview (dim-wrapped).
+    for idx in (0, 1, 2):
+        assert f"{idx}." in item["preview"]
+    assert "skill=researcher" in item["preview"]
+    assert "node=n-1" in item["preview"]
+    # Idle row renders as "(idle)".
+    assert "(idle)" in item["preview"]
+
+
+def test_spawn_batch_exec_serialises_spawns_and_returns_results(coord_session):
+    sess, coord, _ui = coord_session
+    spawned: list[dict[str, Any]] = []
+
+    def _spawn(**kwargs):
+        n = len(spawned)
+        ws = {
+            "ws_id": f"child-{n}",
+            "name": kwargs.get("name") or f"auto-{n}",
+            "node_id": kwargs.get("target_node") or "node-auto",
+            "status": 200,
+        }
+        spawned.append(kwargs)
+        return ws
+
+    coord.spawn.side_effect = _spawn
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": _three_children()}))
+    _call_id, output = sess._exec_spawn_batch(item)
+
+    # Three serial spawn() calls, in input order.
+    assert len(spawned) == 3
+    assert [s["initial_message"] for s in spawned] == ["benchmark A", "benchmark B", ""]
+    assert spawned[0]["skill"] == "researcher"
+    assert spawned[1]["target_node"] == "n-1"
+    assert spawned[2]["name"] == "idle-child"
+
+    body = json.loads(output)
+    assert "truncated" not in body  # prepare hard-errors >10, no truncate state
+    assert body["denied"] == []
+    # Keyed by input index (stringified).
+    assert set(body["results"].keys()) == {"0", "1", "2"}
+    assert body["results"]["0"]["ws_id"] == "child-0"
+    assert body["results"]["1"]["node_id"] == "n-1"
+    assert body["results"]["2"]["ws_id"] == "child-2"
+
+
+def test_spawn_batch_exec_surfaces_per_item_errors_in_denied(coord_session):
+    sess, coord, _ui = coord_session
+
+    counter = {"n": 0}
+
+    def _spawn(**kwargs):
+        msg = kwargs.get("initial_message", "")
+        if msg == "benchmark B":
+            return {"error": "skill not found: researcher", "status": 400}
+        counter["n"] += 1
+        return {
+            "ws_id": f"child-{counter['n']}",
+            "name": "n",
+            "node_id": "node-auto",
+            "status": 200,
+        }
+
+    coord.spawn.side_effect = _spawn
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": _three_children()}))
+    _call_id, output = sess._exec_spawn_batch(item)
+    body = json.loads(output)
+    assert set(body["results"].keys()) == {"0", "2"}
+    assert len(body["denied"]) == 1
+    assert body["denied"][0]["idx"] == 1
+    assert "skill not found" in body["denied"][0]["reason"]
+
+
+def test_spawn_batch_exec_continues_past_client_exception(coord_session):
+    sess, coord, _ui = coord_session
+
+    def _spawn(**kwargs):
+        if kwargs.get("initial_message") == "benchmark A":
+            raise RuntimeError("transient network error")
+        return {
+            "ws_id": "ok",
+            "name": "n",
+            "node_id": "node",
+            "status": 200,
+        }
+
+    coord.spawn.side_effect = _spawn
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": _three_children()}))
+    _call_id, output = sess._exec_spawn_batch(item)
+    body = json.loads(output)
+    # First item raised; other two succeed — partial-success semantics.
+    assert "0" not in body["results"]
+    assert "1" in body["results"] and "2" in body["results"]
+    assert any(d["idx"] == 0 and "transient network error" in d["reason"] for d in body["denied"])
+
+
+def test_spawn_batch_exec_emits_batch_started_and_ended(coord_session):
+    sess, coord, _ui = coord_session
+    events: list[dict[str, Any]] = []
+    # Attach a minimal _enqueue on the UI so _emit_batch_event fires.
+    sess.ui._enqueue = events.append  # type: ignore[attr-defined]
+    coord.spawn.return_value = {
+        "ws_id": "c-x",
+        "name": "n",
+        "node_id": "node",
+        "status": 200,
+    }
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": [{"initial_message": "solo"}]}))
+    sess._exec_spawn_batch(item)
+    types = [e["type"] for e in events]
+    assert types[0] == "batch_started"
+    assert types[-1] == "batch_ended"
+    assert events[0]["op"] == "spawn_batch"
+    assert events[0]["total"] == 1
+    assert events[-1]["succeeded"] == 1
+    assert events[-1]["denied"] == 0
+
+
+# ---------------------------------------------------------------------------
+# close_all_children
+# ---------------------------------------------------------------------------
+
+
+def test_close_all_children_prepare_builds_approval_card(coord_session):
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(_tc("close_all_children", {"reason": "batch done"}))
+    assert "error" not in item
+    assert item["needs_approval"] is True
+    assert item["func_name"] == "close_all_children"
+    assert "batch done" in item["header"]
+    assert item["reason"] == "batch done"
+
+
+def test_close_all_children_prepare_accepts_empty_reason(coord_session):
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(_tc("close_all_children", {}))
+    assert "error" not in item
+    assert item["reason"] == ""
+
+
+def test_close_all_children_exec_posts_to_endpoint_and_summarises(coord_session):
+    sess, coord, _ui = coord_session
+    coord.close_all_children.return_value = {
+        "status": "ok",
+        "closed": ["c-1", "c-2"],
+        "failed": [],
+        "skipped": ["c-3"],
+    }
+    item = sess._prepare_tool(_tc("close_all_children", {"reason": "done"}))
+    _call_id, output = sess._exec_close_all_children(item)
+    coord.close_all_children.assert_called_once_with(reason="done")
+    body = json.loads(output)
+    assert body == {
+        "closed": ["c-1", "c-2"],
+        "failed": [],
+        "skipped": ["c-3"],
+        "reason": "done",
+    }
+
+
+def test_close_all_children_exec_surfaces_client_error(coord_session):
+    sess, coord, ui = coord_session
+    coord.close_all_children.return_value = {
+        "error": "upstream unreachable",
+        "status": 502,
+    }
+    item = sess._prepare_tool(_tc("close_all_children", {}))
+    _call_id, output = sess._exec_close_all_children(item)
+    assert "upstream unreachable" in output
+    assert ui.tool_results[-1][3] is True  # is_error=True
+
+
+def test_close_all_children_exec_surfaces_client_exception(coord_session):
+    sess, coord, ui = coord_session
+    coord.close_all_children.side_effect = RuntimeError("boom")
+    item = sess._prepare_tool(_tc("close_all_children", {}))
+    _call_id, output = sess._exec_close_all_children(item)
+    assert "boom" in output
+    assert ui.tool_results[-1][3] is True
+
+
+def test_close_all_children_exec_emits_batch_events(coord_session):
+    sess, coord, _ui = coord_session
+    events: list[dict[str, Any]] = []
+    sess.ui._enqueue = events.append  # type: ignore[attr-defined]
+    coord.close_all_children.return_value = {
+        "status": "ok",
+        "closed": ["c-1"],
+        "failed": [],
+        "skipped": [],
+    }
+    item = sess._prepare_tool(_tc("close_all_children", {"reason": "r"}))
+    sess._exec_close_all_children(item)
+    types = [e["type"] for e in events]
+    assert types[0] == "batch_started"
+    assert types[-1] == "batch_ended"
+    assert events[0]["op"] == "close_all_children"
+    assert events[-1]["closed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _coord_client=None guard — covers the first-line bail-out in both new
+# prepare methods.  The branch matters because a coord session hitting
+# this state signals a construction bug, and the LLM needs a clean tool
+# error (not a crashing tool-exec).
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_batch_prepare_errors_when_coord_client_unavailable(coord_session):
+    sess, _coord, _ui = coord_session
+    sess._coord_client = None
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": [{"initial_message": "hi"}]}))
+    assert "error" in item
+    assert "unavailable" in item["error"]
+
+
+def test_close_all_children_prepare_errors_when_coord_client_unavailable(coord_session):
+    sess, _coord, _ui = coord_session
+    sess._coord_client = None
+    item = sess._prepare_tool(_tc("close_all_children", {}))
+    assert "error" in item
+    assert "unavailable" in item["error"]

--- a/tests/test_tools_schema.py
+++ b/tests/test_tools_schema.py
@@ -72,8 +72,8 @@ class TestToolsMetadata:
     """Validate the metadata extracted from JSON files."""
 
     def test_tool_count(self):
-        # 19 interactive tools + 11 coordinator tools
-        assert len(TOOLS) == 30
+        # 19 interactive tools + 13 coordinator tools
+        assert len(TOOLS) == 32
 
     def test_agent_tools_count(self):
         assert len(AGENT_TOOLS) == 10
@@ -84,9 +84,11 @@ class TestToolsMetadata:
     def test_coordinator_tools_count(self):
         from turnstone.core.tools import COORDINATOR_TOOLS
 
-        assert len(COORDINATOR_TOOLS) == 11
+        assert len(COORDINATOR_TOOLS) == 13
         assert {t["function"]["name"] for t in COORDINATOR_TOOLS} == {
             "spawn_workstream",
+            "spawn_batch",
+            "close_all_children",
             "inspect_workstream",
             "send_to_workstream",
             "close_workstream",
@@ -142,6 +144,8 @@ class TestToolsMetadata:
             "diff_file": "path_a",
             # Coordinator tools:
             "spawn_workstream": "initial_message",
+            "spawn_batch": "children",
+            "close_all_children": "reason",
             "inspect_workstream": "ws_id",
             "send_to_workstream": "message",
             "close_workstream": "ws_id",

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1190,6 +1190,46 @@ class CoordinatorStopCascadeResponse(BaseModel):
     )
 
 
+class CoordinatorCloseAllChildrenRequest(BaseModel):
+    """Body for POST /v1/api/coordinator/{ws_id}/close_all_children."""
+
+    reason: str = Field(
+        default="",
+        description=(
+            "Optional human-readable reason — propagated to every closed "
+            "child's audit + workstream_config for postmortem.  Capped at "
+            "512 chars."
+        ),
+    )
+
+
+class CoordinatorCloseAllChildrenResponse(BaseModel):
+    """Response body for POST /v1/api/coordinator/{ws_id}/close_all_children."""
+
+    status: str = Field(default="ok")
+    closed: list[str] = Field(
+        default_factory=list,
+        description="Child ws_ids that accepted the close dispatch.",
+    )
+    failed: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Child ws_ids whose close dispatch returned an error other "
+            "than an already-gone 404 — the cascade continues on per-"
+            "child failure so a single unreachable node doesn't abort "
+            "the whole batch."
+        ),
+    )
+    skipped: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Child ws_ids that returned 404 on close (already gone).  "
+            "Reported separately from ``failed`` so operators can "
+            "distinguish already-done from dispatch-broken."
+        ),
+    )
+
+
 class ClusterWsDetailResponse(BaseModel):
     """Response body for GET /v1/api/cluster/ws/{ws_id}/detail.
 

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1195,10 +1195,11 @@ class CoordinatorCloseAllChildrenRequest(BaseModel):
 
     reason: str = Field(
         default="",
+        max_length=512,
         description=(
             "Optional human-readable reason — propagated to every closed "
             "child's audit + workstream_config for postmortem.  Capped at "
-            "512 chars."
+            "512 chars; the handler returns 400 on overflow."
         ),
     )
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -25,6 +25,8 @@ from turnstone.api.console_schemas import (
     CoordinatorApproveRequest,
     CoordinatorChildInfo,
     CoordinatorChildrenResponse,
+    CoordinatorCloseAllChildrenRequest,
+    CoordinatorCloseAllChildrenResponse,
     CoordinatorCreateRequest,
     CoordinatorCreateResponse,
     CoordinatorDetailResponse,
@@ -1360,6 +1362,27 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
+        "/v1/api/coordinator/{ws_id}/close_all_children",
+        "POST",
+        "Soft-close every direct child of the coordinator",
+        description=(
+            "Reads the in-memory child registry and dispatches "
+            "``close_workstream`` via the routing proxy for every direct "
+            "child under a bounded (16-concurrency) semaphore.  Unlike "
+            "``stop_cascade`` this does not touch grandchildren — the "
+            "model-facing tool asks for a bounded teardown of its own "
+            "fan-out.  Returns ``{closed, failed, skipped}`` where "
+            "``skipped`` distinguishes already-gone (404) from dispatch-"
+            "broken (``failed``).  The optional ``reason`` propagates to "
+            "every closed child's audit + workstream_config.  Writes "
+            "``coordinator.closed_all_children`` at the coord level."
+        ),
+        request_model=CoordinatorCloseAllChildrenRequest,
+        response_model=CoordinatorCloseAllChildrenResponse,
+        error_codes=[400, 403, 404, 503],
+        tags=["Coordinator"],
+    ),
+    EndpointSpec(
         "/v1/api/cluster/ws/{ws_id}/detail",
         "GET",
         "Cluster-wide live workstream detail (storage + live block + tail)",
@@ -1425,6 +1448,8 @@ _ALL_MODELS: list[type[BaseModel]] = [
     CoordinatorApproveRequest,
     CoordinatorChildInfo,
     CoordinatorChildrenResponse,
+    CoordinatorCloseAllChildrenRequest,
+    CoordinatorCloseAllChildrenResponse,
     CoordinatorCreateRequest,
     CoordinatorCreateResponse,
     CoordinatorDetailResponse,

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -233,6 +233,12 @@ _ROUTE_PATHS: dict[str, str] = {
     "cancel": "/v1/api/route/cancel",
     "close": "/v1/api/route/workstreams/close",
     "delete": "/v1/api/route/workstreams/delete",
+    # The cascade endpoints live on the console itself (not a node), so
+    # the path uses the coordinator ws_id in the URL rather than a
+    # routing-proxy prefix.  ``_post`` still formats against
+    # ``_base_url``; formatting of the ``{ws_id}`` slot happens at call
+    # time in ``close_all_children``.
+    "close_all_children": "/v1/api/coordinator/{ws_id}/close_all_children",
 }
 
 
@@ -303,11 +309,28 @@ class CoordinatorClient:
 
     def _post(self, path_key: str, body: dict[str, Any]) -> dict[str, Any]:
         path = _ROUTE_PATHS[path_key]
-        url = f"{self._base_url}{path}"
+        return self._post_url(f"{self._base_url}{path}", body, log_path=path)
+
+    def _post_url(
+        self,
+        url: str,
+        body: dict[str, Any],
+        *,
+        log_path: str,
+    ) -> dict[str, Any]:
+        """POST a pre-built URL with the canonical error handling.
+
+        Split out so endpoints whose path slots in runtime data (e.g.
+        the coord's own ``ws_id`` for cascade ops) can reuse the same
+        transport-error / JSON-fallback / setdefault-status shape
+        without duplicating the body of ``_post``.  ``log_path`` is a
+        stable key for telemetry grouping — the URL itself embeds
+        per-session ids that would fragment log aggregation.
+        """
         try:
             resp = self._http.post(url, json=body, headers=self._headers())
         except httpx.HTTPError as exc:
-            log.warning("coord_client.http_error path=%s err=%s", path, exc)
+            log.warning("coord_client.http_error path=%s err=%s", log_path, exc)
             return {"error": f"upstream unreachable: {exc}", "status": 0}
         try:
             data = resp.json() if resp.content else {}
@@ -413,6 +436,21 @@ class CoordinatorClient:
         if reason:
             body["reason"] = reason
         return self._post("close", body)
+
+    def close_all_children(self, reason: str = "") -> dict[str, Any]:
+        """Soft-close every direct child of this coordinator (console-side fan-out).
+
+        Returns ``{closed, failed, skipped}`` — mirrors ``stop_cascade``.
+        The console does the Semaphore-bounded gather so the model-side
+        tool call stays a single HTTP round-trip regardless of fan-out
+        size.  No tenant guard here: ownership is enforced on the
+        endpoint via ``_resolve_coord_session``.
+        """
+        path = _ROUTE_PATHS["close_all_children"].format(ws_id=self._coord_ws_id)
+        body: dict[str, Any] = {}
+        if reason:
+            body["reason"] = reason
+        return self._post_url(f"{self._base_url}{path}", body, log_path=path)
 
     def delete(self, ws_id: str) -> dict[str, Any]:
         if not self._is_own_subtree(ws_id):

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -446,11 +446,16 @@ class CoordinatorClient:
         size.  No tenant guard here: ownership is enforced on the
         endpoint via ``_resolve_coord_session``.
         """
-        path = _ROUTE_PATHS["close_all_children"].format(ws_id=self._coord_ws_id)
+        # Pass the unformatted template as ``log_path`` so telemetry
+        # aggregates cleanly — the baked-in ws_id would fragment log
+        # grouping across sessions.  The URL itself still embeds the
+        # real ws_id.
+        log_path = _ROUTE_PATHS["close_all_children"]
+        path = log_path.format(ws_id=self._coord_ws_id)
         body: dict[str, Any] = {}
         if reason:
             body["reason"] = reason
-        return self._post_url(f"{self._base_url}{path}", body, log_path=path)
+        return self._post_url(f"{self._base_url}{path}", body, log_path=log_path)
 
     def delete(self, ws_id: str) -> dict[str, Any]:
         if not self._is_own_subtree(ws_id):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -64,7 +64,7 @@ from turnstone.core.web_helpers import (
 from turnstone.core.workstream import WorkstreamKind
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Callable
 
     from starlette.requests import Request
 
@@ -3239,10 +3239,68 @@ async def coordinator_metrics(request: Request) -> JSONResponse:
 
 _RESTRICT_MAX_TOOLS = 256
 _RESTRICT_MAX_TOOL_NAME_LEN = 128
-# Bounded concurrency on the cascade dispatch.  Upstream coord_client
-# cancels have a 30s timeout; a 100-child cascade at this cap finishes
-# in ~200s worst case, comfortably inside typical 300s proxy limits.
-_STOP_CASCADE_MAX_CONCURRENCY = 16
+# Bounded concurrency on bulk coordinator fan-out (stop_cascade,
+# close_all_children).  Upstream coord_client calls have a 30s timeout;
+# a 100-child cascade at this cap finishes in ~200s worst case,
+# comfortably inside typical 300s proxy limits.
+_COORD_FANOUT_MAX_CONCURRENCY = 16
+
+
+async def _fanout_on_children(
+    child_ids: list[str],
+    coord_client: Any,
+    action: Callable[[str], Any],
+    *,
+    log_tag: str,
+    concurrency: int = _COORD_FANOUT_MAX_CONCURRENCY,
+) -> tuple[list[str], list[str], list[str]]:
+    """Bounded-concurrency fan-out over a coordinator's children.
+
+    Returns ``(ok, failed, skipped)`` — ``ok`` = action succeeded,
+    ``skipped`` = upstream 404 (already gone), ``failed`` = everything
+    else (dispatch errors, exceptions, non-dict returns).  Routes all
+    ids to ``failed`` when ``coord_client`` is None so the operator
+    sees the unexpected state rather than a silent no-op.  Callers map
+    the three buckets to endpoint-specific response keys (cancelled /
+    closed / ...).
+    """
+    ok: list[str] = []
+    failed: list[str] = []
+    skipped: list[str] = []
+    if not child_ids:
+        return ok, failed, skipped
+    if coord_client is None:
+        return ok, list(child_ids), skipped
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one(cid: str) -> tuple[str, str]:
+        async with sem:
+            try:
+                result = await asyncio.to_thread(action, cid)
+                if not isinstance(result, dict):
+                    return cid, "failed"
+                if not result.get("error"):
+                    return cid, "ok"
+                # Stale registry entry (child row deleted) or upstream
+                # 404 both mean "already gone".  Route to skipped so
+                # operators can distinguish from dispatch failures.
+                if result.get("status") == 404:
+                    return cid, "skipped"
+                return cid, "failed"
+            except Exception:
+                log.debug("%s.child_failed ws=%s", log_tag, cid[:8], exc_info=True)
+                return cid, "failed"
+
+    outcomes = await asyncio.gather(*(_one(cid) for cid in child_ids), return_exceptions=False)
+    for cid, bucket in outcomes:
+        if bucket == "ok":
+            ok.append(cid)
+        elif bucket == "skipped":
+            skipped.append(cid)
+        else:
+            failed.append(cid)
+    return ok, failed, skipped
 
 
 async def _require_json_object(request: Request) -> dict[str, Any] | JSONResponse:
@@ -3440,51 +3498,15 @@ async def coordinator_stop_cascade(request: Request) -> JSONResponse:
     child_ids = list(coord_mgr.children_snapshot(ws_id))
     coord_mgr.cancel(ws_id)
 
-    coord_client = getattr(session, "_coord_client", None)
-    cancelled: list[str] = []
-    failed: list[str] = []
-    skipped: list[str] = []
-
-    if not child_ids:
-        pass
-    elif coord_client is None:
-        failed = list(child_ids)
-    else:
-        sem = asyncio.Semaphore(_STOP_CASCADE_MAX_CONCURRENCY)
-
-        async def _cancel_one(cid: str) -> tuple[str, str]:
-            async with sem:
-                try:
-                    result = await asyncio.to_thread(coord_client.cancel, cid)
-                    if not isinstance(result, dict):
-                        return cid, "failed"
-                    if not result.get("error"):
-                        return cid, "cancelled"
-                    # A subtree-miss (stale _children entry after the
-                    # child's storage row was deleted) and an upstream
-                    # 404 both mean "already gone".  Route to skipped so
-                    # operators can distinguish from dispatch failures.
-                    if result.get("status") == 404:
-                        return cid, "skipped"
-                    return cid, "failed"
-                except Exception:
-                    log.debug(
-                        "coordinator_stop_cascade.child_failed ws=%s",
-                        cid[:8],
-                        exc_info=True,
-                    )
-                    return cid, "failed"
-
-        outcomes = await asyncio.gather(
-            *(_cancel_one(cid) for cid in child_ids), return_exceptions=False
-        )
-        for cid, bucket in outcomes:
-            if bucket == "cancelled":
-                cancelled.append(cid)
-            elif bucket == "skipped":
-                skipped.append(cid)
-            else:
-                failed.append(cid)
+    coord_client: Any = getattr(session, "_coord_client", None)
+    # ``action`` is only called when coord_client is live — the helper
+    # short-circuits on None before invoking it.
+    cancelled, failed, skipped = await _fanout_on_children(
+        child_ids,
+        coord_client,
+        lambda cid: coord_client.cancel(cid),
+        log_tag="coordinator_stop_cascade",
+    )
 
     await _emit_coord_audit(
         storage,
@@ -3503,6 +3525,78 @@ async def coordinator_stop_cascade(request: Request) -> JSONResponse:
         {
             "status": "ok",
             "cancelled": cancelled,
+            "failed": failed,
+            "skipped": skipped,
+        }
+    )
+
+
+_CLOSE_ALL_CHILDREN_MAX_REASON_LEN = 512
+
+
+async def coordinator_close_all_children(request: Request) -> JSONResponse:
+    """POST /v1/api/coordinator/{ws_id}/close_all_children — soft-close the direct children.
+
+    Near-twin of ``coordinator_stop_cascade`` — both fan out over
+    ``children_snapshot`` via ``_fanout_on_children``.  Returns
+    ``{closed, failed, skipped}``.  Unlike ``stop_cascade``, this does
+    NOT recurse into grandchildren (the coordinator's model tool asks
+    for a bounded teardown of its own fan-out; operator-level cascade
+    stays behind ``stop_cascade``).
+    """
+    resolved = await _resolve_coord_session(request, allow_service_bypass=False)
+    if isinstance(resolved, JSONResponse):
+        return resolved
+    session, storage, user_id, ws_id = resolved
+
+    coord_mgr, err503 = _require_coord_mgr(request)
+    if err503 is not None:
+        return err503  # pragma: no cover — _resolve_coord_session already gated this
+
+    body = await _require_json_object(request)
+    if isinstance(body, JSONResponse):
+        return body
+    raw_reason = body.get("reason", "")
+    if raw_reason is not None and not isinstance(raw_reason, str):
+        return JSONResponse(
+            {"error": "reason must be a string"},
+            status_code=400,
+        )
+    reason = (raw_reason or "").strip()
+    if len(reason) > _CLOSE_ALL_CHILDREN_MAX_REASON_LEN:
+        return JSONResponse(
+            {"error": f"reason exceeds {_CLOSE_ALL_CHILDREN_MAX_REASON_LEN} chars"},
+            status_code=400,
+        )
+
+    child_ids = list(coord_mgr.children_snapshot(ws_id))
+
+    coord_client: Any = getattr(session, "_coord_client", None)
+    closed, failed, skipped = await _fanout_on_children(
+        child_ids,
+        coord_client,
+        lambda cid: coord_client.close_workstream(cid, reason),
+        log_tag="coordinator_close_all_children",
+    )
+
+    await _emit_coord_audit(
+        storage,
+        user_id,
+        "coordinator.closed_all_children",
+        ws_id,
+        {
+            "src": "coordinator",
+            "reason": reason,
+            "closed": closed,
+            "failed": failed,
+            "skipped": skipped,
+        },
+        request.client.host if request.client else "",
+    )
+    return JSONResponse(
+        {
+            "status": "ok",
+            "closed": closed,
             "failed": failed,
             "skipped": skipped,
         }
@@ -10176,6 +10270,11 @@ def create_app(
                     Route(
                         "/api/coordinator/{ws_id}/stop_cascade",
                         coordinator_stop_cascade,
+                        methods=["POST"],
+                    ),
+                    Route(
+                        "/api/coordinator/{ws_id}/close_all_children",
+                        coordinator_close_all_children,
                         methods=["POST"],
                     ),
                     Route(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5086,7 +5086,6 @@ class ChatSession:
 
         results: dict[str, dict[str, Any]] = {}
         denied: list[dict[str, Any]] = []
-        spawned_ids: list[str] = []
         for spec in children:
             idx = spec["idx"]
             # Validation failures from _prepare surface here as denied
@@ -5114,7 +5113,6 @@ class ChatSession:
             if not ws_id:
                 denied.append({"idx": idx, "reason": "spawn returned no ws_id"})
                 continue
-            spawned_ids.append(ws_id)
             results[str(idx)] = {
                 "ws_id": ws_id,
                 "name": result.get("name", ""),

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3919,6 +3919,8 @@ class ChatSession:
             # Coordinator tools: only reachable when this session was
             # constructed with kind="coordinator" (COORDINATOR_TOOLS set).
             "spawn_workstream": self._prepare_spawn_workstream,
+            "spawn_batch": self._prepare_spawn_batch,
+            "close_all_children": self._prepare_close_all_children,
             "inspect_workstream": self._prepare_inspect_workstream,
             "send_to_workstream": self._prepare_send_to_workstream,
             "close_workstream": self._prepare_close_workstream,
@@ -4995,6 +4997,172 @@ class ChatSession:
         self._report_tool_result(call_id, "spawn_workstream", f"spawned {result.get('ws_id', '?')}")
         return call_id, summary
 
+    # Cap per batch call.  Matches the ``wait_for_workstream`` ws_ids
+    # intuition (small enough to fit an operator's eyes in one approval
+    # card; if the model wants more, make a second call).  Hard error
+    # rather than silent truncation — a silently-dropped child is much
+    # harder to notice than an explicit retry prompt.
+    _SPAWN_BATCH_MAX_CHILDREN = 10
+
+    def _prepare_spawn_batch(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
+        if self._coord_client is None:
+            return self._coord_tool_error(call_id, "spawn_batch", "coordinator client unavailable")
+        raw_children = args.get("children")
+        if not isinstance(raw_children, list) or not raw_children:
+            return self._coord_tool_error(
+                call_id, "spawn_batch", "children must be a non-empty list"
+            )
+        if len(raw_children) > self._SPAWN_BATCH_MAX_CHILDREN:
+            return self._coord_tool_error(
+                call_id,
+                "spawn_batch",
+                f"children exceeds cap ({len(raw_children)} > "
+                f"{self._SPAWN_BATCH_MAX_CHILDREN}); split across multiple calls",
+            )
+
+        # Per-item normalisation.  Invalid items surface in ``denied`` at
+        # exec time rather than failing the whole batch — we want
+        # partial-success semantics so a single malformed row doesn't
+        # poison the other approved spawns.
+        normalised: list[dict[str, Any]] = []
+        preview_rows: list[str] = []
+        for idx, raw in enumerate(raw_children):
+            if not isinstance(raw, dict):
+                normalised.append({"idx": idx, "_error": "child spec must be an object"})
+                preview_rows.append(f"  {idx}. [invalid — not an object]")
+                continue
+            initial_message = self._coord_str_arg(raw, "initial_message").strip()
+            skill = self._coord_str_arg(raw, "skill").strip()
+            name = self._coord_str_arg(raw, "name").strip()
+            model = self._coord_str_arg(raw, "model").strip()
+            target_node = self._coord_str_arg(raw, "target_node").strip()
+            spec: dict[str, Any] = {
+                "idx": idx,
+                "initial_message": initial_message,
+                "skill": skill,
+                "name": name,
+                "model": model,
+                "target_node": target_node,
+            }
+            normalised.append(spec)
+            if initial_message:
+                first_line = initial_message.splitlines()[0]
+                preview_line = first_line[:80] + ("..." if len(first_line) > 80 else "")
+                tag_bits = []
+                if skill:
+                    tag_bits.append(f"skill={skill}")
+                if target_node:
+                    tag_bits.append(f"node={target_node}")
+                tags = (" [" + ", ".join(tag_bits) + "]") if tag_bits else ""
+                preview_rows.append(f"  {idx}. {preview_line}{tags}")
+            else:
+                preview_rows.append(f"  {idx}. (idle)")
+
+        header = f"\u2699 spawn_batch: {len(normalised)} children"
+        preview_body = f"{DIM}{chr(10).join(preview_rows)}{RESET}"
+        return {
+            "call_id": call_id,
+            "func_name": "spawn_batch",
+            "header": header,
+            "preview": preview_body,
+            "needs_approval": True,
+            "approval_label": "spawn_batch",
+            "execute": self._exec_spawn_batch,
+            "children": normalised,
+        }
+
+    def _exec_spawn_batch(self, item: dict[str, Any]) -> tuple[str, str]:
+        call_id = item["call_id"]
+        children: list[dict[str, Any]] = item["children"]
+        total = len(children)
+
+        # Emit ``batch_started`` so the coordinator sidebar can show a
+        # "spawning N children" indicator.  Mirrors wait_for_workstream's
+        # _emit_wait_event plumbing (best-effort via ui._enqueue).
+        self._emit_batch_event(
+            "batch_started",
+            {"call_id": call_id, "op": "spawn_batch", "total": total},
+        )
+
+        results: dict[str, dict[str, Any]] = {}
+        denied: list[dict[str, Any]] = []
+        spawned_ids: list[str] = []
+        for spec in children:
+            idx = spec["idx"]
+            # Validation failures from _prepare surface here as denied
+            # rows — partial-success: don't abort the rest of the batch.
+            if "_error" in spec:
+                denied.append({"idx": idx, "reason": spec["_error"]})
+                continue
+            try:
+                result = self._coord_client.spawn(
+                    initial_message=spec["initial_message"],
+                    parent_ws_id=self._ws_id,
+                    user_id=self._user_id,
+                    skill=spec["skill"],
+                    name=spec["name"],
+                    model=spec["model"],
+                    target_node=spec["target_node"],
+                )
+            except Exception as e:
+                denied.append({"idx": idx, "reason": f"spawn failed: {e}"})
+                continue
+            if result.get("error"):
+                denied.append({"idx": idx, "reason": str(result["error"])})
+                continue
+            ws_id = str(result.get("ws_id") or "")
+            if not ws_id:
+                denied.append({"idx": idx, "reason": "spawn returned no ws_id"})
+                continue
+            spawned_ids.append(ws_id)
+            results[str(idx)] = {
+                "ws_id": ws_id,
+                "name": result.get("name", ""),
+                "node_id": result.get("node_id", ""),
+                "status": result.get("status"),
+            }
+
+        # ``truncated`` intentionally omitted — the prepare step
+        # hard-errors on >10 children rather than silent truncation,
+        # so the bulk-shape flag would always be false and just pads
+        # the LLM's tool-result payload.
+        summary_payload = {
+            "results": results,
+            "denied": denied,
+        }
+        output = json.dumps(summary_payload, separators=(",", ":"), default=str)
+        desc = f"spawned {len(results)}/{total}"
+        if denied:
+            desc += f" ({len(denied)} denied)"
+        self._report_tool_result(call_id, "spawn_batch", desc)
+        self._emit_batch_event(
+            "batch_ended",
+            {
+                "call_id": call_id,
+                "op": "spawn_batch",
+                "total": total,
+                "succeeded": len(results),
+                "denied": len(denied),
+            },
+        )
+        return call_id, output
+
+    def _emit_batch_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Fan out a ``batch_*`` SSE event via the session UI.  Best-effort.
+
+        Matches the ``_emit_wait_event`` pattern — the batch itself must
+        never fail because of observer plumbing.  The sidebar keys on
+        ``call_id`` to pair started/ended into a single indicator.
+        """
+        ui = getattr(self, "ui", None)
+        enqueue = getattr(ui, "_enqueue", None)
+        if enqueue is None:
+            return
+        try:
+            enqueue({"type": event_type, **payload})
+        except Exception:
+            log.debug("batch_event.enqueue_failed type=%s", event_type, exc_info=True)
+
     def _prepare_inspect_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._coord_client is None:
             return self._coord_tool_error(
@@ -5163,6 +5331,84 @@ class ChatSession:
         if reason:
             desc += f" ({reason[:60]})"
         self._report_tool_result(call_id, "close_workstream", desc)
+        return call_id, output
+
+    def _prepare_close_all_children(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
+        if self._coord_client is None:
+            return self._coord_tool_error(
+                call_id, "close_all_children", "coordinator client unavailable"
+            )
+        reason = self._coord_str_arg(args, "reason").strip()
+        header = "\u2699 close_all_children"
+        if reason:
+            header += f": {reason[:80]}"
+        return {
+            "call_id": call_id,
+            "func_name": "close_all_children",
+            "header": header,
+            "preview": "",
+            "needs_approval": True,
+            "approval_label": "close_all_children",
+            "execute": self._exec_close_all_children,
+            "reason": reason,
+        }
+
+    def _exec_close_all_children(self, item: dict[str, Any]) -> tuple[str, str]:
+        call_id = item["call_id"]
+        reason = item.get("reason", "") or ""
+        self._emit_batch_event(
+            "batch_started",
+            {"call_id": call_id, "op": "close_all_children"},
+        )
+        try:
+            result = self._coord_client.close_all_children(reason=reason)
+        except Exception as e:
+            msg = f"Error: close_all_children failed: {e}"
+            self._report_tool_result(call_id, "close_all_children", msg, is_error=True)
+            self._emit_batch_event(
+                "batch_ended",
+                {"call_id": call_id, "op": "close_all_children", "error": str(e)},
+            )
+            return call_id, msg
+        if result.get("error"):
+            msg = f"Error: {result['error']}"
+            self._report_tool_result(call_id, "close_all_children", msg, is_error=True)
+            self._emit_batch_event(
+                "batch_ended",
+                {
+                    "call_id": call_id,
+                    "op": "close_all_children",
+                    "error": str(result["error"]),
+                },
+            )
+            return call_id, msg
+        closed = [str(x) for x in result.get("closed") or [] if x]
+        failed = [str(x) for x in result.get("failed") or [] if x]
+        skipped = [str(x) for x in result.get("skipped") or [] if x]
+        summary_payload: dict[str, Any] = {
+            "closed": closed,
+            "failed": failed,
+            "skipped": skipped,
+        }
+        if reason:
+            summary_payload["reason"] = reason
+        output = json.dumps(summary_payload, separators=(",", ":"))
+        desc = f"closed {len(closed)}"
+        if failed:
+            desc += f", {len(failed)} failed"
+        if skipped:
+            desc += f", {len(skipped)} skipped"
+        self._report_tool_result(call_id, "close_all_children", desc)
+        self._emit_batch_event(
+            "batch_ended",
+            {
+                "call_id": call_id,
+                "op": "close_all_children",
+                "closed": len(closed),
+                "failed": len(failed),
+                "skipped": len(skipped),
+            },
+        )
         return call_id, output
 
     def _prepare_cancel_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:

--- a/turnstone/prompts/tools_coordinator.md
+++ b/turnstone/prompts/tools_coordinator.md
@@ -10,6 +10,13 @@ Delegate a task → spawn_workstream (required: skill, initial_message):
    spawn_workstream(skill='engineer', initial_message='audit auth.py for CSRF handling', name='csrf-audit')
    spawn_workstream(skill='researcher', initial_message='compare FastAPI vs Starlette for async websockets', node_id='flat-blck-io_43a3')
 
+Fan out to multiple children in one approval → spawn_batch (up to 10):
+   spawn_batch(children=[
+     {'skill': 'researcher', 'initial_message': 'benchmark A'},
+     {'skill': 'researcher', 'initial_message': 'benchmark B'},
+     {'skill': 'engineer', 'initial_message': 'prototype the winner'},
+   ])
+
 Check on a child → inspect_workstream:
    inspect_workstream(ws_id='a1b2c3d4')
 
@@ -30,6 +37,9 @@ Cancel a stuck or runaway child → cancel_workstream (drops the in-flight call,
 Wind a child down → close_workstream (soft; session stops, storage kept) or delete_workstream (hard; removes all traces):
    close_workstream(ws_id='a1b2c3d4', reason='task complete')
    delete_workstream(ws_id='a1b2c3d4')
+
+Wind all direct children down at once → close_all_children (soft-close cascade, single approval):
+   close_all_children(reason='batch complete, synthesising results')
 
 Plan and track work → task_list (your scratchpad; children don't see it):
    task_list(action='add', title='audit auth.py for CSRF')

--- a/turnstone/tools/close_all_children.json
+++ b/turnstone/tools/close_all_children.json
@@ -1,0 +1,16 @@
+{
+  "name": "close_all_children",
+  "description": "Soft-close every direct child of this coordinator in a single approval. Reads the in-memory child registry, then fans out close requests with bounded concurrency. Returns {closed: [ws_id...], failed: [ws_id...], skipped: [ws_id...]} — `skipped` holds children already gone (404 / missing row), `failed` holds transient dispatch errors worth retrying. Indirect descendants (children of children) are NOT closed — run `stop_cascade` from the operator UI for a full-subtree teardown. The optional `reason` is propagated to every closed child's audit + workstream_config for postmortem.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "reason": {
+        "type": "string",
+        "description": "Optional human-readable reason — propagated to every closed child's audit + workstream_config."
+      }
+    },
+    "required": []
+  },
+  "coordinator": true,
+  "primary_key": "reason"
+}

--- a/turnstone/tools/close_all_children.json
+++ b/turnstone/tools/close_all_children.json
@@ -1,12 +1,13 @@
 {
   "name": "close_all_children",
-  "description": "Soft-close every direct child of this coordinator in a single approval. Reads the in-memory child registry, then fans out close requests with bounded concurrency. Returns {closed: [ws_id...], failed: [ws_id...], skipped: [ws_id...]} — `skipped` holds children already gone (404 / missing row), `failed` holds transient dispatch errors worth retrying. Indirect descendants (children of children) are NOT closed — run `stop_cascade` from the operator UI for a full-subtree teardown. The optional `reason` is propagated to every closed child's audit + workstream_config for postmortem.",
+  "description": "Soft-close every direct child of this coordinator in a single approval. Reads the in-memory child registry, then fans out close requests with bounded concurrency. Returns {closed: [ws_id...], failed: [ws_id...], skipped: [ws_id...], reason?: str} — `skipped` holds children already gone (404 / missing row), `failed` holds transient dispatch errors worth retrying, and `reason` is echoed back in the response when supplied. Indirect descendants (children of children) are NOT closed — run `stop_cascade` from the operator UI for a full-subtree teardown. The optional `reason` is propagated to every closed child's audit + workstream_config for postmortem; the server rejects reasons longer than 512 chars with a tool error.",
   "parameters": {
     "type": "object",
     "properties": {
       "reason": {
         "type": "string",
-        "description": "Optional human-readable reason — propagated to every closed child's audit + workstream_config."
+        "maxLength": 512,
+        "description": "Optional human-readable reason (max 512 chars) — propagated to every closed child's audit + workstream_config, and echoed back in the response payload when provided."
       }
     },
     "required": []

--- a/turnstone/tools/spawn_batch.json
+++ b/turnstone/tools/spawn_batch.json
@@ -1,0 +1,44 @@
+{
+  "name": "spawn_batch",
+  "description": "Create up to 10 child workstreams in a single approval. Serialised spawns — children are created in input order so sibling ordering (by created_at) is deterministic. Returns {results: {idx: {ws_id, name, node_id, status}}, denied: [{idx, reason}]}. `results` is keyed by the input-array index (stringified). `denied[]` collects per-item validation / spawn failures. For >10 children, make additional calls (the batch hard-errors rather than truncating). Batch-level approval covers the whole list. Pair with `wait_for_workstream(ws_ids=[...], mode='all')` when the coordinator wants to synthesise the N outputs once every child has finished.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "children": {
+        "type": "array",
+        "description": "Up to 10 child specs. Each spec mirrors spawn_workstream args. An empty `initial_message` creates an idle child that waits for send_to_workstream.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "initial_message": {
+              "type": "string",
+              "description": "First user message to dispatch. Empty → idle child."
+            },
+            "skill": {
+              "type": "string",
+              "description": "Optional skill name."
+            },
+            "name": {
+              "type": "string",
+              "description": "Optional display name. Auto-generated when empty."
+            },
+            "model": {
+              "type": "string",
+              "description": "Optional model alias."
+            },
+            "target_node": {
+              "type": "string",
+              "description": "Optional node_id hint. Pinning is hard — if the named node has dropped the 120s registry heartbeat between list_nodes and this spawn, the item lands in denied[] with a `No available node for routing` reason. Omit unless the workload truly requires that node."
+            }
+          },
+          "required": []
+        },
+        "minItems": 1,
+        "maxItems": 10
+      }
+    },
+    "required": ["children"]
+  },
+  "coordinator": true,
+  "primary_key": "children"
+}


### PR DESCRIPTION
## Summary

Two model-facing batch tools so a coordinator can fan out without burning one approval per child.

- **`spawn_batch`** — create up to 10 child workstreams in a single approval. Serialised spawns keep sibling ordering (by `created_at`) deterministic. Returns `{results: {idx: {ws_id, name, node_id, status}}, denied: [{idx, reason}]}`; per-item validation / spawn failures surface in `denied[]`; batch hard-errors on >10 rather than silent truncation.
- **`close_all_children`** — soft-close every direct child in one approval. Server-side `Sem(16)` fan-out via `coord_client.close_workstream`; `reason` propagates to every closed child's audit + workstream_config. Response mirrors `stop_cascade`'s cascade idiom: `{closed, failed, skipped}` where `skipped` is upstream-404 / already-gone.

## What shipped

- New console endpoint `POST /v1/api/coordinator/{ws_id}/close_all_children` (gated `admin.coordinator`, `allow_service_bypass=False`, 512-char reason cap, `coordinator.closed_all_children` audit).
- Shared `_fanout_on_children` helper — both `stop_cascade` and `close_all_children` delegate to it (one place to own the snapshot → semaphore-gather → bucket-split skeleton).
- `CoordinatorClient.close_all_children(reason)` plus a `_post_url` seam that `_post` now reuses (no duplicated transport-error handling).
- `_emit_batch_event` — best-effort SSE emitter modelled on `_emit_wait_event`. Emits `batch_started` / `batch_ended` keyed by `call_id`. Throttled `batch_progress` deferred to a follow-up.
- OpenAPI request + response schemas, endpoint spec entry, TypeScript SDK regenerated.
- Persona doc (`tools_coordinator.md`) covers the two new patterns.

## Bulk-endpoint shape decision (plan §5a)

Split by semantic category — `{results, denied, truncated}` for bulk-read / bulk-create-with-payload (`cluster/ws/live`, `spawn_batch`), `{<bucket>, failed, skipped}` for cascade-mutation (`stop_cascade`, `close_all_children`). No retrofit needed on `stop_cascade`. The bulk-endpoints contract doc in PR C will codify both shapes per category.

## Deferred (not this PR)

- Per-item selective-deny approval UI (batch-level approve/deny is the PR-A MVP).
- Throttled `batch_progress` SSE events (only `batch_started` / `batch_ended` pair shipped).
- Coordinator-skills guide + bulk-endpoints doc (PR C).
- Spawn budget / rate limit (PR B).

## Test plan

- [x] `pytest -m 'not live'` — 4451 tests pass (up from 4449 — two new `coord_client=None` guard tests).
- [x] `ruff check turnstone tests` clean.
- [x] `mypy turnstone` clean (166 files).
- [x] `/review` pipeline: 1 major + 4 minor + 1 nit — all addressed (`_fanout_on_children` helper, `_post_url` seam, dead `truncated` flag dropped, dead `_ = ANY` removed, guard-branch tests added, stray parens removed).
- [x] TypeScript SDK OpenAPI regenerated via `sdk/typescript/scripts/generate-types.py`.
- [x] Manual browser pass: approval-card preview shows each child row; `close_all_children` approval confirms on a live coord session.

## Follow-ups tracked in plan

- PR B — spawn budget + rate limit (independent).
- PR C — API tour doc, coordinator-skills guide, bulk-endpoints contract, `wait_for_workstream` sequence diagram.