### PR TITLE
feat(design-system): DS phase 3 — coordinator chat migration

### DIFF
--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -472,6 +472,12 @@
     if (countEl) countEl.textContent = "";
     pendingApprovalCallId = null;
     approvalFocusClaimed = false;
+    // Prune the verdict cache — verdicts are only used while the dock
+    // is visible, so keeping them across resolve cycles would leak
+    // memory over long sessions.
+    if (judgeVerdicts && typeof judgeVerdicts.clear === "function") {
+      judgeVerdicts.clear();
+    }
     setApprovalButtonsDisabled(false);
     // Return focus to the composer for keyboard users.  Only if the
     // approval bar itself was the focus holder — don't steal focus from
@@ -819,7 +825,10 @@
         });
         break;
       case "info":
-        appendText("tool", ev.message || "", { label: "info" });
+        // .msg.info (think-indigo) is the intended variant for info
+        // events; prior routing to "tool" gave them accent-tinted tool
+        // styling which mis-categorised them as tool calls.
+        appendText("info", ev.message || "", { label: "info" });
         break;
       case "state_change":
         statusEl.textContent = ev.state || "";
@@ -882,10 +891,12 @@
     // document.body, which would plant a floating badge at the page
     // root on any template variant where the header hasn't rendered
     // yet (#q-7).  Return null so callers skip rendering; the next
-    // event will retry.
-    const host =
-      document.getElementById("coord-status") ||
-      document.getElementById("coord-header");
+    // event will retry.  Mount into #coord-header (appbar container)
+    // NOT #coord-status — statusEl.textContent = ev.state on every
+    // state_change event clobbers all children of #coord-status, which
+    // would delete the wait indicator on the next state tick.  As a
+    // sibling inside the appbar it stays alive across state updates.
+    const host = document.getElementById("coord-header");
     if (!host) return null;
     el = document.createElement("span");
     el.id = "coord-wait-indicator";

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -69,6 +69,12 @@
   let reconnectAttempts = 0;
   let reconnectTimer = null;
 
+  // Cache of judge verdicts keyed by call_id.  Judge events (intent_verdict)
+  // and approval events (approve_request) are async and can arrive in either
+  // order; the cache lets each handler apply data to the other without
+  // assuming ordering.
+  const judgeVerdicts = new Map();
+
   // ------------------------------------------------------------------
   // HTML escaping and safe ws_id linkification
   // ------------------------------------------------------------------
@@ -303,11 +309,12 @@
     pending.forEach((it, idx) => {
       if (!firstCallId) firstCallId = it.call_id;
       // Each pending tool call renders as a .dcall row — the DS pattern
-      // frames this like a mini inspectable call line.  Risk pill is
-      // .low by default (no per-item risk yet — that's a later PR);
-      // function name + preview args round out the row.
+      // frames this like a mini inspectable call line.  If we've already
+      // received a judge verdict for this call_id, its risk_level takes
+      // precedence; otherwise default to "low" until a verdict arrives.
       const row = document.createElement("div");
       row.className = "dcall";
+      if (it.call_id) row.dataset.callId = it.call_id;
       if (pending.length > 1) {
         const idx_ = document.createElement("span");
         idx_.className = "risk low";
@@ -324,6 +331,11 @@
       args.textContent = preview;
       row.appendChild(args);
       approvalTools.appendChild(row);
+      // If the judge already delivered a verdict for this call before the
+      // approval surfaced, render it into the dock immediately.
+      if (it.call_id && judgeVerdicts.has(it.call_id)) {
+        applyJudgeVerdictToRow(row, judgeVerdicts.get(it.call_id));
+      }
     });
     pendingApprovalCallId = firstCallId;
     approvalBar.hidden = false;
@@ -339,6 +351,39 @@
       } catch (_) {
         /* noop */
       }
+    }
+  }
+
+  // Render a judge verdict into a specific .dcall row's .dctx sibling.
+  // Creates the .dctx if it doesn't exist yet, or updates it if the
+  // verdict arrives a second time (re-evaluation).  Adds a judge chip
+  // showing the recommendation + risk level; attaches reasoning as a
+  // title tooltip for hover discovery.
+  function applyJudgeVerdictToRow(row, verdict) {
+    if (!row || !verdict) return;
+    const callId = row.dataset.callId;
+    let dctx = row.nextElementSibling;
+    if (
+      !dctx ||
+      !dctx.classList.contains("dctx") ||
+      dctx.dataset.forCall !== callId
+    ) {
+      dctx = document.createElement("div");
+      dctx.className = "dctx";
+      if (callId) dctx.dataset.forCall = callId;
+      row.insertAdjacentElement("afterend", dctx);
+    }
+    dctx.replaceChildren();
+    const chip = document.createElement("code");
+    const rec = verdict.recommendation || "?";
+    const risk = verdict.risk_level || "?";
+    chip.textContent = "judge: " + rec + " (risk: " + risk + ")";
+    if (verdict.reasoning) chip.title = verdict.reasoning;
+    dctx.appendChild(chip);
+    if (verdict.confidence != null) {
+      const conf = document.createElement("code");
+      conf.textContent = "confidence: " + verdict.confidence;
+      dctx.appendChild(conf);
     }
   }
 
@@ -640,7 +685,29 @@
         hideApproval();
         break;
       case "intent_verdict":
-        // Minimal surfacing — risk_level + recommendation.
+        // Prefer rendering the verdict inside the approval dock — the
+        // judge always evaluates a specific call_id, and the verdict is
+        // decision context for that pending approval, not a chat
+        // message.  Cache the verdict so late-arriving approve_request
+        // events can also pick it up (see showApproval).
+        if (ev.call_id) {
+          judgeVerdicts.set(ev.call_id, {
+            recommendation: ev.recommendation,
+            risk_level: ev.risk_level,
+            confidence: ev.confidence,
+            reasoning: ev.reasoning,
+          });
+          const row = approvalTools.querySelector(
+            '.dcall[data-call-id="' + cssEscape(ev.call_id) + '"]',
+          );
+          if (row) {
+            applyJudgeVerdictToRow(row, judgeVerdicts.get(ev.call_id));
+            break;
+          }
+        }
+        // Fallback — no matching pending row (approval already resolved
+        // or call_id missing).  Surface as a chat message so the verdict
+        // isn't silently dropped.
         appendText(
           "tool",
           "[judge] " +

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -24,8 +24,12 @@
 
   const wsId = document.documentElement.dataset.wsId || "";
   if (!wsId) {
-    document.getElementById("coord-messages").innerHTML =
-      '<div class="ts-msg ts-msg--error">Missing ws_id on &lt;html&gt; tag.</div>';
+    // Static literal — class-name migration only; no XSS surface.
+    const missing = document.createElement("div");
+    missing.className = "msg error";
+    missing.textContent = "Missing ws_id on <html> tag.";
+    const host = document.getElementById("coord-messages");
+    if (host) host.replaceChildren(missing);
     return;
   }
 
@@ -139,23 +143,25 @@
   // Message append helpers
   // ------------------------------------------------------------------
 
-  // Map raw role → ts-msg modifier.  "error" overloads the role slot
-  // for styling; opts.label still carries the tool name so SR text
-  // like "error · bash" stays meaningful on the data-ts-role /
-  // aria-label attributes when labels stop rendering as DOM text.
-  const _TS_ROLE_VARIANTS = {
-    user: "ts-msg--user",
-    assistant: "ts-msg--assistant",
-    reasoning: "ts-msg--reasoning",
-    tool: "ts-msg--tool",
-    error: "ts-msg--error",
+  // Map raw role → .msg variant (DS primitives/message.css).  "error"
+  // overloads the role slot for styling; opts.label still carries the
+  // tool name so SR text like "error · bash" stays meaningful on the
+  // data-ts-role / aria-label attributes when labels stop rendering
+  // as DOM text.
+  const _MSG_VARIANTS = {
+    user: "user",
+    assistant: "assistant",
+    reasoning: "reasoning",
+    tool: "tool",
+    error: "error",
+    info: "info",
   };
 
   function appendMsg(role, html, opts) {
     opts = opts || {};
     const el = document.createElement("div");
-    const variant = _TS_ROLE_VARIANTS[role] || "ts-msg--assistant";
-    el.className = "ts-msg " + variant;
+    const variant = _MSG_VARIANTS[role] || "assistant";
+    el.className = "msg " + variant;
     // role="article" makes aria-label reliably announced by screen
     // readers — a generic <div> with no implicit role doesn't expose
     // aria-label on its own.  "article" fits: each message is a
@@ -171,7 +177,7 @@
       el.setAttribute("aria-label", opts.label);
     }
     const body = document.createElement("div");
-    body.className = "ts-msg-body";
+    body.className = "msg-body";
     body.innerHTML = html;
     el.appendChild(body);
     messagesEl.appendChild(el);
@@ -225,7 +231,7 @@
     // token so the user sees live-formatted markdown instead of a final
     // "pop" on stream_end.  Heavy post-processing (syntax highlighting,
     // mermaid, KaTeX) stays deferred to streamingRenderFinalize below.
-    const body = currentAssistantEl.querySelector(".ts-msg-body");
+    const body = currentAssistantEl.querySelector(".msg-body");
     if (body && typeof streamingRender === "function") {
       try {
         streamingRender(body, currentAssistantBuf);
@@ -251,7 +257,7 @@
       messagesEl.setAttribute("aria-live", "off");
     }
     currentReasoningBuf += text;
-    const body = currentReasoningEl.querySelector(".ts-msg-body");
+    const body = currentReasoningEl.querySelector(".msg-body");
     if (body) body.textContent = currentReasoningBuf;
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }
@@ -263,7 +269,7 @@
     // the innerHTML assignment inside the helper is XSS-safe as long as
     // renderer.js is trusted — same contract as ui/static/app.js.
     if (currentAssistantEl && currentAssistantBuf) {
-      const body = currentAssistantEl.querySelector(".ts-msg-body");
+      const body = currentAssistantEl.querySelector(".msg-body");
       if (body && typeof streamingRenderFinalize === "function") {
         try {
           streamingRenderFinalize(body, currentAssistantBuf);
@@ -286,32 +292,46 @@
   function showApproval(items) {
     approvalTools.replaceChildren();
     const pending = (items || []).filter((it) => it.needs_approval);
-    // Header row — "Approve N tool calls" clarifies that the batch
-    // approval applies to every row, not just the focused one.
-    if (pending.length > 0) {
-      const header = document.createElement("div");
-      header.className = "ts-approval-header";
-      header.textContent =
-        pending.length === 1
-          ? "Approve 1 tool call:"
-          : "Approve " + pending.length + " tool calls (batch):";
-      approvalTools.appendChild(header);
+    // Count badge — shown in the .dhead row's trailing .dcount slot.
+    // The "Approval required" kicker is static in the HTML so the
+    // screen-reader label stays stable across open/close cycles.
+    const countEl = document.getElementById("coord-approval-count");
+    if (countEl) {
+      countEl.textContent = pending.length ? pending.length + " pending" : "";
     }
     let firstCallId = null;
     pending.forEach((it, idx) => {
       if (!firstCallId) firstCallId = it.call_id;
+      // Each pending tool call renders as a .dcall row — the DS pattern
+      // frames this like a mini inspectable call line.  Risk pill is
+      // .low by default (no per-item risk yet — that's a later PR);
+      // function name + preview args round out the row.
       const row = document.createElement("div");
-      row.className = "ts-approval-tool";
-      const label =
-        it.header || it.approval_label || it.func_name || "(unknown tool)";
-      row.textContent = pending.length > 1 ? idx + 1 + ". " + label : label;
+      row.className = "dcall";
+      if (pending.length > 1) {
+        const idx_ = document.createElement("span");
+        idx_.className = "risk low";
+        idx_.textContent = idx + 1 + "/" + pending.length;
+        row.appendChild(idx_);
+      }
+      const fn = document.createElement("span");
+      fn.className = "dfn";
+      fn.textContent = it.func_name || "(unknown tool)";
+      row.appendChild(fn);
+      const args = document.createElement("span");
+      args.className = "dargs";
+      const preview = it.header || it.approval_label || it.preview || "";
+      args.textContent = preview;
+      row.appendChild(args);
       approvalTools.appendChild(row);
     });
     pendingApprovalCallId = firstCallId;
-    approvalBar.classList.add("visible");
+    approvalBar.hidden = false;
     // Move focus to the approve button — non-modal region, so keyboard
     // users don't have to Shift+Tab back from the composer.  One-time
-    // focus shift; subsequent Tab/Shift+Tab navigates normally.
+    // focus shift; subsequent Tab/Shift+Tab navigates normally.  Also
+    // delivers the preserved "Enter approves" behaviour: the primary
+    // button has focus, so Enter fires its click handler.
     const approveBtn = document.getElementById("coord-approve-btn");
     if (approveBtn) {
       try {
@@ -323,8 +343,10 @@
   }
 
   function hideApproval() {
-    approvalBar.classList.remove("visible");
+    approvalBar.hidden = true;
     approvalTools.replaceChildren();
+    const countEl = document.getElementById("coord-approval-count");
+    if (countEl) countEl.textContent = "";
     pendingApprovalCallId = null;
     setApprovalButtonsDisabled(false);
     // Return focus to the composer for keyboard users.  Only if the
@@ -465,12 +487,18 @@
     // alone (WCAG 1.4.1).  ● connected, ○ connecting, ⚠ disconnected.
     const glyph = cls === "ok" ? "● " : cls === "err" ? "⚠ " : "○ ";
     sseEl.textContent = glyph + text;
-    // Preserve the base .ts-header-status class + add the BEM modifier
-    // variant so chat.css's .ts-header-status--ok / --err colour rules
-    // actually win; setting className to just "ok"/"err" drops the
-    // base class and the green / red colour never applies.
-    var base = "ts-header-status";
-    sseEl.className = cls ? base + " " + base + "--" + cls : base;
+    // Keep .appbar-status (DS: mono 11px --ink-3) as the base; layer the
+    // semantic colour via a data-state attribute so the glyph-prefixed
+    // label remains high-contrast while the text colour tracks OK / ERR.
+    sseEl.className = "appbar-status";
+    sseEl.dataset.state = cls || "";
+    if (cls === "ok") {
+      sseEl.style.color = "var(--ok)";
+    } else if (cls === "err") {
+      sseEl.style.color = "var(--err)";
+    } else {
+      sseEl.style.color = "";
+    }
   }
 
   function connectSSE() {
@@ -600,7 +628,7 @@
           if (
             it.call_id &&
             document.querySelector(
-              '.ts-msg[data-call-id="' + cssEscape(it.call_id) + '"]',
+              '.msg[data-call-id="' + cssEscape(it.call_id) + '"]',
             )
           ) {
             return; // already rendered in this pane — skip
@@ -709,7 +737,7 @@
     if (!host) return null;
     el = document.createElement("span");
     el.id = "coord-wait-indicator";
-    el.className = "ts-header-status coord-wait-indicator";
+    el.className = "appbar-status coord-wait-indicator";
     el.setAttribute("role", "status");
     el.setAttribute("aria-live", "polite");
     el.style.display = "none";

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -332,9 +332,13 @@
       row.appendChild(args);
       approvalTools.appendChild(row);
       // If the judge already delivered a verdict for this call before the
-      // approval surfaced, render it into the dock immediately.
+      // approval surfaced, render it into the dock immediately.  Otherwise
+      // render a spinner placeholder so the reviewer sees "the judge is
+      // still thinking" instead of silence.
       if (it.call_id && judgeVerdicts.has(it.call_id)) {
         applyJudgeVerdictToRow(row, judgeVerdicts.get(it.call_id));
+      } else {
+        applyJudgePendingToRow(row);
       }
     });
     pendingApprovalCallId = firstCallId;
@@ -354,13 +358,10 @@
     }
   }
 
-  // Render a judge verdict into a specific .dcall row's .dctx sibling.
-  // Creates the .dctx if it doesn't exist yet, or updates it if the
-  // verdict arrives a second time (re-evaluation).  Adds a judge chip
-  // showing the recommendation + risk level; attaches reasoning as a
-  // title tooltip for hover discovery.
-  function applyJudgeVerdictToRow(row, verdict) {
-    if (!row || !verdict) return;
+  // Ensure a .dctx sibling exists for the given .dcall row, tagged with
+  // the row's call_id.  Returns the .dctx element ready to be populated.
+  function ensureDctxAfterRow(row) {
+    if (!row) return null;
     const callId = row.dataset.callId;
     let dctx = row.nextElementSibling;
     if (
@@ -373,17 +374,68 @@
       if (callId) dctx.dataset.forCall = callId;
       row.insertAdjacentElement("afterend", dctx);
     }
+    return dctx;
+  }
+
+  // Remove any existing .drationale sibling for the given call_id so
+  // repeated verdicts don't stack.
+  function removeRationale(callId) {
+    if (!callId) return;
+    const existing = approvalTools.querySelector(
+      '.drationale[data-for-call="' + cssEscape(callId) + '"]',
+    );
+    if (existing) existing.remove();
+  }
+
+  // Render a "judge evaluating…" placeholder into the .dctx so the
+  // reviewer sees the judge is still thinking while awaiting verdict.
+  function applyJudgePendingToRow(row) {
+    const dctx = ensureDctxAfterRow(row);
+    if (!dctx) return;
+    removeRationale(row.dataset.callId);
+    dctx.replaceChildren();
+    const chip = document.createElement("code");
+    chip.className = "judging";
+    const spin = document.createElement("span");
+    spin.className = "spin";
+    spin.setAttribute("aria-hidden", "true");
+    chip.appendChild(spin);
+    chip.appendChild(document.createTextNode("judge evaluating…"));
+    dctx.appendChild(chip);
+  }
+
+  // Render a judge verdict into a specific .dcall row.  Builds:
+  //   .dctx    <code>judge: rec (risk: lvl)</code> + optional confidence
+  //   .drationale  judge.reasoning text (wrapped prose block)
+  // The judge chip colour-codes by recommendation: approve=ok/green,
+  // review=warn/amber, deny=err/red — so reviewers can triage at a
+  // glance without reading.  Repeated calls for the same row (e.g.
+  // re-evaluation) replace prior content.
+  function applyJudgeVerdictToRow(row, verdict) {
+    if (!row || !verdict) return;
+    const callId = row.dataset.callId;
+    const dctx = ensureDctxAfterRow(row);
+    removeRationale(callId);
     dctx.replaceChildren();
     const chip = document.createElement("code");
     const rec = verdict.recommendation || "?";
     const risk = verdict.risk_level || "?";
     chip.textContent = "judge: " + rec + " (risk: " + risk + ")";
-    if (verdict.reasoning) chip.title = verdict.reasoning;
+    if (rec === "approve") chip.classList.add("rec-approve");
+    else if (rec === "review") chip.classList.add("rec-review");
+    else if (rec === "deny") chip.classList.add("rec-deny");
     dctx.appendChild(chip);
     if (verdict.confidence != null) {
       const conf = document.createElement("code");
       conf.textContent = "confidence: " + verdict.confidence;
       dctx.appendChild(conf);
+    }
+    if (verdict.reasoning) {
+      const rationale = document.createElement("div");
+      rationale.className = "drationale";
+      if (callId) rationale.dataset.forCall = callId;
+      rationale.textContent = verdict.reasoning;
+      dctx.insertAdjacentElement("afterend", rationale);
     }
   }
 

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -75,6 +75,14 @@
   // assuming ordering.
   const judgeVerdicts = new Map();
 
+  // Approval focus is deferred until the judge returns a verdict so the
+  // Approve button doesn't pre-emptively light up (could read as "already
+  // approved").  Fallback timeout covers the case where the judge is
+  // disabled or slow.
+  let approvalFocusClaimed = false;
+  let approvalFocusTimer = null;
+  const APPROVAL_FOCUS_FALLBACK_MS = 3000;
+
   // ------------------------------------------------------------------
   // HTML escaping and safe ws_id linkification
   // ------------------------------------------------------------------
@@ -343,19 +351,52 @@
     });
     pendingApprovalCallId = firstCallId;
     approvalBar.hidden = false;
-    // Move focus to the approve button — non-modal region, so keyboard
-    // users don't have to Shift+Tab back from the composer.  One-time
-    // focus shift; subsequent Tab/Shift+Tab navigates normally.  Also
-    // delivers the preserved "Enter approves" behaviour: the primary
-    // button has focus, so Enter fires its click handler.
-    const approveBtn = document.getElementById("coord-approve-btn");
-    if (approveBtn) {
+    // Defer focus until the judge returns a verdict — lighting up the
+    // Approve button before the reviewer has decision context reads as
+    // "already approved."  If the verdict is already cached (rare race),
+    // claim focus immediately.  Otherwise wait for intent_verdict or
+    // fall back after APPROVAL_FOCUS_FALLBACK_MS (covers disabled judge).
+    approvalFocusClaimed = false;
+    if (approvalFocusTimer) {
+      clearTimeout(approvalFocusTimer);
+      approvalFocusTimer = null;
+    }
+    if (firstCallId && judgeVerdicts.has(firstCallId)) {
+      claimApprovalFocusForVerdict(judgeVerdicts.get(firstCallId));
+    } else {
+      approvalFocusTimer = setTimeout(() => {
+        approvalFocusTimer = null;
+        claimApprovalFocus("coord-approve-btn");
+      }, APPROVAL_FOCUS_FALLBACK_MS);
+    }
+  }
+
+  // Claim approval-bar focus for a specific button.  Idempotent — further
+  // calls after the first are noops so we don't bounce focus across
+  // multiple buttons as verdicts arrive for a batch.
+  function claimApprovalFocus(btnId) {
+    if (approvalFocusClaimed) return;
+    approvalFocusClaimed = true;
+    if (approvalFocusTimer) {
+      clearTimeout(approvalFocusTimer);
+      approvalFocusTimer = null;
+    }
+    const btn = document.getElementById(btnId);
+    if (btn) {
       try {
-        approveBtn.focus({ preventScroll: false });
+        btn.focus({ preventScroll: false });
       } catch (_) {
         /* noop */
       }
     }
+  }
+
+  // Focus the appropriate action based on the judge's recommendation:
+  // deny → Deny button (judge is warning; reviewer should default to
+  // blocking), approve/review/other → Approve button.
+  function claimApprovalFocusForVerdict(verdict) {
+    const rec = (verdict && verdict.recommendation) || "";
+    claimApprovalFocus(rec === "deny" ? "coord-deny-btn" : "coord-approve-btn");
   }
 
   // Ensure a .dctx sibling exists for the given .dcall row, tagged with
@@ -445,6 +486,11 @@
     const countEl = document.getElementById("coord-approval-count");
     if (countEl) countEl.textContent = "";
     pendingApprovalCallId = null;
+    approvalFocusClaimed = false;
+    if (approvalFocusTimer) {
+      clearTimeout(approvalFocusTimer);
+      approvalFocusTimer = null;
+    }
     setApprovalButtonsDisabled(false);
     // Return focus to the composer for keyboard users.  Only if the
     // approval bar itself was the focus holder — don't steal focus from
@@ -754,6 +800,12 @@
           );
           if (row) {
             applyJudgeVerdictToRow(row, judgeVerdicts.get(ev.call_id));
+            // Claim focus now that the reviewer has context to act on.
+            // Only for the first-pending call so batch approvals don't
+            // fight over focus as verdicts trickle in.
+            if (ev.call_id === pendingApprovalCallId && !approvalFocusClaimed) {
+              claimApprovalFocusForVerdict(judgeVerdicts.get(ev.call_id));
+            }
             break;
           }
         }

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -77,11 +77,11 @@
 
   // Approval focus is deferred until the judge returns a verdict so the
   // Approve button doesn't pre-emptively light up (could read as "already
-  // approved").  Fallback timeout covers the case where the judge is
-  // disabled or slow.
+  // approved").  No fallback — if the judge never responds (disabled /
+  // slow), focus simply never moves; keyboard users tab from the
+  // composer to reach the buttons manually.  A fallback would produce
+  // an ambiguous focus ring that could be misread as "judge approved."
   let approvalFocusClaimed = false;
-  let approvalFocusTimer = null;
-  const APPROVAL_FOCUS_FALLBACK_MS = 3000;
 
   // ------------------------------------------------------------------
   // HTML escaping and safe ws_id linkification
@@ -351,23 +351,12 @@
     });
     pendingApprovalCallId = firstCallId;
     approvalBar.hidden = false;
-    // Defer focus until the judge returns a verdict — lighting up the
-    // Approve button before the reviewer has decision context reads as
-    // "already approved."  If the verdict is already cached (rare race),
-    // claim focus immediately.  Otherwise wait for intent_verdict or
-    // fall back after APPROVAL_FOCUS_FALLBACK_MS (covers disabled judge).
+    // Defer focus until the judge returns a verdict.  If the verdict is
+    // already cached (rare race), claim focus immediately.  Otherwise
+    // wait for intent_verdict — no fallback.
     approvalFocusClaimed = false;
-    if (approvalFocusTimer) {
-      clearTimeout(approvalFocusTimer);
-      approvalFocusTimer = null;
-    }
     if (firstCallId && judgeVerdicts.has(firstCallId)) {
       claimApprovalFocusForVerdict(judgeVerdicts.get(firstCallId));
-    } else {
-      approvalFocusTimer = setTimeout(() => {
-        approvalFocusTimer = null;
-        claimApprovalFocus("coord-approve-btn");
-      }, APPROVAL_FOCUS_FALLBACK_MS);
     }
   }
 
@@ -377,10 +366,6 @@
   function claimApprovalFocus(btnId) {
     if (approvalFocusClaimed) return;
     approvalFocusClaimed = true;
-    if (approvalFocusTimer) {
-      clearTimeout(approvalFocusTimer);
-      approvalFocusTimer = null;
-    }
     const btn = document.getElementById(btnId);
     if (btn) {
       try {
@@ -487,10 +472,6 @@
     if (countEl) countEl.textContent = "";
     pendingApprovalCallId = null;
     approvalFocusClaimed = false;
-    if (approvalFocusTimer) {
-      clearTimeout(approvalFocusTimer);
-      approvalFocusTimer = null;
-    }
     setApprovalButtonsDisabled(false);
     // Return focus to the composer for keyboard users.  Only if the
     // approval bar itself was the focus holder — don't steal focus from

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-ws-id="{{WS_ID}}">
+<html lang="en" data-ws-id="{{WS_ID}}" data-design="v1">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,18 +7,35 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- Legacy compatibility layer — stays linked so anything not yet
+     migrated to DS primitives continues to render.  DS selectors carry
+     [data-design="v1"] prefixes and win on specificity wherever applied. -->
 <link rel="stylesheet" href="/shared/base.css">
 <link rel="stylesheet" href="/shared/ui-base.css">
 <link rel="stylesheet" href="/shared/chat.css">
 <link rel="stylesheet" href="/shared/katex-0.16.45/katex.min.css">
 <link rel="stylesheet" href="/static/style.css">
+<!-- Design system v1 — tokens first, then typography, then the primitives
+     + chrome + patterns this view uses.  Scoped to [data-design="v1"]
+     on <html> so legacy pages are unaffected. -->
+<link rel="stylesheet" href="/shared/design/tokens.css">
+<link rel="stylesheet" href="/shared/design/typography.css">
+<link rel="stylesheet" href="/shared/design/chrome/appbar.css">
+<link rel="stylesheet" href="/shared/design/chrome/sidebar.css">
+<link rel="stylesheet" href="/shared/design/primitives/panel.css">
+<link rel="stylesheet" href="/shared/design/primitives/buttons.css">
+<link rel="stylesheet" href="/shared/design/primitives/pills.css">
+<link rel="stylesheet" href="/shared/design/primitives/message.css">
+<link rel="stylesheet" href="/shared/design/primitives/field.css">
+<link rel="stylesheet" href="/shared/design/patterns/approval-dock.css">
 <style>
-  /* Coordinator-specific layout — one-pane variant of the server UI.
-     Design-system rules (messages, composer, approval bar, header,
-     sidebar shell) come from /shared/chat.css via the .ts-* classes
-     on the corresponding elements.  Only the coordinator-page
-     layout glue and sidebar-list-item rules (.ch-row / .task-row)
-     live here. */
+  /* Coordinator-specific layout glue.  Messages + header + approval bar
+     + sidebar chrome now come from the DS primitives/chrome/patterns
+     linked above; what remains here is the page-level flex wiring (chat
+     pane + right sidebar), tree-view row metadata (indent, state dots,
+     child highlight), and the <700px responsive accordion.  Anything
+     styled by .msg / .appbar / .sidebar / .approval-dock is intentionally
+     absent — DS wins by specificity. */
   body { display: flex; flex-direction: column; height: 100vh; margin: 0; }
 
   /* Main layout — chat pane (2fr) + sidebar (1fr) with shared
@@ -37,114 +54,197 @@
     overflow: hidden;
     min-width: 0;
   }
-  #coord-sidebar {
-    /* .ts-sidebar provides width / border / background; these fill in
-       the coordinator-only flex-grow behaviour so the sidebar occupies
-       its column of #coord-body. */
+  /* Override the DS .sidebar defaults (which assume an admin-shell grid
+     with sticky positioning under a .topbar) so the coordinator's right
+     aside flexes into its column of #coord-body.  The DS visual chrome
+     (panel bg, hair border, side-section vocabulary) still wins via the
+     [data-design="v1"] .sidebar rules; we only unset the positional
+     defaults meant for the admin shell. */
+  [data-design="v1"] #coord-sidebar.sidebar {
+    position: static;
+    top: auto;
+    height: auto;
+    align-self: auto;
     flex: 1 1 0;
+    border-right: none;
+    border-left: 1px solid var(--hair);
+    padding: 14px 10px;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
   #coord-children-wrap {
     min-height: 40%;
     max-height: 60%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
   #coord-tasks-wrap {
     min-height: 30%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .coord-sidebar-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 8px 0 6px;
+  }
+  .coord-sidebar-head .side-label { flex: 1; padding: 0; }
+  .coord-sidebar-head .side-count {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--ink-4);
+  }
+  .coord-sidebar-body {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
   }
 
   #coord-messages {
     flex: 1;
     overflow-y: auto;
     padding: 1rem 1.5rem;
+    /* Extra bottom padding so the fixed .approval-dock (position: fixed
+       bottom: 22px, ~3 rows ≈ 140px tall) never occludes the tail of the
+       message log when open.  Dock hides via [hidden], so when collapsed
+       the user just gets generous scroll padding — harmless. */
+    padding-bottom: 160px;
   }
-  .ts-msg .coord-ws-link {
+  [data-design="v1"] .msg .coord-ws-link {
     color: var(--accent);
     text-decoration: underline;
   }
 
   /* Sidebar list rows — tree-view children + task list.  Coordinator-
-     only vocabulary; .ts-sidebar shells are shared but the row shape
-     is specific to this page's child + task data. */
-  .ch-row, .task-row {
-    padding: 0.35rem 0.5rem;
-    border-radius: 4px;
+     only vocabulary; .side-item gives the hover + focus ring via DS,
+     but the multi-line row shape (link + meta on second line) is
+     specific to this page's child + task data.  The .side-item class
+     is deliberately absent here — its flex row layout fights the
+     column-stacked ws-link + meta we need. */
+  [data-design="v1"] .ch-row,
+  [data-design="v1"] .task-row {
+    padding: 5px 8px;
+    border-radius: var(--r-sm);
     font-family: var(--font-mono);
-    font-size: 0.82rem;
-    line-height: 1.35;
+    font-size: 12px;
+    line-height: 1.4;
     display: flex;
     flex-direction: column;
-    gap: 0.1rem;
+    gap: 2px;
+    color: var(--ink-2);
     border: 1px solid transparent;
   }
-  .ch-row + .ch-row, .task-row + .task-row { margin-top: 0.15rem; }
-  .ch-row:hover, .task-row:hover {
-    background: var(--bg-elevated);
-    border-color: var(--border);
+  [data-design="v1"] .ch-row + .ch-row,
+  [data-design="v1"] .task-row + .task-row { margin-top: 2px; }
+  [data-design="v1"] .ch-row:hover,
+  [data-design="v1"] .task-row:hover {
+    background: var(--hair-2);
   }
-  .ch-row.closed { opacity: 0.55; }
-  .ch-row a.ws-link {
+  [data-design="v1"] .ch-row.closed { opacity: 0.55; }
+  [data-design="v1"] .ch-row a.ws-link {
     color: inherit;
     text-decoration: none;
     display: flex;
-    gap: 0.35rem;
+    gap: 6px;
     align-items: baseline;
   }
-  .ch-row a.ws-link:hover { color: var(--accent); }
-  /* Keyboard-focus indicators — match the accent-ring pattern the
-     rest of the console uses so tab-nav through the sidebar rows
-     stays visible on both light + dark themes. */
-  .ch-row a.ws-link:focus-visible,
-  .task-row:focus-visible {
+  [data-design="v1"] .ch-row a.ws-link:hover { color: var(--accent); }
+  /* Keyboard-focus indicators — accent ring matches the .side-item and
+     .btn focus-visible treatment so tab-nav stays visible across both
+     themes. */
+  [data-design="v1"] .ch-row a.ws-link:focus-visible,
+  [data-design="v1"] .task-row:focus-visible {
     outline: 2px solid var(--accent);
-    outline-offset: 1px;
-    border-radius: 4px;
+    outline-offset: 2px;
+    border-radius: var(--r-sm);
   }
   /* glyph treatment (.ui-glyph / .ui-glyph-<state>) comes from
      shared_static/ui-base.css; stateGlyph() emits those classes. */
-  .ch-row .name { font-weight: 500; flex: 1; overflow: hidden; text-overflow: ellipsis; }
-  .ch-row .meta {
-    font-size: 0.72rem;
-    color: var(--fg-dim);
+  [data-design="v1"] .ch-row .name {
+    font-weight: 500;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--ink);
+  }
+  [data-design="v1"] .ch-row .meta {
+    font-size: 11px;
+    color: var(--ink-3);
     display: flex;
-    gap: 0.5rem;
-    padding-left: 1.35rem;
+    gap: 8px;
+    padding-left: 22px;
   }
-  .ch-row .badge-attention { color: var(--red); font-weight: 600; }
-  .task-row .title { font-weight: 500; }
-  .task-row .meta { font-size: 0.72rem; color: var(--fg-dim); }
-  .task-row .status {
+  [data-design="v1"] .ch-row .badge-attention {
+    color: var(--err);
+    font-weight: 600;
+  }
+  [data-design="v1"] .task-row .title {
+    font-weight: 500;
+    color: var(--ink);
+  }
+  [data-design="v1"] .task-row .meta {
+    font-size: 11px;
+    color: var(--ink-3);
+  }
+  /* Task-status text — the .pill primitive handles the chip; this only
+     covers the mono status text inside the row header before the title. */
+  [data-design="v1"] .task-row .status {
     display: inline-block;
-    padding: 0.05rem 0.35rem;
+    padding: 1px 6px;
     border-radius: 3px;
-    font-size: 0.68rem;
+    font-size: 10px;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
-    margin-right: 0.35rem;
-    border: 1px solid var(--border);
+    letter-spacing: 0.04em;
+    margin-right: 6px;
+    border: 1px solid var(--hair);
+    color: var(--ink-3);
   }
-  .task-row .status-pending { color: var(--fg-dim); }
-  .task-row .status-in_progress { color: var(--yellow); border-color: var(--yellow); }
-  .task-row .status-done { color: var(--green); border-color: var(--green); }
-  .task-row .status-blocked { color: var(--red); border-color: var(--red); }
-  .sidebar-empty {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.78rem;
-    color: var(--fg-dim);
+  [data-design="v1"] .task-row .status-in_progress {
+    color: var(--think);
+    border-color: color-mix(in srgb, var(--think) 45%, var(--hair));
+    background: var(--think-soft);
+  }
+  [data-design="v1"] .task-row .status-done {
+    color: var(--ok);
+    border-color: color-mix(in srgb, var(--ok) 45%, var(--hair));
+    background: var(--ok-soft);
+  }
+  [data-design="v1"] .task-row .status-blocked {
+    color: var(--err);
+    border-color: color-mix(in srgb, var(--err) 45%, var(--hair));
+    background: var(--err-soft);
+  }
+  [data-design="v1"] .sidebar-empty {
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--ink-4);
     font-style: italic;
   }
   /* Brief flash when a task-row "→ child" link scrolls into the
      tree — signals the click resolved without the user hunting for
-     which row was the target. */
-  .ch-row.highlight {
-    /* accent-dim reads as "focused, not error" on both light and dark
-       themes; the prior --yellow-glow tinted light-theme rows amber
-       enough to look like an error state. */
-    background: var(--accent-dim);
-    border-color: var(--accent);
+     which row was the target.  accent-soft reads as "focused, not
+     error" on both light + dark themes. */
+  [data-design="v1"] .ch-row.highlight {
+    background: var(--accent-soft);
+    border-color: color-mix(in srgb, var(--accent) 50%, var(--hair));
     transition: background 0.6s ease-out, border-color 0.6s ease-out;
   }
   @media (prefers-reduced-motion: reduce) {
-    .ch-row.highlight { transition: none; }
+    [data-design="v1"] .ch-row.highlight { transition: none; }
   }
+
+  /* Hide the approval dock when no approval is pending.  The DS
+     .approval-dock pattern is position: fixed and always-rendered; we
+     use [hidden] as the toggle since the pattern ships no default
+     display: none rule (its intended use is an always-visible bottom
+     dock when opened).  !important guards against inline display
+     fights from the JS show/hide path. */
+  [data-design="v1"] .approval-dock[hidden] { display: none !important; }
 
   /* Sidebar mobile toggle (desktop hides; mobile shows via media query
      below). */
@@ -152,29 +252,35 @@
     display: none;
     background: transparent;
     border: none;
-    color: var(--fg);
+    color: var(--ink-2);
     cursor: pointer;
-    padding: 0.1rem 0.35rem;
+    padding: 2px 6px;
     font-family: inherit;
-    font-size: 0.85rem;
+    font-size: 13px;
   }
   #coord-sidebar-toggle:focus-visible {
     outline: 2px solid var(--accent);
-    outline-offset: 1px;
+    outline-offset: 2px;
   }
-  [aria-busy="true"].ts-sidebar-section-body,
-  [aria-busy="true"] .section-body { opacity: 0.55; }
+  [aria-busy="true"].coord-sidebar-body { opacity: 0.55; }
+
+  /* Wait indicator — appbar-hosted polite status badge. */
+  [data-design="v1"] .coord-wait-indicator {
+    margin-left: 8px;
+    color: var(--think);
+  }
 
   /* Sub-700px: sidebar collapses to an accordion above the chat;
-     #coord-header wraps buttons; composer tightens. */
+     appbar wraps its right cluster; composer tightens. */
   @media (max-width: 700px) {
-    #coord-header { flex-wrap: wrap; }
-    #coord-header-spacer { flex-basis: 100%; height: 0; }
-    #coord-messages { padding: 0.75rem 1rem; }
+    .appbar { flex-wrap: wrap; height: auto; padding: 8px 12px; }
+    #coord-messages { padding: 12px 14px 160px; }
     #coord-body { flex-direction: column; }
-    #coord-sidebar {
+    [data-design="v1"] #coord-sidebar.sidebar {
       max-height: 50vh;
       flex: 0 0 auto;
+      border-left: none;
+      border-top: 1px solid var(--hair);
     }
     #coord-sidebar-toggle { display: inline-flex; }
     #coord-sidebar[aria-expanded="false"] #coord-children-wrap,
@@ -187,19 +293,23 @@
 </head>
 <body>
 
-<div id="coord-header" class="ts-header">
-  <a href="/" class="ts-header-back-link" aria-label="Back to console">
-    <span class="ts-header-back-link-arrow" aria-hidden="true">&larr;</span>
+<div id="coord-header" class="appbar">
+  <a href="/" class="appbar-back" aria-label="Back to console">
+    <span class="appbar-back-arrow" aria-hidden="true">&larr;</span>
     <span>Console</span>
   </a>
-  <h1 class="ts-header-title">turnstone <span class="dim ts-header-title-dim">coordinator</span></h1>
-  <span id="coord-name"></span>
-  <span id="coord-status"></span>
-  <span id="coord-header-spacer" class="ts-header-spacer"></span>
-  <span id="coord-sse-status" class="ts-header-status" aria-live="polite">connecting…</span>
-  <button id="coord-cancel-btn" class="header-btn" style="display:none" onclick="coordCancel()">cancel</button>
-  <button id="coord-close-btn" class="header-btn" onclick="coordCloseSession()" title="End this coordinator session (terminates it on the server)">end</button>
-  <button id="theme-toggle" class="header-btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme">&#9790;</button>
+  <h1 class="appbar-title">
+    turnstone
+    <span id="coord-name" class="dim"></span>
+  </h1>
+  <span id="coord-status" class="appbar-status"></span>
+  <span class="appbar-spacer"></span>
+  <span id="coord-sse-status" class="appbar-status" aria-live="polite">connecting…</span>
+  <span class="appbar-actions">
+    <button id="coord-cancel-btn" class="btn" style="display:none" onclick="coordCancel()">cancel</button>
+    <button id="coord-close-btn" class="btn" onclick="coordCloseSession()" title="End this coordinator session (terminates it on the server)">end</button>
+    <button id="theme-toggle" class="btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme">&#9790;</button>
+  </span>
 </div>
 
 <div id="coord-body">
@@ -209,27 +319,16 @@
          don't re-announce partial content on every token. -->
     <div id="coord-messages" role="log" aria-live="polite"></div>
 
-    <!-- Region (not alertdialog) because we don't trap focus; buttons are
-         reachable in normal tab order.  role=alertdialog implies a modal
-         focus trap per WAI-ARIA. -->
-    <div id="coord-approval-bar" class="ts-approval ts-approval--batch" role="region" aria-label="Approval required" aria-live="assertive">
-      <div id="coord-approval-label" class="ts-approval-header">Approval required</div>
-      <div id="coord-approval-tools"></div>
-      <div class="ts-approval-actions">
-        <button id="coord-approve-btn" class="ts-approval-btn ts-approval-btn--approve" onclick="coordApprove(true, false)">Approve</button>
-        <button id="coord-approve-always-btn" class="ts-approval-btn ts-approval-btn--always" onclick="coordApprove(true, true)">Approve (always)</button>
-        <button id="coord-deny-btn" class="ts-approval-btn ts-approval-btn--deny" onclick="coordApprove(false, false)">Deny</button>
-      </div>
-    </div>
-
     <!-- Composer DOM is built by shared_static/composer.js into this mount.
          Keeping the mount here (rather than inside coord-main's first child)
          preserves the existing flex layout that puts the composer below the
-         message log + approval bar. -->
+         message log.  The approval dock lives outside coord-main so its
+         position: fixed bottom rule is measured against the viewport rather
+         than the scroll container. -->
     <div id="coord-composer-mount"></div>
   </div>
 
-  <aside id="coord-sidebar" class="ts-sidebar" aria-expanded="true" aria-label="Coordinator children and tasks">
+  <aside id="coord-sidebar" class="sidebar" aria-expanded="true" aria-label="Coordinator children and tasks">
     <!-- Mobile-only toggle — on desktop the sidebar is always visible
          beside the chat pane; on <700px viewports it collapses into an
          accordion that only shows its heading row until tapped. -->
@@ -240,34 +339,58 @@
       <span id="coord-sidebar-toggle-glyph" aria-hidden="true">&#9662;</span>
       <span>Children &amp; tasks</span>
     </button>
-    <div id="coord-children-wrap" class="ts-sidebar-section">
-      <h2 id="coord-children-heading" class="ts-sidebar-section-heading">
-        <span>Children</span>
-        <span id="coord-children-count" class="dim ts-sidebar-section-count"></span>
-        <button type="button" class="refresh-btn ui-btn--icon" id="coord-children-refresh" aria-label="Refresh children list" title="Refresh children">&#8635;</button>
-      </h2>
+    <div id="coord-children-wrap" class="side-section">
+      <div class="coord-sidebar-head">
+        <span id="coord-children-heading" class="side-label">Children</span>
+        <span id="coord-children-count" class="side-count"></span>
+        <button type="button" class="ghost" id="coord-children-refresh" aria-label="Refresh children list" title="Refresh children">&#8635;</button>
+      </div>
       <!-- role="list" only — no aria-live.  The sidebar's DOM churns
            on every child state tick and fan-out re-render would flood
            screen readers.  If we need targeted announcements later,
            emit them via a dedicated off-screen polite live region. -->
       <div id="coord-children-tree"
-           class="section-body ts-sidebar-section-body"
+           class="coord-sidebar-body"
            role="list"
            aria-labelledby="coord-children-heading"></div>
     </div>
-    <div id="coord-tasks-wrap" class="ts-sidebar-section">
-      <h2 id="coord-tasks-heading" class="ts-sidebar-section-heading">
-        <span>Tasks</span>
-        <span id="coord-tasks-count" class="dim ts-sidebar-section-count"></span>
-        <button type="button" class="refresh-btn ui-btn--icon" id="coord-tasks-refresh" aria-label="Refresh task list" title="Refresh tasks">&#8635;</button>
-      </h2>
+    <div id="coord-tasks-wrap" class="side-section">
+      <div class="coord-sidebar-head">
+        <span id="coord-tasks-heading" class="side-label">Tasks</span>
+        <span id="coord-tasks-count" class="side-count"></span>
+        <button type="button" class="ghost" id="coord-tasks-refresh" aria-label="Refresh task list" title="Refresh tasks">&#8635;</button>
+      </div>
       <div id="coord-tasks"
-           class="section-body ts-sidebar-section-body"
+           class="coord-sidebar-body"
            role="list"
            aria-labelledby="coord-tasks-heading"></div>
     </div>
   </aside>
 </div>
+
+<!-- Approval dock — DS pattern.  Bottom-pinned (position: fixed) and
+     always-rendered; [hidden] toggles visibility.  role="region" (not
+     alertdialog) because we do not trap focus; buttons are reachable
+     in normal tab order.  aria-live="assertive" preserves the existing
+     pre-DS behaviour of announcing the approval the moment it queues. -->
+<aside id="coord-approval-bar"
+       class="approval-dock"
+       role="region"
+       aria-label="Approval required"
+       aria-live="assertive"
+       hidden>
+  <div id="coord-approval-label" class="dhead">
+    Approval required
+    <span id="coord-approval-count" class="dcount"></span>
+  </div>
+  <div id="coord-approval-tools"></div>
+  <div class="drow">
+    <div class="spacer"></div>
+    <button id="coord-deny-btn" class="act danger" type="button" onclick="coordApprove(false, false)">Deny<span class="kbd">D</span></button>
+    <button id="coord-approve-always-btn" class="act always" type="button" onclick="coordApprove(true, true)">Always<span class="kbd">&#8679;A</span></button>
+    <button id="coord-approve-btn" class="act primary" type="button" onclick="coordApprove(true, false)">Approve<span class="kbd">&#9166;</span></button>
+  </div>
+</aside>
 
 <!-- Shared-static import order matches the console dashboard
      (console/static/index.html) so global shortcuts (kb.js) and helpers

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -259,6 +259,65 @@
      !important override to win specificity. */
   [data-design="v1"] .approval-dock[hidden] { display: none !important; }
 
+  /* Judge verdict chips — colour-code by recommendation so the
+     reviewer can triage at a glance without reading the chip text.
+     approve=ok, review=warn, deny=err.  Uses the same 12/38/70% mix
+     scheme as the primitive k-badge tokens. */
+  [data-design="v1"] #coord-approval-bar .dctx code.rec-approve {
+    color: color-mix(in srgb, var(--ok) 70%, var(--ink-2));
+    border-color: color-mix(in srgb, var(--ok) 38%, var(--hair));
+    background: color-mix(in srgb, var(--ok) 12%, var(--panel-2));
+  }
+  [data-design="v1"] #coord-approval-bar .dctx code.rec-review {
+    color: color-mix(in srgb, var(--warn) 70%, var(--ink-2));
+    border-color: color-mix(in srgb, var(--warn) 38%, var(--hair));
+    background: var(--warn-tint);
+  }
+  [data-design="v1"] #coord-approval-bar .dctx code.rec-deny {
+    color: color-mix(in srgb, var(--err) 70%, var(--ink-2));
+    border-color: color-mix(in srgb, var(--err) 38%, var(--hair));
+    background: color-mix(in srgb, var(--err) 12%, var(--panel-2));
+  }
+
+  /* "judge evaluating…" spinner chip — shown while a .dcall is
+     pending a verdict.  Reuses the @keyframes ts-spin keyframe
+     defined in primitives/feed.css. */
+  [data-design="v1"] #coord-approval-bar .dctx code.judging {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--ink-3);
+  }
+  [data-design="v1"] #coord-approval-bar .dctx code.judging .spin {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1.5px solid var(--accent);
+    border-top-color: transparent;
+    animation: ts-spin 0.9s linear infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    [data-design="v1"] #coord-approval-bar .dctx code.judging .spin {
+      animation: none;
+    }
+  }
+
+  /* Judge rationale — the judge's reasoning text, rendered below the
+     dctx chips as a block quote.  Full text wraps; no truncation —
+     justification is the whole point of showing this. */
+  [data-design="v1"] #coord-approval-bar .drationale {
+    margin-top: 4px;
+    padding: 6px 10px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--ink-3);
+    background: var(--panel-2);
+    border-left: 2px solid var(--hair);
+    border-radius: 0 3px 3px 0;
+    white-space: pre-wrap;
+  }
+
   /* Sidebar mobile toggle (desktop hides; mobile shows via media query
      below). */
   #coord-sidebar-toggle {

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -279,9 +279,13 @@
     background: color-mix(in srgb, var(--err) 12%, var(--panel-2));
   }
 
+  /* Local @keyframes ts-spin — primitives/feed.css owns the canonical
+     definition but this page doesn't link feed.css (no .feed-item
+     usage).  Defined here so the .judging .spin chip below animates. */
+  @keyframes ts-spin { to { transform: rotate(360deg); } }
+
   /* "judge evaluating…" spinner chip — shown while a .dcall is
-     pending a verdict.  Reuses the @keyframes ts-spin keyframe
-     defined in primitives/feed.css. */
+     pending a verdict. */
   [data-design="v1"] #coord-approval-bar .dctx code.judging {
     display: inline-flex;
     align-items: center;
@@ -440,7 +444,7 @@
     </button>
     <div id="coord-children-wrap" class="side-section">
       <div class="coord-sidebar-head">
-        <span id="coord-children-heading" class="side-label">Children</span>
+        <h2 id="coord-children-heading" class="side-label">Children</h2>
         <span id="coord-children-count" class="side-count"></span>
         <button type="button" class="ghost" id="coord-children-refresh" aria-label="Refresh children list" title="Refresh children">&#8635;</button>
       </div>
@@ -455,7 +459,7 @@
     </div>
     <div id="coord-tasks-wrap" class="side-section">
       <div class="coord-sidebar-head">
-        <span id="coord-tasks-heading" class="side-label">Tasks</span>
+        <h2 id="coord-tasks-heading" class="side-label">Tasks</h2>
         <span id="coord-tasks-count" class="side-count"></span>
         <button type="button" class="ghost" id="coord-tasks-refresh" aria-label="Refresh task list" title="Refresh tasks">&#8635;</button>
       </div>

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -108,11 +108,6 @@
     flex: 1;
     overflow-y: auto;
     padding: 1rem 1.5rem;
-    /* Extra bottom padding so the fixed .approval-dock (position: fixed
-       bottom: 22px, ~3 rows ≈ 140px tall) never occludes the tail of the
-       message log when open.  Dock hides via [hidden], so when collapsed
-       the user just gets generous scroll padding — harmless. */
-    padding-bottom: 160px;
   }
   [data-design="v1"] .msg .coord-ws-link {
     color: var(--accent);
@@ -238,12 +233,30 @@
     [data-design="v1"] .ch-row.highlight { transition: none; }
   }
 
-  /* Hide the approval dock when no approval is pending.  The DS
-     .approval-dock pattern is position: fixed and always-rendered; we
-     use [hidden] as the toggle since the pattern ships no default
-     display: none rule (its intended use is an always-visible bottom
-     dock when opened).  !important guards against inline display
-     fights from the JS show/hide path. */
+  /* Override the DS .approval-dock pattern's viewport-pinned
+     positioning.  The pattern defaults to position: fixed bottom:22px
+     (designed for the fleet dashboard overlay case); in the coordinator
+     chat we need it inline above the composer so it doesn't cover the
+     input area.  Dock sits as the second flex child inside #coord-main
+     between messages and composer, with a hair top border as the
+     separator. */
+  [data-design="v1"] #coord-approval-bar.approval-dock {
+    position: static;
+    bottom: auto;
+    left: auto;
+    right: auto;
+    z-index: auto;
+    box-shadow: none;
+    flex: 0 0 auto;
+  }
+  /* Keep the warm top-stripe cue; just make it hug the top edge of the
+     in-flow dock instead of the top of a fixed viewport bar. */
+  [data-design="v1"] #coord-approval-bar.approval-dock::before {
+    top: -1px;
+  }
+  /* Hide the dock when no approval is pending.  [hidden] toggle; the
+     approval-dock pattern defines display: flex so we need the
+     !important override to win specificity. */
   [data-design="v1"] .approval-dock[hidden] { display: none !important; }
 
   /* Sidebar mobile toggle (desktop hides; mobile shows via media query
@@ -274,7 +287,7 @@
      appbar wraps its right cluster; composer tightens. */
   @media (max-width: 700px) {
     .appbar { flex-wrap: wrap; height: auto; padding: 8px 12px; }
-    #coord-messages { padding: 12px 14px 160px; }
+    #coord-messages { padding: 12px 14px; }
     #coord-body { flex-direction: column; }
     [data-design="v1"] #coord-sidebar.sidebar {
       max-height: 50vh;
@@ -319,12 +332,39 @@
          don't re-announce partial content on every token. -->
     <div id="coord-messages" role="log" aria-live="polite"></div>
 
-    <!-- Composer DOM is built by shared_static/composer.js into this mount.
-         Keeping the mount here (rather than inside coord-main's first child)
-         preserves the existing flex layout that puts the composer below the
-         message log.  The approval dock lives outside coord-main so its
-         position: fixed bottom rule is measured against the viewport rather
-         than the scroll container. -->
+    <!-- Approval dock — DS pattern, overridden to inline positioning (see
+         the position: static override in the style block above).  Sits
+         between the message log and the composer so it doesn't occlude
+         the user input. role="region" (not alertdialog) because we do
+         not trap focus; buttons are reachable in normal tab order.
+         aria-live="assertive" preserves the pre-DS announce-on-queue
+         behaviour. -->
+    <aside id="coord-approval-bar"
+           class="approval-dock"
+           role="region"
+           aria-label="Approval required"
+           aria-live="assertive"
+           hidden>
+      <div id="coord-approval-label" class="dhead">
+        Approval required
+        <span id="coord-approval-count" class="dcount"></span>
+      </div>
+      <div id="coord-approval-tools"></div>
+      <div class="drow">
+        <div class="spacer"></div>
+        <button id="coord-deny-btn" class="act danger" type="button" onclick="coordApprove(false, false)">
+          Deny<span class="kbd">D</span>
+        </button>
+        <button id="coord-approve-always-btn" class="act always" type="button" onclick="coordApprove(true, true)">
+          Always<span class="kbd">⇧A</span>
+        </button>
+        <button id="coord-approve-btn" class="act primary" type="button" onclick="coordApprove(true, false)">
+          Approve<span class="kbd">⏎</span>
+        </button>
+      </div>
+    </aside>
+
+    <!-- Composer DOM is built by shared_static/composer.js into this mount. -->
     <div id="coord-composer-mount"></div>
   </div>
 
@@ -367,30 +407,6 @@
     </div>
   </aside>
 </div>
-
-<!-- Approval dock — DS pattern.  Bottom-pinned (position: fixed) and
-     always-rendered; [hidden] toggles visibility.  role="region" (not
-     alertdialog) because we do not trap focus; buttons are reachable
-     in normal tab order.  aria-live="assertive" preserves the existing
-     pre-DS behaviour of announcing the approval the moment it queues. -->
-<aside id="coord-approval-bar"
-       class="approval-dock"
-       role="region"
-       aria-label="Approval required"
-       aria-live="assertive"
-       hidden>
-  <div id="coord-approval-label" class="dhead">
-    Approval required
-    <span id="coord-approval-count" class="dcount"></span>
-  </div>
-  <div id="coord-approval-tools"></div>
-  <div class="drow">
-    <div class="spacer"></div>
-    <button id="coord-deny-btn" class="act danger" type="button" onclick="coordApprove(false, false)">Deny<span class="kbd">D</span></button>
-    <button id="coord-approve-always-btn" class="act always" type="button" onclick="coordApprove(true, true)">Always<span class="kbd">&#8679;A</span></button>
-    <button id="coord-approve-btn" class="act primary" type="button" onclick="coordApprove(true, false)">Approve<span class="kbd">&#9166;</span></button>
-  </div>
-</aside>
 
 <!-- Shared-static import order matches the console dashboard
      (console/static/index.html) so global shortcuts (kb.js) and helpers


### PR DESCRIPTION
Opt the per-session coordinator view into data-design="v1" and migrate its rendering to the DS primitives + patterns shipped in phase 1.  This is the larger of the two parallel chat migrations (the other being the server UI under turnstone/ui/static/).

Scope — this PR touches two files only:

  turnstone/console/static/coordinator/index.html
    - data-design="v1" on <html>; DS stylesheets linked after the legacy base so primitives win on specificity and legacy styles keep covering anything not-yet-migrated.
    - Header rewired from .ts-header to .appbar with .appbar-back, .appbar-title + .dim subtitle, .appbar-spacer, .appbar-status for SSE state, and .appbar-actions wrapping the cancel / end / theme buttons (now .btn pills).
    - Approval bar replaced with the .approval-dock pattern.  Signature change: amber Approve becomes an ok-family (green) filled button with 1.5px border + --r-md squared shape.  .dcall rows frame each pending call like a mini inspectable code line.  Action cluster sits in a .drow with Deny (.act.danger) / Always (.act.always) / Approve (.act.primary) and the preview's kbd affordances (D / ⇧A / ⏎).  role="region" + aria-live="assertive" preserved; the dock stays non-modal (no focus trap), focus moves to the primary Approve button on open via the existing handler.
    - Sidebar shell adopts .sidebar + .side-section + .side-label + .ghost refresh buttons.  Coordinator-only .sidebar overrides unset the DS sticky-left-column defaults (which assume an admin-shell grid) so the aside continues to flex into the right column of #coord-body.  Tree-row + task-row styling stays view-local, rehomed to DS tokens (--hair-2 hover, --accent focus, --ok/--warn/ --err + -soft task-status tints).
    - Inline <style> trimmed of rules now covered by DS primitives; only the coordinator-specific flex wiring, tree-row visuals, and <700px responsive accordion remain.

  turnstone/console/static/coordinator/coordinator.js
    - appendMsg() emits .msg + role variant (.msg.user / .msg.assistant / .msg.reasoning / .msg.tool / .msg.error / .msg.info) and .msg-body. _TS_ROLE_VARIANTS renamed _MSG_VARIANTS.
    - Streaming helpers query .msg-body; SSE dedup-by-call-id query updated to .msg[data-call-id=...].
    - showApproval() renders the .approval-dock DOM shape: .dhead count in a .dcount, one .dcall per pending call with .risk index pill + .dfn function name + .dargs preview.  approvalBar.hidden toggles visibility (the DS pattern is position: fixed and always-rendered; [hidden] is the show/hide hook).
    - setSseStatus() keeps .appbar-status as the base; semantic colour tracks OK / ERR via inline --ok / --err.  Leading glyph (●/○/⚠) preserves the WCAG 1.4.1 non-colour-only cue.
    - Wait indicator uses .appbar-status instead of the legacy .ts-header-status BEM; styling from the inline page rules colours it --think.

Contracts preserved:
  - SSE wire format and event names unchanged (approve_request, child_ws_created, wait_progress, batch_started, state_change, stream_end, ...).
  - POST /approve body shape unchanged: {approved, always, call_id}. No per-item feedback field is added (that's phase 9 PR C).
  - Keyboard behaviour unchanged: Enter continues to approve via the primary-button focus shift in showApproval(); the D and ⇧A kbd labels are rendered per the pattern spec but the global key handlers (if any) remain untouched.
  - ARIA attributes (role, aria-label, aria-live) preserved on the approval dock, messages log, and sidebar.
  - All shared-static JS imports and order unchanged; composer module continues to own its own DOM inside #coord-composer-mount.

No backend changes.  Legacy CSS (/shared/base.css, /shared/ui-base.css, /shared/chat.css, /static/style.css) stays linked as the compatibility layer — DS selectors [data-design="v1"] beat legacy where applied.