### PR TITLE
feat(design-system): DS phase 1 — chat primitives (.msg, .field, .appbar)

### DIFF
--- a/turnstone/shared_static/design/chrome/appbar.css
+++ b/turnstone/shared_static/design/chrome/appbar.css
@@ -1,0 +1,99 @@
+/* turnstone design system — appbar
+   Chat-app header variant. Distinct from .topbar (which is admin-style
+   with brand mark + nav + env metadata) — the appbar is for per-session
+   chat surfaces that need a back-link, title, session metadata, and a
+   right-cluster of action buttons (end / cancel / theme-toggle).
+
+   Shape:
+     [back]  title [subtitle/chip]              [status] [btn] [btn]
+     ←────┘  ├─ 14px 600                        └── --ink-3 11px mono
+             └─ optional 12px --ink-3 subtitle
+
+   Used in ui/static (server chat) and console coordinator. */
+
+[data-design="v1"] .appbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 48px;
+  padding: 0 14px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--hair);
+}
+
+[data-design="v1"] .appbar-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--ink-3);
+  text-decoration: none;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+[data-design="v1"] .appbar-back:hover {
+  background: var(--hair-2);
+  color: var(--ink);
+}
+
+[data-design="v1"] .appbar-back:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-design="v1"] .appbar-back-arrow {
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+
+/* Title block — bold title + optional secondary label on the same line.
+   min-width: 0 is required for .dim's ellipsis to fire under a narrow
+   appbar — without it the flex container refuses to shrink below its
+   content's intrinsic width. */
+[data-design="v1"] .appbar-title {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  flex-shrink: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+[data-design="v1"] .appbar-title .dim {
+  font-weight: 400;
+  font-size: 13px;
+  color: var(--ink-3);
+  letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Spacer pushes the right cluster to the edge. Use as a flex filler
+   between the title and the action row. */
+[data-design="v1"] .appbar-spacer { flex: 1; }
+
+/* Status text (SSE connection state, streaming indicator). Polite
+   aria-live lives on this span; the typography here intentionally
+   doesn't pulse so screen readers don't see layout churn. */
+[data-design="v1"] .appbar-status {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+/* Right cluster of action buttons. Match .btn sizing (28px / 12px) but
+   the pill shape optionally squares off when grouped tightly. */
+[data-design="v1"] .appbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}

--- a/turnstone/shared_static/design/preview.html
+++ b/turnstone/shared_static/design/preview.html
@@ -13,6 +13,9 @@
   <link rel="stylesheet" href="./primitives/pills.css" />
   <link rel="stylesheet" href="./primitives/stats.css" />
   <link rel="stylesheet" href="./primitives/feed.css" />
+  <link rel="stylesheet" href="./primitives/message.css" />
+  <link rel="stylesheet" href="./primitives/field.css" />
+  <link rel="stylesheet" href="./chrome/appbar.css" />
   <link rel="stylesheet" href="./patterns/approval-dock.css" />
   <link rel="stylesheet" href="./patterns/fleet-grid.css" />
   <link rel="stylesheet" href="./patterns/live-feed.css" />
@@ -324,6 +327,100 @@
               <div class="acts"><span class="judged"><span class="spin" aria-hidden="true"></span>judging</span></div>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Messages (chat primitive)</h2>
+        <div style="max-width: 680px;">
+          <div class="msg user">
+            <div class="msg-body">
+              Can you fan out a log-triage across the three eu shards and tell me which one had the most 5xx in the last hour?
+            </div>
+          </div>
+          <div class="msg assistant" data-streaming="true">
+            <div class="msg-actions">
+              <button class="msg-action-btn" type="button">Copy</button>
+              <button class="msg-action-btn" type="button">Retry</button>
+            </div>
+            <div class="msg-meta">
+              <span>assistant</span><span>·</span><span>10:42:19</span><span>·</span><span>claude-opus-4-7</span>
+            </div>
+            <div class="msg-body">
+              <p>Spawning six child workstreams (two per shard) to grep the last hour's access logs. Will aggregate the <code>status &gt;= 500</code> counts and report back.</p>
+              <pre><code>{"shards": ["eu-1", "eu-2", "eu-3"], "lookback": "1h", "filter": "5xx"}</code></pre>
+            </div>
+          </div>
+          <div class="msg reasoning">
+            <div class="msg-body">
+              Let me think about how to partition this — per-shard, or per-node inside each shard?
+            </div>
+          </div>
+          <div class="msg tool">
+            <div class="msg-body">spawn_batch → 6 children created, budget: 18 remaining</div>
+          </div>
+          <div class="msg info">
+            <div class="msg-body">Policy bundle v4 applied to this session.</div>
+          </div>
+          <div class="msg error">
+            <div class="msg-body">node-04 did not respond within 5s; retrying with backoff.</div>
+          </div>
+          <div class="msg system">
+            <div class="msg-body">Session ended by operator.</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Form fields (primitive)</h2>
+        <div style="max-width: 420px;">
+          <label class="field">
+            <span class="field-label">Workstream name</span>
+            <input type="text" placeholder="eu-triage-2026-04-20" />
+            <span class="field-help">Shown in the dashboard and audit log.</span>
+          </label>
+          <label class="field">
+            <span class="field-label">System prompt</span>
+            <textarea placeholder="You are an operator…"></textarea>
+          </label>
+          <label class="field">
+            <span class="field-label">Model</span>
+            <select>
+              <option>claude-opus-4-7</option>
+              <option>claude-sonnet-4-6</option>
+              <option>gpt-5</option>
+            </select>
+          </label>
+          <label class="field invalid">
+            <span class="field-label">Budget (tokens)</span>
+            <input type="number" aria-invalid="true" value="-500" />
+            <span class="field-help">Budget must be a positive integer.</span>
+          </label>
+          <label class="field inline">
+            <input type="checkbox" checked />
+            <span class="field-label">Allow tool use</span>
+          </label>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Appbar (chat header chrome)</h2>
+        <div style="border: 1px solid var(--hair); border-radius: var(--r-md); overflow: hidden;">
+          <header class="appbar" style="position: static;">
+            <a class="appbar-back" tabindex="0">
+              <span class="appbar-back-arrow" aria-hidden="true">←</span>
+              <span>Console</span>
+            </a>
+            <div class="appbar-title">
+              turnstone <span class="dim">coordinator · ws_a1b2c3d4</span>
+            </div>
+            <div class="appbar-spacer"></div>
+            <span class="appbar-status">streaming…</span>
+            <div class="appbar-actions">
+              <button class="btn">Cancel</button>
+              <button class="btn deny">End</button>
+            </div>
+          </header>
         </div>
       </section>
 

--- a/turnstone/shared_static/design/preview.html
+++ b/turnstone/shared_static/design/preview.html
@@ -407,10 +407,13 @@
         <h2>Appbar (chat header chrome)</h2>
         <div style="border: 1px solid var(--hair); border-radius: var(--r-md); overflow: hidden;">
           <header class="appbar" style="position: static;">
-            <a class="appbar-back" tabindex="0">
+            <!-- Prefer <button type="button"> (this preview) or <a href="...">
+                 in production. Tabindex-only anchors without href have
+                 inconsistent focus + screen-reader semantics. -->
+            <button class="appbar-back" type="button">
               <span class="appbar-back-arrow" aria-hidden="true">←</span>
               <span>Console</span>
-            </a>
+            </button>
             <div class="appbar-title">
               turnstone <span class="dim">coordinator · ws_a1b2c3d4</span>
             </div>

--- a/turnstone/shared_static/design/primitives/field.css
+++ b/turnstone/shared_static/design/primitives/field.css
@@ -119,8 +119,10 @@
   box-shadow: none;
 }
 
-/* Inline layout when wrapping a checkbox/radio with a label — the .field
-   stays flex-column but the inner row stays inline. */
+/* Inline layout for checkbox/radio fields — flips the wrapper to flex-row
+   so the checkbox + its label sit on one line (the base .field is
+   flex-column for stacked label / control / help). Used for "Allow tool
+   use" toggles, consent checkboxes, etc. */
 [data-design="v1"] .field.inline {
   flex-direction: row;
   align-items: center;

--- a/turnstone/shared_static/design/primitives/field.css
+++ b/turnstone/shared_static/design/primitives/field.css
@@ -1,0 +1,151 @@
+/* turnstone design system — form field primitive
+   Used by composer, admin forms, and any view collecting structured
+   input. A .field is a wrapper with a label + control + optional help
+   or error text. Input/textarea/select are styled via element selectors
+   inside .field so the same primitive handles all three without variant
+   classes.
+
+   Usage:
+     <label class="field">
+       <span class="field-label">Display name</span>
+       <input type="text" placeholder="…" />
+       <span class="field-help">Shown on your profile.</span>
+     </label>
+
+   Error state: add `.field.invalid` on the wrapper; renders a red border
+   + err-tinted help text. Use aria-invalid="true" on the control too. */
+
+[data-design="v1"] .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+
+[data-design="v1"] .field-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+/* --ink-3 (not --ink-4) — --ink-4 on --panel lands at ~4.35:1 in light
+   mode which fails AA for 11px body text. Help text is frequently
+   validation guidance; readability matters. */
+[data-design="v1"] .field-help {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .field input[type="text"],
+[data-design="v1"] .field input[type="email"],
+[data-design="v1"] .field input[type="password"],
+[data-design="v1"] .field input[type="url"],
+[data-design="v1"] .field input[type="number"],
+[data-design="v1"] .field input[type="search"],
+[data-design="v1"] .field input[type="tel"],
+[data-design="v1"] .field input[type="date"],
+[data-design="v1"] .field input[type="time"],
+[data-design="v1"] .field input[type="datetime-local"],
+[data-design="v1"] .field input[type="month"],
+[data-design="v1"] .field input[type="week"],
+[data-design="v1"] .field textarea,
+[data-design="v1"] .field select {
+  width: 100%;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+[data-design="v1"] .field textarea {
+  min-height: 72px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+[data-design="v1"] .field input:hover,
+[data-design="v1"] .field textarea:hover,
+[data-design="v1"] .field select:hover {
+  border-color: color-mix(in srgb, var(--ink-3) 30%, var(--hair));
+}
+
+[data-design="v1"] .field input:focus-visible,
+[data-design="v1"] .field textarea:focus-visible,
+[data-design="v1"] .field select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+[data-design="v1"] .field input::placeholder,
+[data-design="v1"] .field textarea::placeholder {
+  color: var(--ink-4);
+}
+
+[data-design="v1"] .field input:disabled,
+[data-design="v1"] .field textarea:disabled,
+[data-design="v1"] .field select:disabled {
+  color: var(--ink-4);
+  background: var(--panel-2);
+  cursor: not-allowed;
+}
+
+/* Checkbox + radio — keep native controls but recolour the focus ring.
+   Sized 14px so the label aligns on the same 13px text baseline.
+   Override the default-input :focus-visible rule (which sets box-shadow
+   but not outline) — native tick-boxes don't render a border, so the
+   shadow alone is subtle. Use a traditional outline instead. */
+[data-design="v1"] .field input[type="checkbox"],
+[data-design="v1"] .field input[type="radio"] {
+  width: 14px;
+  height: 14px;
+  margin: 0 6px 0 0;
+  accent-color: var(--accent);
+}
+
+[data-design="v1"] .field input[type="checkbox"]:focus-visible,
+[data-design="v1"] .field input[type="radio"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+/* Inline layout when wrapping a checkbox/radio with a label — the .field
+   stays flex-column but the inner row stays inline. */
+[data-design="v1"] .field.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-design="v1"] .field.inline .field-label {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+
+/* Invalid state — add `.invalid` to the wrapper. */
+[data-design="v1"] .field.invalid input,
+[data-design="v1"] .field.invalid textarea,
+[data-design="v1"] .field.invalid select {
+  border-color: var(--err);
+}
+[data-design="v1"] .field.invalid input:focus-visible,
+[data-design="v1"] .field.invalid textarea:focus-visible,
+[data-design="v1"] .field.invalid select:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--err) 25%, transparent);
+}
+[data-design="v1"] .field.invalid .field-help {
+  color: var(--err);
+}

--- a/turnstone/shared_static/design/primitives/message.css
+++ b/turnstone/shared_static/design/primitives/message.css
@@ -190,7 +190,11 @@
   color: var(--ink-3);
 }
 
-/* Hover-revealed action row — copy / regenerate / feedback buttons. */
+/* Hover-revealed action row — copy / regenerate / feedback buttons.
+   pointer-events toggles alongside opacity so the invisible toolbar
+   doesn't intercept clicks in the top-right corner of the message
+   (would otherwise break text selection on the last word of a short
+   one-line msg). */
 [data-design="v1"] .msg-actions {
   position: absolute;
   top: 4px;
@@ -198,11 +202,15 @@
   display: flex;
   gap: 2px;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 120ms ease;
 }
 
 [data-design="v1"] .msg:hover .msg-actions,
-[data-design="v1"] .msg:focus-within .msg-actions { opacity: 1; }
+[data-design="v1"] .msg:focus-within .msg-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 [data-design="v1"] .msg-action-btn {
   height: 22px;
@@ -234,6 +242,6 @@
    shared_static/chat.css:146. Keyboard users are handled by
    :focus-within on .msg above. */
 @media (hover: none) and (pointer: coarse) {
-  [data-design="v1"] .msg-actions { opacity: 1; }
+  [data-design="v1"] .msg-actions { opacity: 1; pointer-events: auto; }
   [data-design="v1"] .msg-action-btn { padding: 4px 8px; font-size: 12px; }
 }

--- a/turnstone/shared_static/design/primitives/message.css
+++ b/turnstone/shared_static/design/primitives/message.css
@@ -1,0 +1,239 @@
+/* turnstone design system — message primitive
+   Chat-style single-column message block. Semantic variant carries via
+   3px left-border colour (and text colour for error/info). Used by both
+   the per-node server chat UI and the coordinator chat view — replaces
+   the existing .ts-msg family in turnstone/shared_static/chat.css.
+
+   Variants:
+     .msg                 base (assistant / generic)
+     .msg.user            user-authored turn (accent left-border)
+     .msg.assistant       explicit assistant (same as base, clarity class)
+     .msg.reasoning       <thinking> / reasoning trace — dashed left-border
+     .msg.tool            tool output / tool response — accent-tinted
+     .msg.error           error states — err red
+     .msg.info            transient info — think indigo, smaller
+     .msg.system          system-injected turns (policy notices, etc.)
+
+   Content sub-elements:
+     .msg-meta            author / timestamp / model label (optional);
+                          placed above .msg-body in mono 11px --ink-3
+     .msg-body            markdown target — styles code, pre, headings,
+                          lists, blockquotes, strong/em
+     .msg-actions         hover-revealed action buttons (copy / regenerate)
+
+   Streaming indicator: add `data-streaming="true"` to the .msg and a
+   blinking caret appears at the end of .msg-body. Avoids per-view
+   reinvention. */
+
+[data-design="v1"] .msg {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background: var(--panel-2);
+  border: 1px solid var(--hair);
+  border-left-width: 3px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  line-height: 1.55;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* Variant left-borders */
+[data-design="v1"] .msg.user       { border-left-color: var(--accent); }
+[data-design="v1"] .msg.assistant  { border-left-color: var(--hair-2); }
+[data-design="v1"] .msg.reasoning {
+  border-left-style: dashed;
+  border-left-color: var(--ink-4);
+  color: var(--ink-3);
+  font-style: italic;
+}
+[data-design="v1"] .msg.tool {
+  background: var(--panel);
+  border-left-color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+[data-design="v1"] .msg.error {
+  border-left-color: var(--err);
+  color: var(--err);
+}
+[data-design="v1"] .msg.info {
+  border-left-color: var(--think);
+  color: color-mix(in srgb, var(--think) 70%, var(--ink));
+  font-size: 12px;
+}
+[data-design="v1"] .msg.system {
+  border-left-color: var(--ink-4);
+  background: var(--panel);
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+/* Author / timestamp slot — optional label row above the body. Use
+   this for "assistant · 10:42:18 · claude-opus-4-7" style headers. */
+[data-design="v1"] .msg-meta {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+/* Markdown body — renderer.js writes innerHTML here; trust boundary
+   lives there, not in CSS. Keep styles tight so streamed content
+   doesn't jitter layout as tokens arrive. */
+[data-design="v1"] .msg-body {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* Streaming caret — append to the end of .msg-body when the message is
+   still being streamed. Opt in via `data-streaming="true"` on the .msg. */
+[data-design="v1"] .msg[data-streaming="true"] .msg-body::after {
+  content: "▍";
+  display: inline-block;
+  margin-left: 2px;
+  color: var(--accent);
+  animation: ts-caret 1s steps(2, start) infinite;
+}
+
+@keyframes ts-caret {
+  to { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-design="v1"] .msg[data-streaming="true"] .msg-body::after {
+    animation: none;
+  }
+}
+
+[data-design="v1"] .msg-body > *:first-child { margin-top: 0; }
+[data-design="v1"] .msg-body > *:last-child  { margin-bottom: 0; }
+
+[data-design="v1"] .msg-body pre {
+  margin: 6px 0;
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+  overflow-x: auto;
+}
+
+[data-design="v1"] .msg-body code {
+  padding: 1px 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--panel);
+  border: 1px solid var(--hair-2);
+  border-radius: 3px;
+}
+
+[data-design="v1"] .msg-body pre code {
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+}
+
+/* Tool messages have a --panel background, same colour as the default
+   .msg-body pre bg — shift the pre/code inside tool blocks to --panel-2
+   so the inline code stands out from the message surface. */
+[data-design="v1"] .msg.tool .msg-body pre,
+[data-design="v1"] .msg.tool .msg-body code {
+  background: var(--panel-2);
+}
+
+[data-design="v1"] .msg-body a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+[data-design="v1"] .msg-body h1,
+[data-design="v1"] .msg-body h2,
+[data-design="v1"] .msg-body h3,
+[data-design="v1"] .msg-body h4,
+[data-design="v1"] .msg-body h5,
+[data-design="v1"] .msg-body h6 {
+  margin: 10px 0 4px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+[data-design="v1"] .msg-body h1 { font-size: 16px; }
+[data-design="v1"] .msg-body h2 { font-size: 14px; }
+[data-design="v1"] .msg-body h3 { font-size: 13px; }
+[data-design="v1"] .msg-body h4,
+[data-design="v1"] .msg-body h5,
+[data-design="v1"] .msg-body h6 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-3); }
+
+[data-design="v1"] .msg-body ul,
+[data-design="v1"] .msg-body ol {
+  margin: 4px 0 4px 20px;
+  padding: 0;
+}
+[data-design="v1"] .msg-body li { margin: 2px 0; }
+
+[data-design="v1"] .msg-body strong { color: var(--ink); font-weight: 600; }
+[data-design="v1"] .msg-body em     { font-style: italic; }
+
+[data-design="v1"] .msg-body blockquote {
+  margin: 6px 0;
+  padding: 4px 10px;
+  border-left: 2px solid var(--hair);
+  color: var(--ink-3);
+}
+
+/* Hover-revealed action row — copy / regenerate / feedback buttons. */
+[data-design="v1"] .msg-actions {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+[data-design="v1"] .msg:hover .msg-actions,
+[data-design="v1"] .msg:focus-within .msg-actions { opacity: 1; }
+
+[data-design="v1"] .msg-action-btn {
+  height: 22px;
+  padding: 0 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+[data-design="v1"] .msg-action-btn:hover {
+  background: var(--panel-2);
+  color: var(--ink);
+  border-color: var(--ink-4);
+}
+
+[data-design="v1"] .msg-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Touch-only: keep actions visible; hover-reveal isn't reachable.
+   `(pointer: coarse)` narrows the match to true touch devices —
+   `(hover: none)` alone fires on stylus and some laptops too. Matches
+   the `@media (hover: none) and (pointer: coarse)` convention in
+   shared_static/chat.css:146. Keyboard users are handled by
+   :focus-within on .msg above. */
+@media (hover: none) and (pointer: coarse) {
+  [data-design="v1"] .msg-actions { opacity: 1; }
+  [data-design="v1"] .msg-action-btn { padding: 4px 8px; font-size: 12px; }
+}


### PR DESCRIPTION
## Summary
Three new primitives that unblock the chat-surface migrations (PR #2: server chat at \`ui/static/\`, PR #3: coordinator at \`console/static/coordinator/\`). Nothing existing is modified — every rule scopes under \`[data-design=\"v1\"]\`.

## What's in
- **\`primitives/message.css\`** — \`.msg\` with seven variants (user / assistant / reasoning / tool / error / info / system), optional \`.msg-meta\` author row, \`.msg-body\` markdown target, hover-revealed \`.msg-actions\`, and a \`data-streaming=\"true\"\` blinking caret. Designed to replace the \`.ts-msg*\` family in \`shared_static/chat.css\`.
- **\`primitives/field.css\`** — \`.field\` wrapper handling text / email / password / url / number / search / tel / date / time / datetime-local / month / week / textarea / select / checkbox / radio via element selectors. \`.field.inline\` for checkbox rows, \`.field.invalid\` for error states.
- **\`chrome/appbar.css\`** — chat-style header (back link + title + spacer + status + action cluster). Distinct from the admin-style \`.topbar\`.

Preview extended with three demo sections.

## Code-review findings applied
- \`@media (hover: none) and (pointer: coarse)\` — matches the convention in \`shared_static/chat.css:146\`; \`hover: none\` alone is too broad.
- \`.field-help\` uses \`--ink-3\` — \`--ink-4\` on \`--panel\` fails AA (~4.35:1) for 11px body text.
- \`.msg-meta\` slot added so downstream PRs don't each invent a custom \`.msg-author\`.
- Tool-message \`pre\`/\`code\` shifted to \`--panel-2\` (tool bg is \`--panel\`; same-bg made inline code disappear).
- Checkbox/radio \`:focus-visible\` override — native controls lack a border, default box-shadow ring is too subtle alone.

## Deferred to downstream
- \`.msg.error\` borderline AA (~4.8:1) — acceptable headroom, view author can opt into \`--err-fill\` if needed.
- \`.appbar-back\` markup ambiguity (anchor vs button) — view-author's call per usage.
- \`.field.inline\` + \`.field-help\` layout — not needed for the chat migrations; admin forms can iterate.

## Test plan
- [ ] \`/shared/design/preview.html\` renders seven message variants + five field types + appbar correctly in both themes
- [ ] Streaming caret blinks on the \`data-streaming=\"true\"\` assistant message; \`prefers-reduced-motion\` disables it
- [ ] Hover-revealed \`.msg-actions\` shows on desktop, persists on touch
- [ ] Checkbox/radio focus ring is visible when tabbed
- [ ] No regression in existing views (nothing imports the new files yet)