### PR TITLE
fix(coord): render markdown on history reload

### DIFF
--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1585,7 +1585,28 @@
             content,
             false,
           );
+        } else if (role === "assistant" || role === "reasoning") {
+          // Run assistant + reasoning content through the markdown
+          // pipeline (renderMarkdown + post-render hljs / mermaid / KaTeX)
+          // so a reconnect / page-reload renders the same way a live
+          // stream does.  appendText would only escape and dump the raw
+          // text — markdown tables, code fences, math, and links would
+          // all render as literal characters.
+          const el = appendMsg(role, "", { label: role });
+          const body = el.querySelector(".msg-body");
+          if (body && typeof streamingRenderFinalize === "function") {
+            try {
+              streamingRenderFinalize(body, content);
+            } catch (e) {
+              console.warn("coordinator history render failed", e);
+              body.textContent = content;
+            }
+          } else if (body) {
+            body.textContent = content;
+          }
         } else {
+          // user / system / other roles render as plain text — they're
+          // typed verbatim and don't carry markdown structure.
           appendText(role, content, { label: role });
         }
       });

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1585,13 +1585,13 @@
             content,
             false,
           );
-        } else if (role === "assistant" || role === "reasoning") {
-          // Run assistant + reasoning content through the markdown
-          // pipeline (renderMarkdown + post-render hljs / mermaid / KaTeX)
-          // so a reconnect / page-reload renders the same way a live
-          // stream does.  appendText would only escape and dump the raw
-          // text — markdown tables, code fences, math, and links would
-          // all render as literal characters.
+        } else if (role === "assistant") {
+          // Run assistant content through the markdown pipeline
+          // (renderMarkdown + post-render hljs / mermaid / KaTeX) so a
+          // reconnect / page-reload renders the same way a live stream
+          // does.  appendText would only escape and dump the raw text —
+          // markdown tables, code fences, math, and links would all
+          // render as literal characters.
           const el = appendMsg(role, "", { label: role });
           const body = el.querySelector(".msg-body");
           if (body && typeof streamingRenderFinalize === "function") {
@@ -1605,8 +1605,10 @@
             body.textContent = content;
           }
         } else {
-          // user / system / other roles render as plain text — they're
-          // typed verbatim and don't carry markdown structure.
+          // user / reasoning / system / other roles render as plain
+          // text on history replay — matches the live-streaming paths
+          // (appendReasoningToken uses textContent; user/system are
+          // typed verbatim and don't carry markdown structure).
           appendText(role, content, { label: role });
         }
       });


### PR DESCRIPTION
## Summary

The coordinator chat's history-load path (\`init()\` in \`coordinator.js:1559\`) piped assistant message content through \`appendText\` → \`appendMsg(role, esc(text))\`. That escapes the raw text and dumps it into the message body's \`innerHTML\` without ever calling the markdown converter or the post-render hooks (highlight.js, mermaid, KaTeX).

Live streaming uses \`streamingRender\` / \`streamingRenderFinalize\` which DO render markdown, so a fresh stream rendered correctly. **Page reload / reconnect** (which fetches \`/v1/api/coordinator/{ws_id}/history\` and replays into the empty UI) surfaced every markdown table, code fence, and math block as literal characters.

The interactive \`ui/static\` chat already does this right (\`app.js:1235\` calls \`renderMarkdown\` + \`postRenderMarkdown\`); this brings the coordinator surface to parity.

## Fix

Dispatch by role on the history loop:
- **assistant + reasoning** → \`streamingRenderFinalize\` (mirrors what live streaming does on \`stream_end\`)
- **tool** → \`appendToolResult\` (already correct, special-cases JSON output)
- **user / system / other** → \`appendText\` (typed verbatim, no markdown structure)

## Test plan
- [x] JS parse OK, prettier clean
- [x] Smoke: open a coordinator with assistant messages containing a markdown table or code fence → table renders as table (not pipes-and-dashes), code fence highlights
- [x] Smoke: live-stream a new assistant turn → still renders correctly (path unchanged)
- [x] Smoke: tool messages with JSON content still render via \`renderToolOutput\` (linkified rows or \`<pre>\`)