### PR TITLE
fix(chat): collapse phantom whitespace + tighten paragraph rhythm

### DIFF
--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -104,6 +104,13 @@
   background: var(--bg-highlight);
   padding: 1px 4px;
   border-radius: 2px;
+  /* Preserve internal whitespace + allow wrapping.  The body sets
+     ``white-space: normal`` to collapse phantom inter-block ``\n`` text
+     nodes; inline ``<code>`` would inherit that and silently collapse
+     multiple spaces inside backtick spans.  ``<pre>`` blocks rely on
+     the user-agent ``pre { white-space: pre }`` rule and don't need
+     this override. */
+  white-space: pre-wrap;
 }
 .ts-msg-body pre code {
   background: none;

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -60,13 +60,35 @@
 }
 
 /* Content container.  Markdown renders here (streamingRender writes
-   innerHTML; renderer.js is the trust boundary for that sink). */
+   innerHTML; renderer.js is the trust boundary for that sink).
+   ``white-space: normal`` is intentional: the markdown converter leaves
+   ``\n`` text nodes between block siblings (headings → paragraphs →
+   katex-display → ...).  ``pre-wrap`` rendered every one of those as
+   visible vertical space, stacking 20-30px gaps between every section.
+   ``<pre>`` blocks have ``white-space: pre`` built in, so fenced code
+   still preserves its formatting; mid-stream partial fences before the
+   closing ``\`\`\`` arrives render as collapsed text for a frame and
+   then snap back when the next render tick wraps them in ``<pre>``.
+   User-typed messages render through ``.msg-user-text`` (a separate
+   path that preserves its own newlines), so this change only affects
+   assistant markdown output. */
 .ts-msg-body {
   min-width: 0;
-  white-space: pre-wrap;
+  white-space: normal;
 }
-.ts-msg-body > *:first-child { margin-top: 0; }
-.ts-msg-body > *:last-child { margin-bottom: 0; }
+.ts-msg-body > *:first-child {
+  margin-top: 0;
+}
+.ts-msg-body > *:last-child {
+  margin-bottom: 0;
+}
+/* Tighten paragraph rhythm to match the heading/list margins above —
+   without this, browser-default 1em top + 1em bottom (~28px stacked)
+   makes paragraphs read as if they're in a different document from
+   the surrounding headings. */
+.ts-msg-body p {
+  margin: 6px 0;
+}
 .ts-msg-body pre {
   margin: 6px 0;
   padding: 8px 10px;
@@ -83,27 +105,55 @@
   padding: 1px 4px;
   border-radius: 2px;
 }
-.ts-msg-body pre code { background: none; padding: 0; border-radius: 0; }
-.ts-msg-body a { color: var(--accent); text-decoration: underline; }
-.ts-msg-body h1, .ts-msg-body h2, .ts-msg-body h3,
-.ts-msg-body h4, .ts-msg-body h5, .ts-msg-body h6 {
+.ts-msg-body pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+.ts-msg-body a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.ts-msg-body h1,
+.ts-msg-body h2,
+.ts-msg-body h3,
+.ts-msg-body h4,
+.ts-msg-body h5,
+.ts-msg-body h6 {
   font-family: var(--font-display);
   font-weight: 600;
   margin: 8px 0 4px;
   color: var(--fg-bright);
 }
-.ts-msg-body h1 { font-size: 16px; }
-.ts-msg-body h2 { font-size: 14px; }
-.ts-msg-body h3 { font-size: 13px; }
-.ts-msg-body h4, .ts-msg-body h5, .ts-msg-body h6 {
+.ts-msg-body h1 {
+  font-size: 16px;
+}
+.ts-msg-body h2 {
+  font-size: 14px;
+}
+.ts-msg-body h3 {
+  font-size: 13px;
+}
+.ts-msg-body h4,
+.ts-msg-body h5,
+.ts-msg-body h6 {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.ts-msg-body ul, .ts-msg-body ol { margin: 4px 0 4px 20px; }
-.ts-msg-body li { margin: 2px 0; }
-.ts-msg-body strong { color: var(--fg-bright); }
-.ts-msg-body em { font-style: italic; }
+.ts-msg-body ul,
+.ts-msg-body ol {
+  margin: 4px 0 4px 20px;
+}
+.ts-msg-body li {
+  margin: 2px 0;
+}
+.ts-msg-body strong {
+  color: var(--fg-bright);
+}
+.ts-msg-body em {
+  font-style: italic;
+}
 .ts-msg-body blockquote {
   border-left: 2px solid var(--border-strong);
   padding-left: 10px;
@@ -123,7 +173,9 @@
   transition: opacity 0.15s;
 }
 .ts-msg:hover .ts-msg-actions,
-.ts-msg:focus-within .ts-msg-actions { opacity: 1; }
+.ts-msg:focus-within .ts-msg-actions {
+  opacity: 1;
+}
 .ts-msg-action-btn {
   background: transparent;
   border: 1px solid var(--border);
@@ -133,19 +185,30 @@
   font: inherit;
   font-size: 11px;
   cursor: pointer;
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  transition:
+    background 0.1s,
+    border-color 0.1s,
+    color 0.1s;
 }
 .ts-msg-action-btn:hover {
   background: var(--bg-highlight);
   color: var(--fg-bright);
   border-color: var(--accent-dim);
 }
-.ts-msg-action-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ts-msg-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 
 /* On coarse-pointer / hover-none devices, keep the toolbar visible — no hover. */
 @media (hover: none) and (pointer: coarse) {
-  .ts-msg-actions { opacity: 1; }
-  .ts-msg-action-btn { padding: 4px 8px; font-size: 12px; }
+  .ts-msg-actions {
+    opacity: 1;
+  }
+  .ts-msg-action-btn {
+    padding: 4px 8px;
+    font-size: 12px;
+  }
 }
 
 /* ==========================================================================
@@ -176,7 +239,9 @@
   border-left: 3px solid var(--yellow);
   display: none;
 }
-.ts-approval--batch.visible { display: flex; }
+.ts-approval--batch.visible {
+  display: flex;
+}
 
 .ts-approval-header {
   font-family: var(--font-display);
@@ -195,9 +260,17 @@
   border-radius: var(--radius-sm);
   background: var(--code-bg);
 }
-.ts-approval-tool + .ts-approval-tool { margin-top: 4px; }
-.ts-approval-tool-name { color: var(--yellow); font-weight: 600; }
-.ts-approval-tool-cmd { color: var(--fg-bright); white-space: pre-wrap; }
+.ts-approval-tool + .ts-approval-tool {
+  margin-top: 4px;
+}
+.ts-approval-tool-name {
+  color: var(--yellow);
+  font-weight: 600;
+}
+.ts-approval-tool-cmd {
+  color: var(--fg-bright);
+  white-space: pre-wrap;
+}
 .ts-approval-actions {
   display: flex;
   gap: 6px;
@@ -214,20 +287,44 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
 }
 .ts-approval-btn:hover {
   background: var(--bg-highlight);
   color: var(--fg-bright);
   border-color: var(--accent-dim);
 }
-.ts-approval-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-.ts-approval-btn--approve { border-color: var(--green); color: var(--green); }
-.ts-approval-btn--approve:hover { background: var(--green-glow); color: var(--green); }
-.ts-approval-btn--deny { border-color: var(--red); color: var(--red); }
-.ts-approval-btn--deny:hover { background: var(--red-glow); color: var(--red); }
-.ts-approval-btn--always { border-color: var(--accent); color: var(--accent); }
-.ts-approval-btn--always:hover { background: var(--accent-dim); color: var(--accent); }
+.ts-approval-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.ts-approval-btn--approve {
+  border-color: var(--green);
+  color: var(--green);
+}
+.ts-approval-btn--approve:hover {
+  background: var(--green-glow);
+  color: var(--green);
+}
+.ts-approval-btn--deny {
+  border-color: var(--red);
+  color: var(--red);
+}
+.ts-approval-btn--deny:hover {
+  background: var(--red-glow);
+  color: var(--red);
+}
+.ts-approval-btn--always {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.ts-approval-btn--always:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
 .ts-approval-btn .ts-approval-key {
   display: inline-block;
   background: var(--bg);
@@ -238,7 +335,10 @@
   font-size: 10px;
   color: var(--fg-dim);
 }
-.ts-approval-btn:disabled { opacity: 0.5; cursor: wait; }
+.ts-approval-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
 
 .ts-approval-feedback {
   font: inherit;
@@ -256,7 +356,10 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
-.ts-approval-feedback::placeholder { color: var(--fg-dim); opacity: 0.7; }
+.ts-approval-feedback::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.7;
+}
 
 .ts-approval-badge {
   font-family: var(--font-display);
@@ -270,9 +373,19 @@
   gap: 4px;
   width: max-content;
 }
-.ts-approval-badge--approved { color: var(--green); border: 1px solid var(--green); }
-.ts-approval-badge--denied { color: var(--red); border: 1px solid var(--red); }
-.ts-approval-badge--error { color: var(--red); background: var(--red-glow); border: 1px solid var(--red); }
+.ts-approval-badge--approved {
+  color: var(--green);
+  border: 1px solid var(--green);
+}
+.ts-approval-badge--denied {
+  color: var(--red);
+  border: 1px solid var(--red);
+}
+.ts-approval-badge--error {
+  color: var(--red);
+  background: var(--red-glow);
+  border: 1px solid var(--red);
+}
 
 /* Verdict badge (LLM judge) — inline in the approval block on
    interactive UI.  Coordinator doesn't render verdicts today but the
@@ -289,13 +402,31 @@
   background: var(--bg-surface);
   width: max-content;
 }
-.ts-verdict-badge[data-risk="low"] { border-left-color: var(--green); }
-.ts-verdict-badge[data-risk="medium"] { border-left-color: var(--yellow); }
-.ts-verdict-badge[data-risk="high"] { border-left-color: var(--red); }
-.ts-verdict-badge[data-risk="critical"] { border-left-color: var(--red); background: var(--red-glow); }
-.ts-verdict-risk { font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
-.ts-verdict-rec { color: var(--fg-dim); }
-.ts-verdict-conf { color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.ts-verdict-badge[data-risk="low"] {
+  border-left-color: var(--green);
+}
+.ts-verdict-badge[data-risk="medium"] {
+  border-left-color: var(--yellow);
+}
+.ts-verdict-badge[data-risk="high"] {
+  border-left-color: var(--red);
+}
+.ts-verdict-badge[data-risk="critical"] {
+  border-left-color: var(--red);
+  background: var(--red-glow);
+}
+.ts-verdict-risk {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ts-verdict-rec {
+  color: var(--fg-dim);
+}
+.ts-verdict-conf {
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
 .ts-verdict-expand {
   background: none;
   border: none;
@@ -351,7 +482,9 @@
   flex-wrap: wrap;
   gap: 4px;
 }
-.ts-composer-chips:empty { display: none; }
+.ts-composer-chips:empty {
+  display: none;
+}
 
 .ts-composer-chip {
   display: inline-flex;
@@ -365,7 +498,10 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
 }
-.ts-composer-chip-size { color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.ts-composer-chip-size {
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
 .ts-composer-chip-remove {
   background: none;
   border: none;
@@ -376,7 +512,9 @@
   font-size: 13px;
   line-height: 1;
 }
-.ts-composer-chip-remove:hover { color: var(--red); }
+.ts-composer-chip-remove:hover {
+  color: var(--red);
+}
 
 .ts-composer-row {
   display: flex;
@@ -394,14 +532,20 @@
   padding: 4px 8px;
   line-height: 1;
   height: 32px;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
 }
 .ts-composer-attach:hover {
   background: var(--bg-highlight);
   color: var(--accent);
   border-color: var(--accent-dim);
 }
-.ts-composer-attach:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ts-composer-attach:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 
 .ts-composer-input {
   flex: 1;
@@ -418,15 +562,23 @@
      coordinator.js cap growth; letting the user drag-resize pushes
      the messages pane off-screen on small viewports. */
   resize: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 .ts-composer-input:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
-.ts-composer-input:disabled { opacity: 0.55; cursor: not-allowed; }
-.ts-composer-input::placeholder { color: var(--fg-dim); opacity: 0.7; }
+.ts-composer-input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.ts-composer-input::placeholder {
+  color: var(--fg-dim);
+  opacity: 0.7;
+}
 
 .ts-composer-send {
   font: inherit;
@@ -443,15 +595,27 @@
   transition: filter 0.12s;
   letter-spacing: 0.02em;
 }
-.ts-composer-send:hover { filter: brightness(1.08); }
-.ts-composer-send:focus-visible { outline: 2px solid var(--fg); outline-offset: 2px; }
-.ts-composer-send:disabled { opacity: 0.5; cursor: not-allowed; filter: none; }
+.ts-composer-send:hover {
+  filter: brightness(1.08);
+}
+.ts-composer-send:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+.ts-composer-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: none;
+}
 .ts-composer-send--queue {
   background: transparent;
   color: var(--accent);
   border-color: var(--accent);
 }
-.ts-composer-send--queue:hover { background: var(--accent-dim); filter: none; }
+.ts-composer-send--queue:hover {
+  background: var(--accent-dim);
+  filter: none;
+}
 
 /* Stop button — only rendered when the composer was constructed with
    stopBtn=true.  Distinct red colour signals "interrupt the in-flight
@@ -475,7 +639,9 @@
   outline: 2px solid var(--fg-bright, #e8ecf4);
   outline-offset: 2px;
 }
-[data-theme="light"] .ts-composer-stop { color: #fff; }
+[data-theme="light"] .ts-composer-stop {
+  color: #fff;
+}
 
 /* ============================================================
    Stacked layout — textarea above, actions row below.
@@ -538,7 +704,9 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
 .ts-composer-options-btn:hover {
   background: var(--bg-highlight);
@@ -579,7 +747,9 @@
    and comes later in the cascade, so a bare [hidden] attribute
    alone doesn't hide the panel.  Override here so toggleOptions()
    works via the standard hidden attribute. */
-.ts-composer-options-panel[hidden] { display: none; }
+.ts-composer-options-panel[hidden] {
+  display: none;
+}
 .ts-composer-options-field {
   display: contents;
 }
@@ -629,18 +799,25 @@
   position: relative;
 }
 .ts-header::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, var(--accent-dim), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent-dim),
+    transparent
+  );
 }
 /* Suppress the accent gradient when the header is immediately followed
    by a #tab-bar (server UI) — the tab-bar already carries its own
    border-bottom and the two decorative lines stack visually otherwise. */
-.ts-header:has(+ #tab-bar)::after { display: none; }
+.ts-header:has(+ #tab-bar)::after {
+  display: none;
+}
 .ts-header-title {
   font-family: var(--font-display);
   font-size: 13px;
@@ -649,16 +826,25 @@
   letter-spacing: 0.02em;
   margin: 0;
 }
-.ts-header-title-dim { color: var(--fg-dim); font-weight: 400; }
+.ts-header-title-dim {
+  color: var(--fg-dim);
+  font-weight: 400;
+}
 .ts-header-status {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--fg-dim);
   letter-spacing: 0.03em;
 }
-.ts-header-status--ok { color: var(--green); }
-.ts-header-status--err { color: var(--red); }
-.ts-header-spacer { flex: 1; }
+.ts-header-status--ok {
+  color: var(--green);
+}
+.ts-header-status--err {
+  color: var(--red);
+}
+.ts-header-spacer {
+  flex: 1;
+}
 
 /* Back-to-console navigation — shared affordance used by the
    coordinator page header and by the console's redirect banner
@@ -675,7 +861,10 @@
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   letter-spacing: 0.02em;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
 }
 .ts-header-back-link:hover {
   color: var(--accent);
@@ -686,7 +875,9 @@
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
-.ts-header-back-link-arrow { font-family: var(--font-mono); }
+.ts-header-back-link-arrow {
+  font-family: var(--font-mono);
+}
 .ts-header-actions {
   display: flex;
   align-items: center;
@@ -733,7 +924,10 @@
   align-items: center;
   gap: 6px;
 }
-.ts-sidebar-section-count { color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.ts-sidebar-section-count {
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
 .ts-sidebar-section-body {
   flex: 1 1 auto;
   overflow-y: auto;
@@ -750,17 +944,33 @@
    Mobile (<700px) — chat.css components stack vertically.
    ========================================================================== */
 @media (max-width: 700px) {
-  .ts-msg { padding: 6px 10px; }
-  .ts-msg-body pre { margin: 4px -6px; border-radius: 0; }
-  .ts-composer { padding: 6px 10px; }
-  .ts-composer-input { min-height: 40px; max-height: 120px; resize: none; }
-  .ts-composer-send { height: 40px; padding: 6px 14px; }
+  .ts-msg {
+    padding: 6px 10px;
+  }
+  .ts-msg-body pre {
+    margin: 4px -6px;
+    border-radius: 0;
+  }
+  .ts-composer {
+    padding: 6px 10px;
+  }
+  .ts-composer-input {
+    min-height: 40px;
+    max-height: 120px;
+    resize: none;
+  }
+  .ts-composer-send {
+    height: 40px;
+    padding: 6px 14px;
+  }
   .ts-sidebar {
     width: 100%;
     border-left: none;
     border-top: 1px solid var(--border);
   }
-  .ts-approval--batch { padding: 8px 10px; }
+  .ts-approval--batch {
+    padding: 8px 10px;
+  }
 }
 
 /* ==========================================================================
@@ -772,5 +982,7 @@
   .ts-approval-btn,
   .ts-composer-attach,
   .ts-composer-input,
-  .ts-composer-send { transition: none; }
+  .ts-composer-send {
+    transition: none;
+  }
 }

--- a/turnstone/shared_static/design/primitives/message.css
+++ b/turnstone/shared_static/design/primitives/message.css
@@ -42,8 +42,12 @@
 }
 
 /* Variant left-borders */
-[data-design="v1"] .msg.user       { border-left-color: var(--accent); }
-[data-design="v1"] .msg.assistant  { border-left-color: var(--hair-2); }
+[data-design="v1"] .msg.user {
+  border-left-color: var(--accent);
+}
+[data-design="v1"] .msg.assistant {
+  border-left-color: var(--hair-2);
+}
 [data-design="v1"] .msg.reasoning {
   border-left-style: dashed;
   border-left-color: var(--ink-4);
@@ -102,7 +106,9 @@
 }
 
 @keyframes ts-caret {
-  to { opacity: 0; }
+  to {
+    opacity: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -111,8 +117,12 @@
   }
 }
 
-[data-design="v1"] .msg-body > *:first-child { margin-top: 0; }
-[data-design="v1"] .msg-body > *:last-child  { margin-bottom: 0; }
+[data-design="v1"] .msg-body > *:first-child {
+  margin-top: 0;
+}
+[data-design="v1"] .msg-body > *:last-child {
+  margin-bottom: 0;
+}
 
 [data-design="v1"] .msg-body pre {
   margin: 6px 0;
@@ -166,22 +176,44 @@
   color: var(--ink);
 }
 
-[data-design="v1"] .msg-body h1 { font-size: 16px; }
-[data-design="v1"] .msg-body h2 { font-size: 14px; }
-[data-design="v1"] .msg-body h3 { font-size: 13px; }
+[data-design="v1"] .msg-body h1 {
+  font-size: 16px;
+}
+[data-design="v1"] .msg-body h2 {
+  font-size: 14px;
+}
+[data-design="v1"] .msg-body h3 {
+  font-size: 13px;
+}
 [data-design="v1"] .msg-body h4,
 [data-design="v1"] .msg-body h5,
-[data-design="v1"] .msg-body h6 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-3); }
+[data-design="v1"] .msg-body h6 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-3);
+}
+
+[data-design="v1"] .msg-body p {
+  margin: 6px 0;
+}
 
 [data-design="v1"] .msg-body ul,
 [data-design="v1"] .msg-body ol {
   margin: 4px 0 4px 20px;
   padding: 0;
 }
-[data-design="v1"] .msg-body li { margin: 2px 0; }
+[data-design="v1"] .msg-body li {
+  margin: 2px 0;
+}
 
-[data-design="v1"] .msg-body strong { color: var(--ink); font-weight: 600; }
-[data-design="v1"] .msg-body em     { font-style: italic; }
+[data-design="v1"] .msg-body strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+[data-design="v1"] .msg-body em {
+  font-style: italic;
+}
 
 [data-design="v1"] .msg-body blockquote {
   margin: 6px 0;
@@ -242,6 +274,12 @@
    shared_static/chat.css:146. Keyboard users are handled by
    :focus-within on .msg above. */
 @media (hover: none) and (pointer: coarse) {
-  [data-design="v1"] .msg-actions { opacity: 1; pointer-events: auto; }
-  [data-design="v1"] .msg-action-btn { padding: 4px 8px; font-size: 12px; }
+  [data-design="v1"] .msg-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  [data-design="v1"] .msg-action-btn {
+    padding: 4px 8px;
+    font-size: 12px;
+  }
 }

--- a/turnstone/shared_static/design/primitives/message.css
+++ b/turnstone/shared_static/design/primitives/message.css
@@ -142,6 +142,10 @@
   background: var(--panel);
   border: 1px solid var(--hair-2);
   border-radius: 3px;
+  /* Preserve internal whitespace + allow wrapping; see the matching
+     rule in chat.css for the rationale (the body's ``white-space:
+     normal`` would otherwise collapse spaces inside backtick spans). */
+  white-space: pre-wrap;
 }
 
 [data-design="v1"] .msg-body pre code {


### PR DESCRIPTION
## Summary

The assistant chat body was rendering 30-50px gaps between every section in markdown output. Two compounding causes:

1. **\`white-space: pre-wrap\` on \`.ts-msg-body\`**. The custom regex markdown converter (\`renderer.js\`) leaves \`\\n\` text nodes between block siblings — pre-wrap rendered every one as visible vertical space, stacking ~14-16px between every heading / paragraph / katex-display.
2. **No \`.ts-msg-body p\` margin override**. Paragraphs fell back to browser-default 1em top + 1em bottom (~28px stacked between any two paragraphs). Headings/lists/blockquotes already had tight 6-8px rules; paragraphs were the outlier.

Switched the body to \`white-space: normal\` and added \`.ts-msg-body p { margin: 6px 0 }\` matching the heading rhythm. Mirrored the paragraph rule on the design-v1 \`.msg-body\` selector so both legacy and v1 surfaces stay in sync.

## Tradeoffs

- \`<pre>\` blocks have \`white-space: pre\` built in → fenced code still preserves formatting.
- **Mid-stream partial fences** (before the closing \`\`\`\`\`\` arrives) will render as collapsed text for one frame and snap back when the next render tick wraps them in \`<pre>\`. Acceptable trade vs. the persistent gap regression.
- User-typed messages render through \`.msg-user-text\` (a separate DOM path), so this only affects assistant markdown output.

## Diff stat caveat

The +366/-91 stat for chat.css is mostly Prettier reformatting (single-line CSS rules expanded to multi-line) — the substantive change is ~5 lines (white-space + new \`p\` rule + comment).

## Test plan
- [x] \`prettier --check\` clean
- [ ] Smoke: open the test message from the screenshot (KaTeX + highlight.js + matrix notation) → sections should sit ~12-20px apart instead of 50px+
- [ ] Smoke: stream a long assistant response with mixed paragraphs / lists / fenced code → spacing reads as one document, fences still render with preserved indentation
- [ ] Smoke: user-typed multi-line message → newlines preserved (path unchanged)