### PR TITLE
feat(coord): saved coordinators surface + shared session-card primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ PROGRESS.md
 .coverage
 tools/skill_audit_analysis/data/
 tools/skill_audit_analysis/output/
+design_ideas/
+.claude/

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -302,7 +302,8 @@ def _seed_closed_coord_with_history(
     """
     ws = mgr.create(user_id=user_id, name=name)
     storage.save_message(ws.id, role="user", content="seed")
-    assert mgr.close(ws.id)
+    closed = mgr.close(ws.id)
+    assert closed
     return ws.id
 
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -38,6 +38,7 @@ from turnstone.console.server import (
     coordinator_history,
     coordinator_list,
     coordinator_open,
+    coordinator_saved,
     coordinator_send,
     coordinator_tasks,
 )
@@ -70,6 +71,13 @@ def _make_client(
                 methods=["POST"],
             ),
             Route("/v1/api/coordinator", coordinator_list, methods=["GET"]),
+            # Literal path before the /{ws_id} routes below so Starlette
+            # matches "saved" as the literal, not as a ws_id.
+            Route(
+                "/v1/api/coordinator/saved",
+                coordinator_saved,
+                methods=["GET"],
+            ),
             Route(
                 "/v1/api/coordinator/{ws_id}/send",
                 coordinator_send,
@@ -277,6 +285,143 @@ def test_list_admin_sees_all(storage):
     )
     assert resp.status_code == 200
     assert len(resp.json()["coordinators"]) == 2
+
+
+def _seed_closed_coord_with_history(
+    mgr,
+    storage,
+    *,
+    user_id: str,
+    name: str,
+) -> str:
+    """Create + close a coordinator and seed one conversation row.
+
+    list_workstreams_with_history's WHERE EXISTS guard skips coords with no
+    messages, so the saved-list endpoint won't surface a freshly-closed
+    coordinator unless we've stamped at least one conversation row.
+    """
+    ws = mgr.create(user_id=user_id, name=name)
+    storage.save_message(ws.id, role="user", content="seed")
+    assert mgr.close(ws.id)
+    return ws.id
+
+
+@pytest.fixture
+def saved_storage(tmp_path):
+    """Storage fixture for saved-coordinator tests.
+
+    coordinator_saved goes through ``list_workstreams_with_history``
+    which calls ``get_storage()`` (the singleton registry), not whatever
+    backend the manager holds.  This fixture initialises the registry to
+    a fresh SQLite db and yields the same backend so the test can also
+    seed conversation rows directly.
+    """
+    from turnstone.core.storage import init_storage, reset_storage
+
+    db_path = str(tmp_path / "saved.db")
+    reset_storage()
+    backend = init_storage("sqlite", path=db_path, run_migrations=False)
+    try:
+        yield backend
+    finally:
+        reset_storage()
+
+
+def test_saved_filters_by_caller(saved_storage):
+    storage = saved_storage
+    mgr = _build_mgr(storage)
+    mine_id = _seed_closed_coord_with_history(mgr, storage, user_id="user-1", name="mine")
+    _seed_closed_coord_with_history(mgr, storage, user_id="user-2", name="theirs")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {c["ws_id"] for c in body["coordinators"]} == {mine_id}
+
+
+def test_saved_admin_sees_all(saved_storage):
+    storage = saved_storage
+    mgr = _build_mgr(storage)
+    a = _seed_closed_coord_with_history(mgr, storage, user_id="user-1", name="a")
+    b = _seed_closed_coord_with_history(mgr, storage, user_id="user-2", name="b")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get(
+        "/v1/api/coordinator/saved",
+        headers={
+            "X-Test-User": "admin-1",
+            "X-Test-Perms": "admin.coordinator,admin.users",
+        },
+    )
+    assert resp.status_code == 200
+    assert {c["ws_id"] for c in resp.json()["coordinators"]} == {a, b}
+
+
+def test_saved_blank_uid_returns_empty(saved_storage):
+    """Non-admin caller with no sub gets fail-closed empty list.
+
+    Mirrors list_saved_workstreams — empty user_id must not fall through
+    to a cluster-wide query (would leak orphan / migration rows).
+    """
+    storage = saved_storage
+    mgr = _build_mgr(storage)
+    _seed_closed_coord_with_history(mgr, storage, user_id="someone", name="x")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get(
+        "/v1/api/coordinator/saved",
+        headers={"X-Test-User": "", "X-Test-Perms": "admin.coordinator"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"coordinators": []}
+
+
+def test_saved_excludes_currently_loaded(saved_storage):
+    """A coordinator currently in coord_mgr must NOT appear in saved cards.
+
+    Even if its DB row says state='closed' (e.g. mid-restart race), the
+    in-memory presence wins so the same ws_id can't be in both the
+    active list and the saved-cards grid simultaneously.
+    """
+    storage = saved_storage
+    mgr = _build_mgr(storage)
+    closed_id = _seed_closed_coord_with_history(mgr, storage, user_id="user-1", name="closed")
+    # Create another coord, leave it loaded — should never appear in saved.
+    loaded_ws = mgr.create(user_id="user-1", name="loaded")
+    storage.save_message(loaded_ws.id, role="user", content="seed")
+    # Force it to state='closed' on disk without removing from memory, to
+    # exercise the defence-in-depth ``loaded`` filter.
+    storage.update_workstream_state(loaded_ws.id, "closed")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    saved_ids = {c["ws_id"] for c in resp.json()["coordinators"]}
+    assert closed_id in saved_ids
+    assert loaded_ws.id not in saved_ids
+
+
+def test_saved_excludes_active_state_rows(saved_storage):
+    """Only state='closed' rows surface in the saved list.
+
+    A coordinator that's idle on disk but not currently loaded into
+    coord_mgr (e.g. orphaned across a console restart that hasn't
+    rehydrated yet) is NOT 'saved' — it's just not loaded yet, and the
+    saved grid is for explicit user-closed sessions.
+    """
+    storage = saved_storage
+    mgr = _build_mgr(storage)
+    closed_id = _seed_closed_coord_with_history(mgr, storage, user_id="user-1", name="closed")
+    # An idle row in storage with no in-memory presence — must not appear.
+    orphan = mgr.create(user_id="user-1", name="orphan")
+    storage.save_message(orphan.id, role="user", content="seed")
+    # Drop from memory without changing state (simulates manager restart).
+    mgr._workstreams.pop(orphan.id, None)
+    if orphan.id in mgr._order:
+        mgr._order.remove(orphan.id)
+    assert storage.get_workstream(orphan.id)["state"] == "idle"
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    saved_ids = {c["ws_id"] for c in resp.json()["coordinators"]}
+    assert saved_ids == {closed_id}
 
 
 def test_send_to_someone_elses_coord_returns_404(storage):

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -418,8 +418,10 @@ def test_open_refuses_deleted_coordinator(built_mgr):
     ws = mgr.create(user_id="u1")
     mgr.close(ws.id)
     storage.update_workstream_state(ws.id, "deleted")
-    assert mgr.open(ws.id, "u1") is None
-    assert mgr.open_admin(ws.id) is None
+    user_open = mgr.open(ws.id, "u1")
+    assert user_open is None
+    admin_open = mgr.open_admin(ws.id)
+    assert admin_open is None
 
 
 def test_open_refuses_empty_owner_for_non_admin(built_mgr):

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -388,17 +388,37 @@ def test_open_admin_ignores_ownership(built_mgr):
     assert ws is not None
 
 
-def test_open_refuses_closed_coordinator(built_mgr):
-    """A coordinator that was closed (state=closed in storage) must not
-    silently resurrect on the next GET.  Otherwise the Close button is
-    reversible on URL revisit and burns max_active capacity."""
+def test_open_resurrects_closed_coordinator(built_mgr):
+    """A coordinator that was closed (state='closed' in storage) IS now
+    resurrectable via open().  Restore is an explicit user action via
+    the Saved Coordinators landing UI; ``_reserve_and_install_locked``
+    still enforces ``max_active`` (evicts an idle peer or 429s).  The
+    old "URL revisit silently undoes Close" safety lives in the slot
+    accounting now, not in a flat refusal at the open path."""
     mgr, _calls, storage = built_mgr
     ws = mgr.create(user_id="u1")
     mgr.close(ws.id)
-    # Direct GET via open() must NOT rehydrate the closed row.
+    assert storage.get_workstream(ws.id)["state"] == "closed"
+
     reopened = mgr.open(ws.id, "u1")
-    assert reopened is None
-    # Admin path must also refuse to resurrect — closed means closed.
+    assert reopened is not None
+    assert reopened.id == ws.id
+    # Re-loaded into memory.
+    assert mgr.get(ws.id) is reopened
+
+    # Admin path also resurrects.
+    mgr.close(ws.id)
+    assert mgr.open_admin(ws.id) is not None
+
+
+def test_open_refuses_deleted_coordinator(built_mgr):
+    """A coordinator marked state='deleted' is a tombstone — open() must
+    refuse to resurrect even though closed-state is now resurrectable."""
+    mgr, _calls, storage = built_mgr
+    ws = mgr.create(user_id="u1")
+    mgr.close(ws.id)
+    storage.update_workstream_state(ws.id, "deleted")
+    assert mgr.open(ws.id, "u1") is None
     assert mgr.open_admin(ws.id) is None
 
 

--- a/turnstone/console/coordinator.py
+++ b/turnstone/console/coordinator.py
@@ -360,11 +360,17 @@ class CoordinatorManager:
                 row = self._storage.get_workstream(ws_id)
                 if row is None or row.get("kind") != WorkstreamKind.COORDINATOR:
                     return None
-                # close()/delete() only soft-mark the row — refuse to
-                # resurrect those sessions on any subsequent GET, or the
-                # Close button becomes silently reversible on URL revisit
-                # and burns max_active capacity.
-                if row.get("state") in {"closed", "deleted"}:
+                # ``deleted`` is a tombstone — the row is on its way out
+                # and must never resurrect.  ``closed`` used to be in the
+                # same bucket (so a stray URL revisit couldn't silently
+                # reverse a Close), but the Saved Coordinators landing UI
+                # makes restore an explicit user action: clicking a saved
+                # card calls POST /open and the user is consenting to
+                # reload.  ``_reserve_and_install_locked`` still enforces
+                # ``max_active`` (evicting an idle peer or 429-ing) so the
+                # safety the old guard provided now lives in the slot
+                # accounting, not in a flat-refusal.
+                if row.get("state") == "deleted":
                     return None
                 row_owner = row.get("user_id") or ""
                 # Strict equality (not short-circuit on empty row_owner)
@@ -437,6 +443,23 @@ class CoordinatorManager:
                             ws_id[:8],
                             exc_info=True,
                         )
+
+                # No DB state-flip on resurrect.  The in-memory session
+                # is now IDLE; the DB row may still say 'closed' from the
+                # last close().  We deliberately don't write 'idle' here
+                # because:
+                #   (a) it would race a concurrent close() (which writes
+                #       'closed' under self._lock without acquiring this
+                #       per-ws open_lock) and could overwrite the
+                #       authoritative close;
+                #   (b) the next set_state() call (any state transition
+                #       — running, attention, idle-after-running) syncs
+                #       the DB naturally;
+                #   (c) the saved-coordinators list filters by state +
+                #       excludes coordinators currently loaded into
+                #       coord_mgr, so the stale 'closed' state on disk
+                #       doesn't make a still-loaded coordinator appear
+                #       as a saved card.
                 # Rehydration: fan out a console-pseudo-node
                 # ``ws_created`` so a tab that opens a persisted-but-
                 # unloaded coordinator sees it live on every other

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2834,6 +2834,93 @@ async def coordinator_list(request: Request) -> JSONResponse:
     )
 
 
+async def coordinator_saved(request: Request) -> JSONResponse:
+    """GET /v1/api/coordinator/saved — list saved (closed-but-persisted) coordinator
+    sessions for the caller.
+
+    Mirrors :func:`turnstone.server.list_saved_workstreams` for the
+    coordinator surface so the frontend can render a "saved coordinators"
+    card grid identically to the interactive "saved workstreams" sidebar.
+    Same response item shape, same tenant/admin scoping.
+
+    Returns ONLY rows with ``state='closed'`` — explicitly closed
+    coordinators that the user can re-open via the saved card.  Active /
+    in-flight rows live in the active list above; deleted rows are
+    tombstones that ``_open_impl`` refuses to resurrect.
+
+    Also filters out coordinators currently loaded into ``coord_mgr``
+    (defence-in-depth: a coordinator could be 'closed' on disk but
+    still in the warm pool right after a restart of the close-emit
+    sequence races the in-memory pop).
+    """
+    from turnstone.core.memory import list_workstreams_with_history
+    from turnstone.core.workstream import WorkstreamKind
+
+    err = _require_admin_coordinator(request)
+    if err is not None:
+        return err
+
+    if _is_admin(request):
+        user_filter: str | None = None
+    else:
+        caller_uid = _auth_user_id(request)
+        if not caller_uid:
+            # Blank sub on a non-service / non-admin token — fail closed
+            # rather than match every orphan / migration row with empty
+            # user_id.  Mirrors list_saved_workstreams.
+            return JSONResponse({"coordinators": []})
+        user_filter = caller_uid
+
+    # Offload the blocking storage call + the lock-acquiring list_all
+    # off the event loop, matching coordinator_create's pattern (#perf-2
+    # from the saved-coordinators review).  list_workstreams_with_history
+    # runs a correlated COUNT subquery; coord_mgr.list_all() takes the
+    # manager lock.  Either can stall every other async handler if run
+    # inline.
+    rows = await asyncio.to_thread(
+        list_workstreams_with_history,
+        limit=50,
+        kind=WorkstreamKind.COORDINATOR,
+        user_id=user_filter,
+        state="closed",
+    )
+
+    coord_mgr = getattr(request.app.state, "coord_mgr", None)
+    loaded: set[str] = set()
+    if coord_mgr is not None:
+        try:
+            loaded = await asyncio.to_thread(
+                lambda: {ws.id for ws in coord_mgr.list_all()},
+            )
+        except Exception:
+            log.debug("coordinator_saved.list_all_failed", exc_info=True)
+
+    # Column order from list_workstreams_with_history is
+    # (ws_id, alias, title, name, created, updated, count, node_id) — see
+    # the SELECT in turnstone/core/storage/_sqlite.py:list_workstreams_with_history.
+    # ``*_extra`` swallows the trailing node_id (and any future columns
+    # appended at the tail); keep this comment in sync if the SELECT
+    # changes the prefix order.
+    result = [
+        {
+            "ws_id": wid,
+            "alias": alias,
+            "title": title,
+            "name": name,
+            "created": created,
+            "updated": updated,
+            "message_count": count,
+        }
+        for wid, alias, title, name, created, updated, count, *_extra in rows
+        if wid not in loaded
+    ]
+    # Key is ``coordinators`` (not ``workstreams``) for consistency with
+    # the sibling coordinator_list endpoint.  Item shape matches the
+    # interactive saved-workstreams response so the frontend card renderer
+    # stays a 1:1 mirror.
+    return JSONResponse({"coordinators": result})
+
+
 async def coordinator_page(request: Request) -> Response:
     """GET /coordinator/{ws_id} — serve the one-pane coordinator HTML.
 
@@ -10393,6 +10480,13 @@ def create_app(
                         methods=["POST"],
                     ),
                     Route("/api/coordinator", coordinator_list, methods=["GET"]),
+                    # Literal path BEFORE the /{ws_id} routes below so
+                    # Starlette doesn't match "saved" as a ws_id.
+                    Route(
+                        "/api/coordinator/saved",
+                        coordinator_saved,
+                        methods=["GET"],
+                    ),
                     Route(
                         "/api/coordinator/{ws_id}/send",
                         coordinator_send,

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -20,6 +20,9 @@ window.onLoginSuccess = function () {
   // (#9) — no poller to restart after login.  The home-view renderer
   // reads from clusterState.nodes["console"].workstreams on every SSE
   // patch, so authenticating just unblocks the normal event stream.
+  if (typeof loadSavedCoordinators === "function") {
+    loadSavedCoordinators();
+  }
 };
 window.onLogout = function () {
   if (evtSource) {
@@ -141,12 +144,30 @@ function patchClusterState(data) {
       });
     }
   } else if (t === "ws_closed") {
+    // Peek BEFORE the filter so we can tell whether the closed ws was a
+    // coordinator (lives on the console pseudo-node, kind="coordinator")
+    // and only then refetch the saved list.  ws_closed payloads from
+    // real-node interactive closes don't carry kind on the wire, but
+    // they're already typed in clusterState from the matching ws_created
+    // event.  Skipping interactive closes avoids per-close fan-out into
+    // /v1/api/coordinator/saved on busy clusters.
+    var wasCoordinator = false;
+    Object.keys(clusterState.nodes).forEach(function (nid) {
+      (clusterState.nodes[nid].workstreams || []).forEach(function (ws) {
+        if (ws.id === data.ws_id && ws.kind === "coordinator") {
+          wasCoordinator = true;
+        }
+      });
+    });
     Object.keys(clusterState.nodes).forEach(function (nid) {
       var n = clusterState.nodes[nid];
       n.workstreams = (n.workstreams || []).filter(function (ws) {
         return ws.id !== data.ws_id;
       });
     });
+    if (wasCoordinator && typeof loadSavedCoordinators === "function") {
+      loadSavedCoordinators();
+    }
   } else if (t === "ws_rename") {
     Object.keys(clusterState.nodes).forEach(function (nid) {
       (clusterState.nodes[nid].workstreams || []).forEach(function (ws) {
@@ -2199,6 +2220,114 @@ function _renderHomeView() {
   if (line) line.textContent = summaryText;
 }
 
+// ---------------------------------------------------------------------------
+// Saved coordinators — closed sessions persisted on disk.  Mirrors the
+// interactive UI's "Saved Workstreams" card grid (same /shared/cards.css
+// primitives, same /shared/cards.js renderSessionCard helper, same
+// response item shape from /v1/api/coordinator/saved).  Click a card →
+// POST /open then /coordinator/{ws_id}; coordinator_detail lazily
+// rehydrates from storage on the GET miss.
+// ---------------------------------------------------------------------------
+
+// In-flight de-dup for loadSavedCoordinators.  ws_closed events can
+// arrive in bursts on a busy cluster; without this guard each one
+// triggers a parallel fetch.  Single boolean is enough because the
+// renderer reads from the latest response — a coalesced re-fetch right
+// after the in-flight one resolves catches any state change.
+var _savedCoordsInFlight = false;
+var _savedCoordsRetry = false;
+
+function loadSavedCoordinators() {
+  if (!_hasCoordPermission()) return;
+  if (_savedCoordsInFlight) {
+    _savedCoordsRetry = true;
+    return;
+  }
+  _savedCoordsInFlight = true;
+  authFetch("/v1/api/coordinator/saved")
+    .then(function (r) {
+      return r.ok ? r.json() : { coordinators: [] };
+    })
+    .then(function (data) {
+      renderSavedCoordinators(data.coordinators || []);
+    })
+    .catch(function () {
+      /* silent — saved list is informational, not load-bearing */
+    })
+    .finally(function () {
+      _savedCoordsInFlight = false;
+      // If at least one call arrived while we were in flight, fire one
+      // catch-up fetch (not N) so the UI reflects the latest state
+      // without a per-event fan-out.
+      if (_savedCoordsRetry) {
+        _savedCoordsRetry = false;
+        loadSavedCoordinators();
+      }
+    });
+}
+
+function renderSavedCoordinators(items) {
+  var section = document.getElementById("saved-coordinators");
+  var cards = document.getElementById("saved-coord-cards");
+  var countEl = document.getElementById("saved-coord-count");
+  if (!section || !cards) return;
+  if (!items.length) {
+    section.style.display = "none";
+    cards.replaceChildren();
+    if (countEl) countEl.textContent = "";
+    return;
+  }
+  section.style.display = "";
+  if (countEl) countEl.textContent = "(" + items.length + ")";
+  cards.replaceChildren();
+  items.forEach(function (sess) {
+    var card = renderSessionCard(sess, {
+      ariaLabel: function (s) {
+        return (
+          "Resume coordinator: " + (s.alias || s.title || s.name || s.ws_id)
+        );
+      },
+      onActivate: function (s, cardEl) {
+        // POST /open BEFORE navigating so capacity issues surface as a
+        // toast instead of a broken-looking detail page.  The /open
+        // endpoint calls the same lazy-rehydrate path the GET would,
+        // but we get the status code synchronously so the user learns
+        // "all slots in use" instead of staring at a 404.
+        cardEl.classList.add("is-busy");
+        authFetch(
+          "/v1/api/coordinator/" + encodeURIComponent(s.ws_id) + "/open",
+          { method: "POST" },
+        )
+          .then(function (r) {
+            if (r.ok) {
+              window.location.href =
+                "/coordinator/" + encodeURIComponent(s.ws_id);
+              return;
+            }
+            cardEl.classList.remove("is-busy");
+            if (r.status === 429) {
+              showToast(
+                "All coordinator slots are active — close one first to restore this session",
+              );
+            } else if (r.status === 404) {
+              showToast("Coordinator no longer available");
+              loadSavedCoordinators();
+            } else if (r.status === 503) {
+              showToast("Coordinator subsystem not configured");
+            } else {
+              showToast("Failed to restore coordinator (" + r.status + ")");
+            }
+          })
+          .catch(function () {
+            cardEl.classList.remove("is-busy");
+            showToast("Failed to restore coordinator");
+          });
+      },
+    });
+    cards.appendChild(card);
+  });
+}
+
 // --- Init ---
 // SSE connects after auth is confirmed — either via onLoginSuccess after
 // login, or after the first successful data load (page refresh with valid cookie).
@@ -2217,10 +2346,28 @@ initLogin();
 // coordinator ws_created / ws_closed / cluster_state events.
 loadOverview();
 _ensureHomeComposerInit();
-// Refresh the coord button visibility after initial whoami lands in
-// sessionStorage (auth.js populates it asynchronously).  A short delay
-// is good enough — the shared pattern for permission-gated UI.
-setTimeout(_refreshHomeComposerVisibility, 500);
+// Refresh the coord button visibility once auth.js has populated
+// sessionStorage from the initial whoami.  window.permissionsReady
+// resolves after that completes (success or failure); fall back to a
+// short timeout if the promise isn't available (older auth.js).
+//
+// NOTE: permissionsReady is one-shot — it fires exactly once per page
+// load (see auth.js).  Subsequent re-logins are caught by the
+// onLoginSuccess hook above which calls loadSavedCoordinators() again.
+if (
+  window.permissionsReady &&
+  typeof window.permissionsReady.then === "function"
+) {
+  window.permissionsReady.then(function () {
+    _refreshHomeComposerVisibility();
+    loadSavedCoordinators();
+  });
+} else {
+  setTimeout(function () {
+    _refreshHomeComposerVisibility();
+    loadSavedCoordinators();
+  }, 500);
+}
 
 // --- Node Metadata Panel (read-only in node detail view) ---
 function _loadNodeMetadataPanel(nodeId) {

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1,1692 +1,4042 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>turnstone console</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/shared/base.css">
-<link rel="stylesheet" href="/shared/ui-base.css">
-<link rel="stylesheet" href="/shared/chat.css">
-<link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-<div id="header">
-  <h1><a href="#" id="header-home-link" onclick="showHome(); return false"
-         aria-label="Home (coordinator landing)">turnstone <span class="header-dim">console</span></a></h1>
-  <span id="cluster-summary" aria-live="polite"></span>
-  <span id="status-bar" role="status" aria-live="polite"></span>
-  <button id="new-ws-btn" class="header-btn header-btn-accent" onclick="showNewWsModal()" title="Create workstream">+ new</button>
-  <button id="admin-btn" class="header-btn" onclick="showAdmin()" title="User &amp; token administration" aria-expanded="false" aria-controls="view-admin">admin</button>
-  <button id="logout-btn" class="header-btn" onclick="logout()" style="display:none">logout</button>
-  <button id="theme-toggle" class="header-btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme">&#9790;</button>
-</div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>turnstone console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/shared/base.css" />
+    <link rel="stylesheet" href="/shared/ui-base.css" />
+    <link rel="stylesheet" href="/shared/chat.css" />
+    <link rel="stylesheet" href="/shared/cards.css" />
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <div id="header">
+      <h1>
+        <a
+          href="#"
+          id="header-home-link"
+          onclick="
+            showHome();
+            return false;
+          "
+          aria-label="Home (coordinator landing)"
+          >turnstone <span class="header-dim">console</span></a
+        >
+      </h1>
+      <span id="cluster-summary" aria-live="polite"></span>
+      <span id="status-bar" role="status" aria-live="polite"></span>
+      <button
+        id="new-ws-btn"
+        class="header-btn header-btn-accent"
+        onclick="showNewWsModal()"
+        title="Create workstream"
+      >
+        + new
+      </button>
+      <button
+        id="admin-btn"
+        class="header-btn"
+        onclick="showAdmin()"
+        title="User &amp; token administration"
+        aria-expanded="false"
+        aria-controls="view-admin"
+      >
+        admin
+      </button>
+      <button
+        id="logout-btn"
+        class="header-btn"
+        onclick="logout()"
+        style="display: none"
+      >
+        logout
+      </button>
+      <button
+        id="theme-toggle"
+        class="header-btn"
+        onclick="toggleTheme()"
+        aria-label="Toggle light/dark theme"
+      >
+        &#9790;
+      </button>
+    </div>
 
-<nav id="breadcrumb" class="breadcrumb" style="display:none" aria-label="Breadcrumb">
-  <a href="#" id="breadcrumb-home" onclick="showOverview(); return false">Cluster</a>
-  <span class="breadcrumb-sep" aria-hidden="true">/</span>
-  <span id="breadcrumb-label" aria-current="page"></span>
-</nav>
+    <nav
+      id="breadcrumb"
+      class="breadcrumb"
+      style="display: none"
+      aria-label="Breadcrumb"
+    >
+      <a
+        href="#"
+        id="breadcrumb-home"
+        onclick="
+          showOverview();
+          return false;
+        "
+        >Cluster</a
+      >
+      <span class="breadcrumb-sep" aria-hidden="true">/</span>
+      <span id="breadcrumb-label" aria-current="page"></span>
+    </nav>
 
-<div id="main">
-  <!-- HOME — coordinator-first landing.  The console's primary
+    <div id="main">
+      <!-- HOME — coordinator-first landing.  The console's primary
        workflow on page load is "start / continue a coordinator task";
        the cluster node list is demoted to an expandable one-line
        summary below.  #view-overview / #view-node / #view-filtered
        remain for deep-link compatibility. -->
-  <div id="view-home">
-    <!-- Persistent "start a new coordinator task" composer.  Visibility is
+      <div id="view-home">
+        <!-- Persistent "start a new coordinator task" composer.  Visibility is
          gated on the admin.coordinator permission (same rule the existing
          +coordinator header button + modal use).  Shows a remediation
          banner when the create endpoint would return 503 (no coordinator
          model alias resolves). -->
-    <section id="coord-composer-panel"
-             class="home-panel"
-             style="display:none"
-             aria-label="Start a new orchestration task">
-      <div id="coord-composer-503"
-           class="home-composer-banner"
-           role="status"
-           style="display:none">
-        Coordinator subsystem not configured —
-        <a href="#" onclick="showAdmin(); switchAdminTab('models'); return false">open Admin → Models</a>
-        to set <code>coordinator.model_alias</code> or a registry default.
-      </div>
-      <!-- Composer DOM is built by shared_static/composer.js into this
+        <section
+          id="coord-composer-panel"
+          class="home-panel"
+          style="display: none"
+          aria-label="Start a new orchestration task"
+        >
+          <div
+            id="coord-composer-503"
+            class="home-composer-banner"
+            role="status"
+            style="display: none"
+          >
+            Coordinator subsystem not configured —
+            <a
+              href="#"
+              onclick="
+                showAdmin();
+                switchAdminTab('models');
+                return false;
+              "
+              >open Admin → Models</a
+            >
+            to set <code>coordinator.model_alias</code> or a registry default.
+          </div>
+          <!-- Composer DOM is built by shared_static/composer.js into this
            mount — stacked layout (textarea above, options toggle +
            Start button below) with Name + Skill in an Options
            dropdown to match the webui dashboard composer's shape. -->
-      <div id="home-coord-composer-mount"></div>
-      <div id="home-coord-error"
-           class="home-composer-error"
-           role="alert"
-           aria-live="assertive"
-           style="display:none"></div>
-    </section>
+          <div id="home-coord-composer-mount"></div>
+          <div
+            id="home-coord-error"
+            class="home-composer-error"
+            role="alert"
+            aria-live="assertive"
+            style="display: none"
+          ></div>
+        </section>
 
-    <!-- Active coordinators list — SSE-driven.  Rows render via the shared
+        <!-- Active coordinators list — SSE-driven.  Rows render via the shared
          _renderWsRow helper so state glyph + name + child-count badge +
          last-activity match the existing dashboard tree. -->
-    <section id="active-coordinators" class="home-section" aria-label="Active coordinators">
-      <h2 class="home-section-title">
-        <span>Active coordinators</span>
-        <span id="active-coord-count" class="home-section-count"></span>
-      </h2>
-      <div id="active-coord-list"
-           class="dash-table home-coord-list"
-           role="list"
-           aria-live="polite">
-        <div class="dashboard-empty">Loading…</div>
-      </div>
-    </section>
+        <section
+          id="active-coordinators"
+          class="home-section"
+          aria-label="Coordinators"
+        >
+          <h2 class="home-section-title">
+            <span>Coordinators</span>
+            <span id="active-coord-count" class="home-section-count"></span>
+          </h2>
+          <div
+            id="active-coord-list"
+            class="dash-table home-coord-list"
+            role="list"
+            aria-live="polite"
+          >
+            <div class="dashboard-empty">Loading…</div>
+          </div>
+        </section>
 
-    <!-- Cluster summary — one-line aggregate that toggles the node
+        <!-- Saved coordinators — closed sessions that persist on disk.
+         Mirrors the interactive UI's "Saved Workstreams" card grid
+         (same /shared/cards.css primitives, same response item shape
+         from /v1/api/coordinator/saved).  Click a card →
+         /coordinator/{ws_id} → coordinator_detail lazy-rehydrates from
+         storage.  Hidden until at least one saved coordinator loads. -->
+        <section
+          id="saved-coordinators"
+          class="home-section"
+          style="display: none"
+          aria-label="Saved coordinators"
+        >
+          <h2 class="home-section-title">
+            <span>Saved Coordinators</span>
+            <span id="saved-coord-count" class="home-section-count"></span>
+          </h2>
+          <div
+            id="saved-coord-cards"
+            class="dashboard-cards"
+            role="list"
+            aria-live="polite"
+          ></div>
+        </section>
+
+        <!-- Cluster summary — one-line aggregate that toggles the node
          list inline below.  Lives inside #view-home so operators
          never "leave" the landing page to see cluster state;
          showOverview() is preserved as an alias that opens the
          details section so ?view=overview deep-links still work. -->
-    <section id="cluster-summary-compact" class="home-section" aria-label="Cluster summary">
-      <button type="button"
-              id="cluster-summary-expand"
-              class="home-cluster-summary"
-              aria-expanded="false"
-              aria-controls="view-overview"
-              onclick="toggleClusterDetails()"
-              title="Show / hide cluster nodes">
-        <span id="cluster-summary-line" class="home-cluster-summary-line">Loading cluster…</span>
-        <span class="home-cluster-summary-caret" aria-hidden="true">&#9656;</span>
-      </button>
-    </section>
+        <section
+          id="cluster-summary-compact"
+          class="home-section"
+          aria-label="Cluster summary"
+        >
+          <button
+            type="button"
+            id="cluster-summary-expand"
+            class="home-cluster-summary"
+            aria-expanded="false"
+            aria-controls="view-overview"
+            onclick="toggleClusterDetails()"
+            title="Show / hide cluster nodes"
+          >
+            <span id="cluster-summary-line" class="home-cluster-summary-line"
+              >Loading cluster…</span
+            >
+            <span class="home-cluster-summary-caret" aria-hidden="true"
+              >&#9656;</span
+            >
+          </button>
+        </section>
 
-    <!-- Cluster details — node list, inline below the summary.
+        <!-- Cluster details — node list, inline below the summary.
          Hidden by default; toggleClusterDetails() flips it and
          showOverview() forces it open so popstate + breadcrumb
          callers land on the expanded state. -->
-    <div id="view-overview" hidden>
-      <div class="section-header">NODES</div>
-      <div id="node-table" role="list" aria-label="Nodes" aria-live="polite">
-        <div class="dashboard-empty">Loading cluster data...</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- NODE DRILL-DOWN -->
-  <div id="view-node" style="display:none">
-    <div class="dash-header">
-      <span class="dash-header-title">WORKSTREAMS</span>
-      <span class="dash-header-summary" id="node-ws-summary"></span>
-      <span id="node-mcp-summary" aria-label="MCP status"></span>
-    </div>
-    <div class="dash-colheaders" aria-hidden="true">
-      <span class="dash-col dash-col-state">STATE</span>
-      <span class="dash-col dash-col-name">NAME</span>
-      <span class="dash-col dash-col-model">MODEL</span>
-      <span class="dash-col dash-col-node">NODE</span>
-      <span class="dash-col dash-col-task">TASK</span>
-      <span class="dash-col dash-col-tokens">TOKENS</span>
-      <span class="dash-col dash-col-ctx">CTX</span>
-    </div>
-    <div id="node-ws-table" class="dash-table" role="group" aria-label="Workstreams" aria-live="polite"></div>
-    <div id="node-metadata-section" style="margin-top:16px;display:none">
-      <div class="dash-header">
-        <span class="dash-header-title">METADATA</span>
-      </div>
-      <div id="node-metadata-table" style="font-size:.85rem"></div>
-    </div>
-    <a id="node-link" class="node-link">Open node UI</a>
-  </div>
-
-  <!-- FILTERED WORKSTREAMS -->
-  <div id="view-filtered" style="display:none">
-    <div class="dash-header">
-      <span class="dash-header-title" id="filtered-title">WORKSTREAMS</span>
-      <span class="dash-header-summary" id="filtered-summary"></span>
-    </div>
-    <div class="dash-colheaders" aria-hidden="true">
-      <span class="dash-col dash-col-state">STATE</span>
-      <span class="dash-col dash-col-name">NAME</span>
-      <span class="dash-col dash-col-model">MODEL</span>
-      <span class="dash-col dash-col-node">NODE</span>
-      <span class="dash-col dash-col-task">TASK</span>
-      <span class="dash-col dash-col-tokens">TOKENS</span>
-      <span class="dash-col dash-col-ctx">CTX</span>
-    </div>
-    <div id="filtered-ws-table" class="dash-table" role="group" aria-label="Workstreams" aria-live="polite"></div>
-    <div id="filtered-pagination" class="pagination"></div>
-  </div>
-
-  <!-- ADMIN PANEL -->
-  <div id="view-admin" style="display:none">
-    <div id="admin-layout" class="admin-layout">
-      <!-- Sidebar navigation -->
-      <nav id="admin-sidebar" class="admin-sidebar" role="tablist" aria-label="Admin navigation" aria-orientation="vertical">
-        <div class="admin-sidebar-group" data-group="identity" role="group" aria-label="Identity">
-          <div class="admin-sidebar-group-label" aria-hidden="true">Identity</div>
-          <button id="tab-users" class="admin-nav active" data-tab="users" role="tab" aria-selected="true" aria-controls="admin-users" tabindex="0" onclick="switchAdminTab('users')">Users</button>
-          <button id="tab-tokens" class="admin-nav" data-tab="tokens" role="tab" aria-selected="false" aria-controls="admin-tokens" tabindex="-1" onclick="switchAdminTab('tokens')">API Tokens</button>
-          <button id="tab-channels" class="admin-nav" data-tab="channels" role="tab" aria-selected="false" aria-controls="admin-channels" tabindex="-1" onclick="switchAdminTab('channels')">Channels</button>
-        </div>
-        <div class="admin-sidebar-group" data-group="automation" role="group" aria-label="Automation">
-          <div class="admin-sidebar-group-label" aria-hidden="true">Automation</div>
-          <button id="tab-schedules" class="admin-nav" data-tab="schedules" role="tab" aria-selected="false" aria-controls="admin-schedules" tabindex="-1" onclick="switchAdminTab('schedules')">Schedules</button>
-          <button id="tab-watches" class="admin-nav" data-tab="watches" role="tab" aria-selected="false" aria-controls="admin-watches" tabindex="-1" onclick="switchAdminTab('watches')">Watches</button>
-        </div>
-        <div class="admin-sidebar-group" data-group="governance" role="group" aria-label="Governance">
-          <div class="admin-sidebar-group-label" aria-hidden="true">Governance</div>
-          <button id="tab-roles" class="admin-nav" data-tab="roles" role="tab" aria-selected="false" aria-controls="admin-roles" tabindex="-1" onclick="switchAdminTab('roles')">Roles</button>
-          <button id="tab-policies" class="admin-nav" data-tab="policies" role="tab" aria-selected="false" aria-controls="admin-policies" tabindex="-1" onclick="switchAdminTab('policies')">Policies</button>
-          <button id="tab-prompt-policies" class="admin-nav" data-tab="prompt-policies" role="tab" aria-selected="false" aria-controls="admin-prompt-policies" tabindex="-1" onclick="switchAdminTab('prompt-policies')">Prompts</button>
-          <button id="tab-judge" class="admin-nav" data-tab="judge" role="tab" aria-selected="false" aria-controls="admin-judge" tabindex="-1" onclick="switchAdminTab('judge')">Judge</button>
-        </div>
-        <div class="admin-sidebar-group" data-group="extensions" role="group" aria-label="Extensions">
-          <div class="admin-sidebar-group-label" aria-hidden="true">Extensions</div>
-          <button id="tab-skills" class="admin-nav" data-tab="skills" role="tab" aria-selected="false" aria-controls="admin-skills" tabindex="-1" onclick="switchAdminTab('skills')">Skills</button>
-          <button id="tab-mcp" class="admin-nav" data-tab="mcp" role="tab" aria-selected="false" aria-controls="admin-mcp" tabindex="-1" onclick="switchAdminTab('mcp')">MCP Servers</button>
-        </div>
-        <div class="admin-sidebar-group" data-group="observe" role="group" aria-label="Observe">
-          <div class="admin-sidebar-group-label" aria-hidden="true">Observe</div>
-          <button id="tab-usage" class="admin-nav" data-tab="usage" role="tab" aria-selected="false" aria-controls="admin-usage" tabindex="-1" onclick="switchAdminTab('usage')">Usage</button>
-          <button id="tab-audit" class="admin-nav" data-tab="audit" role="tab" aria-selected="false" aria-controls="admin-audit" tabindex="-1" onclick="switchAdminTab('audit')">Audit</button>
-          <button id="tab-memories" class="admin-nav" data-tab="memories" role="tab" aria-selected="false" aria-controls="admin-memories" tabindex="-1" onclick="switchAdminTab('memories')">Memories</button>
-        </div>
-        <div class="admin-sidebar-group" data-group="system" role="group" aria-label="System">
-          <div class="admin-sidebar-group-label" aria-hidden="true">System</div>
-          <button id="tab-models" class="admin-nav" data-tab="models" role="tab" aria-selected="false" aria-controls="admin-models" tabindex="-1" onclick="switchAdminTab('models')">Models</button>
-          <button id="tab-node-metadata" class="admin-nav" data-tab="node-metadata" role="tab" aria-selected="false" aria-controls="admin-node-metadata" tabindex="-1" onclick="switchAdminTab('node-metadata')">Nodes</button>
-          <button id="tab-settings" class="admin-nav" data-tab="settings" role="tab" aria-selected="false" aria-controls="admin-settings" tabindex="-1" onclick="switchAdminTab('settings')">Settings</button>
-          <button id="tab-tls" class="admin-nav" data-tab="tls" role="tab" aria-selected="false" aria-controls="admin-tls" tabindex="-1" onclick="switchAdminTab('tls')">TLS</button>
-        </div>
-      </nav>
-      <div id="admin-sidebar-backdrop" class="admin-sidebar-backdrop" aria-hidden="true"></div>
-
-      <!-- Content area -->
-      <div id="admin-content" class="admin-content">
-
-    <!-- Users Tab -->
-    <div id="admin-users" class="admin-panel" role="tabpanel" aria-labelledby="tab-users">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">USERS</span>
-        <button class="admin-action-btn" onclick="showCreateUserModal()">+ Create user</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-username">USERNAME</span>
-        <span class="admin-col admin-col-name">DISPLAY NAME</span>
-        <span class="admin-col admin-col-created">CREATED</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-users-table" role="list" aria-label="Users" aria-live="polite">
-        <div class="dashboard-empty">Loading users...</div>
-      </div>
-    </div>
-
-    <!-- Tokens Tab -->
-    <div id="admin-tokens" class="admin-panel" role="tabpanel" aria-labelledby="tab-tokens" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">API TOKENS</span>
-        <label for="admin-token-user" class="sr-only">Filter tokens by user</label>
-        <select id="admin-token-user" onchange="loadAdminTokens()">
-          <option value="">Select user...</option>
-        </select>
-        <button class="admin-action-btn" onclick="showCreateTokenModal()">+ Create token</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-prefix">PREFIX</span>
-        <span class="admin-col admin-col-tname">NAME</span>
-        <span class="admin-col admin-col-scopes">SCOPES</span>
-        <span class="admin-col admin-col-created">CREATED</span>
-        <span class="admin-col admin-col-expires">EXPIRES</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-tokens-table" role="list" aria-label="Tokens" aria-live="polite">
-        <div class="dashboard-empty">Select a user to view tokens</div>
-      </div>
-    </div>
-
-    <!-- Channels Tab -->
-    <div id="admin-channels" class="admin-panel" role="tabpanel" aria-labelledby="tab-channels" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">CHANNEL LINKS</span>
-        <label for="admin-channel-user" class="sr-only">Filter channels by user</label>
-        <select id="admin-channel-user" onchange="loadAdminChannels()">
-          <option value="">Select user...</option>
-        </select>
-        <button class="admin-action-btn" onclick="showCreateChannelModal()">+ Link channel</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-chtype">CHANNEL</span>
-        <span class="admin-col admin-col-chuid">EXTERNAL ID</span>
-        <span class="admin-col admin-col-created">LINKED</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-channels-table" role="list" aria-label="Channel links" aria-live="polite">
-        <div class="dashboard-empty">Select a user to view channel links</div>
-      </div>
-    </div>
-
-    <!-- Schedules Tab -->
-    <div id="admin-schedules" class="admin-panel" role="tabpanel" aria-labelledby="tab-schedules" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">SCHEDULED TASKS</span>
-        <button class="admin-action-btn" onclick="showCreateScheduleModal()">+ New schedule</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-sname">NAME</span>
-        <span class="admin-col admin-col-stype">TYPE</span>
-        <span class="admin-col admin-col-sschedule">SCHEDULE</span>
-        <span class="admin-col admin-col-starget">TARGET</span>
-        <span class="admin-col admin-col-snext">NEXT RUN</span>
-        <span class="admin-col admin-col-sstatus">STATUS</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-schedules-table" role="list" aria-label="Scheduled tasks" aria-live="polite">
-        <div class="dashboard-empty">Loading schedules...</div>
-      </div>
-    </div>
-
-    <!-- Watches Tab -->
-    <div id="admin-watches" class="admin-panel" role="tabpanel" aria-labelledby="tab-watches" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">WATCHES</span>
-        <label for="admin-watch-node" class="sr-only">Filter watches by node</label>
-        <select id="admin-watch-node" onchange="loadAdminWatches()">
-          <option value="">All nodes</option>
-        </select>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-wname">NAME</span>
-        <span class="admin-col admin-col-wnode">NODE</span>
-        <span class="admin-col admin-col-wcmd">COMMAND</span>
-        <span class="admin-col admin-col-winterval">INTERVAL</span>
-        <span class="admin-col admin-col-wpoll">POLL</span>
-        <span class="admin-col admin-col-wcond">CONDITION</span>
-        <span class="admin-col admin-col-wstatus">STATUS</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-watches-table" role="list" aria-label="Watches" aria-live="polite">
-        <div class="dashboard-empty">Loading watches...</div>
-      </div>
-    </div>
-
-    <!-- Roles Tab -->
-    <div id="admin-roles" class="admin-panel" role="tabpanel" aria-labelledby="tab-roles" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">ROLES</span>
-        <button class="admin-action-btn" onclick="showCreateRoleModal()">+ Create role</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-rname">NAME</span>
-        <span class="admin-col admin-col-rperms">PERMISSIONS</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-roles-table" role="list" aria-label="Roles" aria-live="polite">
-        <div class="dashboard-empty">Loading roles...</div>
-      </div>
-    </div>
-
-    <!-- Policies Tab -->
-    <div id="admin-policies" class="admin-panel" role="tabpanel" aria-labelledby="tab-policies" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">TOOL POLICIES</span>
-        <button class="admin-action-btn" onclick="showCreatePolicyModal()">+ Create policy</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-pname">NAME</span>
-        <span class="admin-col admin-col-ppattern">PATTERN</span>
-        <span class="admin-col admin-col-paction">ACTION</span>
-        <span class="admin-col admin-col-ppriority">PRI</span>
-        <span class="admin-col admin-col-pstatus">STATUS</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-policies-table" role="list" aria-label="Tool policies" aria-live="polite">
-        <div class="dashboard-empty">Loading policies...</div>
-      </div>
-    </div>
-
-    <!-- Prompt Policies Tab -->
-    <div id="admin-prompt-policies" class="admin-panel" role="tabpanel" aria-labelledby="tab-prompt-policies" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">PROMPTS</span>
-        <button class="admin-action-btn" onclick="showCreatePromptPolicyModal()">+ Create prompt</button>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-pname">NAME</span>
-        <span class="admin-col admin-col-ppattern">TOOL GATE</span>
-        <span class="admin-col admin-col-ppriority">PRI</span>
-        <span class="admin-col admin-col-pstatus">STATUS</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-prompt-policies-table" role="list" aria-label="Prompt policies" aria-live="polite">
-        <div class="dashboard-empty">Loading prompt policies...</div>
-      </div>
-    </div>
-
-    <!-- Judge Tab -->
-    <div id="admin-judge" class="admin-panel" role="tabpanel" aria-labelledby="tab-judge" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">JUDGE</span>
-      </div>
-
-      <!-- Sub-panel switcher -->
-      <div class="judge-section-switcher" role="tablist" aria-label="Judge sections">
-        <button id="judge-tab-settings" class="judge-section-btn active" role="tab" aria-selected="true" aria-controls="judge-settings-section" tabindex="0" data-section="judge-settings" onclick="switchJudgeSection('judge-settings')">Settings</button>
-        <button id="judge-tab-heuristic" class="judge-section-btn" role="tab" aria-selected="false" aria-controls="judge-heuristic-section" tabindex="-1" data-section="judge-heuristic" onclick="switchJudgeSection('judge-heuristic')">Heuristic Rules</button>
-        <button id="judge-tab-output-guard" class="judge-section-btn" role="tab" aria-selected="false" aria-controls="judge-output-guard-section" tabindex="-1" data-section="judge-output-guard" onclick="switchJudgeSection('judge-output-guard')">Output Guard</button>
-      </div>
-
-      <!-- Settings section -->
-      <div id="judge-settings-section" class="judge-section" role="tabpanel" aria-labelledby="judge-tab-settings">
-        <div id="judge-settings-container" style="max-width:600px">
-          <div class="dashboard-empty">Loading settings...</div>
-        </div>
-      </div>
-
-      <!-- Heuristic Rules section -->
-      <div id="judge-heuristic-section" class="judge-section" role="tabpanel" aria-labelledby="judge-tab-heuristic" style="display:none">
-        <div class="admin-toolbar" style="margin-bottom:12px">
-          <span style="font-size:13px;color:var(--fg-dim)">Pattern rules for pre-execution intent validation</span>
-          <button class="admin-action-btn" onclick="showCreateHeuristicRuleModal()">+ Add rule</button>
-        </div>
-        <div class="admin-colheaders" aria-hidden="true">
-          <span class="admin-col">NAME</span>
-          <span class="admin-col admin-col-htier">TIER</span>
-          <span class="admin-col admin-col-hrisk">RISK</span>
-          <span class="admin-col">TOOL</span>
-          <span class="admin-col admin-col-hrec">REC.</span>
-          <span class="admin-col">SOURCE</span>
-          <span class="admin-col">STATUS</span>
-          <span class="admin-col">ACTIONS</span>
-        </div>
-        <div id="judge-heuristic-table-container" role="list" aria-label="Heuristic rules" aria-live="polite">
-          <div class="dashboard-empty">Loading rules...</div>
-        </div>
-      </div>
-
-      <!-- Output Guard Patterns section -->
-      <div id="judge-output-guard-section" class="judge-section" role="tabpanel" aria-labelledby="judge-tab-output-guard" style="display:none">
-        <div class="admin-toolbar" style="margin-bottom:12px">
-          <span style="font-size:13px;color:var(--fg-dim)">Regex patterns for post-execution output scanning</span>
-          <button class="admin-action-btn" onclick="showCreateOutputGuardPatternModal()">+ Add pattern</button>
-        </div>
-        <div class="admin-colheaders" aria-hidden="true">
-          <span class="admin-col">NAME</span>
-          <span class="admin-col">CATEGORY</span>
-          <span class="admin-col admin-col-ogrisk">RISK</span>
-          <span class="admin-col admin-col-ogflag">FLAG</span>
-          <span class="admin-col">SOURCE</span>
-          <span class="admin-col">STATUS</span>
-          <span class="admin-col">ACTIONS</span>
-        </div>
-        <div id="judge-og-table-container" role="list" aria-label="Output guard patterns" aria-live="polite">
-          <div class="dashboard-empty">Loading patterns...</div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Judge: Create Heuristic Rule Modal -->
-    <div id="create-hr-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-hr-title">
-      <div id="create-hr-box" class="admin-modal admin-modal-wide">
-        <h2 id="create-hr-title">Create Heuristic Rule</h2>
-        <div id="create-hr-error" role="alert" aria-live="assertive"></div>
-        <label for="hr-name">Name</label>
-        <input id="hr-name" type="text" placeholder="my-custom-rule" autocomplete="off" spellcheck="false">
-        <div style="display:flex;gap:12px">
-          <div style="flex:1">
-            <label for="hr-tier">Tier</label>
-            <select id="hr-tier"><option>critical</option><option>high</option><option selected>medium</option><option>low</option></select>
-          </div>
-          <div style="flex:1">
-            <label for="hr-risk">Risk Level</label>
-            <select id="hr-risk"><option>critical</option><option>high</option><option selected>medium</option><option>low</option></select>
-          </div>
-          <div style="flex:1">
-            <label for="hr-rec">Recommendation</label>
-            <select id="hr-rec"><option>approve</option><option selected>review</option><option>deny</option></select>
+        <div id="view-overview" hidden>
+          <div class="section-header">NODES</div>
+          <div
+            id="node-table"
+            role="list"
+            aria-label="Nodes"
+            aria-live="polite"
+          >
+            <div class="dashboard-empty">Loading cluster data...</div>
           </div>
         </div>
-        <label for="hr-tool">Tool Pattern <span class="label-hint">fnmatch syntax: bash, write_file, mcp__*</span></label>
-        <input id="hr-tool" type="text" value="bash" autocomplete="off" spellcheck="false">
-        <label for="hr-args">Arg Patterns <span class="label-hint">one regex per line</span></label>
-        <textarea id="hr-args" rows="3" style="font-family:var(--font-mono);font-size:12px"></textarea>
-        <label for="hr-conf">Confidence <span class="label-hint">0.0 – 1.0</span></label>
-        <input id="hr-conf" type="number" step="0.05" value="0.8" min="0" max="1" style="width:100px">
-        <label for="hr-intent">Intent Description</label>
-        <input id="hr-intent" type="text" placeholder="Detected dangerous operation: {arg_snippet}" autocomplete="off">
-        <label for="hr-reason">Reasoning</label>
-        <input id="hr-reason" type="text" placeholder="Explain why this is risky" autocomplete="off">
+      </div>
+
+      <!-- NODE DRILL-DOWN -->
+      <div id="view-node" style="display: none">
+        <div class="dash-header">
+          <span class="dash-header-title">WORKSTREAMS</span>
+          <span class="dash-header-summary" id="node-ws-summary"></span>
+          <span id="node-mcp-summary" aria-label="MCP status"></span>
+        </div>
+        <div class="dash-colheaders" aria-hidden="true">
+          <span class="dash-col dash-col-state">STATE</span>
+          <span class="dash-col dash-col-name">NAME</span>
+          <span class="dash-col dash-col-model">MODEL</span>
+          <span class="dash-col dash-col-node">NODE</span>
+          <span class="dash-col dash-col-task">TASK</span>
+          <span class="dash-col dash-col-tokens">TOKENS</span>
+          <span class="dash-col dash-col-ctx">CTX</span>
+        </div>
+        <div
+          id="node-ws-table"
+          class="dash-table"
+          role="group"
+          aria-label="Workstreams"
+          aria-live="polite"
+        ></div>
+        <div id="node-metadata-section" style="margin-top: 16px; display: none">
+          <div class="dash-header">
+            <span class="dash-header-title">METADATA</span>
+          </div>
+          <div id="node-metadata-table" style="font-size: 0.85rem"></div>
+        </div>
+        <a id="node-link" class="node-link">Open node UI</a>
+      </div>
+
+      <!-- FILTERED WORKSTREAMS -->
+      <div id="view-filtered" style="display: none">
+        <div class="dash-header">
+          <span class="dash-header-title" id="filtered-title">WORKSTREAMS</span>
+          <span class="dash-header-summary" id="filtered-summary"></span>
+        </div>
+        <div class="dash-colheaders" aria-hidden="true">
+          <span class="dash-col dash-col-state">STATE</span>
+          <span class="dash-col dash-col-name">NAME</span>
+          <span class="dash-col dash-col-model">MODEL</span>
+          <span class="dash-col dash-col-node">NODE</span>
+          <span class="dash-col dash-col-task">TASK</span>
+          <span class="dash-col dash-col-tokens">TOKENS</span>
+          <span class="dash-col dash-col-ctx">CTX</span>
+        </div>
+        <div
+          id="filtered-ws-table"
+          class="dash-table"
+          role="group"
+          aria-label="Workstreams"
+          aria-live="polite"
+        ></div>
+        <div id="filtered-pagination" class="pagination"></div>
+      </div>
+
+      <!-- ADMIN PANEL -->
+      <div id="view-admin" style="display: none">
+        <div id="admin-layout" class="admin-layout">
+          <!-- Sidebar navigation -->
+          <nav
+            id="admin-sidebar"
+            class="admin-sidebar"
+            role="tablist"
+            aria-label="Admin navigation"
+            aria-orientation="vertical"
+          >
+            <div
+              class="admin-sidebar-group"
+              data-group="identity"
+              role="group"
+              aria-label="Identity"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                Identity
+              </div>
+              <button
+                id="tab-users"
+                class="admin-nav active"
+                data-tab="users"
+                role="tab"
+                aria-selected="true"
+                aria-controls="admin-users"
+                tabindex="0"
+                onclick="switchAdminTab('users')"
+              >
+                Users
+              </button>
+              <button
+                id="tab-tokens"
+                class="admin-nav"
+                data-tab="tokens"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-tokens"
+                tabindex="-1"
+                onclick="switchAdminTab('tokens')"
+              >
+                API Tokens
+              </button>
+              <button
+                id="tab-channels"
+                class="admin-nav"
+                data-tab="channels"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-channels"
+                tabindex="-1"
+                onclick="switchAdminTab('channels')"
+              >
+                Channels
+              </button>
+            </div>
+            <div
+              class="admin-sidebar-group"
+              data-group="automation"
+              role="group"
+              aria-label="Automation"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                Automation
+              </div>
+              <button
+                id="tab-schedules"
+                class="admin-nav"
+                data-tab="schedules"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-schedules"
+                tabindex="-1"
+                onclick="switchAdminTab('schedules')"
+              >
+                Schedules
+              </button>
+              <button
+                id="tab-watches"
+                class="admin-nav"
+                data-tab="watches"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-watches"
+                tabindex="-1"
+                onclick="switchAdminTab('watches')"
+              >
+                Watches
+              </button>
+            </div>
+            <div
+              class="admin-sidebar-group"
+              data-group="governance"
+              role="group"
+              aria-label="Governance"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                Governance
+              </div>
+              <button
+                id="tab-roles"
+                class="admin-nav"
+                data-tab="roles"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-roles"
+                tabindex="-1"
+                onclick="switchAdminTab('roles')"
+              >
+                Roles
+              </button>
+              <button
+                id="tab-policies"
+                class="admin-nav"
+                data-tab="policies"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-policies"
+                tabindex="-1"
+                onclick="switchAdminTab('policies')"
+              >
+                Policies
+              </button>
+              <button
+                id="tab-prompt-policies"
+                class="admin-nav"
+                data-tab="prompt-policies"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-prompt-policies"
+                tabindex="-1"
+                onclick="switchAdminTab('prompt-policies')"
+              >
+                Prompts
+              </button>
+              <button
+                id="tab-judge"
+                class="admin-nav"
+                data-tab="judge"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-judge"
+                tabindex="-1"
+                onclick="switchAdminTab('judge')"
+              >
+                Judge
+              </button>
+            </div>
+            <div
+              class="admin-sidebar-group"
+              data-group="extensions"
+              role="group"
+              aria-label="Extensions"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                Extensions
+              </div>
+              <button
+                id="tab-skills"
+                class="admin-nav"
+                data-tab="skills"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-skills"
+                tabindex="-1"
+                onclick="switchAdminTab('skills')"
+              >
+                Skills
+              </button>
+              <button
+                id="tab-mcp"
+                class="admin-nav"
+                data-tab="mcp"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-mcp"
+                tabindex="-1"
+                onclick="switchAdminTab('mcp')"
+              >
+                MCP Servers
+              </button>
+            </div>
+            <div
+              class="admin-sidebar-group"
+              data-group="observe"
+              role="group"
+              aria-label="Observe"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                Observe
+              </div>
+              <button
+                id="tab-usage"
+                class="admin-nav"
+                data-tab="usage"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-usage"
+                tabindex="-1"
+                onclick="switchAdminTab('usage')"
+              >
+                Usage
+              </button>
+              <button
+                id="tab-audit"
+                class="admin-nav"
+                data-tab="audit"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-audit"
+                tabindex="-1"
+                onclick="switchAdminTab('audit')"
+              >
+                Audit
+              </button>
+              <button
+                id="tab-memories"
+                class="admin-nav"
+                data-tab="memories"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-memories"
+                tabindex="-1"
+                onclick="switchAdminTab('memories')"
+              >
+                Memories
+              </button>
+            </div>
+            <div
+              class="admin-sidebar-group"
+              data-group="system"
+              role="group"
+              aria-label="System"
+            >
+              <div class="admin-sidebar-group-label" aria-hidden="true">
+                System
+              </div>
+              <button
+                id="tab-models"
+                class="admin-nav"
+                data-tab="models"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-models"
+                tabindex="-1"
+                onclick="switchAdminTab('models')"
+              >
+                Models
+              </button>
+              <button
+                id="tab-node-metadata"
+                class="admin-nav"
+                data-tab="node-metadata"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-node-metadata"
+                tabindex="-1"
+                onclick="switchAdminTab('node-metadata')"
+              >
+                Nodes
+              </button>
+              <button
+                id="tab-settings"
+                class="admin-nav"
+                data-tab="settings"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-settings"
+                tabindex="-1"
+                onclick="switchAdminTab('settings')"
+              >
+                Settings
+              </button>
+              <button
+                id="tab-tls"
+                class="admin-nav"
+                data-tab="tls"
+                role="tab"
+                aria-selected="false"
+                aria-controls="admin-tls"
+                tabindex="-1"
+                onclick="switchAdminTab('tls')"
+              >
+                TLS
+              </button>
+            </div>
+          </nav>
+          <div
+            id="admin-sidebar-backdrop"
+            class="admin-sidebar-backdrop"
+            aria-hidden="true"
+          ></div>
+
+          <!-- Content area -->
+          <div id="admin-content" class="admin-content">
+            <!-- Users Tab -->
+            <div
+              id="admin-users"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-users"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">USERS</span>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateUserModal()"
+                >
+                  + Create user
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-username">USERNAME</span>
+                <span class="admin-col admin-col-name">DISPLAY NAME</span>
+                <span class="admin-col admin-col-created">CREATED</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-users-table"
+                role="list"
+                aria-label="Users"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading users...</div>
+              </div>
+            </div>
+
+            <!-- Tokens Tab -->
+            <div
+              id="admin-tokens"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-tokens"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">API TOKENS</span>
+                <label for="admin-token-user" class="sr-only"
+                  >Filter tokens by user</label
+                >
+                <select id="admin-token-user" onchange="loadAdminTokens()">
+                  <option value="">Select user...</option>
+                </select>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateTokenModal()"
+                >
+                  + Create token
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-prefix">PREFIX</span>
+                <span class="admin-col admin-col-tname">NAME</span>
+                <span class="admin-col admin-col-scopes">SCOPES</span>
+                <span class="admin-col admin-col-created">CREATED</span>
+                <span class="admin-col admin-col-expires">EXPIRES</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-tokens-table"
+                role="list"
+                aria-label="Tokens"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Select a user to view tokens</div>
+              </div>
+            </div>
+
+            <!-- Channels Tab -->
+            <div
+              id="admin-channels"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-channels"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0"
+                  >CHANNEL LINKS</span
+                >
+                <label for="admin-channel-user" class="sr-only"
+                  >Filter channels by user</label
+                >
+                <select id="admin-channel-user" onchange="loadAdminChannels()">
+                  <option value="">Select user...</option>
+                </select>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateChannelModal()"
+                >
+                  + Link channel
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-chtype">CHANNEL</span>
+                <span class="admin-col admin-col-chuid">EXTERNAL ID</span>
+                <span class="admin-col admin-col-created">LINKED</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-channels-table"
+                role="list"
+                aria-label="Channel links"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">
+                  Select a user to view channel links
+                </div>
+              </div>
+            </div>
+
+            <!-- Schedules Tab -->
+            <div
+              id="admin-schedules"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-schedules"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0"
+                  >SCHEDULED TASKS</span
+                >
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateScheduleModal()"
+                >
+                  + New schedule
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-sname">NAME</span>
+                <span class="admin-col admin-col-stype">TYPE</span>
+                <span class="admin-col admin-col-sschedule">SCHEDULE</span>
+                <span class="admin-col admin-col-starget">TARGET</span>
+                <span class="admin-col admin-col-snext">NEXT RUN</span>
+                <span class="admin-col admin-col-sstatus">STATUS</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-schedules-table"
+                role="list"
+                aria-label="Scheduled tasks"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading schedules...</div>
+              </div>
+            </div>
+
+            <!-- Watches Tab -->
+            <div
+              id="admin-watches"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-watches"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">WATCHES</span>
+                <label for="admin-watch-node" class="sr-only"
+                  >Filter watches by node</label
+                >
+                <select id="admin-watch-node" onchange="loadAdminWatches()">
+                  <option value="">All nodes</option>
+                </select>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-wname">NAME</span>
+                <span class="admin-col admin-col-wnode">NODE</span>
+                <span class="admin-col admin-col-wcmd">COMMAND</span>
+                <span class="admin-col admin-col-winterval">INTERVAL</span>
+                <span class="admin-col admin-col-wpoll">POLL</span>
+                <span class="admin-col admin-col-wcond">CONDITION</span>
+                <span class="admin-col admin-col-wstatus">STATUS</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-watches-table"
+                role="list"
+                aria-label="Watches"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading watches...</div>
+              </div>
+            </div>
+
+            <!-- Roles Tab -->
+            <div
+              id="admin-roles"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-roles"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">ROLES</span>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateRoleModal()"
+                >
+                  + Create role
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-rname">NAME</span>
+                <span class="admin-col admin-col-rperms">PERMISSIONS</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-roles-table"
+                role="list"
+                aria-label="Roles"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading roles...</div>
+              </div>
+            </div>
+
+            <!-- Policies Tab -->
+            <div
+              id="admin-policies"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-policies"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0"
+                  >TOOL POLICIES</span
+                >
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreatePolicyModal()"
+                >
+                  + Create policy
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-pname">NAME</span>
+                <span class="admin-col admin-col-ppattern">PATTERN</span>
+                <span class="admin-col admin-col-paction">ACTION</span>
+                <span class="admin-col admin-col-ppriority">PRI</span>
+                <span class="admin-col admin-col-pstatus">STATUS</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-policies-table"
+                role="list"
+                aria-label="Tool policies"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading policies...</div>
+              </div>
+            </div>
+
+            <!-- Prompt Policies Tab -->
+            <div
+              id="admin-prompt-policies"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-prompt-policies"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">PROMPTS</span>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreatePromptPolicyModal()"
+                >
+                  + Create prompt
+                </button>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-pname">NAME</span>
+                <span class="admin-col admin-col-ppattern">TOOL GATE</span>
+                <span class="admin-col admin-col-ppriority">PRI</span>
+                <span class="admin-col admin-col-pstatus">STATUS</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-prompt-policies-table"
+                role="list"
+                aria-label="Prompt policies"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading prompt policies...</div>
+              </div>
+            </div>
+
+            <!-- Judge Tab -->
+            <div
+              id="admin-judge"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-judge"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">JUDGE</span>
+              </div>
+
+              <!-- Sub-panel switcher -->
+              <div
+                class="judge-section-switcher"
+                role="tablist"
+                aria-label="Judge sections"
+              >
+                <button
+                  id="judge-tab-settings"
+                  class="judge-section-btn active"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="judge-settings-section"
+                  tabindex="0"
+                  data-section="judge-settings"
+                  onclick="switchJudgeSection('judge-settings')"
+                >
+                  Settings
+                </button>
+                <button
+                  id="judge-tab-heuristic"
+                  class="judge-section-btn"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="judge-heuristic-section"
+                  tabindex="-1"
+                  data-section="judge-heuristic"
+                  onclick="switchJudgeSection('judge-heuristic')"
+                >
+                  Heuristic Rules
+                </button>
+                <button
+                  id="judge-tab-output-guard"
+                  class="judge-section-btn"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="judge-output-guard-section"
+                  tabindex="-1"
+                  data-section="judge-output-guard"
+                  onclick="switchJudgeSection('judge-output-guard')"
+                >
+                  Output Guard
+                </button>
+              </div>
+
+              <!-- Settings section -->
+              <div
+                id="judge-settings-section"
+                class="judge-section"
+                role="tabpanel"
+                aria-labelledby="judge-tab-settings"
+              >
+                <div id="judge-settings-container" style="max-width: 600px">
+                  <div class="dashboard-empty">Loading settings...</div>
+                </div>
+              </div>
+
+              <!-- Heuristic Rules section -->
+              <div
+                id="judge-heuristic-section"
+                class="judge-section"
+                role="tabpanel"
+                aria-labelledby="judge-tab-heuristic"
+                style="display: none"
+              >
+                <div class="admin-toolbar" style="margin-bottom: 12px">
+                  <span style="font-size: 13px; color: var(--fg-dim)"
+                    >Pattern rules for pre-execution intent validation</span
+                  >
+                  <button
+                    class="admin-action-btn"
+                    onclick="showCreateHeuristicRuleModal()"
+                  >
+                    + Add rule
+                  </button>
+                </div>
+                <div class="admin-colheaders" aria-hidden="true">
+                  <span class="admin-col">NAME</span>
+                  <span class="admin-col admin-col-htier">TIER</span>
+                  <span class="admin-col admin-col-hrisk">RISK</span>
+                  <span class="admin-col">TOOL</span>
+                  <span class="admin-col admin-col-hrec">REC.</span>
+                  <span class="admin-col">SOURCE</span>
+                  <span class="admin-col">STATUS</span>
+                  <span class="admin-col">ACTIONS</span>
+                </div>
+                <div
+                  id="judge-heuristic-table-container"
+                  role="list"
+                  aria-label="Heuristic rules"
+                  aria-live="polite"
+                >
+                  <div class="dashboard-empty">Loading rules...</div>
+                </div>
+              </div>
+
+              <!-- Output Guard Patterns section -->
+              <div
+                id="judge-output-guard-section"
+                class="judge-section"
+                role="tabpanel"
+                aria-labelledby="judge-tab-output-guard"
+                style="display: none"
+              >
+                <div class="admin-toolbar" style="margin-bottom: 12px">
+                  <span style="font-size: 13px; color: var(--fg-dim)"
+                    >Regex patterns for post-execution output scanning</span
+                  >
+                  <button
+                    class="admin-action-btn"
+                    onclick="showCreateOutputGuardPatternModal()"
+                  >
+                    + Add pattern
+                  </button>
+                </div>
+                <div class="admin-colheaders" aria-hidden="true">
+                  <span class="admin-col">NAME</span>
+                  <span class="admin-col">CATEGORY</span>
+                  <span class="admin-col admin-col-ogrisk">RISK</span>
+                  <span class="admin-col admin-col-ogflag">FLAG</span>
+                  <span class="admin-col">SOURCE</span>
+                  <span class="admin-col">STATUS</span>
+                  <span class="admin-col">ACTIONS</span>
+                </div>
+                <div
+                  id="judge-og-table-container"
+                  role="list"
+                  aria-label="Output guard patterns"
+                  aria-live="polite"
+                >
+                  <div class="dashboard-empty">Loading patterns...</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Judge: Create Heuristic Rule Modal -->
+            <div
+              id="create-hr-overlay"
+              style="display: none"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-hr-title"
+            >
+              <div id="create-hr-box" class="admin-modal admin-modal-wide">
+                <h2 id="create-hr-title">Create Heuristic Rule</h2>
+                <div
+                  id="create-hr-error"
+                  role="alert"
+                  aria-live="assertive"
+                ></div>
+                <label for="hr-name">Name</label>
+                <input
+                  id="hr-name"
+                  type="text"
+                  placeholder="my-custom-rule"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <div style="display: flex; gap: 12px">
+                  <div style="flex: 1">
+                    <label for="hr-tier">Tier</label>
+                    <select id="hr-tier">
+                      <option>critical</option>
+                      <option>high</option>
+                      <option selected>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="hr-risk">Risk Level</label>
+                    <select id="hr-risk">
+                      <option>critical</option>
+                      <option>high</option>
+                      <option selected>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="hr-rec">Recommendation</label>
+                    <select id="hr-rec">
+                      <option>approve</option>
+                      <option selected>review</option>
+                      <option>deny</option>
+                    </select>
+                  </div>
+                </div>
+                <label for="hr-tool"
+                  >Tool Pattern
+                  <span class="label-hint"
+                    >fnmatch syntax: bash, write_file, mcp__*</span
+                  ></label
+                >
+                <input
+                  id="hr-tool"
+                  type="text"
+                  value="bash"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <label for="hr-args"
+                  >Arg Patterns
+                  <span class="label-hint">one regex per line</span></label
+                >
+                <textarea
+                  id="hr-args"
+                  rows="3"
+                  style="font-family: var(--font-mono); font-size: 12px"
+                ></textarea>
+                <label for="hr-conf"
+                  >Confidence <span class="label-hint">0.0 – 1.0</span></label
+                >
+                <input
+                  id="hr-conf"
+                  type="number"
+                  step="0.05"
+                  value="0.8"
+                  min="0"
+                  max="1"
+                  style="width: 100px"
+                />
+                <label for="hr-intent">Intent Description</label>
+                <input
+                  id="hr-intent"
+                  type="text"
+                  placeholder="Detected dangerous operation: {arg_snippet}"
+                  autocomplete="off"
+                />
+                <label for="hr-reason">Reasoning</label>
+                <input
+                  id="hr-reason"
+                  type="text"
+                  placeholder="Explain why this is risky"
+                  autocomplete="off"
+                />
+                <div class="modal-buttons">
+                  <button class="modal-cancel" onclick="hideCreateHRModal()">
+                    Cancel
+                  </button>
+                  <button
+                    id="hr-submit"
+                    class="modal-submit"
+                    onclick="submitCreateHeuristicRule()"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Judge: Create Output Guard Pattern Modal -->
+            <div
+              id="create-ogp-overlay"
+              style="display: none"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-ogp-title"
+            >
+              <div id="create-ogp-box" class="admin-modal admin-modal-wide">
+                <h2 id="create-ogp-title">Create Output Guard Pattern</h2>
+                <div
+                  id="create-ogp-error"
+                  role="alert"
+                  aria-live="assertive"
+                ></div>
+                <label for="ogp-name">Name</label>
+                <input
+                  id="ogp-name"
+                  type="text"
+                  placeholder="my-pattern"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <div style="display: flex; gap: 12px">
+                  <div style="flex: 1">
+                    <label for="ogp-cat">Category</label>
+                    <select id="ogp-cat">
+                      <option>prompt_injection</option>
+                      <option>credentials</option>
+                      <option>encoded_payloads</option>
+                      <option>adversarial_urls</option>
+                      <option>info_disclosure</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="ogp-risk">Risk Level</label>
+                    <select id="ogp-risk">
+                      <option>high</option>
+                      <option selected>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                </div>
+                <label for="ogp-pattern">Regex Pattern</label>
+                <input
+                  id="ogp-pattern"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  style="font-family: var(--font-mono); font-size: 12px"
+                />
+                <button
+                  class="admin-btn-action"
+                  style="margin: 4px 0 8px"
+                  onclick="validateOGRegex()"
+                >
+                  Validate regex
+                </button>
+                <span
+                  id="ogp-regex-result"
+                  role="status"
+                  aria-live="polite"
+                  style="font-size: 11px; margin-left: 8px"
+                ></span>
+                <label for="ogp-flag">Flag Name</label>
+                <input
+                  id="ogp-flag"
+                  type="text"
+                  placeholder="my_flag"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <label for="ogp-ann">Annotation</label>
+                <input
+                  id="ogp-ann"
+                  type="text"
+                  placeholder="Human-readable description"
+                  autocomplete="off"
+                />
+                <label for="ogp-flags"
+                  >Pattern Flags
+                  <span class="label-hint"
+                    >comma-separated: IGNORECASE, MULTILINE, DOTALL</span
+                  ></label
+                >
+                <input id="ogp-flags" type="text" autocomplete="off" />
+                <div style="display: flex; gap: 16px; margin: 8px 0">
+                  <label
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      font-size: 12px;
+                    "
+                    ><input id="ogp-cred" type="checkbox" /> Is
+                    Credential</label
+                  >
+                  <label style="font-size: 12px"
+                    >Redact Label
+                    <input
+                      id="ogp-redact"
+                      type="text"
+                      placeholder="api_key"
+                      style="width: 100px; margin-left: 4px"
+                  /></label>
+                </div>
+                <div class="modal-buttons">
+                  <button class="modal-cancel" onclick="hideCreateOGPModal()">
+                    Cancel
+                  </button>
+                  <button
+                    id="ogp-submit"
+                    class="modal-submit"
+                    onclick="submitCreateOGPattern()"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Judge: Edit Heuristic Rule Modal -->
+            <div
+              id="edit-hr-overlay"
+              style="display: none"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="edit-hr-title"
+            >
+              <div id="edit-hr-box" class="admin-modal admin-modal-wide">
+                <h2 id="edit-hr-title">Edit Heuristic Rule</h2>
+                <div
+                  id="edit-hr-error"
+                  role="alert"
+                  aria-live="assertive"
+                ></div>
+                <input id="ehr-id" type="hidden" />
+                <input id="ehr-builtin" type="hidden" />
+                <input id="ehr-priority" type="hidden" value="0" />
+                <label for="ehr-name">Name</label>
+                <input
+                  id="ehr-name"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <div style="display: flex; gap: 12px">
+                  <div style="flex: 1">
+                    <label for="ehr-tier">Tier</label>
+                    <select id="ehr-tier">
+                      <option>critical</option>
+                      <option>high</option>
+                      <option>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="ehr-risk">Risk Level</label>
+                    <select id="ehr-risk">
+                      <option>critical</option>
+                      <option>high</option>
+                      <option>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="ehr-rec">Recommendation</label>
+                    <select id="ehr-rec">
+                      <option>approve</option>
+                      <option>review</option>
+                      <option>deny</option>
+                    </select>
+                  </div>
+                </div>
+                <label for="ehr-tool"
+                  >Tool Pattern
+                  <span class="label-hint"
+                    >fnmatch syntax: bash, write_file, mcp__*</span
+                  ></label
+                >
+                <input
+                  id="ehr-tool"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <label for="ehr-args"
+                  >Arg Patterns
+                  <span class="label-hint">one regex per line</span></label
+                >
+                <textarea
+                  id="ehr-args"
+                  rows="3"
+                  style="font-family: var(--font-mono); font-size: 12px"
+                ></textarea>
+                <label for="ehr-conf"
+                  >Confidence <span class="label-hint">0.0 – 1.0</span></label
+                >
+                <input
+                  id="ehr-conf"
+                  type="number"
+                  step="0.05"
+                  min="0"
+                  max="1"
+                  style="width: 100px"
+                />
+                <label for="ehr-intent">Intent Description</label>
+                <input id="ehr-intent" type="text" autocomplete="off" />
+                <label for="ehr-reason">Reasoning</label>
+                <input id="ehr-reason" type="text" autocomplete="off" />
+                <div class="modal-buttons">
+                  <button class="modal-cancel" onclick="hideEditHRModal()">
+                    Cancel
+                  </button>
+                  <button
+                    id="ehr-submit"
+                    class="modal-submit"
+                    onclick="submitEditHeuristicRule()"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Judge: Edit Output Guard Pattern Modal -->
+            <div
+              id="edit-ogp-overlay"
+              style="display: none"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="edit-ogp-title"
+            >
+              <div id="edit-ogp-box" class="admin-modal admin-modal-wide">
+                <h2 id="edit-ogp-title">Edit Output Guard Pattern</h2>
+                <div
+                  id="edit-ogp-error"
+                  role="alert"
+                  aria-live="assertive"
+                ></div>
+                <input id="eogp-id" type="hidden" />
+                <input id="eogp-builtin" type="hidden" />
+                <input id="eogp-priority" type="hidden" value="0" />
+                <label for="eogp-name">Name</label>
+                <input
+                  id="eogp-name"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <div style="display: flex; gap: 12px">
+                  <div style="flex: 1">
+                    <label for="eogp-cat">Category</label>
+                    <select id="eogp-cat">
+                      <option>prompt_injection</option>
+                      <option>credentials</option>
+                      <option>encoded_payloads</option>
+                      <option>adversarial_urls</option>
+                      <option>info_disclosure</option>
+                    </select>
+                  </div>
+                  <div style="flex: 1">
+                    <label for="eogp-risk">Risk Level</label>
+                    <select id="eogp-risk">
+                      <option>high</option>
+                      <option>medium</option>
+                      <option>low</option>
+                    </select>
+                  </div>
+                </div>
+                <label for="eogp-pattern">Regex Pattern</label>
+                <input
+                  id="eogp-pattern"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  style="font-family: var(--font-mono); font-size: 12px"
+                />
+                <button
+                  class="admin-btn-action"
+                  style="margin: 4px 0 8px"
+                  onclick="validateEditOGRegex()"
+                >
+                  Validate regex
+                </button>
+                <span
+                  id="eogp-regex-result"
+                  role="status"
+                  aria-live="polite"
+                  style="font-size: 11px; margin-left: 8px"
+                ></span>
+                <label for="eogp-flag">Flag Name</label>
+                <input
+                  id="eogp-flag"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <label for="eogp-ann">Annotation</label>
+                <input id="eogp-ann" type="text" autocomplete="off" />
+                <label for="eogp-flags"
+                  >Pattern Flags
+                  <span class="label-hint"
+                    >comma-separated: IGNORECASE, MULTILINE, DOTALL</span
+                  ></label
+                >
+                <input id="eogp-flags" type="text" autocomplete="off" />
+                <div style="display: flex; gap: 16px; margin: 8px 0">
+                  <label
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      font-size: 12px;
+                    "
+                    ><input id="eogp-cred" type="checkbox" /> Is
+                    Credential</label
+                  >
+                  <label style="font-size: 12px"
+                    >Redact Label
+                    <input
+                      id="eogp-redact"
+                      type="text"
+                      placeholder="api_key"
+                      style="width: 100px; margin-left: 4px"
+                  /></label>
+                </div>
+                <div class="modal-buttons">
+                  <button class="modal-cancel" onclick="hideEditOGPModal()">
+                    Cancel
+                  </button>
+                  <button
+                    id="eogp-submit"
+                    class="modal-submit"
+                    onclick="submitEditOGPattern()"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Skills Tab -->
+            <div
+              id="admin-skills"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-skills"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">SKILLS</span>
+                <div
+                  class="mcp-view-toggle"
+                  role="tablist"
+                  aria-label="Skills view"
+                >
+                  <button
+                    class="mcp-view-btn active"
+                    id="skill-tab-installed"
+                    data-skill-view="installed"
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="skill-view-installed"
+                    tabindex="0"
+                    onclick="switchSkillView('installed')"
+                  >
+                    Installed
+                  </button>
+                  <button
+                    class="mcp-view-btn"
+                    id="skill-tab-discover"
+                    data-skill-view="discover"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="skill-view-discover"
+                    tabindex="-1"
+                    onclick="switchSkillView('discover')"
+                  >
+                    Discover
+                  </button>
+                </div>
+                <span id="skill-installed-toolbar">
+                  <button
+                    class="admin-action-btn"
+                    onclick="showCreateTemplateModal()"
+                  >
+                    + Create skill
+                  </button>
+                </span>
+              </div>
+              <!-- Installed view -->
+              <div
+                id="skill-view-installed"
+                role="tabpanel"
+                aria-labelledby="skill-tab-installed"
+              >
+                <div class="admin-colheaders" aria-hidden="true">
+                  <span class="admin-col admin-col-tmcat">CATEGORY</span>
+                  <span class="admin-col admin-col-tmname">NAME</span>
+                  <span class="admin-col admin-col-tmrisk">RISK</span>
+                  <span class="admin-col admin-col-actions">ACTIONS</span>
+                </div>
+                <div
+                  id="admin-skills-table"
+                  role="list"
+                  aria-label="Skills"
+                  aria-live="polite"
+                >
+                  <div class="dashboard-empty">No skills configured</div>
+                </div>
+              </div>
+              <!-- Discover view -->
+              <div
+                id="skill-view-discover"
+                role="tabpanel"
+                aria-labelledby="skill-tab-discover"
+                style="display: none"
+              >
+                <div class="mcp-registry-notice" role="note">
+                  <span class="mcp-registry-notice-icon" aria-hidden="true"
+                    >&#9432;</span
+                  >
+                  Skills are community-published and not vetted by Turnstone.<br />
+                  <span style="margin-left: 19px"
+                    >Review source content before installing.</span
+                  >
+                </div>
+                <div class="mcp-registry-search">
+                  <input
+                    id="skill-discover-q"
+                    type="search"
+                    placeholder="Search skills..."
+                    autocomplete="off"
+                    aria-label="Search skills"
+                    onkeydown="
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        searchSkillDiscover();
+                      }
+                    "
+                  />
+                  <button
+                    id="skill-discover-search-btn"
+                    class="admin-action-btn"
+                    onclick="searchSkillDiscover()"
+                  >
+                    Search
+                  </button>
+                  <button
+                    class="admin-action-btn admin-action-btn-ghost"
+                    onclick="showGitHubImportModal()"
+                  >
+                    Import from GitHub
+                  </button>
+                </div>
+                <div
+                  id="skill-discover-results"
+                  role="list"
+                  aria-label="Discovered skills"
+                >
+                  <div class="dashboard-empty">
+                    Search external registries to discover and install skills
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Usage Tab -->
+            <div
+              id="admin-usage"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-usage"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">USAGE</span>
+                <div
+                  class="usage-range-group"
+                  role="group"
+                  aria-label="Time range"
+                >
+                  <button
+                    class="usage-range-btn"
+                    data-range="24h"
+                    aria-pressed="false"
+                    onclick="setUsageRange('24h')"
+                  >
+                    24h
+                  </button>
+                  <button
+                    class="usage-range-btn active"
+                    data-range="7d"
+                    aria-pressed="true"
+                    onclick="setUsageRange('7d')"
+                  >
+                    7d
+                  </button>
+                  <button
+                    class="usage-range-btn"
+                    data-range="30d"
+                    aria-pressed="false"
+                    onclick="setUsageRange('30d')"
+                  >
+                    30d
+                  </button>
+                </div>
+                <div
+                  class="usage-range-group"
+                  role="group"
+                  aria-label="Group by"
+                >
+                  <button
+                    class="usage-group-btn active"
+                    data-group="day"
+                    aria-pressed="true"
+                    onclick="setUsageGroupBy('day')"
+                  >
+                    day
+                  </button>
+                  <button
+                    class="usage-group-btn"
+                    data-group="model"
+                    aria-pressed="false"
+                    onclick="setUsageGroupBy('model')"
+                  >
+                    model
+                  </button>
+                  <button
+                    class="usage-group-btn"
+                    data-group="user"
+                    aria-pressed="false"
+                    onclick="setUsageGroupBy('user')"
+                  >
+                    user
+                  </button>
+                </div>
+              </div>
+              <div id="admin-usage-content">
+                <div class="dashboard-empty">Loading usage data...</div>
+              </div>
+            </div>
+
+            <!-- Audit Tab -->
+            <div
+              id="admin-audit"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-audit"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">AUDIT LOG</span>
+                <label for="audit-action-filter" class="sr-only"
+                  >Filter by action</label
+                >
+                <select id="audit-action-filter" onchange="loadGovAudit()">
+                  <option value="">All actions</option>
+                  <option value="user.create">user.create</option>
+                  <option value="user.delete">user.delete</option>
+                  <option value="token.create">token.create</option>
+                  <option value="token.revoke">token.revoke</option>
+                  <option value="role.create">role.create</option>
+                  <option value="role.update">role.update</option>
+                  <option value="role.delete">role.delete</option>
+                  <option value="role.assign">role.assign</option>
+                  <option value="role.unassign">role.unassign</option>
+                  <option value="policy.create">policy.create</option>
+                  <option value="policy.update">policy.update</option>
+                  <option value="policy.delete">policy.delete</option>
+                  <option value="skill.create">skill.create</option>
+                  <option value="skill.update">skill.update</option>
+                  <option value="skill.delete">skill.delete</option>
+                </select>
+                <label for="audit-user-filter" class="sr-only"
+                  >Filter by user</label
+                >
+                <select id="audit-user-filter" onchange="loadGovAudit()">
+                  <option value="">All users</option>
+                </select>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-atime">TIME</span>
+                <span class="admin-col admin-col-auser">USER</span>
+                <span class="admin-col admin-col-aaction">ACTION</span>
+                <span class="admin-col admin-col-aresource">RESOURCE</span>
+                <span class="admin-col admin-col-adetail">DETAIL</span>
+              </div>
+              <div
+                id="admin-audit-table"
+                role="list"
+                aria-label="Audit events"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading audit log...</div>
+              </div>
+            </div>
+
+            <!-- Memories Tab -->
+            <div
+              id="admin-memories"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-memories"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">MEMORIES</span>
+                <div class="admin-toolbar-filters">
+                  <select
+                    id="mem-filter-type"
+                    onchange="loadAdminMemories()"
+                    aria-label="Filter by type"
+                  >
+                    <option value="">All types</option>
+                    <option value="user">user</option>
+                    <option value="project">project</option>
+                    <option value="feedback">feedback</option>
+                    <option value="reference">reference</option>
+                  </select>
+                  <select
+                    id="mem-filter-scope"
+                    onchange="loadAdminMemories()"
+                    aria-label="Filter by scope"
+                  >
+                    <option value="">All scopes</option>
+                    <option value="global">global</option>
+                    <option value="workstream">workstream</option>
+                    <option value="user">user</option>
+                  </select>
+                  <input
+                    id="mem-search"
+                    type="search"
+                    placeholder="Search memories…"
+                    aria-label="Search memories"
+                    autocomplete="off"
+                  />
+                </div>
+              </div>
+              <div class="admin-colheaders" aria-hidden="true">
+                <span class="admin-col admin-col-mname">NAME</span>
+                <span class="admin-col admin-col-mtype">TYPE</span>
+                <span class="admin-col admin-col-mscope">SCOPE</span>
+                <span class="admin-col admin-col-mdesc">DESCRIPTION</span>
+                <span class="admin-col admin-col-mupdated">UPDATED</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="admin-memories-table"
+                role="list"
+                aria-label="Memories"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading…</div>
+              </div>
+            </div>
+
+            <!-- Models Tab -->
+            <div
+              id="admin-models"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-models"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header">Models</span>
+                <button
+                  id="model-sync-btn"
+                  class="admin-action-btn admin-action-btn-ghost"
+                  onclick="reloadModelNodes()"
+                  title="Push model config to all cluster nodes"
+                >
+                  Sync to Nodes
+                </button>
+                <button
+                  class="admin-action-btn"
+                  onclick="showCreateModelModal()"
+                >
+                  + Add Model
+                </button>
+              </div>
+              <div class="admin-colheaders models-grid" aria-hidden="true">
+                <span class="admin-col">ALIAS</span>
+                <span class="admin-col">MODEL</span>
+                <span class="admin-col">PROVIDER</span>
+                <span class="admin-col">CTX WINDOW</span>
+                <span class="admin-col">STATUS</span>
+                <span class="admin-col">ACTIONS</span>
+              </div>
+              <div
+                id="admin-models-table"
+                role="list"
+                aria-label="Model definitions"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading...</div>
+              </div>
+            </div>
+
+            <!-- Node Metadata Tab -->
+            <div
+              id="admin-node-metadata"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-node-metadata"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0"
+                  >NODE METADATA</span
+                >
+              </div>
+              <div
+                id="admin-node-metadata-content"
+                role="list"
+                aria-label="Node metadata"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading&hellip;</div>
+              </div>
+            </div>
+
+            <!-- Settings Tab -->
+            <div
+              id="admin-settings"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-settings"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0">SETTINGS</span>
+                <a
+                  href="/docs#/System:%20Settings"
+                  target="_blank"
+                  rel="noopener"
+                  class="settings-docs-link"
+                  title="Settings API reference"
+                  >docs</a
+                >
+              </div>
+              <div id="admin-settings-content">
+                <div class="dashboard-empty">Loading&hellip;</div>
+              </div>
+            </div>
+
+            <!-- TLS Tab -->
+            <div
+              id="admin-tls"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-tls"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header" style="margin: 0"
+                  >TLS / CERTIFICATES</span
+                >
+              </div>
+              <div id="tls-ca-status"></div>
+              <div
+                class="admin-colheaders admin-colheaders-tls"
+                aria-hidden="true"
+              >
+                <span class="admin-col">DOMAIN</span>
+                <span class="admin-col">SANS</span>
+                <span class="admin-col">ISSUED</span>
+                <span class="admin-col">EXPIRES</span>
+                <span class="admin-col admin-col-actions">ACTIONS</span>
+              </div>
+              <div
+                id="tls-cert-list"
+                role="list"
+                aria-label="TLS certificates"
+                aria-live="polite"
+              >
+                <div class="dashboard-empty">Loading&hellip;</div>
+              </div>
+            </div>
+
+            <div
+              id="admin-mcp"
+              class="admin-panel"
+              role="tabpanel"
+              aria-labelledby="tab-mcp"
+              style="display: none"
+            >
+              <div class="admin-toolbar">
+                <span class="section-header">MCP</span>
+                <div
+                  class="mcp-view-toggle"
+                  role="tablist"
+                  aria-label="MCP view"
+                >
+                  <button
+                    class="mcp-view-btn active"
+                    data-mcp-view="servers"
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="mcp-view-servers"
+                    tabindex="0"
+                    onclick="switchMcpView('servers')"
+                  >
+                    Servers
+                  </button>
+                  <button
+                    class="mcp-view-btn"
+                    data-mcp-view="registry"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="mcp-view-registry"
+                    tabindex="-1"
+                    onclick="switchMcpView('registry')"
+                  >
+                    Discover
+                  </button>
+                </div>
+                <span id="mcp-servers-toolbar">
+                  <button
+                    id="mcp-sync-btn"
+                    class="admin-action-btn admin-action-btn-ghost"
+                    onclick="reloadMcpNodes()"
+                    title="Push MCP server config to all cluster nodes and reconnect"
+                  >
+                    Sync to Nodes
+                  </button>
+                  <button
+                    class="admin-action-btn admin-action-btn-ghost"
+                    onclick="showImportMcpModal()"
+                  >
+                    Import JSON
+                  </button>
+                  <button
+                    class="admin-action-btn"
+                    onclick="showCreateMcpModal()"
+                  >
+                    + Add Server
+                  </button>
+                </span>
+              </div>
+              <div id="mcp-view-servers" role="tabpanel">
+                <div class="admin-colheaders mcp-grid" aria-hidden="true">
+                  <span class="admin-col admin-col-mname">NAME</span>
+                  <span class="admin-col admin-col-mtransport">TRANSPORT</span>
+                  <span class="admin-col admin-col-mtools">TOOLS</span>
+                  <span class="admin-col admin-col-mres">RES</span>
+                  <span class="admin-col admin-col-mprompts">PROMPTS</span>
+                  <span class="admin-col admin-col-mstatus">STATUS</span>
+                  <span class="admin-col admin-col-mactions">ACTIONS</span>
+                </div>
+                <div id="admin-mcp-table" role="list" aria-label="MCP servers">
+                  <div class="dashboard-empty">Loading...</div>
+                </div>
+              </div>
+              <div id="mcp-view-registry" role="tabpanel" style="display: none">
+                <div class="mcp-registry-notice" role="note">
+                  <span class="mcp-registry-notice-icon" aria-hidden="true"
+                    >&#9432;</span
+                  >
+                  Servers are community-published via the
+                  <a
+                    href="https://registry.modelcontextprotocol.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >official MCP Registry</a
+                  >
+                  and not vetted by Turnstone.<br />
+                  <span style="margin-left: 19px"
+                    >Review source repositories before installing.</span
+                  >
+                </div>
+                <div class="mcp-registry-search">
+                  <input
+                    id="mcp-registry-q"
+                    type="search"
+                    placeholder="Search MCP servers..."
+                    autocomplete="off"
+                    aria-label="Search registry"
+                    onkeydown="
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        searchMcpRegistry();
+                      }
+                    "
+                  />
+                  <select
+                    id="mcp-registry-filter"
+                    aria-label="Filter by type"
+                    onchange="_applyRegistryFilter()"
+                  >
+                    <option value="">All types</option>
+                    <option value="remote">Remote only</option>
+                    <option value="npm">npm only</option>
+                    <option value="pypi">PyPI only</option>
+                  </select>
+                  <button
+                    id="mcp-registry-search-btn"
+                    class="admin-action-btn"
+                    onclick="searchMcpRegistry()"
+                  >
+                    Search
+                  </button>
+                </div>
+                <div
+                  id="mcp-registry-results"
+                  role="list"
+                  aria-label="Registry servers"
+                >
+                  <div class="dashboard-empty">
+                    Search the official MCP Registry to discover and install
+                    servers
+                  </div>
+                </div>
+                <div id="mcp-registry-pagination" style="display: none">
+                  <button
+                    id="mcp-registry-more"
+                    class="admin-action-btn admin-action-btn-ghost"
+                    onclick="loadMoreRegistry()"
+                  >
+                    Load more
+                  </button>
+                  <span
+                    id="mcp-registry-count"
+                    class="mcp-registry-count-label"
+                  ></span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- /admin-content -->
+        </div>
+        <!-- /admin-layout -->
+      </div>
+    </div>
+
+    <div id="cluster-status-bar" role="region" aria-label="Cluster status">
+      <div class="csb-states" id="csb-states">
+        <span class="csb-loading">Loading...</span>
+      </div>
+      <div class="csb-divider" aria-hidden="true"></div>
+      <div class="csb-metrics" id="csb-metrics"></div>
+    </div>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+    <script>
+      window.TURNSTONE_AUTH_TITLE = "turnstone console";
+      window.TURNSTONE_TOAST_TIMEOUT = 4000;
+      window.TURNSTONE_KB_SHORTCUTS = [
+        {
+          title: "Navigation",
+          keys: [
+            {
+              desc: "Activate card / row",
+              badge: '<span class="kb-key">Enter</span>',
+            },
+            {
+              desc: "Activate card / row",
+              badge: '<span class="kb-key">Space</span>',
+            },
+            {
+              desc: "Navigate rows",
+              badge:
+                '<span class="kb-key">\u2191</span> <span class="kb-key">\u2193</span>',
+            },
+          ],
+        },
+        {
+          title: "General",
+          keys: [
+            {
+              desc: "Submit form from textarea",
+              badge:
+                '<span class="kb-key">' +
+                (navigator.platform && navigator.platform.indexOf("Mac") > -1
+                  ? "\u2318"
+                  : "Ctrl") +
+                '</span>+<span class="kb-key">Enter</span>',
+            },
+            { desc: "Show this help", badge: '<span class="kb-key">?</span>' },
+            { desc: "Close overlay", badge: '<span class="kb-key">Esc</span>' },
+          ],
+        },
+      ];
+    </script>
+    <script src="/shared/utils.js"></script>
+    <script src="/shared/cards.js"></script>
+    <script src="/shared/toast.js"></script>
+    <script src="/shared/theme.js"></script>
+    <script src="/shared/auth.js"></script>
+    <script src="/shared/kb.js"></script>
+    <script src="/shared/composer.js"></script>
+
+    <div
+      id="new-ws-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-ws-title"
+    >
+      <div id="new-ws-box">
+        <h2 id="new-ws-title">New Workstream</h2>
+        <div id="new-ws-error" role="alert" aria-live="assertive"></div>
+        <label for="new-ws-task"
+          >Task
+          <span class="label-hint"
+            >optional &mdash; sent as first message</span
+          ></label
+        >
+        <textarea
+          id="new-ws-task"
+          rows="4"
+          placeholder="What should this workstream work on?"
+        ></textarea>
+        <label for="new-ws-node">Node</label>
+        <select id="new-ws-node">
+          <option value="">Auto (best available)</option>
+        </select>
+        <label for="new-ws-name"
+          >Name <span class="label-hint">optional</span></label
+        >
+        <input
+          id="new-ws-name"
+          type="text"
+          placeholder="Auto-generated if empty"
+          autocomplete="off"
+        />
+        <label for="new-ws-model"
+          >Model <span class="label-hint">optional</span></label
+        >
+        <select id="new-ws-model">
+          <option value="">Default model</option>
+        </select>
+        <label for="new-ws-skill"
+          >Skill <span class="label-hint">optional</span></label
+        >
+        <select id="new-ws-skill">
+          <option value="">Use defaults</option>
+        </select>
+        <label for="new-ws-judge"
+          >Judge Model <span class="label-hint">optional</span></label
+        >
+        <select id="new-ws-judge">
+          <option value="">Default (agent model)</option>
+        </select>
+        <div id="new-ws-buttons">
+          <button id="new-ws-cancel" onclick="hideNewWsModal()">Cancel</button>
+          <button id="new-ws-submit" onclick="submitNewWs()">Create</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- GitHub Import Modal -->
+    <div
+      id="github-import-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="github-import-title"
+    >
+      <div id="github-import-box" class="admin-modal">
+        <h2 id="github-import-title">Import from GitHub</h2>
+        <div id="github-import-error" role="alert" aria-live="assertive"></div>
+        <label for="gi-url">GitHub URL</label>
+        <input
+          id="gi-url"
+          type="url"
+          placeholder="https://github.com/owner/repo"
+          autocomplete="off"
+          spellcheck="false"
+          aria-describedby="gi-url-hint"
+        />
+        <p
+          id="gi-url-hint"
+          style="font-size: 11px; color: var(--fg-dim); margin: 4px 0 12px"
+        >
+          Paste a link to a repository or SKILL.md file
+        </p>
         <div class="modal-buttons">
-          <button class="modal-cancel" onclick="hideCreateHRModal()">Cancel</button>
-          <button id="hr-submit" class="modal-submit" onclick="submitCreateHeuristicRule()">Create</button>
+          <button class="modal-cancel" onclick="hideGitHubImportModal()">
+            Cancel
+          </button>
+          <button
+            id="gi-submit"
+            class="modal-submit"
+            onclick="submitGitHubImport()"
+          >
+            Install
+          </button>
         </div>
       </div>
     </div>
 
-    <!-- Judge: Create Output Guard Pattern Modal -->
-    <div id="create-ogp-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-ogp-title">
-      <div id="create-ogp-box" class="admin-modal admin-modal-wide">
-        <h2 id="create-ogp-title">Create Output Guard Pattern</h2>
-        <div id="create-ogp-error" role="alert" aria-live="assertive"></div>
-        <label for="ogp-name">Name</label>
-        <input id="ogp-name" type="text" placeholder="my-pattern" autocomplete="off" spellcheck="false">
-        <div style="display:flex;gap:12px">
-          <div style="flex:1">
-            <label for="ogp-cat">Category</label>
-            <select id="ogp-cat"><option>prompt_injection</option><option>credentials</option><option>encoded_payloads</option><option>adversarial_urls</option><option>info_disclosure</option></select>
-          </div>
-          <div style="flex:1">
-            <label for="ogp-risk">Risk Level</label>
-            <select id="ogp-risk"><option>high</option><option selected>medium</option><option>low</option></select>
-          </div>
+    <!-- Create User Modal -->
+    <div
+      id="create-user-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-user-title"
+    >
+      <div id="create-user-box" class="admin-modal">
+        <h2 id="create-user-title">Create User</h2>
+        <div id="create-user-error" role="alert" aria-live="assertive"></div>
+        <label for="cu-username">Username</label>
+        <input
+          id="cu-username"
+          type="text"
+          placeholder="login username"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <label for="cu-displayname">Display name</label>
+        <input
+          id="cu-displayname"
+          type="text"
+          placeholder="Full name"
+          autocomplete="off"
+        />
+        <label for="cu-password">Password</label>
+        <input
+          id="cu-password"
+          type="password"
+          placeholder="Minimum 8 characters"
+          autocomplete="new-password"
+        />
+        <label for="cu-confirm">Confirm password</label>
+        <input
+          id="cu-confirm"
+          type="password"
+          placeholder="Confirm password"
+          autocomplete="new-password"
+        />
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateUserModal()">
+            Cancel
+          </button>
+          <button
+            id="cu-submit"
+            class="modal-submit"
+            onclick="submitCreateUser()"
+          >
+            Create
+          </button>
         </div>
-        <label for="ogp-pattern">Regex Pattern</label>
-        <input id="ogp-pattern" type="text" autocomplete="off" spellcheck="false" style="font-family:var(--font-mono);font-size:12px">
-        <button class="admin-btn-action" style="margin:4px 0 8px" onclick="validateOGRegex()">Validate regex</button>
-        <span id="ogp-regex-result" role="status" aria-live="polite" style="font-size:11px;margin-left:8px"></span>
-        <label for="ogp-flag">Flag Name</label>
-        <input id="ogp-flag" type="text" placeholder="my_flag" autocomplete="off" spellcheck="false">
-        <label for="ogp-ann">Annotation</label>
-        <input id="ogp-ann" type="text" placeholder="Human-readable description" autocomplete="off">
-        <label for="ogp-flags">Pattern Flags <span class="label-hint">comma-separated: IGNORECASE, MULTILINE, DOTALL</span></label>
-        <input id="ogp-flags" type="text" autocomplete="off">
-        <div style="display:flex;gap:16px;margin:8px 0">
-          <label style="display:flex;align-items:center;gap:6px;font-size:12px"><input id="ogp-cred" type="checkbox"> Is Credential</label>
-          <label style="font-size:12px">Redact Label <input id="ogp-redact" type="text" placeholder="api_key" style="width:100px;margin-left:4px"></label>
+      </div>
+    </div>
+
+    <!-- Create Token Modal -->
+    <div
+      id="create-token-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-token-title"
+    >
+      <div id="create-token-box" class="admin-modal">
+        <h2 id="create-token-title">Create API Token</h2>
+        <div id="create-token-error" role="alert" aria-live="assertive"></div>
+        <label for="ct-name"
+          >Token name <span class="label-hint">optional</span></label
+        >
+        <input
+          id="ct-name"
+          type="text"
+          placeholder="e.g. CI pipeline, bridge-prod"
+          autocomplete="off"
+        />
+        <label for="ct-scopes">Scopes</label>
+        <select id="ct-scopes">
+          <option value="read,write,approve">
+            Full access (read, write, approve)
+          </option>
+          <option value="read,write">Read + write</option>
+          <option value="read">Read only</option>
+        </select>
+        <label for="ct-expires"
+          >Expiry <span class="label-hint">optional</span></label
+        >
+        <select id="ct-expires">
+          <option value="">Never</option>
+          <option value="30">30 days</option>
+          <option value="90">90 days</option>
+          <option value="365">1 year</option>
+        </select>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateTokenModal()">
+            Cancel
+          </button>
+          <button
+            id="ct-submit"
+            class="modal-submit"
+            onclick="submitCreateToken()"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Token Created (show-once) Modal -->
+    <div
+      id="token-created-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="token-created-title"
+    >
+      <div id="token-created-box" class="admin-modal">
+        <h2 id="token-created-title">Token Created</h2>
+        <p class="token-created-warning">
+          Copy this token now. It will not be shown again.
+        </p>
+        <div id="token-created-value" class="token-display"></div>
+        <div class="modal-buttons">
+          <button class="modal-submit" onclick="copyCreatedToken()">
+            Copy to clipboard
+          </button>
+          <button class="modal-cancel" onclick="hideTokenCreatedModal()">
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Confirm Action Modal (reusable) -->
+    <div
+      id="confirm-overlay"
+      style="display: none"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      aria-describedby="confirm-message"
+    >
+      <div id="confirm-box" class="admin-modal">
+        <h2 id="confirm-title">Confirm</h2>
+        <p
+          id="confirm-message"
+          style="color: var(--fg-dim); margin: 12px 0 20px; line-height: 1.5"
+        ></p>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideConfirmModal()">
+            Cancel
+          </button>
+          <button
+            id="confirm-submit"
+            class="modal-submit"
+            style="background: var(--red); border-color: var(--red)"
+            onclick="_confirmCallback()"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Channel Link Modal -->
+    <div
+      id="create-channel-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-channel-title"
+    >
+      <div id="create-channel-box" class="admin-modal">
+        <h2 id="create-channel-title">Link Channel Account</h2>
+        <div id="create-channel-error" role="alert" aria-live="assertive"></div>
+        <label for="cc-type">Channel type</label>
+        <select id="cc-type">
+          <option value="discord">Discord</option>
+          <option value="slack">Slack</option>
+        </select>
+        <label for="cc-uid"
+          >External user ID
+          <span class="label-hint">the user's ID on the platform</span></label
+        >
+        <input id="cc-uid" type="text" autocomplete="off" spellcheck="false" />
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateChannelModal()">
+            Cancel
+          </button>
+          <button
+            id="cc-submit"
+            class="modal-submit"
+            onclick="submitCreateChannel()"
+          >
+            Link
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Schedule Modal -->
+    <div
+      id="create-schedule-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-schedule-title"
+    >
+      <div id="create-schedule-box" class="admin-modal admin-modal-wide">
+        <h2 id="create-schedule-title">New Schedule</h2>
+        <div
+          id="create-schedule-error"
+          role="alert"
+          aria-live="assertive"
+        ></div>
+        <div class="modal-columns">
+          <div class="modal-col">
+            <div class="modal-col-heading">Schedule</div>
+            <label for="cs-name">Name</label>
+            <input
+              id="cs-name"
+              type="text"
+              placeholder="Daily health check"
+              autocomplete="off"
+            />
+            <label for="cs-desc"
+              >Description <span class="label-hint">optional</span></label
+            >
+            <input id="cs-desc" type="text" placeholder="" autocomplete="off" />
+            <label for="cs-type">Schedule type</label>
+            <select id="cs-type" onchange="toggleScheduleTypeFields()">
+              <option value="cron">Cron (recurring)</option>
+              <option value="at">At (one-shot)</option>
+            </select>
+            <div id="cs-cron-group">
+              <label for="cs-cron">Cron expression</label>
+              <input
+                id="cs-cron"
+                type="text"
+                placeholder="0 9 * * MON-FRI"
+                autocomplete="off"
+                spellcheck="false"
+                aria-describedby="cs-cron-hint"
+              />
+              <span
+                id="cs-cron-hint"
+                class="label-hint"
+                style="display: block; margin-top: 3px"
+                >min hour day month weekday</span
+              >
+            </div>
+            <div id="cs-at-group" style="display: none">
+              <label for="cs-at">Run at</label>
+              <input id="cs-at" type="datetime-local" />
+            </div>
+            <label for="cs-target">Target</label>
+            <select id="cs-target" onchange="toggleScheduleNodeField()">
+              <option value="auto">Auto (best available)</option>
+              <option value="pool">Pool (any bridge)</option>
+              <option value="all">All nodes</option>
+              <option value="node">Specific node...</option>
+            </select>
+            <div id="cs-node-group" style="display: none">
+              <label for="cs-node">Node ID</label>
+              <input
+                id="cs-node"
+                type="text"
+                placeholder="node-001"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+          </div>
+          <div class="modal-col">
+            <div class="modal-col-heading">Execution</div>
+            <label for="cs-model"
+              >Model <span class="label-hint">optional</span></label
+            >
+            <select id="cs-model">
+              <option value="">Default model</option>
+            </select>
+            <label for="cs-template"
+              >Skill <span class="label-hint">optional</span></label
+            >
+            <select id="cs-template">
+              <option value="">None</option>
+            </select>
+            <label for="cs-message">Initial message</label>
+            <textarea
+              id="cs-message"
+              rows="3"
+              placeholder="What should the workstream do?"
+            ></textarea>
+            <label class="admin-checkbox"
+              ><input id="cs-autoapprove" type="checkbox" /> Auto-approve tool
+              calls</label
+            >
+            <label
+              >Notify on completion
+              <span class="label-hint">optional</span></label
+            >
+            <div id="cs-notify-rows"></div>
+            <button
+              type="button"
+              class="admin-inline-add"
+              onclick="_addNotifyRow('cs')"
+              aria-label="Add notification target"
+            >
+              + Add target
+            </button>
+          </div>
         </div>
         <div class="modal-buttons">
-          <button class="modal-cancel" onclick="hideCreateOGPModal()">Cancel</button>
-          <button id="ogp-submit" class="modal-submit" onclick="submitCreateOGPattern()">Create</button>
+          <button class="modal-cancel" onclick="hideCreateScheduleModal()">
+            Cancel
+          </button>
+          <button
+            id="cs-submit"
+            class="modal-submit"
+            onclick="submitCreateSchedule()"
+          >
+            Create
+          </button>
         </div>
       </div>
     </div>
 
-    <!-- Judge: Edit Heuristic Rule Modal -->
-    <div id="edit-hr-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-hr-title">
-      <div id="edit-hr-box" class="admin-modal admin-modal-wide">
-        <h2 id="edit-hr-title">Edit Heuristic Rule</h2>
-        <div id="edit-hr-error" role="alert" aria-live="assertive"></div>
-        <input id="ehr-id" type="hidden">
-        <input id="ehr-builtin" type="hidden">
-        <input id="ehr-priority" type="hidden" value="0">
-        <label for="ehr-name">Name</label>
-        <input id="ehr-name" type="text" autocomplete="off" spellcheck="false">
-        <div style="display:flex;gap:12px">
-          <div style="flex:1">
-            <label for="ehr-tier">Tier</label>
-            <select id="ehr-tier"><option>critical</option><option>high</option><option>medium</option><option>low</option></select>
+    <!-- Edit Schedule Modal -->
+    <div
+      id="edit-schedule-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-schedule-title"
+    >
+      <div id="edit-schedule-box" class="admin-modal admin-modal-wide">
+        <h2 id="edit-schedule-title">Edit Schedule</h2>
+        <div id="edit-schedule-error" role="alert" aria-live="assertive"></div>
+        <input id="es-id" type="hidden" />
+        <div class="modal-columns">
+          <div class="modal-col">
+            <div class="modal-col-heading">Schedule</div>
+            <label for="es-name">Name</label>
+            <input id="es-name" type="text" autocomplete="off" />
+            <label for="es-desc">Description</label>
+            <input id="es-desc" type="text" autocomplete="off" />
+            <label for="es-type">Schedule type</label>
+            <select id="es-type" onchange="toggleEditScheduleTypeFields()">
+              <option value="cron">Cron (recurring)</option>
+              <option value="at">At (one-shot)</option>
+            </select>
+            <div id="es-cron-group">
+              <label for="es-cron">Cron expression</label>
+              <input
+                id="es-cron"
+                type="text"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+            <div id="es-at-group" style="display: none">
+              <label for="es-at">Run at</label>
+              <input id="es-at" type="datetime-local" />
+            </div>
+            <label for="es-target">Target</label>
+            <select id="es-target" onchange="toggleEditScheduleNodeField()">
+              <option value="auto">Auto (best available)</option>
+              <option value="pool">Pool (any bridge)</option>
+              <option value="all">All nodes</option>
+              <option value="node">Specific node...</option>
+            </select>
+            <div id="es-node-group" style="display: none">
+              <label for="es-node">Node ID</label>
+              <input
+                id="es-node"
+                type="text"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
           </div>
-          <div style="flex:1">
-            <label for="ehr-risk">Risk Level</label>
-            <select id="ehr-risk"><option>critical</option><option>high</option><option>medium</option><option>low</option></select>
-          </div>
-          <div style="flex:1">
-            <label for="ehr-rec">Recommendation</label>
-            <select id="ehr-rec"><option>approve</option><option>review</option><option>deny</option></select>
+          <div class="modal-col">
+            <div class="modal-col-heading">Execution</div>
+            <label for="es-model">Model</label>
+            <select id="es-model">
+              <option value="">Default model</option>
+            </select>
+            <label for="es-template"
+              >Skill <span class="label-hint">optional</span></label
+            >
+            <select id="es-template">
+              <option value="">None</option>
+            </select>
+            <label for="es-message">Initial message</label>
+            <textarea id="es-message" rows="3"></textarea>
+            <label class="admin-checkbox"
+              ><input id="es-autoapprove" type="checkbox" /> Auto-approve tool
+              calls</label
+            >
+            <label class="admin-checkbox"
+              ><input id="es-enabled" type="checkbox" /> Enabled</label
+            >
+            <label
+              >Notify on completion
+              <span class="label-hint">optional</span></label
+            >
+            <div id="es-notify-rows"></div>
+            <button
+              type="button"
+              class="admin-inline-add"
+              onclick="_addNotifyRow('es')"
+              aria-label="Add notification target"
+            >
+              + Add target
+            </button>
           </div>
         </div>
-        <label for="ehr-tool">Tool Pattern <span class="label-hint">fnmatch syntax: bash, write_file, mcp__*</span></label>
-        <input id="ehr-tool" type="text" autocomplete="off" spellcheck="false">
-        <label for="ehr-args">Arg Patterns <span class="label-hint">one regex per line</span></label>
-        <textarea id="ehr-args" rows="3" style="font-family:var(--font-mono);font-size:12px"></textarea>
-        <label for="ehr-conf">Confidence <span class="label-hint">0.0 – 1.0</span></label>
-        <input id="ehr-conf" type="number" step="0.05" min="0" max="1" style="width:100px">
-        <label for="ehr-intent">Intent Description</label>
-        <input id="ehr-intent" type="text" autocomplete="off">
-        <label for="ehr-reason">Reasoning</label>
-        <input id="ehr-reason" type="text" autocomplete="off">
         <div class="modal-buttons">
-          <button class="modal-cancel" onclick="hideEditHRModal()">Cancel</button>
-          <button id="ehr-submit" class="modal-submit" onclick="submitEditHeuristicRule()">Save</button>
+          <button class="modal-cancel" onclick="hideEditScheduleModal()">
+            Cancel
+          </button>
+          <button
+            id="es-submit"
+            class="modal-submit"
+            onclick="submitEditSchedule()"
+          >
+            Save
+          </button>
         </div>
       </div>
     </div>
 
-    <!-- Judge: Edit Output Guard Pattern Modal -->
-    <div id="edit-ogp-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-ogp-title">
-      <div id="edit-ogp-box" class="admin-modal admin-modal-wide">
-        <h2 id="edit-ogp-title">Edit Output Guard Pattern</h2>
-        <div id="edit-ogp-error" role="alert" aria-live="assertive"></div>
-        <input id="eogp-id" type="hidden">
-        <input id="eogp-builtin" type="hidden">
-        <input id="eogp-priority" type="hidden" value="0">
-        <label for="eogp-name">Name</label>
-        <input id="eogp-name" type="text" autocomplete="off" spellcheck="false">
-        <div style="display:flex;gap:12px">
-          <div style="flex:1">
-            <label for="eogp-cat">Category</label>
-            <select id="eogp-cat"><option>prompt_injection</option><option>credentials</option><option>encoded_payloads</option><option>adversarial_urls</option><option>info_disclosure</option></select>
+    <!-- Schedule Runs Modal -->
+    <div
+      id="schedule-runs-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="schedule-runs-title"
+    >
+      <div id="schedule-runs-box" class="admin-modal admin-modal-wide">
+        <h2 id="schedule-runs-title">Run History</h2>
+        <div id="schedule-runs-table"></div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideScheduleRunsModal()">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Role Modal -->
+    <div
+      id="create-role-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-role-title"
+    >
+      <div id="create-role-box" class="admin-modal admin-modal-wide">
+        <h2 id="create-role-title">Create Role</h2>
+        <div id="create-role-error" role="alert" aria-live="assertive"></div>
+        <label for="cr-name">Name</label>
+        <input
+          id="cr-name"
+          type="text"
+          placeholder="e.g. security-reviewer"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <label for="cr-displayname">Display name</label>
+        <input
+          id="cr-displayname"
+          type="text"
+          placeholder="Security Reviewer"
+          autocomplete="off"
+        />
+        <fieldset class="perm-fieldset">
+          <legend>Permissions</legend>
+          <div
+            id="cr-perms-container"
+            role="group"
+            aria-label="Permissions"
+          ></div>
+        </fieldset>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateRoleModal()">
+            Cancel
+          </button>
+          <button
+            id="cr-submit"
+            class="modal-submit"
+            onclick="submitCreateRole()"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Edit Role Modal -->
+    <div
+      id="edit-role-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-role-title"
+    >
+      <div id="edit-role-box" class="admin-modal admin-modal-wide">
+        <h2 id="edit-role-title">Edit Role</h2>
+        <div id="edit-role-error" role="alert" aria-live="assertive"></div>
+        <input id="er-id" type="hidden" />
+        <label for="er-name">Display name</label>
+        <input id="er-name" type="text" autocomplete="off" />
+        <fieldset class="perm-fieldset">
+          <legend>Permissions</legend>
+          <div
+            id="er-perms-container"
+            role="group"
+            aria-label="Permissions"
+          ></div>
+        </fieldset>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideEditRoleModal()">
+            Cancel
+          </button>
+          <button
+            id="er-submit"
+            class="modal-submit"
+            onclick="submitEditRole()"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- User Roles Modal -->
+    <div
+      id="user-roles-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="user-roles-title"
+    >
+      <div id="user-roles-box" class="admin-modal">
+        <h2 id="user-roles-title">Assign Roles</h2>
+        <div id="user-roles-error" role="alert" aria-live="assertive"></div>
+        <input id="ur-user-id" type="hidden" />
+        <div id="ur-roles-container"></div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideUserRolesModal()">
+            Cancel
+          </button>
+          <button class="modal-submit" onclick="submitUserRoles()">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Policy Modal -->
+    <div
+      id="create-policy-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-policy-title"
+    >
+      <div id="create-policy-box" class="admin-modal">
+        <h2 id="create-policy-title">Create Tool Policy</h2>
+        <div id="create-policy-error" role="alert" aria-live="assertive"></div>
+        <label for="cp-name">Name</label>
+        <input
+          id="cp-name"
+          type="text"
+          placeholder="e.g. Block shell access"
+          autocomplete="off"
+        />
+        <label for="cp-pattern"
+          >Tool pattern
+          <span class="label-hint"
+            >glob syntax: bash*, file_write, *</span
+          ></label
+        >
+        <input
+          id="cp-pattern"
+          type="text"
+          placeholder="bash*"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <label for="cp-action">Action</label>
+        <select id="cp-action">
+          <option value="ask">Ask (require approval)</option>
+          <option value="allow">Allow (auto-approve)</option>
+          <option value="deny">Deny (block)</option>
+        </select>
+        <label for="cp-priority"
+          >Priority
+          <span class="label-hint">higher = evaluated first</span></label
+        >
+        <input id="cp-priority" type="number" value="0" min="0" max="9999" />
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreatePolicyModal()">
+            Cancel
+          </button>
+          <button
+            id="cp-submit"
+            class="modal-submit"
+            onclick="submitCreatePolicy()"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Edit Policy Modal -->
+    <div
+      id="edit-policy-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-policy-title"
+    >
+      <div id="edit-policy-box" class="admin-modal">
+        <h2 id="edit-policy-title">Edit Tool Policy</h2>
+        <div id="edit-policy-error" role="alert" aria-live="assertive"></div>
+        <input id="ep-id" type="hidden" />
+        <label for="ep-name">Name</label>
+        <input id="ep-name" type="text" autocomplete="off" />
+        <label for="ep-pattern">Tool pattern</label>
+        <input
+          id="ep-pattern"
+          type="text"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <label for="ep-action">Action</label>
+        <select id="ep-action">
+          <option value="ask">Ask (require approval)</option>
+          <option value="allow">Allow (auto-approve)</option>
+          <option value="deny">Deny (block)</option>
+        </select>
+        <label for="ep-priority">Priority</label>
+        <input id="ep-priority" type="number" value="0" min="0" max="9999" />
+        <label class="admin-checkbox"
+          ><input id="ep-enabled" type="checkbox" checked /> Enabled</label
+        >
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideEditPolicyModal()">
+            Cancel
+          </button>
+          <button
+            id="ep-submit"
+            class="modal-submit"
+            onclick="submitEditPolicy()"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Prompt Policy Modal -->
+    <div
+      id="create-ppolicy-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-ppolicy-title"
+    >
+      <div id="create-ppolicy-box" class="admin-modal admin-modal-wide">
+        <h2 id="create-ppolicy-title">Create Prompt</h2>
+        <div id="cpp-error" role="alert" aria-live="assertive"></div>
+        <label for="cpp-name"
+          >Name <span class="label-hint">slug-style identifier</span></label
+        >
+        <input
+          id="cpp-name"
+          type="text"
+          placeholder="e.g. web_search, data_handling"
+          autocomplete="off"
+        />
+        <label for="cpp-gate"
+          >Tool Gate
+          <span class="label-hint"
+            >tool name or blank for unconditional</span
+          ></label
+        >
+        <input
+          id="cpp-gate"
+          type="text"
+          placeholder="e.g. web_search"
+          autocomplete="off"
+        />
+        <label for="cpp-content"
+          >Content
+          <span class="label-hint"
+            >markdown body for system message</span
+          ></label
+        >
+        <textarea
+          id="cpp-content"
+          rows="10"
+          placeholder="## Policy Name&#10;&#10;Behavioral guidance..."
+          spellcheck="false"
+        ></textarea>
+        <label for="cpp-priority"
+          >Priority
+          <span class="label-hint"
+            >higher = assembled later (closer to conversation)</span
+          ></label
+        >
+        <input id="cpp-priority" type="number" value="0" min="0" max="9999" />
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreatePromptPolicyModal()">
+            Cancel
+          </button>
+          <button
+            id="cpp-submit"
+            class="modal-submit"
+            onclick="submitCreatePromptPolicy()"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Edit Prompt Policy Modal -->
+    <div
+      id="edit-ppolicy-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-ppolicy-title"
+    >
+      <div id="edit-ppolicy-box" class="admin-modal admin-modal-wide">
+        <h2 id="edit-ppolicy-title">Edit Prompt</h2>
+        <div id="epp-error" role="alert" aria-live="assertive"></div>
+        <input id="epp-id" type="hidden" />
+        <label for="epp-name">Name</label>
+        <input id="epp-name" type="text" autocomplete="off" />
+        <label for="epp-gate">Tool Gate</label>
+        <input id="epp-gate" type="text" autocomplete="off" />
+        <label for="epp-content">Content</label>
+        <textarea id="epp-content" rows="10" spellcheck="false"></textarea>
+        <label for="epp-priority">Priority</label>
+        <input id="epp-priority" type="number" value="0" min="0" max="9999" />
+        <label class="admin-checkbox"
+          ><input id="epp-enabled" type="checkbox" checked /> Enabled</label
+        >
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideEditPromptPolicyModal()">
+            Cancel
+          </button>
+          <button
+            id="epp-submit"
+            class="modal-submit"
+            onclick="submitEditPromptPolicy()"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Skill Modal -->
+    <div
+      id="create-template-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-template-title"
+    >
+      <div
+        id="create-template-box"
+        class="admin-modal admin-modal-wide admin-modal-skill"
+      >
+        <h2 id="create-template-title">Create Skill</h2>
+        <div
+          id="create-template-error"
+          role="alert"
+          aria-live="assertive"
+        ></div>
+        <div class="skill-spec-body">
+          <div class="skill-spec-col skill-spec-col-meta">
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Identity</h3>
+              <label for="ctm-name">Name</label>
+              <input
+                id="ctm-name"
+                type="text"
+                placeholder="e.g. code-review"
+                autocomplete="off"
+              />
+              <label for="ctm-category">Category</label>
+              <select id="ctm-category">
+                <option value="general">General</option>
+                <option value="engineering">Engineering</option>
+                <option value="support">Support</option>
+                <option value="custom">Custom</option>
+              </select>
+              <label for="skill-description">Description</label>
+              <textarea
+                id="skill-description"
+                rows="2"
+                placeholder="Brief description for skill discovery"
+              ></textarea>
+            </div>
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Manifest</h3>
+              <label for="skill-tags">Tags</label>
+              <input
+                id="skill-tags"
+                type="text"
+                placeholder="python, review, quality"
+              />
+              <label for="skill-author">Author</label>
+              <input id="skill-author" type="text" placeholder="Author name" />
+              <label for="skill-version">Version</label>
+              <input id="skill-version" type="text" placeholder="1.0.0" />
+              <label for="skill-license">License</label>
+              <select id="skill-license">
+                <option value="">— not specified —</option>
+                <option value="MIT">MIT</option>
+                <option value="Apache-2.0">Apache-2.0</option>
+                <option value="GPL-2.0">GPL-2.0</option>
+                <option value="GPL-3.0">GPL-3.0</option>
+                <option value="LGPL-2.1">LGPL-2.1</option>
+                <option value="LGPL-3.0">LGPL-3.0</option>
+                <option value="AGPL-3.0">AGPL-3.0</option>
+                <option value="BSD-2-Clause">BSD-2-Clause</option>
+                <option value="BSD-3-Clause">BSD-3-Clause</option>
+                <option value="ISC">ISC</option>
+                <option value="MPL-2.0">MPL-2.0</option>
+                <option value="Unlicense">Unlicense</option>
+                <option value="Proprietary">Proprietary</option>
+              </select>
+              <label for="skill-compatibility"
+                >Compatibility
+                <span class="label-hint"
+                  >environment requirements, max 500 chars</span
+                ></label
+              >
+              <input
+                id="skill-compatibility"
+                type="text"
+                placeholder="Requires git, docker, etc."
+                maxlength="500"
+              />
+            </div>
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Deployment</h3>
+              <label for="skill-activation"
+                >Activation
+                <span class="label-hint"
+                  >how models discover this skill</span
+                ></label
+              >
+              <select id="skill-activation">
+                <option value="named">
+                  Named — explicit /skill invocation
+                </option>
+                <option value="default">
+                  Default — auto-applied to every session
+                </option>
+                <option value="search">Search — BM25 discoverable</option>
+              </select>
+              <label class="admin-checkbox"
+                ><input id="ctm-default" type="checkbox" /> Apply to new
+                workstreams by default</label
+              >
+            </div>
           </div>
-          <div style="flex:1">
-            <label for="eogp-risk">Risk Level</label>
-            <select id="eogp-risk"><option>high</option><option>medium</option><option>low</option></select>
+          <div class="skill-spec-col skill-spec-col-content">
+            <div class="skill-spec-section skill-spec-section-content">
+              <h3 class="skill-spec-heading">
+                Skill Content
+                <span class="label-hint"
+                  >system message &mdash; {{model}}, {{ws_id}},
+                  {{node_id}}</span
+                >
+              </h3>
+              <textarea
+                id="ctm-content"
+                class="skill-content-area"
+                placeholder="You are a code reviewer using {{model}}..."
+              ></textarea>
+              <div class="skill-vars-row">
+                <span class="skill-vars-label">Variables</span>
+                <div
+                  id="ctm-variables"
+                  class="skill-vars-display label-hint"
+                ></div>
+              </div>
+            </div>
           </div>
         </div>
-        <label for="eogp-pattern">Regex Pattern</label>
-        <input id="eogp-pattern" type="text" autocomplete="off" spellcheck="false" style="font-family:var(--font-mono);font-size:12px">
-        <button class="admin-btn-action" style="margin:4px 0 8px" onclick="validateEditOGRegex()">Validate regex</button>
-        <span id="eogp-regex-result" role="status" aria-live="polite" style="font-size:11px;margin-left:8px"></span>
-        <label for="eogp-flag">Flag Name</label>
-        <input id="eogp-flag" type="text" autocomplete="off" spellcheck="false">
-        <label for="eogp-ann">Annotation</label>
-        <input id="eogp-ann" type="text" autocomplete="off">
-        <label for="eogp-flags">Pattern Flags <span class="label-hint">comma-separated: IGNORECASE, MULTILINE, DOTALL</span></label>
-        <input id="eogp-flags" type="text" autocomplete="off">
-        <div style="display:flex;gap:16px;margin:8px 0">
-          <label style="display:flex;align-items:center;gap:6px;font-size:12px"><input id="eogp-cred" type="checkbox"> Is Credential</label>
-          <label style="font-size:12px">Redact Label <input id="eogp-redact" type="text" placeholder="api_key" style="width:100px;margin-left:4px"></label>
+        <details class="admin-details">
+          <summary>
+            Runtime Config
+            <span class="label-hint">model, temperature, token limits</span>
+          </summary>
+          <div class="skill-config-grid">
+            <div>
+              <label for="csk-model">Model</label
+              ><input id="csk-model" type="text" placeholder="Default model" />
+            </div>
+            <div>
+              <label for="csk-temperature">Temperature</label
+              ><input
+                id="csk-temperature"
+                type="number"
+                step="0.1"
+                min="0"
+                max="2"
+                placeholder="System default"
+              />
+            </div>
+            <div>
+              <label for="csk-reasoning-effort">Reasoning Effort</label>
+              <select id="csk-reasoning-effort">
+                <option value="">System default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="xhigh">Extra High</option>
+                <option value="max">Max</option>
+              </select>
+            </div>
+            <div>
+              <label for="csk-max-tokens">Max Tokens</label
+              ><input
+                id="csk-max-tokens"
+                type="number"
+                min="1"
+                placeholder="System default"
+              />
+            </div>
+            <div>
+              <label for="csk-token-budget">Token Budget</label
+              ><input
+                id="csk-token-budget"
+                type="number"
+                min="0"
+                placeholder="0 = unlimited"
+              />
+            </div>
+            <div>
+              <label for="csk-agent-max-turns">Agent Max Turns</label
+              ><input
+                id="csk-agent-max-turns"
+                type="number"
+                min="1"
+                placeholder="System default"
+              />
+            </div>
+          </div>
+          <label class="admin-checkbox"
+            ><input id="csk-auto-approve" type="checkbox" /> Auto-approve all
+            tools</label
+          >
+          <label for="csk-allowed-tools"
+            >Allowed Tools
+            <span class="label-hint"
+              >comma-separated tool names for auto-approve</span
+            ></label
+          >
+          <input
+            id="csk-allowed-tools"
+            type="text"
+            placeholder="bash, read_file, write_file"
+          />
+          <label for="csk-notify-on-complete"
+            >Notify on completion
+            <span class="label-hint">optional</span></label
+          >
+          <textarea
+            id="csk-notify-on-complete"
+            rows="2"
+            placeholder='[{"channel_type":"discord","channel_id":"123..."},{"channel_type":"slack","channel_id":"C0..."}]'
+            spellcheck="false"
+            aria-describedby="csk-notify-hint"
+            style="font-family: var(--font-mono); font-size: 12px"
+          ></textarea>
+          <span
+            id="csk-notify-hint"
+            class="label-hint"
+            style="display: block; margin-top: 3px"
+            >JSON array. Each: channel_type + channel_id or user_id</span
+          >
+          <label class="admin-checkbox"
+            ><input id="csk-enabled" type="checkbox" checked /> Enabled</label
+          >
+        </details>
+        <details class="admin-details">
+          <summary>
+            Resources
+            <span class="label-hint"
+              >bundled files (scripts, references, assets)</span
+            >
+          </summary>
+          <div
+            id="ctm-resources-list"
+            role="list"
+            aria-live="polite"
+            aria-label="Pending resources"
+          ></div>
+          <div
+            style="
+              margin-top: 8px;
+              display: flex;
+              flex-direction: column;
+              gap: 6px;
+            "
+          >
+            <label for="ctm-res-path">Path</label>
+            <input
+              id="ctm-res-path"
+              type="text"
+              placeholder="scripts/setup.sh or references/guide.md"
+            />
+            <label for="ctm-res-content-type">Content Type</label>
+            <input id="ctm-res-content-type" type="text" value="text/plain" />
+            <label for="ctm-res-content">Content</label>
+            <textarea
+              id="ctm-res-content"
+              rows="4"
+              placeholder="Resource file content"
+            ></textarea>
+            <button
+              type="button"
+              class="admin-btn-action"
+              onclick="_addPendingResource()"
+            >
+              Add Resource
+            </button>
+          </div>
+        </details>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateTemplateModal()">
+            Cancel
+          </button>
+          <button
+            id="ctm-submit"
+            class="modal-submit"
+            onclick="submitCreateTemplate()"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Edit Skill Modal -->
+    <div
+      id="edit-template-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-template-title"
+    >
+      <div
+        id="edit-template-box"
+        class="admin-modal admin-modal-wide admin-modal-skill"
+      >
+        <h2 id="edit-template-title">Edit Skill</h2>
+        <div
+          id="etm-origin-badge"
+          class="skill-origin-badge"
+          style="display: none"
+        ></div>
+        <div id="edit-template-error" role="alert" aria-live="assertive"></div>
+        <input id="etm-id" type="hidden" />
+        <div class="skill-spec-body">
+          <div class="skill-spec-col skill-spec-col-meta">
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Identity</h3>
+              <label for="etm-name">Name</label>
+              <input id="etm-name" type="text" autocomplete="off" />
+              <label for="etm-category">Category</label>
+              <select id="etm-category">
+                <option value="general">General</option>
+                <option value="engineering">Engineering</option>
+                <option value="support">Support</option>
+                <option value="custom">Custom</option>
+              </select>
+              <label for="etm-description">Description</label>
+              <textarea
+                id="etm-description"
+                rows="2"
+                placeholder="Brief description for skill discovery"
+              ></textarea>
+            </div>
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Manifest</h3>
+              <label for="etm-tags">Tags</label>
+              <input
+                id="etm-tags"
+                type="text"
+                placeholder="python, review, quality"
+              />
+              <label for="etm-author">Author</label>
+              <input id="etm-author" type="text" placeholder="Author name" />
+              <label for="etm-version">Version</label>
+              <input id="etm-version" type="text" placeholder="1.0.0" />
+              <label for="etm-license">License</label>
+              <select id="etm-license">
+                <option value="">— not specified —</option>
+                <option value="MIT">MIT</option>
+                <option value="Apache-2.0">Apache-2.0</option>
+                <option value="GPL-2.0">GPL-2.0</option>
+                <option value="GPL-3.0">GPL-3.0</option>
+                <option value="LGPL-2.1">LGPL-2.1</option>
+                <option value="LGPL-3.0">LGPL-3.0</option>
+                <option value="AGPL-3.0">AGPL-3.0</option>
+                <option value="BSD-2-Clause">BSD-2-Clause</option>
+                <option value="BSD-3-Clause">BSD-3-Clause</option>
+                <option value="ISC">ISC</option>
+                <option value="MPL-2.0">MPL-2.0</option>
+                <option value="Unlicense">Unlicense</option>
+                <option value="Proprietary">Proprietary</option>
+              </select>
+              <label for="etm-compatibility"
+                >Compatibility
+                <span class="label-hint"
+                  >environment requirements, max 500 chars</span
+                ></label
+              >
+              <input
+                id="etm-compatibility"
+                type="text"
+                placeholder="Requires git, docker, etc."
+                maxlength="500"
+              />
+            </div>
+            <div class="skill-spec-section">
+              <h3 class="skill-spec-heading">Deployment</h3>
+              <label for="etm-activation"
+                >Activation
+                <span class="label-hint"
+                  >how models discover this skill</span
+                ></label
+              >
+              <select id="etm-activation">
+                <option value="named">
+                  Named — explicit /skill invocation
+                </option>
+                <option value="default">
+                  Default — auto-applied to every session
+                </option>
+                <option value="search">Search — BM25 discoverable</option>
+              </select>
+              <label class="admin-checkbox"
+                ><input id="etm-default" type="checkbox" /> Apply to new
+                workstreams by default</label
+              >
+            </div>
+          </div>
+          <div class="skill-spec-col skill-spec-col-content">
+            <div class="skill-spec-section skill-spec-section-content">
+              <h3 class="skill-spec-heading">
+                Skill Content
+                <span class="label-hint"
+                  >{{model}}, {{ws_id}}, {{node_id}}</span
+                >
+              </h3>
+              <textarea id="etm-content" class="skill-content-area"></textarea>
+              <div class="skill-vars-row">
+                <span class="skill-vars-label">Variables</span>
+                <div
+                  id="etm-variables"
+                  class="skill-vars-display label-hint"
+                ></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <details class="admin-details">
+          <summary>
+            Runtime Config
+            <span class="label-hint">model, temperature, token limits</span>
+          </summary>
+          <div class="skill-config-grid">
+            <div>
+              <label for="esk-model">Model</label
+              ><input id="esk-model" type="text" placeholder="Default model" />
+            </div>
+            <div>
+              <label for="esk-temperature">Temperature</label
+              ><input
+                id="esk-temperature"
+                type="number"
+                step="0.1"
+                min="0"
+                max="2"
+                placeholder="System default"
+              />
+            </div>
+            <div>
+              <label for="esk-reasoning-effort">Reasoning Effort</label>
+              <select id="esk-reasoning-effort">
+                <option value="">System default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="xhigh">Extra High</option>
+                <option value="max">Max</option>
+              </select>
+            </div>
+            <div>
+              <label for="esk-max-tokens">Max Tokens</label
+              ><input
+                id="esk-max-tokens"
+                type="number"
+                min="1"
+                placeholder="System default"
+              />
+            </div>
+            <div>
+              <label for="esk-token-budget">Token Budget</label
+              ><input
+                id="esk-token-budget"
+                type="number"
+                min="0"
+                placeholder="0 = unlimited"
+              />
+            </div>
+            <div>
+              <label for="esk-agent-max-turns">Agent Max Turns</label
+              ><input
+                id="esk-agent-max-turns"
+                type="number"
+                min="1"
+                placeholder="System default"
+              />
+            </div>
+          </div>
+          <label class="admin-checkbox"
+            ><input id="esk-auto-approve" type="checkbox" /> Auto-approve all
+            tools</label
+          >
+          <label for="esk-allowed-tools"
+            >Allowed Tools
+            <span class="label-hint"
+              >comma-separated tool names for auto-approve</span
+            ></label
+          >
+          <input
+            id="esk-allowed-tools"
+            type="text"
+            placeholder="bash, read_file, write_file"
+          />
+          <label for="esk-notify-on-complete"
+            >Notify on completion
+            <span class="label-hint">optional</span></label
+          >
+          <textarea
+            id="esk-notify-on-complete"
+            rows="2"
+            placeholder='[{"channel_type":"discord","channel_id":"123..."},{"channel_type":"slack","channel_id":"C0..."}]'
+            spellcheck="false"
+            aria-describedby="esk-notify-hint"
+            style="font-family: var(--font-mono); font-size: 12px"
+          ></textarea>
+          <span
+            id="esk-notify-hint"
+            class="label-hint"
+            style="display: block; margin-top: 3px"
+            >JSON array. Each: channel_type + channel_id or user_id</span
+          >
+          <label class="admin-checkbox"
+            ><input id="esk-enabled" type="checkbox" checked /> Enabled</label
+          >
+        </details>
+        <div id="etm-scan-section" style="display: none" class="admin-field">
+          <span class="admin-field-heading" id="etm-scan-heading"
+            >Security Scan</span
+          >
+          <div id="etm-scan-report" aria-labelledby="etm-scan-heading"></div>
+          <button
+            type="button"
+            id="etm-rescan-btn"
+            class="admin-btn-action"
+            style="margin-top: 8px"
+          >
+            Re-scan
+          </button>
+        </div>
+        <details id="etm-resources-section" class="admin-details">
+          <summary>
+            Resources
+            <span class="label-hint">bundled files for this skill</span>
+          </summary>
+          <div
+            id="etm-resources-list"
+            role="list"
+            aria-live="polite"
+            aria-label="Skill resources"
+          ></div>
+          <button
+            type="button"
+            id="etm-add-resource-btn"
+            class="admin-btn-action"
+            style="margin-top: 8px"
+            onclick="
+              _showAddResourceForm(document.getElementById('etm-id').value)
+            "
+          >
+            Add Resource
+          </button>
+          <div id="etm-add-resource-form" style="display: none">
+            <div
+              style="
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                margin-top: 8px;
+              "
+            >
+              <label for="etm-res-path">Path</label>
+              <input
+                id="etm-res-path"
+                type="text"
+                placeholder="scripts/setup.sh or references/guide.md"
+              />
+              <label for="etm-res-content-type">Content Type</label>
+              <input id="etm-res-content-type" type="text" value="text/plain" />
+              <label for="etm-res-content">Content</label>
+              <textarea
+                id="etm-res-content"
+                rows="4"
+                placeholder="Resource file content"
+              ></textarea>
+              <button
+                type="button"
+                id="etm-res-submit"
+                class="admin-btn-action"
+              >
+                Upload
+              </button>
+            </div>
+          </div>
+        </details>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideEditTemplateModal()">
+            Cancel
+          </button>
+          <button
+            id="etm-submit"
+            class="modal-submit"
+            onclick="submitEditTemplate()"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      id="memory-detail-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="memory-detail-title"
+    >
+      <div id="memory-detail-box" class="admin-modal admin-modal-wide">
+        <h2 id="memory-detail-title">Memory Detail</h2>
+        <div id="memory-detail-body"></div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideMemoryDetailModal()">
+            Close
+          </button>
+          <button id="mem-detail-delete" class="modal-submit admin-btn-danger">
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      id="mcp-create-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mcp-create-title"
+    >
+      <div id="mcp-create-box" class="admin-modal">
+        <h2 id="mcp-create-title">Add MCP Server</h2>
+        <div
+          id="mcp-create-error"
+          role="alert"
+          aria-live="assertive"
+          style="display: none"
+        ></div>
+        <input type="hidden" id="mcp-edit-id" value="" />
+        <label for="mcp-name">Server Name</label>
+        <input
+          type="text"
+          id="mcp-name"
+          placeholder="e.g. filesystem"
+          maxlength="64"
+          pattern="[a-zA-Z0-9._-]+"
+        />
+        <label for="mcp-transport">Transport</label>
+        <select id="mcp-transport" onchange="toggleMcpTransport()">
+          <option value="stdio">stdio</option>
+          <option value="streamable-http">streamable-http</option>
+        </select>
+        <div id="mcp-stdio-fields">
+          <label for="mcp-command">Command</label>
+          <input type="text" id="mcp-command" placeholder="e.g. npx" />
+          <label for="mcp-args"
+            >Arguments
+            <span style="font-weight: 400; text-transform: none"
+              >(one per line)</span
+            ></label
+          >
+          <textarea
+            id="mcp-args"
+            rows="3"
+            placeholder="-y&#10;@modelcontextprotocol/server-filesystem&#10;/tmp"
+          ></textarea>
+          <label for="mcp-env"
+            >Environment Variables
+            <span style="font-weight: 400; text-transform: none"
+              >(KEY=VALUE, one per line)</span
+            ></label
+          >
+          <textarea id="mcp-env" rows="2" placeholder="API_KEY=..."></textarea>
+        </div>
+        <div id="mcp-http-fields" style="display: none">
+          <label for="mcp-url">URL</label>
+          <input type="text" id="mcp-url" placeholder="https://..." />
+          <label for="mcp-headers"
+            >Headers
+            <span style="font-weight: 400; text-transform: none"
+              >(KEY: VALUE, one per line)</span
+            ></label
+          >
+          <textarea
+            id="mcp-headers"
+            rows="2"
+            placeholder="Authorization: Bearer ..."
+          ></textarea>
+        </div>
+        <div style="display: flex; gap: 20px; margin-top: 14px">
+          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            ><input
+              type="checkbox"
+              id="mcp-auto-approve"
+              style="margin-right: 5px"
+            />Auto-approve tools</label
+          >
+          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            ><input
+              type="checkbox"
+              id="mcp-enabled"
+              checked
+              style="margin-right: 5px"
+            />Enabled</label
+          >
         </div>
         <div class="modal-buttons">
-          <button class="modal-cancel" onclick="hideEditOGPModal()">Cancel</button>
-          <button id="eogp-submit" class="modal-submit" onclick="submitEditOGPattern()">Save</button>
+          <button class="modal-cancel" onclick="hideCreateMcpModal()">
+            Cancel
+          </button>
+          <button
+            id="mcp-create-submit"
+            class="modal-submit"
+            onclick="submitCreateMcp()"
+          >
+            Create
+          </button>
         </div>
       </div>
     </div>
 
-    <!-- Skills Tab -->
-    <div id="admin-skills" class="admin-panel" role="tabpanel" aria-labelledby="tab-skills" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">SKILLS</span>
-        <div class="mcp-view-toggle" role="tablist" aria-label="Skills view">
-          <button class="mcp-view-btn active" id="skill-tab-installed" data-skill-view="installed" role="tab" aria-selected="true" aria-controls="skill-view-installed" tabindex="0" onclick="switchSkillView('installed')">Installed</button>
-          <button class="mcp-view-btn" id="skill-tab-discover" data-skill-view="discover" role="tab" aria-selected="false" aria-controls="skill-view-discover" tabindex="-1" onclick="switchSkillView('discover')">Discover</button>
-        </div>
-        <span id="skill-installed-toolbar">
-          <button class="admin-action-btn" onclick="showCreateTemplateModal()">+ Create skill</button>
-        </span>
-      </div>
-      <!-- Installed view -->
-      <div id="skill-view-installed" role="tabpanel" aria-labelledby="skill-tab-installed">
-        <div class="admin-colheaders" aria-hidden="true">
-          <span class="admin-col admin-col-tmcat">CATEGORY</span>
-          <span class="admin-col admin-col-tmname">NAME</span>
-          <span class="admin-col admin-col-tmrisk">RISK</span>
-          <span class="admin-col admin-col-actions">ACTIONS</span>
-        </div>
-        <div id="admin-skills-table" role="list" aria-label="Skills" aria-live="polite">
-          <div class="dashboard-empty">No skills configured</div>
-        </div>
-      </div>
-      <!-- Discover view -->
-      <div id="skill-view-discover" role="tabpanel" aria-labelledby="skill-tab-discover" style="display:none">
-        <div class="mcp-registry-notice" role="note">
-          <span class="mcp-registry-notice-icon" aria-hidden="true">&#9432;</span>
-          Skills are community-published and not vetted by Turnstone.<br>
-          <span style="margin-left:19px">Review source content before installing.</span>
-        </div>
-        <div class="mcp-registry-search">
-          <input id="skill-discover-q" type="search" placeholder="Search skills..." autocomplete="off" aria-label="Search skills" onkeydown="if(event.key==='Enter'){event.preventDefault();searchSkillDiscover()}">
-          <button id="skill-discover-search-btn" class="admin-action-btn" onclick="searchSkillDiscover()">Search</button>
-          <button class="admin-action-btn admin-action-btn-ghost" onclick="showGitHubImportModal()">Import from GitHub</button>
-        </div>
-        <div id="skill-discover-results" role="list" aria-label="Discovered skills">
-          <div class="dashboard-empty">Search external registries to discover and install skills</div>
+    <div
+      id="mcp-import-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mcp-import-title"
+    >
+      <div id="mcp-import-box" class="admin-modal">
+        <h2 id="mcp-import-title">Import MCP Config</h2>
+        <div
+          id="mcp-import-error"
+          role="alert"
+          aria-live="assertive"
+          style="display: none"
+        ></div>
+        <label for="mcp-import-json">Paste JSON</label>
+        <textarea
+          id="mcp-import-json"
+          rows="10"
+          placeholder='{"mcpServers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}'
+          style="font-family: var(--font-mono); font-size: 11px"
+        ></textarea>
+        <p style="font-size: 11px; color: var(--fg-dim); margin-top: 8px">
+          Paste a JSON object with a <code>mcpServers</code> key (Claude Desktop
+          / VS Code / Cursor format). Existing servers with the same name will
+          be skipped.
+        </p>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideImportMcpModal()">
+            Cancel
+          </button>
+          <button
+            id="mcp-import-submit"
+            class="modal-submit"
+            onclick="submitImportMcp()"
+          >
+            Import
+          </button>
         </div>
       </div>
     </div>
 
-    <!-- Usage Tab -->
-    <div id="admin-usage" class="admin-panel" role="tabpanel" aria-labelledby="tab-usage" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">USAGE</span>
-        <div class="usage-range-group" role="group" aria-label="Time range">
-          <button class="usage-range-btn" data-range="24h" aria-pressed="false" onclick="setUsageRange('24h')">24h</button>
-          <button class="usage-range-btn active" data-range="7d" aria-pressed="true" onclick="setUsageRange('7d')">7d</button>
-          <button class="usage-range-btn" data-range="30d" aria-pressed="false" onclick="setUsageRange('30d')">30d</button>
+    <div
+      id="mcp-detail-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mcp-detail-title"
+    >
+      <div
+        id="mcp-detail-box"
+        class="admin-modal admin-modal-wide mcp-detail-modal"
+      >
+        <h2 id="mcp-detail-title">MCP Server Detail</h2>
+        <div id="mcp-detail-content"></div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideMcpDetailModal()">
+            Close
+          </button>
         </div>
-        <div class="usage-range-group" role="group" aria-label="Group by">
-          <button class="usage-group-btn active" data-group="day" aria-pressed="true" onclick="setUsageGroupBy('day')">day</button>
-          <button class="usage-group-btn" data-group="model" aria-pressed="false" onclick="setUsageGroupBy('model')">model</button>
-          <button class="usage-group-btn" data-group="user" aria-pressed="false" onclick="setUsageGroupBy('user')">user</button>
-        </div>
-      </div>
-      <div id="admin-usage-content">
-        <div class="dashboard-empty">Loading usage data...</div>
       </div>
     </div>
 
-    <!-- Audit Tab -->
-    <div id="admin-audit" class="admin-panel" role="tabpanel" aria-labelledby="tab-audit" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">AUDIT LOG</span>
-        <label for="audit-action-filter" class="sr-only">Filter by action</label>
-        <select id="audit-action-filter" onchange="loadGovAudit()">
-          <option value="">All actions</option>
-          <option value="user.create">user.create</option>
-          <option value="user.delete">user.delete</option>
-          <option value="token.create">token.create</option>
-          <option value="token.revoke">token.revoke</option>
-          <option value="role.create">role.create</option>
-          <option value="role.update">role.update</option>
-          <option value="role.delete">role.delete</option>
-          <option value="role.assign">role.assign</option>
-          <option value="role.unassign">role.unassign</option>
-          <option value="policy.create">policy.create</option>
-          <option value="policy.update">policy.update</option>
-          <option value="policy.delete">policy.delete</option>
-          <option value="skill.create">skill.create</option>
-          <option value="skill.update">skill.update</option>
-          <option value="skill.delete">skill.delete</option>
+    <div
+      id="mcp-install-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mcp-install-title"
+    >
+      <div id="mcp-install-box" class="admin-modal">
+        <h2 id="mcp-install-title">Install MCP Server</h2>
+        <div
+          id="mcp-install-error"
+          role="alert"
+          aria-live="assertive"
+          style="display: none"
+        ></div>
+        <div id="mcp-install-summary"></div>
+        <div id="mcp-install-source-select"></div>
+        <div id="mcp-install-fields"></div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideInstallMcpModal()">
+            Cancel
+          </button>
+          <button
+            id="mcp-install-submit"
+            class="modal-submit"
+            onclick="submitInstallMcp()"
+          >
+            Install
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Model create/edit modal -->
+    <div
+      id="model-create-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="model-create-title"
+    >
+      <div id="model-create-box" class="admin-modal">
+        <h2 id="model-create-title">Add Model</h2>
+        <div id="model-create-error" role="alert" aria-live="assertive"></div>
+        <input type="hidden" id="model-edit-id" value="" />
+        <label for="model-alias">Alias</label>
+        <input
+          type="text"
+          id="model-alias"
+          placeholder="e.g. gpt5-prod"
+          maxlength="64"
+          pattern="[a-zA-Z0-9._-]+"
+        />
+        <label for="model-name"
+          >Model ID
+          <span style="font-weight: 400; text-transform: none"
+            >(type to autocomplete)</span
+          ></label
+        >
+        <input
+          type="text"
+          id="model-name"
+          placeholder="e.g. gpt-5"
+          list="model-name-suggestions"
+        />
+        <datalist id="model-name-suggestions"></datalist>
+        <label for="model-provider">Provider</label>
+        <select id="model-provider">
+          <option value="openai">openai</option>
+          <option value="anthropic">anthropic</option>
+          <option value="google">google</option>
+          <option value="openai-compatible">openai-compatible</option>
         </select>
-        <label for="audit-user-filter" class="sr-only">Filter by user</label>
-        <select id="audit-user-filter" onchange="loadGovAudit()">
-          <option value="">All users</option>
+        <label for="model-base-url"
+          >Base URL
+          <span style="font-weight: 400; text-transform: none"
+            >(empty = provider default)</span
+          ></label
+        >
+        <input
+          type="text"
+          id="model-base-url"
+          placeholder="https://api.openai.com/v1"
+        />
+        <label for="model-api-key"
+          >API Key
+          <span style="font-weight: 400; text-transform: none"
+            >(write-only, never displayed)</span
+          ></label
+        >
+        <input
+          type="password"
+          id="model-api-key"
+          placeholder="sk-..."
+          autocomplete="off"
+        />
+        <label for="model-ctx-window"
+          >Context Window
+          <span style="font-weight: 400; text-transform: none"
+            >(0 = auto-detect from model)</span
+          ></label
+        >
+        <input type="number" id="model-ctx-window" value="0" min="0" />
+        <div class="modal-section-divider" role="separator">
+          Sampling Defaults
+        </div>
+        <label for="model-temperature"
+          >Temperature
+          <span style="font-weight: 400; text-transform: none"
+            >(empty = use global default)</span
+          ></label
+        >
+        <input
+          type="number"
+          id="model-temperature"
+          placeholder="Global default"
+          step="0.1"
+          min="0"
+          max="2"
+        />
+        <label for="model-max-tokens"
+          >Max Tokens
+          <span style="font-weight: 400; text-transform: none"
+            >(empty = use global default)</span
+          ></label
+        >
+        <input
+          type="number"
+          id="model-max-tokens"
+          placeholder="Global default"
+          min="1"
+        />
+        <label for="model-reasoning-effort"
+          >Reasoning Effort
+          <span style="font-weight: 400; text-transform: none"
+            >(empty = use global default)</span
+          ></label
+        >
+        <select id="model-reasoning-effort">
+          <option value="">Global default</option>
+          <option value="none">None</option>
+          <option value="minimal">Minimal</option>
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+          <option value="xhigh">Extra High</option>
+          <option value="max">Max</option>
         </select>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-atime">TIME</span>
-        <span class="admin-col admin-col-auser">USER</span>
-        <span class="admin-col admin-col-aaction">ACTION</span>
-        <span class="admin-col admin-col-aresource">RESOURCE</span>
-        <span class="admin-col admin-col-adetail">DETAIL</span>
-      </div>
-      <div id="admin-audit-table" role="list" aria-label="Audit events" aria-live="polite">
-        <div class="dashboard-empty">Loading audit log...</div>
-      </div>
-    </div>
-
-    <!-- Memories Tab -->
-    <div id="admin-memories" class="admin-panel" role="tabpanel" aria-labelledby="tab-memories" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">MEMORIES</span>
-        <div class="admin-toolbar-filters">
-          <select id="mem-filter-type" onchange="loadAdminMemories()" aria-label="Filter by type">
-            <option value="">All types</option>
-            <option value="user">user</option>
-            <option value="project">project</option>
-            <option value="feedback">feedback</option>
-            <option value="reference">reference</option>
-          </select>
-          <select id="mem-filter-scope" onchange="loadAdminMemories()" aria-label="Filter by scope">
-            <option value="">All scopes</option>
-            <option value="global">global</option>
-            <option value="workstream">workstream</option>
-            <option value="user">user</option>
-          </select>
-          <input id="mem-search" type="search" placeholder="Search memories…" aria-label="Search memories" autocomplete="off">
-        </div>
-      </div>
-      <div class="admin-colheaders" aria-hidden="true">
-        <span class="admin-col admin-col-mname">NAME</span>
-        <span class="admin-col admin-col-mtype">TYPE</span>
-        <span class="admin-col admin-col-mscope">SCOPE</span>
-        <span class="admin-col admin-col-mdesc">DESCRIPTION</span>
-        <span class="admin-col admin-col-mupdated">UPDATED</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="admin-memories-table" role="list" aria-label="Memories" aria-live="polite">
-        <div class="dashboard-empty">Loading…</div>
-      </div>
-    </div>
-
-    <!-- Models Tab -->
-    <div id="admin-models" class="admin-panel" role="tabpanel" aria-labelledby="tab-models" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header">Models</span>
-        <button id="model-sync-btn" class="admin-action-btn admin-action-btn-ghost" onclick="reloadModelNodes()" title="Push model config to all cluster nodes">Sync to Nodes</button>
-        <button class="admin-action-btn" onclick="showCreateModelModal()">+ Add Model</button>
-      </div>
-      <div class="admin-colheaders models-grid" aria-hidden="true">
-        <span class="admin-col">ALIAS</span>
-        <span class="admin-col">MODEL</span>
-        <span class="admin-col">PROVIDER</span>
-        <span class="admin-col">CTX WINDOW</span>
-        <span class="admin-col">STATUS</span>
-        <span class="admin-col">ACTIONS</span>
-      </div>
-      <div id="admin-models-table" role="list" aria-label="Model definitions" aria-live="polite">
-        <div class="dashboard-empty">Loading...</div>
-      </div>
-    </div>
-
-    <!-- Node Metadata Tab -->
-    <div id="admin-node-metadata" class="admin-panel" role="tabpanel" aria-labelledby="tab-node-metadata" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">NODE METADATA</span>
-      </div>
-      <div id="admin-node-metadata-content" role="list" aria-label="Node metadata" aria-live="polite">
-        <div class="dashboard-empty">Loading&hellip;</div>
-      </div>
-    </div>
-
-    <!-- Settings Tab -->
-    <div id="admin-settings" class="admin-panel" role="tabpanel" aria-labelledby="tab-settings" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">SETTINGS</span>
-        <a href="/docs#/System:%20Settings" target="_blank" rel="noopener" class="settings-docs-link" title="Settings API reference">docs</a>
-      </div>
-      <div id="admin-settings-content">
-        <div class="dashboard-empty">Loading&hellip;</div>
-      </div>
-    </div>
-
-    <!-- TLS Tab -->
-    <div id="admin-tls" class="admin-panel" role="tabpanel" aria-labelledby="tab-tls" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header" style="margin:0">TLS / CERTIFICATES</span>
-      </div>
-      <div id="tls-ca-status"></div>
-      <div class="admin-colheaders admin-colheaders-tls" aria-hidden="true">
-        <span class="admin-col">DOMAIN</span>
-        <span class="admin-col">SANS</span>
-        <span class="admin-col">ISSUED</span>
-        <span class="admin-col">EXPIRES</span>
-        <span class="admin-col admin-col-actions">ACTIONS</span>
-      </div>
-      <div id="tls-cert-list" role="list" aria-label="TLS certificates" aria-live="polite">
-        <div class="dashboard-empty">Loading&hellip;</div>
-      </div>
-    </div>
-
-    <div id="admin-mcp" class="admin-panel" role="tabpanel" aria-labelledby="tab-mcp" style="display:none">
-      <div class="admin-toolbar">
-        <span class="section-header">MCP</span>
-        <div class="mcp-view-toggle" role="tablist" aria-label="MCP view">
-          <button class="mcp-view-btn active" data-mcp-view="servers" role="tab" aria-selected="true" aria-controls="mcp-view-servers" tabindex="0" onclick="switchMcpView('servers')">Servers</button>
-          <button class="mcp-view-btn" data-mcp-view="registry" role="tab" aria-selected="false" aria-controls="mcp-view-registry" tabindex="-1" onclick="switchMcpView('registry')">Discover</button>
-        </div>
-        <span id="mcp-servers-toolbar">
-          <button id="mcp-sync-btn" class="admin-action-btn admin-action-btn-ghost" onclick="reloadMcpNodes()" title="Push MCP server config to all cluster nodes and reconnect">Sync to Nodes</button>
-          <button class="admin-action-btn admin-action-btn-ghost" onclick="showImportMcpModal()">Import JSON</button>
-          <button class="admin-action-btn" onclick="showCreateMcpModal()">+ Add Server</button>
-        </span>
-      </div>
-      <div id="mcp-view-servers" role="tabpanel">
-        <div class="admin-colheaders mcp-grid" aria-hidden="true">
-          <span class="admin-col admin-col-mname">NAME</span>
-          <span class="admin-col admin-col-mtransport">TRANSPORT</span>
-          <span class="admin-col admin-col-mtools">TOOLS</span>
-          <span class="admin-col admin-col-mres">RES</span>
-          <span class="admin-col admin-col-mprompts">PROMPTS</span>
-          <span class="admin-col admin-col-mstatus">STATUS</span>
-          <span class="admin-col admin-col-mactions">ACTIONS</span>
-        </div>
-        <div id="admin-mcp-table" role="list" aria-label="MCP servers">
-          <div class="dashboard-empty">Loading...</div>
-        </div>
-      </div>
-      <div id="mcp-view-registry" role="tabpanel" style="display:none">
-        <div class="mcp-registry-notice" role="note">
-          <span class="mcp-registry-notice-icon" aria-hidden="true">&#9432;</span>
-          Servers are community-published via the <a href="https://registry.modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">official MCP Registry</a> and not vetted by Turnstone.<br>
-          <span style="margin-left:19px">Review source repositories before installing.</span>
-        </div>
-        <div class="mcp-registry-search">
-          <input id="mcp-registry-q" type="search" placeholder="Search MCP servers..." autocomplete="off" aria-label="Search registry" onkeydown="if(event.key==='Enter'){event.preventDefault();searchMcpRegistry()}">
-          <select id="mcp-registry-filter" aria-label="Filter by type" onchange="_applyRegistryFilter()">
-            <option value="">All types</option>
-            <option value="remote">Remote only</option>
-            <option value="npm">npm only</option>
-            <option value="pypi">PyPI only</option>
-          </select>
-          <button id="mcp-registry-search-btn" class="admin-action-btn" onclick="searchMcpRegistry()">Search</button>
-        </div>
-        <div id="mcp-registry-results" role="list" aria-label="Registry servers">
-          <div class="dashboard-empty">Search the official MCP Registry to discover and install servers</div>
-        </div>
-        <div id="mcp-registry-pagination" style="display:none">
-          <button id="mcp-registry-more" class="admin-action-btn admin-action-btn-ghost" onclick="loadMoreRegistry()">Load more</button>
-          <span id="mcp-registry-count" class="mcp-registry-count-label"></span>
-        </div>
-      </div>
-    </div>
-
-      </div><!-- /admin-content -->
-    </div><!-- /admin-layout -->
-  </div>
-</div>
-
-<div id="cluster-status-bar" role="region" aria-label="Cluster status">
-  <div class="csb-states" id="csb-states"><span class="csb-loading">Loading...</span></div>
-  <div class="csb-divider" aria-hidden="true"></div>
-  <div class="csb-metrics" id="csb-metrics"></div>
-</div>
-
-<div id="toast" role="status" aria-live="polite"></div>
-<script>
-window.TURNSTONE_AUTH_TITLE = "turnstone console";
-window.TURNSTONE_TOAST_TIMEOUT = 4000;
-window.TURNSTONE_KB_SHORTCUTS = [
-  { title: "Navigation", keys: [
-    { desc: "Activate card / row", badge: '<span class="kb-key">Enter</span>' },
-    { desc: "Activate card / row", badge: '<span class="kb-key">Space</span>' },
-    { desc: "Navigate rows", badge: '<span class="kb-key">\u2191</span> <span class="kb-key">\u2193</span>' }
-  ]},
-  { title: "General", keys: [
-    { desc: "Submit form from textarea", badge: '<span class="kb-key">' + (navigator.platform && navigator.platform.indexOf("Mac") > -1 ? "\u2318" : "Ctrl") + '</span>+<span class="kb-key">Enter</span>' },
-    { desc: "Show this help", badge: '<span class="kb-key">?</span>' },
-    { desc: "Close overlay", badge: '<span class="kb-key">Esc</span>' }
-  ]}
-];
-</script>
-<script src="/shared/utils.js"></script>
-<script src="/shared/toast.js"></script>
-<script src="/shared/theme.js"></script>
-<script src="/shared/auth.js"></script>
-<script src="/shared/kb.js"></script>
-<script src="/shared/composer.js"></script>
-
-<div id="new-ws-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="new-ws-title">
-  <div id="new-ws-box">
-    <h2 id="new-ws-title">New Workstream</h2>
-    <div id="new-ws-error" role="alert" aria-live="assertive"></div>
-    <label for="new-ws-task">Task <span class="label-hint">optional &mdash; sent as first message</span></label>
-    <textarea id="new-ws-task" rows="4" placeholder="What should this workstream work on?"></textarea>
-    <label for="new-ws-node">Node</label>
-    <select id="new-ws-node">
-      <option value="">Auto (best available)</option>
-    </select>
-    <label for="new-ws-name">Name <span class="label-hint">optional</span></label>
-    <input id="new-ws-name" type="text" placeholder="Auto-generated if empty" autocomplete="off">
-    <label for="new-ws-model">Model <span class="label-hint">optional</span></label>
-    <select id="new-ws-model">
-      <option value="">Default model</option>
-    </select>
-    <label for="new-ws-skill">Skill <span class="label-hint">optional</span></label>
-    <select id="new-ws-skill">
-      <option value="">Use defaults</option>
-    </select>
-    <label for="new-ws-judge">Judge Model <span class="label-hint">optional</span></label>
-    <select id="new-ws-judge">
-      <option value="">Default (agent model)</option>
-    </select>
-    <div id="new-ws-buttons">
-      <button id="new-ws-cancel" onclick="hideNewWsModal()">Cancel</button>
-      <button id="new-ws-submit" onclick="submitNewWs()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- GitHub Import Modal -->
-<div id="github-import-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="github-import-title">
-  <div id="github-import-box" class="admin-modal">
-    <h2 id="github-import-title">Import from GitHub</h2>
-    <div id="github-import-error" role="alert" aria-live="assertive"></div>
-    <label for="gi-url">GitHub URL</label>
-    <input id="gi-url" type="url" placeholder="https://github.com/owner/repo" autocomplete="off" spellcheck="false" aria-describedby="gi-url-hint">
-    <p id="gi-url-hint" style="font-size:11px;color:var(--fg-dim);margin:4px 0 12px">Paste a link to a repository or SKILL.md file</p>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideGitHubImportModal()">Cancel</button>
-      <button id="gi-submit" class="modal-submit" onclick="submitGitHubImport()">Install</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create User Modal -->
-<div id="create-user-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-user-title">
-  <div id="create-user-box" class="admin-modal">
-    <h2 id="create-user-title">Create User</h2>
-    <div id="create-user-error" role="alert" aria-live="assertive"></div>
-    <label for="cu-username">Username</label>
-    <input id="cu-username" type="text" placeholder="login username" autocomplete="off" spellcheck="false">
-    <label for="cu-displayname">Display name</label>
-    <input id="cu-displayname" type="text" placeholder="Full name" autocomplete="off">
-    <label for="cu-password">Password</label>
-    <input id="cu-password" type="password" placeholder="Minimum 8 characters" autocomplete="new-password">
-    <label for="cu-confirm">Confirm password</label>
-    <input id="cu-confirm" type="password" placeholder="Confirm password" autocomplete="new-password">
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateUserModal()">Cancel</button>
-      <button id="cu-submit" class="modal-submit" onclick="submitCreateUser()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Token Modal -->
-<div id="create-token-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-token-title">
-  <div id="create-token-box" class="admin-modal">
-    <h2 id="create-token-title">Create API Token</h2>
-    <div id="create-token-error" role="alert" aria-live="assertive"></div>
-    <label for="ct-name">Token name <span class="label-hint">optional</span></label>
-    <input id="ct-name" type="text" placeholder="e.g. CI pipeline, bridge-prod" autocomplete="off">
-    <label for="ct-scopes">Scopes</label>
-    <select id="ct-scopes">
-      <option value="read,write,approve">Full access (read, write, approve)</option>
-      <option value="read,write">Read + write</option>
-      <option value="read">Read only</option>
-    </select>
-    <label for="ct-expires">Expiry <span class="label-hint">optional</span></label>
-    <select id="ct-expires">
-      <option value="">Never</option>
-      <option value="30">30 days</option>
-      <option value="90">90 days</option>
-      <option value="365">1 year</option>
-    </select>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateTokenModal()">Cancel</button>
-      <button id="ct-submit" class="modal-submit" onclick="submitCreateToken()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Token Created (show-once) Modal -->
-<div id="token-created-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="token-created-title">
-  <div id="token-created-box" class="admin-modal">
-    <h2 id="token-created-title">Token Created</h2>
-    <p class="token-created-warning">Copy this token now. It will not be shown again.</p>
-    <div id="token-created-value" class="token-display"></div>
-    <div class="modal-buttons">
-      <button class="modal-submit" onclick="copyCreatedToken()">Copy to clipboard</button>
-      <button class="modal-cancel" onclick="hideTokenCreatedModal()">Done</button>
-    </div>
-  </div>
-</div>
-
-<!-- Confirm Action Modal (reusable) -->
-<div id="confirm-overlay" style="display:none" role="alertdialog" aria-modal="true" aria-labelledby="confirm-title" aria-describedby="confirm-message">
-  <div id="confirm-box" class="admin-modal">
-    <h2 id="confirm-title">Confirm</h2>
-    <p id="confirm-message" style="color:var(--fg-dim);margin:12px 0 20px;line-height:1.5"></p>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideConfirmModal()">Cancel</button>
-      <button id="confirm-submit" class="modal-submit" style="background:var(--red);border-color:var(--red)" onclick="_confirmCallback()">Confirm</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Channel Link Modal -->
-<div id="create-channel-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-channel-title">
-  <div id="create-channel-box" class="admin-modal">
-    <h2 id="create-channel-title">Link Channel Account</h2>
-    <div id="create-channel-error" role="alert" aria-live="assertive"></div>
-    <label for="cc-type">Channel type</label>
-    <select id="cc-type">
-      <option value="discord">Discord</option>
-      <option value="slack">Slack</option>
-    </select>
-    <label for="cc-uid">External user ID <span class="label-hint">the user's ID on the platform</span></label>
-    <input id="cc-uid" type="text" autocomplete="off" spellcheck="false">
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateChannelModal()">Cancel</button>
-      <button id="cc-submit" class="modal-submit" onclick="submitCreateChannel()">Link</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Schedule Modal -->
-<div id="create-schedule-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-schedule-title">
-  <div id="create-schedule-box" class="admin-modal admin-modal-wide">
-    <h2 id="create-schedule-title">New Schedule</h2>
-    <div id="create-schedule-error" role="alert" aria-live="assertive"></div>
-    <div class="modal-columns">
-      <div class="modal-col">
-        <div class="modal-col-heading">Schedule</div>
-        <label for="cs-name">Name</label>
-        <input id="cs-name" type="text" placeholder="Daily health check" autocomplete="off">
-        <label for="cs-desc">Description <span class="label-hint">optional</span></label>
-        <input id="cs-desc" type="text" placeholder="" autocomplete="off">
-        <label for="cs-type">Schedule type</label>
-        <select id="cs-type" onchange="toggleScheduleTypeFields()">
-          <option value="cron">Cron (recurring)</option>
-          <option value="at">At (one-shot)</option>
-        </select>
-        <div id="cs-cron-group">
-          <label for="cs-cron">Cron expression</label>
-          <input id="cs-cron" type="text" placeholder="0 9 * * MON-FRI" autocomplete="off" spellcheck="false" aria-describedby="cs-cron-hint">
-          <span id="cs-cron-hint" class="label-hint" style="display:block;margin-top:3px">min hour day month weekday</span>
-        </div>
-        <div id="cs-at-group" style="display:none">
-          <label for="cs-at">Run at</label>
-          <input id="cs-at" type="datetime-local">
-        </div>
-        <label for="cs-target">Target</label>
-        <select id="cs-target" onchange="toggleScheduleNodeField()">
-          <option value="auto">Auto (best available)</option>
-          <option value="pool">Pool (any bridge)</option>
-          <option value="all">All nodes</option>
-          <option value="node">Specific node...</option>
-        </select>
-        <div id="cs-node-group" style="display:none">
-          <label for="cs-node">Node ID</label>
-          <input id="cs-node" type="text" placeholder="node-001" autocomplete="off" spellcheck="false">
-        </div>
-      </div>
-      <div class="modal-col">
-        <div class="modal-col-heading">Execution</div>
-        <label for="cs-model">Model <span class="label-hint">optional</span></label>
-        <select id="cs-model"><option value="">Default model</option></select>
-        <label for="cs-template">Skill <span class="label-hint">optional</span></label>
-        <select id="cs-template"><option value="">None</option></select>
-        <label for="cs-message">Initial message</label>
-        <textarea id="cs-message" rows="3" placeholder="What should the workstream do?"></textarea>
-        <label class="admin-checkbox"><input id="cs-autoapprove" type="checkbox"> Auto-approve tool calls</label>
-        <label>Notify on completion <span class="label-hint">optional</span></label>
-        <div id="cs-notify-rows"></div>
-        <button type="button" class="admin-inline-add" onclick="_addNotifyRow('cs')" aria-label="Add notification target">+ Add target</button>
-      </div>
-    </div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateScheduleModal()">Cancel</button>
-      <button id="cs-submit" class="modal-submit" onclick="submitCreateSchedule()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Schedule Modal -->
-<div id="edit-schedule-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-schedule-title">
-  <div id="edit-schedule-box" class="admin-modal admin-modal-wide">
-    <h2 id="edit-schedule-title">Edit Schedule</h2>
-    <div id="edit-schedule-error" role="alert" aria-live="assertive"></div>
-    <input id="es-id" type="hidden">
-    <div class="modal-columns">
-      <div class="modal-col">
-        <div class="modal-col-heading">Schedule</div>
-        <label for="es-name">Name</label>
-        <input id="es-name" type="text" autocomplete="off">
-        <label for="es-desc">Description</label>
-        <input id="es-desc" type="text" autocomplete="off">
-        <label for="es-type">Schedule type</label>
-        <select id="es-type" onchange="toggleEditScheduleTypeFields()">
-          <option value="cron">Cron (recurring)</option>
-          <option value="at">At (one-shot)</option>
-        </select>
-        <div id="es-cron-group">
-          <label for="es-cron">Cron expression</label>
-          <input id="es-cron" type="text" autocomplete="off" spellcheck="false">
-        </div>
-        <div id="es-at-group" style="display:none">
-          <label for="es-at">Run at</label>
-          <input id="es-at" type="datetime-local">
-        </div>
-        <label for="es-target">Target</label>
-        <select id="es-target" onchange="toggleEditScheduleNodeField()">
-          <option value="auto">Auto (best available)</option>
-          <option value="pool">Pool (any bridge)</option>
-          <option value="all">All nodes</option>
-          <option value="node">Specific node...</option>
-        </select>
-        <div id="es-node-group" style="display:none">
-          <label for="es-node">Node ID</label>
-          <input id="es-node" type="text" autocomplete="off" spellcheck="false">
-        </div>
-      </div>
-      <div class="modal-col">
-        <div class="modal-col-heading">Execution</div>
-        <label for="es-model">Model</label>
-        <select id="es-model"><option value="">Default model</option></select>
-        <label for="es-template">Skill <span class="label-hint">optional</span></label>
-        <select id="es-template"><option value="">None</option></select>
-        <label for="es-message">Initial message</label>
-        <textarea id="es-message" rows="3"></textarea>
-        <label class="admin-checkbox"><input id="es-autoapprove" type="checkbox"> Auto-approve tool calls</label>
-        <label class="admin-checkbox"><input id="es-enabled" type="checkbox"> Enabled</label>
-        <label>Notify on completion <span class="label-hint">optional</span></label>
-        <div id="es-notify-rows"></div>
-        <button type="button" class="admin-inline-add" onclick="_addNotifyRow('es')" aria-label="Add notification target">+ Add target</button>
-      </div>
-    </div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideEditScheduleModal()">Cancel</button>
-      <button id="es-submit" class="modal-submit" onclick="submitEditSchedule()">Save</button>
-    </div>
-  </div>
-</div>
-
-<!-- Schedule Runs Modal -->
-<div id="schedule-runs-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="schedule-runs-title">
-  <div id="schedule-runs-box" class="admin-modal admin-modal-wide">
-    <h2 id="schedule-runs-title">Run History</h2>
-    <div id="schedule-runs-table"></div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideScheduleRunsModal()">Close</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Role Modal -->
-<div id="create-role-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-role-title">
-  <div id="create-role-box" class="admin-modal admin-modal-wide">
-    <h2 id="create-role-title">Create Role</h2>
-    <div id="create-role-error" role="alert" aria-live="assertive"></div>
-    <label for="cr-name">Name</label>
-    <input id="cr-name" type="text" placeholder="e.g. security-reviewer" autocomplete="off" spellcheck="false">
-    <label for="cr-displayname">Display name</label>
-    <input id="cr-displayname" type="text" placeholder="Security Reviewer" autocomplete="off">
-    <fieldset class="perm-fieldset"><legend>Permissions</legend>
-    <div id="cr-perms-container" role="group" aria-label="Permissions"></div>
-    </fieldset>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateRoleModal()">Cancel</button>
-      <button id="cr-submit" class="modal-submit" onclick="submitCreateRole()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Role Modal -->
-<div id="edit-role-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-role-title">
-  <div id="edit-role-box" class="admin-modal admin-modal-wide">
-    <h2 id="edit-role-title">Edit Role</h2>
-    <div id="edit-role-error" role="alert" aria-live="assertive"></div>
-    <input id="er-id" type="hidden">
-    <label for="er-name">Display name</label>
-    <input id="er-name" type="text" autocomplete="off">
-    <fieldset class="perm-fieldset"><legend>Permissions</legend>
-    <div id="er-perms-container" role="group" aria-label="Permissions"></div>
-    </fieldset>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideEditRoleModal()">Cancel</button>
-      <button id="er-submit" class="modal-submit" onclick="submitEditRole()">Save</button>
-    </div>
-  </div>
-</div>
-
-<!-- User Roles Modal -->
-<div id="user-roles-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="user-roles-title">
-  <div id="user-roles-box" class="admin-modal">
-    <h2 id="user-roles-title">Assign Roles</h2>
-    <div id="user-roles-error" role="alert" aria-live="assertive"></div>
-    <input id="ur-user-id" type="hidden">
-    <div id="ur-roles-container"></div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideUserRolesModal()">Cancel</button>
-      <button class="modal-submit" onclick="submitUserRoles()">Save</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Policy Modal -->
-<div id="create-policy-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-policy-title">
-  <div id="create-policy-box" class="admin-modal">
-    <h2 id="create-policy-title">Create Tool Policy</h2>
-    <div id="create-policy-error" role="alert" aria-live="assertive"></div>
-    <label for="cp-name">Name</label>
-    <input id="cp-name" type="text" placeholder="e.g. Block shell access" autocomplete="off">
-    <label for="cp-pattern">Tool pattern <span class="label-hint">glob syntax: bash*, file_write, *</span></label>
-    <input id="cp-pattern" type="text" placeholder="bash*" autocomplete="off" spellcheck="false">
-    <label for="cp-action">Action</label>
-    <select id="cp-action">
-      <option value="ask">Ask (require approval)</option>
-      <option value="allow">Allow (auto-approve)</option>
-      <option value="deny">Deny (block)</option>
-    </select>
-    <label for="cp-priority">Priority <span class="label-hint">higher = evaluated first</span></label>
-    <input id="cp-priority" type="number" value="0" min="0" max="9999">
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreatePolicyModal()">Cancel</button>
-      <button id="cp-submit" class="modal-submit" onclick="submitCreatePolicy()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Policy Modal -->
-<div id="edit-policy-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-policy-title">
-  <div id="edit-policy-box" class="admin-modal">
-    <h2 id="edit-policy-title">Edit Tool Policy</h2>
-    <div id="edit-policy-error" role="alert" aria-live="assertive"></div>
-    <input id="ep-id" type="hidden">
-    <label for="ep-name">Name</label>
-    <input id="ep-name" type="text" autocomplete="off">
-    <label for="ep-pattern">Tool pattern</label>
-    <input id="ep-pattern" type="text" autocomplete="off" spellcheck="false">
-    <label for="ep-action">Action</label>
-    <select id="ep-action">
-      <option value="ask">Ask (require approval)</option>
-      <option value="allow">Allow (auto-approve)</option>
-      <option value="deny">Deny (block)</option>
-    </select>
-    <label for="ep-priority">Priority</label>
-    <input id="ep-priority" type="number" value="0" min="0" max="9999">
-    <label class="admin-checkbox"><input id="ep-enabled" type="checkbox" checked> Enabled</label>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideEditPolicyModal()">Cancel</button>
-      <button id="ep-submit" class="modal-submit" onclick="submitEditPolicy()">Save</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Prompt Policy Modal -->
-<div id="create-ppolicy-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-ppolicy-title">
-  <div id="create-ppolicy-box" class="admin-modal admin-modal-wide">
-    <h2 id="create-ppolicy-title">Create Prompt</h2>
-    <div id="cpp-error" role="alert" aria-live="assertive"></div>
-    <label for="cpp-name">Name <span class="label-hint">slug-style identifier</span></label>
-    <input id="cpp-name" type="text" placeholder="e.g. web_search, data_handling" autocomplete="off">
-    <label for="cpp-gate">Tool Gate <span class="label-hint">tool name or blank for unconditional</span></label>
-    <input id="cpp-gate" type="text" placeholder="e.g. web_search" autocomplete="off">
-    <label for="cpp-content">Content <span class="label-hint">markdown body for system message</span></label>
-    <textarea id="cpp-content" rows="10" placeholder="## Policy Name&#10;&#10;Behavioral guidance..." spellcheck="false"></textarea>
-    <label for="cpp-priority">Priority <span class="label-hint">higher = assembled later (closer to conversation)</span></label>
-    <input id="cpp-priority" type="number" value="0" min="0" max="9999">
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreatePromptPolicyModal()">Cancel</button>
-      <button id="cpp-submit" class="modal-submit" onclick="submitCreatePromptPolicy()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Prompt Policy Modal -->
-<div id="edit-ppolicy-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-ppolicy-title">
-  <div id="edit-ppolicy-box" class="admin-modal admin-modal-wide">
-    <h2 id="edit-ppolicy-title">Edit Prompt</h2>
-    <div id="epp-error" role="alert" aria-live="assertive"></div>
-    <input id="epp-id" type="hidden">
-    <label for="epp-name">Name</label>
-    <input id="epp-name" type="text" autocomplete="off">
-    <label for="epp-gate">Tool Gate</label>
-    <input id="epp-gate" type="text" autocomplete="off">
-    <label for="epp-content">Content</label>
-    <textarea id="epp-content" rows="10" spellcheck="false"></textarea>
-    <label for="epp-priority">Priority</label>
-    <input id="epp-priority" type="number" value="0" min="0" max="9999">
-    <label class="admin-checkbox"><input id="epp-enabled" type="checkbox" checked> Enabled</label>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideEditPromptPolicyModal()">Cancel</button>
-      <button id="epp-submit" class="modal-submit" onclick="submitEditPromptPolicy()">Save</button>
-    </div>
-  </div>
-</div>
-
-<!-- Create Skill Modal -->
-<div id="create-template-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="create-template-title">
-  <div id="create-template-box" class="admin-modal admin-modal-wide admin-modal-skill">
-    <h2 id="create-template-title">Create Skill</h2>
-    <div id="create-template-error" role="alert" aria-live="assertive"></div>
-    <div class="skill-spec-body">
-      <div class="skill-spec-col skill-spec-col-meta">
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Identity</h3>
-          <label for="ctm-name">Name</label>
-          <input id="ctm-name" type="text" placeholder="e.g. code-review" autocomplete="off">
-          <label for="ctm-category">Category</label>
-          <select id="ctm-category">
-            <option value="general">General</option>
-            <option value="engineering">Engineering</option>
-            <option value="support">Support</option>
-            <option value="custom">Custom</option>
-          </select>
-          <label for="skill-description">Description</label>
-          <textarea id="skill-description" rows="2" placeholder="Brief description for skill discovery"></textarea>
-        </div>
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Manifest</h3>
-          <label for="skill-tags">Tags</label>
-          <input id="skill-tags" type="text" placeholder="python, review, quality">
-          <label for="skill-author">Author</label>
-          <input id="skill-author" type="text" placeholder="Author name">
-          <label for="skill-version">Version</label>
-          <input id="skill-version" type="text" placeholder="1.0.0">
-          <label for="skill-license">License</label>
-          <select id="skill-license">
-            <option value="">— not specified —</option>
-            <option value="MIT">MIT</option>
-            <option value="Apache-2.0">Apache-2.0</option>
-            <option value="GPL-2.0">GPL-2.0</option>
-            <option value="GPL-3.0">GPL-3.0</option>
-            <option value="LGPL-2.1">LGPL-2.1</option>
-            <option value="LGPL-3.0">LGPL-3.0</option>
-            <option value="AGPL-3.0">AGPL-3.0</option>
-            <option value="BSD-2-Clause">BSD-2-Clause</option>
-            <option value="BSD-3-Clause">BSD-3-Clause</option>
-            <option value="ISC">ISC</option>
-            <option value="MPL-2.0">MPL-2.0</option>
-            <option value="Unlicense">Unlicense</option>
-            <option value="Proprietary">Proprietary</option>
-          </select>
-          <label for="skill-compatibility">Compatibility <span class="label-hint">environment requirements, max 500 chars</span></label>
-          <input id="skill-compatibility" type="text" placeholder="Requires git, docker, etc." maxlength="500">
-        </div>
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Deployment</h3>
-          <label for="skill-activation">Activation <span class="label-hint">how models discover this skill</span></label>
-          <select id="skill-activation">
-            <option value="named">Named — explicit /skill invocation</option>
-            <option value="default">Default — auto-applied to every session</option>
-            <option value="search">Search — BM25 discoverable</option>
-          </select>
-          <label class="admin-checkbox"><input id="ctm-default" type="checkbox"> Apply to new workstreams by default</label>
-        </div>
-      </div>
-      <div class="skill-spec-col skill-spec-col-content">
-        <div class="skill-spec-section skill-spec-section-content">
-          <h3 class="skill-spec-heading">Skill Content <span class="label-hint">system message &mdash; {{model}}, {{ws_id}}, {{node_id}}</span></h3>
-          <textarea id="ctm-content" class="skill-content-area" placeholder="You are a code reviewer using {{model}}..."></textarea>
-          <div class="skill-vars-row">
-            <span class="skill-vars-label">Variables</span>
-            <div id="ctm-variables" class="skill-vars-display label-hint"></div>
+        <div id="model-server-compat-section" style="display: none">
+          <div class="modal-section-divider" role="separator">
+            Server Compatibility
           </div>
-        </div>
-      </div>
-    </div>
-    <details class="admin-details">
-      <summary>Runtime Config <span class="label-hint">model, temperature, token limits</span></summary>
-      <div class="skill-config-grid">
-        <div><label for="csk-model">Model</label><input id="csk-model" type="text" placeholder="Default model"></div>
-        <div><label for="csk-temperature">Temperature</label><input id="csk-temperature" type="number" step="0.1" min="0" max="2" placeholder="System default"></div>
-        <div>
-          <label for="csk-reasoning-effort">Reasoning Effort</label>
-          <select id="csk-reasoning-effort">
-            <option value="">System default</option>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-            <option value="xhigh">Extra High</option>
-            <option value="max">Max</option>
+          <label for="model-server-type"
+            >Server Type
+            <span style="font-weight: 400; text-transform: none"
+              >(auto-detected or manual)</span
+            ></label
+          >
+          <select id="model-server-type">
+            <option value="">Auto / Unknown</option>
+            <option value="vllm">vLLM</option>
+            <option value="llama.cpp">llama.cpp</option>
+            <option value="openai-compatible">Other OpenAI-compatible</option>
           </select>
-        </div>
-        <div><label for="csk-max-tokens">Max Tokens</label><input id="csk-max-tokens" type="number" min="1" placeholder="System default"></div>
-        <div><label for="csk-token-budget">Token Budget</label><input id="csk-token-budget" type="number" min="0" placeholder="0 = unlimited"></div>
-        <div><label for="csk-agent-max-turns">Agent Max Turns</label><input id="csk-agent-max-turns" type="number" min="1" placeholder="System default"></div>
-      </div>
-      <label class="admin-checkbox"><input id="csk-auto-approve" type="checkbox"> Auto-approve all tools</label>
-      <label for="csk-allowed-tools">Allowed Tools <span class="label-hint">comma-separated tool names for auto-approve</span></label>
-      <input id="csk-allowed-tools" type="text" placeholder="bash, read_file, write_file">
-      <label for="csk-notify-on-complete">Notify on completion <span class="label-hint">optional</span></label>
-      <textarea id="csk-notify-on-complete" rows="2" placeholder='[{"channel_type":"discord","channel_id":"123..."},{"channel_type":"slack","channel_id":"C0..."}]' spellcheck="false" aria-describedby="csk-notify-hint" style="font-family:var(--font-mono);font-size:12px"></textarea>
-      <span id="csk-notify-hint" class="label-hint" style="display:block;margin-top:3px">JSON array. Each: channel_type + channel_id or user_id</span>
-      <label class="admin-checkbox"><input id="csk-enabled" type="checkbox" checked> Enabled</label>
-    </details>
-    <details class="admin-details">
-      <summary>Resources <span class="label-hint">bundled files (scripts, references, assets)</span></summary>
-      <div id="ctm-resources-list" role="list" aria-live="polite" aria-label="Pending resources"></div>
-      <div style="margin-top:8px;display:flex;flex-direction:column;gap:6px">
-        <label for="ctm-res-path">Path</label>
-        <input id="ctm-res-path" type="text" placeholder="scripts/setup.sh or references/guide.md">
-        <label for="ctm-res-content-type">Content Type</label>
-        <input id="ctm-res-content-type" type="text" value="text/plain">
-        <label for="ctm-res-content">Content</label>
-        <textarea id="ctm-res-content" rows="4" placeholder="Resource file content"></textarea>
-        <button type="button" class="admin-btn-action" onclick="_addPendingResource()">Add Resource</button>
-      </div>
-    </details>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateTemplateModal()">Cancel</button>
-      <button id="ctm-submit" class="modal-submit" onclick="submitCreateTemplate()">Create</button>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Skill Modal -->
-<div id="edit-template-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-template-title">
-  <div id="edit-template-box" class="admin-modal admin-modal-wide admin-modal-skill">
-    <h2 id="edit-template-title">Edit Skill</h2>
-    <div id="etm-origin-badge" class="skill-origin-badge" style="display:none"></div>
-    <div id="edit-template-error" role="alert" aria-live="assertive"></div>
-    <input id="etm-id" type="hidden">
-    <div class="skill-spec-body">
-      <div class="skill-spec-col skill-spec-col-meta">
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Identity</h3>
-          <label for="etm-name">Name</label>
-          <input id="etm-name" type="text" autocomplete="off">
-          <label for="etm-category">Category</label>
-          <select id="etm-category">
-            <option value="general">General</option>
-            <option value="engineering">Engineering</option>
-            <option value="support">Support</option>
-            <option value="custom">Custom</option>
+          <label for="model-thinking-mode"
+            >Thinking Mode
+            <span style="font-weight: 400; text-transform: none"
+              >(reasoning / chain-of-thought)</span
+            ></label
+          >
+          <select id="model-thinking-mode" onchange="_toggleThinkingParam()">
+            <option value="">None</option>
+            <option value="manual">Enabled</option>
           </select>
-          <label for="etm-description">Description</label>
-          <textarea id="etm-description" rows="2" placeholder="Brief description for skill discovery"></textarea>
-        </div>
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Manifest</h3>
-          <label for="etm-tags">Tags</label>
-          <input id="etm-tags" type="text" placeholder="python, review, quality">
-          <label for="etm-author">Author</label>
-          <input id="etm-author" type="text" placeholder="Author name">
-          <label for="etm-version">Version</label>
-          <input id="etm-version" type="text" placeholder="1.0.0">
-          <label for="etm-license">License</label>
-          <select id="etm-license">
-            <option value="">— not specified —</option>
-            <option value="MIT">MIT</option>
-            <option value="Apache-2.0">Apache-2.0</option>
-            <option value="GPL-2.0">GPL-2.0</option>
-            <option value="GPL-3.0">GPL-3.0</option>
-            <option value="LGPL-2.1">LGPL-2.1</option>
-            <option value="LGPL-3.0">LGPL-3.0</option>
-            <option value="AGPL-3.0">AGPL-3.0</option>
-            <option value="BSD-2-Clause">BSD-2-Clause</option>
-            <option value="BSD-3-Clause">BSD-3-Clause</option>
-            <option value="ISC">ISC</option>
-            <option value="MPL-2.0">MPL-2.0</option>
-            <option value="Unlicense">Unlicense</option>
-            <option value="Proprietary">Proprietary</option>
-          </select>
-          <label for="etm-compatibility">Compatibility <span class="label-hint">environment requirements, max 500 chars</span></label>
-          <input id="etm-compatibility" type="text" placeholder="Requires git, docker, etc." maxlength="500">
-        </div>
-        <div class="skill-spec-section">
-          <h3 class="skill-spec-heading">Deployment</h3>
-          <label for="etm-activation">Activation <span class="label-hint">how models discover this skill</span></label>
-          <select id="etm-activation">
-            <option value="named">Named — explicit /skill invocation</option>
-            <option value="default">Default — auto-applied to every session</option>
-            <option value="search">Search — BM25 discoverable</option>
-          </select>
-          <label class="admin-checkbox"><input id="etm-default" type="checkbox"> Apply to new workstreams by default</label>
-        </div>
-      </div>
-      <div class="skill-spec-col skill-spec-col-content">
-        <div class="skill-spec-section skill-spec-section-content">
-          <h3 class="skill-spec-heading">Skill Content <span class="label-hint">{{model}}, {{ws_id}}, {{node_id}}</span></h3>
-          <textarea id="etm-content" class="skill-content-area"></textarea>
-          <div class="skill-vars-row">
-            <span class="skill-vars-label">Variables</span>
-            <div id="etm-variables" class="skill-vars-display label-hint"></div>
+          <div id="model-thinking-param-row" style="display: none">
+            <label for="model-thinking-param" style="font-size: 11px"
+              >Template param name
+              <span style="font-weight: 400; text-transform: none"
+                >(Granite/DeepSeek use "thinking")</span
+              ></label
+            >
+            <input
+              type="text"
+              id="model-thinking-param"
+              value="enable_thinking"
+              placeholder="enable_thinking"
+              style="font-family: var(--font-mono); font-size: 11px"
+            />
           </div>
+          <label for="model-extra-body"
+            >Extra body params
+            <span style="font-weight: 400; text-transform: none"
+              >(JSON, merged into every request)</span
+            ></label
+          >
+          <textarea
+            id="model-extra-body"
+            rows="2"
+            placeholder='{"skip_special_tokens": false}'
+            style="font-family: var(--font-mono); font-size: 11px"
+          ></textarea>
+        </div>
+        <label for="model-capabilities"
+          >Capabilities
+          <span style="font-weight: 400; text-transform: none"
+            >(JSON)</span
+          ></label
+        >
+        <textarea
+          id="model-capabilities"
+          rows="3"
+          placeholder='{"supports_vision": true}'
+          style="font-family: var(--font-mono); font-size: 11px"
+        ></textarea>
+        <div style="display: flex; gap: 20px; margin-top: 14px">
+          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            ><input
+              type="checkbox"
+              id="model-enabled"
+              checked
+              style="margin-right: 5px"
+            />Enabled</label
+          >
+        </div>
+        <div id="model-detect-area" style="margin-top: 14px">
+          <button
+            type="button"
+            id="model-detect-btn"
+            class="admin-action-btn"
+            onclick="detectModel()"
+            style="width: auto; padding: 7px 16px; font-size: 12px"
+            title="Probe endpoint to verify connectivity and discover models"
+          >
+            Detect
+          </button>
+          <div
+            id="model-detect-result"
+            role="status"
+            aria-live="polite"
+            style="
+              display: none;
+              margin-top: 8px;
+              padding: 10px 12px;
+              border-radius: 6px;
+              font-size: 12px;
+              border: 1px solid var(--border);
+              word-break: break-word;
+            "
+          ></div>
+        </div>
+        <div class="modal-buttons">
+          <button class="modal-cancel" onclick="hideCreateModelModal()">
+            Cancel
+          </button>
+          <button
+            id="model-create-submit"
+            class="modal-submit"
+            onclick="submitCreateModel()"
+          >
+            Create
+          </button>
         </div>
       </div>
     </div>
-    <details class="admin-details">
-      <summary>Runtime Config <span class="label-hint">model, temperature, token limits</span></summary>
-      <div class="skill-config-grid">
-        <div><label for="esk-model">Model</label><input id="esk-model" type="text" placeholder="Default model"></div>
-        <div><label for="esk-temperature">Temperature</label><input id="esk-temperature" type="number" step="0.1" min="0" max="2" placeholder="System default"></div>
-        <div>
-          <label for="esk-reasoning-effort">Reasoning Effort</label>
-          <select id="esk-reasoning-effort">
-            <option value="">System default</option>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-            <option value="xhigh">Extra High</option>
-            <option value="max">Max</option>
-          </select>
-        </div>
-        <div><label for="esk-max-tokens">Max Tokens</label><input id="esk-max-tokens" type="number" min="1" placeholder="System default"></div>
-        <div><label for="esk-token-budget">Token Budget</label><input id="esk-token-budget" type="number" min="0" placeholder="0 = unlimited"></div>
-        <div><label for="esk-agent-max-turns">Agent Max Turns</label><input id="esk-agent-max-turns" type="number" min="1" placeholder="System default"></div>
-      </div>
-      <label class="admin-checkbox"><input id="esk-auto-approve" type="checkbox"> Auto-approve all tools</label>
-      <label for="esk-allowed-tools">Allowed Tools <span class="label-hint">comma-separated tool names for auto-approve</span></label>
-      <input id="esk-allowed-tools" type="text" placeholder="bash, read_file, write_file">
-      <label for="esk-notify-on-complete">Notify on completion <span class="label-hint">optional</span></label>
-      <textarea id="esk-notify-on-complete" rows="2" placeholder='[{"channel_type":"discord","channel_id":"123..."},{"channel_type":"slack","channel_id":"C0..."}]' spellcheck="false" aria-describedby="esk-notify-hint" style="font-family:var(--font-mono);font-size:12px"></textarea>
-      <span id="esk-notify-hint" class="label-hint" style="display:block;margin-top:3px">JSON array. Each: channel_type + channel_id or user_id</span>
-      <label class="admin-checkbox"><input id="esk-enabled" type="checkbox" checked> Enabled</label>
-    </details>
-    <div id="etm-scan-section" style="display:none" class="admin-field">
-      <span class="admin-field-heading" id="etm-scan-heading">Security Scan</span>
-      <div id="etm-scan-report" aria-labelledby="etm-scan-heading"></div>
-      <button type="button" id="etm-rescan-btn" class="admin-btn-action" style="margin-top:8px">Re-scan</button>
-    </div>
-    <details id="etm-resources-section" class="admin-details">
-      <summary>Resources <span class="label-hint">bundled files for this skill</span></summary>
-      <div id="etm-resources-list" role="list" aria-live="polite" aria-label="Skill resources"></div>
-      <button type="button" id="etm-add-resource-btn" class="admin-btn-action" style="margin-top:8px" onclick="_showAddResourceForm(document.getElementById('etm-id').value)">Add Resource</button>
-      <div id="etm-add-resource-form" style="display:none">
-        <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px">
-          <label for="etm-res-path">Path</label>
-          <input id="etm-res-path" type="text" placeholder="scripts/setup.sh or references/guide.md">
-          <label for="etm-res-content-type">Content Type</label>
-          <input id="etm-res-content-type" type="text" value="text/plain">
-          <label for="etm-res-content">Content</label>
-          <textarea id="etm-res-content" rows="4" placeholder="Resource file content"></textarea>
-          <button type="button" id="etm-res-submit" class="admin-btn-action">Upload</button>
-        </div>
-      </div>
-    </details>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideEditTemplateModal()">Cancel</button>
-      <button id="etm-submit" class="modal-submit" onclick="submitEditTemplate()">Save</button>
-    </div>
-  </div>
-</div>
 
-<div id="memory-detail-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="memory-detail-title">
-  <div id="memory-detail-box" class="admin-modal admin-modal-wide">
-    <h2 id="memory-detail-title">Memory Detail</h2>
-    <div id="memory-detail-body"></div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideMemoryDetailModal()">Close</button>
-      <button id="mem-detail-delete" class="modal-submit admin-btn-danger">Delete</button>
-    </div>
-  </div>
-</div>
-
-<div id="mcp-create-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="mcp-create-title">
-  <div id="mcp-create-box" class="admin-modal">
-    <h2 id="mcp-create-title">Add MCP Server</h2>
-    <div id="mcp-create-error" role="alert" aria-live="assertive" style="display:none"></div>
-    <input type="hidden" id="mcp-edit-id" value="">
-    <label for="mcp-name">Server Name</label>
-    <input type="text" id="mcp-name" placeholder="e.g. filesystem" maxlength="64" pattern="[a-zA-Z0-9._-]+">
-    <label for="mcp-transport">Transport</label>
-    <select id="mcp-transport" onchange="toggleMcpTransport()">
-      <option value="stdio">stdio</option>
-      <option value="streamable-http">streamable-http</option>
-    </select>
-    <div id="mcp-stdio-fields">
-      <label for="mcp-command">Command</label>
-      <input type="text" id="mcp-command" placeholder="e.g. npx">
-      <label for="mcp-args">Arguments <span style="font-weight:400;text-transform:none">(one per line)</span></label>
-      <textarea id="mcp-args" rows="3" placeholder="-y&#10;@modelcontextprotocol/server-filesystem&#10;/tmp"></textarea>
-      <label for="mcp-env">Environment Variables <span style="font-weight:400;text-transform:none">(KEY=VALUE, one per line)</span></label>
-      <textarea id="mcp-env" rows="2" placeholder="API_KEY=..."></textarea>
-    </div>
-    <div id="mcp-http-fields" style="display:none">
-      <label for="mcp-url">URL</label>
-      <input type="text" id="mcp-url" placeholder="https://...">
-      <label for="mcp-headers">Headers <span style="font-weight:400;text-transform:none">(KEY: VALUE, one per line)</span></label>
-      <textarea id="mcp-headers" rows="2" placeholder="Authorization: Bearer ..."></textarea>
-    </div>
-    <div style="display:flex;gap:20px;margin-top:14px">
-      <label style="margin:0;font-size:12px;color:var(--fg-dim)"><input type="checkbox" id="mcp-auto-approve" style="margin-right:5px">Auto-approve tools</label>
-      <label style="margin:0;font-size:12px;color:var(--fg-dim)"><input type="checkbox" id="mcp-enabled" checked style="margin-right:5px">Enabled</label>
-    </div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateMcpModal()">Cancel</button>
-      <button id="mcp-create-submit" class="modal-submit" onclick="submitCreateMcp()">Create</button>
-    </div>
-  </div>
-</div>
-
-<div id="mcp-import-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="mcp-import-title">
-  <div id="mcp-import-box" class="admin-modal">
-    <h2 id="mcp-import-title">Import MCP Config</h2>
-    <div id="mcp-import-error" role="alert" aria-live="assertive" style="display:none"></div>
-    <label for="mcp-import-json">Paste JSON</label>
-    <textarea id="mcp-import-json" rows="10" placeholder='{"mcpServers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}'  style="font-family:var(--font-mono);font-size:11px"></textarea>
-    <p style="font-size:11px;color:var(--fg-dim);margin-top:8px">Paste a JSON object with a <code>mcpServers</code> key (Claude Desktop / VS Code / Cursor format). Existing servers with the same name will be skipped.</p>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideImportMcpModal()">Cancel</button>
-      <button id="mcp-import-submit" class="modal-submit" onclick="submitImportMcp()">Import</button>
-    </div>
-  </div>
-</div>
-
-<div id="mcp-detail-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="mcp-detail-title">
-  <div id="mcp-detail-box" class="admin-modal admin-modal-wide mcp-detail-modal">
-    <h2 id="mcp-detail-title">MCP Server Detail</h2>
-    <div id="mcp-detail-content"></div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideMcpDetailModal()">Close</button>
-    </div>
-  </div>
-</div>
-
-<div id="mcp-install-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="mcp-install-title">
-  <div id="mcp-install-box" class="admin-modal">
-    <h2 id="mcp-install-title">Install MCP Server</h2>
-    <div id="mcp-install-error" role="alert" aria-live="assertive" style="display:none"></div>
-    <div id="mcp-install-summary"></div>
-    <div id="mcp-install-source-select"></div>
-    <div id="mcp-install-fields"></div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideInstallMcpModal()">Cancel</button>
-      <button id="mcp-install-submit" class="modal-submit" onclick="submitInstallMcp()">Install</button>
-    </div>
-  </div>
-</div>
-
-<!-- Model create/edit modal -->
-<div id="model-create-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="model-create-title">
-  <div id="model-create-box" class="admin-modal">
-    <h2 id="model-create-title">Add Model</h2>
-    <div id="model-create-error" role="alert" aria-live="assertive"></div>
-    <input type="hidden" id="model-edit-id" value="">
-    <label for="model-alias">Alias</label>
-    <input type="text" id="model-alias" placeholder="e.g. gpt5-prod" maxlength="64" pattern="[a-zA-Z0-9._-]+">
-    <label for="model-name">Model ID <span style="font-weight:400;text-transform:none">(type to autocomplete)</span></label>
-    <input type="text" id="model-name" placeholder="e.g. gpt-5" list="model-name-suggestions">
-    <datalist id="model-name-suggestions"></datalist>
-    <label for="model-provider">Provider</label>
-    <select id="model-provider">
-      <option value="openai">openai</option>
-      <option value="anthropic">anthropic</option>
-      <option value="google">google</option>
-      <option value="openai-compatible">openai-compatible</option>
-    </select>
-    <label for="model-base-url">Base URL <span style="font-weight:400;text-transform:none">(empty = provider default)</span></label>
-    <input type="text" id="model-base-url" placeholder="https://api.openai.com/v1">
-    <label for="model-api-key">API Key <span style="font-weight:400;text-transform:none">(write-only, never displayed)</span></label>
-    <input type="password" id="model-api-key" placeholder="sk-..." autocomplete="off">
-    <label for="model-ctx-window">Context Window <span style="font-weight:400;text-transform:none">(0 = auto-detect from model)</span></label>
-    <input type="number" id="model-ctx-window" value="0" min="0">
-    <div class="modal-section-divider" role="separator">Sampling Defaults</div>
-    <label for="model-temperature">Temperature <span style="font-weight:400;text-transform:none">(empty = use global default)</span></label>
-    <input type="number" id="model-temperature" placeholder="Global default" step="0.1" min="0" max="2">
-    <label for="model-max-tokens">Max Tokens <span style="font-weight:400;text-transform:none">(empty = use global default)</span></label>
-    <input type="number" id="model-max-tokens" placeholder="Global default" min="1">
-    <label for="model-reasoning-effort">Reasoning Effort <span style="font-weight:400;text-transform:none">(empty = use global default)</span></label>
-    <select id="model-reasoning-effort">
-      <option value="">Global default</option>
-      <option value="none">None</option>
-      <option value="minimal">Minimal</option>
-      <option value="low">Low</option>
-      <option value="medium">Medium</option>
-      <option value="high">High</option>
-      <option value="xhigh">Extra High</option>
-      <option value="max">Max</option>
-    </select>
-    <div id="model-server-compat-section" style="display:none">
-    <div class="modal-section-divider" role="separator">Server Compatibility</div>
-    <label for="model-server-type">Server Type <span style="font-weight:400;text-transform:none">(auto-detected or manual)</span></label>
-    <select id="model-server-type">
-      <option value="">Auto / Unknown</option>
-      <option value="vllm">vLLM</option>
-      <option value="llama.cpp">llama.cpp</option>
-      <option value="openai-compatible">Other OpenAI-compatible</option>
-    </select>
-    <label for="model-thinking-mode">Thinking Mode <span style="font-weight:400;text-transform:none">(reasoning / chain-of-thought)</span></label>
-    <select id="model-thinking-mode" onchange="_toggleThinkingParam()">
-      <option value="">None</option>
-      <option value="manual">Enabled</option>
-    </select>
-    <div id="model-thinking-param-row" style="display:none">
-      <label for="model-thinking-param" style="font-size:11px">Template param name <span style="font-weight:400;text-transform:none">(Granite/DeepSeek use "thinking")</span></label>
-      <input type="text" id="model-thinking-param" value="enable_thinking" placeholder="enable_thinking" style="font-family:var(--font-mono);font-size:11px"></div>
-    <label for="model-extra-body">Extra body params <span style="font-weight:400;text-transform:none">(JSON, merged into every request)</span></label>
-    <textarea id="model-extra-body" rows="2" placeholder='{"skip_special_tokens": false}' style="font-family:var(--font-mono);font-size:11px"></textarea>
-    </div>
-    <label for="model-capabilities">Capabilities <span style="font-weight:400;text-transform:none">(JSON)</span></label>
-    <textarea id="model-capabilities" rows="3" placeholder='{"supports_vision": true}' style="font-family:var(--font-mono);font-size:11px"></textarea>
-    <div style="display:flex;gap:20px;margin-top:14px">
-      <label style="margin:0;font-size:12px;color:var(--fg-dim)"><input type="checkbox" id="model-enabled" checked style="margin-right:5px">Enabled</label>
-    </div>
-    <div id="model-detect-area" style="margin-top:14px">
-      <button type="button" id="model-detect-btn" class="admin-action-btn" onclick="detectModel()" style="width:auto;padding:7px 16px;font-size:12px" title="Probe endpoint to verify connectivity and discover models">Detect</button>
-      <div id="model-detect-result" role="status" aria-live="polite" style="display:none;margin-top:8px;padding:10px 12px;border-radius:6px;font-size:12px;border:1px solid var(--border);word-break:break-word"></div>
-    </div>
-    <div class="modal-buttons">
-      <button class="modal-cancel" onclick="hideCreateModelModal()">Cancel</button>
-      <button id="model-create-submit" class="modal-submit" onclick="submitCreateModel()">Create</button>
-    </div>
-  </div>
-</div>
-
-<script src="/static/admin.js"></script>
-<script src="/static/governance.js"></script>
-<script src="/static/app.js"></script>
-</body>
+    <script src="/static/admin.js"></script>
+    <script src="/static/governance.js"></script>
+    <script src="/static/app.js"></script>
+  </body>
 </html>

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -6,16 +6,30 @@
 /* ==========================================================================
    Header overrides — wider padding for console layout
    ========================================================================== */
-#header { padding: 10px 20px; gap: 16px; }
+#header {
+  padding: 10px 20px;
+  gap: 16px;
+}
 #header-home-link {
   color: inherit;
   text-decoration: none;
   letter-spacing: inherit;
 }
-#header-home-link:hover { color: var(--accent); }
-#header-home-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-#status-bar { font-size: 11px; color: var(--fg-dim); margin-left: auto; }
-#status-bar.disconnected { color: var(--red); }
+#header-home-link:hover {
+  color: var(--accent);
+}
+#header-home-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+#status-bar {
+  font-size: 11px;
+  color: var(--fg-dim);
+  margin-left: auto;
+}
+#status-bar.disconnected {
+  color: var(--red);
+}
 .header-dim {
   color: var(--fg-dim);
   font-weight: 400;
@@ -25,7 +39,9 @@
   color: var(--fg-dim);
   letter-spacing: 0.03em;
 }
-#theme-toggle { color: var(--fg); }
+#theme-toggle {
+  color: var(--fg);
+}
 
 /* ==========================================================================
    Main content
@@ -45,13 +61,18 @@
    Home landing — coordinator-first view
    Stacked panels: composer → active coordinators → cluster summary.
    ========================================================================== */
-#view-home { display: flex; flex-direction: column; gap: 22px; }
+#view-home {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
 
+/* Composer wrapper — layout-only.  The inner Composer (mounted by
+   shared_static/composer.js) carries its own background + border + radius;
+   double-framing made the section look chunky vs the node-detail composer
+   in ui/static, so this wrapper now only stacks the 503 banner + composer
+   + error row vertically. */
 .home-panel {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px 18px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -93,27 +114,39 @@
   padding: 4px 2px 0;
 }
 
-.home-section { display: flex; flex-direction: column; gap: 8px; }
+.home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+/* Mirrors .section-header (the 'NODES' heading below) so coordinators
+   and nodes read as peer sections instead of one looking demoted. */
 .home-section-title {
   margin: 0;
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 600;
-  color: var(--fg-dim);
+  color: var(--accent);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   display: flex;
   align-items: center;
   gap: 8px;
 }
-.home-section-count { color: var(--fg-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
+.home-section-count {
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
 
 .home-coord-list {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
 }
-.home-coord-list .dashboard-empty { padding: 18px 0; }
+.home-coord-list .dashboard-empty {
+  padding: 18px 0;
+}
 
 /* One-line cluster summary — button styled to look like an info strip
    so the click affordance stays clear without dominating the layout. */
@@ -131,7 +164,10 @@
   font-size: 12px;
   cursor: pointer;
   text-align: left;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
   font-variant-numeric: tabular-nums;
 }
 .home-cluster-summary:hover {
@@ -143,9 +179,20 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.home-cluster-summary-line { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.home-cluster-summary-caret { color: var(--fg-dim); font-size: 10px; transition: transform 0.12s; }
-.home-cluster-summary:hover .home-cluster-summary-caret { transform: translateX(2px); }
+.home-cluster-summary-line {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-cluster-summary-caret {
+  color: var(--fg-dim);
+  font-size: 10px;
+  transition: transform 0.12s;
+}
+.home-cluster-summary:hover .home-cluster-summary-caret {
+  transform: translateX(2px);
+}
 
 /* Sub-700px: collapse the composer row and tighten padding.  The
    phase-4 designer-review "composer wrap 340-699px" observation is
@@ -154,14 +201,22 @@
    2×8px gap ≈ 500-540px preferred) fits comfortably in every
    desktop viewport, so a mid-zone break rule is unnecessary. */
 @media (max-width: 700px) {
-  #main { padding: 14px 12px 48px; }
-  #view-home { gap: 16px; }
-  .home-panel { padding: 12px 12px; }
+  #main {
+    padding: 14px 12px 48px;
+  }
+  #view-home {
+    gap: 16px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .home-cluster-summary, .home-cluster-summary-caret { transition: none; }
-  .home-cluster-summary:hover .home-cluster-summary-caret { transform: none; }
+  .home-cluster-summary,
+  .home-cluster-summary-caret {
+    transition: none;
+  }
+  .home-cluster-summary:hover .home-cluster-summary-caret {
+    transform: none;
+  }
 }
 
 /* ==========================================================================
@@ -181,8 +236,14 @@
   text-decoration: none;
   font-weight: 500;
 }
-.breadcrumb a:hover { text-decoration: underline; }
-.breadcrumb-sep { margin: 0 8px; color: var(--fg-dim); opacity: 0.5; }
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+.breadcrumb-sep {
+  margin: 0 8px;
+  color: var(--fg-dim);
+  opacity: 0.5;
+}
 
 /* ==========================================================================
    Cluster Status Bar — the instrument panel
@@ -209,17 +270,26 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 #cluster-status-bar::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -1px;
   left: 10%;
   right: 10%;
   height: 1px;
-  background: linear-gradient(90deg, transparent, var(--accent-glow-strong), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent-glow-strong),
+    transparent
+  );
   pointer-events: none;
 }
 
-.csb-states { display: flex; gap: 2px; align-items: center; }
+.csb-states {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
 
 .csb-state {
   display: flex;
@@ -228,7 +298,10 @@
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
   white-space: nowrap;
   color: var(--fg-dim);
   font-size: 12px;
@@ -242,14 +315,22 @@
   border-color: var(--border-strong);
   color: var(--fg-bright);
 }
-.csb-state:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.csb-state:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .csb-state.active {
   background: var(--accent-dim);
   border-color: var(--accent);
   color: var(--accent);
 }
-.csb-state.active .csb-state-count { color: var(--accent); }
-.csb-state.active .csb-state-label { color: var(--accent); opacity: 0.8; }
+.csb-state.active .csb-state-count {
+  color: var(--accent);
+}
+.csb-state.active .csb-state-label {
+  color: var(--accent);
+  opacity: 0.8;
+}
 
 /* State indicator dots — LED effect with glow */
 .csb-state-dot {
@@ -258,14 +339,41 @@
   border-radius: 50%;
   flex-shrink: 0;
 }
-.csb-state-dot[data-state="running"]   { background: var(--green); border-radius: 2px; box-shadow: 0 0 6px var(--green-glow); }
-.csb-state-dot[data-state="thinking"]  { background: var(--cyan); box-shadow: 0 0 6px var(--cyan-glow); }
-.csb-state-dot[data-state="attention"] { background: var(--yellow); border-radius: 1px; transform: rotate(45deg); box-shadow: 0 0 6px var(--yellow-glow); }
-.csb-state-dot[data-state="idle"]      { background: var(--fg-dim); opacity: 0.5; }
-.csb-state-dot[data-state="error"]     { background: var(--red); border-radius: 0; box-shadow: 0 0 6px var(--red-glow); }
+.csb-state-dot[data-state="running"] {
+  background: var(--green);
+  border-radius: 2px;
+  box-shadow: 0 0 6px var(--green-glow);
+}
+.csb-state-dot[data-state="thinking"] {
+  background: var(--cyan);
+  box-shadow: 0 0 6px var(--cyan-glow);
+}
+.csb-state-dot[data-state="attention"] {
+  background: var(--yellow);
+  border-radius: 1px;
+  transform: rotate(45deg);
+  box-shadow: 0 0 6px var(--yellow-glow);
+}
+.csb-state-dot[data-state="idle"] {
+  background: var(--fg-dim);
+  opacity: 0.5;
+}
+.csb-state-dot[data-state="error"] {
+  background: var(--red);
+  border-radius: 0;
+  box-shadow: 0 0 6px var(--red-glow);
+}
 
-.csb-state-count { font-weight: 600; color: var(--fg-bright); font-variant-numeric: tabular-nums; }
-.csb-state-count.zero { color: var(--fg-dim); font-weight: 400; opacity: 0.6; }
+.csb-state-count {
+  font-weight: 600;
+  color: var(--fg-bright);
+  font-variant-numeric: tabular-nums;
+}
+.csb-state-count.zero {
+  color: var(--fg-dim);
+  font-weight: 400;
+  opacity: 0.6;
+}
 
 .csb-state-label {
   color: var(--fg-dim);
@@ -276,7 +384,12 @@
   font-weight: 500;
 }
 
-.csb-divider { width: 1px; height: 22px; background: var(--border-strong); flex-shrink: 0; }
+.csb-divider {
+  width: 1px;
+  height: 22px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
 
 .csb-metrics {
   display: flex;
@@ -287,8 +400,16 @@
   margin-left: auto;
   white-space: nowrap;
 }
-.csb-metric { display: flex; align-items: center; gap: 5px; }
-.csb-metric-value { color: var(--fg-bright); font-weight: 500; font-variant-numeric: tabular-nums; }
+.csb-metric {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.csb-metric-value {
+  color: var(--fg-bright);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
 .csb-metric-label {
   color: var(--fg-dim);
   font-size: 10px;
@@ -309,11 +430,18 @@
   flex-shrink: 0;
 }
 
-.csb-loading { color: var(--fg-dim); font-size: 11px; font-style: italic; opacity: 0.8; }
+.csb-loading {
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.8;
+}
 
-#cluster-status-bar.stale { border-top-color: var(--yellow); }
+#cluster-status-bar.stale {
+  border-top-color: var(--yellow);
+}
 #cluster-status-bar.stale::after {
-  content: 'STALE';
+  content: "STALE";
   position: absolute;
   top: -10px;
   left: 50%;
@@ -360,8 +488,16 @@
   top: 0;
   z-index: 10;
 }
-.ncol-ws, .ncol-run, .ncol-attn, .ncol-tokens { text-align: right; }
-.ncol-health, .node-cell-health { padding-left: 10px; }
+.ncol-ws,
+.ncol-run,
+.ncol-attn,
+.ncol-tokens {
+  text-align: right;
+}
+.ncol-health,
+.node-cell-health {
+  padding-left: 10px;
+}
 
 /* ==========================================================================
    Node rows — individual instrument readouts
@@ -371,27 +507,55 @@
   grid-template-columns: 1fr 50px 50px 50px 70px 60px 140px;
   padding: 9px 16px;
   cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
   border-left: 3px solid transparent;
   position: relative;
 }
-.node-row:nth-child(odd) { background: var(--bg); }
-.node-row:nth-child(even) { background: var(--row-alt); }
+.node-row:nth-child(odd) {
+  background: var(--bg);
+}
+.node-row:nth-child(even) {
+  background: var(--row-alt);
+}
 .node-row:hover {
   background: var(--bg-highlight);
   box-shadow: inset 0 0 0 1px var(--border);
 }
-.node-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.node-row.has-attention { border-left-color: var(--yellow); background: linear-gradient(90deg, var(--yellow-glow), transparent 30%); }
-.node-row.has-running   { border-left-color: var(--green); background: linear-gradient(90deg, var(--green-glow), transparent 30%); }
-.node-row.has-thinking  { border-left-color: var(--cyan); background: linear-gradient(90deg, var(--cyan-glow), transparent 30%); }
-.node-row.has-error     { border-left-color: var(--red); background: linear-gradient(90deg, var(--red-glow), transparent 30%); }
-.node-row.has-attention:hover, .node-row.has-running:hover,
-.node-row.has-thinking:hover, .node-row.has-error:hover {
+.node-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.node-row.has-attention {
+  border-left-color: var(--yellow);
+  background: linear-gradient(90deg, var(--yellow-glow), transparent 30%);
+}
+.node-row.has-running {
+  border-left-color: var(--green);
+  background: linear-gradient(90deg, var(--green-glow), transparent 30%);
+}
+.node-row.has-thinking {
+  border-left-color: var(--cyan);
+  background: linear-gradient(90deg, var(--cyan-glow), transparent 30%);
+}
+.node-row.has-error {
+  border-left-color: var(--red);
+  background: linear-gradient(90deg, var(--red-glow), transparent 30%);
+}
+.node-row.has-attention:hover,
+.node-row.has-running:hover,
+.node-row.has-thinking:hover,
+.node-row.has-error:hover {
   background: var(--bg-highlight);
 }
 
-.node-cell { font-size: 12px; display: flex; align-items: center; }
+.node-cell {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+}
 .node-cell-name {
   color: var(--fg-bright);
   font-weight: 500;
@@ -442,8 +606,12 @@
   gap: 4px;
   font-variant-numeric: tabular-nums;
 }
-.node-cell-version.drift { color: var(--yellow); }
-.ncol-version { text-align: right; }
+.node-cell-version.drift {
+  color: var(--yellow);
+}
+.ncol-version {
+  text-align: right;
+}
 .node-version-drift-badge {
   font-size: 9px;
   font-family: var(--font-display);
@@ -472,8 +640,15 @@
   justify-content: flex-end;
   font-variant-numeric: tabular-nums;
 }
-.node-cell-num.has-value { color: var(--fg-bright); }
-.node-cell-health { gap: 8px; font-size: 11px; color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.node-cell-num.has-value {
+  color: var(--fg-bright);
+}
+.node-cell-health {
+  gap: 8px;
+  font-size: 11px;
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
 
 /* Health bar — precision gauge */
 .health-bar {
@@ -491,41 +666,70 @@
   border-radius: 2px;
   transition: width 0.3s ease;
 }
-.health-bar-fill.low { background: var(--green); box-shadow: 0 0 4px var(--green-glow); }
-.health-bar-fill.mid { background: var(--yellow); box-shadow: 0 0 4px var(--yellow-glow); }
-.health-bar-fill.high { background: var(--red); box-shadow: 0 0 4px var(--red-glow); }
+.health-bar-fill.low {
+  background: var(--green);
+  box-shadow: 0 0 4px var(--green-glow);
+}
+.health-bar-fill.mid {
+  background: var(--yellow);
+  box-shadow: 0 0 4px var(--yellow-glow);
+}
+.health-bar-fill.high {
+  background: var(--red);
+  box-shadow: 0 0 4px var(--red-glow);
+}
 
 /* ==========================================================================
    Node groups — rack panel sections
    ========================================================================== */
-.node-group { margin-bottom: 1px; }
+.node-group {
+  margin-bottom: 1px;
+}
 
 .node-group-header {
   display: grid;
   grid-template-columns: 1fr 50px 50px 50px 70px 60px 140px;
   padding: 10px 16px;
   cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
   background: var(--bg-surface);
   border-left: 3px solid transparent;
   border-bottom: 1px solid var(--border);
   position: relative;
 }
 .node-group-header::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   opacity: 0;
   transition: opacity 0.15s;
   pointer-events: none;
 }
-.node-group-header:hover { background: var(--bg-highlight); }
-.node-group-header:hover::before { opacity: 1; }
-.node-group-header:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.node-group-header.has-attention { border-left-color: var(--yellow); }
-.node-group-header.has-running   { border-left-color: var(--green); }
-.node-group-header.has-thinking  { border-left-color: var(--cyan); }
-.node-group-header.has-error     { border-left-color: var(--red); }
+.node-group-header:hover {
+  background: var(--bg-highlight);
+}
+.node-group-header:hover::before {
+  opacity: 1;
+}
+.node-group-header:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.node-group-header.has-attention {
+  border-left-color: var(--yellow);
+}
+.node-group-header.has-running {
+  border-left-color: var(--green);
+}
+.node-group-header.has-thinking {
+  border-left-color: var(--cyan);
+}
+.node-group-header.has-error {
+  border-left-color: var(--red);
+}
 
 .node-group-name {
   display: flex;
@@ -547,7 +751,9 @@
   display: inline-block;
   text-align: center;
 }
-.node-group-chevron.expanded { transform: rotate(90deg); }
+.node-group-chevron.expanded {
+  transform: rotate(90deg);
+}
 .node-group-badge {
   font-size: 10px;
   font-family: var(--font-display);
@@ -559,20 +765,45 @@
   font-weight: 500;
   letter-spacing: 0.02em;
 }
-.node-group-cell { font-size: 12px; display: flex; align-items: center; }
-.node-group-cell.num { color: var(--fg-dim); font-size: 11px; justify-content: flex-end; font-variant-numeric: tabular-nums; }
-.node-group-cell.num.has-value { color: var(--fg-bright); }
+.node-group-cell {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+}
+.node-group-cell.num {
+  color: var(--fg-dim);
+  font-size: 11px;
+  justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+.node-group-cell.num.has-value {
+  color: var(--fg-bright);
+}
 
-.node-group-body { overflow: hidden; }
-.node-group-body.collapsed { display: none; }
-.node-group-body .node-colheaders { position: static; z-index: auto; opacity: 0.85; }
-.node-group-body .node-row { padding-left: 32px; }
-.node-group-single .node-row { padding-left: 16px; }
+.node-group-body {
+  overflow: hidden;
+}
+.node-group-body.collapsed {
+  display: none;
+}
+.node-group-body .node-colheaders {
+  position: static;
+  z-index: auto;
+  opacity: 0.85;
+}
+.node-group-body .node-row {
+  padding-left: 32px;
+}
+.node-group-single .node-row {
+  padding-left: 16px;
+}
 
 /* ==========================================================================
    Dashboard table — console overrides
    ========================================================================== */
-.dash-row.has-link { cursor: pointer; }
+.dash-row.has-link {
+  cursor: pointer;
+}
 .dash-row.has-link::after {
   content: "\2197";
   position: absolute;
@@ -584,7 +815,9 @@
   transition: opacity 0.15s;
 }
 .dash-row.has-link:hover::after,
-.dash-row.has-link:focus-visible::after { opacity: 0.6; }
+.dash-row.has-link:focus-visible::after {
+  opacity: 0.6;
+}
 
 .dash-cell-node {
   color: var(--accent);
@@ -595,7 +828,10 @@
   cursor: pointer;
   transition: color 0.1s;
 }
-.dash-cell-node:hover { text-decoration: underline; color: var(--fg-bright); }
+.dash-cell-node:hover {
+  text-decoration: underline;
+  color: var(--fg-bright);
+}
 
 /* Coordinator / child / orphan tree grouping ---------------------------- */
 .dash-caret,
@@ -615,23 +851,44 @@
   cursor: pointer;
   border-radius: 3px;
 }
-.dash-caret:hover { background: var(--bg-elevated); color: var(--fg); }
+.dash-caret:hover {
+  background: var(--bg-elevated);
+  color: var(--fg);
+}
 .dash-caret:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
-.dash-caret-placeholder { visibility: hidden; }
-.dash-row--coordinator .dash-cell-name { font-weight: 600; }
-.dash-row--child { padding-left: 1.75rem; opacity: 0.95; }
-.dash-row--child .dash-row-main { border-left: 2px solid var(--border); padding-left: 0.5rem; }
+.dash-caret-placeholder {
+  visibility: hidden;
+}
+.dash-row--coordinator .dash-cell-name {
+  font-weight: 600;
+}
+.dash-row--child {
+  padding-left: 1.75rem;
+  opacity: 0.95;
+}
+.dash-row--child .dash-row-main {
+  border-left: 2px solid var(--border);
+  padding-left: 0.5rem;
+}
 /* Caret-driven collapse: child rows render in the DOM always; the
    caret toggles this class on the matching [data-parent-ws-id].  No
    table rebuild, so focus and screen-reader position survive. */
-.dash-row--child.dash-row--collapsed { display: none; }
-.dash-child-count { color: var(--fg-dim); font-weight: 400; font-size: 0.85em; }
+.dash-row--child.dash-row--collapsed {
+  display: none;
+}
+.dash-child-count {
+  color: var(--fg-dim);
+  font-weight: 400;
+  font-size: 0.85em;
+}
 /* Hide the "(N children)" summary when the caret is expanded — the
    indented child rows make the count self-evident. */
-.dash-row--coordinator[data-expanded="true"] .dash-child-count { display: none; }
+.dash-row--coordinator[data-expanded="true"] .dash-child-count {
+  display: none;
+}
 .dash-orphan-badge {
   display: inline-block;
   margin-left: 0.4rem;
@@ -671,7 +928,9 @@
   border-bottom: 1px solid transparent;
   transition: border-color 0.15s;
 }
-.node-link:hover { border-bottom-color: var(--accent); }
+.node-link:hover {
+  border-bottom-color: var(--accent);
+}
 
 /* ==========================================================================
    Pagination
@@ -694,17 +953,31 @@
   font: inherit;
   font-size: 11px;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
   font-family: var(--font-display);
   font-weight: 500;
 }
-.pagination button:hover { background: var(--bg-highlight); border-color: var(--accent-dim); }
-.pagination button:disabled { opacity: 0.25; cursor: not-allowed; }
+.pagination button:hover {
+  background: var(--bg-highlight);
+  border-color: var(--accent-dim);
+}
+.pagination button:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
 
 /* ==========================================================================
    Toast override — position above cluster status bar
    ========================================================================== */
-#toast { bottom: 56px; z-index: 200; color: var(--fg-bright); border-color: var(--border-strong); }
+#toast {
+  bottom: 56px;
+  z-index: 200;
+  color: var(--fg-bright);
+  border-color: var(--border-strong);
+}
 
 /* ==========================================================================
    Header accent button (+ new)
@@ -729,7 +1002,7 @@
   overflow: visible;
 }
 #admin-btn::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -2px;
   left: 0;
@@ -740,7 +1013,9 @@
   opacity: 0;
   transition: opacity 0.2s ease;
 }
-#admin-btn.active::before { opacity: 1; }
+#admin-btn.active::before {
+  opacity: 1;
+}
 #admin-btn.active {
   color: var(--accent);
   border-color: var(--accent);
@@ -775,7 +1050,7 @@
   position: relative;
 }
 #new-ws-box::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -1px;
   left: 20%;
@@ -809,7 +1084,9 @@
   letter-spacing: 0;
   opacity: 0.75;
 }
-#new-ws-box label:first-of-type { margin-top: 0; }
+#new-ws-box label:first-of-type {
+  margin-top: 0;
+}
 #new-ws-box select,
 #new-ws-box input[type="text"],
 #new-ws-box textarea {
@@ -821,10 +1098,18 @@
   color: var(--fg);
   font: inherit;
   font-size: 13px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
-#new-ws-box textarea { resize: vertical; min-height: 60px; }
-#new-ws-box textarea::placeholder { color: var(--fg-dim); opacity: 0.6; }
+#new-ws-box textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+#new-ws-box textarea::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.6;
+}
 #new-ws-box select:focus,
 #new-ws-box input:focus,
 #new-ws-box textarea:focus {
@@ -832,7 +1117,10 @@
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
-#new-ws-box input::placeholder { color: var(--fg-dim); opacity: 0.6; }
+#new-ws-box input::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.6;
+}
 #new-ws-box select {
   cursor: pointer;
   appearance: none;
@@ -863,56 +1151,143 @@
   border: 1px solid var(--border-strong);
   background: var(--bg-highlight);
   color: var(--fg);
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
   font-family: var(--font-display);
   font-weight: 500;
   letter-spacing: 0.02em;
 }
-#new-ws-cancel:hover { background: var(--bg-elevated); border-color: var(--border-strong); }
-#new-ws-cancel:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+#new-ws-cancel:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+}
+#new-ws-cancel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 #new-ws-submit {
   background: var(--accent);
   color: var(--bg);
   border-color: var(--accent);
   font-weight: 600;
 }
-#new-ws-submit:hover { filter: brightness(1.1); }
-#new-ws-submit:focus-visible { outline: 2px solid var(--fg); outline-offset: 2px; }
-#new-ws-submit:disabled { opacity: 0.4; cursor: not-allowed; filter: none; }
-@media (max-width: 380px) { #new-ws-box { padding: 24px 18px; } }
+#new-ws-submit:hover {
+  filter: brightness(1.1);
+}
+#new-ws-submit:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+#new-ws-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: none;
+}
+@media (max-width: 380px) {
+  #new-ws-box {
+    padding: 24px 18px;
+  }
+}
 
 /* ==========================================================================
    Responsive
    ========================================================================== */
 @media (max-width: 700px) {
-  :root { --dash-grid: 68px 110px 1fr 56px 44px; }
-  .dash-col-model, .dash-cell-model, .dash-col-node, .dash-cell-node { display: none; }
-  .node-colheaders, .node-row { grid-template-columns: 1fr 40px 40px 40px 60px; }
-  .node-group-header { grid-template-columns: 1fr 40px 40px 40px 60px; }
-  .node-group-header .node-group-cell:last-child { display: none; }
-  .ncol-version, .node-cell-version { display: none; }
-  .ncol-health, .node-cell-health { display: none; }
-  #node-mcp-summary { display: none; }
-  #main { padding: 16px; padding-bottom: 60px; }
+  :root {
+    --dash-grid: 68px 110px 1fr 56px 44px;
+  }
+  .dash-col-model,
+  .dash-cell-model,
+  .dash-col-node,
+  .dash-cell-node {
+    display: none;
+  }
+  .node-colheaders,
+  .node-row {
+    grid-template-columns: 1fr 40px 40px 40px 60px;
+  }
+  .node-group-header {
+    grid-template-columns: 1fr 40px 40px 40px 60px;
+  }
+  .node-group-header .node-group-cell:last-child {
+    display: none;
+  }
+  .ncol-version,
+  .node-cell-version {
+    display: none;
+  }
+  .ncol-health,
+  .node-cell-health {
+    display: none;
+  }
+  #node-mcp-summary {
+    display: none;
+  }
+  #main {
+    padding: 16px;
+    padding-bottom: 60px;
+  }
 }
 @media (max-width: 480px) {
-  :root { --dash-grid: 50px 1fr 50px; }
-  .dash-col-model, .dash-cell-model, .dash-col-node, .dash-cell-node, .dash-col-task, .dash-cell-task, .dash-col-ctx, .dash-cell-ctx { display: none; }
-  #cluster-status-bar { height: auto; flex-wrap: wrap; padding: 8px 12px; gap: 6px; }
-  .csb-states { flex-wrap: wrap; gap: 2px; }
-  .csb-state { padding: 4px 6px; font-size: 11px; }
-  .csb-divider { display: none; }
-  .csb-metrics { width: 100%; justify-content: center; }
-  #main { padding-bottom: 80px; }
-  #header h1 { font-size: 13px; }
+  :root {
+    --dash-grid: 50px 1fr 50px;
+  }
+  .dash-col-model,
+  .dash-cell-model,
+  .dash-col-node,
+  .dash-cell-node,
+  .dash-col-task,
+  .dash-cell-task,
+  .dash-col-ctx,
+  .dash-cell-ctx {
+    display: none;
+  }
+  #cluster-status-bar {
+    height: auto;
+    flex-wrap: wrap;
+    padding: 8px 12px;
+    gap: 6px;
+  }
+  .csb-states {
+    flex-wrap: wrap;
+    gap: 2px;
+  }
+  .csb-state {
+    padding: 4px 6px;
+    font-size: 11px;
+  }
+  .csb-divider {
+    display: none;
+  }
+  .csb-metrics {
+    width: 100%;
+    justify-content: center;
+  }
+  #main {
+    padding-bottom: 80px;
+  }
+  #header h1 {
+    font-size: 13px;
+  }
 }
 
 /* ==========================================================================
    Admin panel — sidebar layout
    ========================================================================== */
 
-#view-admin { animation: admin-fadein 0.15s ease-out; }
-@keyframes admin-fadein { from { opacity: 0; } to { opacity: 1; } }
+#view-admin {
+  animation: admin-fadein 0.15s ease-out;
+}
+@keyframes admin-fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 
 .admin-layout {
   display: flex;
@@ -936,7 +1311,9 @@
 }
 
 /* Group labels */
-.admin-sidebar-group { margin-bottom: 2px; }
+.admin-sidebar-group {
+  margin-bottom: 2px;
+}
 .admin-sidebar-group-label {
   font-family: var(--font-display);
   font-size: 9px;
@@ -965,12 +1342,19 @@
   padding: 6px 14px 6px 16px;
   cursor: pointer;
   text-align: left;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.admin-nav:hover { color: var(--fg); background: var(--bg-highlight); border-right-color: var(--border-strong); }
+.admin-nav:hover {
+  color: var(--fg);
+  background: var(--bg-highlight);
+  border-right-color: var(--border-strong);
+}
 .admin-nav.active {
   color: var(--accent);
   border-right-color: var(--accent);
@@ -1005,7 +1389,9 @@
 }
 
 /* Close header — hidden on desktop, shown via mobile media query */
-.admin-sidebar-close { display: none; }
+.admin-sidebar-close {
+  display: none;
+}
 
 /* Mobile menu toggle — visible only on mobile, lives in toolbars */
 .admin-mobile-toggle {
@@ -1024,20 +1410,26 @@
   padding: 0;
 }
 .admin-mobile-toggle::before {
-  content: '';
+  content: "";
   display: block;
   width: 14px;
   height: 2px;
   background: currentColor;
-  box-shadow: 0 4px 0 currentColor, 0 8px 0 currentColor;
+  box-shadow:
+    0 4px 0 currentColor,
+    0 8px 0 currentColor;
 }
-.admin-mobile-toggle:hover { color: var(--fg); }
+.admin-mobile-toggle:hover {
+  color: var(--fg);
+}
 .admin-mobile-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 @media (max-width: 700px) {
-  .admin-mobile-toggle { display: flex; }
+  .admin-mobile-toggle {
+    display: flex;
+  }
 }
 
 .admin-toolbar {
@@ -1060,9 +1452,17 @@
   letter-spacing: 0.02em;
   transition: filter 0.15s;
 }
-.admin-action-btn:hover { filter: brightness(1.1); }
-.admin-action-btn:focus-visible { outline: 2px solid var(--fg-bright); outline-offset: 2px; }
-.admin-action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.admin-action-btn:hover {
+  filter: brightness(1.1);
+}
+.admin-action-btn:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
+.admin-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 
 .admin-toolbar select {
   background: var(--bg);
@@ -1079,7 +1479,11 @@
   background-repeat: no-repeat;
   background-position: right 10px center;
 }
-.admin-toolbar select:focus { border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-dim); }
+.admin-toolbar select:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
 
 /* Admin table grid */
 .admin-colheaders {
@@ -1102,11 +1506,24 @@
   border-radius: var(--radius-sm);
   transition: background 0.1s;
 }
-.admin-row:nth-child(even) { background: var(--row-alt, rgba(255,255,255,0.015)); }
-.admin-row:hover { background: var(--bg-highlight); }
+.admin-row:nth-child(even) {
+  background: var(--row-alt, rgba(255, 255, 255, 0.015));
+}
+.admin-row:hover {
+  background: var(--bg-highlight);
+}
 
-.admin-col { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.admin-col code { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); }
+.admin-col {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.admin-col code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+}
 .admin-col-subtitle {
   display: block;
   font-size: 11px;
@@ -1164,24 +1581,65 @@
   color: var(--fg-dim);
   border: 1px solid var(--border);
 }
-.scope-write { color: var(--cyan); border-color: rgba(103, 232, 249, 0.2); }
-.scope-approve { color: var(--accent); border-color: var(--accent-dim); }
+.scope-write {
+  color: var(--cyan);
+  border-color: rgba(103, 232, 249, 0.2);
+}
+.scope-approve {
+  color: var(--accent);
+  border-color: var(--accent-dim);
+}
 /* Per-platform channel badges first — a row uses scope-discord OR
    scope-slack OR (for unknown platforms) the generic scope-channel
    fallback below.  Source order matters less now that the per-platform
    classes are exclusive of scope-channel; keeping it tidy regardless. */
-.scope-discord { color: var(--discord); border-color: var(--discord-glow); }
-.scope-slack { color: var(--slack); border-color: var(--slack-glow); }
-.scope-channel { color: var(--magenta); border-color: var(--magenta-glow); }
-.scope-mcp { color: var(--magenta); border-color: rgba(192, 132, 252, 0.25); }
-.scope-deny { color: var(--red); border-color: rgba(255, 80, 80, 0.25); }
-.scope-scan-safe { color: var(--green); border-color: var(--green-glow); }
-.scope-scan-low { color: var(--fg-dim); border-color: var(--border); }
-.scope-scan-medium { color: var(--yellow); border-color: var(--yellow-glow); }
-.scope-scan-high { color: var(--red); border-color: var(--red-glow); }
-.scope-scan-critical { color: var(--red); border-color: var(--red-glow); background: rgba(248, 113, 113, 0.08); }
+.scope-discord {
+  color: var(--discord);
+  border-color: var(--discord-glow);
+}
+.scope-slack {
+  color: var(--slack);
+  border-color: var(--slack-glow);
+}
+.scope-channel {
+  color: var(--magenta);
+  border-color: var(--magenta-glow);
+}
+.scope-mcp {
+  color: var(--magenta);
+  border-color: rgba(192, 132, 252, 0.25);
+}
+.scope-deny {
+  color: var(--red);
+  border-color: rgba(255, 80, 80, 0.25);
+}
+.scope-scan-safe {
+  color: var(--green);
+  border-color: var(--green-glow);
+}
+.scope-scan-low {
+  color: var(--fg-dim);
+  border-color: var(--border);
+}
+.scope-scan-medium {
+  color: var(--yellow);
+  border-color: var(--yellow-glow);
+}
+.scope-scan-high {
+  color: var(--red);
+  border-color: var(--red-glow);
+}
+.scope-scan-critical {
+  color: var(--red);
+  border-color: var(--red-glow);
+  background: rgba(248, 113, 113, 0.08);
+}
 
-.admin-field { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
+.admin-field {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
 .admin-field-heading {
   font-family: var(--font-display);
   font-size: 10px;
@@ -1193,12 +1651,33 @@
   display: block;
 }
 
-.scan-composite { font-size: 11px; color: var(--fg-dim); margin-left: 6px; }
-.scan-version { font-size: 10px; color: var(--fg-dim); margin-left: 6px; }
-.scan-axis { font-size: 11px; padding: 2px 0; color: var(--fg-dim); }
-.scan-axis-name { text-transform: capitalize; display: inline-block; min-width: 100px; }
-.scan-axis-score { font-family: var(--font-mono); }
-.scan-axis-flags { color: var(--yellow); font-size: 10px; }
+.scan-composite {
+  font-size: 11px;
+  color: var(--fg-dim);
+  margin-left: 6px;
+}
+.scan-version {
+  font-size: 10px;
+  color: var(--fg-dim);
+  margin-left: 6px;
+}
+.scan-axis {
+  font-size: 11px;
+  padding: 2px 0;
+  color: var(--fg-dim);
+}
+.scan-axis-name {
+  text-transform: capitalize;
+  display: inline-block;
+  min-width: 100px;
+}
+.scan-axis-score {
+  font-family: var(--font-mono);
+}
+.scan-axis-flags {
+  color: var(--yellow);
+  font-size: 10px;
+}
 
 /* Action buttons */
 .admin-btn-danger {
@@ -1212,10 +1691,18 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.8;
-  transition: opacity 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
 }
-.admin-btn-danger:hover { opacity: 1; background: rgba(248, 113, 113, 0.1); }
-.admin-btn-danger:focus-visible { outline: 2px solid var(--red); outline-offset: 2px; }
+.admin-btn-danger:hover {
+  opacity: 1;
+  background: rgba(248, 113, 113, 0.1);
+}
+.admin-btn-danger:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 2px;
+}
 
 .admin-btn-caution {
   background: none;
@@ -1228,10 +1715,18 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.8;
-  transition: opacity 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
 }
-.admin-btn-caution:hover { opacity: 1; background: rgba(251, 191, 36, 0.1); }
-.admin-btn-caution:focus-visible { outline: 2px solid var(--yellow); outline-offset: 2px; }
+.admin-btn-caution:hover {
+  opacity: 1;
+  background: rgba(251, 191, 36, 0.1);
+}
+.admin-btn-caution:focus-visible {
+  outline: 2px solid var(--yellow);
+  outline-offset: 2px;
+}
 
 .admin-btn-action {
   background: none;
@@ -1244,11 +1739,20 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.8;
-  transition: opacity 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
   margin-right: 4px;
 }
-.admin-btn-action:hover { opacity: 1; background: rgba(255, 255, 255, 0.05); color: var(--fg); }
-.admin-btn-action:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.admin-btn-action:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--fg);
+}
+.admin-btn-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* Schedules grid: NAME | TYPE | SCHEDULE | TARGET | NEXT RUN | STATUS | ACTIONS */
 #admin-schedules .admin-colheaders,
@@ -1257,12 +1761,21 @@
 }
 
 /* Schedule runs grid: STARTED | NODE | STATUS | ERROR */
-.sched-runs-grid { grid-template-columns: 2fr 1fr 1fr 2fr; }
+.sched-runs-grid {
+  grid-template-columns: 2fr 1fr 1fr 2fr;
+}
 
 /* Schedule status indicators */
-.sched-active { color: var(--green); font-weight: 500; }
-.sched-disabled { color: var(--fg-dim); }
-.sched-expired { color: var(--accent); }
+.sched-active {
+  color: var(--green);
+  font-weight: 500;
+}
+.sched-disabled {
+  color: var(--fg-dim);
+}
+.sched-expired {
+  color: var(--accent);
+}
 
 /* Watches grid: NAME | NODE | COMMAND | INTERVAL | POLL | CONDITION | STATUS | ACTIONS */
 #admin-watches .admin-colheaders,
@@ -1271,8 +1784,13 @@
 }
 
 /* Watch status indicators */
-.watch-active { color: var(--green); font-weight: 500; }
-.watch-completed { color: var(--accent); }
+.watch-active {
+  color: var(--green);
+  font-weight: 500;
+}
+.watch-completed {
+  color: var(--accent);
+}
 
 /* Two-column form layout for wide modals */
 .modal-columns {
@@ -1281,7 +1799,9 @@
   gap: 0;
 }
 .modal-col > label:first-child,
-.modal-col > .modal-col-heading + label { margin-top: 0; }
+.modal-col > .modal-col-heading + label {
+  margin-top: 0;
+}
 .modal-col-heading {
   font-family: var(--font-display);
   font-size: 9px;
@@ -1328,25 +1848,38 @@
   max-width: 90vw;
   max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.5), 0 0 80px -20px var(--accent-dim);
+  box-shadow:
+    0 24px 48px -12px rgba(0, 0, 0, 0.5),
+    0 0 80px -20px var(--accent-dim);
   position: relative;
 }
-.admin-modal.admin-modal-wide { width: 820px; }
+.admin-modal.admin-modal-wide {
+  width: 820px;
+}
 @media (max-width: 700px) {
-  .admin-modal.admin-modal-wide { width: auto; }
-  .modal-columns { grid-template-columns: 1fr; gap: 20px 0; }
+  .admin-modal.admin-modal-wide {
+    width: auto;
+  }
+  .modal-columns {
+    grid-template-columns: 1fr;
+    gap: 20px 0;
+  }
   .modal-columns > .modal-col:first-child {
     border-right: none;
     padding-right: 0;
     border-bottom: 1px solid var(--border);
     padding-bottom: 16px;
   }
-  .modal-columns > .modal-col:last-child { padding-left: 0; }
+  .modal-columns > .modal-col:last-child {
+    padding-left: 0;
+  }
 }
 .admin-modal::before {
-  content: '';
+  content: "";
   position: absolute;
-  top: 0; left: 20%; right: 20%;
+  top: 0;
+  left: 20%;
+  right: 20%;
   height: 2px;
   background: linear-gradient(90deg, transparent, var(--accent), transparent);
   border-radius: 1px;
@@ -1372,8 +1905,12 @@
   margin-bottom: 5px;
   margin-top: 12px;
 }
-.admin-modal label:first-of-type { margin-top: 0; }
-.admin-modal input:not([type="hidden"]), .admin-modal select, .admin-modal textarea {
+.admin-modal label:first-of-type {
+  margin-top: 0;
+}
+.admin-modal input:not([type="hidden"]),
+.admin-modal select,
+.admin-modal textarea {
   width: 100%;
   padding: 9px 12px;
   background: var(--bg);
@@ -1382,64 +1919,149 @@
   color: var(--fg);
   font: inherit;
   font-size: 13px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
-.admin-modal input:focus, .admin-modal select:focus, .admin-modal textarea:focus {
+.admin-modal input:focus,
+.admin-modal select:focus,
+.admin-modal textarea:focus {
   border-color: var(--accent);
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
-.admin-modal input:disabled, .admin-modal select:disabled, .admin-modal textarea:disabled {
+.admin-modal input:disabled,
+.admin-modal select:disabled,
+.admin-modal textarea:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   background: var(--bg-highlight);
   border-color: var(--border);
   color: var(--fg-dim);
 }
-.admin-modal label.admin-checkbox input:disabled { opacity: 0.4; }
-.admin-modal input::placeholder, .admin-modal textarea::placeholder { color: var(--fg-dim); opacity: 0.6; }
-.admin-modal textarea { resize: vertical; min-height: 40px; }
-.admin-modal [role="alert"] { display: none; color: var(--red); font-size: 12px; margin-bottom: 8px; }
-.admin-modal [role="alert"].is-visible { display: block; }
+.admin-modal label.admin-checkbox input:disabled {
+  opacity: 0.4;
+}
+.admin-modal input::placeholder,
+.admin-modal textarea::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.6;
+}
+.admin-modal textarea {
+  resize: vertical;
+  min-height: 40px;
+}
+.admin-modal [role="alert"] {
+  display: none;
+  color: var(--red);
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.admin-modal [role="alert"].is-visible {
+  display: block;
+}
 
 .admin-inline-add {
-  background: none; border: 1px dashed var(--border-strong); border-radius: var(--radius-sm);
-  color: var(--fg-dim); font: inherit; font-size: 12px; padding: 5px 10px; cursor: pointer;
-  width: 100%; margin-top: 6px; transition: border-color 0.15s, color 0.15s;
+  background: none;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 6px;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 }
-.admin-inline-add:hover { border-color: var(--accent); color: var(--accent); }
-.admin-inline-add:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.admin-inline-add:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.admin-inline-add:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .notify-row {
-  display: flex; gap: 6px; margin-bottom: 4px; align-items: center;
+  display: flex;
+  gap: 6px;
+  margin-bottom: 4px;
+  align-items: center;
   flex-wrap: wrap;
 }
-.notify-row select, .notify-row input {
+.notify-row select,
+.notify-row input {
   padding: 7px 8px;
-  background: var(--bg); border: 1px solid var(--border-strong);
-  border-radius: var(--radius-sm); color: var(--fg); font: inherit; font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
 }
 /* Tighter platform select — labels are short ("Discord"/"Slack") */
-.notify-row-ct { width: 76px; flex-shrink: 0; }
-.notify-row-target { width: 90px; flex-shrink: 0; }
-.notify-row-id { flex: 1 1 140px; min-width: 0; }
-/* Older rows that didn't get the per-element classes still need to size */
-.notify-row select:not([class*="notify-row-"]) { width: 90px; flex-shrink: 0; }
-.notify-row input:not([class*="notify-row-"]) { flex: 1; min-width: 0; }
-.notify-row-remove {
-  background: none; border: none; color: var(--fg-dim); cursor: pointer;
-  font-size: 16px; padding: 0 4px; line-height: 1; flex-shrink: 0;
+.notify-row-ct {
+  width: 76px;
+  flex-shrink: 0;
 }
-.notify-row-remove:hover { color: var(--red); }
-.notify-row-remove:focus-visible { outline: 2px solid var(--red); outline-offset: 2px; }
+.notify-row-target {
+  width: 90px;
+  flex-shrink: 0;
+}
+.notify-row-id {
+  flex: 1 1 140px;
+  min-width: 0;
+}
+/* Older rows that didn't get the per-element classes still need to size */
+.notify-row select:not([class*="notify-row-"]) {
+  width: 90px;
+  flex-shrink: 0;
+}
+.notify-row input:not([class*="notify-row-"]) {
+  flex: 1;
+  min-width: 0;
+}
+.notify-row-remove {
+  background: none;
+  border: none;
+  color: var(--fg-dim);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.notify-row-remove:hover {
+  color: var(--red);
+}
+.notify-row-remove:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 2px;
+}
 /* Narrow viewports — drop the ID input to its own line so snowflakes
    and Slack ids aren't truncated to ~80px on phones. */
 @media (max-width: 700px) {
-  .notify-row-id { flex-basis: 100%; order: 3; }
-  .notify-row-remove { order: 2; margin-left: auto; }
+  .notify-row-id {
+    flex-basis: 100%;
+    order: 3;
+  }
+  .notify-row-remove {
+    order: 2;
+    margin-left: auto;
+  }
 }
 
-.admin-details { margin-top: 12px; border: 1px solid var(--border); border-radius: 6px; padding: 0 12px; }
-.admin-details[open] { padding-bottom: 12px; }
+.admin-details {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 12px;
+}
+.admin-details[open] {
+  padding-bottom: 12px;
+}
 .admin-details summary {
   cursor: pointer;
   padding: 10px 0;
@@ -1454,7 +2076,9 @@
   align-items: center;
   list-style: none;
 }
-.admin-details summary::-webkit-details-marker { display: none; }
+.admin-details summary::-webkit-details-marker {
+  display: none;
+}
 .admin-details summary::after {
   content: "\25B8";
   font-size: 11px;
@@ -1464,14 +2088,20 @@
 .admin-details[open] summary::after {
   transform: rotate(90deg);
 }
-.admin-details summary .label-hint { font-weight: 400; }
-.admin-details label:first-of-type { margin-top: 4px; }
+.admin-details summary .label-hint {
+  font-weight: 400;
+}
+.admin-details label:first-of-type {
+  margin-top: 4px;
+}
 
 /* ==========================================================================
    Skill Spec Modal — two-column manifest layout
    Left: Identity / Manifest / Deployment  |  Right: Skill Content
    ========================================================================== */
-.admin-modal-skill { padding: 28px 28px 24px; }
+.admin-modal-skill {
+  padding: 28px 28px 24px;
+}
 
 .skill-spec-body {
   display: grid;
@@ -1491,11 +2121,18 @@
   flex-direction: column;
 }
 
-.skill-spec-section { margin-bottom: 14px; }
-.skill-spec-section:last-child { margin-bottom: 0; }
+.skill-spec-section {
+  margin-bottom: 14px;
+}
+.skill-spec-section:last-child {
+  margin-bottom: 0;
+}
 
 /* h3 used for screen-reader heading structure; reset UA defaults */
-h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
+h3.skill-spec-heading {
+  font-size: inherit;
+  margin-block: 0;
+}
 .skill-spec-heading {
   font-family: var(--font-display);
   font-size: 10px;
@@ -1507,7 +2144,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   margin: 14px 0 6px;
   border-bottom: 1px solid var(--accent-dim);
 }
-.skill-spec-section:first-child .skill-spec-heading { margin-top: 0; }
+.skill-spec-section:first-child .skill-spec-heading {
+  margin-top: 0;
+}
 .skill-spec-heading .label-hint {
   text-transform: none;
   letter-spacing: 0;
@@ -1549,7 +2188,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   flex-shrink: 0;
 }
 
-.skill-vars-display { font-size: 11px; }
+.skill-vars-display {
+  font-size: 11px;
+}
 
 .skill-config-grid {
   display: grid;
@@ -1557,7 +2198,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   gap: 8px 14px;
   margin: 4px 0 2px;
 }
-.skill-config-grid > div { min-width: 0; }
+.skill-config-grid > div {
+  min-width: 0;
+}
 
 /* Origin badge — shown for remotely installed (readonly) skills */
 .skill-origin-badge {
@@ -1587,7 +2230,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 @media (max-width: 700px) {
-  .skill-spec-body { grid-template-columns: 1fr; }
+  .skill-spec-body {
+    grid-template-columns: 1fr;
+  }
   .skill-spec-col-meta {
     border-right: none;
     padding-right: 0;
@@ -1595,11 +2240,19 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
     padding-bottom: 16px;
     margin-bottom: 16px;
   }
-  .skill-spec-col-content { padding-left: 0; }
-  .skill-config-grid { grid-template-columns: 1fr 1fr; }
+  .skill-spec-col-content {
+    padding-left: 0;
+  }
+  .skill-config-grid {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
-.modal-buttons { display: flex; gap: 10px; margin-top: 20px; }
+.modal-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
 .modal-cancel {
   flex: 1;
   padding: 9px;
@@ -1614,9 +2267,18 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   cursor: pointer;
   transition: background 0.15s;
 }
-.modal-cancel:hover { background: var(--bg-elevated); }
-.modal-cancel:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.modal-cancel:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+.modal-cancel:hover {
+  background: var(--bg-elevated);
+}
+.modal-cancel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.modal-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 .modal-submit {
   flex: 1;
   padding: 9px;
@@ -1631,21 +2293,47 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   cursor: pointer;
   transition: filter 0.15s;
 }
-.modal-submit:hover { filter: brightness(1.1); }
-.modal-submit:focus-visible { outline: 2px solid var(--fg-bright); outline-offset: 2px; }
-.modal-submit:disabled { opacity: 0.4; cursor: not-allowed; filter: none; }
+.modal-submit:hover {
+  filter: brightness(1.1);
+}
+.modal-submit:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
+.modal-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: none;
+}
 
-#create-user-overlay, #create-token-overlay, #token-created-overlay, #create-channel-overlay, #confirm-overlay,
-#create-schedule-overlay, #edit-schedule-overlay, #schedule-runs-overlay,
-#create-role-overlay, #edit-role-overlay, #user-roles-overlay,
-#create-policy-overlay, #edit-policy-overlay,
-#create-ppolicy-overlay, #edit-ppolicy-overlay,
-#create-template-overlay, #edit-template-overlay,
+#create-user-overlay,
+#create-token-overlay,
+#token-created-overlay,
+#create-channel-overlay,
+#confirm-overlay,
+#create-schedule-overlay,
+#edit-schedule-overlay,
+#schedule-runs-overlay,
+#create-role-overlay,
+#edit-role-overlay,
+#user-roles-overlay,
+#create-policy-overlay,
+#edit-policy-overlay,
+#create-ppolicy-overlay,
+#edit-ppolicy-overlay,
+#create-template-overlay,
+#edit-template-overlay,
 #memory-detail-overlay,
-#mcp-create-overlay, #mcp-import-overlay, #mcp-detail-overlay, #mcp-install-overlay,
+#mcp-create-overlay,
+#mcp-import-overlay,
+#mcp-detail-overlay,
+#mcp-install-overlay,
 #github-import-overlay,
 #model-create-overlay,
-#create-hr-overlay, #edit-hr-overlay, #create-ogp-overlay, #edit-ogp-overlay {
+#create-hr-overlay,
+#edit-hr-overlay,
+#create-ogp-overlay,
+#edit-ogp-overlay {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.7);
@@ -1677,40 +2365,67 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 @media (max-width: 700px) {
-  #admin-users .admin-colheaders, #admin-users .admin-row {
+  #admin-users .admin-colheaders,
+  #admin-users .admin-row {
     grid-template-columns: 100px 1fr 80px;
   }
-  .admin-col-created { display: none; }
-  #admin-tokens .admin-colheaders, #admin-tokens .admin-row {
+  .admin-col-created {
+    display: none;
+  }
+  #admin-tokens .admin-colheaders,
+  #admin-tokens .admin-row {
     grid-template-columns: 80px 1fr 100px 80px;
   }
-  .admin-col-created, .admin-col-expires { display: none; }
-  #admin-channels .admin-colheaders, #admin-channels .admin-row {
+  .admin-col-created,
+  .admin-col-expires {
+    display: none;
+  }
+  #admin-channels .admin-colheaders,
+  #admin-channels .admin-row {
     grid-template-columns: 80px 1fr 80px;
   }
-  #admin-channels .admin-col-created { display: none; }
-  #admin-schedules .admin-colheaders, #admin-schedules .admin-row {
+  #admin-channels .admin-col-created {
+    display: none;
+  }
+  #admin-schedules .admin-colheaders,
+  #admin-schedules .admin-row {
     grid-template-columns: 1fr 60px 80px 130px;
   }
-  .admin-col-sschedule, .admin-col-starget, .admin-col-snext { display: none; }
-  #admin-watches .admin-colheaders, #admin-watches .admin-row {
+  .admin-col-sschedule,
+  .admin-col-starget,
+  .admin-col-snext {
+    display: none;
+  }
+  #admin-watches .admin-colheaders,
+  #admin-watches .admin-row {
     grid-template-columns: 1.2fr 80px 70px 70px 70px;
   }
-  .admin-col-wcmd, .admin-col-wcond, .admin-col-winterval { display: none; }
+  .admin-col-wcmd,
+  .admin-col-wcond,
+  .admin-col-winterval {
+    display: none;
+  }
 
   /* Judge: Heuristic Rules - hide Tier, Risk, Rec on mobile */
   #judge-heuristic-section .admin-colheaders,
   #judge-heuristic-section .admin-row {
     grid-template-columns: 1fr 100px 90px 60px 160px;
   }
-  .admin-col-htier, .admin-col-hrisk, .admin-col-hrec { display: none; }
+  .admin-col-htier,
+  .admin-col-hrisk,
+  .admin-col-hrec {
+    display: none;
+  }
 
   /* Judge: Output Guard - hide Risk, Flag on mobile */
   #judge-output-guard-section .admin-colheaders,
   #judge-output-guard-section .admin-row {
     grid-template-columns: 1fr 120px 90px 60px 160px;
   }
-  .admin-col-ogrisk, .admin-col-ogflag { display: none; }
+  .admin-col-ogrisk,
+  .admin-col-ogflag {
+    display: none;
+  }
 }
 
 /* ==========================================================================
@@ -1736,9 +2451,15 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }
-  .admin-sidebar.open { transform: translateX(0); }
-  .admin-sidebar.collapsed { transform: translateX(100%); }
-  .admin-content { padding-right: 0; }
+  .admin-sidebar.open {
+    transform: translateX(0);
+  }
+  .admin-sidebar.collapsed {
+    transform: translateX(100%);
+  }
+  .admin-content {
+    padding-right: 0;
+  }
 
   /* Close button at top of mobile drawer */
   .admin-sidebar-close {
@@ -1769,16 +2490,27 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
     justify-content: center;
     border-radius: var(--radius-sm);
   }
-  .admin-sidebar-close button:hover { color: var(--fg); }
+  .admin-sidebar-close button:hover {
+    color: var(--fg);
+  }
   .admin-sidebar-close button:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
   /* Flip active indicator to left border on mobile (drawer is on right edge) */
-  .admin-nav { border-right: none; border-left: 2px solid transparent; }
-  .admin-nav:hover { border-right-color: transparent; border-left-color: var(--border-strong); }
-  .admin-nav.active { border-right-color: transparent; border-left-color: var(--accent); }
+  .admin-nav {
+    border-right: none;
+    border-left: 2px solid transparent;
+  }
+  .admin-nav:hover {
+    border-right-color: transparent;
+    border-left-color: var(--border-strong);
+  }
+  .admin-nav.active {
+    border-right-color: transparent;
+    border-left-color: var(--accent);
+  }
 }
 
 /* ==========================================================================
@@ -1863,9 +2595,13 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   cursor: pointer;
   font-family: var(--font-display);
   font-size: 13px;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
-.judge-section-btn:hover { color: var(--fg); }
+.judge-section-btn:hover {
+  color: var(--fg);
+}
 .judge-section-btn.active {
   border-bottom-color: var(--accent);
   color: var(--fg);
@@ -1902,8 +2638,14 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   color: var(--fg-dim);
   border: 1px solid var(--border);
 }
-.audit-danger { color: var(--red); border-color: var(--red-glow); }
-.audit-success { color: var(--green); border-color: var(--green-glow); }
+.audit-danger {
+  color: var(--red);
+  border-color: var(--red-glow);
+}
+.audit-success {
+  color: var(--green);
+  border-color: var(--green-glow);
+}
 
 /* ==========================================================================
    Memories tab
@@ -1941,15 +2683,42 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 /* Memory type badges */
-.mem-type-project { background: var(--bg-highlight); color: var(--cyan); border-color: var(--cyan-glow, var(--border)); }
-.mem-type-user { background: var(--bg-highlight); color: var(--green); border-color: var(--green-glow, var(--border)); }
-.mem-type-feedback { background: var(--bg-highlight); color: var(--yellow); border-color: var(--yellow-glow, var(--border)); }
-.mem-type-reference { background: var(--bg-highlight); color: var(--magenta); border-color: var(--magenta-glow, var(--border)); }
+.mem-type-project {
+  background: var(--bg-highlight);
+  color: var(--cyan);
+  border-color: var(--cyan-glow, var(--border));
+}
+.mem-type-user {
+  background: var(--bg-highlight);
+  color: var(--green);
+  border-color: var(--green-glow, var(--border));
+}
+.mem-type-feedback {
+  background: var(--bg-highlight);
+  color: var(--yellow);
+  border-color: var(--yellow-glow, var(--border));
+}
+.mem-type-reference {
+  background: var(--bg-highlight);
+  color: var(--magenta);
+  border-color: var(--magenta-glow, var(--border));
+}
 
 /* Memory scope badges */
-.mem-scope-global { background: var(--bg-highlight); color: var(--fg-dim); }
-.mem-scope-workstream { background: var(--bg-highlight); color: var(--cyan); border-color: var(--cyan-glow, var(--border)); }
-.mem-scope-user { background: var(--bg-highlight); color: var(--green); border-color: var(--green-glow, var(--border)); }
+.mem-scope-global {
+  background: var(--bg-highlight);
+  color: var(--fg-dim);
+}
+.mem-scope-workstream {
+  background: var(--bg-highlight);
+  color: var(--cyan);
+  border-color: var(--cyan-glow, var(--border));
+}
+.mem-scope-user {
+  background: var(--bg-highlight);
+  color: var(--green);
+  border-color: var(--green-glow, var(--border));
+}
 
 /* Memory detail modal */
 .mem-detail-grid {
@@ -2021,10 +2790,18 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   color: var(--fg-dim);
 }
 /* Secondary readouts (cache stats) — smaller to denote supplementary metrics */
-.usage-readout-secondary .usage-readout-value { font-size: 16px; font-weight: 500; color: var(--fg-dim); }
-.usage-readout-secondary .usage-readout-label { font-size: 9px; }
+.usage-readout-secondary .usage-readout-value {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--fg-dim);
+}
+.usage-readout-secondary .usage-readout-label {
+  font-size: 9px;
+}
 /* Dim zero-value secondary readouts to reduce noise */
-.usage-readout-zero { opacity: 0.35; }
+.usage-readout-zero {
+  opacity: 0.35;
+}
 /* Vertical divider between primary and secondary readout groups */
 .usage-summary-divider {
   width: 1px;
@@ -2034,7 +2811,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 /* Usage bar chart */
-.usage-chart { padding-top: 4px; }
+.usage-chart {
+  padding-top: 4px;
+}
 .usage-bar-row {
   display: grid;
   grid-template-columns: 90px 1fr 60px;
@@ -2080,7 +2859,8 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   border-radius: var(--radius-sm);
   overflow: hidden;
 }
-.usage-range-btn, .usage-group-btn {
+.usage-range-btn,
+.usage-group-btn {
   background: var(--bg);
   color: var(--fg-dim);
   border: none;
@@ -2091,17 +2871,22 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   letter-spacing: 0.06em;
   padding: 5px 10px;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
-.usage-range-btn:hover, .usage-group-btn:hover {
+.usage-range-btn:hover,
+.usage-group-btn:hover {
   background: var(--bg-highlight);
   color: var(--fg);
 }
-.usage-range-btn.active, .usage-group-btn.active {
+.usage-range-btn.active,
+.usage-group-btn.active {
   background: var(--accent-dim);
   color: var(--accent);
 }
-.usage-range-btn:focus-visible, .usage-group-btn:focus-visible {
+.usage-range-btn:focus-visible,
+.usage-group-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -2152,43 +2937,81 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
    Governance: Responsive
    ========================================================================== */
 @media (max-width: 700px) {
-  #admin-roles .admin-colheaders, #admin-roles .admin-row {
+  #admin-roles .admin-colheaders,
+  #admin-roles .admin-row {
     grid-template-columns: 1fr 100px;
   }
-  .admin-col-rperms { display: none; }
-  #admin-policies .admin-colheaders, #admin-policies .admin-row {
+  .admin-col-rperms {
+    display: none;
+  }
+  #admin-policies .admin-colheaders,
+  #admin-policies .admin-row {
     grid-template-columns: 1fr 70px 50px 100px;
   }
-  .admin-col-pstatus, .admin-col-ppriority { display: none; }
-  #admin-prompt-policies .admin-colheaders, #admin-prompt-policies .admin-row {
+  .admin-col-pstatus,
+  .admin-col-ppriority {
+    display: none;
+  }
+  #admin-prompt-policies .admin-colheaders,
+  #admin-prompt-policies .admin-row {
     grid-template-columns: 1fr 70px 100px;
   }
-  #admin-skills .admin-colheaders, #admin-skills .admin-row {
+  #admin-skills .admin-colheaders,
+  #admin-skills .admin-row {
     grid-template-columns: 1fr 100px;
   }
-  .admin-col-tmcat, .admin-col-tmrisk { display: none; }
-  #admin-audit .admin-colheaders, #admin-audit .admin-row {
+  .admin-col-tmcat,
+  .admin-col-tmrisk {
+    display: none;
+  }
+  #admin-audit .admin-colheaders,
+  #admin-audit .admin-row {
     grid-template-columns: 60px 1fr 100px;
   }
-  .admin-col-auser, .admin-col-adetail { display: none; }
-  #admin-memories .admin-colheaders, #admin-memories .admin-row {
+  .admin-col-auser,
+  .admin-col-adetail {
+    display: none;
+  }
+  #admin-memories .admin-colheaders,
+  #admin-memories .admin-row {
     grid-template-columns: 1fr 70px 90px 80px;
   }
-  .admin-col-mdesc, .admin-col-mupdated { display: none; }
-  .admin-toolbar-filters { flex-wrap: wrap; }
-  .admin-toolbar-filters input[type="search"] { width: 120px; }
-  .mem-detail-grid { grid-template-columns: 1fr 1fr; }
-  .usage-summary { gap: 14px; }
-  .usage-readout-value { font-size: 18px; }
-  .usage-readout-secondary .usage-readout-value { font-size: 14px; }
-  .usage-bar-row { grid-template-columns: 70px 1fr 50px; }
-  .perm-grid { grid-template-columns: 1fr; }
+  .admin-col-mdesc,
+  .admin-col-mupdated {
+    display: none;
+  }
+  .admin-toolbar-filters {
+    flex-wrap: wrap;
+  }
+  .admin-toolbar-filters input[type="search"] {
+    width: 120px;
+  }
+  .mem-detail-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .usage-summary {
+    gap: 14px;
+  }
+  .usage-readout-value {
+    font-size: 18px;
+  }
+  .usage-readout-secondary .usage-readout-value {
+    font-size: 14px;
+  }
+  .usage-bar-row {
+    grid-template-columns: 70px 1fr 50px;
+  }
+  .perm-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ==========================================================================
    Settings tab — form editor
    ========================================================================== */
-.settings-section { margin-bottom: 12px; }
+.settings-section {
+  margin-bottom: 12px;
+}
 .settings-section-header {
   cursor: pointer;
   padding: 8px 12px;
@@ -2204,10 +3027,20 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   align-items: center;
   user-select: none;
 }
-.settings-section-header:hover { color: var(--fg); }
-.settings-section-header::after { content: "\25BE"; margin-left: 8px; font-size: 11px; }
-.settings-section[data-collapsed] .settings-section-body { display: none; }
-.settings-section[data-collapsed] .settings-section-header::after { content: "\25B8"; }
+.settings-section-header:hover {
+  color: var(--fg);
+}
+.settings-section-header::after {
+  content: "\25BE";
+  margin-left: 8px;
+  font-size: 11px;
+}
+.settings-section[data-collapsed] .settings-section-body {
+  display: none;
+}
+.settings-section[data-collapsed] .settings-section-header::after {
+  content: "\25B8";
+}
 /* Setting row — 3-column grid */
 .settings-row {
   display: grid;
@@ -2217,12 +3050,25 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   align-items: start;
   border-bottom: 1px solid var(--border);
 }
-.settings-row:hover { background: var(--row-alt, rgba(255,255,255,0.015)); }
+.settings-row:hover {
+  background: var(--row-alt, rgba(255, 255, 255, 0.015));
+}
 
 /* Label column */
-.settings-label-col { min-width: 0; }
-.settings-label { font-size: 12px; color: var(--fg); font-family: var(--font-mono); }
-.settings-desc { font-size: 10px; color: var(--fg-dim); margin-top: 2px; line-height: 1.3; }
+.settings-label-col {
+  min-width: 0;
+}
+.settings-label {
+  font-size: 12px;
+  color: var(--fg);
+  font-family: var(--font-mono);
+}
+.settings-desc {
+  font-size: 10px;
+  color: var(--fg-dim);
+  margin-top: 2px;
+  line-height: 1.3;
+}
 
 /* Input column */
 .settings-input input[type="text"],
@@ -2241,9 +3087,14 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   box-sizing: border-box;
 }
 /* Hide number spin buttons (Firefox + WebKit) */
-.settings-input input[type="number"] { -moz-appearance: textfield; }
+.settings-input input[type="number"] {
+  -moz-appearance: textfield;
+}
 .settings-input input[type="number"]::-webkit-inner-spin-button,
-.settings-input input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+.settings-input input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
 
 .settings-input input:focus,
 .settings-input select:focus {
@@ -2260,7 +3111,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 /* Bool toggle */
-.settings-input .settings-toggle { margin-top: 2px; }
+.settings-input .settings-toggle {
+  margin-top: 2px;
+}
 .settings-toggle {
   position: relative;
   display: inline-block;
@@ -2268,7 +3121,12 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   height: 20px;
   cursor: pointer;
 }
-.settings-toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
+.settings-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
 .settings-toggle-slider {
   position: absolute;
   inset: 0;
@@ -2286,7 +3144,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   bottom: 2px;
   background: var(--fg-dim);
   border-radius: 50%;
-  transition: transform 0.2s, background 0.2s;
+  transition:
+    transform 0.2s,
+    background 0.2s;
 }
 .settings-toggle input:checked + .settings-toggle-slider {
   background: var(--accent-dim);
@@ -2301,7 +3161,12 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 /* Actions column */
-.settings-actions { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.settings-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
 
 /* Save button */
 .settings-save-btn {
@@ -2316,12 +3181,29 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   border: 1px solid var(--accent);
   color: var(--accent);
   background: none;
-  transition: opacity 0.15s, visibility 0s 0.15s;
+  transition:
+    opacity 0.15s,
+    visibility 0s 0.15s;
 }
-.settings-save-btn.visible { visibility: visible; opacity: 0.8; transition: opacity 0.15s, visibility 0s; }
-.settings-save-btn.visible:hover { opacity: 1; background: var(--accent-dim); }
-.settings-save-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.settings-save-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.settings-save-btn.visible {
+  visibility: visible;
+  opacity: 0.8;
+  transition:
+    opacity 0.15s,
+    visibility 0s;
+}
+.settings-save-btn.visible:hover {
+  opacity: 1;
+  background: var(--accent-dim);
+}
+.settings-save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.settings-save-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* Reset button */
 .settings-reset-btn {
@@ -2337,11 +3219,21 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   opacity: 0.7;
   transition: opacity 0.15s;
 }
-.settings-reset-btn:hover { opacity: 1; color: var(--red); border-color: var(--red); }
-.settings-reset-btn:focus-visible { outline: 2px solid var(--red); outline-offset: 2px; }
+.settings-reset-btn:hover {
+  opacity: 1;
+  color: var(--red);
+  border-color: var(--red);
+}
+.settings-reset-btn:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 2px;
+}
 
 /* Badges */
-.settings-badge-default { color: var(--fg-dim); border-color: var(--border); }
+.settings-badge-default {
+  color: var(--fg-dim);
+  border-color: var(--border);
+}
 .settings-restart-badge {
   display: none;
   font-family: var(--font-display);
@@ -2354,8 +3246,12 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   border: 1px solid var(--yellow-glow);
   border-radius: 2px;
 }
-.settings-restart-badge.visible { display: inline-block; }
-.settings-restart-badge.saved { background: var(--yellow-glow); }
+.settings-restart-badge.visible {
+  display: inline-block;
+}
+.settings-restart-badge.saved {
+  background: var(--yellow-glow);
+}
 
 /* Help tooltip */
 .settings-help-btn {
@@ -2377,12 +3273,24 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   padding: 0;
   line-height: 1;
   position: relative;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 /* Expand tap target to ~26px without changing visual size */
-.settings-help-btn::before { content: ""; position: absolute; inset: -5px; }
-.settings-help-btn:hover { background: var(--accent); color: var(--bg); }
-.settings-help-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.settings-help-btn::before {
+  content: "";
+  position: absolute;
+  inset: -5px;
+}
+.settings-help-btn:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+.settings-help-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 .settings-help-popover {
   margin-top: 4px;
@@ -2395,7 +3303,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   line-height: 1.4;
   color: var(--fg);
 }
-.settings-help-text { color: var(--fg); }
+.settings-help-text {
+  color: var(--fg);
+}
 .settings-help-ref {
   color: var(--accent);
   text-decoration: none;
@@ -2403,7 +3313,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   font-family: var(--font-display);
   white-space: nowrap;
 }
-.settings-help-ref:hover { text-decoration: underline; }
+.settings-help-ref:hover {
+  text-decoration: underline;
+}
 
 /* Docs link in toolbar */
 .settings-docs-link {
@@ -2416,132 +3328,546 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   border-radius: var(--radius-sm);
   padding: 2px 8px;
   margin-left: auto;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
-.settings-docs-link:hover { color: var(--accent); border-color: var(--accent-dim); }
-.settings-docs-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.settings-docs-link:hover {
+  color: var(--accent);
+  border-color: var(--accent-dim);
+}
+.settings-docs-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* Settings mobile */
 @media (max-width: 700px) {
-  .settings-row { grid-template-columns: 1fr; gap: 4px; }
-  .settings-desc { display: none; }
+  .settings-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .settings-desc {
+    display: none;
+  }
   .settings-input input[type="text"],
   .settings-input input[type="number"],
   .settings-input input[type="password"],
-  .settings-input select { max-width: 100%; }
+  .settings-input select {
+    max-width: 100%;
+  }
 }
 
 /* -- MCP Servers grid ----------------------------------------------------- */
-.admin-col-mname a{color:var(--fg);text-decoration:none;transition:color .15s}
-.admin-col-mname a:hover{color:var(--magenta)}
-.admin-col-mname a:focus-visible{outline:2px solid var(--magenta);outline-offset:2px}
-.mcp-grid{grid-template-columns:1.5fr 80px 55px 45px 80px 95px 120px;gap:0 6px}
-@media(max-width:700px){
-  .mcp-grid{grid-template-columns:1fr 100px 130px}
-  .admin-col-mtransport,.admin-col-mtools,.admin-col-mres,.admin-col-mprompts{display:none}
+.admin-col-mname a {
+  color: var(--fg);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.admin-col-mname a:hover {
+  color: var(--magenta);
+}
+.admin-col-mname a:focus-visible {
+  outline: 2px solid var(--magenta);
+  outline-offset: 2px;
+}
+.mcp-grid {
+  grid-template-columns: 1.5fr 80px 55px 45px 80px 95px 120px;
+  gap: 0 6px;
+}
+@media (max-width: 700px) {
+  .mcp-grid {
+    grid-template-columns: 1fr 100px 130px;
+  }
+  .admin-col-mtransport,
+  .admin-col-mtools,
+  .admin-col-mres,
+  .admin-col-mprompts {
+    display: none;
+  }
 }
 
-.mcp-status-dot{display:inline-block;width:8px;height:8px;border-radius:50%;vertical-align:middle;margin-right:6px}
-.mcp-status-dot.connected{background:var(--magenta);box-shadow:0 0 6px var(--magenta-glow, rgba(192,132,252,.45))}
-.mcp-status-dot.error{background:var(--red);box-shadow:0 0 6px var(--red-glow);border-radius:1px}
-.mcp-status-dot.disabled{background:var(--fg-dim);opacity:.35}
-.mcp-status-dot.connecting{background:var(--magenta);animation:mcp-pulse 1.2s ease-in-out infinite}
-@keyframes mcp-pulse{0%,100%{opacity:.3}50%{opacity:1}}
+.mcp-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+.mcp-status-dot.connected {
+  background: var(--magenta);
+  box-shadow: 0 0 6px var(--magenta-glow, rgba(192, 132, 252, 0.45));
+}
+.mcp-status-dot.error {
+  background: var(--red);
+  box-shadow: 0 0 6px var(--red-glow);
+  border-radius: 1px;
+}
+.mcp-status-dot.disabled {
+  background: var(--fg-dim);
+  opacity: 0.35;
+}
+.mcp-status-dot.connecting {
+  background: var(--magenta);
+  animation: mcp-pulse 1.2s ease-in-out infinite;
+}
+@keyframes mcp-pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
 
-.mcp-row-connected{border-left:3px solid var(--magenta)}
-.mcp-row-error{border-left:3px solid var(--red)}
-.mcp-row-disabled{border-left:3px solid transparent}
+.mcp-row-connected {
+  border-left: 3px solid var(--magenta);
+}
+.mcp-row-error {
+  border-left: 3px solid var(--red);
+}
+.mcp-row-disabled {
+  border-left: 3px solid transparent;
+}
 
-.mcp-transport-badge{display:inline-block;font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;padding:1px 6px;border-radius:2px;background:var(--bg-highlight);border:1px solid var(--border)}
-.mcp-transport-stdio{color:var(--cyan);border-color:rgba(103,232,249,.2)}
-.mcp-transport-http{color:var(--magenta);border-color:rgba(192,132,252,.25)}
+.mcp-transport-badge {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 6px;
+  border-radius: 2px;
+  background: var(--bg-highlight);
+  border: 1px solid var(--border);
+}
+.mcp-transport-stdio {
+  color: var(--cyan);
+  border-color: rgba(103, 232, 249, 0.2);
+}
+.mcp-transport-http {
+  color: var(--magenta);
+  border-color: rgba(192, 132, 252, 0.25);
+}
 
-.admin-col-mtools,.admin-col-mres,.admin-col-mprompts{text-align:right;font-variant-numeric:tabular-nums}
-.mcp-count-dim{opacity:.4}
+.admin-col-mtools,
+.admin-col-mres,
+.admin-col-mprompts {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.mcp-count-dim {
+  opacity: 0.4;
+}
 
-.mcp-detail-modal::before{background:linear-gradient(90deg,transparent,var(--magenta),transparent)!important}
-.mcp-detail-modal h2{color:var(--magenta)!important}
-.mcp-detail-section{margin-top:16px}
-.mcp-detail-section h3{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--magenta);margin-bottom:8px}
-.mcp-detail-list{list-style:none;padding:0;margin:0}
-.mcp-detail-list li{font-size:12px;padding:3px 0;border-bottom:1px solid var(--border);color:var(--fg-dim)}
-.mcp-detail-list li:last-child{border-bottom:none}
+.mcp-detail-modal::before {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--magenta),
+    transparent
+  ) !important;
+}
+.mcp-detail-modal h2 {
+  color: var(--magenta) !important;
+}
+.mcp-detail-section {
+  margin-top: 16px;
+}
+.mcp-detail-section h3 {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--magenta);
+  margin-bottom: 8px;
+}
+.mcp-detail-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.mcp-detail-list li {
+  font-size: 12px;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg-dim);
+}
+.mcp-detail-list li:last-child {
+  border-bottom: none;
+}
 
-.admin-action-btn-ghost{background:transparent;color:var(--fg-dim);border:1px solid var(--border-strong)}
-.admin-action-btn-ghost:hover{color:var(--fg);background:var(--bg-highlight)}
-.mcp-sync-pending,.model-sync-pending{color:var(--yellow)!important;border-color:var(--yellow)!important;animation:mcp-sync-pulse 2s ease-in-out infinite}
-@keyframes mcp-sync-pulse{0%,100%{border-color:var(--yellow)}50%{border-color:rgba(251,191,36,.3)}}
+.admin-action-btn-ghost {
+  background: transparent;
+  color: var(--fg-dim);
+  border: 1px solid var(--border-strong);
+}
+.admin-action-btn-ghost:hover {
+  color: var(--fg);
+  background: var(--bg-highlight);
+}
+.mcp-sync-pending,
+.model-sync-pending {
+  color: var(--yellow) !important;
+  border-color: var(--yellow) !important;
+  animation: mcp-sync-pulse 2s ease-in-out infinite;
+}
+@keyframes mcp-sync-pulse {
+  0%,
+  100% {
+    border-color: var(--yellow);
+  }
+  50% {
+    border-color: rgba(251, 191, 36, 0.3);
+  }
+}
 
 /* -- MCP sub-view toggle -------------------------------------------------- */
-.mcp-view-toggle{display:flex;gap:2px;border:1px solid var(--border-strong);border-radius:var(--radius-sm);overflow:hidden}
-.mcp-view-btn{background:var(--bg);color:var(--fg-dim);border:none;font-family:var(--font-display);font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;padding:5px 12px;cursor:pointer;transition:background .15s,color .15s}
-.mcp-view-btn:hover{background:var(--bg-highlight);color:var(--fg)}
-.mcp-view-btn.active{background:rgba(192,132,252,.15);color:var(--magenta)}
-.mcp-view-btn:focus-visible{outline:2px solid var(--magenta);outline-offset:-2px}
+.mcp-view-toggle {
+  display: flex;
+  gap: 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.mcp-view-btn {
+  background: var(--bg);
+  color: var(--fg-dim);
+  border: none;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.mcp-view-btn:hover {
+  background: var(--bg-highlight);
+  color: var(--fg);
+}
+.mcp-view-btn.active {
+  background: rgba(192, 132, 252, 0.15);
+  color: var(--magenta);
+}
+.mcp-view-btn:focus-visible {
+  outline: 2px solid var(--magenta);
+  outline-offset: -2px;
+}
 
 /* -- MCP source badges ---------------------------------------------------- */
-.scope-config{color:var(--magenta);border-color:rgba(192,132,252,.25)}
-.scope-default{color:var(--yellow);border-color:rgba(251,191,36,.3)}
-.scope-manual{color:var(--cyan);border-color:rgba(103,232,249,.2)}
-.scope-registry{color:var(--green);border-color:rgba(52,211,153,.2)}
+.scope-config {
+  color: var(--magenta);
+  border-color: rgba(192, 132, 252, 0.25);
+}
+.scope-default {
+  color: var(--yellow);
+  border-color: rgba(251, 191, 36, 0.3);
+}
+.scope-manual {
+  color: var(--cyan);
+  border-color: rgba(103, 232, 249, 0.2);
+}
+.scope-registry {
+  color: var(--green);
+  border-color: rgba(52, 211, 153, 0.2);
+}
 
 /* -- MCP Registry notice -------------------------------------------------- */
-.mcp-registry-notice{padding:10px 14px;margin-bottom:12px;background:rgba(251,191,36,.06);border:1px solid rgba(251,191,36,.15);border-left:3px solid var(--yellow);border-radius:var(--radius-sm);font-size:11px;line-height:1.5;color:var(--fg-dim)}
-.mcp-registry-notice-icon{color:var(--yellow);font-size:13px;margin-right:6px}
-.mcp-registry-notice a{color:var(--yellow);text-decoration:underline;text-underline-offset:2px}
-.mcp-registry-notice a:hover{color:var(--fg-bright)}
+.mcp-registry-notice {
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  background: rgba(251, 191, 36, 0.06);
+  border: 1px solid rgba(251, 191, 36, 0.15);
+  border-left: 3px solid var(--yellow);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--fg-dim);
+}
+.mcp-registry-notice-icon {
+  color: var(--yellow);
+  font-size: 13px;
+  margin-right: 6px;
+}
+.mcp-registry-notice a {
+  color: var(--yellow);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.mcp-registry-notice a:hover {
+  color: var(--fg-bright);
+}
 
 /* -- MCP Registry search -------------------------------------------------- */
-.mcp-registry-search{display:flex;gap:10px;margin-bottom:16px}
-.mcp-registry-search input[type="search"]{flex:1;padding:9px 14px;background:var(--bg);border:1px solid var(--border-strong);border-radius:var(--radius-sm);color:var(--fg);font:inherit;font-size:13px;transition:border-color .15s,box-shadow .15s}
-.mcp-registry-search input[type="search"]:focus{border-color:var(--magenta);outline:none;box-shadow:0 0 0 3px rgba(192,132,252,.15)}
-.mcp-registry-search input[type="search"]::placeholder{color:var(--fg-dim);opacity:.8}
-.mcp-registry-search select{padding:9px 30px 9px 10px;background:var(--bg);border:1px solid var(--border-strong);border-radius:var(--radius-sm);color:var(--fg);font:inherit;font-size:12px;min-width:110px;cursor:pointer;appearance:none;-webkit-appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%238a93ad' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 10px center}
-.mcp-registry-search select:focus{border-color:var(--magenta);outline:none;box-shadow:0 0 0 3px rgba(192,132,252,.15)}
+.mcp-registry-search {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.mcp-registry-search input[type="search"] {
+  flex: 1;
+  padding: 9px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.mcp-registry-search input[type="search"]:focus {
+  border-color: var(--magenta);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.15);
+}
+.mcp-registry-search input[type="search"]::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.8;
+}
+.mcp-registry-search select {
+  padding: 9px 30px 9px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+  min-width: 110px;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%238a93ad' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.mcp-registry-search select:focus {
+  border-color: var(--magenta);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.15);
+}
 
 /* -- MCP Registry result cards -------------------------------------------- */
-.mcp-reg-card{display:grid;grid-template-columns:1fr auto;gap:12px;align-items:start;padding:14px 16px;background:var(--bg-surface);border:1px solid var(--border);border-left:3px solid var(--border);border-radius:var(--radius-sm);margin-bottom:6px;transition:border-color .15s}
-.mcp-reg-card:hover{border-color:var(--border-strong);border-left-color:var(--magenta)}
-.mcp-reg-card-info{min-width:0}
-.mcp-reg-card-name{font-family:var(--font-display);font-size:13px;font-weight:600;color:var(--fg-bright);margin-bottom:3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.mcp-reg-card-repo{color:var(--fg-dim);text-decoration:none;font-size:11px;margin-left:4px;opacity:.6;transition:opacity .15s}
-.mcp-reg-card-repo:hover{opacity:1;color:var(--magenta)}
-.mcp-reg-card-repo:focus-visible{opacity:1;color:var(--magenta);outline:2px solid var(--magenta);outline-offset:2px}
-.mcp-reg-card-desc{font-size:11px;color:var(--fg-dim);line-height:1.4;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;margin-bottom:4px}
-.mcp-reg-card-meta{display:flex;gap:6px;margin-top:4px;flex-wrap:wrap}
-.mcp-reg-card-meta .scope-badge{font-size:9px}
-.mcp-reg-card-actions{display:flex;flex-direction:column;align-items:flex-end;gap:6px;flex-shrink:0}
-.mcp-reg-card-version{font-family:var(--font-mono);font-size:10px;color:var(--fg-dim)}
+.mcp-reg-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: start;
+  padding: 14px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  transition: border-color 0.15s;
+}
+.mcp-reg-card:hover {
+  border-color: var(--border-strong);
+  border-left-color: var(--magenta);
+}
+.mcp-reg-card-info {
+  min-width: 0;
+}
+.mcp-reg-card-name {
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-bright);
+  margin-bottom: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mcp-reg-card-repo {
+  color: var(--fg-dim);
+  text-decoration: none;
+  font-size: 11px;
+  margin-left: 4px;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+.mcp-reg-card-repo:hover {
+  opacity: 1;
+  color: var(--magenta);
+}
+.mcp-reg-card-repo:focus-visible {
+  opacity: 1;
+  color: var(--magenta);
+  outline: 2px solid var(--magenta);
+  outline-offset: 2px;
+}
+.mcp-reg-card-desc {
+  font-size: 11px;
+  color: var(--fg-dim);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+.mcp-reg-card-meta {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.mcp-reg-card-meta .scope-badge {
+  font-size: 9px;
+}
+.mcp-reg-card-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.mcp-reg-card-version {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-dim);
+}
 
-.mcp-install-btn{background:var(--magenta);color:var(--bg);border:none;border-radius:var(--radius-sm);font-family:var(--font-display);font-size:10px;font-weight:600;padding:5px 14px;cursor:pointer;letter-spacing:.02em;transition:filter .15s;white-space:nowrap}
-.mcp-install-btn:hover{filter:brightness(1.15)}
-.mcp-install-btn:focus-visible{outline:2px solid var(--fg-bright);outline-offset:2px}
-.mcp-install-btn:disabled{opacity:.4;cursor:not-allowed}
-.mcp-install-btn.mcp-update-btn{background:transparent;color:var(--yellow);border:1px solid var(--yellow)}
-.mcp-install-btn.mcp-update-btn:hover{background:rgba(251,191,36,.1);filter:none}
-.mcp-installed-badge{display:inline-block;font-family:var(--font-display);font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;padding:3px 8px;border-radius:2px;background:rgba(52,211,153,.1);color:var(--green);border:1px solid rgba(52,211,153,.2)}
+.mcp-install-btn {
+  background: var(--magenta);
+  color: var(--bg);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 5px 14px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: filter 0.15s;
+  white-space: nowrap;
+}
+.mcp-install-btn:hover {
+  filter: brightness(1.15);
+}
+.mcp-install-btn:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
+.mcp-install-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.mcp-install-btn.mcp-update-btn {
+  background: transparent;
+  color: var(--yellow);
+  border: 1px solid var(--yellow);
+}
+.mcp-install-btn.mcp-update-btn:hover {
+  background: rgba(251, 191, 36, 0.1);
+  filter: none;
+}
+.mcp-installed-badge {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: 2px;
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--green);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
 
-#mcp-registry-pagination{display:flex;align-items:center;padding:12px 0}
-.mcp-registry-count-label{font-size:11px;color:var(--fg-dim);margin-left:10px}
+#mcp-registry-pagination {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+}
+.mcp-registry-count-label {
+  font-size: 11px;
+  color: var(--fg-dim);
+  margin-left: 10px;
+}
 
 /* -- MCP Install modal ---------------------------------------------------- */
-.mcp-install-summary-name{font-family:var(--font-display);font-size:14px;font-weight:600;color:var(--magenta);margin-bottom:4px}
-.mcp-install-summary-desc{font-size:12px;color:var(--fg-dim);margin-bottom:12px;line-height:1.4}
-.mcp-install-source-group{margin-bottom:14px}
-.mcp-install-source-label{display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--border-strong);border-radius:var(--radius-sm);margin-bottom:4px;cursor:pointer;transition:border-color .15s;font-size:12px;color:var(--fg)}
-.mcp-install-source-label:hover{border-color:var(--magenta)}
-.mcp-install-source-label input[type="radio"]{width:auto;margin:0}
-.mcp-install-source-type{font-family:var(--font-mono);font-size:10px;color:var(--fg-dim)}
+.mcp-install-summary-name {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--magenta);
+  margin-bottom: 4px;
+}
+.mcp-install-summary-desc {
+  font-size: 12px;
+  color: var(--fg-dim);
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+.mcp-install-source-group {
+  margin-bottom: 14px;
+}
+.mcp-install-source-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  margin-bottom: 4px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+  font-size: 12px;
+  color: var(--fg);
+}
+.mcp-install-source-label:hover {
+  border-color: var(--magenta);
+}
+.mcp-install-source-label input[type="radio"] {
+  width: auto;
+  margin: 0;
+}
+.mcp-install-source-type {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-dim);
+}
 
-@media(max-width:700px){
-  .mcp-reg-card{grid-template-columns:1fr;gap:8px}
-  .mcp-reg-card-actions{flex-direction:row;align-items:center}
-  .mcp-registry-search{flex-direction:column}
+@media (max-width: 700px) {
+  .mcp-reg-card {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .mcp-reg-card-actions {
+    flex-direction: row;
+    align-items: center;
+  }
+  .mcp-registry-search {
+    flex-direction: column;
+  }
   #admin-mcp .admin-toolbar,
-  #admin-models .admin-toolbar{flex-wrap:wrap;gap:8px}
-  #mcp-servers-toolbar{display:flex;gap:6px;width:100%}
-  #admin-skills .admin-toolbar{flex-wrap:wrap;gap:8px}
-  #skill-installed-toolbar{display:flex;gap:6px;width:100%}
+  #admin-models .admin-toolbar {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  #mcp-servers-toolbar {
+    display: flex;
+    gap: 6px;
+    width: 100%;
+  }
+  #admin-skills .admin-toolbar {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  #skill-installed-toolbar {
+    display: flex;
+    gap: 6px;
+    width: 100%;
+  }
 }
 
 /* ==========================================================================
@@ -2611,7 +3937,9 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   color: var(--fg-dim);
   font-size: 11px;
 }
-.oidc-identity-actions .admin-btn-danger { font-size: 11px; }
+.oidc-identity-actions .admin-btn-danger {
+  font-size: 11px;
+}
 .oidc-detail-empty {
   color: var(--fg-dim);
   font-size: 12px;
@@ -2619,9 +3947,15 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 /* Expand indicator on user rows */
-.admin-row[data-expandable] { cursor: pointer; }
-.admin-row[data-expandable]:hover { background: var(--bg-highlight); }
-.admin-row[data-expandable]:hover .admin-expand-indicator { color: var(--fg); }
+.admin-row[data-expandable] {
+  cursor: pointer;
+}
+.admin-row[data-expandable]:hover {
+  background: var(--bg-highlight);
+}
+.admin-row[data-expandable]:hover .admin-expand-indicator {
+  color: var(--fg);
+}
 .admin-row[data-expandable]:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
@@ -2634,72 +3968,215 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   transition: transform 150ms ease;
   transform-origin: center;
 }
-.admin-expand-indicator.expanded { transform: rotate(90deg); }
+.admin-expand-indicator.expanded {
+  transform: rotate(90deg);
+}
 
 @media (max-width: 700px) {
-  .oidc-identity-row { grid-template-columns: 70px 1fr 50px; }
-  .oidc-identity-email, .oidc-identity-time { display: none; }
-  .oidc-detail-panel { margin-left: 8px; }
+  .oidc-identity-row {
+    grid-template-columns: 70px 1fr 50px;
+  }
+  .oidc-identity-email,
+  .oidc-identity-time {
+    display: none;
+  }
+  .oidc-detail-panel {
+    margin-left: 8px;
+  }
 }
 
 /* -- Models grid --------------------------------------------------------- */
-.models-grid{grid-template-columns:1.2fr 1.2fr 80px 90px 80px 160px;gap:0 6px}
-@media(max-width:700px){
-  .models-grid{grid-template-columns:1fr 80px 160px}
+.models-grid {
+  grid-template-columns: 1.2fr 1.2fr 80px 90px 80px 160px;
+  gap: 0 6px;
+}
+@media (max-width: 700px) {
+  .models-grid {
+    grid-template-columns: 1fr 80px 160px;
+  }
   .models-grid .admin-col:nth-child(2),
   .models-grid .admin-col:nth-child(3),
-  .models-grid .admin-col:nth-child(4){display:none}
-  .models-grid .admin-col:last-child{white-space:normal;display:flex;flex-wrap:wrap;gap:2px}
+  .models-grid .admin-col:nth-child(4) {
+    display: none;
+  }
+  .models-grid .admin-col:last-child {
+    white-space: normal;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+  }
 }
 
 /* Model status indicators */
-.model-status-dot{display:inline-block;width:8px;height:8px;border-radius:50%;vertical-align:middle;margin-right:6px}
-.model-status-dot.enabled{background:var(--blue);box-shadow:0 0 6px var(--blue-glow)}
-.model-status-dot.disabled{background:var(--fg-dim);opacity:.35}
+.model-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+.model-status-dot.enabled {
+  background: var(--blue);
+  box-shadow: 0 0 6px var(--blue-glow);
+}
+.model-status-dot.disabled {
+  background: var(--fg-dim);
+  opacity: 0.35;
+}
 
-.model-row-enabled{border-left:3px solid var(--blue)}
-.model-row-disabled{border-left:3px solid transparent}
+.model-row-enabled {
+  border-left: 3px solid var(--blue);
+}
+.model-row-disabled {
+  border-left: 3px solid transparent;
+}
 
 /* Provider badges */
-.model-provider-badge{display:inline-block;font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;padding:1px 6px;border-radius:2px;background:var(--bg-highlight);border:1px solid var(--border)}
-.model-provider-openai{color:var(--blue);border-color:rgba(56,189,248,.2)}
-.model-provider-anthropic{color:var(--magenta);border-color:rgba(192,132,252,.25)}
-.model-provider-google{color:var(--green);border-color:rgba(52,211,153,.2)}
-.model-provider-compat{color:var(--fg-dim);border-color:var(--border-strong)}
+.model-provider-badge {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 6px;
+  border-radius: 2px;
+  background: var(--bg-highlight);
+  border: 1px solid var(--border);
+}
+.model-provider-openai {
+  color: var(--blue);
+  border-color: rgba(56, 189, 248, 0.2);
+}
+.model-provider-anthropic {
+  color: var(--magenta);
+  border-color: rgba(192, 132, 252, 0.25);
+}
+.model-provider-google {
+  color: var(--green);
+  border-color: rgba(52, 211, 153, 0.2);
+}
+.model-provider-compat {
+  color: var(--fg-dim);
+  border-color: var(--border-strong);
+}
 
 /* Per-model override hints */
-.model-overrides-hint{font-size:10px;color:var(--fg-dim);font-family:var(--font-mono);letter-spacing:.02em}
+.model-overrides-hint {
+  font-size: 10px;
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
 
 /* Modal section divider for field groups */
-.modal-section-divider{font-family:var(--font-display);font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--fg-dim);margin:16px 0 4px;padding-top:12px;border-top:1px solid var(--border)}
+.modal-section-divider {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-dim);
+  margin: 16px 0 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
 
 /* Model source badge */
-.scope-db{color:var(--blue);border-color:rgba(56,189,248,.2)}
+.scope-db {
+  color: var(--blue);
+  border-color: rgba(56, 189, 248, 0.2);
+}
 
 /* ==========================================================================
    Reduced motion — console-specific
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {
-  .node-group-chevron { transition: none; }
-  .health-bar-fill { transition: none; }
-  .csb-state, .node-row, .node-group-header { transition: none; }
-  .node-link, .dash-cell-node, .pagination button { transition: none; }
-  .dash-row.has-link::after, .node-group-header::before { transition: none; }
-  #new-ws-box select, #new-ws-box input, #new-ws-buttons button { transition: none; }
-  .admin-nav, .admin-row, .admin-btn-danger, .admin-btn-caution, .admin-btn-action, .judge-section-btn { transition: none; }
-  .settings-toggle-slider, .settings-toggle-slider::before { transition: none; }
-  .settings-save-btn, .settings-reset-btn, .settings-docs-link, .settings-help-btn { transition: none; }
-  .admin-sidebar, .admin-sidebar-backdrop { transition: none; }
-  #view-admin { animation: none; }
-  .admin-action-btn, .modal-cancel, .modal-submit { transition: none; }
-  .admin-modal input, .admin-modal select { transition: none; }
-  .mcp-status-dot.connecting { animation: none; }
-  .oidc-detail-panel, .admin-expand-indicator { transition: none; }
-  .admin-details summary::after { transition: none; }
-  .mcp-view-btn, .mcp-reg-card, .mcp-install-btn, .mcp-install-source-label { transition: none; }
-  .mcp-registry-search input[type="search"] { transition: none; }
-  .mcp-reg-card-repo { transition: none; }
-  .mcp-sync-pending, .model-sync-pending { animation: none; }
+  .node-group-chevron {
+    transition: none;
+  }
+  .health-bar-fill {
+    transition: none;
+  }
+  .csb-state,
+  .node-row,
+  .node-group-header {
+    transition: none;
+  }
+  .node-link,
+  .dash-cell-node,
+  .pagination button {
+    transition: none;
+  }
+  .dash-row.has-link::after,
+  .node-group-header::before {
+    transition: none;
+  }
+  #new-ws-box select,
+  #new-ws-box input,
+  #new-ws-buttons button {
+    transition: none;
+  }
+  .admin-nav,
+  .admin-row,
+  .admin-btn-danger,
+  .admin-btn-caution,
+  .admin-btn-action,
+  .judge-section-btn {
+    transition: none;
+  }
+  .settings-toggle-slider,
+  .settings-toggle-slider::before {
+    transition: none;
+  }
+  .settings-save-btn,
+  .settings-reset-btn,
+  .settings-docs-link,
+  .settings-help-btn {
+    transition: none;
+  }
+  .admin-sidebar,
+  .admin-sidebar-backdrop {
+    transition: none;
+  }
+  #view-admin {
+    animation: none;
+  }
+  .admin-action-btn,
+  .modal-cancel,
+  .modal-submit {
+    transition: none;
+  }
+  .admin-modal input,
+  .admin-modal select {
+    transition: none;
+  }
+  .mcp-status-dot.connecting {
+    animation: none;
+  }
+  .oidc-detail-panel,
+  .admin-expand-indicator {
+    transition: none;
+  }
+  .admin-details summary::after {
+    transition: none;
+  }
+  .mcp-view-btn,
+  .mcp-reg-card,
+  .mcp-install-btn,
+  .mcp-install-source-label {
+    transition: none;
+  }
+  .mcp-registry-search input[type="search"] {
+    transition: none;
+  }
+  .mcp-reg-card-repo {
+    transition: none;
+  }
+  .mcp-sync-pending,
+  .model-sync-pending {
+    animation: none;
+  }
 }
 
 /* Node metadata */
@@ -2707,16 +4184,28 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   display: inline-block;
   padding: 1px 6px;
   border-radius: var(--radius-sm);
-  font-size: .75rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.nm-source-auto { background: var(--green-glow); color: var(--green); }
-.nm-source-user { background: var(--cyan-glow); color: var(--cyan); }
-.nm-source-config { background: var(--yellow-glow); color: var(--yellow); }
+.nm-source-auto {
+  background: var(--green-glow);
+  color: var(--green);
+}
+.nm-source-user {
+  background: var(--cyan-glow);
+  color: var(--cyan);
+}
+.nm-source-config {
+  background: var(--yellow-glow);
+  color: var(--yellow);
+}
 
-.nm-table { width: 100%; border-collapse: collapse; }
+.nm-table {
+  width: 100%;
+  border-collapse: collapse;
+}
 .nm-table th {
   font-family: var(--font-display);
   font-size: 10px;
@@ -2759,10 +4248,16 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
   color: var(--fg);
   font: inherit;
   font-size: 12px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
-.nm-add-row input[type="text"]:first-of-type { width: 120px; }
-.nm-add-row input[type="text"]:nth-of-type(2) { flex: 1; }
+.nm-add-row input[type="text"]:first-of-type {
+  width: 120px;
+}
+.nm-add-row input[type="text"]:nth-of-type(2) {
+  flex: 1;
+}
 .nm-add-row input[type="text"]:focus {
   border-color: var(--accent);
   outline: none;
@@ -2778,11 +4273,20 @@ h3.skill-spec-heading { font-size: inherit; margin-block: 0; }
 }
 
 @media (max-width: 700px) {
-  .nm-add-row { flex-wrap: wrap; }
-  .nm-add-row input[type="text"] { width: 100% !important; flex: none; }
-  .nm-val { max-width: 150px; }
+  .nm-add-row {
+    flex-wrap: wrap;
+  }
+  .nm-add-row input[type="text"] {
+    width: 100% !important;
+    flex: none;
+  }
+  .nm-val {
+    max-width: 150px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .nm-add-row input[type="text"] { transition: none; }
+  .nm-add-row input[type="text"] {
+    transition: none;
+  }
 }

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -321,6 +321,7 @@ def list_workstreams_with_history(
     *,
     kind: WorkstreamKind | str | None = None,
     user_id: str | None = None,
+    state: str | None = None,
 ) -> list[Any]:
     """List workstreams that have conversation messages.
 
@@ -334,12 +335,17 @@ def list_workstreams_with_history(
     authenticated caller's uid from any tenant-visible endpoint;
     leaving it as ``None`` means cluster-wide (service-scoped
     callers only).
+
+    ``state`` filters by lifecycle state — pass ``"closed"`` from the
+    coordinator-saved surface so deleted / currently-active rows don't
+    end up in the saved cards.  Default ``None`` preserves all-states.
     """
     try:
         return get_storage().list_workstreams_with_history(
             limit,
             kind=kind,
             user_id=user_id,
+            state=state,
         )
     except Exception:
         log.warning("Failed to list workstreams with history", exc_info=True)

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -304,17 +304,22 @@ class PostgreSQLBackend:
         *,
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
+        state: str | None = None,
     ) -> list[Any]:
-        # See SQLite sibling for the rationale on the kind + user_id filters.
+        # See SQLite sibling for the rationale on the kind / user_id / state filters.
         params: dict[str, Any] = {"limit": limit}
         kind_clause = ""
         user_clause = ""
+        state_clause = ""
         if kind is not None:
             params["kind"] = WorkstreamKind(kind).value
             kind_clause = "AND w.kind = :kind "
         if user_id is not None:
             params["user_id"] = user_id
             user_clause = "AND w.user_id = :user_id "
+        if state is not None:
+            params["state"] = state
+            state_clause = "AND w.state = :state "
         with self._conn() as conn:
             return list(
                 conn.execute(
@@ -328,6 +333,7 @@ class PostgreSQLBackend:
                         "  (SELECT 1 FROM conversations c WHERE c.ws_id = w.ws_id) "
                         f"{kind_clause}"
                         f"{user_clause}"
+                        f"{state_clause}"
                         "ORDER BY w.updated DESC LIMIT :limit"
                     ),
                     params,

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -237,6 +237,7 @@ class StorageBackend(Protocol):
         *,
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
+        state: str | None = None,
     ) -> list[Any]:
         """List workstreams that have messages, ordered by updated DESC.
 
@@ -251,6 +252,12 @@ class StorageBackend(Protocol):
         uid from any tenant-visible endpoint; pass ``None`` for
         service-scoped callers that legitimately need cluster-wide
         visibility.  Mirrors the same contract on ``list_workstreams``.
+
+        ``state`` filters by lifecycle state — pass ``"closed"`` from the
+        coordinator "saved" surface so the list excludes deleted /
+        currently-active rows.  Default ``None`` preserves all-states
+        behaviour.  Accepts a string (rather than the WorkstreamState
+        enum) to match the on-disk column type.
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -387,6 +387,7 @@ class SQLiteBackend:
         *,
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
+        state: str | None = None,
     ) -> list[Any]:
         # ``kind`` filter applied at the SQL layer so coordinator rows
         # (which persist conversation history the same way interactive
@@ -397,15 +398,22 @@ class SQLiteBackend:
         # can't accidentally leak another tenant's workstreams.  None
         # = cluster-wide (service callers); empty string is a separate
         # filter value the caller chose deliberately.
+        # ``state`` filter — coordinator-saved surface passes "closed"
+        # so deleted / currently-active rows don't end up in the saved
+        # cards (which would 404 on click or duplicate the active list).
         params: dict[str, Any] = {"limit": limit}
         kind_clause = ""
         user_clause = ""
+        state_clause = ""
         if kind is not None:
             params["kind"] = WorkstreamKind(kind).value
             kind_clause = "AND w.kind = :kind "
         if user_id is not None:
             params["user_id"] = user_id
             user_clause = "AND w.user_id = :user_id "
+        if state is not None:
+            params["state"] = state
+            state_clause = "AND w.state = :state "
         with self._conn() as conn:
             return list(
                 conn.execute(
@@ -419,6 +427,7 @@ class SQLiteBackend:
                         "  (SELECT 1 FROM conversations c WHERE c.ws_id = w.ws_id) "
                         f"{kind_clause}"
                         f"{user_clause}"
+                        f"{state_clause}"
                         "ORDER BY w.updated DESC LIMIT :limit"
                     ),
                     params,

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -1,0 +1,78 @@
+/* ==========================================================================
+   Shared card primitives — used by ui/static (Saved Workstreams) and
+   console/static (Saved Coordinators).  Single source of truth so the two
+   surfaces don't drift on hover affordance, padding, or typography.
+   ==========================================================================
+   Class names match the original ui/static rules they replaced; the
+   delete-mode subset stays in ui/static/style.css until coordinator gets
+   the same UX (then it can move here too).
+   ========================================================================== */
+
+.dashboard-cards {
+  display: grid;
+  /* Denser default than the original 200px floor — cards carry a short
+     title + one-line meta, so 160-180px fits 4 across at the 1140px
+     content cap and keeps the row from looking padded-out. */
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 8px;
+}
+
+.dashboard-card {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    opacity 0.15s;
+}
+.dashboard-card.is-busy {
+  opacity: 0.6;
+  cursor: progress;
+}
+.dashboard-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-highlight);
+}
+.dashboard-card:active {
+  background: var(--bg-highlight);
+  border-color: var(--accent);
+}
+.dashboard-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.dashboard-card .card-title {
+  font-size: 12px;
+  color: var(--fg-bright);
+  font-weight: 500;
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dashboard-card .card-meta {
+  font-size: 10px;
+  color: var(--fg-dim);
+}
+
+/* Subtle ws_id badge on each card — also used inline in card-meta. */
+.card-wsid {
+  font-size: 9px;
+  color: var(--fg-dim);
+  opacity: 0.45;
+  margin-left: 6px;
+  font-family: "IBM Plex Mono", monospace;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+}
+
+@media (max-width: 480px) {
+  .dashboard-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -66,7 +66,11 @@
   color: var(--fg-dim);
   opacity: 0.45;
   margin-left: 6px;
-  font-family: "IBM Plex Mono", monospace;
+  /* Prefer the design-system token; fall back to a literal stack so
+     surfaces that don't load /shared/design/typography.css (i.e.
+     console, until it migrates onto data-design="v1") still get a
+     mono font here. */
+  font-family: var(--font-mono, "IBM Plex Mono", monospace);
   letter-spacing: 0.02em;
   vertical-align: middle;
 }

--- a/turnstone/shared_static/cards.js
+++ b/turnstone/shared_static/cards.js
@@ -1,0 +1,79 @@
+/* Shared session card primitive — used by ui/static (Saved Workstreams)
+   and console/static (Saved Coordinators).  Single source so the two
+   surfaces don't drift on field cascade, ARIA roles, keyboard handling,
+   or DOM shape.
+
+   Card structure (also see /shared/cards.css for styling):
+
+     .dashboard-card               role="button" tabindex="0"
+       .card-title                 sess.alias || title || name || ws_id[:12]
+       .card-meta                  "X msgs · Y ago "
+         .card-wsid                ws_id[:7]
+
+   Built with safe DOM APIs (createElement + textContent) — never
+   innerHTML — so user-supplied alias/title/name fields don't reach the
+   DOM as HTML.
+
+   Caller passes:
+     sess          — {ws_id, alias?, title?, name?, message_count?, updated?}
+     opts.onActivate(sess)  — fired on click + Enter/Space
+     opts.ariaLabel(sess)?  — optional aria-label override; default
+                              "Resume: {label}"
+     opts.busy?             — boolean; adds `is-busy` class (visual dim
+                              + cursor: progress) and suppresses re-entry
+                              into onActivate.
+
+   Returns the card DOM node.  Caller appends it.
+
+   Depends on: formatRelativeTime (from /shared/utils.js).
+*/
+
+function renderSessionCard(sess, opts) {
+  opts = opts || {};
+  var card = document.createElement("div");
+  card.className = "dashboard-card" + (opts.busy ? " is-busy" : "");
+  card.dataset.wsId = sess.ws_id;
+  var label = sess.alias || sess.title || sess.name || sess.ws_id;
+  card.setAttribute("role", "button");
+  card.setAttribute("tabindex", "0");
+  card.setAttribute(
+    "aria-label",
+    typeof opts.ariaLabel === "function"
+      ? opts.ariaLabel(sess)
+      : "Resume: " + label,
+  );
+
+  var activate = function () {
+    if (card.classList.contains("is-busy")) return;
+    if (typeof opts.onActivate === "function") opts.onActivate(sess, card);
+  };
+  card.onclick = activate;
+  card.onkeydown = function (e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      activate();
+    }
+  };
+
+  var title =
+    sess.alias || sess.title || sess.name || sess.ws_id.substring(0, 12);
+  var titleEl = document.createElement("div");
+  titleEl.className = "card-title";
+  titleEl.textContent = title;
+
+  var metaEl = document.createElement("div");
+  metaEl.className = "card-meta";
+  var metaText = (sess.message_count || 0) + " msgs";
+  if (sess.updated && typeof formatRelativeTime === "function") {
+    metaText += " · " + formatRelativeTime(sess.updated);
+  }
+  metaEl.appendChild(document.createTextNode(metaText + " "));
+  var wsidEl = document.createElement("span");
+  wsidEl.className = "card-wsid";
+  wsidEl.textContent = sess.ws_id.substring(0, 7);
+  metaEl.appendChild(wsidEl);
+
+  card.appendChild(titleEl);
+  card.appendChild(metaEl);
+  return card;
+}

--- a/turnstone/shared_static/design/tokens.css
+++ b/turnstone/shared_static/design/tokens.css
@@ -3,7 +3,10 @@
    live light + dark previews.
 
    Hue map:
-     --accent   182 (teal, brand)
+     --accent   75  (amber/gold, brand — original turnstone hue;
+                     deliberately near --warn at 80 so the brand and
+                     attention tones read as one warm family, matching
+                     the pre-v1 palette)
      --ok       150 (green; approve / success / liveness)
      --warn     80  (gold; attention / k-tools / risk-med)
      --err      25  (red; deny / errors / risk-high / risk-crit)
@@ -23,25 +26,26 @@
        panel mud that produces brown for low-L warm mixes */
 
 [data-design="v1"] {
-  /* Accent — teal (Claude Design default hue).
-     Tunable via these three vars without touching downstream primitives.
-     Lightness + chroma held at the amber values so both themes retain
-     the same visual weight — only the hue changes. */
-  --accent-h: 182;
-  --accent-c: 0.10;
-  --accent-l: 0.62;
+  /* Accent — amber/gold (turnstone's original brand hue, restored after
+     the Claude Design handoff briefly swapped it for teal at hue 182).
+     Tunable via these three vars without touching downstream primitives;
+     lightness + chroma stay at the unified palette values so light/dark
+     visual weight matches the rest of the semantic family. */
+  --accent-h: 75;
+  --accent-c: 0.13;
+  --accent-l: 0.7;
   --density: 1;
 
   /* Neutrals (light) */
-  --bg:      #f7f7f4;
-  --panel:   #ffffff;
+  --bg: #f7f7f4;
+  --panel: #ffffff;
   --panel-2: #fbfbf8;
-  --ink:     #101316;
-  --ink-2:   #2d3238;
-  --ink-3:   #565b63;
-  --ink-4:   #7a7f87;
-  --hair:    #dcdbd4;
-  --hair-2:  #e7e5dc;
+  --ink: #101316;
+  --ink-2: #2d3238;
+  --ink-3: #565b63;
+  --ink-4: #7a7f87;
+  --hair: #dcdbd4;
+  --hair-2: #e7e5dc;
 
   /* Semantic palette — unified L and C so ok / warn / err / think feel
      like siblings, hue is the only discriminator. Darkened from 0.58
@@ -49,79 +53,82 @@
      backgrounds. err holds higher chroma (0.17) because red reads washed
      at 0.15; warn holds lower chroma (0.13) because gold at higher
      chroma + low L turns mustard. */
-  --accent:      oklch(var(--accent-l) var(--accent-c) var(--accent-h));
+  --accent: oklch(var(--accent-l) var(--accent-c) var(--accent-h));
   --accent-soft: oklch(0.94 0.05 var(--accent-h));
-  --ok:          oklch(0.50 0.15 150);
-  --ok-live:     oklch(0.58 0.19 150);  /* brighter/more saturated — running / liveness */
-  --ok-soft:     oklch(0.94 0.05 150);
+  --ok: oklch(0.5 0.15 150);
+  --ok-live: oklch(
+    0.58 0.19 150
+  ); /* brighter/more saturated — running / liveness */
+  --ok-soft: oklch(0.94 0.05 150);
   /* Theme-aware text colour for tinted ok surfaces (approve button, etc).
      Light needs a dark green for contrast against pale bg; dark needs a
      bright green for contrast against dark forest bg. Hard to express
      cleanly as a single color-mix, so defined directly per theme. */
-  --ok-text:     oklch(0.36 0.15 150);
-  --warn:        oklch(0.58 0.13 80);
-  --warn-soft:   oklch(0.94 0.05 80);
+  --ok-text: oklch(0.36 0.15 150);
+  --warn: oklch(0.58 0.13 80);
+  --warn-soft: oklch(0.94 0.05 80);
   /* warn tints for k-tools k-badge — pale gold surface (k-approval now
      uses the ok family for semantic coherence with the Approve button). */
-  --warn-tint:        oklch(0.92 0.10 80);
+  --warn-tint: oklch(0.92 0.1 80);
   --warn-tint-border: oklch(0.64 0.15 80);
-  --err:         oklch(0.50 0.17 25);
-  --err-soft:    oklch(0.94 0.05 25);
+  --err: oklch(0.5 0.17 25);
+  --err-soft: oklch(0.94 0.05 25);
   /* --err-fill — darker err for filled destructive surfaces like
      .risk.crit; bright --err as a fill reads as alarm-loud. Text on
      top is always #fff so we don't need a matching --err-fill-text. */
-  --err-fill:    oklch(0.45 0.17 25);
-  --think:       oklch(0.50 0.15 260);
-  --think-soft:  oklch(0.94 0.05 260);
+  --err-fill: oklch(0.45 0.17 25);
+  --think: oklch(0.5 0.15 260);
+  --think-soft: oklch(0.94 0.05 260);
 
   /* Shape */
   --r-sm: 4px;
   --r-md: 6px;
   --r-lg: 8px;
-  --shadow-sm: 0 1px 0 rgba(21, 24, 27, 0.03),
-               0 1px 2px rgba(21, 24, 27, 0.04);
+  --shadow-sm: 0 1px 0 rgba(21, 24, 27, 0.03), 0 1px 2px rgba(21, 24, 27, 0.04);
 
   /* Rhythm */
-  --gap:   calc(12px * var(--density));
+  --gap: calc(12px * var(--density));
   --row-h: calc(32px * var(--density));
 }
 
 [data-design="v1"]:not([data-theme]),
 [data-design="v1"][data-theme=""],
 [data-design="v1"][data-theme="dark"] {
-  --bg:      #0e1013;
-  --panel:   #15181c;
+  --bg: #0e1013;
+  --panel: #15181c;
   --panel-2: #1a1e23;
-  --ink:     #f2f3f5;
-  --ink-2:   #d4d7db;
-  --ink-3:   #a6abb3;
-  --ink-4:   #808690;
-  --hair:    #2a2e35;
-  --hair-2:  #333842;
+  --ink: #f2f3f5;
+  --ink-2: #d4d7db;
+  --ink-3: #a6abb3;
+  --ink-4: #808690;
+  --hair: #2a2e35;
+  --hair-2: #333842;
 
   /* Dark semantic palette — unified L (0.68) and C matching light. L
      came down from 0.73 so the colours read as richer/darker jewel
      tones rather than pastels on the dark panel. */
   --accent-soft: oklch(0.29 0.07 var(--accent-h));
-  --ok:          oklch(0.68 0.15 150);
-  --ok-live:     oklch(0.78 0.20 150);  /* brighter/more saturated — running / liveness */
-  --ok-soft:     oklch(0.29 0.07 150);
+  --ok: oklch(0.68 0.15 150);
+  --ok-live: oklch(
+    0.78 0.2 150
+  ); /* brighter/more saturated — running / liveness */
+  --ok-soft: oklch(0.29 0.07 150);
   /* Dark --ok-text — bright mint-green for ~7.5:1 on the dark forest
      approve-button bg. Brighter than --ok to compensate for the
      pale-on-dark-forest that the color-mix-with-ink pattern produced. */
-  --ok-text:     oklch(0.86 0.18 150);
-  --warn:        oklch(0.70 0.13 80);
-  --warn-soft:   oklch(0.29 0.07 80);
+  --ok-text: oklch(0.86 0.18 150);
+  --warn: oklch(0.7 0.13 80);
+  --warn-soft: oklch(0.29 0.07 80);
   /* Dark-mode warn-tint — dropped L to 0.22 so the fill reads as a
      subtle warm whisper rather than dark-gold-reads-as-brown. The gold
      signal lives in the border + text, not the bg surface. */
-  --warn-tint:        oklch(0.22 0.05 80);
+  --warn-tint: oklch(0.22 0.05 80);
   --warn-tint-border: oklch(0.58 0.15 80);
-  --err:         oklch(0.68 0.17 25);
-  --err-soft:    oklch(0.29 0.07 25);
+  --err: oklch(0.68 0.17 25);
+  --err-soft: oklch(0.29 0.07 25);
   /* Dark --err-fill — pulled down from 0.68 to 0.56 so .risk.crit reads
      as "deeply concerning" instead of "screaming bright." */
-  --err-fill:    oklch(0.56 0.17 25);
-  --think:       oklch(0.68 0.15 260);
-  --think-soft:  oklch(0.29 0.07 260);
+  --err-fill: oklch(0.56 0.17 25);
+  --think: oklch(0.68 0.15 260);
+  --think-soft: oklch(0.29 0.07 260);
 }

--- a/turnstone/shared_static/utils.js
+++ b/turnstone/shared_static/utils.js
@@ -35,6 +35,26 @@ function formatCount(n) {
   return String(n);
 }
 
+// Naive ISO-8601 → "Nm ago" / "Nh ago" / "Nd ago" / locale date.
+// Tolerates space-as-separator (SQLite default) and missing TZ marker
+// (assumes UTC, matching the storage layer's stamp).
+function formatRelativeTime(iso) {
+  if (!iso) return "";
+  var s = String(iso).replace(" ", "T");
+  if (!s.endsWith("Z") && !s.includes("+")) s += "Z";
+  var d = new Date(s);
+  if (isNaN(d)) return "";
+  var ms = new Date() - d;
+  var min = Math.floor(ms / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return min + "m ago";
+  var hr = Math.floor(min / 60);
+  if (hr < 24) return hr + "h ago";
+  var day = Math.floor(hr / 24);
+  if (day < 30) return day + "d ago";
+  return d.toLocaleDateString();
+}
+
 // Safe CSS attribute-selector escape.  CSS.escape is universally
 // supported in modern browsers, but we keep a minimal polyfill so
 // selector-construction never throws on an older browser or a

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -3802,27 +3802,41 @@ var _wsSavedItems = [];
 function renderSavedWorkstreams(items) {
   _wsSavedItems = items;
   var c = document.getElementById("dashboard-saved-cards");
-  c.innerHTML = "";
+  c.replaceChildren();
   if (!items.length) {
-    c.innerHTML = '<div class="dashboard-empty">No saved workstreams</div>';
+    var empty = document.createElement("div");
+    empty.className = "dashboard-empty";
+    empty.textContent = "No saved workstreams";
+    c.appendChild(empty);
     return;
   }
   items.forEach(function (sess) {
-    var card = document.createElement("div");
-    card.className =
-      "dashboard-card" + (_wsDeleteMode ? " ws-delete-mode" : "");
-    card.dataset.wsId = sess.ws_id;
-    var label = sess.alias || sess.title || sess.ws_id;
-    card.setAttribute(
-      "aria-label",
-      _wsDeleteMode ? "Select: " + label : "Resume: " + label,
-    );
+    // Default card shape (title + meta + wsid + Resume click) comes from
+    // the shared /shared/cards.js helper so console (Saved Coordinators)
+    // and ui/static (Saved Workstreams) stay in lock-step.  Delete mode
+    // is interactive-only; we layer the checkbox + selection wiring on
+    // top of the shared card after construction.
+    var card = renderSessionCard(sess, {
+      ariaLabel: function (s) {
+        var label = s.alias || s.title || s.ws_id;
+        return _wsDeleteMode ? "Select: " + label : "Resume: " + label;
+      },
+      onActivate: function (s) {
+        // Suppressed in delete mode \u2014 the layered checkbox handler below
+        // owns clicks while delete-mode is active.
+        if (_wsDeleteMode) return;
+        dashboardResumeSession(s.ws_id);
+      },
+    });
 
     if (_wsDeleteMode) {
+      card.classList.add("ws-delete-mode");
+      card.removeAttribute("role"); // becomes a checkbox host, not a button
       var chk = document.createElement("input");
       chk.type = "checkbox";
       chk.className = "ws-card-check";
       chk.checked = !!_wsDeleteSelected[sess.ws_id];
+      var label = sess.alias || sess.title || sess.ws_id;
       chk.setAttribute("aria-label", "Select " + label + " for deletion");
       chk.onclick = function (e) {
         e.stopPropagation();
@@ -3831,8 +3845,9 @@ function renderSavedWorkstreams(items) {
         card.classList.toggle("ws-selected", chk.checked);
         updateWsDeleteBar();
       };
-      card.appendChild(chk);
-      card.setAttribute("tabindex", "0");
+      card.insertBefore(chk, card.firstChild);
+      // Override the shared helper's onclick/onkeydown \u2014 in delete mode
+      // a card click toggles the checkbox instead of activating Resume.
       card.onclick = function (e) {
         if (e.target === chk) return;
         chk.checked = !chk.checked;
@@ -3845,40 +3860,9 @@ function renderSavedWorkstreams(items) {
           chk.onclick(e);
         }
       };
-    } else {
-      card.setAttribute("role", "button");
-      card.setAttribute("tabindex", "0");
-      card.onclick = function () {
-        dashboardResumeSession(sess.ws_id);
-      };
-      card.onkeydown = function (e) {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          dashboardResumeSession(sess.ws_id);
-        }
-      };
+      if (_wsDeleteSelected[sess.ws_id]) card.classList.add("ws-selected");
     }
 
-    var title =
-      sess.alias || sess.title || sess.name || sess.ws_id.substring(0, 12);
-    var meta = sess.message_count + " msgs";
-    if (sess.updated) meta += " \u00b7 " + formatRelativeTime(sess.updated);
-    var inner = document.createElement("div");
-    inner.innerHTML =
-      '<div class="card-title">' +
-      escapeHtml(title) +
-      "</div>" +
-      '<div class="card-meta">' +
-      escapeHtml(meta) +
-      ' <span class="card-wsid">' +
-      escapeHtml(sess.ws_id.substring(0, 7)) +
-      "</span>" +
-      "</div>";
-    while (inner.firstChild) card.appendChild(inner.firstChild);
-
-    if (_wsDeleteMode && _wsDeleteSelected[sess.ws_id]) {
-      card.classList.add("ws-selected");
-    }
     c.appendChild(card);
   });
 }
@@ -4340,23 +4324,7 @@ function forkWorkstream(optWsId) {
   showNewWsModal(wsId);
 }
 
-function formatRelativeTime(iso) {
-  if (!iso) return "";
-  var s = iso.replace(" ", "T");
-  if (!s.endsWith("Z") && !s.includes("+")) s += "Z";
-  var d = new Date(s);
-  if (isNaN(d)) return "";
-  var now = new Date();
-  var ms = now - d;
-  var min = Math.floor(ms / 60000);
-  if (min < 1) return "just now";
-  if (min < 60) return min + "m ago";
-  var hr = Math.floor(min / 60);
-  if (hr < 24) return hr + "h ago";
-  var day = Math.floor(hr / 24);
-  if (day < 30) return day + "d ago";
-  return d.toLocaleDateString();
-}
+// formatRelativeTime moved to /shared/utils.js so both surfaces share it.
 
 function dashboardSwitchWorkstream(wsId) {
   if (workstreams[wsId]) {

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -1,248 +1,566 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-design="v1">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>turnstone</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<!-- DS typography.css @imports Inter + JetBrains Mono from Google Fonts;
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>turnstone</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- DS typography.css @imports Inter + JetBrains Mono from Google Fonts;
      no separate font link for legacy Outfit/IBM Plex Mono (those were
      removed to avoid loading two font stacks under data-design="v1"). -->
-<link rel="stylesheet" href="/shared/base.css">
-<link rel="stylesheet" href="/shared/ui-base.css">
-<link rel="stylesheet" href="/shared/chat.css">
-<link rel="stylesheet" href="/shared/katex-0.16.45/katex.min.css">
-<!-- Design system v1 — opt-in via data-design="v1" on <html>. Tokens
+    <link rel="stylesheet" href="/shared/base.css" />
+    <link rel="stylesheet" href="/shared/ui-base.css" />
+    <link rel="stylesheet" href="/shared/chat.css" />
+    <link rel="stylesheet" href="/shared/cards.css" />
+    <link rel="stylesheet" href="/shared/katex-0.16.45/katex.min.css" />
+    <!-- Design system v1 — opt-in via data-design="v1" on <html>. Tokens
      + primitives scope under the attribute selector so legacy styles
      below continue to own anything not yet migrated. -->
-<link rel="stylesheet" href="/shared/design/tokens.css">
-<link rel="stylesheet" href="/shared/design/typography.css">
-<link rel="stylesheet" href="/shared/design/chrome/appbar.css">
-<link rel="stylesheet" href="/shared/design/primitives/panel.css">
-<link rel="stylesheet" href="/shared/design/primitives/buttons.css">
-<link rel="stylesheet" href="/shared/design/primitives/pills.css">
-<link rel="stylesheet" href="/shared/design/primitives/message.css">
-<link rel="stylesheet" href="/shared/design/primitives/field.css">
-<link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-<div id="header" class="ts-header appbar">
-  <h1 class="appbar-title">turnstone</h1>
-  <span id="mcp-status" class="appbar-status" role="status" aria-live="polite"></span>
-  <span id="health-indicator" class="health-ok appbar-status" role="status" aria-live="polite" aria-atomic="true"></span>
-  <span class="header-spacer appbar-spacer"></span>
-  <span class="appbar-actions">
-    <button id="theme-toggle" class="header-btn btn" onclick="toggleTheme()" aria-label="Toggle light/dark theme" title="Switch to light theme">&#9790;</button>
-  </span>
-</div>
-
-<div id="tab-bar" role="toolbar" aria-label="Workstreams">
-  <div id="tab-list" role="tablist"></div>
-  <button id="new-tab-btn" onclick="newWorkstream()" title="New workstream (Ctrl+T)" aria-label="New workstream" aria-keyshortcuts="Control+t">+</button>
-  <button id="split-btn" onclick="splitFocusedPane()" title="Split pane (Ctrl+\)" aria-label="Split pane" aria-keyshortcuts="Control+Backslash">&#x29C9;</button>
-</div>
-
-<div id="dashboard" class="dashboard-overlay" role="dialog" aria-modal="true" aria-label="Dashboard">
-  <div class="dashboard-content">
-    <div class="dashboard-composer" id="dashboard-composer">
-      <textarea id="dashboard-input" class="dashboard-input" rows="3"
-                placeholder="What are you working on?"
-                aria-label="Start a new conversation"></textarea>
-      <div class="dashboard-composer-row">
-        <div class="dashboard-composer-actions">
-          <button id="dashboard-attach-btn" class="dashboard-icon-btn" type="button"
-                  title="Attach files" aria-label="Attach files">
-            <span aria-hidden="true">&#128206;</span>
-          </button>
-          <input id="dashboard-attach-input" type="file" multiple style="display:none"
-                 accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.txt,.json,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.java,.c,.cpp,.h,.hpp,.sh,.sql,.ini,.conf">
-          <button id="dashboard-options-btn" class="dashboard-icon-btn dashboard-options-btn" type="button"
-                  title="Options" aria-label="Toggle options" aria-expanded="false"
-                  aria-controls="dashboard-options">
-            Options <span aria-hidden="true" class="dashboard-options-caret">&#9662;</span>
-          </button>
-          <span id="dashboard-options-summary" class="dashboard-options-summary" aria-live="polite" hidden></span>
-        </div>
-        <button id="dashboard-submit-btn" class="dashboard-new-btn" type="button"
-                onclick="dashboardSubmit()" aria-label="Create workstream">Create</button>
-      </div>
-      <div id="dashboard-error" class="dashboard-error" role="status" aria-live="polite"></div>
-      <div id="dashboard-attach-chips" role="list" aria-label="Pending attachments" aria-live="polite"></div>
-      <div id="dashboard-options" class="dashboard-options"
-           role="region" aria-labelledby="dashboard-options-btn" hidden>
-        <label for="dashboard-model">Model</label>
-        <select id="dashboard-model"><option value="">Default model</option></select>
-        <label for="dashboard-judge-model">Judge Model</label>
-        <select id="dashboard-judge-model"><option value="">Default (agent model)</option></select>
-        <label for="dashboard-skill">Skill</label>
-        <select id="dashboard-skill"><option value="">Use defaults</option></select>
-      </div>
+    <link rel="stylesheet" href="/shared/design/tokens.css" />
+    <link rel="stylesheet" href="/shared/design/typography.css" />
+    <link rel="stylesheet" href="/shared/design/chrome/appbar.css" />
+    <link rel="stylesheet" href="/shared/design/primitives/panel.css" />
+    <link rel="stylesheet" href="/shared/design/primitives/buttons.css" />
+    <link rel="stylesheet" href="/shared/design/primitives/pills.css" />
+    <link rel="stylesheet" href="/shared/design/primitives/message.css" />
+    <link rel="stylesheet" href="/shared/design/primitives/field.css" />
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <div id="header" class="ts-header appbar">
+      <h1 class="appbar-title">turnstone</h1>
+      <span
+        id="mcp-status"
+        class="appbar-status"
+        role="status"
+        aria-live="polite"
+      ></span>
+      <span
+        id="health-indicator"
+        class="health-ok appbar-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      ></span>
+      <span class="header-spacer appbar-spacer"></span>
+      <span class="appbar-actions">
+        <button
+          id="theme-toggle"
+          class="header-btn btn"
+          onclick="toggleTheme()"
+          aria-label="Toggle light/dark theme"
+          title="Switch to light theme"
+        >
+          &#9790;
+        </button>
+      </span>
     </div>
-    <div class="dash-header">
-      <span class="dash-header-title">WORKSTREAMS</span>
-      <span class="dash-header-summary" id="dash-summary"></span>
-    </div>
-    <div class="dash-colheaders" aria-hidden="true">
-      <span class="dash-col dash-col-state">STATE</span>
-      <span class="dash-col dash-col-name">NAME</span>
-      <span class="dash-col dash-col-model">MODEL</span>
-      <span class="dash-col dash-col-node">NODE</span>
-      <span class="dash-col dash-col-task">TASK</span>
-      <span class="dash-col dash-col-tokens">TOKENS</span>
-      <span class="dash-col dash-col-ctx">CTX</span>
-    </div>
-    <div class="dash-table" id="dash-ws-table" role="group" aria-label="Workstreams"></div>
-    <div class="dash-footer" id="dash-footer">
-      <span class="dash-footer-nodes" id="dash-footer-nodes"></span>
-      <span class="dash-footer-stats" id="dash-footer-stats"></span>
-    </div>
-    <section class="dashboard-section" id="dashboard-saved-ws" aria-label="Saved workstreams">
-      <div class="dashboard-section-header">
-        <h2 class="dashboard-section-title">Saved Workstreams</h2>
-        <button id="ws-delete-btn" class="ws-delete-btn" onclick="startWsDeleteMode()" title="Delete workstreams"><span aria-hidden="true">&#x1f5d1;</span> Delete</button>
-      </div>
-      <div class="dashboard-cards" id="dashboard-saved-cards"></div>
-      <div id="ws-delete-bar" class="ws-delete-bar">
-        <span class="ws-delete-count-label" id="ws-delete-bar-count" role="status" aria-live="polite" aria-atomic="true">0 selected</span>
-        <button class="ws-delete-cancel-btn" onclick="cancelWsDeleteMode()">Cancel</button>
-        <button class="ws-delete-selectall-btn" id="ws-delete-bar-select-all" onclick="toggleSelectAll()">Select All</button>
-        <button class="ws-delete-bar-btn" id="ws-delete-bar-delete" onclick="confirmWsDeleteSelection()" disabled>Delete Selected</button>
-      </div>
-    </section>
-  </div>
-</div>
 
-<div id="split-root"></div>
-
-<!-- New workstream modal -->
-<div id="new-ws-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="new-ws-title">
-  <div id="new-ws-box">
-    <h3 id="new-ws-title">New Workstream</h3>
-    <div id="new-ws-error" role="alert" aria-live="assertive"></div>
-    <label for="new-ws-name">Name <span class="nws-hint">optional</span></label>
-    <input id="new-ws-name" type="text" placeholder="Auto-generated if empty" autocomplete="off">
-    <label for="new-ws-model">Model <span class="nws-hint">optional</span></label>
-    <select id="new-ws-model"><option value="">Default model</option></select>
-    <label for="new-ws-judge-model">Judge Model <span class="nws-hint">optional</span></label>
-    <select id="new-ws-judge-model"><option value="">Default (agent model)</option></select>
-    <label for="new-ws-skill">Skill <span class="nws-hint">optional</span></label>
-    <select id="new-ws-skill"><option value="">Use defaults</option></select>
-    <label for="new-ws-initial-message">First message <span class="nws-hint">optional</span></label>
-    <textarea id="new-ws-initial-message" rows="3" placeholder="Sent as the first turn after the workstream is created"></textarea>
-    <div id="new-ws-attach-row">
-      <button id="new-ws-attach-btn" type="button" title="Attach files to the first turn" aria-label="Attach files">
-        <span aria-hidden="true">&#128206;</span> Attach
+    <div id="tab-bar" role="toolbar" aria-label="Workstreams">
+      <div id="tab-list" role="tablist"></div>
+      <button
+        id="new-tab-btn"
+        onclick="newWorkstream()"
+        title="New workstream (Ctrl+T)"
+        aria-label="New workstream"
+        aria-keyshortcuts="Control+t"
+      >
+        +
       </button>
-      <input id="new-ws-attach-input" type="file" multiple style="display:none" accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.txt,.json,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.java,.c,.cpp,.h,.hpp,.sh,.sql,.ini,.conf">
-      <div id="new-ws-attach-chips" role="list" aria-label="Pending attachments"></div>
+      <button
+        id="split-btn"
+        onclick="splitFocusedPane()"
+        title="Split pane (Ctrl+\)"
+        aria-label="Split pane"
+        aria-keyshortcuts="Control+Backslash"
+      >
+        &#x29C9;
+      </button>
     </div>
-    <div id="new-ws-buttons">
-      <button id="new-ws-cancel" type="button">Cancel</button>
-      <button id="new-ws-submit" type="button">Create</button>
-    </div>
-  </div>
-</div>
 
-<!-- Edit title modal -->
-<div id="edit-title-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="edit-title-heading">
-  <div id="edit-title-box">
-    <h3 id="edit-title-heading">Edit Title</h3>
-    <input id="edit-title-input" type="text" maxlength="80" placeholder="Enter title..." onkeydown="if(event.key==='Enter')submitEditTitle();if(event.key==='Escape')cancelEditTitle();">
-    <div id="edit-title-buttons">
-      <button type="button" onclick="cancelEditTitle()">Cancel</button>
-      <button type="button" onclick="submitEditTitle()">Save</button>
+    <div
+      id="dashboard"
+      class="dashboard-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Dashboard"
+    >
+      <div class="dashboard-content">
+        <div class="dashboard-composer" id="dashboard-composer">
+          <textarea
+            id="dashboard-input"
+            class="dashboard-input"
+            rows="3"
+            placeholder="What are you working on?"
+            aria-label="Start a new conversation"
+          ></textarea>
+          <div class="dashboard-composer-row">
+            <div class="dashboard-composer-actions">
+              <button
+                id="dashboard-attach-btn"
+                class="dashboard-icon-btn"
+                type="button"
+                title="Attach files"
+                aria-label="Attach files"
+              >
+                <span aria-hidden="true">&#128206;</span>
+              </button>
+              <input
+                id="dashboard-attach-input"
+                type="file"
+                multiple
+                style="display: none"
+                accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.txt,.json,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.java,.c,.cpp,.h,.hpp,.sh,.sql,.ini,.conf"
+              />
+              <button
+                id="dashboard-options-btn"
+                class="dashboard-icon-btn dashboard-options-btn"
+                type="button"
+                title="Options"
+                aria-label="Toggle options"
+                aria-expanded="false"
+                aria-controls="dashboard-options"
+              >
+                Options
+                <span aria-hidden="true" class="dashboard-options-caret"
+                  >&#9662;</span
+                >
+              </button>
+              <span
+                id="dashboard-options-summary"
+                class="dashboard-options-summary"
+                aria-live="polite"
+                hidden
+              ></span>
+            </div>
+            <button
+              id="dashboard-submit-btn"
+              class="dashboard-new-btn"
+              type="button"
+              onclick="dashboardSubmit()"
+              aria-label="Create workstream"
+            >
+              Create
+            </button>
+          </div>
+          <div
+            id="dashboard-error"
+            class="dashboard-error"
+            role="status"
+            aria-live="polite"
+          ></div>
+          <div
+            id="dashboard-attach-chips"
+            role="list"
+            aria-label="Pending attachments"
+            aria-live="polite"
+          ></div>
+          <div
+            id="dashboard-options"
+            class="dashboard-options"
+            role="region"
+            aria-labelledby="dashboard-options-btn"
+            hidden
+          >
+            <label for="dashboard-model">Model</label>
+            <select id="dashboard-model">
+              <option value="">Default model</option>
+            </select>
+            <label for="dashboard-judge-model">Judge Model</label>
+            <select id="dashboard-judge-model">
+              <option value="">Default (agent model)</option>
+            </select>
+            <label for="dashboard-skill">Skill</label>
+            <select id="dashboard-skill">
+              <option value="">Use defaults</option>
+            </select>
+          </div>
+        </div>
+        <div class="dash-header">
+          <span class="dash-header-title">WORKSTREAMS</span>
+          <span class="dash-header-summary" id="dash-summary"></span>
+        </div>
+        <div class="dash-colheaders" aria-hidden="true">
+          <span class="dash-col dash-col-state">STATE</span>
+          <span class="dash-col dash-col-name">NAME</span>
+          <span class="dash-col dash-col-model">MODEL</span>
+          <span class="dash-col dash-col-node">NODE</span>
+          <span class="dash-col dash-col-task">TASK</span>
+          <span class="dash-col dash-col-tokens">TOKENS</span>
+          <span class="dash-col dash-col-ctx">CTX</span>
+        </div>
+        <div
+          class="dash-table"
+          id="dash-ws-table"
+          role="group"
+          aria-label="Workstreams"
+        ></div>
+        <div class="dash-footer" id="dash-footer">
+          <span class="dash-footer-nodes" id="dash-footer-nodes"></span>
+          <span class="dash-footer-stats" id="dash-footer-stats"></span>
+        </div>
+        <section
+          class="dashboard-section"
+          id="dashboard-saved-ws"
+          aria-label="Saved workstreams"
+        >
+          <div class="dashboard-section-header">
+            <h2 class="dashboard-section-title">Saved Workstreams</h2>
+            <button
+              id="ws-delete-btn"
+              class="ws-delete-btn"
+              onclick="startWsDeleteMode()"
+              title="Delete workstreams"
+            >
+              <span aria-hidden="true">&#x1f5d1;</span> Delete
+            </button>
+          </div>
+          <div class="dashboard-cards" id="dashboard-saved-cards"></div>
+          <div id="ws-delete-bar" class="ws-delete-bar">
+            <span
+              class="ws-delete-count-label"
+              id="ws-delete-bar-count"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              >0 selected</span
+            >
+            <button class="ws-delete-cancel-btn" onclick="cancelWsDeleteMode()">
+              Cancel
+            </button>
+            <button
+              class="ws-delete-selectall-btn"
+              id="ws-delete-bar-select-all"
+              onclick="toggleSelectAll()"
+            >
+              Select All
+            </button>
+            <button
+              class="ws-delete-bar-btn"
+              id="ws-delete-bar-delete"
+              onclick="confirmWsDeleteSelection()"
+              disabled
+            >
+              Delete Selected
+            </button>
+          </div>
+        </section>
+      </div>
     </div>
-  </div>
-</div>
 
-<!-- Delete workstream confirmation modal -->
-<div id="delete-ws-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="delete-ws-heading">
-  <div id="delete-ws-box">
-    <h3 id="delete-ws-heading">Delete Workstream</h3>
-    <p id="delete-ws-message"></p>
-    <div id="delete-ws-buttons">
-      <button type="button" onclick="cancelDeleteWs()">Cancel</button>
-      <button type="button" class="danger" onclick="executeDeleteWs()">Delete</button>
+    <div id="split-root"></div>
+
+    <!-- New workstream modal -->
+    <div
+      id="new-ws-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-ws-title"
+    >
+      <div id="new-ws-box">
+        <h3 id="new-ws-title">New Workstream</h3>
+        <div id="new-ws-error" role="alert" aria-live="assertive"></div>
+        <label for="new-ws-name"
+          >Name <span class="nws-hint">optional</span></label
+        >
+        <input
+          id="new-ws-name"
+          type="text"
+          placeholder="Auto-generated if empty"
+          autocomplete="off"
+        />
+        <label for="new-ws-model"
+          >Model <span class="nws-hint">optional</span></label
+        >
+        <select id="new-ws-model">
+          <option value="">Default model</option>
+        </select>
+        <label for="new-ws-judge-model"
+          >Judge Model <span class="nws-hint">optional</span></label
+        >
+        <select id="new-ws-judge-model">
+          <option value="">Default (agent model)</option>
+        </select>
+        <label for="new-ws-skill"
+          >Skill <span class="nws-hint">optional</span></label
+        >
+        <select id="new-ws-skill">
+          <option value="">Use defaults</option>
+        </select>
+        <label for="new-ws-initial-message"
+          >First message <span class="nws-hint">optional</span></label
+        >
+        <textarea
+          id="new-ws-initial-message"
+          rows="3"
+          placeholder="Sent as the first turn after the workstream is created"
+        ></textarea>
+        <div id="new-ws-attach-row">
+          <button
+            id="new-ws-attach-btn"
+            type="button"
+            title="Attach files to the first turn"
+            aria-label="Attach files"
+          >
+            <span aria-hidden="true">&#128206;</span> Attach
+          </button>
+          <input
+            id="new-ws-attach-input"
+            type="file"
+            multiple
+            style="display: none"
+            accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.txt,.json,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.go,.rs,.java,.c,.cpp,.h,.hpp,.sh,.sql,.ini,.conf"
+          />
+          <div
+            id="new-ws-attach-chips"
+            role="list"
+            aria-label="Pending attachments"
+          ></div>
+        </div>
+        <div id="new-ws-buttons">
+          <button id="new-ws-cancel" type="button">Cancel</button>
+          <button id="new-ws-submit" type="button">Create</button>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
 
-<!-- Delete workstreams confirmation modal (batch) -->
-<div id="ws-delete-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="ws-delete-title">
-  <div id="ws-delete-box">
-    <h3 id="ws-delete-title">Delete Workstreams</h3>
-    <div id="ws-delete-error" role="alert" aria-live="assertive"></div>
-    <p id="ws-delete-count"></p>
-    <div id="ws-delete-list"></div>
-    <div id="ws-delete-buttons">
-      <button id="ws-delete-cancel-btn" type="button" onclick="cancelWsDelete()">Cancel</button>
-      <button id="ws-delete-confirm-btn" type="button" onclick="confirmWsDelete()">Delete</button>
+    <!-- Edit title modal -->
+    <div
+      id="edit-title-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-title-heading"
+    >
+      <div id="edit-title-box">
+        <h3 id="edit-title-heading">Edit Title</h3>
+        <input
+          id="edit-title-input"
+          type="text"
+          maxlength="80"
+          placeholder="Enter title..."
+          onkeydown="
+            if (event.key === 'Enter') submitEditTitle();
+            if (event.key === 'Escape') cancelEditTitle();
+          "
+        />
+        <div id="edit-title-buttons">
+          <button type="button" onclick="cancelEditTitle()">Cancel</button>
+          <button type="button" onclick="submitEditTitle()">Save</button>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
 
-<!-- Plan review dialog -->
-<div id="plan-overlay">
-  <div id="plan-dialog" role="dialog" aria-modal="true" aria-labelledby="plan-dialog-title">
-    <h3 id="plan-dialog-title">Plan Review</h3>
-    <div id="plan-content"></div>
-    <input type="text" id="plan-feedback" placeholder="feedback (optional)" aria-label="Plan feedback">
-    <div id="plan-buttons">
-      <button id="btn-plan-reject"><span class="key">Esc</span> Reject</button>
-      <button id="btn-plan-approve" onclick="resolvePlan('')"><span class="key">&crarr;</span> Approve</button>
+    <!-- Delete workstream confirmation modal -->
+    <div
+      id="delete-ws-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-ws-heading"
+    >
+      <div id="delete-ws-box">
+        <h3 id="delete-ws-heading">Delete Workstream</h3>
+        <p id="delete-ws-message"></p>
+        <div id="delete-ws-buttons">
+          <button type="button" onclick="cancelDeleteWs()">Cancel</button>
+          <button type="button" class="danger" onclick="executeDeleteWs()">
+            Delete
+          </button>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
 
-<div id="toast" role="status" aria-live="polite"></div>
-<script>
-window.TURNSTONE_AUTH_TITLE = "turnstone";
-window.TURNSTONE_KB_SHORTCUTS = [
-  { title: "Workstreams", keys: [
-    { desc: "Toggle dashboard", badge: '<span class="kb-key">Ctrl+D</span>' },
-    { desc: "New workstream", badge: '<span class="kb-key">Ctrl+T</span>' },
-    { desc: "Close workstream", badge: '<span class="kb-key">Ctrl+W</span>' },
-    { desc: "Switch to tab 1\u20139", badge: '<span class="kb-key">Ctrl+1</span>\u2026<span class="kb-key">9</span>' },
-    { desc: "Refresh title", badge: '<span class="kb-key">Ctrl+Shift+R</span>' },
-    { desc: "Edit title", badge: '<span class="kb-key">Ctrl+Shift+E</span>' },
-    { desc: "Fork workstream", badge: '<span class="kb-key">Ctrl+Shift+F</span>' },
-    { desc: "Delete workstream", badge: '<span class="kb-key">Ctrl+Shift+X</span>' }
-  ]},
-  { title: "Split panes", keys: [
-    { desc: "Split right", badge: '<span class="kb-key">Ctrl+\\</span>' },
-    { desc: "Split down", badge: '<span class="kb-key">Ctrl+Shift+\\</span>' },
-    { desc: "Close pane", badge: '<span class="kb-key">Ctrl+Shift+W</span>' },
-    { desc: "Cycle pane focus", badge: '<span class="kb-key">Ctrl+Alt+\u2190</span> <span class="kb-key">\u2192</span>' }
-  ]},
-  { title: "Tool approval", keys: [
-    { desc: "Approve", badge: '<span class="kb-key">y</span> / <span class="kb-key">Enter</span>' },
-    { desc: "Deny", badge: '<span class="kb-key">n</span> / <span class="kb-key">Esc</span>' },
-    { desc: "Always approve", badge: '<span class="kb-key">a</span>' }
-  ]},
-  { title: "Chat", keys: [
-    { desc: "Send message", badge: '<span class="kb-key">Enter</span>' },
-    { desc: "Stop generation", badge: '<span class="kb-key">Esc</span>' },
-    { desc: "New line", badge: '<span class="kb-key">Shift+Enter</span>' }
-  ]},
-  { title: "Navigation", keys: [
-    { desc: "Navigate table rows", badge: '<span class="kb-key">\u2191</span> <span class="kb-key">\u2193</span>' },
-    { desc: "Close dashboard", badge: '<span class="kb-key">Esc</span>' }
-  ]},
-  { title: "General", keys: [
-    { desc: "Show this help", badge: '<span class="kb-key">?</span>' }
-  ]}
-];
-</script>
-<script src="/shared/utils.js"></script>
-<script src="/shared/toast.js"></script>
-<script src="/shared/composer.js"></script>
-<script src="/shared/theme.js"></script>
-<script src="/shared/auth.js"></script>
-<script src="/shared/kb.js"></script>
-<script src="/shared/katex-0.16.45/katex.min.js"></script>
-<script src="/shared/hljs-11.11.1/highlight.min.js"></script>
-<script src="/shared/renderer.js"></script>
-<script src="/static/app.js"></script>
-</body>
+    <!-- Delete workstreams confirmation modal (batch) -->
+    <div
+      id="ws-delete-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ws-delete-title"
+    >
+      <div id="ws-delete-box">
+        <h3 id="ws-delete-title">Delete Workstreams</h3>
+        <div id="ws-delete-error" role="alert" aria-live="assertive"></div>
+        <p id="ws-delete-count"></p>
+        <div id="ws-delete-list"></div>
+        <div id="ws-delete-buttons">
+          <button
+            id="ws-delete-cancel-btn"
+            type="button"
+            onclick="cancelWsDelete()"
+          >
+            Cancel
+          </button>
+          <button
+            id="ws-delete-confirm-btn"
+            type="button"
+            onclick="confirmWsDelete()"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Plan review dialog -->
+    <div id="plan-overlay">
+      <div
+        id="plan-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="plan-dialog-title"
+      >
+        <h3 id="plan-dialog-title">Plan Review</h3>
+        <div id="plan-content"></div>
+        <input
+          type="text"
+          id="plan-feedback"
+          placeholder="feedback (optional)"
+          aria-label="Plan feedback"
+        />
+        <div id="plan-buttons">
+          <button id="btn-plan-reject">
+            <span class="key">Esc</span> Reject
+          </button>
+          <button id="btn-plan-approve" onclick="resolvePlan('')">
+            <span class="key">&crarr;</span> Approve
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+    <script>
+      window.TURNSTONE_AUTH_TITLE = "turnstone";
+      window.TURNSTONE_KB_SHORTCUTS = [
+        {
+          title: "Workstreams",
+          keys: [
+            {
+              desc: "Toggle dashboard",
+              badge: '<span class="kb-key">Ctrl+D</span>',
+            },
+            {
+              desc: "New workstream",
+              badge: '<span class="kb-key">Ctrl+T</span>',
+            },
+            {
+              desc: "Close workstream",
+              badge: '<span class="kb-key">Ctrl+W</span>',
+            },
+            {
+              desc: "Switch to tab 1\u20139",
+              badge:
+                '<span class="kb-key">Ctrl+1</span>\u2026<span class="kb-key">9</span>',
+            },
+            {
+              desc: "Refresh title",
+              badge: '<span class="kb-key">Ctrl+Shift+R</span>',
+            },
+            {
+              desc: "Edit title",
+              badge: '<span class="kb-key">Ctrl+Shift+E</span>',
+            },
+            {
+              desc: "Fork workstream",
+              badge: '<span class="kb-key">Ctrl+Shift+F</span>',
+            },
+            {
+              desc: "Delete workstream",
+              badge: '<span class="kb-key">Ctrl+Shift+X</span>',
+            },
+          ],
+        },
+        {
+          title: "Split panes",
+          keys: [
+            {
+              desc: "Split right",
+              badge: '<span class="kb-key">Ctrl+\\</span>',
+            },
+            {
+              desc: "Split down",
+              badge: '<span class="kb-key">Ctrl+Shift+\\</span>',
+            },
+            {
+              desc: "Close pane",
+              badge: '<span class="kb-key">Ctrl+Shift+W</span>',
+            },
+            {
+              desc: "Cycle pane focus",
+              badge:
+                '<span class="kb-key">Ctrl+Alt+\u2190</span> <span class="kb-key">\u2192</span>',
+            },
+          ],
+        },
+        {
+          title: "Tool approval",
+          keys: [
+            {
+              desc: "Approve",
+              badge:
+                '<span class="kb-key">y</span> / <span class="kb-key">Enter</span>',
+            },
+            {
+              desc: "Deny",
+              badge:
+                '<span class="kb-key">n</span> / <span class="kb-key">Esc</span>',
+            },
+            { desc: "Always approve", badge: '<span class="kb-key">a</span>' },
+          ],
+        },
+        {
+          title: "Chat",
+          keys: [
+            {
+              desc: "Send message",
+              badge: '<span class="kb-key">Enter</span>',
+            },
+            {
+              desc: "Stop generation",
+              badge: '<span class="kb-key">Esc</span>',
+            },
+            {
+              desc: "New line",
+              badge: '<span class="kb-key">Shift+Enter</span>',
+            },
+          ],
+        },
+        {
+          title: "Navigation",
+          keys: [
+            {
+              desc: "Navigate table rows",
+              badge:
+                '<span class="kb-key">\u2191</span> <span class="kb-key">\u2193</span>',
+            },
+            {
+              desc: "Close dashboard",
+              badge: '<span class="kb-key">Esc</span>',
+            },
+          ],
+        },
+        {
+          title: "General",
+          keys: [
+            { desc: "Show this help", badge: '<span class="kb-key">?</span>' },
+          ],
+        },
+      ];
+    </script>
+    <script src="/shared/utils.js"></script>
+    <script src="/shared/cards.js"></script>
+    <script src="/shared/toast.js"></script>
+    <script src="/shared/composer.js"></script>
+    <script src="/shared/theme.js"></script>
+    <script src="/shared/auth.js"></script>
+    <script src="/shared/kb.js"></script>
+    <script src="/shared/katex-0.16.45/katex.min.js"></script>
+    <script src="/shared/hljs-11.11.1/highlight.min.js"></script>
+    <script src="/shared/renderer.js"></script>
+    <script src="/static/app.js"></script>
+  </body>
 </html>

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -20,7 +20,9 @@
   border-radius: 8px;
   margin-left: 8px;
   font-family: var(--font-mono);
-  transition: opacity 0.3s ease, background 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    background 0.3s ease;
 }
 #health-indicator.health-ok {
   opacity: 0;
@@ -45,16 +47,33 @@
 /* ==========================================================================
    Theme toggle
    ========================================================================== */
-#theme-toggle { color: var(--fg); margin-left: auto; font-size: 14px; line-height: 1; }
+#theme-toggle {
+  color: var(--fg);
+  margin-left: auto;
+  font-size: 14px;
+  line-height: 1;
+}
 
 /* ==========================================================================
    Mobile overrides
    ========================================================================== */
 @media (max-width: 600px) {
-  .ws-tab .tab-chevron { opacity: 1; padding: 8px 10px; font-size: 14px; min-width: 36px; min-height: 36px; }
-  .ws-tab-dropdown-item.mobile-hide { display: none; }
-  #split-btn { display: none; }
-  .tab-wsid { display: none; }
+  .ws-tab .tab-chevron {
+    opacity: 1;
+    padding: 8px 10px;
+    font-size: 14px;
+    min-width: 36px;
+    min-height: 36px;
+  }
+  .ws-tab-dropdown-item.mobile-hide {
+    display: none;
+  }
+  #split-btn {
+    display: none;
+  }
+  .tab-wsid {
+    display: none;
+  }
 }
 
 /* ==========================================================================
@@ -75,8 +94,13 @@
   align-items: center;
   gap: 2px;
 }
-#tab-bar::-webkit-scrollbar { height: 3px; }
-#tab-bar::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 2px; }
+#tab-bar::-webkit-scrollbar {
+  height: 3px;
+}
+#tab-bar::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 2px;
+}
 
 .ws-tab {
   padding: 6px 10px;
@@ -93,9 +117,15 @@
   white-space: nowrap;
   user-select: none;
   position: relative;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
 }
-.ws-tab:hover { background: var(--bg-highlight); color: var(--fg-bright); }
+.ws-tab:hover {
+  background: var(--bg-highlight);
+  color: var(--fg-bright);
+}
 .ws-tab.active {
   background: var(--bg-highlight);
   color: var(--fg-bright);
@@ -103,12 +133,41 @@
 }
 
 /* Tab state indicators — LED glow */
-.ws-tab .tab-indicator { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.ws-tab .tab-indicator[data-state="idle"] { background: var(--fg-dim); opacity: 0.3; }
-.ws-tab .tab-indicator[data-state="thinking"] { background: var(--cyan); box-shadow: 0 0 6px var(--cyan-glow); animation: pulse 1.5s ease-in-out infinite; will-change: opacity; }
-.ws-tab .tab-indicator[data-state="running"] { background: var(--green); border-radius: 2px; box-shadow: 0 0 6px var(--green-glow); animation: pulse 1s ease-in-out infinite; will-change: opacity; }
-.ws-tab .tab-indicator[data-state="attention"] { background: var(--yellow); border-radius: 1px; transform: rotate(45deg); box-shadow: 0 0 6px var(--yellow-glow); animation: pulse 1s ease-in-out infinite; will-change: opacity; }
-.ws-tab .tab-indicator[data-state="error"] { background: var(--red); box-shadow: 0 0 4px var(--red-glow); }
+.ws-tab .tab-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ws-tab .tab-indicator[data-state="idle"] {
+  background: var(--fg-dim);
+  opacity: 0.3;
+}
+.ws-tab .tab-indicator[data-state="thinking"] {
+  background: var(--cyan);
+  box-shadow: 0 0 6px var(--cyan-glow);
+  animation: pulse 1.5s ease-in-out infinite;
+  will-change: opacity;
+}
+.ws-tab .tab-indicator[data-state="running"] {
+  background: var(--green);
+  border-radius: 2px;
+  box-shadow: 0 0 6px var(--green-glow);
+  animation: pulse 1s ease-in-out infinite;
+  will-change: opacity;
+}
+.ws-tab .tab-indicator[data-state="attention"] {
+  background: var(--yellow);
+  border-radius: 1px;
+  transform: rotate(45deg);
+  box-shadow: 0 0 6px var(--yellow-glow);
+  animation: pulse 1s ease-in-out infinite;
+  will-change: opacity;
+}
+.ws-tab .tab-indicator[data-state="error"] {
+  background: var(--red);
+  box-shadow: 0 0 4px var(--red-glow);
+}
 
 .ws-tab .tab-chevron {
   background: none;
@@ -119,14 +178,29 @@
   padding: 4px 6px;
   line-height: 1;
   opacity: 0;
-  transition: opacity 0.15s, color 0.1s, background 0.1s;
+  transition:
+    opacity 0.15s,
+    color 0.1s,
+    background 0.1s;
   border-radius: var(--radius-sm);
   margin-right: -4px;
 }
-.ws-tab:hover .tab-chevron, .ws-tab:focus-within .tab-chevron, .ws-tab .tab-chevron:focus-visible { opacity: 1; }
-.ws-tab.active .tab-chevron { opacity: 0.7; }
-.ws-tab .tab-chevron[aria-expanded="true"] { opacity: 1; color: var(--fg-bright); }
-.ws-tab .tab-chevron:hover { color: var(--fg-bright); background: rgba(255, 255, 255, 0.06); }
+.ws-tab:hover .tab-chevron,
+.ws-tab:focus-within .tab-chevron,
+.ws-tab .tab-chevron:focus-visible {
+  opacity: 1;
+}
+.ws-tab.active .tab-chevron {
+  opacity: 0.7;
+}
+.ws-tab .tab-chevron[aria-expanded="true"] {
+  opacity: 1;
+  color: var(--fg-bright);
+}
+.ws-tab .tab-chevron:hover {
+  color: var(--fg-bright);
+  background: rgba(255, 255, 255, 0.06);
+}
 
 /* Subtle ws_id badge in tabs */
 .tab-wsid {
@@ -134,23 +208,17 @@
   color: var(--fg-dim);
   opacity: 0;
   margin-left: 4px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: "IBM Plex Mono", monospace;
   letter-spacing: 0.02em;
   transition: opacity 0.15s;
 }
 .ws-tab:hover .tab-wsid,
-.ws-tab.active .tab-wsid { opacity: 0.45; }
-
-/* Subtle ws_id badge in saved workstream cards */
-.card-wsid {
-  font-size: 9px;
-  color: var(--fg-dim);
+.ws-tab.active .tab-wsid {
   opacity: 0.45;
-  margin-left: 6px;
-  font-family: 'IBM Plex Mono', monospace;
-  letter-spacing: 0.02em;
-  vertical-align: middle;
 }
+
+/* .card-wsid moved to /shared/cards.css (with vertical-align added so it
+   aligns with .card-meta).  Single source for both surfaces. */
 
 #new-tab-btn {
   background: none;
@@ -163,9 +231,16 @@
   font-size: 14px;
   line-height: 1;
   flex-shrink: 0;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
-#new-tab-btn:hover { background: var(--bg-highlight); color: var(--accent); border-color: var(--accent); }
+#new-tab-btn:hover {
+  background: var(--bg-highlight);
+  color: var(--accent);
+  border-color: var(--accent);
+}
 
 #split-btn {
   background: none;
@@ -178,14 +253,32 @@
   font-size: 13px;
   line-height: 1;
   flex-shrink: 0;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
   margin-left: 2px;
 }
-#split-btn:hover { background: var(--bg-highlight); color: var(--accent); border-color: var(--accent); }
-#split-btn.hidden { display: none; }
+#split-btn:hover {
+  background: var(--bg-highlight);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+#split-btn.hidden {
+  display: none;
+}
 
 /* Tab dropdown menu */
-@keyframes dropdown-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 .ws-tab-dropdown {
   position: fixed;
   background: var(--bg-surface);
@@ -198,7 +291,9 @@
   padding: 4px 0;
   animation: dropdown-in 0.1s ease-out;
 }
-[data-theme="light"] .ws-tab-dropdown { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12); }
+[data-theme="light"] .ws-tab-dropdown {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
 .ws-tab-dropdown-item {
   display: flex;
   align-items: center;
@@ -217,24 +312,48 @@
   white-space: nowrap;
   transition: background 0.1s;
 }
-.ws-tab-dropdown-item:hover:not([aria-disabled="true"]) { background: var(--bg-highlight); color: var(--fg-bright); }
-.ws-tab-dropdown-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.ws-tab-dropdown-item[aria-disabled="true"] { color: var(--fg-dim); opacity: 0.55; cursor: not-allowed; }
+.ws-tab-dropdown-item:hover:not([aria-disabled="true"]) {
+  background: var(--bg-highlight);
+  color: var(--fg-bright);
+}
+.ws-tab-dropdown-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.ws-tab-dropdown-item[aria-disabled="true"] {
+  color: var(--fg-dim);
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 .ws-tab-dropdown-item.destructive:hover:not([aria-disabled="true"]),
-.ws-tab-dropdown-item.destructive:focus-visible:not([aria-disabled="true"]) { color: var(--red); background: rgba(248, 113, 113, 0.08); }
-.ws-tab-dropdown-item.destructive:focus-visible:not([aria-disabled="true"]) { outline-color: var(--red); }
-.ws-tab-dropdown-label { flex: 1; }
+.ws-tab-dropdown-item.destructive:focus-visible:not([aria-disabled="true"]) {
+  color: var(--red);
+  background: rgba(248, 113, 113, 0.08);
+}
+.ws-tab-dropdown-item.destructive:focus-visible:not([aria-disabled="true"]) {
+  outline-color: var(--red);
+}
+.ws-tab-dropdown-label {
+  flex: 1;
+}
 .ws-tab-dropdown-key {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--fg-dim);
   flex-shrink: 0;
 }
-.ws-tab-dropdown-sep { height: 1px; background: var(--border-strong); margin: 6px 0; }
-.header-spacer { flex: 1; }
+.ws-tab-dropdown-sep {
+  height: 1px;
+  background: var(--border-strong);
+  margin: 6px 0;
+}
+.header-spacer {
+  flex: 1;
+}
 
 /* Edit title & delete modals */
-#edit-title-overlay, #delete-ws-overlay {
+#edit-title-overlay,
+#delete-ws-overlay {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
@@ -243,7 +362,8 @@
   justify-content: center;
   z-index: 10000;
 }
-#edit-title-box, #delete-ws-box {
+#edit-title-box,
+#delete-ws-box {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -251,7 +371,12 @@
   max-width: 400px;
   width: 90%;
 }
-#edit-title-box h3, #delete-ws-box h3 { margin: 0 0 12px; font-size: 16px; color: var(--fg-bright); }
+#edit-title-box h3,
+#delete-ws-box h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: var(--fg-bright);
+}
 #edit-title-input {
   width: 100%;
   padding: 8px 10px;
@@ -264,9 +389,18 @@
   margin-bottom: 16px;
   box-sizing: border-box;
 }
-#edit-title-input:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
-#edit-title-buttons, #delete-ws-buttons { display: flex; gap: 8px; justify-content: flex-end; }
-#edit-title-buttons button, #delete-ws-buttons button {
+#edit-title-input:focus {
+  outline: 1px solid var(--accent);
+  border-color: var(--accent);
+}
+#edit-title-buttons,
+#delete-ws-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+#edit-title-buttons button,
+#delete-ws-buttons button {
   padding: 8px 20px;
   border-radius: var(--radius);
   font-size: 13px;
@@ -281,7 +415,11 @@
   color: #fff;
   border-color: var(--red);
 }
-#delete-ws-message { font-size: 14px; color: var(--fg-bright); margin: 0 0 16px; }
+#delete-ws-message {
+  font-size: 14px;
+  color: var(--fg-bright);
+  margin: 0 0 16px;
+}
 
 /* ==========================================================================
    Split panes
@@ -297,8 +435,12 @@
   min-height: 0;
   min-width: 0;
 }
-.split-horizontal { flex-direction: row; }
-.split-vertical { flex-direction: column; }
+.split-horizontal {
+  flex-direction: row;
+}
+.split-vertical {
+  flex-direction: column;
+}
 .split-child {
   display: flex;
   min-width: 0;
@@ -315,19 +457,29 @@
 }
 .split-handle:hover,
 .split-handle:active,
-.split-handle.dragging { background: var(--accent); }
-.split-vertical > .split-handle { cursor: row-resize; }
+.split-handle.dragging {
+  background: var(--accent);
+}
+.split-vertical > .split-handle {
+  cursor: row-resize;
+}
 /* Expand hit area to 12px via pseudoelement */
 .split-handle::before {
-  content: '';
+  content: "";
   position: absolute;
   z-index: 1;
 }
 .split-horizontal > .split-handle::before {
-  top: 0; bottom: 0; left: -4px; right: -4px;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+  right: -4px;
 }
 .split-vertical > .split-handle::before {
-  left: 0; right: 0; top: -4px; bottom: -4px;
+  left: 0;
+  right: 0;
+  top: -4px;
+  bottom: -4px;
 }
 
 /* Pane */
@@ -340,14 +492,19 @@
   overflow: hidden;
   position: relative;
 }
-.pane.focused { outline: 1px solid var(--accent-dim); outline-offset: -1px; }
+.pane.focused {
+  outline: 1px solid var(--accent-dim);
+  outline-offset: -1px;
+}
 .multi-pane .pane.focused .pane-header {
   border-bottom-color: var(--accent);
   background: var(--bg-highlight);
 }
 
 /* Pane header — only visible in multi-pane mode */
-.pane-header { display: none; }
+.pane-header {
+  display: none;
+}
 .multi-pane .pane-header {
   display: flex;
   align-items: center;
@@ -366,8 +523,14 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.pane.focused .pane-ws-name { color: var(--accent); }
-.pane-actions { display: flex; gap: 2px; flex-shrink: 0; }
+.pane.focused .pane-ws-name {
+  color: var(--accent);
+}
+.pane-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
 .pane-action-btn {
   background: none;
   border: none;
@@ -378,13 +541,25 @@
   border-radius: var(--radius-sm);
   line-height: 1;
   opacity: 0.3;
-  transition: opacity 0.15s, color 0.1s, background 0.1s;
+  transition:
+    opacity 0.15s,
+    color 0.1s,
+    background 0.1s;
 }
-.pane.focused .pane-action-btn { opacity: 0.5; }
+.pane.focused .pane-action-btn {
+  opacity: 0.5;
+}
 .pane-header:hover .pane-action-btn,
-.pane-action-btn:focus-visible { opacity: 1; }
-.pane-action-btn:hover { color: var(--fg-bright); background: var(--bg-highlight); }
-.pane-close-btn:hover { color: var(--red); }
+.pane-action-btn:focus-visible {
+  opacity: 1;
+}
+.pane-action-btn:hover {
+  color: var(--fg-bright);
+  background: var(--bg-highlight);
+}
+.pane-close-btn:hover {
+  color: var(--red);
+}
 
 /* Pane context menu */
 .pane-ctx-menu {
@@ -398,7 +573,9 @@
   overflow: hidden;
   padding: 4px 0;
 }
-[data-theme="light"] .pane-ctx-menu { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12); }
+[data-theme="light"] .pane-ctx-menu {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
 .pane-ctx-item {
   display: flex;
   align-items: center;
@@ -417,17 +594,32 @@
   white-space: nowrap;
   transition: background 0.1s;
 }
-.pane-ctx-item:hover:not(:disabled) { background: var(--bg-highlight); }
-.pane-ctx-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.pane-ctx-item:disabled { color: var(--fg-dim); opacity: 0.4; cursor: default; }
-.pane-ctx-label { flex: 1; }
+.pane-ctx-item:hover:not(:disabled) {
+  background: var(--bg-highlight);
+}
+.pane-ctx-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.pane-ctx-item:disabled {
+  color: var(--fg-dim);
+  opacity: 0.4;
+  cursor: default;
+}
+.pane-ctx-label {
+  flex: 1;
+}
 .pane-ctx-key {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--fg-dim);
   flex-shrink: 0;
 }
-.pane-ctx-sep { height: 1px; background: var(--border-strong); margin: 4px 0; }
+.pane-ctx-sep {
+  height: 1px;
+  background: var(--border-strong);
+  margin: 4px 0;
+}
 
 /* ==========================================================================
    Messages
@@ -447,8 +639,12 @@
    on wide displays, and a brighter text colour on user messages so
    "the thing I said" reads distinctly against the lower-chroma
    assistant colour. */
-.ts-msg { max-width: 95%; }
-.ts-msg--user { color: var(--fg-bright); }
+.ts-msg {
+  max-width: 95%;
+}
+.ts-msg--user {
+  color: var(--fg-bright);
+}
 .msg-queued {
   opacity: 0.65;
   border-style: dashed;
@@ -486,7 +682,9 @@
    adds a pre-wrap override for info messages and a tightened
    tool-message shape with the yellow accent bar the instrument-panel
    look established. */
-.ts-msg--info { white-space: pre-wrap; }
+.ts-msg--info {
+  white-space: pre-wrap;
+}
 .ts-msg--tool {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -496,31 +694,95 @@
   align-self: flex-start;
   max-width: 95%;
 }
-.ts-msg--tool .tool-header { color: var(--yellow); font-weight: 600; margin-bottom: 4px; font-size: 11px; }
-.ts-msg--tool .tool-preview { color: var(--fg-dim); white-space: pre-wrap; font-size: 12px; max-height: 300px; overflow-y: auto; }
+.ts-msg--tool .tool-header {
+  color: var(--yellow);
+  font-weight: 600;
+  margin-bottom: 4px;
+  font-size: 11px;
+}
+.ts-msg--tool .tool-preview {
+  color: var(--fg-dim);
+  white-space: pre-wrap;
+  font-size: 12px;
+  max-height: 300px;
+  overflow-y: auto;
+}
 
 /* Streaming content — .ts-msg--reasoning (chat.css) styles reasoning
    bubbles; .reasoning was the legacy role class and is no longer
    emitted. */
-.thinking-indicator { color: var(--fg-dim); font-size: 12px; padding: 6px 14px; }
-.thinking-indicator::after { content: '...'; animation: dots 1.5s steps(3, end) infinite; }
-@keyframes dots { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }
+.thinking-indicator {
+  color: var(--fg-dim);
+  font-size: 12px;
+  padding: 6px 14px;
+}
+.thinking-indicator::after {
+  content: "...";
+  animation: dots 1.5s steps(3, end) infinite;
+}
+@keyframes dots {
+  0% {
+    content: ".";
+  }
+  33% {
+    content: "..";
+  }
+  66% {
+    content: "...";
+  }
+}
 
 /* ==========================================================================
    Markdown styling
    ========================================================================== */
 /* Override KaTeX body rule — our layout requires body as a static flex container */
-body { position: static; }
-.ts-msg--assistant h1, .ts-msg--assistant h2, .ts-msg--assistant h3, .ts-msg--assistant h4, .ts-msg--assistant h5, .ts-msg--assistant h6 { color: var(--accent); margin: 8px 0 4px; font-family: var(--font-display); }
-.ts-msg--assistant h1 { font-size: 18px; }
-.ts-msg--assistant h2 { font-size: 16px; }
-.ts-msg--assistant h3 { font-size: 14px; }
-.ts-msg--assistant h4 { font-size: 13px; font-weight: 600; }
-.ts-msg--assistant h5 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
-.ts-msg--assistant h6 { font-size: 12px; font-weight: 500; color: var(--fg-dim); }
-.ts-msg--assistant strong { color: var(--fg-bright); }
-.ts-msg--assistant em { color: var(--magenta); }
-.ts-msg--assistant del { color: var(--fg-dim); text-decoration: line-through; }
+body {
+  position: static;
+}
+.ts-msg--assistant h1,
+.ts-msg--assistant h2,
+.ts-msg--assistant h3,
+.ts-msg--assistant h4,
+.ts-msg--assistant h5,
+.ts-msg--assistant h6 {
+  color: var(--accent);
+  margin: 8px 0 4px;
+  font-family: var(--font-display);
+}
+.ts-msg--assistant h1 {
+  font-size: 18px;
+}
+.ts-msg--assistant h2 {
+  font-size: 16px;
+}
+.ts-msg--assistant h3 {
+  font-size: 14px;
+}
+.ts-msg--assistant h4 {
+  font-size: 13px;
+  font-weight: 600;
+}
+.ts-msg--assistant h5 {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ts-msg--assistant h6 {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-dim);
+}
+.ts-msg--assistant strong {
+  color: var(--fg-bright);
+}
+.ts-msg--assistant em {
+  color: var(--magenta);
+}
+.ts-msg--assistant del {
+  color: var(--fg-dim);
+  text-decoration: line-through;
+}
 .ts-msg--assistant code {
   background: var(--code-bg);
   padding: 2px 6px;
@@ -536,68 +798,239 @@ body { position: static; }
   margin: 8px 0;
   border: 1px solid var(--border);
 }
-.ts-msg--assistant pre code { background: none; padding: 0; border: none; }
-.ts-msg--assistant ul, .ts-msg--assistant ol { margin: 4px 0 4px 20px; }
-.ts-msg--assistant li { margin: 2px 0; }
-.ts-msg--assistant a { color: var(--accent); text-decoration: underline; }
-.ts-msg--assistant blockquote { border-left: 3px solid var(--accent-dim); padding-left: 12px; color: var(--fg-dim); margin: 6px 0; }
-.ts-msg--assistant hr { border: none; border-top: 1px solid var(--border); margin: 8px 0; }
-.ts-msg--assistant p { margin: 4px 0; }
-.ts-msg--assistant .table-wrap { overflow-x: auto; margin: 8px 0; -webkit-overflow-scrolling: touch; }
-.ts-msg--assistant .table-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.ts-msg--assistant table { border-collapse: collapse; width: auto; min-width: 50%; font-size: 13px; }
-.ts-msg--assistant thead { border-bottom: 2px solid var(--border-strong); }
-.ts-msg--assistant th { background: var(--code-bg); font-weight: 600; color: var(--fg-bright); }
-.ts-msg--assistant th, .ts-msg--assistant td { padding: 6px 12px; border: 1px solid var(--border-strong); }
-.ts-msg--assistant tbody tr { transition: background 0.12s ease; }
-.ts-msg--assistant tbody tr:nth-child(even) { background: var(--row-alt); }
-.ts-msg--assistant tbody tr:hover { background: var(--bg-highlight); }
-.ts-msg--assistant .align-left { text-align: left; }
-.ts-msg--assistant .align-center { text-align: center; }
-.ts-msg--assistant .align-right { text-align: right; }
-.ts-msg--assistant img { display: block; max-width: 100%; height: auto; border-radius: var(--radius); margin: 4px 0; }
+.ts-msg--assistant pre code {
+  background: none;
+  padding: 0;
+  border: none;
+}
+.ts-msg--assistant ul,
+.ts-msg--assistant ol {
+  margin: 4px 0 4px 20px;
+}
+.ts-msg--assistant li {
+  margin: 2px 0;
+}
+.ts-msg--assistant a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.ts-msg--assistant blockquote {
+  border-left: 3px solid var(--accent-dim);
+  padding-left: 12px;
+  color: var(--fg-dim);
+  margin: 6px 0;
+}
+.ts-msg--assistant hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 8px 0;
+}
+.ts-msg--assistant p {
+  margin: 4px 0;
+}
+.ts-msg--assistant .table-wrap {
+  overflow-x: auto;
+  margin: 8px 0;
+  -webkit-overflow-scrolling: touch;
+}
+.ts-msg--assistant .table-wrap:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.ts-msg--assistant table {
+  border-collapse: collapse;
+  width: auto;
+  min-width: 50%;
+  font-size: 13px;
+}
+.ts-msg--assistant thead {
+  border-bottom: 2px solid var(--border-strong);
+}
+.ts-msg--assistant th {
+  background: var(--code-bg);
+  font-weight: 600;
+  color: var(--fg-bright);
+}
+.ts-msg--assistant th,
+.ts-msg--assistant td {
+  padding: 6px 12px;
+  border: 1px solid var(--border-strong);
+}
+.ts-msg--assistant tbody tr {
+  transition: background 0.12s ease;
+}
+.ts-msg--assistant tbody tr:nth-child(even) {
+  background: var(--row-alt);
+}
+.ts-msg--assistant tbody tr:hover {
+  background: var(--bg-highlight);
+}
+.ts-msg--assistant .align-left {
+  text-align: left;
+}
+.ts-msg--assistant .align-center {
+  text-align: center;
+}
+.ts-msg--assistant .align-right {
+  text-align: right;
+}
+.ts-msg--assistant img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+  margin: 4px 0;
+}
 .ts-msg--assistant .img-placeholder {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 8px 14px; margin: 4px 0;
-  background: var(--code-bg); border: 1px solid var(--border-strong);
-  border-radius: var(--radius); cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  margin: 4px 0;
+  background: var(--code-bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  cursor: pointer;
   transition: border-color 0.12s ease;
 }
-.ts-msg--assistant .img-placeholder:hover { border-color: var(--accent); }
-.ts-msg--assistant .img-placeholder:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.ts-msg--assistant .img-placeholder-icon { font-size: 16px; }
-.ts-msg--assistant .img-placeholder-label { color: var(--fg-bright); font-size: 13px; }
-.ts-msg--assistant .img-placeholder-domain { color: var(--fg-dim); font-size: 11px; }
-.ts-msg--assistant li > input[type="checkbox"] { margin-right: 6px; vertical-align: middle; accent-color: var(--accent); }
-.ts-msg--assistant blockquote blockquote { margin: 4px 0; border-left-color: var(--border-strong); }
-.ts-msg--assistant blockquote blockquote blockquote { border-left-color: var(--border); }
-.ts-msg--assistant .katex-display { margin: 8px 0; padding: 8px 0; overflow-x: auto; overflow-y: hidden; }
-.ts-msg--assistant .katex-error { color: var(--red) !important; font-size: 12px; }
+.ts-msg--assistant .img-placeholder:hover {
+  border-color: var(--accent);
+}
+.ts-msg--assistant .img-placeholder:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.ts-msg--assistant .img-placeholder-icon {
+  font-size: 16px;
+}
+.ts-msg--assistant .img-placeholder-label {
+  color: var(--fg-bright);
+  font-size: 13px;
+}
+.ts-msg--assistant .img-placeholder-domain {
+  color: var(--fg-dim);
+  font-size: 11px;
+}
+.ts-msg--assistant li > input[type="checkbox"] {
+  margin-right: 6px;
+  vertical-align: middle;
+  accent-color: var(--accent);
+}
+.ts-msg--assistant blockquote blockquote {
+  margin: 4px 0;
+  border-left-color: var(--border-strong);
+}
+.ts-msg--assistant blockquote blockquote blockquote {
+  border-left-color: var(--border);
+}
+.ts-msg--assistant .katex-display {
+  margin: 8px 0;
+  padding: 8px 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.ts-msg--assistant .katex-error {
+  color: var(--red) !important;
+  font-size: 12px;
+}
 
 /* Syntax highlighting — highlight.js theme (instrument panel) */
-.ts-msg--assistant pre code.hljs { background: var(--code-bg); color: var(--fg); padding: 0; }
-.hljs-keyword, .hljs-selector-tag, .hljs-built_in, .hljs-type { color: var(--magenta); }
-.hljs-string, .hljs-attr, .hljs-template-tag, .hljs-template-variable { color: var(--green); }
-.hljs-number, .hljs-literal, .hljs-variable, .hljs-symbol, .hljs-bullet { color: var(--cyan); }
-.hljs-title, .hljs-title.class_, .hljs-title.function_ { color: var(--accent); }
-.hljs-comment, .hljs-quote { color: var(--fg-dim); font-style: italic; }
-.hljs-meta { color: var(--fg-dim); }
-.hljs-doctag { color: var(--cyan); font-weight: 500; }
-.hljs-char.escape_ { color: var(--cyan); }
-.hljs-emphasis { font-style: italic; }
-.hljs-strong { font-weight: bold; color: var(--fg-bright); }
-.hljs-attribute { color: var(--yellow); }
-.hljs-regexp, .hljs-link { color: var(--cyan); }
-.hljs-selector-id, .hljs-selector-class { color: var(--yellow); }
-.hljs-section { color: var(--accent); font-weight: bold; }
-.hljs-tag { color: var(--fg-dim); }
-.hljs-name { color: var(--magenta); }
-.hljs-params { color: var(--fg); }
-.hljs-addition { color: var(--green); background: rgba(52, 211, 153, 0.08); display: inline-block; width: 100%; }
-.hljs-deletion { color: var(--red); background: rgba(248, 113, 113, 0.08); display: inline-block; width: 100%; }
-.ts-msg--assistant pre.code-terminal { border-left: 2px solid var(--green); }
-[data-theme="light"] .hljs-addition { background: rgba(4, 120, 87, 0.06); }
-[data-theme="light"] .hljs-deletion { background: rgba(220, 38, 38, 0.06); }
+.ts-msg--assistant pre code.hljs {
+  background: var(--code-bg);
+  color: var(--fg);
+  padding: 0;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-built_in,
+.hljs-type {
+  color: var(--magenta);
+}
+.hljs-string,
+.hljs-attr,
+.hljs-template-tag,
+.hljs-template-variable {
+  color: var(--green);
+}
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-symbol,
+.hljs-bullet {
+  color: var(--cyan);
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.function_ {
+  color: var(--accent);
+}
+.hljs-comment,
+.hljs-quote {
+  color: var(--fg-dim);
+  font-style: italic;
+}
+.hljs-meta {
+  color: var(--fg-dim);
+}
+.hljs-doctag {
+  color: var(--cyan);
+  font-weight: 500;
+}
+.hljs-char.escape_ {
+  color: var(--cyan);
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+  color: var(--fg-bright);
+}
+.hljs-attribute {
+  color: var(--yellow);
+}
+.hljs-regexp,
+.hljs-link {
+  color: var(--cyan);
+}
+.hljs-selector-id,
+.hljs-selector-class {
+  color: var(--yellow);
+}
+.hljs-section {
+  color: var(--accent);
+  font-weight: bold;
+}
+.hljs-tag {
+  color: var(--fg-dim);
+}
+.hljs-name {
+  color: var(--magenta);
+}
+.hljs-params {
+  color: var(--fg);
+}
+.hljs-addition {
+  color: var(--green);
+  background: rgba(52, 211, 153, 0.08);
+  display: inline-block;
+  width: 100%;
+}
+.hljs-deletion {
+  color: var(--red);
+  background: rgba(248, 113, 113, 0.08);
+  display: inline-block;
+  width: 100%;
+}
+.ts-msg--assistant pre.code-terminal {
+  border-left: 2px solid var(--green);
+}
+[data-theme="light"] .hljs-addition {
+  background: rgba(4, 120, 87, 0.06);
+}
+[data-theme="light"] .hljs-deletion {
+  background: rgba(220, 38, 38, 0.06);
+}
 
 /* Mermaid diagrams */
 .ts-msg--assistant .mermaid-container {
@@ -607,7 +1040,10 @@ body { position: static; }
   overflow-x: auto;
   min-height: 40px;
 }
-.ts-msg--assistant .mermaid-container svg { max-width: 100%; height: auto; }
+.ts-msg--assistant .mermaid-container svg {
+  max-width: 100%;
+  height: auto;
+}
 .ts-msg--assistant .mermaid-loading {
   padding: 16px;
   color: var(--fg-dim);
@@ -615,7 +1051,9 @@ body { position: static; }
   background: var(--bg-surface);
   border: 1px solid var(--border);
 }
-.ts-msg--assistant .mermaid-error { text-align: left; }
+.ts-msg--assistant .mermaid-error {
+  text-align: left;
+}
 .ts-msg--assistant .mermaid-error-msg {
   padding: 8px 12px;
   color: var(--red);
@@ -624,7 +1062,9 @@ body { position: static; }
   border-bottom: 1px solid var(--border);
 }
 @media (prefers-reduced-motion: reduce) {
-  .ts-msg--assistant .mermaid-container svg * { animation: none !important; }
+  .ts-msg--assistant .mermaid-container svg * {
+    animation: none !important;
+  }
 }
 
 /* Safe HTML elements */
@@ -642,9 +1082,15 @@ body { position: static; }
   color: var(--fg-bright);
   user-select: none;
 }
-.ts-msg--assistant details summary:hover { color: var(--accent); }
-.ts-msg--assistant details[open] > summary { border-bottom: 1px solid var(--border); }
-.ts-msg--assistant details > :not(summary) { padding: 0 12px; }
+.ts-msg--assistant details summary:hover {
+  color: var(--accent);
+}
+.ts-msg--assistant details[open] > summary {
+  border-bottom: 1px solid var(--border);
+}
+.ts-msg--assistant details > :not(summary) {
+  padding: 0 12px;
+}
 .ts-msg--assistant kbd {
   background: var(--bg-highlight);
   border: 1px solid var(--border-strong);
@@ -654,7 +1100,12 @@ body { position: static; }
   font-family: var(--font-mono);
   box-shadow: 0 1px 0 var(--border-strong);
 }
-.ts-msg--assistant mark { background: var(--yellow-glow); color: var(--fg-bright); border-radius: 2px; padding: 0 2px; }
+.ts-msg--assistant mark {
+  background: var(--yellow-glow);
+  color: var(--fg-bright);
+  border-radius: 2px;
+  padding: 0 2px;
+}
 
 /* GFM Callouts / Alerts */
 .ts-msg--assistant .callout {
@@ -672,29 +1123,62 @@ body { position: static; }
   align-items: center;
   gap: 6px;
 }
-.ts-msg--assistant .callout-icon { font-size: 14px; }
-.ts-msg--assistant .callout-body { padding: 0 12px 8px; color: var(--fg); }
-.ts-msg--assistant .callout-body p:first-child { margin-top: 0; }
-.ts-msg--assistant .callout-body p:last-child { margin-bottom: 0; }
-.ts-msg--assistant .callout-note { border-left-color: var(--cyan); }
-.ts-msg--assistant .callout-note .callout-title { color: var(--cyan); }
-.ts-msg--assistant .callout-tip { border-left-color: var(--green); }
-.ts-msg--assistant .callout-tip .callout-title { color: var(--green); }
-.ts-msg--assistant .callout-important { border-left-color: var(--magenta); }
-.ts-msg--assistant .callout-important .callout-title { color: var(--magenta); }
-.ts-msg--assistant .callout-warning { border-left-color: var(--yellow); }
-.ts-msg--assistant .callout-warning .callout-title { color: var(--yellow); }
-.ts-msg--assistant .callout-caution { border-left-color: var(--red); }
-.ts-msg--assistant .callout-caution .callout-title { color: var(--red); }
+.ts-msg--assistant .callout-icon {
+  font-size: 14px;
+}
+.ts-msg--assistant .callout-body {
+  padding: 0 12px 8px;
+  color: var(--fg);
+}
+.ts-msg--assistant .callout-body p:first-child {
+  margin-top: 0;
+}
+.ts-msg--assistant .callout-body p:last-child {
+  margin-bottom: 0;
+}
+.ts-msg--assistant .callout-note {
+  border-left-color: var(--cyan);
+}
+.ts-msg--assistant .callout-note .callout-title {
+  color: var(--cyan);
+}
+.ts-msg--assistant .callout-tip {
+  border-left-color: var(--green);
+}
+.ts-msg--assistant .callout-tip .callout-title {
+  color: var(--green);
+}
+.ts-msg--assistant .callout-important {
+  border-left-color: var(--magenta);
+}
+.ts-msg--assistant .callout-important .callout-title {
+  color: var(--magenta);
+}
+.ts-msg--assistant .callout-warning {
+  border-left-color: var(--yellow);
+}
+.ts-msg--assistant .callout-warning .callout-title {
+  color: var(--yellow);
+}
+.ts-msg--assistant .callout-caution {
+  border-left-color: var(--red);
+}
+.ts-msg--assistant .callout-caution .callout-title {
+  color: var(--red);
+}
 
 /* Definition lists */
-.ts-msg--assistant dl { margin: 8px 0; }
+.ts-msg--assistant dl {
+  margin: 8px 0;
+}
 .ts-msg--assistant dt {
   font-weight: 600;
   color: var(--fg-bright);
   margin-top: 8px;
 }
-.ts-msg--assistant dt:first-child { margin-top: 0; }
+.ts-msg--assistant dt:first-child {
+  margin-top: 0;
+}
 .ts-msg--assistant dd {
   margin: 2px 0 0 20px;
   padding-left: 12px;
@@ -702,24 +1186,42 @@ body { position: static; }
 }
 
 /* Footnotes */
-.ts-msg--assistant .footnotes { margin-top: 16px; font-size: 12px; color: var(--fg-dim); }
-.ts-msg--assistant .footnotes-sep { border: none; border-top: 1px solid var(--border); margin-bottom: 8px; }
-.ts-msg--assistant .footnotes-list { margin: 0 0 0 20px; padding: 0; }
-.ts-msg--assistant .footnote-item { margin: 4px 0; line-height: 1.5; }
+.ts-msg--assistant .footnotes {
+  margin-top: 16px;
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.ts-msg--assistant .footnotes-sep {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.ts-msg--assistant .footnotes-list {
+  margin: 0 0 0 20px;
+  padding: 0;
+}
+.ts-msg--assistant .footnote-item {
+  margin: 4px 0;
+  line-height: 1.5;
+}
 .ts-msg--assistant .fn-ref a {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   font-weight: 600;
 }
-.ts-msg--assistant .fn-ref a:hover { text-decoration: underline; }
+.ts-msg--assistant .fn-ref a:hover {
+  text-decoration: underline;
+}
 .ts-msg--assistant .fn-backref {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   margin-left: 4px;
 }
-.ts-msg--assistant .fn-backref:hover { text-decoration: underline; }
+.ts-msg--assistant .fn-backref:hover {
+  text-decoration: underline;
+}
 .ts-msg--assistant .fn-ref a:focus-visible,
 .ts-msg--assistant .fn-backref:focus-visible {
   outline: 2px solid var(--accent);
@@ -730,7 +1232,10 @@ body { position: static; }
 /* ==========================================================================
    Message action toolbar (hover controls for retry / edit / rewind)
    ========================================================================== */
-.ts-msg--user, .ts-msg--assistant { position: relative; }
+.ts-msg--user,
+.ts-msg--assistant {
+  position: relative;
+}
 .msg-actions {
   position: absolute;
   top: 4px;
@@ -750,7 +1255,10 @@ body { position: static; }
 .ts-msg--assistant:hover .msg-actions,
 .ts-msg--user:focus-within .msg-actions,
 .ts-msg--assistant:focus-within .msg-actions,
-.msg-actions:hover { opacity: 1; pointer-events: auto; }
+.msg-actions:hover {
+  opacity: 1;
+  pointer-events: auto;
+}
 .msg-action-btn {
   display: flex;
   align-items: center;
@@ -761,16 +1269,28 @@ body { position: static; }
   border: none;
   cursor: pointer;
   color: var(--fg-dim);
-  transition: color 0.1s ease, background 0.1s ease;
+  transition:
+    color 0.1s ease,
+    background 0.1s ease;
   padding: 0;
 }
-.msg-action-btn:hover { color: var(--accent); background: var(--bg-highlight); box-shadow: 0 0 6px var(--accent-glow); }
-.msg-action-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.msg-action-btn + .msg-action-btn { border-left: 1px solid var(--border); }
+.msg-action-btn:hover {
+  color: var(--accent);
+  background: var(--bg-highlight);
+  box-shadow: 0 0 6px var(--accent-glow);
+}
+.msg-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.msg-action-btn + .msg-action-btn {
+  border-left: 1px solid var(--border);
+}
 
 /* Icon: retry (circular arrow) */
 .icon-retry {
-  width: 13px; height: 13px;
+  width: 13px;
+  height: 13px;
   border: 1.5px solid currentColor;
   border-radius: 50%;
   border-bottom-color: transparent;
@@ -779,8 +1299,10 @@ body { position: static; }
 .icon-retry::after {
   content: "";
   position: absolute;
-  bottom: -1px; right: -1px;
-  width: 0; height: 0;
+  bottom: -1px;
+  right: -1px;
+  width: 0;
+  height: 0;
   border-left: 2px solid transparent;
   border-right: 2px solid transparent;
   border-top: 3px solid currentColor;
@@ -789,15 +1311,18 @@ body { position: static; }
 
 /* Icon: edit (pencil) */
 .icon-edit {
-  width: 12px; height: 12px;
+  width: 12px;
+  height: 12px;
   position: relative;
   transform: rotate(-45deg);
 }
 .icon-edit::before {
   content: "";
   position: absolute;
-  top: 0; left: 3px;
-  width: 6px; height: 8px;
+  top: 0;
+  left: 3px;
+  width: 6px;
+  height: 8px;
   border: 1.5px solid currentColor;
   border-radius: 1px 1px 0 0;
   box-sizing: border-box;
@@ -805,8 +1330,10 @@ body { position: static; }
 .icon-edit::after {
   content: "";
   position: absolute;
-  bottom: 0; left: 3px;
-  width: 0; height: 0;
+  bottom: 0;
+  left: 3px;
+  width: 0;
+  height: 0;
   border-left: 3px solid transparent;
   border-right: 3px solid transparent;
   border-top: 3px solid currentColor;
@@ -814,20 +1341,27 @@ body { position: static; }
 
 /* Icon: rewind (chevrons pointing left) */
 .icon-rewind {
-  width: 14px; height: 12px;
+  width: 14px;
+  height: 12px;
   position: relative;
 }
-.icon-rewind::before, .icon-rewind::after {
+.icon-rewind::before,
+.icon-rewind::after {
   content: "";
   position: absolute;
   top: 1px;
-  width: 6px; height: 6px;
+  width: 6px;
+  height: 6px;
   border-left: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   transform: rotate(45deg);
 }
-.icon-rewind::before { left: 1px; }
-.icon-rewind::after { left: 6px; }
+.icon-rewind::before {
+  left: 1px;
+}
+.icon-rewind::after {
+  left: 6px;
+}
 
 /* Edit-in-place form */
 .msg-edit-form {
@@ -853,7 +1387,9 @@ body { position: static; }
   transition: border-color 0.12s ease;
   box-sizing: border-box;
 }
-.msg-edit-textarea:focus { border-color: var(--accent); }
+.msg-edit-textarea:focus {
+  border-color: var(--accent);
+}
 .msg-edit-actions {
   display: flex;
   gap: 6px;
@@ -869,22 +1405,39 @@ body { position: static; }
   border: 1px solid var(--border-strong);
   background: var(--bg);
   color: var(--fg);
-  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease;
+  transition:
+    background 0.1s ease,
+    border-color 0.1s ease,
+    color 0.1s ease;
 }
-.msg-edit-btn:hover { background: var(--bg-highlight); }
+.msg-edit-btn:hover {
+  background: var(--bg-highlight);
+}
 .msg-edit-btn-send {
   background: var(--accent-dim);
   color: var(--accent);
   border-color: var(--accent);
 }
-.msg-edit-btn-send:hover { background: var(--accent); color: #fff; }
+.msg-edit-btn-send:hover {
+  background: var(--accent);
+  color: #fff;
+}
 
 /* Edit-in-place active state */
-.msg-editing { background: var(--bg-surface); border-color: var(--accent-dim); }
-.msg-editing .msg-actions { display: none; }
+.msg-editing {
+  background: var(--bg-surface);
+  border-color: var(--accent-dim);
+}
+.msg-editing .msg-actions {
+  display: none;
+}
 
 /* Busy-state disables action buttons */
-[data-busy="true"] .msg-action-btn { opacity: 0.3; pointer-events: none; cursor: not-allowed; }
+[data-busy="true"] .msg-action-btn {
+  opacity: 0.3;
+  pointer-events: none;
+  cursor: not-allowed;
+}
 
 /* Touch devices: always show action buttons inline */
 @media (hover: none) and (pointer: coarse) {
@@ -897,12 +1450,20 @@ body { position: static; }
     background: transparent;
     justify-content: flex-end;
   }
-  .msg-action-btn { width: 36px; height: 36px; }
+  .msg-action-btn {
+    width: 36px;
+    height: 36px;
+  }
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .msg-actions, .msg-action-btn, .msg-edit-textarea, .msg-edit-btn { transition: none; }
+  .msg-actions,
+  .msg-action-btn,
+  .msg-edit-textarea,
+  .msg-edit-btn {
+    transition: none;
+  }
 }
 
 /* ==========================================================================
@@ -916,7 +1477,9 @@ body { position: static; }
   flex-wrap: wrap;
   gap: 6px;
 }
-.ts-composer-chips:empty { display: none; }
+.ts-composer-chips:empty {
+  display: none;
+}
 .ts-composer-chip {
   display: inline-flex;
   align-items: center;
@@ -930,14 +1493,21 @@ body { position: static; }
   font-size: 11px;
   max-width: 280px;
 }
-.ts-composer-chip-icon { font-size: 12px; opacity: 0.7; }
+.ts-composer-chip-icon {
+  font-size: 12px;
+  opacity: 0.7;
+}
 .ts-composer-chip-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 180px;
 }
-.ts-composer-chip-size { color: var(--fg-dim, var(--fg)); opacity: 0.65; font-size: 10px; }
+.ts-composer-chip-size {
+  color: var(--fg-dim, var(--fg));
+  opacity: 0.65;
+  font-size: 10px;
+}
 .ts-composer-chip-remove {
   background: transparent;
   color: var(--fg-dim, var(--fg));
@@ -948,8 +1518,14 @@ body { position: static; }
   cursor: pointer;
   border-radius: 50%;
 }
-.ts-composer-chip-remove:hover { color: var(--red, #c94040); background: var(--bg-surface); }
-.ts-composer-chip-remove:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ts-composer-chip-remove:hover {
+  color: var(--red, #c94040);
+  background: var(--bg-surface);
+}
+.ts-composer-chip-remove:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 
 /* New-workstream modal: attachment row + chips */
 #new-ws-attach-row {
@@ -969,14 +1545,21 @@ body { position: static; }
   border-radius: 4px;
   cursor: pointer;
 }
-#new-ws-attach-btn:hover { background: var(--bg-surface); }
-#new-ws-attach-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+#new-ws-attach-btn:hover {
+  background: var(--bg-surface);
+}
+#new-ws-attach-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 #new-ws-attach-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
-#new-ws-attach-chips:empty { display: none; }
+#new-ws-attach-chips:empty {
+  display: none;
+}
 .new-ws-attach-chip {
   display: inline-flex;
   align-items: center;
@@ -996,7 +1579,11 @@ body { position: static; }
   white-space: nowrap;
   max-width: 180px;
 }
-.new-ws-attach-chip-size { color: var(--fg-dim, var(--fg)); opacity: 0.65; font-size: 10px; }
+.new-ws-attach-chip-size {
+  color: var(--fg-dim, var(--fg));
+  opacity: 0.65;
+  font-size: 10px;
+}
 .new-ws-attach-chip-remove {
   background: transparent;
   color: var(--fg-dim, var(--fg));
@@ -1007,8 +1594,14 @@ body { position: static; }
   cursor: pointer;
   border-radius: 50%;
 }
-.new-ws-attach-chip-remove:hover { color: var(--red, #c94040); background: var(--bg-surface); }
-.new-ws-attach-chip-remove:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.new-ws-attach-chip-remove:hover {
+  color: var(--red, #c94040);
+  background: var(--bg-surface);
+}
+.new-ws-attach-chip-remove:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 #new-ws-initial-message {
   width: 100%;
   font-family: var(--font-mono);
@@ -1065,8 +1658,16 @@ body { position: static; }
   font-family: var(--font-mono);
   font-size: 10px;
 }
-.msg-user-attach-icon { font-size: 11px; opacity: 0.7; }
-.msg-user-attach-name { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.msg-user-attach-icon {
+  font-size: 11px;
+  opacity: 0.7;
+}
+.msg-user-attach-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* ==========================================================================
    Per-workstream status bar — above input
@@ -1086,7 +1687,9 @@ body { position: static; }
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.01em;
   overflow: hidden;
-  transition: background 0.3s, border-color 0.3s;
+  transition:
+    background 0.3s,
+    border-color 0.3s;
 }
 .ws-sb-model {
   font-family: var(--font-display);
@@ -1098,31 +1701,52 @@ body { position: static; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.ws-sb-tokens { color: var(--fg-dim); white-space: nowrap; }
-.ws-sb-tools  { color: var(--fg-dim); white-space: nowrap; }
-.ws-sb-turns  { color: var(--fg-dim); white-space: nowrap; margin-left: auto; }
+.ws-sb-tokens {
+  color: var(--fg-dim);
+  white-space: nowrap;
+}
+.ws-sb-tools {
+  color: var(--fg-dim);
+  white-space: nowrap;
+}
+.ws-sb-turns {
+  color: var(--fg-dim);
+  white-space: nowrap;
+  margin-left: auto;
+}
 
 /* Context warning states */
-.ws-status-bar.ws-sb-warn .ws-sb-tokens { color: var(--yellow); font-weight: 600; }
+.ws-status-bar.ws-sb-warn .ws-sb-tokens {
+  color: var(--yellow);
+  font-weight: 600;
+}
 .ws-status-bar.ws-sb-danger .ws-sb-tokens {
   color: var(--red);
   font-weight: 600;
   text-shadow: 0 0 4px var(--red-glow);
 }
-[data-theme="light"] .ws-status-bar.ws-sb-danger .ws-sb-tokens { text-shadow: none; }
+[data-theme="light"] .ws-status-bar.ws-sb-danger .ws-sb-tokens {
+  text-shadow: none;
+}
 
 /* Disconnected state */
 .ws-status-bar.ws-sb-disconnected {
   border-top: 2px solid var(--red);
   background: rgba(248, 113, 113, 0.04);
 }
-.ws-status-bar.ws-sb-disconnected .ws-sb-tokens { color: var(--red); }
+.ws-status-bar.ws-sb-disconnected .ws-sb-tokens {
+  color: var(--red);
+}
 .ws-status-bar.ws-sb-disconnected .ws-sb-model,
 .ws-status-bar.ws-sb-disconnected .ws-sb-tools,
-.ws-status-bar.ws-sb-disconnected .ws-sb-turns { opacity: 0.4; }
+.ws-status-bar.ws-sb-disconnected .ws-sb-turns {
+  opacity: 0.4;
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .ws-status-bar { transition: none; }
+  .ws-status-bar {
+    transition: none;
+  }
 }
 
 /* ==========================================================================
@@ -1138,28 +1762,73 @@ body { position: static; }
   max-width: 95%;
   font-size: 12px;
 }
-.ts-approval.approved { border-left-color: var(--green); }
-.ts-approval.error { border-left-color: var(--red); }
-.ts-approval.denied { border-left-color: var(--red); }
-.ts-approval.denied .ts-approval-tool { opacity: 0.55; }
-.ts-approval.denied .ts-approval-tool .tool-name { color: var(--fg-dim); }
+.ts-approval.approved {
+  border-left-color: var(--green);
+}
+.ts-approval.error {
+  border-left-color: var(--red);
+}
+.ts-approval.denied {
+  border-left-color: var(--red);
+}
+.ts-approval.denied .ts-approval-tool {
+  opacity: 0.55;
+}
+.ts-approval.denied .ts-approval-tool .tool-name {
+  color: var(--fg-dim);
+}
 /* .ts-approval (chat.css) stacks children with flex gap; the old
    border-bottom would dangle between rows now. */
-.ts-approval-tool { padding: 8px 12px; }
-.ts-approval-tool:last-of-type { border-bottom: none; }
-.ts-approval-tool .tool-name { color: var(--yellow); font-weight: 600; font-size: 11px; margin-bottom: 3px; }
-.ts-approval-tool .tool-cmd { color: var(--fg-bright); white-space: pre-wrap; word-break: break-all; max-height: 120px; overflow: hidden; }
-.ts-approval-tool .tool-cmd .dollar { color: var(--green); }
-.ts-approval-tool .tool-diff { white-space: pre-wrap; font-size: 12px; margin-top: 4px; }
-.ts-approval-tool .tool-diff .diff-del { color: var(--red); }
-.ts-approval-tool .tool-diff .diff-add { color: var(--green); }
-.ts-approval-tool .tool-diff .diff-warn { color: var(--yellow); }
+.ts-approval-tool {
+  padding: 8px 12px;
+}
+.ts-approval-tool:last-of-type {
+  border-bottom: none;
+}
+.ts-approval-tool .tool-name {
+  color: var(--yellow);
+  font-weight: 600;
+  font-size: 11px;
+  margin-bottom: 3px;
+}
+.ts-approval-tool .tool-cmd {
+  color: var(--fg-bright);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 120px;
+  overflow: hidden;
+}
+.ts-approval-tool .tool-cmd .dollar {
+  color: var(--green);
+}
+.ts-approval-tool .tool-diff {
+  white-space: pre-wrap;
+  font-size: 12px;
+  margin-top: 4px;
+}
+.ts-approval-tool .tool-diff .diff-del {
+  color: var(--red);
+}
+.ts-approval-tool .tool-diff .diff-add {
+  color: var(--green);
+}
+.ts-approval-tool .tool-diff .diff-warn {
+  color: var(--yellow);
+}
 /* .ts-approval (chat.css) stacks its children with flex gap, so a
    border-top on the body would float above a strip of container
    background instead of sitting flush against the previous tool row.
    Rely on the gap as the separator. */
-.ts-approval-body { padding: 8px 12px; font-size: 12px; background: var(--bg-highlight); }
-.ts-approval-actions { display: flex; gap: 6px; margin-bottom: 6px; }
+.ts-approval-body {
+  padding: 8px 12px;
+  font-size: 12px;
+  background: var(--bg-highlight);
+}
+.ts-approval-actions {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
 .ts-approval-btn {
   background: var(--bg);
   border: 1px solid var(--border-strong);
@@ -1172,9 +1841,14 @@ body { position: static; }
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  transition:
+    background 0.1s,
+    border-color 0.1s,
+    color 0.1s;
 }
-.ts-approval-btn:hover { background: var(--bg-highlight); }
+.ts-approval-btn:hover {
+  background: var(--bg-highlight);
+}
 .ts-approval-btn .key {
   display: inline-block;
   background: var(--bg-surface);
@@ -1203,14 +1877,24 @@ body { position: static; }
   outline: none;
   transition: border-color 0.15s;
 }
-.ts-approval-feedback:focus { border-color: var(--accent); }
-.ts-approval-feedback::placeholder { color: var(--fg-dim); }
+.ts-approval-feedback:focus {
+  border-color: var(--accent);
+}
+.ts-approval-feedback::placeholder {
+  color: var(--fg-dim);
+}
 /* chat.css shrinks .ts-approval-badge to max-content width, so a
    border-top would only span the text and read as a truncated line
    (same rationale as .verdict-badge).  Colour variants come from
    chat.css .ts-approval-badge--approved / --denied / --error — the
    legacy .badge-* modifiers are no longer emitted. */
-.ts-approval-badge { padding: 6px 12px; font-size: 12px; font-weight: 600; overflow-wrap: break-word; word-break: break-word; }
+.ts-approval-badge {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
 .tool-output {
   padding: 8px 12px;
   background: var(--code-bg);
@@ -1221,19 +1905,30 @@ body { position: static; }
   max-height: 300px;
   overflow-y: auto;
 }
-.tool-output-error { color: var(--red); }
+.tool-output-error {
+  color: var(--red);
+}
 .tool-output-stream {
   border-left: 2px solid var(--accent);
   max-height: 400px;
   animation: stream-pulse 2s ease-in-out infinite;
 }
 @keyframes stream-pulse {
-  0%, 100% { border-left-color: var(--accent); }
-  50% { border-left-color: var(--accent-dim); }
+  0%,
+  100% {
+    border-left-color: var(--accent);
+  }
+  50% {
+    border-left-color: var(--accent-dim);
+  }
 }
-.tool-output.collapsed { max-height: 150px; position: relative; overflow: hidden; }
+.tool-output.collapsed {
+  max-height: 150px;
+  position: relative;
+  overflow: hidden;
+}
 .tool-output.collapsed::after {
-  content: 'click to expand';
+  content: "click to expand";
   position: absolute;
   bottom: 0;
   left: 0;
@@ -1365,9 +2060,17 @@ audio.media-player {
   padding: 4px 0;
 }
 @media (max-width: 480px) {
-  .media-card { flex-direction: column; }
-  .media-card-thumb { width: 100%; height: auto; max-height: 200px; }
-  .media-player { max-height: 280px; }
+  .media-card {
+    flex-direction: column;
+  }
+  .media-card-thumb {
+    width: 100%;
+    height: auto;
+    max-height: 200px;
+  }
+  .media-player {
+    max-height: 280px;
+  }
 }
 
 /* ==========================================================================
@@ -1384,7 +2087,9 @@ audio.media-player {
   justify-content: center;
   align-items: center;
 }
-#plan-overlay.active { display: flex; }
+#plan-overlay.active {
+  display: flex;
+}
 #plan-dialog {
   background: var(--bg-surface);
   border: 1px solid var(--border-strong);
@@ -1398,7 +2103,7 @@ audio.media-player {
   position: relative;
 }
 #plan-dialog::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -1px;
   left: 20%;
@@ -1440,8 +2145,14 @@ audio.media-player {
   outline: none;
   transition: border-color 0.15s;
 }
-#plan-feedback:focus { border-color: var(--accent); }
-#plan-buttons { display: flex; gap: 8px; justify-content: flex-end; }
+#plan-feedback:focus {
+  border-color: var(--accent);
+}
+#plan-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
 #plan-buttons button {
   padding: 8px 20px;
   border: none;
@@ -1454,20 +2165,33 @@ audio.media-player {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  transition: filter 0.15s, background 0.2s;
+  transition:
+    filter 0.15s,
+    background 0.2s;
 }
-#plan-buttons button:hover { filter: brightness(1.1); }
-#plan-buttons button:focus-visible { outline: 2px solid var(--fg-bright); outline-offset: 2px; }
+#plan-buttons button:hover {
+  filter: brightness(1.1);
+}
+#plan-buttons button:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
 #plan-buttons button .key {
   display: inline-block;
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-sm);
   padding: 0 4px;
   font-size: 10px;
   font-weight: 600;
 }
-#btn-plan-approve { background: var(--green); color: var(--on-color); }
-#btn-plan-reject { background: var(--red); color: var(--on-color); }
+#btn-plan-approve {
+  background: var(--green);
+  color: var(--on-color);
+}
+#btn-plan-reject {
+  background: var(--red);
+  color: var(--on-color);
+}
 
 /* Inline plan block (rendered in chat after plan review) */
 .plan-inline {
@@ -1485,9 +2209,15 @@ audio.media-player {
   font-weight: 600;
   letter-spacing: 0.02em;
 }
-.plan-inline-label.plan-approved { color: var(--green); }
-.plan-inline-label.plan-rejected { color: var(--red); }
-.plan-inline-label.plan-amending { color: var(--accent); }
+.plan-inline-label.plan-approved {
+  color: var(--green);
+}
+.plan-inline-label.plan-rejected {
+  color: var(--red);
+}
+.plan-inline-label.plan-amending {
+  color: var(--accent);
+}
 .plan-inline-body {
   padding: 10px 14px;
   background: var(--code-bg);
@@ -1496,11 +2226,17 @@ audio.media-player {
   max-height: 300px;
   overflow-y: auto;
 }
-.plan-inline-body.collapsed { max-height: 150px; position: relative; overflow: hidden; }
+.plan-inline-body.collapsed {
+  max-height: 150px;
+  position: relative;
+  overflow: hidden;
+}
 .plan-inline-body.collapsed::after {
-  content: 'click to expand';
+  content: "click to expand";
   position: absolute;
-  bottom: 0; left: 0; right: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   text-align: center;
   padding: 8px 0 4px;
   background: linear-gradient(transparent, var(--code-bg));
@@ -1508,9 +2244,20 @@ audio.media-player {
   font-size: 11px;
   cursor: pointer;
 }
-.plan-inline-body h2, .plan-inline-body h3 { font-size: 13px; margin: 10px 0 4px; color: var(--accent); }
-.plan-inline-body p { margin: 4px 0; }
-.plan-inline-body ol, .plan-inline-body ul { margin: 4px 0; padding-left: 20px; }
+.plan-inline-body h2,
+.plan-inline-body h3 {
+  font-size: 13px;
+  margin: 10px 0 4px;
+  color: var(--accent);
+}
+.plan-inline-body p {
+  margin: 4px 0;
+}
+.plan-inline-body ol,
+.plan-inline-body ul {
+  margin: 4px 0;
+  padding-left: 20px;
+}
 .plan-inline-feedback {
   padding: 6px 12px;
   border-top: 1px solid var(--border);
@@ -1525,7 +2272,11 @@ audio.media-player {
 /* Slightly thicker ring than chat.css (2px → 3px) — the interactive
    pane sits over denser pane-bottom chrome, so the ring needs more
    visual weight to pop. */
-.ts-composer-input:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
+.ts-composer-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
 
 /* ==========================================================================
    Empty state
@@ -1543,9 +2294,24 @@ audio.media-player {
 /* ==========================================================================
    Dashboard overlay
    ========================================================================== */
-.dashboard-overlay { display: none; position: fixed; inset: 0; background: var(--bg); z-index: 50; overflow-y: auto; }
-.dashboard-overlay.active { display: flex; justify-content: center; align-items: flex-start; }
-.dashboard-content { width: 100%; max-width: 960px; padding: 32px 20px 24px; }
+.dashboard-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  z-index: 50;
+  overflow-y: auto;
+}
+.dashboard-overlay.active {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.dashboard-content {
+  width: 100%;
+  max-width: 960px;
+  padding: 32px 20px 24px;
+}
 .dashboard-composer {
   display: flex;
   flex-direction: column;
@@ -1557,7 +2323,9 @@ audio.media-player {
   padding: 10px;
   /* position context for the .dashboard-composer-drop::before overlay */
   position: relative;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 .dashboard-composer:focus-within {
   border-color: var(--accent);
@@ -1605,7 +2373,9 @@ audio.media-player {
   min-height: 60px;
   font-family: var(--font-mono);
 }
-.dashboard-input::placeholder { color: var(--fg-dim); }
+.dashboard-input::placeholder {
+  color: var(--fg-dim);
+}
 .dashboard-input.dashboard-input-error {
   outline: 2px solid var(--red);
   outline-offset: -1px;
@@ -1617,7 +2387,9 @@ audio.media-player {
   min-height: 14px;
   padding: 0 4px;
 }
-.dashboard-error:empty { display: none; }
+.dashboard-error:empty {
+  display: none;
+}
 .dashboard-options-caret {
   font-size: 9px;
   opacity: 0.7;
@@ -1642,11 +2414,15 @@ audio.media-player {
   text-overflow: ellipsis;
   max-width: 280px;
 }
-.dashboard-options-summary[hidden] { display: none; }
+.dashboard-options-summary[hidden] {
+  display: none;
+}
 @media (max-width: 600px) {
   /* On phones the action row stacks; the summary hides to keep the
      row compact — power users on mobile can expand the panel itself. */
-  .dashboard-options-summary { display: none; }
+  .dashboard-options-summary {
+    display: none;
+  }
 }
 .dashboard-composer-row {
   display: flex;
@@ -1675,8 +2451,14 @@ audio.media-player {
   /* Larger comfortable hit target without growing the visible chrome */
   min-height: 28px;
 }
-.dashboard-icon-btn:hover { color: var(--fg); background: var(--bg); }
-.dashboard-icon-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.dashboard-icon-btn:hover {
+  color: var(--fg);
+  background: var(--bg);
+}
+.dashboard-icon-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 .dashboard-options-btn[aria-expanded="true"] {
   color: var(--fg);
   background: var(--bg);
@@ -1687,7 +2469,9 @@ audio.media-player {
   gap: 6px;
   padding: 0 4px;
 }
-#dashboard-attach-chips:empty { display: none; }
+#dashboard-attach-chips:empty {
+  display: none;
+}
 .dashboard-options {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -1700,7 +2484,9 @@ audio.media-player {
   font-family: var(--font-mono);
   font-size: 12px;
 }
-.dashboard-options[hidden] { display: none; }
+.dashboard-options[hidden] {
+  display: none;
+}
 .dashboard-options label {
   color: var(--fg-dim, var(--fg));
   text-transform: uppercase;
@@ -1731,9 +2517,17 @@ audio.media-player {
   letter-spacing: 0.02em;
   transition: filter 0.15s;
 }
-.dashboard-new-btn:hover { filter: brightness(1.1); }
-.dashboard-new-btn:disabled { opacity: 0.35; cursor: not-allowed; filter: none; }
-.dashboard-section { margin-bottom: 24px; }
+.dashboard-new-btn:hover {
+  filter: brightness(1.1);
+}
+.dashboard-new-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  filter: none;
+}
+.dashboard-section {
+  margin-bottom: 24px;
+}
 .dashboard-section-header {
   display: flex;
   align-items: center;
@@ -1757,35 +2551,41 @@ audio.media-player {
   font-size: 12px;
   padding: 4px 10px;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 .ws-delete-btn:hover {
   color: var(--red);
   border-color: var(--red);
 }
-.dashboard-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px; }
-.dashboard-card {
-  position: relative;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 12px 14px;
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-}
-.dashboard-card:hover { border-color: var(--accent); background: var(--bg-highlight); }
-.dashboard-card:active { background: var(--bg-highlight); border-color: var(--accent); }
-.dashboard-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.dashboard-card .card-title { font-size: 13px; color: var(--fg-bright); font-weight: 500; margin-bottom: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.dashboard-card .card-meta { font-size: 11px; color: var(--fg-dim); }
+/* .dashboard-cards / .dashboard-card / .card-title / .card-meta moved to
+   /shared/cards.css so console (Saved Coordinators) and ui/static (Saved
+   Workstreams) share one source of truth for the basic card primitive.
+   Delete-mode rules stay below — they're ui/static-only until coordinator
+   gets the same UX. */
 
 /* Delete mode */
-.dashboard-card.ws-delete-mode { cursor: pointer; }
-.dashboard-card.ws-delete-mode:hover { border-color: var(--red); background: rgba(248, 113, 113, 0.04); }
-.dashboard-card.ws-delete-mode.ws-selected { cursor: default; }
-.dashboard-card.ws-delete-mode.ws-selected:hover { border-color: var(--red); background: rgba(248, 113, 113, 0.08); }
-[data-theme="light"] .dashboard-card.ws-delete-mode:hover { background: rgba(220, 38, 38, 0.04); }
-[data-theme="light"] .dashboard-card.ws-delete-mode.ws-selected:hover { background: rgba(220, 38, 38, 0.08); }
+.dashboard-card.ws-delete-mode {
+  cursor: pointer;
+}
+.dashboard-card.ws-delete-mode:hover {
+  border-color: var(--red);
+  background: rgba(248, 113, 113, 0.04);
+}
+.dashboard-card.ws-delete-mode.ws-selected {
+  cursor: default;
+}
+.dashboard-card.ws-delete-mode.ws-selected:hover {
+  border-color: var(--red);
+  background: rgba(248, 113, 113, 0.08);
+}
+[data-theme="light"] .dashboard-card.ws-delete-mode:hover {
+  background: rgba(220, 38, 38, 0.04);
+}
+[data-theme="light"] .dashboard-card.ws-delete-mode.ws-selected:hover {
+  background: rgba(220, 38, 38, 0.08);
+}
 .ws-card-check {
   position: absolute;
   top: 8px;
@@ -1798,7 +2598,11 @@ audio.media-player {
   opacity: 0;
   animation: ws-check-fadein 0.2s ease-out forwards;
 }
-@keyframes ws-check-fadein { to { opacity: 1; } }
+@keyframes ws-check-fadein {
+  to {
+    opacity: 1;
+  }
+}
 .dashboard-card.ws-selected {
   border-color: var(--red);
   background: rgba(248, 113, 113, 0.08);
@@ -1816,13 +2620,33 @@ audio.media-player {
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
-.ws-delete-bar.visible { display: flex; animation: ws-bar-slide 0.2s ease-out; }
-@keyframes ws-bar-slide { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
-@media (prefers-reduced-motion: reduce) {
-  .ws-card-check { animation: none; opacity: 1; }
-  .ws-delete-bar.visible { animation: none; }
+.ws-delete-bar.visible {
+  display: flex;
+  animation: ws-bar-slide 0.2s ease-out;
 }
-.ws-delete-bar .ws-delete-count-label { font-size: 12px; color: var(--fg-dim); }
+@keyframes ws-bar-slide {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ws-card-check {
+    animation: none;
+    opacity: 1;
+  }
+  .ws-delete-bar.visible {
+    animation: none;
+  }
+}
+.ws-delete-bar .ws-delete-count-label {
+  font-size: 12px;
+  color: var(--fg-dim);
+}
 .ws-delete-bar .ws-delete-bar-btn {
   margin-left: auto;
   background: var(--red);
@@ -1835,8 +2659,13 @@ audio.media-player {
   cursor: pointer;
   transition: filter 0.15s;
 }
-.ws-delete-bar .ws-delete-bar-btn:hover:not(:disabled) { filter: brightness(1.1); }
-.ws-delete-bar .ws-delete-bar-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.ws-delete-bar .ws-delete-bar-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+.ws-delete-bar .ws-delete-bar-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 .ws-delete-bar .ws-delete-cancel-btn {
   background: transparent;
   color: var(--fg-dim);
@@ -1884,17 +2713,34 @@ audio.media-player {
   max-width: 480px;
   width: 90%;
 }
-#ws-delete-box h3 { margin: 0 0 12px; font-size: 16px; color: var(--fg-bright); }
-#ws-delete-list { max-height: 200px; overflow-y: auto; margin: 12px 0; }
+#ws-delete-box h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: var(--fg-bright);
+}
+#ws-delete-list {
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 12px 0;
+}
 #ws-delete-list .ws-delete-item {
   padding: 6px 0;
   font-size: 13px;
   color: var(--fg-bright);
   border-bottom: 1px solid var(--border);
 }
-#ws-delete-list .ws-delete-item:last-child { border-bottom: none; }
-#ws-delete-list .ws-delete-item.ws-delete-error { color: var(--red); }
-#ws-delete-buttons { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+#ws-delete-list .ws-delete-item:last-child {
+  border-bottom: none;
+}
+#ws-delete-list .ws-delete-item.ws-delete-error {
+  color: var(--red);
+}
+#ws-delete-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
 #ws-delete-buttons button {
   padding: 8px 20px;
   border-radius: var(--radius);
@@ -1917,7 +2763,9 @@ audio.media-player {
 }
 
 /* Server dashboard row — clickable */
-.dash-row { cursor: pointer; }
+.dash-row {
+  cursor: pointer;
+}
 
 /* Dashboard footer */
 .dash-footer {
@@ -1931,34 +2779,91 @@ audio.media-player {
   font-size: 11px;
   margin-bottom: 24px;
 }
-.dash-footer-nodes { color: var(--fg-dim); display: flex; align-items: center; gap: 6px; }
-.dash-footer-node-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); display: inline-block; flex-shrink: 0; box-shadow: 0 0 4px var(--green-glow); }
-.dash-footer-stats { color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.dash-footer-nodes {
+  color: var(--fg-dim);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.dash-footer-node-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  display: inline-block;
+  flex-shrink: 0;
+  box-shadow: 0 0 4px var(--green-glow);
+}
+.dash-footer-stats {
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
 
 /* Dashboard responsive */
 @media (max-width: 700px) {
-  :root { --dash-grid: 68px 110px 1fr 56px 44px; }
-  .dash-col-model, .dash-cell-model, .dash-col-node, .dash-cell-node { display: none; }
-  .dash-row-sub { padding-left: 76px; }
+  :root {
+    --dash-grid: 68px 110px 1fr 56px 44px;
+  }
+  .dash-col-model,
+  .dash-cell-model,
+  .dash-col-node,
+  .dash-cell-node {
+    display: none;
+  }
+  .dash-row-sub {
+    padding-left: 76px;
+  }
 }
 @media (max-width: 600px) {
   /* Drop the row constraint and let composer children flow vertically so
      Send can naturally come after chips + options instead of breaking the
      reading order with a giant button mid-card. */
-  .dashboard-composer-row { display: contents; }
-  .dashboard-composer-actions { order: 2; justify-content: flex-start; }
-  .dashboard-composer #dashboard-error { order: 3; }
-  .dashboard-composer #dashboard-attach-chips { order: 4; }
-  .dashboard-composer .dashboard-options { order: 5; }
-  .dashboard-composer .dashboard-new-btn { order: 6; width: 100%; }
+  .dashboard-composer-row {
+    display: contents;
+  }
+  .dashboard-composer-actions {
+    order: 2;
+    justify-content: flex-start;
+  }
+  .dashboard-composer #dashboard-error {
+    order: 3;
+  }
+  .dashboard-composer #dashboard-attach-chips {
+    order: 4;
+  }
+  .dashboard-composer .dashboard-options {
+    order: 5;
+  }
+  .dashboard-composer .dashboard-new-btn {
+    order: 6;
+    width: 100%;
+  }
 }
 @media (max-width: 480px) {
-  .dashboard-content { padding: 24px 12px 16px; }
-  .dashboard-cards { grid-template-columns: 1fr; }
-  :root { --dash-grid: 50px 1fr 50px; }
-  .dash-col-model, .dash-cell-model, .dash-col-node, .dash-cell-node, .dash-col-task, .dash-cell-task, .dash-col-ctx, .dash-cell-ctx { display: none; }
-  .dash-row-sub { padding-left: 66px; }
-  .tool-output, .tool-output-stream { max-height: 200px; }
+  .dashboard-content {
+    padding: 24px 12px 16px;
+  }
+  /* .dashboard-cards 1-col at 480px lives in /shared/cards.css */
+  :root {
+    --dash-grid: 50px 1fr 50px;
+  }
+  .dash-col-model,
+  .dash-cell-model,
+  .dash-col-node,
+  .dash-cell-node,
+  .dash-col-task,
+  .dash-cell-task,
+  .dash-col-ctx,
+  .dash-cell-ctx {
+    display: none;
+  }
+  .dash-row-sub {
+    padding-left: 66px;
+  }
+  .tool-output,
+  .tool-output-stream {
+    max-height: 200px;
+  }
 }
 
 /* ==========================================================================
@@ -1976,11 +2881,23 @@ audio.media-player {
      max-content width, and a 1px border-top would extend only under
      the badge text and read as a truncated line. */
 }
-.verdict-low      { color: var(--green);  border-left: 3px solid var(--green);  }
-.verdict-medium   { color: var(--yellow); border-left: 3px solid var(--yellow); }
-.verdict-high     { color: var(--red);    border-left: 3px solid var(--red);    }
-.verdict-critical { color: var(--red);    border-left: 3px solid var(--red);
-                    background: rgba(255, 80, 80, 0.05); }
+.verdict-low {
+  color: var(--green);
+  border-left: 3px solid var(--green);
+}
+.verdict-medium {
+  color: var(--yellow);
+  border-left: 3px solid var(--yellow);
+}
+.verdict-high {
+  color: var(--red);
+  border-left: 3px solid var(--red);
+}
+.verdict-critical {
+  color: var(--red);
+  border-left: 3px solid var(--red);
+  background: rgba(255, 80, 80, 0.05);
+}
 
 .verdict-detail {
   padding: 6px 12px;
@@ -1988,10 +2905,23 @@ audio.media-player {
   border-top: 1px solid var(--border);
   line-height: 1.5;
 }
-.verdict-detail .verdict-summary   { margin-bottom: 4px; font-weight: 600; }
-.verdict-detail .verdict-reasoning { color: var(--fg-dim); margin-bottom: 4px; }
-.verdict-detail .verdict-evidence  { color: var(--fg-dim); font-style: italic; margin-bottom: 4px; }
-.verdict-detail .verdict-tier      { color: var(--fg-dim); font-size: 10px; }
+.verdict-detail .verdict-summary {
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+.verdict-detail .verdict-reasoning {
+  color: var(--fg-dim);
+  margin-bottom: 4px;
+}
+.verdict-detail .verdict-evidence {
+  color: var(--fg-dim);
+  font-style: italic;
+  margin-bottom: 4px;
+}
+.verdict-detail .verdict-tier {
+  color: var(--fg-dim);
+  font-size: 10px;
+}
 
 .verdict-expand {
   background: none;
@@ -2002,7 +2932,10 @@ audio.media-player {
   text-decoration: underline;
   padding: 0;
 }
-.verdict-expand:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.verdict-expand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 .verdict-judge-spinner {
   font-size: 10px;
@@ -2020,8 +2953,13 @@ audio.media-player {
   animation: judge-pulse 1.2s ease-in-out infinite;
 }
 @keyframes judge-pulse {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 /* Verdict glow on approval action buttons — amplifies chat.css's
@@ -2042,12 +2980,31 @@ audio.media-player {
 }
 
 /* Output guard warning */
-.output-warning { padding: 4px 8px; font-size: 11px; border-left: 3px solid; margin: 2px 0 2px 16px; }
-.output-warning-low { border-color: var(--cyan); color: var(--cyan); }
-.output-warning-medium { border-color: var(--yellow); color: var(--yellow); }
-.output-warning-high { border-color: var(--red); color: var(--red); }
-.output-warning-label { font-weight: 600; }
-.output-warning-redacted { color: var(--fg-dim); font-style: italic; }
+.output-warning {
+  padding: 4px 8px;
+  font-size: 11px;
+  border-left: 3px solid;
+  margin: 2px 0 2px 16px;
+}
+.output-warning-low {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.output-warning-medium {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+.output-warning-high {
+  border-color: var(--red);
+  color: var(--red);
+}
+.output-warning-label {
+  font-weight: 600;
+}
+.output-warning-redacted {
+  color: var(--fg-dim);
+  font-style: italic;
+}
 
 /* ==========================================================================
    New workstream modal
@@ -2072,12 +3029,13 @@ audio.media-player {
   max-width: 90vw;
   max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.5),
-              0 0 80px -20px var(--accent-dim);
+  box-shadow:
+    0 24px 48px -12px rgba(0, 0, 0, 0.5),
+    0 0 80px -20px var(--accent-dim);
   position: relative;
 }
 #new-ws-box::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -1px;
   left: 20%;
@@ -2105,7 +3063,9 @@ audio.media-player {
   margin-top: 14px;
   margin-bottom: 5px;
 }
-#new-ws-box label:first-of-type { margin-top: 0; }
+#new-ws-box label:first-of-type {
+  margin-top: 0;
+}
 .nws-hint {
   font-weight: 400;
   text-transform: none;
@@ -2124,7 +3084,9 @@ audio.media-player {
   font: inherit;
   font-size: 13px;
   box-sizing: border-box;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 #new-ws-box input[type="text"]:focus,
 #new-ws-box select:focus {
@@ -2132,7 +3094,9 @@ audio.media-player {
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
-#new-ws-box input[type="text"]::placeholder { color: var(--fg-dim); }
+#new-ws-box input[type="text"]::placeholder {
+  color: var(--fg-dim);
+}
 #new-ws-box select {
   cursor: pointer;
   appearance: none;
@@ -2164,10 +3128,17 @@ audio.media-player {
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
-#new-ws-cancel:hover { background: var(--bg-elevated); }
-#new-ws-cancel:focus-visible { outline: 2px solid var(--fg-bright); outline-offset: 2px; }
+#new-ws-cancel:hover {
+  background: var(--bg-elevated);
+}
+#new-ws-cancel:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
 #new-ws-submit {
   padding: 9px 20px;
   background: var(--accent);
@@ -2180,9 +3151,18 @@ audio.media-player {
   cursor: pointer;
   transition: filter 0.15s;
 }
-#new-ws-submit:hover { filter: brightness(1.1); }
-#new-ws-submit:disabled { opacity: 0.4; cursor: not-allowed; filter: none; }
-#new-ws-submit:focus-visible { outline: 2px solid var(--fg-bright); outline-offset: 2px; }
+#new-ws-submit:hover {
+  filter: brightness(1.1);
+}
+#new-ws-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: none;
+}
+#new-ws-submit:focus-visible {
+  outline: 2px solid var(--fg-bright);
+  outline-offset: 2px;
+}
 
 /* ==========================================================================
    Reduced motion — page-specific
@@ -2190,24 +3170,52 @@ audio.media-player {
 @media (prefers-reduced-motion: reduce) {
   .ws-tab .tab-indicator[data-state="thinking"],
   .ws-tab .tab-indicator[data-state="running"],
-  .ws-tab .tab-indicator[data-state="attention"] { animation: none; opacity: 1; }
-  .tool-output-stream { animation: none; border-left-color: var(--accent); }
-  .judge-spinner-dot { animation: none; opacity: 1; }
-  .thinking-indicator::after { animation: none; content: '...'; }
-  .ws-tab, .ws-tab .tab-chevron, #new-tab-btn, #split-btn,
+  .ws-tab .tab-indicator[data-state="attention"] {
+    animation: none;
+    opacity: 1;
+  }
+  .tool-output-stream {
+    animation: none;
+    border-left-color: var(--accent);
+  }
+  .judge-spinner-dot {
+    animation: none;
+    opacity: 1;
+  }
+  .thinking-indicator::after {
+    animation: none;
+    content: "...";
+  }
+  .ws-tab,
+  .ws-tab .tab-chevron,
+  #new-tab-btn,
+  #split-btn,
   .dashboard-card,
-  .ts-approval-btn, .ts-approval-feedback,
-  #plan-buttons button, .ts-composer button,
-  .dashboard-new-btn, .dashboard-input,
-  #health-indicator, #theme-toggle,
-  #mcp-status, .ts-msg--assistant tbody tr,
+  .ts-approval-btn,
+  .ts-approval-feedback,
+  #plan-buttons button,
+  .ts-composer button,
+  .dashboard-new-btn,
+  .dashboard-input,
+  #health-indicator,
+  #theme-toggle,
+  #mcp-status,
+  .ts-msg--assistant tbody tr,
   .ts-msg--assistant .img-placeholder,
   .media-play-btn,
-  #new-ws-cancel, #new-ws-submit,
-  #new-ws-box input, #new-ws-box select,
-  .split-handle, .pane-action-btn,
-  .pane-ctx-item, .ws-tab-dropdown-item { transition: none; }
-  .ws-tab-dropdown { animation: none; }
+  #new-ws-cancel,
+  #new-ws-submit,
+  #new-ws-box input,
+  #new-ws-box select,
+  .split-handle,
+  .pane-action-btn,
+  .pane-ctx-item,
+  .ws-tab-dropdown-item {
+    transition: none;
+  }
+  .ws-tab-dropdown {
+    animation: none;
+  }
 }
 
 /* ==========================================================================
@@ -2254,7 +3262,9 @@ audio.media-player {
 [data-design="v1"] .ts-msg.msg:not(.tool) {
   font-family: var(--font-ui);
 }
-[data-design="v1"] .ts-msg-body.msg-body { font-family: inherit; }
+[data-design="v1"] .ts-msg-body.msg-body {
+  font-family: inherit;
+}
 
 [data-design="v1"] .ts-approval-tool {
   padding: 8px 12px;
@@ -2263,7 +3273,9 @@ audio.media-player {
   border-radius: var(--r-sm);
 }
 
-[data-design="v1"] .ts-approval-tool + .ts-approval-tool { margin-top: 6px; }
+[data-design="v1"] .ts-approval-tool + .ts-approval-tool {
+  margin-top: 6px;
+}
 
 [data-design="v1"] .ts-approval-tool .tool-name {
   font-family: var(--font-mono);
@@ -2277,7 +3289,9 @@ audio.media-player {
 /* Error variant of the tool name (replaces the prior inline
    name.style.color = "var(--red)" in buildToolDiv — inline styles win
    over CSS and broke the DS token mapping). */
-[data-design="v1"] .ts-approval-tool .tool-name--error { color: var(--err); }
+[data-design="v1"] .ts-approval-tool .tool-name--error {
+  color: var(--err);
+}
 
 [data-design="v1"] .ts-approval-tool .tool-cmd {
   color: var(--ink-2);
@@ -2287,12 +3301,24 @@ audio.media-player {
   word-break: break-all;
 }
 
-[data-design="v1"] .ts-approval-tool .tool-cmd .dollar { color: var(--ok); }
+[data-design="v1"] .ts-approval-tool .tool-cmd .dollar {
+  color: var(--ok);
+}
 
-[data-design="v1"] .ts-approval-tool .tool-diff { white-space: pre-wrap; font-size: 12px; margin-top: 4px; }
-[data-design="v1"] .ts-approval-tool .tool-diff .diff-del  { color: var(--err); }
-[data-design="v1"] .ts-approval-tool .tool-diff .diff-add  { color: var(--ok); }
-[data-design="v1"] .ts-approval-tool .tool-diff .diff-warn { color: var(--warn); }
+[data-design="v1"] .ts-approval-tool .tool-diff {
+  white-space: pre-wrap;
+  font-size: 12px;
+  margin-top: 4px;
+}
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-del {
+  color: var(--err);
+}
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-add {
+  color: var(--ok);
+}
+[data-design="v1"] .ts-approval-tool .tool-diff .diff-warn {
+  color: var(--warn);
+}
 
 /* Verdict badge — map to DS semantic colours using the same color-mix
    pattern as DS k-badge (12% bg / 38% border / 70% text).  Risk level
@@ -2340,8 +3366,13 @@ audio.media-player {
   letter-spacing: 0.04em;
   font-size: 10px;
 }
-[data-design="v1"] .verdict-badge .verdict-rec  { color: inherit; }
-[data-design="v1"] .verdict-badge .verdict-conf { color: var(--ink-3); font-size: 10px; }
+[data-design="v1"] .verdict-badge .verdict-rec {
+  color: inherit;
+}
+[data-design="v1"] .verdict-badge .verdict-conf {
+  color: var(--ink-3);
+  font-size: 10px;
+}
 
 [data-design="v1"] .verdict-judge-spinner {
   display: inline-flex;
@@ -2371,7 +3402,9 @@ audio.media-player {
   text-underline-offset: 2px;
   cursor: pointer;
 }
-[data-design="v1"] .verdict-expand:hover         { color: var(--ink); }
+[data-design="v1"] .verdict-expand:hover {
+  color: var(--ink);
+}
 [data-design="v1"] .verdict-expand:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -2388,10 +3421,24 @@ audio.media-player {
   border: 1px solid var(--hair);
   border-radius: var(--r-sm);
 }
-[data-design="v1"] .verdict-detail .verdict-summary   { color: var(--ink-2); font-weight: 600; margin-bottom: 4px; }
-[data-design="v1"] .verdict-detail .verdict-reasoning { color: var(--ink-3); margin-bottom: 4px; }
-[data-design="v1"] .verdict-detail .verdict-evidence  { color: var(--ink-4); font-style: italic; margin-bottom: 4px; }
-[data-design="v1"] .verdict-detail .verdict-tier      { color: var(--ink-4); font-size: 10px; }
+[data-design="v1"] .verdict-detail .verdict-summary {
+  color: var(--ink-2);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+[data-design="v1"] .verdict-detail .verdict-reasoning {
+  color: var(--ink-3);
+  margin-bottom: 4px;
+}
+[data-design="v1"] .verdict-detail .verdict-evidence {
+  color: var(--ink-4);
+  font-style: italic;
+  margin-bottom: 4px;
+}
+[data-design="v1"] .verdict-detail .verdict-tier {
+  color: var(--ink-4);
+  font-size: 10px;
+}
 
 /* Auto-approved / denied badges — flat badge aesthetic (matches the DS
    .risk primitive), not a button.  Uppercase mono label on a soft
@@ -2433,8 +3480,12 @@ audio.media-player {
   border-radius: var(--r-sm);
   border: 1px solid var(--hair);
 }
-[data-design="v1"] .tool-output-error  { color: var(--err); }
-[data-design="v1"] .tool-output-stream { border-left: 2px solid var(--accent); }
+[data-design="v1"] .tool-output-error {
+  color: var(--err);
+}
+[data-design="v1"] .tool-output-stream {
+  border-left: 2px solid var(--accent);
+}
 
 [data-design="v1"] .tool-output.collapsed::after {
   background: linear-gradient(transparent, var(--panel) 70%);


### PR DESCRIPTION
## Summary

Three commits, reviewable in order:

**1. `feat(coord): saved coordinators surface + shared session-card primitives`** (load-bearing)

- New `GET /v1/api/coordinator/saved` endpoint — mirrors `list_saved_workstreams` for the coordinator surface. Filters at the SQL layer to `state='closed'` via a new optional `state` parameter on `list_workstreams_with_history` (added to the protocol + sqlite + postgres backends). Drops any rows currently loaded into `coord_mgr` as defence in depth. Blocking storage call + lock-acquiring `list_all` offloaded via `asyncio.to_thread`.
- `CoordinatorManager._open_impl` now allows resurrect of `state='closed'` rows (deleted is still a tombstone). The DB state-flip on resurrect that the first cut had is gone — it raced concurrent `close()`s and the next `set_state()` syncs the DB naturally; the saved-list filters keep a still-loaded coordinator from appearing as a saved card even when its on-disk state lags.
- New `Saved Coordinators` card grid on the console home view. Card click → POST `/open` first, navigates only on 200; capacity issues surface as a toast instead of a broken detail page. `is-busy` class de-dupes rapid double-clicks.
- Frontend dedup that paid for the saved surface: `shared_static/cards.css` (lifted from `ui/static/style.css`), `shared_static/cards.js` (`renderSessionCard` helper used by both Saved Workstreams and Saved Coordinators), `formatRelativeTime` moved to `shared_static/utils.js`.
- Coordinator landing visual fixes folded in: `.home-section-title` uses `var(--accent)` so COORDINATORS reads as a peer of NODES; `.home-panel` lost its bg/border/padding so the composer is no longer double-framed; "Active coordinators" → "Saved Coordinators" rename.
- `ws_closed` SSE handler now gates on the closed ws's kind so interactive closes don't spam `/v1/api/coordinator/saved` on busy clusters. `loadSavedCoordinators` in-flight de-dup coalesces close-event bursts to one fetch instead of N.
- Tests: caller-scoping, admin sees-all, blank-uid fail-closed, loaded-coordinator filtering, state filter (idle rows excluded), plus manager-level open-resurrect / open-refuses-deleted contracts.

Closes bug-{1,2}, perf-{1,2}, sec-2, q-{1,2,3,4,5,6,7} from the prior multi-stage review.

**2. `fix(design): restore amber accent on the v1 design system`**

- `--accent-h: 182 → 75` (teal → amber/gold). Lightness + chroma bumped slightly (`0.62→0.7`, `0.10→0.13`) so the restored gold matches the visual weight of the legacy `#e5a042` token.
- Only surfaces with `data-design="v1"` pick this up — currently just `turnstone-server`'s webui.

**3. `chore: gitignore design_ideas/ and .claude/ dev directories`**

- Personal Claude Design handoff scratch + per-user Claude Code state shouldn't be tracked.

## Test plan

### Backend
- [x] `pytest tests/test_coordinator_endpoints.py tests/test_coordinator_manager.py tests/test_storage_sqlite.py` — 163 tests pass (5 new `coordinator_saved` tests + updated manager-level resurrect/tombstone tests)
- [x] `ruff` + `mypy` clean on all touched Python
- [x] `prettier --check` clean on all touched JS/CSS/HTML

### Frontend smoke
- [x] Close an active coordinator from its detail page → it appears as a Saved Coordinators card on home
- [x] Click a saved card → `POST /open` succeeds → navigates to `/coordinator/{id}` with full history
- [x] Fill `coordinator.max_active` with active coords (none idle) → click saved → toast "All coordinator slots are active — close one first…"
- [x] Same scenario but with one idle peer → idle peer evicted, saved coord restored, count stays at `max_active`
- [x] Close an interactive workstream from `ui/static` → DevTools Network shows NO call to `/v1/api/coordinator/saved`
- [x] Server webui — header brand, focus rings, links should all be amber/gold (not teal)
- [x] Saved Workstreams cards in `ui/static` still render correctly (now using shared `cards.css` + `renderSessionCard`)