### PR TITLE
fix(server): trusted-team workstream visibility on listing endpoints

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -635,6 +635,12 @@ class TestServerAuth:
         mock_ws.name = "test"
         mock_ws.state = WorkstreamState.IDLE
         mock_ws.session = mock_session
+        # Set kind / parent_ws_id / user_id explicitly so list_workstreams
+        # JSON-serializes them — a bare MagicMock attribute returns another
+        # MagicMock that fails json.dumps and surfaces as 500.
+        mock_ws.kind = "interactive"
+        mock_ws.parent_ws_id = None
+        mock_ws.user_id = "u1"
         mock_mgr = MagicMock()
         mock_mgr.list_all.return_value = [mock_ws]
         mock_mgr.max_workstreams = 10
@@ -851,6 +857,12 @@ class TestServerLogin:
         mock_ws.name = "test"
         mock_ws.state = WorkstreamState.IDLE
         mock_ws.session = mock_session
+        # Set kind / parent_ws_id / user_id explicitly so list_workstreams
+        # JSON-serializes them — a bare MagicMock attribute returns another
+        # MagicMock that fails json.dumps and surfaces as 500.
+        mock_ws.kind = "interactive"
+        mock_ws.parent_ws_id = None
+        mock_ws.user_id = "u1"
         mock_mgr = MagicMock()
         mock_mgr.list_all.return_value = [mock_ws]
         mock_mgr.max_workstreams = 10

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -371,11 +371,9 @@ class TestCrossTenantOpen:
 
 class TestListWorkstreamsTrustedTeamVisibility:
     """Listing endpoints (/workstreams, /dashboard, /workstreams/saved)
-    return the cluster-wide set to any authenticated caller — turnstone
-    is deployed as a self-hosted, trusted-team tool and the previous
-    per-user filter created friction without preventing the relevant
-    threats (mutations are gated independently on the per-workstream
-    handlers; see TestCrossTenant{Delete,Approve,Close,Title,Open})."""
+    return the cluster-wide set to any authenticated caller.  Mutations
+    are gated independently on the per-workstream handlers — see
+    TestCrossTenant{Delete,Approve,Close,Title,Open} for those gates."""
 
     def test_list_returns_all_owners(self, app_client):
         client, _mgr = app_client
@@ -416,11 +414,11 @@ class TestDashboardTrustedTeamVisibility:
 
 
 class TestSavedWorkstreamsTrustedTeamVisibility:
-    """Listing returns the cluster-wide set across all owners (no
-    per-user filter).  Resuming a saved workstream still goes through
-    the per-workstream ownership gate on /open, so this endpoint only
-    leaks metadata (name, message_count, updated) — see TestCrossTenantOpen
-    for the resume-side guard."""
+    """Listing returns the cluster-wide set across all owners.  Resuming
+    an owned saved workstream goes through the per-workstream ownership
+    gate on /open (see TestCrossTenantOpen); ownerless persisted rows
+    are claimable by any authenticated caller via /open, consistent
+    with the same trusted-team model."""
 
     def _seed(self, client):
         """Create two workstreams per user, each with a message so they
@@ -457,10 +455,11 @@ class TestSavedWorkstreamsTrustedTeamVisibility:
         assert {"alice-saved", "bob-saved"}.issubset(ids)
 
     def test_orphan_rows_visible(self, app_client):
-        """Orphan rows (empty user_id from migrations / pre-002) are no
-        longer fail-closed since the whole-listing now exposes
-        cluster-wide metadata.  Resume of an orphan still requires
-        admin path on /open."""
+        """Ownerless rows (empty user_id from migrations / startup
+        ``name="default"``) appear in the cluster-wide listing alongside
+        owned rows.  /open lets any authenticated caller claim them —
+        intentional under the trusted-team model — so the listing isn't
+        leaking anything the resume path wouldn't already grant."""
         client, _mgr = app_client
         storage = self._seed(client)
         _register_ws(storage, "orphan-saved", "")

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -369,10 +369,16 @@ class TestCrossTenantOpen:
         assert resp.status_code == 404
 
 
-class TestListWorkstreamsFiltered:
-    def test_list_excludes_other_tenants(self, app_client):
-        client, mgr = app_client
-        # Seed two workstreams in the in-memory manager — one per tenant.
+class TestListWorkstreamsTrustedTeamVisibility:
+    """Listing endpoints (/workstreams, /dashboard, /workstreams/saved)
+    return the cluster-wide set to any authenticated caller — turnstone
+    is deployed as a self-hosted, trusted-team tool and the previous
+    per-user filter created friction without preventing the relevant
+    threats (mutations are gated independently on the per-workstream
+    handlers; see TestCrossTenant{Delete,Approve,Close,Title,Open})."""
+
+    def test_list_returns_all_owners(self, app_client):
+        client, _mgr = app_client
         resp_a = client.post(
             "/v1/api/workstreams/new",
             json={"name": "a"},
@@ -386,16 +392,15 @@ class TestListWorkstreamsFiltered:
         assert resp_a.status_code == 200 and resp_b.status_code == 200
         ws_a, ws_b = resp_a.json()["ws_id"], resp_b.json()["ws_id"]
 
-        # user-a sees only ws_a.
+        # user-a now sees both.
         resp = client.get("/v1/api/workstreams", headers=_auth("user-a"))
         assert resp.status_code == 200
         ids = {w["id"] for w in resp.json()["workstreams"]}
-        assert ws_a in ids
-        assert ws_b not in ids
+        assert {ws_a, ws_b}.issubset(ids), ids
 
 
-class TestDashboardFiltered:
-    def test_dashboard_aggregate_scoped_to_caller(self, app_client):
+class TestDashboardTrustedTeamVisibility:
+    def test_dashboard_aggregate_includes_all_owners(self, app_client):
         client, _mgr = app_client
         client.post("/v1/api/workstreams/new", json={"name": "a"}, headers=_auth("user-a"))
         client.post("/v1/api/workstreams/new", json={"name": "b"}, headers=_auth("user-b"))
@@ -404,19 +409,18 @@ class TestDashboardFiltered:
         resp = client.get("/v1/api/dashboard", headers=_auth("user-b"))
         assert resp.status_code == 200
         data = resp.json()
-        # user-b owns 2; aggregate total_count reflects filtered set.
-        assert data["aggregate"]["total_count"] == 2
+        # All three workstreams visible regardless of caller identity.
+        assert data["aggregate"]["total_count"] == 3
         owners = {w["user_id"] for w in data["workstreams"]}
-        assert owners == {"user-b"}
+        assert {"user-a", "user-b"}.issubset(owners)
 
 
-class TestSavedWorkstreamsTenantScoping:
-    """Regression for Copilot review on #380: /v1/api/workstreams/saved
-    used to call list_workstreams_with_history with no tenant filter,
-    so every authenticated user could see every other user's saved
-    workstream aliases / titles / names.  Fix tightens to
-    ``list_workstreams_with_history(user_id=caller)`` with the
-    service-scope bypass matching _visible_workstreams."""
+class TestSavedWorkstreamsTrustedTeamVisibility:
+    """Listing returns the cluster-wide set across all owners (no
+    per-user filter).  Resuming a saved workstream still goes through
+    the per-workstream ownership gate on /open, so this endpoint only
+    leaks metadata (name, message_count, updated) — see TestCrossTenantOpen
+    for the resume-side guard."""
 
     def _seed(self, client):
         """Create two workstreams per user, each with a message so they
@@ -432,19 +436,16 @@ class TestSavedWorkstreamsTenantScoping:
         storage.save_message("bob-saved", "user", "bob's plan")
         return storage
 
-    def test_non_service_caller_sees_only_own_rows(self, app_client):
+    def test_any_caller_sees_all_rows(self, app_client):
         client, _mgr = app_client
         self._seed(client)
         resp = client.get("/v1/api/workstreams/saved", headers=_auth("alice"))
         assert resp.status_code == 200
-        rows = resp.json()["workstreams"]
-        ids = {r["ws_id"] for r in rows}
-        assert ids == {"alice-saved"}, f"alice must not see bob's saved rows: {ids}"
+        ids = {r["ws_id"] for r in resp.json()["workstreams"]}
+        assert {"alice-saved", "bob-saved"}.issubset(ids), ids
 
     def test_service_scope_sees_all_rows(self, app_client):
-        """Cluster-wide visibility is preserved for service callers
-        (console collector, cluster tooling) so they can still hydrate
-        cross-tenant state when needed."""
+        """Service-scope still works — same set, different auth path."""
         client, _mgr = app_client
         self._seed(client)
         resp = client.get(
@@ -452,26 +453,25 @@ class TestSavedWorkstreamsTenantScoping:
             headers=_auth("cluster-collector", scopes=frozenset({"read", "service"})),
         )
         assert resp.status_code == 200
-        rows = resp.json()["workstreams"]
-        ids = {r["ws_id"] for r in rows}
+        ids = {r["ws_id"] for r in resp.json()["workstreams"]}
         assert {"alice-saved", "bob-saved"}.issubset(ids)
 
-    def test_blank_sub_non_service_returns_empty(self, app_client):
-        """Defense-in-depth — a non-service token with an empty ``sub``
-        claim (orphan / migration-artifact auth path) must not match
-        every workstream with empty ``user_id``.  Fail closed."""
+    def test_orphan_rows_visible(self, app_client):
+        """Orphan rows (empty user_id from migrations / pre-002) are no
+        longer fail-closed since the whole-listing now exposes
+        cluster-wide metadata.  Resume of an orphan still requires
+        admin path on /open."""
         client, _mgr = app_client
         storage = self._seed(client)
-        # Also seed an orphan row so the test would fail loudly if the
-        # handler leaked it.
         _register_ws(storage, "orphan-saved", "")
         storage.save_message("orphan-saved", "user", "orphan content")
         resp = client.get(
             "/v1/api/workstreams/saved",
-            headers=_auth("", scopes=frozenset({"read"})),
+            headers=_auth("alice", scopes=frozenset({"read"})),
         )
         assert resp.status_code == 200
-        assert resp.json()["workstreams"] == []
+        ids = {r["ws_id"] for r in resp.json()["workstreams"]}
+        assert "orphan-saved" in ids
 
     def test_coordinator_rows_excluded_even_for_service(self, app_client):
         """kind filter is orthogonal to the user_id filter — even a

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -11099,12 +11099,7 @@ def main() -> None:
 
     # ``service`` scope is REQUIRED — ``/v1/api/events/global`` on every
     # upstream node hard-gates on it (server.py global_events_sse).
-    # The dashboard / workstreams listing endpoints no longer tenant-
-    # filter (the per-user filter was retired in favour of the trusted-
-    # team visibility model — see the rationale on list_workstreams),
-    # so service scope here is now load-bearing only for the SSE event
-    # stream.  Kept for that reason plus belt-and-braces.  ``read`` is
-    # kept for legacy read-path compatibility.
+    # ``read`` is kept for legacy read-path compatibility.
     collector_token_mgr = ServiceTokenManager(
         user_id="console-collector",
         scopes=frozenset({"read", "service"}),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -11098,13 +11098,12 @@ def main() -> None:
     from turnstone.core.auth import JWT_AUD_SERVER, ServiceTokenManager
 
     # ``service`` scope is REQUIRED — ``/v1/api/events/global`` on every
-    # upstream node hard-gates on it (server.py global_events_sse), and
-    # ``/v1/api/dashboard`` / ``/v1/api/workstreams`` silently tenant-
-    # filter away all rows for non-service callers (server.py
-    # _visible_workstreams).  Without ``service`` here, every
-    # console→upstream SSE connect 403s, no dashboard rows flow, the
-    # browser's cluster-view is empty, and the failure surfaces only
-    # as DEBUG-level log lines in the collector (#sev-0).  ``read`` is
+    # upstream node hard-gates on it (server.py global_events_sse).
+    # The dashboard / workstreams listing endpoints no longer tenant-
+    # filter (the per-user filter was retired in favour of the trusted-
+    # team visibility model — see the rationale on list_workstreams),
+    # so service scope here is now load-bearing only for the SSE event
+    # stream.  Kept for that reason plus belt-and-braces.  ``read`` is
     # kept for legacy read-path compatibility.
     collector_token_mgr = ServiceTokenManager(
         user_id="console-collector",

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1211,25 +1211,23 @@ async def list_workstreams(request: Request) -> JSONResponse:
     """GET /v1/api/workstreams — list workstreams visible to any
     authenticated caller.
 
-    Listing intentionally returns the full set across all owners (no
-    per-user filter).  turnstone is deployed as a self-hosted, trusted-
-    team tool: console operators already see cluster-wide state via
-    service scope, and the previous ``_visible_workstreams`` filter (PR
-    #375) created more friction than security in that shape — it also
-    hid the auto-created ``name="default"`` startup workstream from
-    every web user, leaving fresh installs staring at a blank dashboard.
+    Trusted-team visibility: listing returns the full cluster set
+    across all owners (no per-user filter).  Self-hosted deployments
+    are the assumed shape; console operators already see cluster-wide
+    state via service scope, and a per-user filter would also hide
+    ownerless rows like the auto-created ``name="default"`` startup
+    workstream from every authenticated caller.
 
-    Per-workstream MUTATIONS (/send, /close, /open, /title, /delete,
-    /refresh-title) keep their independent ownership checks — see those
-    handlers for the cross-tenant guards that PR #375 also added and
-    which DO remain in force.  What you can read here is metadata
-    (name, state, kind); message history requires the per-workstream
-    ownership gate on /history.
+    Per-workstream mutations (``/send``, ``/close``, ``/open``,
+    ``/title``, ``/delete``, ``/refresh-title``) keep their independent
+    ownership checks — see those handlers for the cross-tenant guards
+    that stay in force.  This endpoint exposes metadata only (name,
+    state, kind, parent_ws_id); message history requires the per-
+    workstream ownership gate on ``/history``.
 
-    If turnstone is ever deployed as a multi-tenant SaaS, the right
-    boundary is a real ``tenant_id`` column with row-level filtering at
-    the storage layer, not the empty-user_id heuristic this used to
-    apply.
+    For a multi-tenant SaaS deployment, the right boundary is a real
+    ``tenant_id`` column with row-level filtering at the storage
+    layer, not an empty-user_id heuristic.
     """
     from turnstone.core.memory import get_workstream_display_name
 
@@ -1316,15 +1314,20 @@ async def dashboard(request: Request) -> JSONResponse:
 
 
 async def list_saved_workstreams(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams/saved — list saved interactive workstreams
-    with conversation history, visible to any authenticated caller.
+    """GET /v1/api/workstreams/saved — list saved interactive workstream
+    metadata, visible to any authenticated caller.
 
-    Listing returns the cluster-wide set across all owners (no per-user
-    filter) — see ``list_workstreams`` above for the rationale.
-    Resuming a saved workstream still goes through the per-workstream
-    ownership gate on ``/v1/api/workstreams/{ws_id}/open``, so this
-    endpoint only exposes metadata (name, message_count, updated), not
-    history.
+    Trusted-team visibility: returns the cluster-wide set across all
+    owners (no per-user filter) — see ``list_workstreams`` for the
+    rationale.  This endpoint exposes summary fields only (ws_id,
+    alias, title, name, created, updated, message_count); message
+    history requires the per-workstream ownership gate on
+    ``/v1/api/workstreams/{ws_id}/history``.
+
+    Resuming an owned saved workstream goes through ``/open``'s
+    ownership check; ownerless persisted rows (legacy / migration /
+    startup ``name="default"``) are claimable by any authenticated
+    caller via ``/open``, consistent with the same trusted-team model.
 
     Restricted to ``kind="interactive"`` — the interactive UI's "saved
     workstreams" sidebar is not a coordinator surface, and coordinator
@@ -3506,11 +3509,14 @@ async def open_workstream(request: Request) -> JSONResponse:
     scopes = _auth_scopes(request)
 
     # Ownership gate: the stored owner must match the caller (or the
-    # caller must hold the service scope, which covers the console
-    # routing proxy and cluster rehydration paths).  A legacy row with
-    # a blank owner is claimable by the authenticated caller — same
-    # semantics as _require_ws_access for the interactive handlers.
-    # 404 (not 403) so existence isn't enumerable by non-owners.
+    # caller must hold service scope — used by the console routing proxy
+    # and cluster rehydration paths).  Ownerless persisted rows (the
+    # startup ``name="default"`` workstream, pre-migration legacy rows)
+    # are claimable by any authenticated caller — consistent with the
+    # trusted-team visibility model the listing endpoints assume, and
+    # symmetric with how _require_ws_access handles the same rows on
+    # the per-workstream interactive handlers.  404 (not 403) so
+    # existence isn't enumerable by non-owners.
     stored_owner = (ws_row.get("user_id") or "").strip()
     if stored_owner and "service" not in scopes and stored_owner != uid:
         return JSONResponse({"error": "Workstream not found"}, status_code=404)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1207,29 +1207,35 @@ async def global_events_sse(request: Request) -> Response:
     return EventSourceResponse(event_generator(), ping=5)
 
 
-def _visible_workstreams(request: Request, wss: list[Workstream]) -> list[Workstream]:
-    """Filter an in-memory workstream list to the caller's tenant view.
-
-    Service-scoped tokens see everything (internal cluster callers,
-    console routing proxy).  End-user tokens see only workstreams they
-    own — a blank ``ws.user_id`` (legacy / pre-migration rows) is
-    hidden from non-service callers to prevent orphan leakage.
-    """
-    if "service" in _auth_scopes(request):
-        return wss
-    caller = _auth_user_id(request)
-    if not caller:
-        return []
-    return [ws for ws in wss if ws.user_id and ws.user_id == caller]
-
-
 async def list_workstreams(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams — list workstreams visible to the caller."""
+    """GET /v1/api/workstreams — list workstreams visible to any
+    authenticated caller.
+
+    Listing intentionally returns the full set across all owners (no
+    per-user filter).  turnstone is deployed as a self-hosted, trusted-
+    team tool: console operators already see cluster-wide state via
+    service scope, and the previous ``_visible_workstreams`` filter (PR
+    #375) created more friction than security in that shape — it also
+    hid the auto-created ``name="default"`` startup workstream from
+    every web user, leaving fresh installs staring at a blank dashboard.
+
+    Per-workstream MUTATIONS (/send, /close, /open, /title, /delete,
+    /refresh-title) keep their independent ownership checks — see those
+    handlers for the cross-tenant guards that PR #375 also added and
+    which DO remain in force.  What you can read here is metadata
+    (name, state, kind); message history requires the per-workstream
+    ownership gate on /history.
+
+    If turnstone is ever deployed as a multi-tenant SaaS, the right
+    boundary is a real ``tenant_id`` column with row-level filtering at
+    the storage layer, not the empty-user_id heuristic this used to
+    apply.
+    """
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: WorkstreamManager = request.app.state.workstreams
     result = []
-    for ws in _visible_workstreams(request, mgr.list_all()):
+    for ws in mgr.list_all():
         title = get_workstream_display_name(ws.id) or ws.name
         # kind + parent_ws_id mirror the shape /dashboard returns below so
         # client consumers (SDK, frontend, integrators) see one consistent
@@ -1252,7 +1258,9 @@ async def dashboard(request: Request) -> JSONResponse:
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: WorkstreamManager = request.app.state.workstreams
-    wss = _visible_workstreams(request, mgr.list_all())
+    # No per-user filter — see list_workstreams above for the rationale
+    # (trusted-team deployment shape; mutations stay owner-gated).
+    wss = mgr.list_all()
     total_tokens = 0
     total_tool_calls = 0
     active_count = 0
@@ -1308,13 +1316,15 @@ async def dashboard(request: Request) -> JSONResponse:
 
 
 async def list_saved_workstreams(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams/saved — list saved workstreams with conversation history.
+    """GET /v1/api/workstreams/saved — list saved interactive workstreams
+    with conversation history, visible to any authenticated caller.
 
-    Tenant-scoped — service-scoped callers (console collector, cluster
-    tooling) see cluster-wide rows; end-user callers see only their
-    own workstreams (matching ``_visible_workstreams``).  A non-service
-    call with a blank ``user_id`` returns an empty list rather than
-    leaking orphan rows.
+    Listing returns the cluster-wide set across all owners (no per-user
+    filter) — see ``list_workstreams`` above for the rationale.
+    Resuming a saved workstream still goes through the per-workstream
+    ownership gate on ``/v1/api/workstreams/{ws_id}/open``, so this
+    endpoint only exposes metadata (name, message_count, updated), not
+    history.
 
     Restricted to ``kind="interactive"`` — the interactive UI's "saved
     workstreams" sidebar is not a coordinator surface, and coordinator
@@ -1324,23 +1334,10 @@ async def list_saved_workstreams(request: Request) -> JSONResponse:
     from turnstone.core.memory import list_workstreams_with_history
     from turnstone.core.workstream import WorkstreamKind
 
-    scopes = _auth_scopes(request)
-    if "service" in scopes:
-        # Cluster-wide visibility for service-scoped callers.
-        user_filter: str | None = None
-    else:
-        caller_uid = _auth_user_id(request)
-        if not caller_uid:
-            # Blank sub on a non-service token — fail closed instead of
-            # matching every orphan / migration-artifact row with empty
-            # user_id.  Mirrors _visible_workstreams.
-            return JSONResponse({"workstreams": []})
-        user_filter = caller_uid
-
     rows = list_workstreams_with_history(
         limit=50,
         kind=WorkstreamKind.INTERACTIVE,
-        user_id=user_filter,
+        user_id=None,
     )
     result = [
         {


### PR DESCRIPTION
## Summary

The auto-created \`name=\"default\"\` startup workstream has no owner (nothing passes a \`user_id\` to \`manager.create()\` at \`server.py:5194\`). PR #375's \`_visible_workstreams\` helper fail-closes empty-owner rows for non-service callers, so the default — and any other unowned row — gets filtered out of \`/v1/api/workstreams\`, \`/v1/api/dashboard\`, and \`/v1/api/workstreams/saved\` for every web user. Result: fresh installs land on a blank dashboard with no tabs and the \"always at least one workstream\" close-guard invariant turns into a slot held by an invisible workstream.

The right fix isn't to assign a synthetic owner (any choice is arbitrary in multi-user installs) — it's to recognise that turnstone's deployment shape is self-hosted, trusted-team, single-process. The per-user listing filter was written against a multi-tenant SaaS threat model that doesn't apply.

This PR drops the per-user filter on the three listing endpoints. **Per-workstream mutations stay owner-gated unchanged** — \`TestCrossTenant{Delete,Approve,Close,Title,Open}\` still passes; \`/send\`, \`/close\`, \`/open\`, \`/title\`, \`/delete\`, \`/refresh-title\` keep their independent ownership checks. Resuming a saved workstream goes through \`/open\`'s owner check, so the metadata-leak surface ends at \"you can see workstream X exists\" — not at any actionable cross-user capability.

If turnstone is ever deployed as a true multi-tenant SaaS, the right boundary is a real \`tenant_id\` column with row-level filtering at the storage layer, not the empty-user_id heuristic this used to apply.

## Changes

- \`turnstone/server.py\`: deleted \`_visible_workstreams\` helper; \`list_workstreams\` and \`dashboard\` use \`mgr.list_all()\` directly; \`list_saved_workstreams\` calls \`list_workstreams_with_history(user_id=None)\` unconditionally. Docstrings record the decision so a future contributor doesn't reflexively re-add the filter.
- \`turnstone/console/server.py\`: updated the comment on the collector's service-scope token (now load-bearing only for the SSE event stream gate, not for listing visibility).
- \`tests/test_server_authz.py\`: \`TestListWorkstreamsTrustedTeamVisibility\`, \`TestDashboardTrustedTeamVisibility\`, \`TestSavedWorkstreamsTrustedTeamVisibility\` — assert the new contract (listing returns all owners; mutation gates unchanged).

## Test plan

- [x] \`pytest tests/test_server_authz.py tests/test_workstream.py tests/test_workstream_endpoints.py tests/test_workstream_kind.py\` — 137 pass
- [x] \`ruff\` + \`mypy\` clean
- [x] Smoke: fresh \`turnstone-server\` start, log in as admin → web UI lands on the default workstream tab (not a blank dashboard)
- [x] Smoke: log in as a second user → can see the admin's workstreams in the dashboard list, can NOT \`/send\` to them (existing per-handler 404)
- [x] Smoke: console node-detail page now shows the default workstream count instead of \"0 active · 0 total\"