### PR TITLE
feat(design-system): DS phase 2 — opt server chat UI into v1 primitives

### DIFF
--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -4820,9 +4820,8 @@ function buildToolDiv(item) {
   div.dataset.callId = item.call_id || "";
 
   var name = document.createElement("div");
-  name.className = "tool-name";
+  name.className = "tool-name" + (item.error ? " tool-name--error" : "");
   name.textContent = item.func_name || "";
-  if (item.error) name.style.color = "var(--red)";
   div.appendChild(name);
 
   var cmd = document.createElement("div");

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -611,7 +611,8 @@ Pane.prototype.handleEvent = function (evt) {
       this.removeThinkingIndicator();
       if (!this.currentReasoningEl) {
         this.currentReasoningEl = document.createElement("div");
-        this.currentReasoningEl.className = "ts-msg ts-msg--reasoning";
+        this.currentReasoningEl.className =
+          "ts-msg ts-msg--reasoning msg reasoning";
         this.messagesEl.appendChild(this.currentReasoningEl);
       }
       this.currentReasoningEl.textContent += evt.text;
@@ -625,14 +626,15 @@ Pane.prototype.handleEvent = function (evt) {
       }
       if (!this.currentAssistantEl) {
         this.currentAssistantEl = document.createElement("div");
-        this.currentAssistantEl.className = "ts-msg ts-msg--assistant";
+        this.currentAssistantEl.className =
+          "ts-msg ts-msg--assistant msg assistant";
         // streamingRender targets a .ts-msg-body inner wrapper so the
         // shared markdown rules in chat.css (h1/h2/h3/code/blockquote
         // scoped to .ts-msg-body *) actually match on this page — the
         // coordinator page uses the same .ts-msg-body wrapper so the
         // two chat views stay visually aligned.
         this.currentAssistantBodyEl = document.createElement("div");
-        this.currentAssistantBodyEl.className = "ts-msg-body";
+        this.currentAssistantBodyEl.className = "ts-msg-body msg-body";
         this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
         this.messagesEl.appendChild(this.currentAssistantEl);
       }
@@ -855,7 +857,7 @@ Pane.prototype.removeThinkingIndicator = function () {
 Pane.prototype.addUserMessage = function (text, attachments) {
   this.removeEmptyState();
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--user";
+  el.className = "ts-msg ts-msg--user msg user";
   var textEl = document.createElement("div");
   textEl.className = "msg-user-text";
   textEl.textContent = text;
@@ -890,7 +892,7 @@ Pane.prototype.addQueuedMessage = function (text, priority) {
   this.removeEmptyState();
   var self = this;
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--user msg-queued";
+  el.className = "ts-msg ts-msg--user msg user msg-queued";
   el.setAttribute("role", "status");
   if (priority === "important") {
     el.classList.add("msg-queued-important");
@@ -1227,9 +1229,9 @@ Pane.prototype.replayHistory = function (messages) {
       }
       if (msg.content) {
         var el = document.createElement("div");
-        el.className = "ts-msg ts-msg--assistant";
+        el.className = "ts-msg ts-msg--assistant msg assistant";
         var bodyEl = document.createElement("div");
-        bodyEl.className = "ts-msg-body";
+        bodyEl.className = "ts-msg-body msg-body";
         var rendered = renderMarkdown(msg.content);
         bodyEl.innerHTML = rendered;
         el.appendChild(bodyEl);
@@ -1732,7 +1734,7 @@ Pane.prototype.updateVerdictGlow = function (recommendation) {
 
 Pane.prototype.addInfoMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--info";
+  el.className = "ts-msg ts-msg--info msg info";
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);
   this.scrollToBottom();
@@ -1740,7 +1742,7 @@ Pane.prototype.addInfoMessage = function (text) {
 
 Pane.prototype.addErrorMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--error";
+  el.className = "ts-msg ts-msg--error msg error";
   el.setAttribute("role", "alert");
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-design="v1">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,15 +11,28 @@
 <link rel="stylesheet" href="/shared/ui-base.css">
 <link rel="stylesheet" href="/shared/chat.css">
 <link rel="stylesheet" href="/shared/katex-0.16.45/katex.min.css">
+<!-- Design system v1 — opt-in via data-design="v1" on <html>. Tokens
+     + primitives scope under the attribute selector so legacy styles
+     below continue to own anything not yet migrated. -->
+<link rel="stylesheet" href="/shared/design/tokens.css">
+<link rel="stylesheet" href="/shared/design/typography.css">
+<link rel="stylesheet" href="/shared/design/chrome/appbar.css">
+<link rel="stylesheet" href="/shared/design/primitives/panel.css">
+<link rel="stylesheet" href="/shared/design/primitives/buttons.css">
+<link rel="stylesheet" href="/shared/design/primitives/pills.css">
+<link rel="stylesheet" href="/shared/design/primitives/message.css">
+<link rel="stylesheet" href="/shared/design/primitives/field.css">
 <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-<div id="header" class="ts-header">
-  <h1 class="ts-header-title">turnstone</h1>
-  <span id="mcp-status" role="status" aria-live="polite"></span>
-  <span id="health-indicator" class="health-ok" role="status" aria-live="polite" aria-atomic="true"></span>
-  <span class="header-spacer"></span>
-  <button id="theme-toggle" class="header-btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme" title="Switch to light theme">&#9790;</button>
+<div id="header" class="ts-header appbar">
+  <h1 class="ts-header-title appbar-title">turnstone</h1>
+  <span id="mcp-status" class="appbar-status" role="status" aria-live="polite"></span>
+  <span id="health-indicator" class="health-ok appbar-status" role="status" aria-live="polite" aria-atomic="true"></span>
+  <span class="header-spacer appbar-spacer"></span>
+  <span class="appbar-actions">
+    <button id="theme-toggle" class="header-btn btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme" title="Switch to light theme">&#9790;</button>
+  </span>
 </div>
 
 <div id="tab-bar" role="toolbar" aria-label="Workstreams">

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -6,7 +6,9 @@
 <title>turnstone</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- DS typography.css @imports Inter + JetBrains Mono from Google Fonts;
+     no separate font link for legacy Outfit/IBM Plex Mono (those were
+     removed to avoid loading two font stacks under data-design="v1"). -->
 <link rel="stylesheet" href="/shared/base.css">
 <link rel="stylesheet" href="/shared/ui-base.css">
 <link rel="stylesheet" href="/shared/chat.css">
@@ -26,7 +28,7 @@
 </head>
 <body>
 <div id="header" class="ts-header appbar">
-  <h1 class="ts-header-title appbar-title">turnstone</h1>
+  <h1 class="appbar-title">turnstone</h1>
   <span id="mcp-status" class="appbar-status" role="status" aria-live="polite"></span>
   <span id="health-indicator" class="health-ok appbar-status" role="status" aria-live="polite" aria-atomic="true"></span>
   <span class="header-spacer appbar-spacer"></span>

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -2209,3 +2209,225 @@ audio.media-player {
   .pane-ctx-item, .ws-tab-dropdown-item { transition: none; }
   .ws-tab-dropdown { animation: none; }
 }
+
+/* ==========================================================================
+   DS migration — tool call + approval block overrides
+   Scoped under [data-design="v1"] so only applies under the opt-in root.
+   The outer .ts-msg.ts-approval--inline wrapper already picks up DS .msg
+   styling via the dual-class approach in app.js, but the inner structure
+   (.ts-approval-tool, .verdict-badge, .ts-approval-badge) was still
+   rendering with legacy yellow/green/red palette. These overrides map
+   the legacy vocabulary onto DS semantic tokens.
+
+   DOM shape rendered by buildToolDiv() + renderVerdictBadge():
+     .ts-msg.ts-approval.ts-approval--inline[.approved]  ← DS .msg styled
+       .ts-approval-tool
+         .tool-name                   ← tool function name
+         .tool-cmd                    ← header / command
+         .tool-diff .diff-[del|add|warn]
+         (.tool-output appended dynamically by appendToolOutput)
+       .verdict-badge.verdict-[low|medium|high|critical]
+         .verdict-risk, .verdict-rec, .verdict-conf
+         button.verdict-expand
+       .verdict-detail (hidden until expand)
+       .ts-approval-badge[--approved|--denied]          ← auto-approved pill
+   ========================================================================== */
+
+[data-design="v1"] .ts-msg.ts-approval--inline {
+  /* Accent (teal) for tool-call kind — matches .msg.tool convention. */
+  border-left-color: var(--accent);
+  background: var(--panel-2);
+}
+
+[data-design="v1"] .ts-approval-tool {
+  padding: 8px 12px;
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+}
+
+[data-design="v1"] .ts-approval-tool + .ts-approval-tool { margin-top: 6px; }
+
+[data-design="v1"] .ts-approval-tool .tool-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 4px;
+  letter-spacing: 0;
+}
+
+[data-design="v1"] .ts-approval-tool .tool-cmd {
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+[data-design="v1"] .ts-approval-tool .tool-cmd .dollar { color: var(--ok); }
+
+[data-design="v1"] .ts-approval-tool .tool-diff { white-space: pre-wrap; font-size: 12px; margin-top: 4px; }
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-del  { color: var(--err); }
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-add  { color: var(--ok); }
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-warn { color: var(--warn); }
+
+/* Verdict badge — map to DS semantic colours using the same color-mix
+   pattern as DS k-badge (12% bg / 38% border / 70% text).  Risk level
+   drives the hue: low=ok, medium=warn, high/critical=err. */
+[data-design="v1"] .verdict-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--hair);
+  border-radius: 3px;
+  background: var(--panel-2);
+  color: var(--ink-2);
+  border-left-width: 3px;
+  max-width: max-content;
+}
+
+[data-design="v1"] .verdict-badge.verdict-low {
+  color: color-mix(in srgb, var(--ok) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--ok) 38%, var(--hair));
+  border-left-color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, var(--panel-2));
+}
+[data-design="v1"] .verdict-badge.verdict-medium {
+  color: color-mix(in srgb, var(--warn) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--warn) 38%, var(--hair));
+  border-left-color: var(--warn);
+  background: var(--warn-tint);
+}
+[data-design="v1"] .verdict-badge.verdict-high,
+[data-design="v1"] .verdict-badge.verdict-critical {
+  color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
+  border-color: color-mix(in srgb, var(--err) 38%, var(--hair));
+  border-left-color: var(--err);
+  background: color-mix(in srgb, var(--err) 12%, var(--panel-2));
+}
+
+[data-design="v1"] .verdict-badge .verdict-risk {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+[data-design="v1"] .verdict-badge .verdict-rec  { color: inherit; }
+[data-design="v1"] .verdict-badge .verdict-conf { color: var(--ink-3); font-size: 10px; }
+
+[data-design="v1"] .verdict-judge-spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--ink-3);
+  font-size: 10px;
+}
+[data-design="v1"] .verdict-judge-spinner .judge-spinner-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: ts-pulse 1.2s infinite;
+}
+/* ts-pulse keyframe + prefers-reduced-motion guard are defined in
+   primitives/pills.css; no local duplicate needed. */
+
+[data-design="v1"] .verdict-expand {
+  background: transparent;
+  border: none;
+  padding: 0 4px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+[data-design="v1"] .verdict-expand:hover         { color: var(--ink); }
+[data-design="v1"] .verdict-expand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+[data-design="v1"] .verdict-detail {
+  margin-top: 6px;
+  padding: 8px 12px;
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--ink-3);
+  background: var(--panel-2);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+}
+[data-design="v1"] .verdict-detail .verdict-summary   { color: var(--ink-2); font-weight: 600; margin-bottom: 4px; }
+[data-design="v1"] .verdict-detail .verdict-reasoning { color: var(--ink-3); margin-bottom: 4px; }
+[data-design="v1"] .verdict-detail .verdict-evidence  { color: var(--ink-4); font-style: italic; margin-bottom: 4px; }
+[data-design="v1"] .verdict-detail .verdict-tier      { color: var(--ink-4); font-size: 10px; }
+
+/* Auto-approved / denied badges — pill shape matching the DS approve
+   button family (green fill, ink-darkened text).  max-width: max-content
+   so the pill hugs its text instead of stretching the block. */
+[data-design="v1"] .ts-approval-badge {
+  padding: 4px 10px;
+  margin-top: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 999px;
+  max-width: max-content;
+  border: 1px solid var(--hair);
+}
+[data-design="v1"] .ts-approval-badge--approved {
+  color: var(--ok-text);
+  background: color-mix(in srgb, var(--ok) 20%, var(--panel-2));
+  border-color: color-mix(in srgb, var(--ok) 50%, var(--hair));
+}
+[data-design="v1"] .ts-approval-badge--denied {
+  color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
+  background: color-mix(in srgb, var(--err) 15%, var(--panel-2));
+  border-color: color-mix(in srgb, var(--err) 45%, var(--hair));
+}
+[data-design="v1"] .ts-approval-badge--error {
+  color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
+  background: color-mix(in srgb, var(--err) 20%, var(--panel-2));
+  border-color: var(--err);
+}
+
+/* Tool output (streamed command/fetch result).  Map legacy --code-bg /
+   --fg-dim to DS panel / ink tokens. */
+[data-design="v1"] .tool-output {
+  background: var(--panel);
+  color: var(--ink-2);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--hair);
+}
+[data-design="v1"] .tool-output-error  { color: var(--err); }
+[data-design="v1"] .tool-output-stream { border-left: 2px solid var(--accent); }
+
+[data-design="v1"] .tool-output.collapsed::after {
+  background: linear-gradient(transparent, var(--panel) 70%);
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  padding-top: 14px;
+}
+
+/* Verdict-glow halo on action buttons — soft coloured ring when the
+   heuristic verdict suggests an action. */
+[data-design="v1"] .ts-verdict-glow--approve .ts-approval-btn--approve {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ok) 25%, transparent);
+}
+[data-design="v1"] .ts-verdict-glow--deny .ts-approval-btn--deny {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--err) 25%, transparent);
+}
+[data-design="v1"] .ts-verdict-glow--review .ts-approval-btn--approve,
+[data-design="v1"] .ts-verdict-glow--review .ts-approval-btn--deny {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--warn) 25%, transparent);
+}

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -2213,11 +2213,13 @@ audio.media-player {
 /* ==========================================================================
    DS migration — tool call + approval block overrides
    Scoped under [data-design="v1"] so only applies under the opt-in root.
-   The outer .ts-msg.ts-approval--inline wrapper already picks up DS .msg
-   styling via the dual-class approach in app.js, but the inner structure
-   (.ts-approval-tool, .verdict-badge, .ts-approval-badge) was still
-   rendering with legacy yellow/green/red palette. These overrides map
-   the legacy vocabulary onto DS semantic tokens.
+   Approval blocks render on the legacy .ts-msg.ts-approval.ts-approval
+   --inline wrapper (NOT a DS .msg primitive — the dual-class approach
+   used for user/assistant/reasoning messages wasn't extended to approval
+   blocks).  These overrides give that outer card a DS-aligned surface
+   + accent treatment, then remap the inner approval structure
+   (.ts-approval-tool, .verdict-badge, .ts-approval-badge) away from the
+   legacy yellow/green/red palette onto DS semantic tokens.
 
    DOM shape rendered by buildToolDiv() + renderVerdictBadge():
      .ts-msg.ts-approval.ts-approval--inline[.approved]  ← DS .msg styled
@@ -2245,6 +2247,15 @@ audio.media-player {
   align-self: stretch;
 }
 
+/* Legacy .ts-msg rule forces font-family: var(--font-mono) on every
+   chat turn.  Override for user/assistant/reasoning/info/error where
+   body prose is meant to be UI font.  .msg.tool keeps mono via the
+   primitive's own rule (higher specificity inside [data-design=v1]). */
+[data-design="v1"] .ts-msg.msg:not(.tool) {
+  font-family: var(--font-ui);
+}
+[data-design="v1"] .ts-msg-body.msg-body { font-family: inherit; }
+
 [data-design="v1"] .ts-approval-tool {
   padding: 8px 12px;
   background: var(--panel);
@@ -2262,6 +2273,11 @@ audio.media-player {
   margin-bottom: 4px;
   letter-spacing: 0;
 }
+
+/* Error variant of the tool name (replaces the prior inline
+   name.style.color = "var(--red)" in buildToolDiv — inline styles win
+   over CSS and broke the DS token mapping). */
+[data-design="v1"] .ts-approval-tool .tool-name--error { color: var(--err); }
 
 [data-design="v1"] .ts-approval-tool .tool-cmd {
   color: var(--ink-2);

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -2234,9 +2234,15 @@ audio.media-player {
    ========================================================================== */
 
 [data-design="v1"] .ts-msg.ts-approval--inline {
-  /* Accent (teal) for tool-call kind — matches .msg.tool convention. */
+  /* Accent (teal) for tool-call kind — matches .msg.tool convention.
+     width: 100% forces consistent card width across tool calls; without
+     it, cards shrink to content width (short-output cards read narrow,
+     long-output cards read full-width → jagged column). */
   border-left-color: var(--accent);
   background: var(--panel-2);
+  width: 100%;
+  box-sizing: border-box;
+  align-self: stretch;
 }
 
 [data-design="v1"] .ts-approval-tool {
@@ -2371,32 +2377,36 @@ audio.media-player {
 [data-design="v1"] .verdict-detail .verdict-evidence  { color: var(--ink-4); font-style: italic; margin-bottom: 4px; }
 [data-design="v1"] .verdict-detail .verdict-tier      { color: var(--ink-4); font-size: 10px; }
 
-/* Auto-approved / denied badges — pill shape matching the DS approve
-   button family (green fill, ink-darkened text).  max-width: max-content
-   so the pill hugs its text instead of stretching the block. */
+/* Auto-approved / denied badges — flat badge aesthetic (matches the DS
+   .risk primitive), not a button.  Uppercase mono label on a soft
+   semantic-coloured background, no border — reads as "status tag" not
+   "click me." */
 [data-design="v1"] .ts-approval-badge {
-  padding: 4px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
   margin-top: 6px;
-  font-size: 11px;
-  font-weight: 500;
-  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
   max-width: max-content;
-  border: 1px solid var(--hair);
+  border: none;
 }
 [data-design="v1"] .ts-approval-badge--approved {
-  color: var(--ok-text);
-  background: color-mix(in srgb, var(--ok) 20%, var(--panel-2));
-  border-color: color-mix(in srgb, var(--ok) 50%, var(--hair));
+  color: var(--ok);
+  background: var(--ok-soft);
 }
 [data-design="v1"] .ts-approval-badge--denied {
-  color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
-  background: color-mix(in srgb, var(--err) 15%, var(--panel-2));
-  border-color: color-mix(in srgb, var(--err) 45%, var(--hair));
+  color: var(--err);
+  background: var(--err-soft);
 }
 [data-design="v1"] .ts-approval-badge--error {
-  color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
-  background: color-mix(in srgb, var(--err) 20%, var(--panel-2));
-  border-color: var(--err);
+  color: #fff;
+  background: var(--err-fill);
 }
 
 /* Tool output (streamed command/fetch result).  Map legacy --code-bg /


### PR DESCRIPTION
ui/static/index.html:
  - data-design="v1" on <html> opts this view into design system tokens and primitives scoped under the attribute selector.
  - Link DS stylesheets after the legacy cascade: tokens + typography + appbar (chrome) + panel / buttons / pills / message / field (primitives). Legacy /shared/base.css, /shared/ui-base.css, /shared/chat.css, and /static/style.css stay linked to handle anything not yet migrated (rich markdown, tabs, dashboard, split panes, approvals, modals).
  - Header <div id="header"> picks up .appbar + .appbar-title + .appbar-status + .appbar-spacer + .appbar-actions alongside the legacy .ts-header classes. Theme-toggle gets .btn for DS pill shape while keeping .header-btn for palette continuity.

ui/static/app.js:
  - Chat message elements emit both legacy and DS class names so the DS primitive picks up the message surface while legacy .ts-msg--* rules keep view-specific markdown styling (tables, callouts, katex, mermaid, hljs). Pairs:
      ts-msg ts-msg--user       → + msg user
      ts-msg ts-msg--assistant  → + msg assistant
      ts-msg ts-msg--reasoning  → + msg reasoning
      ts-msg ts-msg--info       → + msg info
      ts-msg ts-msg--error      → + msg error
      ts-msg-body               → + msg-body
  - Approval blocks keep legacy-only styling — their shape is distinct
    from the DS .msg primitive (the DS approval-dock pattern is a
    fixed bottom dock, not inline-in-chat).

No backend or wire-format changes. SSE events, POST bodies, endpoint URLs, ARIA attributes, and keyboard shortcuts all unchanged.