### PR TITLE
feat(design-system): DS-A + DS-B + DS-C — tokens, primitives, patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ include = [
   "turnstone/console/static/coordinator/*.js",
   "turnstone/shared_static/*.css",
   "turnstone/shared_static/*.js",
+  "turnstone/shared_static/design/**/*",
   "turnstone/shared_static/katex-0.16.45/**/*",
   "turnstone/shared_static/hljs-11.11.1/**/*",
   "turnstone/shared_static/mermaid-11.14.0/**/*",

--- a/turnstone/shared_static/design/chrome/sidebar.css
+++ b/turnstone/shared_static/design/chrome/sidebar.css
@@ -1,0 +1,88 @@
+/* turnstone design system — sidebar
+   240px sticky left column under the topbar. Section labels are 10px
+   uppercase; items show a leading 6px swatch (semantic dot) and a
+   trailing mono count. */
+
+[data-design="v1"] .shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: calc(100vh - 48px);
+}
+
+[data-design="v1"] .sidebar {
+  position: sticky;
+  top: 48px;
+  align-self: start;
+  height: calc(100vh - 48px);
+  padding: 16px 10px;
+  background: var(--panel);
+  border-right: 1px solid var(--hair);
+  overflow: auto;
+}
+
+[data-design="v1"] .side-section {
+  margin-bottom: 18px;
+}
+
+[data-design="v1"] .side-label {
+  padding: 0 8px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .side-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  font-size: 13px;
+  color: var(--ink-2);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+[data-design="v1"] .side-item:hover {
+  background: var(--hair-2);
+}
+
+[data-design="v1"] .side-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-design="v1"] .side-item.active {
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 60%, var(--ink));
+  font-weight: 500;
+}
+
+[data-design="v1"] .side-item .lead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-design="v1"] .side-item .swatch {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-4);
+}
+
+[data-design="v1"] .side-item .swatch.ok    { background: var(--ok); }
+[data-design="v1"] .side-item .swatch.warn  { background: var(--warn); }
+[data-design="v1"] .side-item .swatch.err   { background: var(--err); }
+[data-design="v1"] .side-item .swatch.think { background: var(--think); }
+
+[data-design="v1"] .side-item .count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .side-item.active .count {
+  color: color-mix(in srgb, var(--accent) 60%, var(--ink));
+}

--- a/turnstone/shared_static/design/chrome/topbar.css
+++ b/turnstone/shared_static/design/chrome/topbar.css
@@ -1,0 +1,99 @@
+/* turnstone design system — topbar
+   48px sticky header: 240px brand cell / flex nav / right metadata cluster.
+   Brand mark is a 20x20 conic-gradient checker — no image, no icon font. */
+
+[data-design="v1"] .topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: 240px 1fr auto;
+  align-items: center;
+  height: 48px;
+  padding: 0 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--hair);
+}
+
+[data-design="v1"] .brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+[data-design="v1"] .brand-mark {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  background: var(--ink);
+  border-radius: 3px;
+}
+
+[data-design="v1"] .brand-mark::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 3px;
+  background: conic-gradient(
+    from 45deg at 50% 50%,
+    var(--ink) 0 25%,
+    var(--accent) 25% 50%,
+    var(--ink) 50% 75%,
+    var(--accent) 75% 100%
+  );
+}
+
+[data-design="v1"] .brand .v {
+  margin-left: 4px;
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .topnav {
+  display: flex;
+  gap: 2px;
+}
+
+[data-design="v1"] .topnav a {
+  padding: 6px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  text-decoration: none;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+[data-design="v1"] .topnav a:hover:not(.active) {
+  background: var(--hair-2);
+}
+
+[data-design="v1"] .topnav a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-design="v1"] .topnav a.active {
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 60%, var(--ink));
+}
+
+[data-design="v1"] .top-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .top-right .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 20%, transparent);
+}

--- a/turnstone/shared_static/design/patterns/approval-dock.css
+++ b/turnstone/shared_static/design/patterns/approval-dock.css
@@ -1,0 +1,237 @@
+/* turnstone design system — approval dock pattern
+   Bottom-pinned strip that appears when pending approvals exist. The
+   signature product pattern: a neutral dock (not a modal, not inline) that
+   surfaces the approval contract without hijacking focus.
+
+   Layout:
+     .approval-dock        position: fixed bottom
+       .dhead              11px uppercase warn kicker + count on right
+       .dcall              risk pill + function name + arg preview
+       .dctx               context code snippets
+       .drow               right-aligned action cluster + nav spacer
+
+   Actions (action cluster):
+     button.act           neutral default ("dismiss" / "view")
+     button.act.primary   warn-tinted amber — primary "Approve" action
+                          (NEVER green; amber signals "needs attention →
+                          resolving"). 1.5px border, --r-md squared.
+     button.act.always    dashed border — "Always approve for this rule"
+     button.act.danger    err-tinted red — "Deny"
+
+   Keyboard shortcuts (wired in coordinator.js):
+     Enter  → primary approve
+     D      → deny
+     ⇧A     → always approve
+
+   Focus policy: when the dock opens, move focus to button.act.primary so
+   keyboard users can confirm without hunting. Do NOT trap focus. */
+
+[data-design="v1"] .approval-dock {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 22px; /* clears the statusbar if one is present */
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 20px;
+  background: var(--panel);
+  border-top: 1px solid var(--hair);
+  box-shadow: 0 -6px 24px -12px rgba(21, 24, 27, 0.18);
+}
+
+[data-design="v1"] .approval-dock::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--warn) 50%, transparent),
+    transparent
+  );
+}
+
+[data-design="v1"] .approval-dock .dhead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--warn);
+}
+
+[data-design="v1"] .approval-dock .dhead::before {
+  content: "⚠";
+  font-size: 12px;
+}
+
+[data-design="v1"] .approval-dock .dhead .dcount {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink-3);
+}
+
+/* Inline code-panel framing — the .dcall row reads as "the exact call you
+   are approving," so we frame it like a mini inspectable code line rather
+   than bare text on the dock surface. */
+[data-design="v1"] .approval-dock .dcall {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 6px 10px;
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+}
+
+[data-design="v1"] .approval-dock .dcall .risk { flex-shrink: 0; }
+
+[data-design="v1"] .approval-dock .dcall .dfn {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--ink);
+}
+
+[data-design="v1"] .approval-dock .dcall .dargs {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .approval-dock .dctx {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .approval-dock .dctx code {
+  padding: 0 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  background: var(--panel-2);
+  border: 1px solid var(--hair);
+  border-radius: 3px;
+}
+
+[data-design="v1"] .approval-dock .drow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+[data-design="v1"] .approval-dock .drow .spacer { flex: 1; }
+
+[data-design="v1"] .approval-dock .drow .nav {
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+[data-design="v1"] .approval-dock .drow .nav:hover {
+  background: var(--panel-2);
+  color: var(--ink);
+}
+
+/* Action buttons — 1.5px border, --r-md squared (NOT pill — these are
+   primary-action surfaces, not inline buttons). */
+[data-design="v1"] .approval-dock button.act {
+  padding: 7px 16px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-2);
+  background: var(--panel);
+  border: 1.5px solid var(--hair-2);
+  border-radius: var(--r-md);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+[data-design="v1"] .approval-dock button.act:hover {
+  color: var(--ink);
+  border-color: var(--ink-4);
+}
+
+[data-design="v1"] .approval-dock button.act:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-design="v1"] .approval-dock button.act.primary {
+  background: color-mix(in srgb, var(--warn) 22%, var(--panel));
+  /* Same darkening pattern as .btn.approve — warn-on-warn-tint needs ink
+     to pass AA. */
+  color: color-mix(in srgb, var(--warn) 55%, var(--ink));
+  border-color: color-mix(in srgb, var(--warn) 60%, var(--hair));
+  font-weight: 600;
+}
+
+[data-design="v1"] .approval-dock button.act.primary:hover {
+  background: color-mix(in srgb, var(--warn) 32%, var(--panel));
+  color: var(--ink);
+  border-color: var(--warn);
+}
+
+[data-design="v1"] .approval-dock button.act.always {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--ink-3) 45%, var(--hair));
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .approval-dock button.act.always:hover {
+  color: var(--ink);
+  border-color: var(--ink-3);
+}
+
+[data-design="v1"] .approval-dock button.act.danger {
+  color: var(--err);
+  border-color: color-mix(in srgb, var(--err) 42%, var(--hair));
+}
+
+[data-design="v1"] .approval-dock button.act.danger:hover {
+  background: var(--err-soft);
+  color: var(--err);
+  border-color: var(--err);
+}
+
+/* Match .btn .kbd (primitives/buttons.css) — --ink-3 clears AA at 10px,
+   --ink-4 is borderline on light panels. */
+[data-design="v1"] .approval-dock button.act .kbd {
+  margin-left: 6px;
+  padding: 0 3px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+}
+
+[data-design="v1"] .approval-dock button.act.primary .kbd {
+  color: color-mix(in srgb, var(--warn) 70%, var(--ink-3));
+  border-color: color-mix(in srgb, var(--warn) 40%, var(--hair));
+}

--- a/turnstone/shared_static/design/patterns/fleet-grid.css
+++ b/turnstone/shared_static/design/patterns/fleet-grid.css
@@ -1,0 +1,97 @@
+/* turnstone design system — fleet grid pattern
+   14-column grid of .node squares. Each node carries a state modifier
+   (.s-ok / .s-thinking / .s-attn / .s-err / .s-idle / .s-unreach) and a
+   --pct CSS var driving a bottom-filling load gradient on ::after.
+
+   The grid lives inside a .panel; a .fleet-legend below the grid explains
+   state colours using the same swatches.
+
+   Interaction: hover uses `outline`, never `box-shadow` — the bleed into
+   adjacent cells is the intended look (fleet density visualization). */
+
+[data-design="v1"] .fleet {
+  display: grid;
+  grid-template-columns: repeat(14, 1fr);
+  gap: 4px;
+  padding: 14px;
+}
+
+[data-design="v1"] .fleet .node {
+  position: relative;
+  aspect-ratio: 1;
+  background: var(--ok-soft);
+  border: 1px solid transparent;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+[data-design="v1"] .fleet .node::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 1px;
+  background: linear-gradient(
+    to top,
+    var(--fill, var(--ok)) var(--pct, 30%),
+    transparent var(--pct, 30%)
+  );
+  opacity: 0.75;
+}
+
+[data-design="v1"] .fleet .node.s-ok       { --fill: var(--ok);    background: var(--ok-soft); }
+[data-design="v1"] .fleet .node.s-thinking { --fill: var(--think); background: var(--think-soft); }
+[data-design="v1"] .fleet .node.s-attn     { --fill: var(--warn);  background: var(--warn-soft); border-color: var(--warn); }
+[data-design="v1"] .fleet .node.s-err      { --fill: var(--err);   background: var(--err-soft);  border-color: var(--err); }
+[data-design="v1"] .fleet .node.s-idle     { --fill: var(--ink-4); background: var(--hair-2); }
+
+/* .s-unreach — unreachable nodes use a hatch pattern; no load fill. */
+[data-design="v1"] .fleet .node.s-unreach {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--hair) 0 3px,
+    var(--hair-2) 3px 6px
+  );
+  opacity: 0.6;
+}
+
+/* Hover + focus — outline, not shadow. Bleed into neighbours is deliberate;
+   the outline overlaps adjacent cells and that's how the density visual
+   reads. */
+[data-design="v1"] .fleet .node:hover,
+[data-design="v1"] .fleet .node:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  z-index: 2;
+}
+
+/* Legend row below the grid */
+[data-design="v1"] .fleet-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  padding: 10px 14px;
+  font-size: 11px;
+  color: var(--ink-3);
+  border-top: 1px solid var(--hair);
+}
+
+[data-design="v1"] .fleet-legend .k {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+[data-design="v1"] .fleet-legend .sw {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+[data-design="v1"] .fleet-legend .sw.ok       { background: var(--ok); }
+[data-design="v1"] .fleet-legend .sw.thinking { background: var(--think); }
+[data-design="v1"] .fleet-legend .sw.attn     { background: var(--warn); }
+[data-design="v1"] .fleet-legend .sw.err      { background: var(--err); }
+[data-design="v1"] .fleet-legend .sw.idle     { background: var(--ink-4); }
+[data-design="v1"] .fleet-legend .sw.unreach {
+  background: repeating-linear-gradient(-45deg, var(--hair) 0 2px, var(--hair-2) 2px 4px);
+}

--- a/turnstone/shared_static/design/patterns/live-feed.css
+++ b/turnstone/shared_static/design/patterns/live-feed.css
@@ -1,0 +1,38 @@
+/* turnstone design system — live feed pattern
+   Thin wrapper around .feed-item that adds the scrollable container and
+   the streaming polite aria-live region. Mounts inside a .panel.
+
+   Use this when rendering an SSE stream or any chronological event log.
+   Keep individual rows as .feed-item (primitive) so structure stays
+   consistent with standalone event lists. */
+
+[data-design="v1"] .live-feed {
+  display: flex;
+  flex-direction: column;
+  max-height: 560px;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+/* Fade the top edge as new entries push older ones up — signals that the
+   stream is live without requiring animation. */
+[data-design="v1"] .live-feed::before {
+  content: "";
+  position: sticky;
+  top: 0;
+  display: block;
+  height: 18px;
+  margin-bottom: -18px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, var(--panel), transparent);
+  z-index: 1;
+}
+
+/* Empty state — centred mono hint. */
+[data-design="v1"] .live-feed .feed-empty {
+  padding: 40px 14px;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-4);
+}

--- a/turnstone/shared_static/design/preview.html
+++ b/turnstone/shared_static/design/preview.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en" data-design="v1">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>turnstone — design system preview</title>
+  <link rel="stylesheet" href="./tokens.css" />
+  <link rel="stylesheet" href="./typography.css" />
+  <link rel="stylesheet" href="./chrome/topbar.css" />
+  <link rel="stylesheet" href="./chrome/sidebar.css" />
+  <link rel="stylesheet" href="./primitives/panel.css" />
+  <link rel="stylesheet" href="./primitives/buttons.css" />
+  <link rel="stylesheet" href="./primitives/pills.css" />
+  <link rel="stylesheet" href="./primitives/stats.css" />
+  <link rel="stylesheet" href="./primitives/feed.css" />
+  <style>
+    /* preview-page-only styles — not part of the design system */
+    body { margin: 0; min-width: 1280px; }
+    .section { padding: 18px 22px; border-top: 1px solid var(--hair); }
+    .section h2 {
+      margin: 0 0 12px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+    }
+    .row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+    .row + .row { margin-top: 10px; }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .swatches { display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px; }
+    .swatches .sw {
+      padding: 10px;
+      border: 1px solid var(--hair);
+      border-radius: var(--r-md);
+      background: var(--panel);
+      font-size: 11px;
+    }
+    .swatches .sw .band {
+      height: 40px;
+      border-radius: var(--r-sm);
+      margin-bottom: 6px;
+    }
+    .fleet-demo {
+      display: grid;
+      grid-template-columns: repeat(14, 1fr);
+      gap: 4px;
+      padding: 14px;
+      max-width: 600px;
+    }
+    .fleet-demo .node {
+      aspect-ratio: 1;
+      border-radius: 3px;
+      background: var(--ok-soft);
+      position: relative;
+      border: 1px solid transparent;
+      cursor: pointer;
+    }
+    .fleet-demo .node::after {
+      content: "";
+      position: absolute;
+      inset: 2px;
+      border-radius: 1px;
+      background: linear-gradient(to top, var(--fill, var(--ok)) var(--pct, 30%), transparent var(--pct, 30%));
+      opacity: 0.75;
+    }
+    .fleet-demo .node.s-ok       { --fill: var(--ok);    background: var(--ok-soft); }
+    .fleet-demo .node.s-thinking { --fill: var(--think); background: var(--think-soft); }
+    .fleet-demo .node.s-attn     { --fill: var(--warn);  background: var(--warn-soft); border-color: var(--warn); }
+    .fleet-demo .node.s-err      { --fill: var(--err);   background: var(--err-soft);  border-color: var(--err); }
+    .fleet-demo .node.s-idle     { --fill: var(--ink-4); background: var(--hair-2); }
+    .fleet-demo .node.s-unreach {
+      background: repeating-linear-gradient(-45deg, var(--hair) 0 3px, var(--hair-2) 3px 6px);
+      opacity: 0.6;
+    }
+    .fleet-demo .node:hover { outline: 2px solid var(--accent); outline-offset: 1px; z-index: 2; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="brand-mark"></span>
+      <span>turnstone<span class="v">v1.5.0a2</span></span>
+    </div>
+    <nav class="topnav">
+      <a class="active">Coordinator</a>
+      <a>Cluster</a>
+      <a>Skills</a>
+      <a>Policies</a>
+      <a>Audit</a>
+    </nav>
+    <div class="top-right">
+      <span class="dot" aria-label="live"></span>
+      <span class="chip">env: prod-eu</span>
+      <button class="btn" id="themeToggle" aria-label="Toggle theme">
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+  </header>
+
+  <div class="shell">
+    <aside class="sidebar">
+      <div class="side-section">
+        <div class="side-label">Workstreams</div>
+        <div class="side-item active"><span class="lead"><span class="swatch ok"></span>Active</span><span class="count">14</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch think"></span>Thinking</span><span class="count">3</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch warn"></span>Awaiting approval</span><span class="count">2</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch err"></span>Errored</span><span class="count">1</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch"></span>Idle</span><span class="count">8</span></div>
+      </div>
+      <div class="side-section">
+        <div class="side-label">Fleet</div>
+        <div class="side-item"><span class="lead">All nodes</span><span class="count">42</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch ok"></span>Healthy</span><span class="count">39</span></div>
+        <div class="side-item"><span class="lead"><span class="swatch warn"></span>Attention</span><span class="count">3</span></div>
+      </div>
+    </aside>
+
+    <main>
+      <section class="section">
+        <h2>Buttons</h2>
+        <div class="row">
+          <button class="btn">Default</button>
+          <button class="btn primary">Primary</button>
+          <button class="btn deny">Deny</button>
+          <button class="btn approve">Approve <span class="kbd">⏎</span></button>
+          <button class="ghost">Ghost</button>
+          <button class="ghost on">Ghost on</button>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Pills (status — what something is DOING)</h2>
+        <div class="row">
+          <span class="pill running"><span class="d"></span>running</span>
+          <span class="pill thinking"><span class="d"></span>thinking</span>
+          <span class="pill attn"><span class="d"></span>needs approval</span>
+          <span class="pill idle"><span class="d"></span>idle</span>
+          <span class="pill err"><span class="d"></span>errored</span>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>K-badges (kind — what something IS)</h2>
+        <div class="row">
+          <span class="k-badge k-tools">tools</span>
+          <span class="k-badge k-approval">approval</span>
+          <span class="k-badge k-policy">policy</span>
+          <span class="k-badge k-role">role</span>
+          <span class="k-badge k-judge">judge</span>
+          <span class="k-badge k-query">query</span>
+          <span class="k-badge k-workstream">workstream</span>
+          <span class="k-badge k-session">session</span>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Chips + risks</h2>
+        <div class="row">
+          <span class="chip">ws_a1b2c3d4</span>
+          <span class="chip">tok_f00bar</span>
+          <span class="chip">node-04</span>
+          <span class="risk low">low</span>
+          <span class="risk med">med</span>
+          <span class="risk high">high</span>
+          <span class="risk crit">crit</span>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Typography scale</h2>
+        <div class="t-h1">t-h1 — heading (24px)</div>
+        <div class="t-stat">42,195</div>
+        <div class="t-kicker">t-kicker — section label</div>
+        <div class="t-body">t-body — base 14px / 1.45 for prose.</div>
+        <div class="t-row">t-row — 13px for table rows and sidebar items.</div>
+        <div class="t-btn">t-btn — 12px for button labels.</div>
+        <div class="t-meta">t-meta — 11px mono for counts, timestamps, kbd hints.</div>
+      </section>
+
+      <section class="section">
+        <h2>Stat row</h2>
+        <div class="stat-row">
+          <div class="stat all"><div class="lbl">Workstreams</div><div class="val">28</div><div class="delta">+3 / 24h</div></div>
+          <div class="stat running"><div class="lbl">Running</div><div class="val">14</div><div class="delta">steady</div></div>
+          <div class="stat thinking"><div class="lbl">Thinking</div><div class="val">3</div><div class="delta">-1</div></div>
+          <div class="stat attention"><div class="lbl">Attention</div><div class="val">2</div><div class="delta">+2</div></div>
+          <div class="stat idle"><div class="lbl">Idle</div><div class="val">8</div><div class="delta">—</div></div>
+          <div class="stat error"><div class="lbl">Errored</div><div class="val">1</div><div class="delta">+1</div></div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Panels + mini-bar + spark</h2>
+        <div class="grid-2">
+          <div class="panel">
+            <div class="panel-head">
+              <h3>Load</h3>
+              <span class="meta">node-04</span>
+              <div class="tools"><button class="ghost">Live</button><button class="ghost">1h</button></div>
+            </div>
+            <div style="padding: 14px;">
+              <div class="t-kicker" style="margin-bottom: 8px;">CPU</div>
+              <span class="mini-bar"><i style="--pct: 72%;"></i></span>
+              <span class="t-meta" style="margin-left: 8px;">72%</span>
+              <div class="t-kicker" style="margin-top: 12px; margin-bottom: 8px;">Memory</div>
+              <span class="mini-bar warn"><i style="--pct: 88%;"></i></span>
+              <span class="t-meta" style="margin-left: 8px;">88%</span>
+              <div class="spark" style="margin-top: 12px;">
+                <i style="--h: 30%;"></i><i style="--h: 55%;"></i><i style="--h: 40%;"></i>
+                <i style="--h: 70%;"></i><i style="--h: 65%;"></i><i style="--h: 80%;"></i>
+                <i style="--h: 50%;"></i><i style="--h: 90%;"></i><i style="--h: 72%;"></i>
+                <i style="--h: 45%;"></i><i style="--h: 60%;"></i><i style="--h: 78%;"></i>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel-head">
+              <h3>Fleet</h3>
+              <span class="meta">42 nodes</span>
+              <div class="tools"><button class="ghost on">Grid</button><button class="ghost">List</button></div>
+            </div>
+            <div class="fleet-demo">
+              <div class="node s-ok" style="--pct: 30%;"></div>
+              <div class="node s-ok" style="--pct: 45%;"></div>
+              <div class="node s-ok" style="--pct: 60%;"></div>
+              <div class="node s-thinking" style="--pct: 75%;"></div>
+              <div class="node s-attn" style="--pct: 50%;"></div>
+              <div class="node s-ok" style="--pct: 20%;"></div>
+              <div class="node s-ok" style="--pct: 35%;"></div>
+              <div class="node s-idle" style="--pct: 10%;"></div>
+              <div class="node s-ok" style="--pct: 90%;"></div>
+              <div class="node s-err" style="--pct: 0%;"></div>
+              <div class="node s-ok" style="--pct: 55%;"></div>
+              <div class="node s-ok" style="--pct: 40%;"></div>
+              <div class="node s-thinking" style="--pct: 65%;"></div>
+              <div class="node s-unreach"></div>
+              <div class="node s-ok" style="--pct: 25%;"></div>
+              <div class="node s-ok" style="--pct: 50%;"></div>
+              <div class="node s-idle" style="--pct: 5%;"></div>
+              <div class="node s-ok" style="--pct: 70%;"></div>
+              <div class="node s-attn" style="--pct: 80%;"></div>
+              <div class="node s-ok" style="--pct: 45%;"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Live feed</h2>
+        <div class="panel">
+          <div class="feed-item">
+            <div class="ts">10:42:18</div>
+            <div class="body">
+              <div class="hd">
+                <span class="k-badge k-tools">tools</span>
+                <span class="fn">spawn_batch</span>
+                <span class="target">workstream ws_a1b2c3d4</span>
+              </div>
+              <div class="sum">Created 6 child workstreams to fan out log-triage across shards.</div>
+              <div class="evi">{"shard": "eu-1", "count": 6, "budget_remaining": 18}</div>
+            </div>
+            <div class="acts">
+              <span class="conf">0.94</span>
+            </div>
+          </div>
+          <div class="feed-item">
+            <div class="ts">10:42:21</div>
+            <div class="body">
+              <div class="hd">
+                <span class="k-badge k-approval">approval</span>
+                <span class="fn">exec</span>
+                <span class="target">node-12 / rm -rf /tmp/cache</span>
+              </div>
+              <div class="sum">Requesting approval to clear cache on node-12 — low risk.</div>
+            </div>
+            <div class="acts">
+              <div class="buttons">
+                <button class="btn deny">Deny</button>
+                <button class="btn approve">Approve</button>
+              </div>
+            </div>
+          </div>
+          <div class="feed-item decided">
+            <div class="ts">10:41:02</div>
+            <div class="body">
+              <div class="hd">
+                <span class="k-badge k-policy">policy</span>
+                <span class="fn">allow</span>
+                <span class="target">role:operator</span>
+              </div>
+              <div class="sum">Applied policy bundle v4 (3 deny rules, 2 step-up requirements).</div>
+            </div>
+            <div class="acts">
+              <span class="judged"><span class="spin" aria-hidden="true"></span>judging</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Semantic token swatches</h2>
+        <div class="swatches">
+          <div class="sw"><div class="band" style="background: var(--accent);"></div>accent</div>
+          <div class="sw"><div class="band" style="background: var(--accent-soft);"></div>accent-soft</div>
+          <div class="sw"><div class="band" style="background: var(--ok);"></div>ok</div>
+          <div class="sw"><div class="band" style="background: var(--warn);"></div>warn</div>
+          <div class="sw"><div class="band" style="background: var(--err);"></div>err</div>
+          <div class="sw"><div class="band" style="background: var(--think);"></div>think</div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      var btn = document.getElementById("themeToggle");
+      var label = document.getElementById("themeLabel");
+      function apply(theme) {
+        if (theme === "dark") {
+          document.documentElement.dataset.theme = "dark";
+          label.textContent = "Light";
+        } else {
+          delete document.documentElement.dataset.theme;
+          label.textContent = "Dark";
+        }
+      }
+      // Respect system pref on first load, no localStorage write (preview page).
+      var mql = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+      apply(mql && mql.matches ? "dark" : "light");
+      btn.addEventListener("click", function () {
+        var current = document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+        apply(current === "dark" ? "light" : "dark");
+      });
+      if (mql && mql.addEventListener) {
+        mql.addEventListener("change", function (e) { apply(e.matches ? "dark" : "light"); });
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/turnstone/shared_static/design/preview.html
+++ b/turnstone/shared_static/design/preview.html
@@ -13,6 +13,9 @@
   <link rel="stylesheet" href="./primitives/pills.css" />
   <link rel="stylesheet" href="./primitives/stats.css" />
   <link rel="stylesheet" href="./primitives/feed.css" />
+  <link rel="stylesheet" href="./patterns/approval-dock.css" />
+  <link rel="stylesheet" href="./patterns/fleet-grid.css" />
+  <link rel="stylesheet" href="./patterns/live-feed.css" />
   <style>
     /* preview-page-only styles — not part of the design system */
     body { margin: 0; min-width: 1280px; }
@@ -41,39 +44,10 @@
       border-radius: var(--r-sm);
       margin-bottom: 6px;
     }
-    .fleet-demo {
-      display: grid;
-      grid-template-columns: repeat(14, 1fr);
-      gap: 4px;
-      padding: 14px;
-      max-width: 600px;
-    }
-    .fleet-demo .node {
-      aspect-ratio: 1;
-      border-radius: 3px;
-      background: var(--ok-soft);
-      position: relative;
-      border: 1px solid transparent;
-      cursor: pointer;
-    }
-    .fleet-demo .node::after {
-      content: "";
-      position: absolute;
-      inset: 2px;
-      border-radius: 1px;
-      background: linear-gradient(to top, var(--fill, var(--ok)) var(--pct, 30%), transparent var(--pct, 30%));
-      opacity: 0.75;
-    }
-    .fleet-demo .node.s-ok       { --fill: var(--ok);    background: var(--ok-soft); }
-    .fleet-demo .node.s-thinking { --fill: var(--think); background: var(--think-soft); }
-    .fleet-demo .node.s-attn     { --fill: var(--warn);  background: var(--warn-soft); border-color: var(--warn); }
-    .fleet-demo .node.s-err      { --fill: var(--err);   background: var(--err-soft);  border-color: var(--err); }
-    .fleet-demo .node.s-idle     { --fill: var(--ink-4); background: var(--hair-2); }
-    .fleet-demo .node.s-unreach {
-      background: repeating-linear-gradient(-45deg, var(--hair) 0 3px, var(--hair-2) 3px 6px);
-      opacity: 0.6;
-    }
-    .fleet-demo .node:hover { outline: 2px solid var(--accent); outline-offset: 1px; z-index: 2; }
+    /* Keep the preview's fleet grid compact for inline viewing. */
+    .fleet-demo-wrap .fleet { max-width: 600px; }
+    /* Room below the last section for the fixed approval dock. */
+    main { padding-bottom: 220px; }
   </style>
 </head>
 <body>
@@ -221,27 +195,37 @@
               <span class="meta">42 nodes</span>
               <div class="tools"><button class="ghost on">Grid</button><button class="ghost">List</button></div>
             </div>
-            <div class="fleet-demo">
-              <div class="node s-ok" style="--pct: 30%;"></div>
-              <div class="node s-ok" style="--pct: 45%;"></div>
-              <div class="node s-ok" style="--pct: 60%;"></div>
-              <div class="node s-thinking" style="--pct: 75%;"></div>
-              <div class="node s-attn" style="--pct: 50%;"></div>
-              <div class="node s-ok" style="--pct: 20%;"></div>
-              <div class="node s-ok" style="--pct: 35%;"></div>
-              <div class="node s-idle" style="--pct: 10%;"></div>
-              <div class="node s-ok" style="--pct: 90%;"></div>
-              <div class="node s-err" style="--pct: 0%;"></div>
-              <div class="node s-ok" style="--pct: 55%;"></div>
-              <div class="node s-ok" style="--pct: 40%;"></div>
-              <div class="node s-thinking" style="--pct: 65%;"></div>
-              <div class="node s-unreach"></div>
-              <div class="node s-ok" style="--pct: 25%;"></div>
-              <div class="node s-ok" style="--pct: 50%;"></div>
-              <div class="node s-idle" style="--pct: 5%;"></div>
-              <div class="node s-ok" style="--pct: 70%;"></div>
-              <div class="node s-attn" style="--pct: 80%;"></div>
-              <div class="node s-ok" style="--pct: 45%;"></div>
+            <div class="fleet-demo-wrap">
+              <div class="fleet">
+                <div class="node s-ok" style="--pct: 30%;"></div>
+                <div class="node s-ok" style="--pct: 45%;"></div>
+                <div class="node s-ok" style="--pct: 60%;"></div>
+                <div class="node s-thinking" style="--pct: 75%;"></div>
+                <div class="node s-attn" style="--pct: 50%;"></div>
+                <div class="node s-ok" style="--pct: 20%;"></div>
+                <div class="node s-ok" style="--pct: 35%;"></div>
+                <div class="node s-idle" style="--pct: 10%;"></div>
+                <div class="node s-ok" style="--pct: 90%;"></div>
+                <div class="node s-err" style="--pct: 0%;"></div>
+                <div class="node s-ok" style="--pct: 55%;"></div>
+                <div class="node s-ok" style="--pct: 40%;"></div>
+                <div class="node s-thinking" style="--pct: 65%;"></div>
+                <div class="node s-unreach"></div>
+                <div class="node s-ok" style="--pct: 25%;"></div>
+                <div class="node s-ok" style="--pct: 50%;"></div>
+                <div class="node s-idle" style="--pct: 5%;"></div>
+                <div class="node s-ok" style="--pct: 70%;"></div>
+                <div class="node s-attn" style="--pct: 80%;"></div>
+                <div class="node s-ok" style="--pct: 45%;"></div>
+              </div>
+              <div class="fleet-legend">
+                <div class="k"><span class="sw ok"></span>ok</div>
+                <div class="k"><span class="sw thinking"></span>thinking</div>
+                <div class="k"><span class="sw attn"></span>attention</div>
+                <div class="k"><span class="sw err"></span>error</div>
+                <div class="k"><span class="sw idle"></span>idle</div>
+                <div class="k"><span class="sw unreach"></span>unreachable</div>
+              </div>
             </div>
           </div>
         </div>
@@ -300,6 +284,50 @@
       </section>
 
       <section class="section">
+        <h2>Live feed (pattern)</h2>
+        <div class="panel">
+          <div class="live-feed" role="log" aria-live="polite">
+            <div class="feed-item">
+              <div class="ts">10:42:18</div>
+              <div class="body">
+                <div class="hd">
+                  <span class="k-badge k-tools">tools</span>
+                  <span class="fn">spawn_batch</span>
+                  <span class="target">ws_a1b2c3d4</span>
+                </div>
+                <div class="sum">Fanning out 6 child workstreams to shard log triage.</div>
+              </div>
+              <div class="acts"><span class="conf">0.94</span></div>
+            </div>
+            <div class="feed-item">
+              <div class="ts">10:42:19</div>
+              <div class="body">
+                <div class="hd">
+                  <span class="k-badge k-judge">judge</span>
+                  <span class="fn">score</span>
+                  <span class="target">child ws_ff11</span>
+                </div>
+                <div class="sum">Scored child output: 0.88 confidence.</div>
+              </div>
+              <div class="acts"><span class="conf">0.88</span></div>
+            </div>
+            <div class="feed-item">
+              <div class="ts">10:42:20</div>
+              <div class="body">
+                <div class="hd">
+                  <span class="k-badge k-policy">policy</span>
+                  <span class="fn">allow</span>
+                  <span class="target">role:operator</span>
+                </div>
+                <div class="sum">Policy bundle v4 applied.</div>
+              </div>
+              <div class="acts"><span class="judged"><span class="spin" aria-hidden="true"></span>judging</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
         <h2>Semantic token swatches</h2>
         <div class="swatches">
           <div class="sw"><div class="band" style="background: var(--accent);"></div>accent</div>
@@ -312,6 +340,36 @@
       </section>
     </main>
   </div>
+
+  <!-- Approval dock (pattern) — bottom-pinned demo. Only visible when
+       pending approvals exist; in production this is toggled by JS. -->
+  <!-- aria-live="polite" so screen readers announce when a new approval
+       queues while focus is elsewhere. Don't use "assertive" — the dock
+       intentionally does NOT hijack focus. -->
+  <aside class="approval-dock" role="region" aria-label="Approval required" aria-live="polite">
+    <div class="dhead">
+      Approval required
+      <span class="dcount">2 pending</span>
+    </div>
+    <div class="dcall">
+      <span class="risk med">med</span>
+      <span class="dfn">exec</span>
+      <span class="dargs">node-12 / rm -rf /tmp/cache</span>
+    </div>
+    <div class="dctx">
+      <code>ws_a1b2c3d4</code>
+      <code>role:operator</code>
+      <code>judge: 0.88</code>
+    </div>
+    <div class="drow">
+      <button class="nav" type="button">← prev</button>
+      <button class="nav" type="button">next →</button>
+      <div class="spacer"></div>
+      <button class="act danger" type="button">Deny<span class="kbd">D</span></button>
+      <button class="act always" type="button">Always<span class="kbd">⇧A</span></button>
+      <button class="act primary" type="button">Approve<span class="kbd">⏎</span></button>
+    </div>
+  </aside>
 
   <script>
     (function () {

--- a/turnstone/shared_static/design/preview.html
+++ b/turnstone/shared_static/design/preview.html
@@ -380,7 +380,7 @@
           document.documentElement.dataset.theme = "dark";
           label.textContent = "Light";
         } else {
-          delete document.documentElement.dataset.theme;
+          document.documentElement.dataset.theme = "light";
           label.textContent = "Dark";
         }
       }

--- a/turnstone/shared_static/design/primitives/buttons.css
+++ b/turnstone/shared_static/design/primitives/buttons.css
@@ -1,0 +1,86 @@
+/* turnstone design system — button primitive
+   Default shape is pill (999px) per the prototype; approval-dock buttons
+   get a 6px-radius squared shape in patterns/approval-dock.css.
+
+   Variants:
+     .btn           neutral (hair border, panel bg)
+     .btn.primary   accent-tinted (used for key ok/continue actions)
+     .btn.deny      err-tinted (destructive secondary)
+     .btn.approve   warn-tinted (approval actions — NEVER green; amber is
+                    the product signal for "needs attention → resolved") */
+
+[data-design="v1"] .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-2);
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+[data-design="v1"] .btn:hover {
+  background: var(--panel-2);
+  color: var(--ink);
+  border-color: color-mix(in srgb, var(--ink-3) 30%, var(--hair));
+}
+
+[data-design="v1"] .btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-design="v1"] .btn.primary {
+  background: var(--accent-soft);
+  /* Raw --accent on pale --accent-soft is borderline AA at 12px; darken
+     with ink to push contrast > 4.5:1 in both themes. */
+  color: color-mix(in srgb, var(--accent) 60%, var(--ink));
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--hair));
+}
+
+[data-design="v1"] .btn.primary:hover {
+  background: color-mix(in srgb, var(--accent-soft) 70%, var(--panel));
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+[data-design="v1"] .btn.deny {
+  color: var(--err);
+  border-color: color-mix(in srgb, var(--err) 28%, var(--hair));
+}
+
+[data-design="v1"] .btn.deny:hover {
+  background: var(--err-soft);
+  border-color: var(--err);
+}
+
+[data-design="v1"] .btn.approve {
+  background: color-mix(in srgb, var(--warn) 22%, var(--panel));
+  /* Warn-on-warn-tinted is borderline AA; darken resting text so the
+     primary approval call-to-action is readable without hover. */
+  color: color-mix(in srgb, var(--warn) 55%, var(--ink));
+  border-color: color-mix(in srgb, var(--warn) 60%, var(--hair));
+  font-weight: 600;
+}
+
+[data-design="v1"] .btn.approve:hover {
+  background: color-mix(in srgb, var(--warn) 32%, var(--panel));
+  color: var(--ink);
+  border-color: var(--warn);
+}
+
+[data-design="v1"] .btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+  padding: 1px 4px;
+  border: 1px solid var(--hair);
+  border-radius: 3px;
+}

--- a/turnstone/shared_static/design/primitives/feed.css
+++ b/turnstone/shared_static/design/primitives/feed.css
@@ -1,0 +1,118 @@
+/* turnstone design system — live feed
+   Vertical stream of rows, each a three-column grid: timestamp / body /
+   actions. Evidence blocks inside the body use a 2px left-border callout
+   pattern, not nested panels. */
+
+[data-design="v1"] .feed-item {
+  display: grid;
+  grid-template-columns: 44px 1fr auto;
+  gap: 10px;
+  align-items: start;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--hair-2);
+}
+
+[data-design="v1"] .feed-item:last-child { border-bottom: none; }
+[data-design="v1"] .feed-item:hover      { background: var(--panel-2); }
+
+[data-design="v1"] .feed-item .ts {
+  margin-top: 2px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .feed-item .body { min-width: 0; }
+
+[data-design="v1"] .feed-item .hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+[data-design="v1"] .feed-item .hd .fn {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--ink);
+}
+
+[data-design="v1"] .feed-item .hd .target {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .feed-item .sum {
+  margin-top: 4px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--ink-2);
+}
+
+[data-design="v1"] .feed-item .evi {
+  margin-top: 6px;
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  background: var(--panel-2);
+  border-left: 2px solid var(--hair);
+  border-radius: 0 3px 3px 0;
+  white-space: pre-wrap;
+}
+
+[data-design="v1"] .feed-item .acts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+[data-design="v1"] .feed-item .acts .conf {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .feed-item .acts .buttons {
+  display: flex;
+  gap: 4px;
+}
+
+/* Compact action buttons inside feed-item .acts — only for plain <button>
+   without a .btn class. .btn-classed buttons keep their pill shape so
+   approval-dock / pattern-level styles can square them deliberately. */
+[data-design="v1"] .feed-item .acts button:not(.btn) {
+  height: 24px;
+  padding: 0 8px;
+  font-size: 11px;
+  border-radius: 3px;
+}
+
+[data-design="v1"] .feed-item.decided { opacity: 0.55; }
+
+[data-design="v1"] .feed-item .judged {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .feed-item .judged .spin {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent);
+  border-top-color: transparent;
+  animation: ts-spin 0.9s linear infinite;
+}
+
+@keyframes ts-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-design="v1"] .feed-item .judged .spin { animation: none; }
+}

--- a/turnstone/shared_static/design/primitives/panel.css
+++ b/turnstone/shared_static/design/primitives/panel.css
@@ -1,0 +1,86 @@
+/* turnstone design system — panel primitive
+   Container card used everywhere: data tables, stat tiles, side pages.
+   Optional .panel-head has an 11px uppercase title and a .tools slot for
+   .ghost actions. Panels do not nest — callouts inside a panel use the
+   .feed-item .evi evidence-block pattern. */
+
+[data-design="v1"] .panel {
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+[data-design="v1"] .panel + .panel {
+  margin-top: var(--gap);
+}
+
+[data-design="v1"] .panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--hair);
+}
+
+[data-design="v1"] .panel-head h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+
+[data-design="v1"] .panel-head .meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+/* Pin .tools to the right regardless of how many head children are present,
+   so two-child heads (h3 + tools) and three-child heads (h3 + meta + tools)
+   both read right-aligned on the trailing edge. */
+[data-design="v1"] .panel-head .tools {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+/* .ghost — low-emphasis tool button; lives in panel heads or toolbars */
+[data-design="v1"] .ghost {
+  height: 22px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-3);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+[data-design="v1"] .ghost:hover {
+  background: var(--hair-2);
+  color: var(--ink);
+}
+
+[data-design="v1"] .ghost:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Darker accent on accent-soft — raw --accent on pale --accent-soft in
+   light mode falls below WCAG AA at 12px; mix 60% accent + 40% ink to
+   land comfortably above 4.5:1 in both themes. */
+[data-design="v1"] .ghost.on {
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 60%, var(--ink));
+}

--- a/turnstone/shared_static/design/primitives/pills.css
+++ b/turnstone/shared_static/design/primitives/pills.css
@@ -1,0 +1,178 @@
+/* turnstone design system — pill / k-badge / chip / risk
+   Three shapes, three semantics — do not cross-use:
+     .pill     what this thing is DOING right now. Pulses on active states.
+     .k-badge  what KIND of thing this is. Glyph-prefixed (WCAG 1.4.1
+               non-colour-only signaling). Static.
+     .chip     a literal identifier or tag. Static. */
+
+[data-design="v1"] .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  border-radius: 999px;
+  /* Fallback surface for plain `<span class="pill">` without a state
+     modifier — every .pill.X variant supplies its own bg+color. */
+  background: var(--hair-2);
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .pill .d {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+[data-design="v1"] .pill.running {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+[data-design="v1"] .pill.running .d {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 25%, transparent);
+  animation: ts-pulse 1.8s infinite;
+}
+
+[data-design="v1"] .pill.thinking {
+  background: var(--think-soft);
+  color: var(--think);
+}
+[data-design="v1"] .pill.thinking .d {
+  background: var(--think);
+  animation: ts-pulse 1.2s infinite;
+}
+
+[data-design="v1"] .pill.attn {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+[data-design="v1"] .pill.attn .d { background: var(--warn); }
+
+[data-design="v1"] .pill.idle {
+  background: var(--hair-2);
+  color: var(--ink-3);
+}
+[data-design="v1"] .pill.idle .d { background: var(--ink-4); }
+
+[data-design="v1"] .pill.err {
+  background: var(--err-soft);
+  color: var(--err);
+}
+[data-design="v1"] .pill.err .d { background: var(--err); }
+
+@keyframes ts-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
+
+/* Respect prefers-reduced-motion — disable pulses for users who opt out. */
+@media (prefers-reduced-motion: reduce) {
+  [data-design="v1"] .pill.running .d,
+  [data-design="v1"] .pill.thinking .d {
+    animation: none;
+  }
+}
+
+/* k-badge — "what kind of thing". Glyph-prefixed; colour reinforces but
+   does not carry the signal alone (WCAG 1.4.1). */
+[data-design="v1"] .k-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 6px 0 5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: lowercase;
+  white-space: nowrap;
+  background: var(--panel-2);
+  color: var(--ink-2);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+}
+
+[data-design="v1"] .k-badge::before {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: inherit;
+  opacity: 0.9;
+}
+
+[data-design="v1"] .k-badge.k-tools,
+[data-design="v1"] .k-badge.k-approval {
+  background: color-mix(in srgb, var(--warn) 14%, var(--panel));
+  color: color-mix(in srgb, var(--warn) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--warn) 38%, var(--hair));
+}
+[data-design="v1"] .k-badge.k-tools::before,
+[data-design="v1"] .k-badge.k-approval::before { content: "▲"; }
+
+[data-design="v1"] .k-badge.k-policy,
+[data-design="v1"] .k-badge.k-role,
+[data-design="v1"] .k-badge.k-oidc,
+[data-design="v1"] .k-badge.k-token,
+[data-design="v1"] .k-badge.k-step-up {
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+  color: color-mix(in srgb, var(--accent) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--hair));
+}
+[data-design="v1"] .k-badge.k-policy::before,
+[data-design="v1"] .k-badge.k-role::before,
+[data-design="v1"] .k-badge.k-oidc::before,
+[data-design="v1"] .k-badge.k-token::before,
+[data-design="v1"] .k-badge.k-step-up::before { content: "◆"; }
+
+[data-design="v1"] .k-badge.k-judge {
+  background: color-mix(in srgb, var(--think) 14%, var(--panel));
+  color: color-mix(in srgb, var(--think) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--think) 38%, var(--hair));
+}
+[data-design="v1"] .k-badge.k-judge::before { content: "◇"; }
+
+[data-design="v1"] .k-badge.k-query::before { content: "■"; }
+
+[data-design="v1"] .k-badge.k-session::before,
+[data-design="v1"] .k-badge.k-skill::before,
+[data-design="v1"] .k-badge.k-workstream::before,
+[data-design="v1"] .k-badge.k-fanout::before,
+[data-design="v1"] .k-badge.k-default::before { content: "•"; }
+
+/* chip — literal id or tag */
+[data-design="v1"] .chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-2);
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: 999px;
+}
+
+/* risk — tiny uppercase mono tag */
+[data-design="v1"] .risk {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+}
+
+[data-design="v1"] .risk.low  { background: var(--ok-soft);   color: var(--ok); }
+[data-design="v1"] .risk.med  { background: var(--warn-soft); color: var(--warn); }
+[data-design="v1"] .risk.high { background: var(--err-soft);  color: var(--err); }
+/* .risk.crit always-white — dark-mode --panel (#15181c) on bright err falls
+   to ~3:1 and fails AA; white stays high-contrast in both themes. */
+[data-design="v1"] .risk.crit { background: var(--err);       color: #fff; }

--- a/turnstone/shared_static/design/primitives/stats.css
+++ b/turnstone/shared_static/design/primitives/stats.css
@@ -1,0 +1,110 @@
+/* turnstone design system — stat / mini-bar / spark
+   .stat      KPI tile with 2px top accent bar. Modifier classes
+              (.running / .thinking / .attention / .idle / .error / .all)
+              switch the accent bar colour to a semantic token.
+   .mini-bar  inline progress fill. Set width via --pct on the <i>.
+   .spark     row of thin bars; set height per bar via --h on each <i>. */
+
+[data-design="v1"] .stat-row {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--hair);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  margin-bottom: 18px;
+}
+
+[data-design="v1"] .stat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+[data-design="v1"] .stat:hover { background: var(--panel-2); }
+
+[data-design="v1"] .stat:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+[data-design="v1"] .stat::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--ink-4);
+}
+
+[data-design="v1"] .stat.running::before   { background: var(--ok); }
+[data-design="v1"] .stat.thinking::before  { background: var(--think); }
+[data-design="v1"] .stat.attention::before { background: var(--warn); }
+[data-design="v1"] .stat.idle::before      { background: var(--ink-4); }
+[data-design="v1"] .stat.error::before     { background: var(--err); }
+[data-design="v1"] .stat.all::before       { background: var(--accent); }
+
+[data-design="v1"] .stat .lbl {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .stat .val {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+[data-design="v1"] .stat .delta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+/* mini-bar */
+[data-design="v1"] .mini-bar {
+  display: inline-block;
+  width: 64px;
+  height: 6px;
+  border-radius: 2px;
+  background: var(--hair-2);
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+[data-design="v1"] .mini-bar > i {
+  display: block;
+  height: 100%;
+  width: var(--pct, 0%);
+  background: var(--accent);
+}
+
+[data-design="v1"] .mini-bar.warn > i { background: var(--warn); }
+[data-design="v1"] .mini-bar.err  > i { background: var(--err); }
+
+/* spark — sparkline row */
+[data-design="v1"] .spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 24px;
+}
+
+[data-design="v1"] .spark i {
+  flex: 1;
+  height: var(--h, 50%);
+  background: var(--accent);
+  border-radius: 1px;
+  opacity: 0.7;
+}

--- a/turnstone/shared_static/design/tokens.css
+++ b/turnstone/shared_static/design/tokens.css
@@ -1,0 +1,80 @@
+/* turnstone design system — tokens
+   Source: design_ideas/README.md (Claude Design handoff)
+
+   Accent customised: warm amber (hue 70) — preserves turnstone's signature
+   colour from the prior "Instrument Panel" palette. All other values follow
+   Claude Design spec verbatim.
+
+   Hard rules (do not drift):
+     - color-mix always uses `in srgb`, never `oklch`/`oklab`
+       (oklch interpolation takes the shortest hue arc and paints pink-tinted
+       borders between warm + cool neutrals)
+     - --warn is amber (hue 78), never 90+ (yellow-green)
+     - --ok is green (hue 150), never 155 (tips teal in dark)
+     - approve UI is warn-tinted, never green (approvals signal "needs
+       attention"; approving resolves amber rather than creating green) */
+
+:root {
+  /* Accent — warm amber (turnstone signature).
+     Tunable via these three vars without touching downstream primitives. */
+  --accent-h: 70;
+  --accent-c: 0.13;
+  --accent-l: 0.62;
+  --density: 1;
+
+  /* Neutrals (light) */
+  --bg:      #f7f7f4;
+  --panel:   #ffffff;
+  --panel-2: #fbfbf8;
+  --ink:     #101316;
+  --ink-2:   #2d3238;
+  --ink-3:   #565b63;
+  --ink-4:   #7a7f87;
+  --hair:    #dcdbd4;
+  --hair-2:  #e7e5dc;
+
+  /* Semantic */
+  --accent:      oklch(var(--accent-l) var(--accent-c) var(--accent-h));
+  --accent-soft: oklch(0.94 0.03 var(--accent-h));
+  --ok:          oklch(0.52 0.13 150);
+  --ok-soft:     oklch(0.93 0.05 150);
+  --warn:        oklch(0.62 0.13 78);
+  --warn-soft:   oklch(0.95 0.05 78);
+  --err:         oklch(0.50 0.18 25);
+  --err-soft:    oklch(0.93 0.06 25);
+  --think:       oklch(0.48 0.12 260);
+  --think-soft:  oklch(0.94 0.04 260);
+
+  /* Shape */
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 8px;
+  --shadow-sm: 0 1px 0 rgba(21, 24, 27, 0.03),
+               0 1px 2px rgba(21, 24, 27, 0.04);
+
+  /* Rhythm */
+  --gap:   calc(12px * var(--density));
+  --row-h: calc(32px * var(--density));
+}
+
+[data-theme="dark"] {
+  --bg:      #0e1013;
+  --panel:   #15181c;
+  --panel-2: #1a1e23;
+  --ink:     #f2f3f5;
+  --ink-2:   #d4d7db;
+  --ink-3:   #a6abb3;
+  --ink-4:   #808690;
+  --hair:    #2a2e35;
+  --hair-2:  #333842;
+
+  --accent-soft: oklch(0.28 0.05 var(--accent-h));
+  --ok:          oklch(0.75 0.14 150);
+  --ok-soft:     oklch(0.28 0.06 150);
+  --warn:        oklch(0.72 0.12 78);
+  --warn-soft:   oklch(0.28 0.06 78);
+  --err:         oklch(0.72 0.17 25);
+  --err-soft:    oklch(0.30 0.09 25);
+  --think:       oklch(0.72 0.13 260);
+  --think-soft:  oklch(0.28 0.06 260);
+}

--- a/turnstone/shared_static/design/tokens.css
+++ b/turnstone/shared_static/design/tokens.css
@@ -14,7 +14,7 @@
      - approve UI is warn-tinted, never green (approvals signal "needs
        attention"; approving resolves amber rather than creating green) */
 
-:root {
+[data-design="v1"] {
   /* Accent — warm amber (turnstone signature).
      Tunable via these three vars without touching downstream primitives. */
   --accent-h: 70;
@@ -57,7 +57,7 @@
   --row-h: calc(32px * var(--density));
 }
 
-[data-theme="dark"] {
+[data-design="v1"][data-theme="dark"] {
   --bg:      #0e1013;
   --panel:   #15181c;
   --panel-2: #1a1e23;

--- a/turnstone/shared_static/design/tokens.css
+++ b/turnstone/shared_static/design/tokens.css
@@ -57,6 +57,8 @@
   --row-h: calc(32px * var(--density));
 }
 
+[data-design="v1"]:not([data-theme]),
+[data-design="v1"][data-theme=""],
 [data-design="v1"][data-theme="dark"] {
   --bg:      #0e1013;
   --panel:   #15181c;

--- a/turnstone/shared_static/design/typography.css
+++ b/turnstone/shared_static/design/typography.css
@@ -11,16 +11,13 @@
    here only so DS-A stands alone with zero HTML edits. */
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
 
-:root {
-  --font-ui:   "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "JetBrains Mono", "SF Mono", "IBM Plex Mono", Consolas, monospace;
-}
-
 /* Applies defaults on the opt-in root (the element carrying data-design="v1").
    font-family and color inherit to descendants; background does not — panels
    set their own --panel background in DS-B. Existing views are untouched
    until they add the attribute. */
 [data-design="v1"] {
+  --font-ui:   "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "IBM Plex Mono", Consolas, monospace;
   font-family: var(--font-ui);
   font-size: 14px;
   line-height: 1.45;

--- a/turnstone/shared_static/design/typography.css
+++ b/turnstone/shared_static/design/typography.css
@@ -1,0 +1,90 @@
+/* turnstone design system — typography
+   Source: design_ideas/README.md (Claude Design handoff)
+
+   UI:   Inter 400/500/600/700 + ss01/cv11 features
+   Mono: JetBrains Mono 400/500/600 + zero/ss01
+   Base: 14px / 1.45 */
+
+/* NOTE for DS-B wiring: @import here is parser-blocking and serialized —
+   prefer <link rel="preconnect" href="https://fonts.googleapis.com"> plus
+   <link rel="stylesheet" ...> in each opting view's <head>. Kept as @import
+   here only so DS-A stands alone with zero HTML edits. */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --font-ui:   "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "IBM Plex Mono", Consolas, monospace;
+}
+
+/* Applies defaults on the opt-in root (the element carrying data-design="v1").
+   font-family and color inherit to descendants; background does not — panels
+   set their own --panel background in DS-B. Existing views are untouched
+   until they add the attribute. */
+[data-design="v1"] {
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.45;
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+[data-design="v1"] code,
+[data-design="v1"] pre,
+[data-design="v1"] kbd,
+[data-design="v1"] .t-mono {
+  font-family: var(--font-mono);
+  font-feature-settings: "zero", "ss01";
+}
+
+/* Six-step scale — values per README. Use these utility classes or compose
+   the same declarations inside view-specific selectors. */
+
+/* --ink-4 on light --panel is ~4.05:1 — fails WCAG AA for 10px text. Spec-
+   inherited from Claude Design; DS-B can swap to --ink-3 on white panels
+   if accessibility audit requires. Dark mode passes (~5.8:1). */
+.t-kicker {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+}
+
+.t-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.t-btn {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.t-row {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.t-body {
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.t-stat {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.t-h1 {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}


### PR DESCRIPTION
## Summary
Lands the turnstone design-system library in three internal phases on one branch. View-level rewrites (coordinator chat, admin/cluster dashboards) are follow-ups — they need live-server testing.

Source: Anthropic Claude Design handoff. Authoritative spec is \`design_ideas/README.md\` (kept untracked; follow-up PR will move to \`docs/design-system/\`).

## What landed (three commits)

**DS-A — tokens + typography scaffold** (\`tokens.css\`, \`typography.css\`)
- Full palette, shape, rhythm. Light default with \`[data-theme=\"dark\"]\` override.
- Accent customised to turnstone's warm amber (oklch h=70, c=0.13, l=0.62); all other tokens per Claude Design spec.
- Inter + JetBrains Mono, six-step scale utility classes (.t-kicker/.t-meta/.t-btn/.t-row/.t-body/.t-stat/.t-h1).

**DS-B — chrome + primitives + preview page**
- primitives: \`panel\`, \`buttons\`, \`pills\` (.pill / .k-badge / .chip / .risk), \`stats\` (+ .mini-bar / .spark), \`feed\` (.feed-item).
- chrome: \`topbar\` (48px, conic-gradient brand mark), \`sidebar\` (240px, semantic swatches).
- \`preview.html\`: renders every primitive with an in-page theme toggle that tracks \`prefers-color-scheme\`.

**DS-C — patterns**
- \`approval-dock\` — bottom-pinned strip with amber Approve / dashed Always / red Deny actions. 1.5px borders, 6px squared, kbd hints.
- \`fleet-grid\` — 14-col node grid with \`--pct\` load fill + hatch-patterned unreachable state + legend.
- \`live-feed\` — scroll-container wrapper over \`.feed-item\` with a sticky top fade.

## Scope is additive — nothing existing is modified
Every rule scopes under \`[data-design=\"v1\"]\`; \`base.css\` and per-view stylesheets are untouched. Views opt in individually by adding the attribute + linking the needed stylesheets.

## Spec deviations (all intentional)

| Deviation | Why |
|---|---|
| Accent = amber (h=70) not teal (h=182) | User-confirmed: preserve turnstone's \"Instrument Panel\" signature colour |
| \`color-mix(in srgb, …)\` everywhere | Prototype had two \`in oklab\` usages; README's hard rule is srgb to avoid pink-tinted interpolation across warm+cool hues |
| \`.btn.approve\` amber, not green | README rule: approvals signal \"needs attention\"; amber resolves on approval |
| k-badge tints via \`color-mix\` not \`oklch(from …)\` | Broader browser support |
| \`@keyframes ts-pulse/ts-spin\` (prefixed) | Avoid clashing with \`base.css\` on pages that load both |
| \`prefers-reduced-motion\` disables pulse + spin | A11y |
| Text-on-accent-soft + text-on-warn-tint darkened via \`color-mix(…, var(--ink))\` | Pass WCAG AA at 12px (same-hue text-on-tinted-bg fails otherwise) |
| \`.risk.crit\` uses \`#fff\` text, not \`--panel\` | Dark-mode \`--panel\` on bright err fails AA |
| Focus-visible rings across interactive primitives | Prototype had none |

## Code review
Each commit had an independent code-review pass with findings applied before push. Key fixes:
- \`.feed-item .acts button:not(.btn)\` — original rule silently overrode \`.btn\` pill shape; now scoped to only plain buttons.
- Contrast darkening pattern propagated consistently across \`.btn.primary\`, \`.ghost.on\`, \`.topnav a.active\`, \`.side-item.active\`, \`.btn.approve\`, \`.approval-dock button.act.primary\`.
- \`.approval-dock\` gets \`aria-live=\"polite\"\` so new approvals announce without hijacking focus.
- \`.approval-dock .dcall\` framed as an inline code-panel (prototype-parity); the row reads as \"the exact call you're approving.\"

## Follow-ups (not in this PR)
- **Coordinator chat view rewrite** — opt \`coordinator/index.html\` + \`coordinator.js\` into \`data-design=\"v1\"\` and swap \`.ts-approval*\` to \`.approval-dock\`. Needs live-server testing (SSE streams, approval POST contract, keyboard shortcuts).
- **Admin / cluster dashboard rebuild** — \`console/static/index.html\` is the actual fleet-overview surface matching the Claude Design reference. Needs live-server testing.
- **Move \`design_ideas/\` → \`docs/design-system/\`** (or delete once views have migrated).

## Test plan
- [ ] \`/shared/design/tokens.css\`, \`/shared/design/typography.css\`, \`/shared/design/primitives/*\`, \`/shared/design/chrome/*\`, \`/shared/design/patterns/*\`, \`/shared/design/preview.html\` all return 200 from a running turnstone-server and turnstone-console.
- [ ] \`/shared/design/preview.html\` renders all primitives + patterns in both themes. Theme toggle tracks system preference changes live.
- [ ] No regression in any existing view (nothing imports the new files yet).
- [ ] No test suite breakage — diff is CSS + static HTML only.