### PR TITLE
feat(server): Stage 2 Priority 0 — unify session HTTP under /v1/api/workstreams/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ Three release tracks are maintained:
   `/v1/api/coordinator/`, so this change is a no-op for anyone
   upgrading from a stable line.
 
+  Two handler bodies (`approve`, `close`) lifted into the shared
+  registrar with kind branching behind `SessionEndpointConfig` —
+  both kinds share one implementation per verb. The `close`
+  failure-status code standardized to 404 across both kinds (was
+  500 on coord; "popped between .get() and .close()" is a not-
+  found semantic, not a server error). Other shared verbs (`send`,
+  `cancel`, `open`, `events`, `create`, `list`, `saved`, `history`,
+  `detail`) keep their per-kind handlers — body convergence for
+  those requires SessionManager-side refactors (e.g. Priority 1's
+  worker-dispatch unification for `send`) or coordinated frontend
+  changes (response-shape unification for `list` / `saved`) that
+  fall outside Priority 0 scope.
+
+- **TypeScript SDK bumped to 0.4.0** to flag the URL change for any
+  1.5.0aN-era consumer of the experimental coord client. The
+  `openapi-{server,console}.json` reference specs ship with the
+  unified path tree.
+
 ## [1.4.0]
 
 User-visible additions: a full attachment system (images + text documents,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,16 +40,26 @@ Three release tracks are maintained:
 
   Two handler bodies (`approve`, `close`) lifted into the shared
   registrar with kind branching behind `SessionEndpointConfig` —
-  both kinds share one implementation per verb. The `close`
-  failure-status code standardized to 404 across both kinds (was
-  500 on coord; "popped between .get() and .close()" is a not-
-  found semantic, not a server error). Other shared verbs (`send`,
-  `cancel`, `open`, `events`, `create`, `list`, `saved`, `history`,
-  `detail`) keep their per-kind handlers — body convergence for
-  those requires SessionManager-side refactors (e.g. Priority 1's
-  worker-dispatch unification for `send`) or coordinated frontend
-  changes (response-shape unification for `list` / `saved`) that
-  fall outside Priority 0 scope.
+  both kinds share one implementation per verb. Two related
+  behavior changes on the interactive close path:
+
+  - `mgr.close()` race-loss returns 404 (was 500 on coord;
+    "popped between .get() and .close()" is a not-found semantic,
+    not a server error).
+  - Audit-write failures (`record_audit` raising on the storage
+    write) are now caught and logged at `warning` level; the close
+    still returns 200. Previously the interactive path let the
+    exception propagate as HTTP 500. Coord previously already
+    swallowed; convergence is intentional — operators monitor the
+    `ws.close.audit_failed` log line in both kinds the same way.
+
+  Other shared verbs (`send`, `cancel`, `open`, `events`, `create`,
+  `list`, `saved`, `history`, `detail`) keep their per-kind
+  handlers — body convergence for those requires SessionManager-
+  side refactors (e.g. Priority 1's worker-dispatch unification
+  for `send`) or coordinated frontend changes (response-shape
+  unification for `list` / `saved`) that fall outside Priority 0
+  scope.
 
 - **TypeScript SDK bumped to 0.4.0** to flag the URL change for any
   1.5.0aN-era consumer of the experimental coord client. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ Three release tracks are maintained:
 
 ## [Unreleased]
 
+### Changed
+
+- **Coordinator HTTP surface unified under `/v1/api/workstreams/`**
+  ([Stage 2 Priority 0]). The experimental `/v1/api/coordinator/*`
+  URL tree from 1.5.0aN is removed; coord verbs now mount at the
+  same shape as interactive workstreams via a shared route
+  registrar (`turnstone.core.session_routes`). Path mapping:
+
+  | Was (1.5.0aN)                                    | Now                                              |
+  |--------------------------------------------------|--------------------------------------------------|
+  | `POST /v1/api/coordinator/new`                   | `POST /v1/api/workstreams/new`                   |
+  | `GET  /v1/api/coordinator`                       | `GET  /v1/api/workstreams`                       |
+  | `GET  /v1/api/coordinator/saved`                 | `GET  /v1/api/workstreams/saved`                 |
+  | `GET  /v1/api/coordinator/{ws_id}`               | `GET  /v1/api/workstreams/{ws_id}`               |
+  | `POST /v1/api/coordinator/{ws_id}/{verb}`        | `POST /v1/api/workstreams/{ws_id}/{verb}`        |
+
+  Permission scopes, request / response bodies, and SSE event shapes
+  are unchanged. Callers on the experimental 1.5.0aN coord SDK must
+  swap their URL prefix; the legacy paths are gone with no compat
+  shim. Stable releases (1.0 / 1.3 / 1.4) never exposed
+  `/v1/api/coordinator/`, so this change is a no-op for anyone
+  upgrading from a stable line.
+
 ## [1.4.0]
 
 User-visible additions: a full attachment system (images + text documents,

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -4497,10 +4497,10 @@
         }
       }
     },
-    "/v1/api/coordinator/new": {
+    "/v1/api/workstreams/new": {
       "post": {
         "summary": "Create a new coordinator workstream",
-        "operationId": "v1_api_coordinator_new_post",
+        "operationId": "v1_api_workstreams_new_post",
         "tags": [
           "Coordinator"
         ],
@@ -4589,10 +4589,10 @@
         }
       }
     },
-    "/v1/api/coordinator": {
+    "/v1/api/workstreams": {
       "get": {
         "summary": "List coordinator workstreams visible to the caller",
-        "operationId": "v1_api_coordinator_get",
+        "operationId": "v1_api_workstreams_get",
         "tags": [
           "Coordinator"
         ],
@@ -4631,10 +4631,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}": {
+    "/v1/api/workstreams/{ws_id}": {
       "get": {
         "summary": "Get coordinator detail (rehydrates lazily on miss)",
-        "operationId": "v1_api_coordinator_{ws_id}_get",
+        "operationId": "v1_api_workstreams_{ws_id}_get",
         "tags": [
           "Coordinator"
         ],
@@ -4713,10 +4713,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/open": {
+    "/v1/api/workstreams/{ws_id}/open": {
       "post": {
         "summary": "Open (rehydrate) a coordinator workstream by ws_id",
-        "operationId": "v1_api_coordinator_{ws_id}_open_post",
+        "operationId": "v1_api_workstreams_{ws_id}_open_post",
         "tags": [
           "Coordinator"
         ],
@@ -4795,10 +4795,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/send": {
+    "/v1/api/workstreams/{ws_id}/send": {
       "post": {
         "summary": "Queue a user message onto the coordinator session",
-        "operationId": "v1_api_coordinator_{ws_id}_send_post",
+        "operationId": "v1_api_workstreams_{ws_id}_send_post",
         "tags": [
           "Coordinator"
         ],
@@ -4897,10 +4897,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/approve": {
+    "/v1/api/workstreams/{ws_id}/approve": {
       "post": {
         "summary": "Resolve a pending tool approval on the coordinator session",
-        "operationId": "v1_api_coordinator_{ws_id}_approve_post",
+        "operationId": "v1_api_workstreams_{ws_id}_approve_post",
         "tags": [
           "Coordinator"
         ],
@@ -4989,10 +4989,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/cancel": {
+    "/v1/api/workstreams/{ws_id}/cancel": {
       "post": {
         "summary": "Cancel in-flight generation on the coordinator session",
-        "operationId": "v1_api_coordinator_{ws_id}_cancel_post",
+        "operationId": "v1_api_workstreams_{ws_id}_cancel_post",
         "tags": [
           "Coordinator"
         ],
@@ -5051,10 +5051,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/close": {
+    "/v1/api/workstreams/{ws_id}/close": {
       "post": {
         "summary": "Soft-close the coordinator (unload from memory; storage preserved)",
-        "operationId": "v1_api_coordinator_{ws_id}_close_post",
+        "operationId": "v1_api_workstreams_{ws_id}_close_post",
         "tags": [
           "Coordinator"
         ],
@@ -5123,10 +5123,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/events": {
+    "/v1/api/workstreams/{ws_id}/events": {
       "get": {
         "summary": "Subscribe to the coordinator's SSE event stream",
-        "operationId": "v1_api_coordinator_{ws_id}_events_get",
+        "operationId": "v1_api_workstreams_{ws_id}_events_get",
         "tags": [
           "Coordinator"
         ],
@@ -5188,10 +5188,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/history": {
+    "/v1/api/workstreams/{ws_id}/history": {
       "get": {
         "summary": "Read the coordinator's reconstructed message history",
-        "operationId": "v1_api_coordinator_{ws_id}_history_get",
+        "operationId": "v1_api_workstreams_{ws_id}_history_get",
         "tags": [
           "Coordinator"
         ],
@@ -5260,10 +5260,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/children": {
+    "/v1/api/workstreams/{ws_id}/children": {
       "get": {
         "summary": "List the coordinator's spawned child workstreams",
-        "operationId": "v1_api_coordinator_{ws_id}_children_get",
+        "operationId": "v1_api_workstreams_{ws_id}_children_get",
         "tags": [
           "Coordinator"
         ],
@@ -5342,10 +5342,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/tasks": {
+    "/v1/api/workstreams/{ws_id}/tasks": {
       "get": {
         "summary": "Read the coordinator's task list envelope",
-        "operationId": "v1_api_coordinator_{ws_id}_tasks_get",
+        "operationId": "v1_api_workstreams_{ws_id}_tasks_get",
         "tags": [
           "Coordinator"
         ],
@@ -5414,10 +5414,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/trust": {
+    "/v1/api/workstreams/{ws_id}/trust": {
       "post": {
         "summary": "Toggle trusted-session mode for send_to_workstream",
-        "operationId": "v1_api_coordinator_{ws_id}_trust_post",
+        "operationId": "v1_api_workstreams_{ws_id}_trust_post",
         "tags": [
           "Coordinator"
         ],
@@ -5496,10 +5496,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/restrict": {
+    "/v1/api/workstreams/{ws_id}/restrict": {
       "post": {
         "summary": "Revoke tool access on a live coordinator session",
-        "operationId": "v1_api_coordinator_{ws_id}_restrict_post",
+        "operationId": "v1_api_workstreams_{ws_id}_restrict_post",
         "tags": [
           "Coordinator"
         ],
@@ -5578,10 +5578,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/stop_cascade": {
+    "/v1/api/workstreams/{ws_id}/stop_cascade": {
       "post": {
         "summary": "Cancel the coordinator and every direct child",
-        "operationId": "v1_api_coordinator_{ws_id}_stop_cascade_post",
+        "operationId": "v1_api_workstreams_{ws_id}_stop_cascade_post",
         "tags": [
           "Coordinator"
         ],
@@ -5650,10 +5650,10 @@
         }
       }
     },
-    "/v1/api/coordinator/{ws_id}/close_all_children": {
+    "/v1/api/workstreams/{ws_id}/close_all_children": {
       "post": {
         "summary": "Soft-close every direct child of the coordinator",
-        "operationId": "v1_api_coordinator_{ws_id}_close_all_children_post",
+        "operationId": "v1_api_workstreams_{ws_id}_close_all_children_post",
         "tags": [
           "Coordinator"
         ],
@@ -6916,7 +6916,7 @@
         "type": "object"
       },
       "CoordinatorApproveRequest": {
-        "description": "Body for POST /v1/api/coordinator/{ws_id}/approve.",
+        "description": "Body for POST /v1/api/workstreams/{ws_id}/approve.",
         "properties": {
           "approved": {
             "description": "True approves the pending tool call(s); False denies.",
@@ -7072,7 +7072,7 @@
         "type": "object"
       },
       "CoordinatorChildrenResponse": {
-        "description": "Response body for GET /v1/api/coordinator/{ws_id}/children.",
+        "description": "Response body for GET /v1/api/workstreams/{ws_id}/children.",
         "properties": {
           "items": {
             "items": {
@@ -7092,7 +7092,7 @@
         "type": "object"
       },
       "CoordinatorCloseAllChildrenRequest": {
-        "description": "Body for POST /v1/api/coordinator/{ws_id}/close_all_children.",
+        "description": "Body for POST /v1/api/workstreams/{ws_id}/close_all_children.",
         "properties": {
           "reason": {
             "default": "",
@@ -7106,7 +7106,7 @@
         "type": "object"
       },
       "CoordinatorCloseAllChildrenResponse": {
-        "description": "Response body for POST /v1/api/coordinator/{ws_id}/close_all_children.",
+        "description": "Response body for POST /v1/api/workstreams/{ws_id}/close_all_children.",
         "properties": {
           "status": {
             "default": "ok",
@@ -7142,7 +7142,7 @@
         "type": "object"
       },
       "CoordinatorCreateRequest": {
-        "description": "Body for POST /v1/api/coordinator/new.",
+        "description": "Body for POST /v1/api/workstreams/new.",
         "properties": {
           "name": {
             "default": "",
@@ -7174,7 +7174,7 @@
         "type": "object"
       },
       "CoordinatorCreateResponse": {
-        "description": "Response body for POST /v1/api/coordinator/new (201).",
+        "description": "Response body for POST /v1/api/workstreams/new (201).",
         "properties": {
           "ws_id": {
             "title": "Ws Id",
@@ -7193,7 +7193,7 @@
         "type": "object"
       },
       "CoordinatorDetailResponse": {
-        "description": "Response body for GET /v1/api/coordinator/{ws_id}.",
+        "description": "Response body for GET /v1/api/workstreams/{ws_id}.",
         "properties": {
           "ws_id": {
             "title": "Ws Id",
@@ -7227,7 +7227,7 @@
         "type": "object"
       },
       "CoordinatorHistoryResponse": {
-        "description": "Response body for GET /v1/api/coordinator/{ws_id}/history.",
+        "description": "Response body for GET /v1/api/workstreams/{ws_id}/history.",
         "properties": {
           "ws_id": {
             "title": "Ws Id",
@@ -7279,7 +7279,7 @@
         "type": "object"
       },
       "CoordinatorListResponse": {
-        "description": "Response body for GET /v1/api/coordinator.",
+        "description": "Response body for GET /v1/api/workstreams.",
         "properties": {
           "coordinators": {
             "items": {
@@ -7293,7 +7293,7 @@
         "type": "object"
       },
       "CoordinatorOpenResponse": {
-        "description": "Response body for POST /v1/api/coordinator/{ws_id}/open.",
+        "description": "Response body for POST /v1/api/workstreams/{ws_id}/open.",
         "properties": {
           "ws_id": {
             "title": "Ws Id",
@@ -7325,7 +7325,7 @@
         "type": "object"
       },
       "CoordinatorRestrictRequest": {
-        "description": "Body for POST /v1/api/coordinator/{ws_id}/restrict.",
+        "description": "Body for POST /v1/api/workstreams/{ws_id}/restrict.",
         "properties": {
           "revoke": {
             "description": "Tool names to add to the session's revoked set.  Once revoked the coordinator cannot invoke the named tools on subsequent turns without closing and re-opening the session.",
@@ -7343,7 +7343,7 @@
         "type": "object"
       },
       "CoordinatorRestrictResponse": {
-        "description": "Response body for POST /v1/api/coordinator/{ws_id}/restrict.",
+        "description": "Response body for POST /v1/api/workstreams/{ws_id}/restrict.",
         "properties": {
           "status": {
             "default": "ok",
@@ -7366,7 +7366,7 @@
         "type": "object"
       },
       "CoordinatorSendRequest": {
-        "description": "Body for POST /v1/api/coordinator/{ws_id}/send.",
+        "description": "Body for POST /v1/api/workstreams/{ws_id}/send.",
         "properties": {
           "message": {
             "description": "User message to queue onto the coordinator's worker.",
@@ -7381,7 +7381,7 @@
         "type": "object"
       },
       "CoordinatorStopCascadeResponse": {
-        "description": "Response body for POST /v1/api/coordinator/{ws_id}/stop_cascade.",
+        "description": "Response body for POST /v1/api/workstreams/{ws_id}/stop_cascade.",
         "properties": {
           "status": {
             "default": "ok",
@@ -7457,7 +7457,7 @@
         "type": "object"
       },
       "CoordinatorTasksResponse": {
-        "description": "Response body for GET /v1/api/coordinator/{ws_id}/tasks.\n\nMirrors the envelope the ``task_list(action='list')`` model tool returns.",
+        "description": "Response body for GET /v1/api/workstreams/{ws_id}/tasks.\n\nMirrors the envelope the ``task_list(action='list')`` model tool returns.",
         "properties": {
           "version": {
             "default": 1,
@@ -7476,7 +7476,7 @@
         "type": "object"
       },
       "CoordinatorTrustRequest": {
-        "description": "Body for POST /v1/api/coordinator/{ws_id}/trust.",
+        "description": "Body for POST /v1/api/workstreams/{ws_id}/trust.",
         "properties": {
           "send": {
             "description": "When true, ``send_to_workstream`` calls that target a ws_id in the coordinator's own subtree skip the approval prompt.  Foreign ws_ids continue to require approval \u2014 trust only relaxes the guard for work the orchestrator itself spawned.",
@@ -7491,7 +7491,7 @@
         "type": "object"
       },
       "CoordinatorTrustResponse": {
-        "description": "Response body for POST /v1/api/coordinator/{ws_id}/trust.",
+        "description": "Response body for POST /v1/api/workstreams/{ws_id}/trust.",
         "properties": {
           "status": {
             "default": "ok",

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -1931,7 +1931,7 @@
           "kind": {
             "$ref": "#/components/schemas/WorkstreamKind",
             "default": "interactive",
-            "description": "Workstream kind \u2014 'interactive' (default) or 'coordinator'. Coordinator workstreams are created by the console's own /v1/api/coordinator/new endpoint; clients hitting /v1/api/workstreams/new should leave this at the default."
+            "description": "Workstream kind \u2014 'interactive' (default) or 'coordinator'. Coordinator workstreams are created by the console's own /v1/api/workstreams/new endpoint; clients hitting /v1/api/workstreams/new should leave this at the default."
           },
           "parent_ws_id": {
             "anyOf": [

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnstone/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript client SDK for the turnstone AI orchestration platform",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/_coord_test_helpers.py
+++ b/tests/_coord_test_helpers.py
@@ -114,7 +114,5 @@ class MockStorage:
     def __init__(self) -> None:
         self.services: list[dict[str, str]] = []
 
-    def list_services(
-        self, service_type: str, max_age_seconds: int = 120
-    ) -> list[dict[str, str]]:
+    def list_services(self, service_type: str, max_age_seconds: int = 120) -> list[dict[str, str]]:
         return list(self.services)

--- a/tests/_coord_test_helpers.py
+++ b/tests/_coord_test_helpers.py
@@ -100,3 +100,21 @@ def _build_mgr(storage: Any) -> SessionManager:
     )
     adapter.attach(mgr)
     return mgr
+
+
+class MockStorage:
+    """Minimal storage mock that implements ``list_services``.
+
+    Used by the collector tests + the console route-walk tests. The
+    collector calls ``list_services("turnstone-server", ...)`` to
+    discover nodes; tests that don't care about discovery push an
+    empty list (the default).
+    """
+
+    def __init__(self) -> None:
+        self.services: list[dict[str, str]] = []
+
+    def list_services(
+        self, service_type: str, max_age_seconds: int = 120
+    ) -> list[dict[str, str]]:
+        return list(self.services)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -31,16 +31,7 @@ _TEST_AUTH_HEADERS = {"Authorization": f"Bearer {_test_jwt()}"}
 # Mock storage for collector tests
 # ---------------------------------------------------------------------------
 
-
-class MockStorage:
-    """Minimal storage mock that implements list_services for collector tests."""
-
-    def __init__(self):
-        self.services: list[dict[str, str]] = []
-
-    def list_services(self, service_type: str, max_age_seconds: int = 120) -> list[dict[str, str]]:
-        return list(self.services)
-
+from tests._coord_test_helpers import MockStorage  # noqa: E402, F401
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -178,7 +178,7 @@ def test_route_map_matches_console_routes():
     assert _ROUTE_PATHS["delete"] == "/v1/api/route/workstreams/delete"
     # Cascade endpoint lives on the console itself (not a node), so the
     # path slots in the coord ws_id rather than routing through a proxy.
-    assert _ROUTE_PATHS["close_all_children"] == "/v1/api/coordinator/{ws_id}/close_all_children"
+    assert _ROUTE_PATHS["close_all_children"] == "/v1/api/workstreams/{ws_id}/close_all_children"
 
 
 def test_spawn_posts_to_routing_proxy_with_bearer_token():
@@ -256,7 +256,7 @@ def test_close_all_children_posts_to_console_endpoint():
     )
     result = client.close_all_children(reason="batch done")
     assert result["closed"] == ["c-1", "c-2"]
-    assert captured[0].url.path == "/v1/api/coordinator/coord-1/close_all_children"
+    assert captured[0].url.path == "/v1/api/workstreams/coord-1/close_all_children"
     assert captured[0].headers["Authorization"] == "Bearer test-token"
     body = json.loads(captured[0].content)
     assert body == {"reason": "batch done"}

--- a/tests/test_coordinator_close_all_children.py
+++ b/tests/test_coordinator_close_all_children.py
@@ -39,7 +39,7 @@ def _make_client(storage, *, coord_mgr, alias="my-model", registry=None) -> Test
     app = Starlette(
         routes=[
             Route(
-                "/v1/api/coordinator/{ws_id}/close_all_children",
+                "/v1/api/workstreams/{ws_id}/close_all_children",
                 coordinator_close_all_children,
                 methods=["POST"],
             ),
@@ -73,7 +73,7 @@ def test_close_all_children_closes_each_child_and_audits(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={"reason": "tests done"},
         headers=_COORD_HEADERS,
     )
@@ -122,7 +122,7 @@ def test_close_all_children_routes_404_to_skipped_bucket(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -141,7 +141,7 @@ def test_close_all_children_empty_children_still_audits(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -162,7 +162,7 @@ def test_close_all_children_without_coord_client_marks_all_failed(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -181,7 +181,7 @@ def test_close_all_children_rejects_non_string_reason(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={"reason": 123},
         headers=_COORD_HEADERS,
     )
@@ -196,7 +196,7 @@ def test_close_all_children_rejects_overlong_reason(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={"reason": "x" * 600},
         headers=_COORD_HEADERS,
     )
@@ -209,7 +209,7 @@ def test_close_all_children_404_when_session_not_loaded(storage):
     coord.session = None
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -229,7 +229,7 @@ def test_close_all_children_service_token_cannot_bypass_admin_coordinator(storag
     headers = {"X-Test-User": "user-1", "X-Test-Perms": ""}
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/close_all_children",
+        f"/v1/api/workstreams/{coord.id}/close_all_children",
         json={},
         headers=headers,
     )

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -6,7 +6,7 @@ real in-process components:
 1. Create + list + detail round-trip via the Starlette TestClient.
 2. CoordinatorClient against a MockTransport "server node" stub.
 3. list_children storage read flow (kind filtering, parent scoping).
-4. Lazy rehydration via GET /v1/api/coordinator/{ws_id}.
+4. Lazy rehydration via GET /v1/api/workstreams/{ws_id}.
 
 Intentionally no real LLM infrastructure — session factories return
 MagicMock-backed stubs.  All four tests run in < 2 s total.
@@ -118,18 +118,18 @@ def _make_client(
     app = Starlette(
         routes=[
             Route(
-                "/v1/api/coordinator/new",
+                "/v1/api/workstreams/new",
                 coordinator_create,
                 methods=["POST"],
             ),
-            Route("/v1/api/coordinator", coordinator_list, methods=["GET"]),
+            Route("/v1/api/workstreams", coordinator_list, methods=["GET"]),
             Route(
-                "/v1/api/coordinator/{ws_id}/close",
+                "/v1/api/workstreams/{ws_id}/close",
                 coordinator_close,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}",
+                "/v1/api/workstreams/{ws_id}",
                 coordinator_detail,
                 methods=["GET"],
             ),
@@ -161,7 +161,7 @@ def test_create_list_detail_lifecycle(tmp_path):
 
     # --- Create ---
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={"name": "e2e-coord"},
         headers=_COORD_HEADERS,
     )
@@ -172,7 +172,7 @@ def test_create_list_detail_lifecycle(tmp_path):
     assert "e2e-coord" in body["name"]
 
     # --- List: caller sees their own coordinator ---
-    resp = client.get("/v1/api/coordinator", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams", headers=_COORD_HEADERS)
     assert resp.status_code == 200, resp.text
     coordinators = resp.json()["coordinators"]
     ids = {c["ws_id"] for c in coordinators}
@@ -181,13 +181,13 @@ def test_create_list_detail_lifecycle(tmp_path):
     # Trusted-team visibility: every ``admin.coordinator`` caller sees
     # every active coordinator regardless of owner.
     mgr.create(user_id="other-user", name="not-mine")
-    resp = client.get("/v1/api/coordinator", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     names = {c["name"] for c in resp.json()["coordinators"]}
     assert "not-mine" in names
 
     # --- Detail ---
-    resp = client.get(f"/v1/api/coordinator/{ws_id}", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws_id}", headers=_COORD_HEADERS)
     assert resp.status_code == 200, resp.text
     detail = resp.json()
     assert detail["ws_id"] == ws_id
@@ -195,7 +195,7 @@ def test_create_list_detail_lifecycle(tmp_path):
     assert detail["user_id"] == "user-1"
 
     # --- Close ---
-    resp = client.post(f"/v1/api/coordinator/{ws_id}/close", headers=_COORD_HEADERS)
+    resp = client.post(f"/v1/api/workstreams/{ws_id}/close", headers=_COORD_HEADERS)
     assert resp.status_code == 200
 
     # Manager no longer tracks it after close.
@@ -391,7 +391,7 @@ def test_list_children_skill_filter(seeded_storage):
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — Lazy rehydration via GET /v1/api/coordinator/{ws_id}
+# Test 4 — Lazy rehydration via GET /v1/api/workstreams/{ws_id}
 # ---------------------------------------------------------------------------
 
 
@@ -401,7 +401,7 @@ def test_lazy_rehydration_on_detail_get(tmp_path):
     Sequence:
     1. Pre-seed storage with a coordinator row (simulating a previous process).
     2. Build a SessionManager (coordinator kind) that doesn't know about it yet.
-    3. Hit GET /v1/api/coordinator/{ws_id} — expect 200.
+    3. Hit GET /v1/api/workstreams/{ws_id} — expect 200.
     4. Manager now tracks the rehydrated session.
     5. The response body carries the correct kind / user_id metadata.
     """
@@ -421,7 +421,7 @@ def test_lazy_rehydration_on_detail_get(tmp_path):
     assert mgr.get("persisted-coord") is None
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/persisted-coord", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/persisted-coord", headers=_COORD_HEADERS)
     assert resp.status_code == 200, resp.text
 
     body = resp.json()
@@ -435,7 +435,7 @@ def test_lazy_rehydration_on_detail_get(tmp_path):
     # Trusted-team visibility: any admin.coordinator caller can read
     # the coordinator's detail, regardless of ``user_id``.
     resp_stranger = client.get(
-        "/v1/api/coordinator/persisted-coord",
+        "/v1/api/workstreams/persisted-coord",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp_stranger.status_code == 200
@@ -444,5 +444,5 @@ def test_lazy_rehydration_on_detail_get(tmp_path):
     # A workstream with kind='interactive' is not reachable via the coordinator
     # endpoint even when it exists in storage.
     storage.register_workstream("interactive-ws", kind="interactive", user_id="user-1")
-    resp_int = client.get("/v1/api/coordinator/interactive-ws", headers=_COORD_HEADERS)
+    resp_int = client.get("/v1/api/workstreams/interactive-ws", headers=_COORD_HEADERS)
     assert resp_int.status_code == 404

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -15,7 +15,7 @@ MagicMock-backed stubs.  All four tests run in < 2 s total.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import httpx
@@ -31,14 +31,43 @@ from turnstone.console.coordinator_adapter import CoordinatorAdapter
 from turnstone.console.coordinator_client import CoordinatorClient
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
-    coordinator_close,
+    _auth_user_id,
+    _require_admin_coordinator,
+    _require_coord_mgr,
     coordinator_create,
     coordinator_detail,
     coordinator_list,
 )
+from turnstone.core.audit import record_audit
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_manager import SessionManager
+from turnstone.core.session_routes import (
+    SessionEndpointConfig,
+    make_close_handler,
+)
 from turnstone.core.storage._sqlite import SQLiteBackend
+
+if TYPE_CHECKING:
+    from turnstone.core.workstream import Workstream
+
+
+def _audit_close_coordinator_e2e(
+    request,
+    ws_id: str,
+    ws_before: Workstream,  # noqa: ARG001
+    reason: str,  # noqa: ARG001
+) -> None:
+    storage = request.app.state.auth_storage
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "coordinator.close",
+        "workstream",
+        ws_id,
+        {"coord_ws_id": ws_id, "src": "coordinator"},
+        request.client.host if request.client else "",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Shared auth-injection middleware (mirrors test_coordinator_endpoints.py)
@@ -125,7 +154,10 @@ def _make_client(
             Route("/v1/api/workstreams", coordinator_list, methods=["GET"]),
             Route(
                 "/v1/api/workstreams/{ws_id}/close",
-                coordinator_close,
+                make_close_handler(
+                    audit_emit=_audit_close_coordinator_e2e,
+                    supports_close_reason=False,
+                ),
                 methods=["POST"],
             ),
             Route(
@@ -143,6 +175,13 @@ def _make_client(
     app.state.coord_registry_error = "" if coord_mgr else "registry missing"
     app.state.auth_storage = storage
     app.state.jwt_secret = "x" * 64
+    app.state.session_endpoint_config = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=_require_coord_mgr,
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
     return TestClient(app)
 
 

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -15,7 +15,7 @@ MagicMock-backed stubs.  All four tests run in < 2 s total.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
@@ -31,14 +31,13 @@ from turnstone.console.coordinator_adapter import CoordinatorAdapter
 from turnstone.console.coordinator_client import CoordinatorClient
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
-    _auth_user_id,
+    _audit_close_coordinator,
     _require_admin_coordinator,
     _require_coord_mgr,
     coordinator_create,
     coordinator_detail,
     coordinator_list,
 )
-from turnstone.core.audit import record_audit
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_manager import SessionManager
 from turnstone.core.session_routes import (
@@ -47,26 +46,14 @@ from turnstone.core.session_routes import (
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
 
-if TYPE_CHECKING:
-    from turnstone.core.workstream import Workstream
-
-
-def _audit_close_coordinator_e2e(
-    request,
-    ws_id: str,
-    ws_before: Workstream,  # noqa: ARG001
-    reason: str,  # noqa: ARG001
-) -> None:
-    storage = request.app.state.auth_storage
-    record_audit(
-        storage,
-        _auth_user_id(request),
-        "coordinator.close",
-        "workstream",
-        ws_id,
-        {"coord_ws_id": ws_id, "src": "coordinator"},
-        request.client.host if request.client else "",
-    )
+# Per-kind config the lifted handler factories capture by closure.
+_coord_endpoint_config = SessionEndpointConfig(
+    permission_gate=_require_admin_coordinator,
+    manager_lookup=_require_coord_mgr,
+    tenant_check=None,
+    not_found_label="coordinator not found",
+    audit_action_prefix="coordinator",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +142,8 @@ def _make_client(
             Route(
                 "/v1/api/workstreams/{ws_id}/close",
                 make_close_handler(
-                    audit_emit=_audit_close_coordinator_e2e,
+                    _coord_endpoint_config,
+                    audit_emit=_audit_close_coordinator,
                     supports_close_reason=False,
                 ),
                 methods=["POST"],
@@ -175,13 +163,6 @@ def _make_client(
     app.state.coord_registry_error = "" if coord_mgr else "registry missing"
     app.state.auth_storage = storage
     app.state.jwt_secret = "x" * 64
-    app.state.session_endpoint_config = SessionEndpointConfig(
-        permission_gate=_require_admin_coordinator,
-        manager_lookup=_require_coord_mgr,
-        tenant_check=None,
-        not_found_label="coordinator not found",
-        audit_action_prefix="coordinator",
-    )
     return TestClient(app)
 
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -28,8 +28,9 @@ from tests._coord_test_helpers import (
 )
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
+    _require_admin_coordinator,
+    _require_coord_mgr,
     cluster_ws_detail,
-    coordinator_approve,
     coordinator_cancel,
     coordinator_children,
     coordinator_close,
@@ -43,6 +44,7 @@ from turnstone.console.server import (
     coordinator_tasks,
 )
 from turnstone.core.auth import AuthResult
+from turnstone.core.session_routes import SessionEndpointConfig, make_approve_handler
 from turnstone.core.storage._sqlite import SQLiteBackend
 
 # ---------------------------------------------------------------------------
@@ -85,7 +87,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/approve",
-                coordinator_approve,
+                make_approve_handler(),
                 methods=["POST"],
             ),
             Route(
@@ -138,6 +140,14 @@ def _make_client(
     app.state.coord_registry_error = "" if coord_mgr else "registry missing"
     app.state.auth_storage = storage
     app.state.jwt_secret = "x" * 64
+    # Wire the per-kind endpoint config the lifted handlers consult.
+    app.state.session_endpoint_config = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=_require_coord_mgr,
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
     return TestClient(app)
 
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -8,6 +8,7 @@ enforcement, and lazy rehydration on GET /{ws_id}.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import httpx
@@ -28,12 +29,12 @@ from tests._coord_test_helpers import (
 )
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
+    _auth_user_id,
     _require_admin_coordinator,
     _require_coord_mgr,
     cluster_ws_detail,
     coordinator_cancel,
     coordinator_children,
-    coordinator_close,
     coordinator_create,
     coordinator_detail,
     coordinator_history,
@@ -43,9 +44,36 @@ from turnstone.console.server import (
     coordinator_send,
     coordinator_tasks,
 )
+from turnstone.core.audit import record_audit
 from turnstone.core.auth import AuthResult
-from turnstone.core.session_routes import SessionEndpointConfig, make_approve_handler
+from turnstone.core.session_routes import (
+    SessionEndpointConfig,
+    make_approve_handler,
+    make_close_handler,
+)
 from turnstone.core.storage._sqlite import SQLiteBackend
+
+if TYPE_CHECKING:
+    from turnstone.core.workstream import Workstream
+
+
+def _audit_close_coordinator_for_test(
+    request,
+    ws_id: str,
+    ws_before: Workstream,  # noqa: ARG001
+    reason: str,  # noqa: ARG001
+) -> None:
+    storage = request.app.state.auth_storage
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "coordinator.close",
+        "workstream",
+        ws_id,
+        {"coord_ws_id": ws_id, "src": "coordinator"},
+        request.client.host if request.client else "",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -97,7 +125,10 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/close",
-                coordinator_close,
+                make_close_handler(
+                    audit_emit=_audit_close_coordinator_for_test,
+                    supports_close_reason=False,
+                ),
                 methods=["POST"],
             ),
             Route(

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -3,12 +3,14 @@
 Builds a minimal Starlette app wiring only the coordinator routes and
 an auth-injector middleware.  Verifies the permission gate, 503
 remediation when coord_mgr / model alias is missing, ownership
-enforcement, and lazy rehydration on GET /{ws_id}.
+enforcement, and lazy rehydration on GET /{ws_id}. Also exercises
+the lifted ``approve`` and ``close`` handlers from
+``turnstone.core.session_routes`` wired through the coord
+``SessionEndpointConfig`` — same code path the live console uses.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import httpx
@@ -29,7 +31,7 @@ from tests._coord_test_helpers import (
 )
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
-    _auth_user_id,
+    _audit_close_coordinator,
     _require_admin_coordinator,
     _require_coord_mgr,
     cluster_ws_detail,
@@ -44,7 +46,6 @@ from turnstone.console.server import (
     coordinator_send,
     coordinator_tasks,
 )
-from turnstone.core.audit import record_audit
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_routes import (
     SessionEndpointConfig,
@@ -53,31 +54,21 @@ from turnstone.core.session_routes import (
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
 
-if TYPE_CHECKING:
-    from turnstone.core.workstream import Workstream
-
-
-def _audit_close_coordinator_for_test(
-    request,
-    ws_id: str,
-    ws_before: Workstream,  # noqa: ARG001
-    reason: str,  # noqa: ARG001
-) -> None:
-    storage = request.app.state.auth_storage
-    record_audit(
-        storage,
-        _auth_user_id(request),
-        "coordinator.close",
-        "workstream",
-        ws_id,
-        {"coord_ws_id": ws_id, "src": "coordinator"},
-        request.client.host if request.client else "",
-    )
-
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+# Per-kind config the lifted handler factories capture by closure.
+# Mirrors the production console wiring so tests exercise the same
+# code path as the live server.
+_coord_endpoint_config = SessionEndpointConfig(
+    permission_gate=_require_admin_coordinator,
+    manager_lookup=_require_coord_mgr,
+    tenant_check=None,
+    not_found_label="coordinator not found",
+    audit_action_prefix="coordinator",
+)
 
 
 @pytest.fixture
@@ -115,7 +106,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/approve",
-                make_approve_handler(),
+                make_approve_handler(_coord_endpoint_config),
                 methods=["POST"],
             ),
             Route(
@@ -126,7 +117,8 @@ def _make_client(
             Route(
                 "/v1/api/workstreams/{ws_id}/close",
                 make_close_handler(
-                    audit_emit=_audit_close_coordinator_for_test,
+                    _coord_endpoint_config,
+                    audit_emit=_audit_close_coordinator,
                     supports_close_reason=False,
                 ),
                 methods=["POST"],
@@ -171,14 +163,6 @@ def _make_client(
     app.state.coord_registry_error = "" if coord_mgr else "registry missing"
     app.state.auth_storage = storage
     app.state.jwt_secret = "x" * 64
-    # Wire the per-kind endpoint config the lifted handlers consult.
-    app.state.session_endpoint_config = SessionEndpointConfig(
-        permission_gate=_require_admin_coordinator,
-        manager_lookup=_require_coord_mgr,
-        tenant_check=None,
-        not_found_label="coordinator not found",
-        audit_action_prefix="coordinator",
-    )
     return TestClient(app)
 
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -66,60 +66,60 @@ def _make_client(
     app = Starlette(
         routes=[
             Route(
-                "/v1/api/coordinator/new",
+                "/v1/api/workstreams/new",
                 coordinator_create,
                 methods=["POST"],
             ),
-            Route("/v1/api/coordinator", coordinator_list, methods=["GET"]),
+            Route("/v1/api/workstreams", coordinator_list, methods=["GET"]),
             # Literal path before the /{ws_id} routes below so Starlette
             # matches "saved" as the literal, not as a ws_id.
             Route(
-                "/v1/api/coordinator/saved",
+                "/v1/api/workstreams/saved",
                 coordinator_saved,
                 methods=["GET"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/send",
+                "/v1/api/workstreams/{ws_id}/send",
                 coordinator_send,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/approve",
+                "/v1/api/workstreams/{ws_id}/approve",
                 coordinator_approve,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/cancel",
+                "/v1/api/workstreams/{ws_id}/cancel",
                 coordinator_cancel,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/close",
+                "/v1/api/workstreams/{ws_id}/close",
                 coordinator_close,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/history",
+                "/v1/api/workstreams/{ws_id}/history",
                 coordinator_history,
                 methods=["GET"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/open",
+                "/v1/api/workstreams/{ws_id}/open",
                 coordinator_open,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/children",
+                "/v1/api/workstreams/{ws_id}/children",
                 coordinator_children,
                 methods=["GET"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/tasks",
+                "/v1/api/workstreams/{ws_id}/tasks",
                 coordinator_tasks,
                 methods=["GET"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}",
+                "/v1/api/workstreams/{ws_id}",
                 coordinator_detail,
                 methods=["GET"],
             ),
@@ -150,7 +150,7 @@ def test_missing_permission_returns_403(storage):
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={"name": "c1"},
         headers={"X-Test-User": "user-1", "X-Test-Perms": "read"},
     )
@@ -161,7 +161,7 @@ def test_no_auth_returns_401(storage):
     """No AuthResult in request.state → 401 (require_permission semantics)."""
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post("/v1/api/coordinator/new", json={"name": "c1"})
+    resp = client.post("/v1/api/workstreams/new", json={"name": "c1"})
     assert resp.status_code == 401
 
 
@@ -173,7 +173,7 @@ def test_no_auth_returns_401(storage):
 def test_missing_coord_mgr_returns_503(storage):
     client = _make_client(storage, coord_mgr=None)
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={"name": "c1"},
         headers={"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"},
     )
@@ -189,7 +189,7 @@ def test_missing_model_alias_falls_back_to_registry_default(storage):
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr, alias="", registry=_fake_registry())
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={},
         headers={"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"},
     )
@@ -209,7 +209,7 @@ def test_missing_alias_and_no_default_returns_503(storage):
     broken_registry.resolve.side_effect = KeyError("no-default")
     client = _make_client(storage, coord_mgr=mgr, alias="", registry=broken_registry)
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={},
         headers={"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"},
     )
@@ -223,7 +223,7 @@ def test_unresolvable_alias_returns_503(storage):
     broken_registry.resolve.side_effect = KeyError("no-such-alias")
     client = _make_client(storage, coord_mgr=mgr, alias="my-alias", registry=broken_registry)
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={},
         headers={"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"},
     )
@@ -243,7 +243,7 @@ def test_create_returns_ws_id_and_records_audit(storage):
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         json={"name": "my-coord"},
         headers=_COORD_HEADERS,
     )
@@ -268,7 +268,7 @@ def test_list_returns_cluster_wide(storage):
     mgr.create(user_id="user-1", name="mine")
     mgr.create(user_id="user-2", name="theirs")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     names = {c["name"] for c in body["coordinators"]}
@@ -324,7 +324,7 @@ def test_saved_returns_cluster_wide(saved_storage):
     a = _seed_closed_coord_with_history(mgr, storage, user_id="user-1", name="a")
     b = _seed_closed_coord_with_history(mgr, storage, user_id="user-2", name="b")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/saved", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert {c["ws_id"] for c in resp.json()["coordinators"]} == {a, b}
 
@@ -346,7 +346,7 @@ def test_saved_excludes_currently_loaded(saved_storage):
     # exercise the defence-in-depth ``loaded`` filter.
     storage.update_workstream_state(loaded_ws.id, "closed")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/saved", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     saved_ids = {c["ws_id"] for c in resp.json()["coordinators"]}
     assert closed_id in saved_ids
@@ -373,7 +373,7 @@ def test_saved_excludes_active_state_rows(saved_storage):
         mgr._order.remove(orphan.id)
     assert storage.get_workstream(orphan.id)["state"] == "idle"
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/saved", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/saved", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     saved_ids = {c["ws_id"] for c in resp.json()["coordinators"]}
     assert saved_ids == {closed_id}
@@ -387,7 +387,7 @@ def test_send_any_admin_coordinator_caller_can_send(storage):
     ws = mgr.create(user_id="owner", name="theirs")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{ws.id}/send",
+        f"/v1/api/workstreams/{ws.id}/send",
         json={"message": "hi"},
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
@@ -399,7 +399,7 @@ def test_send_requires_message(storage):
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{ws.id}/send",
+        f"/v1/api/workstreams/{ws.id}/send",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -410,7 +410,7 @@ def test_close_records_audit_and_removes_from_mgr(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(f"/v1/api/coordinator/{ws.id}/close", headers=_COORD_HEADERS)
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/close", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert mgr.get(ws.id) is None
     events = storage.list_audit_events(user_id="user-1", limit=10)
@@ -436,7 +436,7 @@ def test_approve_resolves_ui_event(storage):
     ws.ui._approval_event.clear()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{ws.id}/approve",
+        f"/v1/api/workstreams/{ws.id}/approve",
         json={"approved": True, "always": True, "call_id": "c-1"},
         headers=_COORD_HEADERS,
     )
@@ -452,7 +452,7 @@ def test_approve_resolves_ui_event(storage):
 
 
 def test_detail_triggers_lazy_rehydration(storage):
-    """GET /v1/api/coordinator/{ws_id} finds the row and rehydrates it."""
+    """GET /v1/api/workstreams/{ws_id} finds the row and rehydrates it."""
     mgr = _build_mgr(storage)
     # Simulate a coordinator persisted by a previous console process.
     storage.register_workstream(
@@ -463,7 +463,7 @@ def test_detail_triggers_lazy_rehydration(storage):
     )
     assert mgr.get("persisted-coord") is None
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/persisted-coord", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/persisted-coord", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     # Now tracked in the manager.
     assert mgr.get("persisted-coord") is not None
@@ -477,7 +477,7 @@ def test_detail_any_admin_coordinator_caller_can_open(storage):
     storage.register_workstream("coord-x", kind="coordinator", user_id="owner")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.get(
-        "/v1/api/coordinator/coord-x",
+        "/v1/api/workstreams/coord-x",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp.status_code == 200
@@ -489,7 +489,7 @@ def test_detail_404_when_kind_interactive(storage):
     mgr = _build_mgr(storage)
     storage.register_workstream("ws-int", kind="interactive", user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/ws-int", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/ws-int", headers=_COORD_HEADERS)
     assert resp.status_code == 404
 
 
@@ -504,7 +504,7 @@ def test_history_returns_messages(storage):
     # Seed a message in storage.
     storage.save_message(ws.id, "user", "hello")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/history", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/history", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     assert body["ws_id"] == ws.id
@@ -519,7 +519,7 @@ def test_history_any_admin_coordinator_caller_can_read(storage):
     storage.save_message(ws.id, "user", "hello")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/history",
+        f"/v1/api/workstreams/{ws.id}/history",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp.status_code == 200
@@ -538,7 +538,7 @@ def test_cancel_resolves_pending_approval(storage):
     ws.ui._pending_approval = {"type": "approve_request", "items": []}
     ws.ui._approval_event.clear()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(f"/v1/api/coordinator/{ws.id}/cancel", headers=_COORD_HEADERS)
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert ws.ui._approval_event.is_set()
 
@@ -552,7 +552,7 @@ def test_open_returns_already_loaded_when_in_memory(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1", name="live")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(f"/v1/api/coordinator/{ws.id}/open", headers=_COORD_HEADERS)
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/open", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     assert body["ws_id"] == ws.id
@@ -566,7 +566,7 @@ def test_open_any_admin_coordinator_caller_succeeds_in_memory(storage):
     ws = mgr.create(user_id="owner", name="theirs")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{ws.id}/open",
+        f"/v1/api/workstreams/{ws.id}/open",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp.status_code == 200
@@ -581,7 +581,7 @@ def test_open_rehydrates_when_not_in_memory(storage, monkeypatch):
     rehydrated.user_id = "user-1"
     monkeypatch.setattr(mgr, "open", MagicMock(return_value=rehydrated))
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post("/v1/api/coordinator/coord-rehy/open", headers=_COORD_HEADERS)
+    resp = client.post("/v1/api/workstreams/coord-rehy/open", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     assert body["ws_id"] == "coord-rehy"
@@ -596,13 +596,13 @@ def test_open_returns_404_when_unknown_ws_id(storage, monkeypatch):
     mgr = _build_mgr(storage)
     monkeypatch.setattr(mgr, "open", MagicMock(return_value=None))
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post("/v1/api/coordinator/nonexistent/open", headers=_COORD_HEADERS)
+    resp = client.post("/v1/api/workstreams/nonexistent/open", headers=_COORD_HEADERS)
     assert resp.status_code == 404
 
 
 def test_open_503_on_coord_mgr_unavailable(storage):
     client = _make_client(storage, coord_mgr=None)
-    resp = client.post("/v1/api/coordinator/any-ws/open", headers=_COORD_HEADERS)
+    resp = client.post("/v1/api/workstreams/any-ws/open", headers=_COORD_HEADERS)
     assert resp.status_code == 503
 
 
@@ -610,7 +610,7 @@ def test_open_correlation_id_on_factory_failure(storage, monkeypatch):
     mgr = _build_mgr(storage)
     monkeypatch.setattr(mgr, "open", MagicMock(side_effect=RuntimeError("boom")))
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post("/v1/api/coordinator/bad-ws/open", headers=_COORD_HEADERS)
+    resp = client.post("/v1/api/workstreams/bad-ws/open", headers=_COORD_HEADERS)
     assert resp.status_code == 500
     assert "correlation_id=" in resp.json()["error"]
 
@@ -620,13 +620,13 @@ def test_open_503_when_open_raises_value_error(storage, monkeypatch):
     mgr = _build_mgr(storage)
     monkeypatch.setattr(mgr, "open", MagicMock(side_effect=ValueError("coord registry missing")))
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post("/v1/api/coordinator/bad-ws/open", headers=_COORD_HEADERS)
+    resp = client.post("/v1/api/workstreams/bad-ws/open", headers=_COORD_HEADERS)
     assert resp.status_code == 503
     assert "registry missing" in resp.json()["error"]
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/api/coordinator/{ws_id}/children — phase 3 tree view backend
+# GET /v1/api/workstreams/{ws_id}/children — phase 3 tree view backend
 # ---------------------------------------------------------------------------
 
 
@@ -647,7 +647,7 @@ def test_children_empty_for_new_coordinator(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/children", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/children", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     assert body == {"items": [], "truncated": False}
@@ -659,7 +659,7 @@ def test_children_returns_interactive_children(storage):
     _seed_child(storage, ws.id, "c" * 32)
     _seed_child(storage, ws.id, "d" * 32, state="running")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/children", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/children", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     body = resp.json()
     assert len(body["items"]) == 2
@@ -677,7 +677,7 @@ def test_children_any_admin_coordinator_caller_sees_subtree(storage):
     _seed_child(storage, ws.id, "a" * 32)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/children",
+        f"/v1/api/workstreams/{ws.id}/children",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp.status_code == 200
@@ -687,12 +687,12 @@ def test_children_any_admin_coordinator_caller_sees_subtree(storage):
 def test_children_invalid_ws_id_400(storage):
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get("/v1/api/coordinator/INVALID-WS-SHOUT/children", headers=_COORD_HEADERS)
+    resp = client.get("/v1/api/workstreams/INVALID-WS-SHOUT/children", headers=_COORD_HEADERS)
     assert resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/api/coordinator/{ws_id}/tasks — phase 3 task pane backend
+# GET /v1/api/workstreams/{ws_id}/tasks — phase 3 task pane backend
 # ---------------------------------------------------------------------------
 
 
@@ -700,7 +700,7 @@ def test_tasks_empty_envelope_for_new_coordinator(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/tasks", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/tasks", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert resp.json() == {"version": 1, "tasks": []}
 
@@ -725,7 +725,7 @@ def test_tasks_round_trips_stored_envelope(storage):
     }
     storage.save_workstream_config(ws.id, {"tasks": json.dumps(envelope)})
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/tasks", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/tasks", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert resp.json() == envelope
 
@@ -735,7 +735,7 @@ def test_tasks_corrupt_envelope_returns_empty(storage):
     ws = mgr.create(user_id="user-1")
     storage.save_workstream_config(ws.id, {"tasks": "NOT-JSON"})
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.get(f"/v1/api/coordinator/{ws.id}/tasks", headers=_COORD_HEADERS)
+    resp = client.get(f"/v1/api/workstreams/{ws.id}/tasks", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert resp.json() == {"version": 1, "tasks": []}
 
@@ -747,7 +747,7 @@ def test_tasks_any_admin_coordinator_caller_can_read(storage):
     ws = mgr.create(user_id="owner")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/tasks",
+        f"/v1/api/workstreams/{ws.id}/tasks",
         headers={"X-Test-User": "stranger", "X-Test-Perms": "admin.coordinator"},
     )
     assert resp.status_code == 200

--- a/tests/test_coordinator_governance.py
+++ b/tests/test_coordinator_governance.py
@@ -46,17 +46,17 @@ def _make_client(storage, *, coord_mgr, alias="my-model", registry=None) -> Test
     app = Starlette(
         routes=[
             Route(
-                "/v1/api/coordinator/{ws_id}/trust",
+                "/v1/api/workstreams/{ws_id}/trust",
                 coordinator_trust,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/restrict",
+                "/v1/api/workstreams/{ws_id}/restrict",
                 coordinator_restrict,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/stop_cascade",
+                "/v1/api/workstreams/{ws_id}/stop_cascade",
                 coordinator_stop_cascade,
                 methods=["POST"],
             ),
@@ -121,7 +121,7 @@ def test_trust_toggle_requires_trust_send_permission(storage):
     coord = mgr.create(user_id="user-1", name="coord-a")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
         headers=_COORD_HEADERS,
     )
@@ -136,7 +136,7 @@ def test_trust_toggle_flips_session_flag_and_audits(storage):
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
 
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
         headers=_TRUST_HEADERS,
     )
@@ -168,17 +168,17 @@ def _service_token_client(
     app = Starlette(
         routes=[
             Route(
-                "/v1/api/coordinator/{ws_id}/trust",
+                "/v1/api/workstreams/{ws_id}/trust",
                 coordinator_trust,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/restrict",
+                "/v1/api/workstreams/{ws_id}/restrict",
                 coordinator_restrict,
                 methods=["POST"],
             ),
             Route(
-                "/v1/api/coordinator/{ws_id}/stop_cascade",
+                "/v1/api/workstreams/{ws_id}/stop_cascade",
                 coordinator_stop_cascade,
                 methods=["POST"],
             ),
@@ -223,7 +223,7 @@ def test_trust_toggle_service_token_cannot_bypass_permission(storage):
         permissions=frozenset({"admin.coordinator"}),
     )
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
     )
     assert resp.status_code == 403
@@ -246,7 +246,7 @@ def test_trust_toggle_service_token_with_permission_succeeds(storage):
         permissions=frozenset({"admin.coordinator", "coordinator.trust.send"}),
     )
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
     )
     assert resp.status_code == 200
@@ -269,7 +269,7 @@ def test_restrict_service_token_cannot_bypass_admin_coordinator(storage):
         permissions=frozenset(),  # no admin.coordinator
     )
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["bash"]},
     )
     assert resp.status_code == 403
@@ -288,7 +288,7 @@ def test_stop_cascade_service_token_cannot_bypass_admin_coordinator(storage):
         permissions=frozenset(),
     )
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
     )
     assert resp.status_code == 403
@@ -300,7 +300,7 @@ def test_trust_toggle_rejects_non_bool(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": "yes"},
         headers=_TRUST_HEADERS,
     )
@@ -320,7 +320,7 @@ def test_trust_toggle_rejects_non_object_body(storage):
     # only care that none 500.
     for body in ([], 42, "string"):
         resp = client.post(
-            f"/v1/api/coordinator/{coord.id}/trust",
+            f"/v1/api/workstreams/{coord.id}/trust",
             json=body,
             headers=_TRUST_HEADERS,
         )
@@ -334,7 +334,7 @@ def test_restrict_rejects_non_object_body(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json=[],
         headers=_COORD_HEADERS,
     )
@@ -350,7 +350,7 @@ def test_trust_toggle_cluster_wide_access(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
         headers={
             "X-Test-User": "user-other",
@@ -369,7 +369,7 @@ def test_trust_toggle_404_when_session_not_loaded(storage):
     coord.session = None  # simulate a closed / lazy-rehydrate coord
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/trust",
+        f"/v1/api/workstreams/{coord.id}/trust",
         json={"send": True},
         headers=_TRUST_HEADERS,
     )
@@ -472,7 +472,7 @@ def test_restrict_adds_to_revoked_tools_and_audits(storage):
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
 
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["spawn_workstream", "delete_workstream"]},
         headers=_COORD_HEADERS,
     )
@@ -494,12 +494,12 @@ def test_restrict_is_additive_across_calls(storage):
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
 
     client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["spawn_workstream"]},
         headers=_COORD_HEADERS,
     )
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["delete_workstream"]},
         headers=_COORD_HEADERS,
     )
@@ -519,7 +519,7 @@ def test_restrict_empty_revoke_is_noop_but_audits(storage):
     coord.session, _state = _make_session_mock(revoked=frozenset({"spawn_workstream"}))
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": []},
         headers=_COORD_HEADERS,
     )
@@ -538,7 +538,7 @@ def test_restrict_rejects_non_list_body(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": "spawn_workstream"},
         headers=_COORD_HEADERS,
     )
@@ -553,7 +553,7 @@ def test_restrict_rejects_oversize_list(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": [f"tool_{i}" for i in range(500)]},
         headers=_COORD_HEADERS,
     )
@@ -566,7 +566,7 @@ def test_restrict_rejects_oversize_name(storage):
     coord.session, _ = _make_session_mock()
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["x" * 1000]},
         headers=_COORD_HEADERS,
     )
@@ -579,7 +579,7 @@ def test_restrict_404_when_session_not_loaded(storage):
     coord.session = None
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/restrict",
+        f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["bash"]},
         headers=_COORD_HEADERS,
     )
@@ -654,7 +654,7 @@ def test_stop_cascade_cancels_coord_and_each_child(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -701,7 +701,7 @@ def test_stop_cascade_routes_404_to_skipped_bucket(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -720,7 +720,7 @@ def test_stop_cascade_empty_children_still_audits(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -742,7 +742,7 @@ def test_stop_cascade_without_coord_client_marks_all_failed(storage):
 
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
         headers=_COORD_HEADERS,
     )
@@ -759,7 +759,7 @@ def test_stop_cascade_404_when_session_not_loaded(storage):
     coord.session = None
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
-        f"/v1/api/coordinator/{coord.id}/stop_cascade",
+        f"/v1/api/workstreams/{coord.id}/stop_cascade",
         json={},
         headers=_COORD_HEADERS,
     )

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -123,18 +123,18 @@ class TestConsoleSpec:
         spec = build_console_spec()
         paths = set(spec["paths"].keys())
         expected = {
-            "/v1/api/coordinator/new",
-            "/v1/api/coordinator",
-            "/v1/api/coordinator/{ws_id}",
-            "/v1/api/coordinator/{ws_id}/open",
-            "/v1/api/coordinator/{ws_id}/send",
-            "/v1/api/coordinator/{ws_id}/approve",
-            "/v1/api/coordinator/{ws_id}/cancel",
-            "/v1/api/coordinator/{ws_id}/close",
-            "/v1/api/coordinator/{ws_id}/events",
-            "/v1/api/coordinator/{ws_id}/history",
-            "/v1/api/coordinator/{ws_id}/children",
-            "/v1/api/coordinator/{ws_id}/tasks",
+            "/v1/api/workstreams/new",
+            "/v1/api/workstreams",
+            "/v1/api/workstreams/{ws_id}",
+            "/v1/api/workstreams/{ws_id}/open",
+            "/v1/api/workstreams/{ws_id}/send",
+            "/v1/api/workstreams/{ws_id}/approve",
+            "/v1/api/workstreams/{ws_id}/cancel",
+            "/v1/api/workstreams/{ws_id}/close",
+            "/v1/api/workstreams/{ws_id}/events",
+            "/v1/api/workstreams/{ws_id}/history",
+            "/v1/api/workstreams/{ws_id}/children",
+            "/v1/api/workstreams/{ws_id}/tasks",
             "/v1/api/cluster/ws/{ws_id}/detail",
         }
         assert expected.issubset(paths), f"Missing: {expected - paths}"
@@ -144,7 +144,7 @@ class TestConsoleSpec:
         from turnstone.api.console_spec import build_console_spec
 
         spec = build_console_spec()
-        op = spec["paths"]["/v1/api/coordinator/new"]["post"]
+        op = spec["paths"]["/v1/api/workstreams/new"]["post"]
         assert "requestBody" in op
         assert "application/json" in op["requestBody"]["content"]
         # Pin the 201 success code.
@@ -154,7 +154,7 @@ class TestConsoleSpec:
         from turnstone.api.console_spec import build_console_spec
 
         spec = build_console_spec()
-        op = spec["paths"]["/v1/api/coordinator/{ws_id}/history"]["get"]
+        op = spec["paths"]["/v1/api/workstreams/{ws_id}/history"]["get"]
         param_names = [p["name"] for p in op.get("parameters", [])]
         assert "ws_id" in param_names  # auto-added from path
         assert "limit" in param_names

--- a/tests/test_phase6_endpoints.py
+++ b/tests/test_phase6_endpoints.py
@@ -13,80 +13,28 @@ upstream node fetches.
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import MagicMock
-
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from turnstone.console.collector import ClusterCollector
-from turnstone.console.coordinator_adapter import CoordinatorAdapter
-from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
+from tests._coord_test_helpers import (
+    _AuthMiddleware,
+    _build_mgr,
+    _fake_registry,
+    _FakeConfigStore,
+)
 from turnstone.console.server import (
     cluster_ws_live_bulk,
     coordinator_metrics,
 )
-from turnstone.core.auth import AuthResult
-from turnstone.core.session_manager import SessionManager
 from turnstone.core.storage._sqlite import SQLiteBackend
-
-
-class _AuthMiddleware(BaseHTTPMiddleware):
-    """Inject a configurable AuthResult from header-based contract."""
-
-    async def dispatch(self, request, call_next):
-        perms = request.headers.get("X-Test-Perms", "")
-        user_id = request.headers.get("X-Test-User", "")
-        if perms or user_id:
-            request.state.auth_result = AuthResult(
-                user_id=user_id,
-                scopes=frozenset({"approve"}),
-                token_source="test",
-                permissions=frozenset(p for p in perms.split(",") if p),
-            )
-        return await call_next(request)
-
-
-class _FakeConfigStore:
-    def __init__(self, values: dict[str, Any]) -> None:
-        self._values = values
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._values.get(key, default)
 
 
 @pytest.fixture
 def storage(tmp_path):
     return SQLiteBackend(str(tmp_path / "phase6.db"))
-
-
-def _build_mgr(storage) -> SessionManager:
-    def _sf(ui, model_alias=None, ws_id=None, **kw):
-        return MagicMock()
-
-    adapter = CoordinatorAdapter(
-        collector=MagicMock(),
-        ui_factory=lambda ws: ConsoleCoordinatorUI(ws_id=ws.id, user_id=ws.user_id or ""),
-        session_factory=_sf,
-    )
-    mgr = SessionManager(
-        adapter,
-        storage=storage,
-        max_active=3,
-        node_id=ClusterCollector.CONSOLE_PSEUDO_NODE_ID,
-    )
-    adapter.attach(mgr)
-    return mgr
-
-
-def _fake_registry() -> MagicMock:
-    reg = MagicMock()
-    reg.resolve.return_value = (MagicMock(), "gpt-4", MagicMock())
-    return reg
 
 
 def _make_client(storage, *, coord_mgr=None) -> TestClient:

--- a/tests/test_phase6_endpoints.py
+++ b/tests/test_phase6_endpoints.py
@@ -3,7 +3,7 @@
 Covers:
 
 - GET /v1/api/cluster/ws/live — bulk live-block fetch (admin.cluster.inspect).
-- GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot.
+- GET /v1/api/workstreams/{ws_id}/metrics — per-coordinator health snapshot.
 
 Both endpoints ride on the same test harness as
 ``test_coordinator_endpoints.py`` — a minimal Starlette app with an
@@ -94,7 +94,7 @@ def _make_client(storage, *, coord_mgr=None) -> TestClient:
         routes=[
             Route("/v1/api/cluster/ws/live", cluster_ws_live_bulk, methods=["GET"]),
             Route(
-                "/v1/api/coordinator/{ws_id}/metrics",
+                "/v1/api/workstreams/{ws_id}/metrics",
                 coordinator_metrics,
                 methods=["GET"],
             ),
@@ -283,7 +283,7 @@ def test_bulk_live_coordinator_row_uses_manager_snapshot(storage):
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot
+# GET /v1/api/workstreams/{ws_id}/metrics — per-coordinator health snapshot
 # ---------------------------------------------------------------------------
 
 
@@ -295,7 +295,7 @@ def test_metrics_requires_permission(storage):
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers={"X-Test-User": "user-1", "X-Test-Perms": "read"},
     )
     assert resp.status_code == 403
@@ -305,7 +305,7 @@ def test_metrics_invalid_ws_id_400(storage):
     mgr = _build_mgr(storage)
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        "/v1/api/coordinator/NOT-HEX/metrics",
+        "/v1/api/workstreams/NOT-HEX/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 400
@@ -318,7 +318,7 @@ def test_metrics_any_admin_coordinator_caller_can_read(storage):
     ws = mgr.create(user_id="stranger")
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 200
@@ -332,7 +332,7 @@ def test_metrics_empty_coordinator_defaults(storage):
     ws = mgr.create(user_id="user-1")
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 200
@@ -381,7 +381,7 @@ def test_metrics_spawns_and_state_counts(storage):
     )
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 200
@@ -418,7 +418,7 @@ def test_metrics_cluster_wide_aggregates(storage):
     # Every admin.coordinator caller sees both children.
     for caller in ("alice", "bob", "admin-1"):
         resp = client.get(
-            f"/v1/api/coordinator/{ws.id}/metrics",
+            f"/v1/api/workstreams/{ws.id}/metrics",
             headers={"X-Test-User": caller, "X-Test-Perms": "admin.coordinator"},
         )
         assert resp.status_code == 200, caller
@@ -456,7 +456,7 @@ def test_metrics_judge_fallback_rate_substring_match(storage):
         )
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 200
@@ -499,7 +499,7 @@ def test_metrics_spawns_last_hour_boundary(storage):
     )
     client = _make_client(storage, coord_mgr=mgr)
     resp = client.get(
-        f"/v1/api/coordinator/{ws.id}/metrics",
+        f"/v1/api/workstreams/{ws.id}/metrics",
         headers=_METRICS_HEADERS,
     )
     assert resp.status_code == 200

--- a/tests/test_session_routes.py
+++ b/tests/test_session_routes.py
@@ -1,11 +1,10 @@
 """Tests for the shared session HTTP route registrar.
 
-Stage 2 Priority 0 Step 0.2 — verifies that
-:func:`turnstone.core.session_routes.register_session_routes` mounts
-the right route table per the configured handler bundle, and that
-the console's ``create_app`` exposes the unified
-``/v1/api/workstreams/`` URL shape for coord alongside the legacy
-``/v1/api/coordinator/`` paths during the transition window.
+Verifies that :func:`turnstone.core.session_routes.register_session_routes`
+and :func:`turnstone.core.session_routes.register_coord_verbs` mount
+the right route table per the supplied handler bundles, and that the
+console's ``create_app`` exposes the unified ``/v1/api/workstreams/``
+URL shape (the legacy ``/v1/api/coordinator/`` shape is gone).
 
 Body-level behavior is covered by the per-kind endpoint tests
 (``tests/test_workstream_endpoints.py``,
@@ -17,14 +16,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pytest
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from turnstone.core.session_routes import (
-    CoordVerbHandlers,
-    SessionRouteConfig,
-    SessionRouteHandlers,
+    AttachmentHandlers,
+    CoordOnlyVerbHandlers,
+    SharedSessionVerbHandlers,
     register_coord_verbs,
     register_session_routes,
 )
@@ -35,6 +33,10 @@ if TYPE_CHECKING:
 
 async def _stub(_request: Request) -> JSONResponse:
     return JSONResponse({"ok": True})
+
+
+def _attach() -> AttachmentHandlers:
+    return AttachmentHandlers(upload=_stub, list=_stub, get_content=_stub, delete=_stub)
 
 
 def _route_paths(routes: list[Any]) -> list[tuple[str, frozenset[str]]]:
@@ -51,117 +53,9 @@ def test_empty_handlers_register_no_routes() -> None:
     register_session_routes(
         routes,
         prefix="/api/workstreams",
-        config=SessionRouteConfig(),
-        handlers=SessionRouteHandlers(),
+        handlers=SharedSessionVerbHandlers(),
     )
     assert routes == []
-
-
-def test_coord_shape_mounts_expected_verbs() -> None:
-    """Coord wiring exposes list / saved / new / detail + the
-    per-``{ws_id}`` interaction verbs at the unified prefix."""
-    routes: list[Any] = []
-    register_session_routes(
-        routes,
-        prefix="/api/workstreams",
-        config=SessionRouteConfig(),
-        handlers=SessionRouteHandlers(
-            list_workstreams=_stub,
-            list_saved=_stub,
-            create=_stub,
-            detail=_stub,
-            open=_stub,
-            close=_stub,
-            send=_stub,
-            approve=_stub,
-            cancel=_stub,
-            events=_stub,
-            history=_stub,
-        ),
-    )
-    paths = _route_paths(routes)
-    expected = {
-        ("/api/workstreams", frozenset({"GET", "HEAD"})),
-        ("/api/workstreams/saved", frozenset({"GET", "HEAD"})),
-        ("/api/workstreams/new", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/open", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/close", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/send", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/approve", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/cancel", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/events", frozenset({"GET", "HEAD"})),
-        ("/api/workstreams/{ws_id}/history", frozenset({"GET", "HEAD"})),
-        ("/api/workstreams/{ws_id}", frozenset({"GET", "HEAD"})),
-    }
-    assert set(paths) == expected
-
-
-def test_interactive_shape_mounts_legacy_close_and_attachments() -> None:
-    """Interactive wiring exposes legacy body-keyed close + the
-    full attachments quartet under the unified prefix."""
-    routes: list[Any] = []
-    register_session_routes(
-        routes,
-        prefix="/api/workstreams",
-        config=SessionRouteConfig(supports_legacy_close=True),
-        handlers=SessionRouteHandlers(
-            list_workstreams=_stub,
-            list_saved=_stub,
-            create=_stub,
-            close_legacy=_stub,
-            delete=_stub,
-            open=_stub,
-            refresh_title=_stub,
-            set_title=_stub,
-            upload_attachment=_stub,
-            list_attachments=_stub,
-            get_attachment_content=_stub,
-            delete_attachment=_stub,
-        ),
-    )
-    paths = {(p, m) for p, m in _route_paths(routes)}
-    assert ("/api/workstreams/close", frozenset({"POST"})) in paths
-    assert ("/api/workstreams/{ws_id}/delete", frozenset({"POST"})) in paths
-    assert ("/api/workstreams/{ws_id}/refresh-title", frozenset({"POST"})) in paths
-    assert ("/api/workstreams/{ws_id}/title", frozenset({"POST"})) in paths
-    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"POST"})) in paths
-    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"GET", "HEAD"})) in paths
-    assert (
-        "/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
-        frozenset({"GET", "HEAD"}),
-    ) in paths
-    assert (
-        "/api/workstreams/{ws_id}/attachments/{attachment_id}",
-        frozenset({"DELETE"}),
-    ) in paths
-
-
-def test_supports_legacy_close_without_handler_raises() -> None:
-    routes: list[Any] = []
-    with pytest.raises(ValueError, match="close_legacy"):
-        register_session_routes(
-            routes,
-            prefix="/api/workstreams",
-            config=SessionRouteConfig(supports_legacy_close=True),
-            handlers=SessionRouteHandlers(),
-        )
-
-
-def test_partial_attachment_handlers_raise() -> None:
-    """Setting one or two attachment handlers without all four is a
-    config error — partial surfaces leave broken frontend flows."""
-    routes: list[Any] = []
-    with pytest.raises(ValueError, match="attachment handlers"):
-        register_session_routes(
-            routes,
-            prefix="/api/workstreams",
-            config=SessionRouteConfig(),
-            handlers=SessionRouteHandlers(
-                upload_attachment=_stub,
-                list_attachments=_stub,
-                # missing get_attachment_content + delete_attachment
-            ),
-        )
 
 
 def test_saved_registers_before_detail() -> None:
@@ -171,8 +65,7 @@ def test_saved_registers_before_detail() -> None:
     register_session_routes(
         routes,
         prefix="/api/workstreams",
-        config=SessionRouteConfig(),
-        handlers=SessionRouteHandlers(
+        handlers=SharedSessionVerbHandlers(
             list_saved=_stub,
             detail=_stub,
         ),
@@ -189,8 +82,7 @@ def test_specific_verbs_register_before_bare_detail() -> None:
     register_session_routes(
         routes,
         prefix="/api/workstreams",
-        config=SessionRouteConfig(),
-        handlers=SessionRouteHandlers(
+        handlers=SharedSessionVerbHandlers(
             detail=_stub,
             close=_stub,
             send=_stub,
@@ -204,14 +96,60 @@ def test_specific_verbs_register_before_bare_detail() -> None:
     assert paths.index("/api/workstreams/{ws_id}/events") < detail_idx
 
 
-def test_register_coord_verbs_mounts_expected_paths() -> None:
+def test_attachment_routes_mount_when_quartet_provided() -> None:
+    """All four attachment routes mount when ``handlers.attachments``
+    is non-``None`` — the type system requires the four-handler
+    quartet to be set together."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        handlers=SharedSessionVerbHandlers(attachments=_attach()),
+    )
+    paths = {(p, m) for p, m in _route_paths(routes)}
+    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"GET", "HEAD"})) in paths
+    assert (
+        "/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
+        frozenset({"GET", "HEAD"}),
+    ) in paths
+    assert (
+        "/api/workstreams/{ws_id}/attachments/{attachment_id}",
+        frozenset({"DELETE"}),
+    ) in paths
+
+
+def test_close_legacy_mounts_when_handler_provided() -> None:
+    """The legacy body-keyed close (``POST {prefix}/close``) mounts
+    when ``handlers.close_legacy`` is non-``None`` — there is no
+    separate config flag, just the handler's presence."""
+    routes_with: list[Any] = []
+    register_session_routes(
+        routes_with,
+        prefix="/api/workstreams",
+        handlers=SharedSessionVerbHandlers(close_legacy=_stub),
+    )
+    assert any(r.path == "/api/workstreams/close" for r in routes_with if isinstance(r, Route))
+
+    routes_without: list[Any] = []
+    register_session_routes(
+        routes_without,
+        prefix="/api/workstreams",
+        handlers=SharedSessionVerbHandlers(),
+    )
+    assert not any(
+        r.path == "/api/workstreams/close" for r in routes_without if isinstance(r, Route)
+    )
+
+
+def test_register_coord_verbs_mounts_seven_paths() -> None:
     """``register_coord_verbs`` mounts the seven coord-only verbs
     at the unified prefix."""
     routes: list[Any] = []
     register_coord_verbs(
         routes,
         prefix="/api/workstreams",
-        handlers=CoordVerbHandlers(
+        handlers=CoordOnlyVerbHandlers(
             children=_stub,
             tasks=_stub,
             metrics=_stub,
@@ -233,17 +171,16 @@ def test_register_coord_verbs_mounts_expected_paths() -> None:
     }
 
 
-def test_console_create_app_exposes_unified_workstream_paths() -> None:
-    """The console's ``create_app`` mounts coord verbs at the unified
-    ``/api/workstreams/`` shape and no longer mounts the legacy
-    ``/api/coordinator/`` shape (deleted in Step 0.4)."""
-    from tests.test_console import MockStorage
+def test_console_create_app_only_mounts_unified_workstream_paths() -> None:
+    """The console's ``create_app`` mounts coord verbs only at the
+    unified ``/api/workstreams/`` shape — no path under
+    ``/api/coordinator/`` should remain (deleted in Step 0.4)."""
+    from tests._coord_test_helpers import MockStorage
     from turnstone.console.collector import ClusterCollector
     from turnstone.console.server import create_app
 
     collector = ClusterCollector(storage=MockStorage(), discovery_interval=999)
     app = create_app(collector=collector)
-    # Walk the route tree to collect every mounted path.
     paths: set[str] = set()
 
     def _walk(routes: Any) -> None:
@@ -255,19 +192,15 @@ def test_console_create_app_exposes_unified_workstream_paths() -> None:
                 _walk(sub)
 
     _walk(app.routes)
-    # Legacy shape is gone — no path under ``/api/coordinator/`` should
-    # remain (the bare ``/api/coordinator`` literal is also gone).
     assert not any("/api/coordinator" in p for p in paths), (
         f"legacy /api/coordinator paths still mounted: "
         f"{sorted(p for p in paths if '/api/coordinator' in p)}"
     )
-    # Unified shape carries the workstream verb tree.
     assert any(p.endswith("/api/workstreams") for p in paths)
+    # Spot-check one verb per category from the registrar.
     assert any(p.endswith("/api/workstreams/{ws_id}/send") for p in paths)
-    assert any(p.endswith("/api/workstreams/{ws_id}/approve") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}/events") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}") for p in paths)
-    # Coord-only verbs from Step 0.3 are also present at the unified prefix.
+    # And one from the coord-only registrar.
     assert any(p.endswith("/api/workstreams/{ws_id}/trust") for p in paths)
-    assert any(p.endswith("/api/workstreams/{ws_id}/children") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}/close_all_children") for p in paths)

--- a/tests/test_session_routes.py
+++ b/tests/test_session_routes.py
@@ -1,0 +1,286 @@
+"""Tests for the shared session HTTP route registrar.
+
+Stage 2 Priority 0 Step 0.2 — verifies that
+:func:`turnstone.core.session_routes.register_session_routes` mounts
+the right route table per the configured handler bundle, and that
+the console's ``create_app`` exposes the unified
+``/v1/api/workstreams/`` URL shape for coord alongside the legacy
+``/v1/api/coordinator/`` paths during the transition window.
+
+Body-level behavior is covered by the per-kind endpoint tests
+(``tests/test_workstream_endpoints.py``,
+``tests/test_coordinator_endpoints.py``); this module checks only the
+routing surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from turnstone.core.session_routes import (
+    SessionRouteConfig,
+    SessionRouteHandlers,
+    register_session_routes,
+)
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+
+async def _stub(_request: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+def _route_paths(routes: list[Any]) -> list[tuple[str, frozenset[str]]]:
+    out = []
+    for r in routes:
+        assert isinstance(r, Route)
+        out.append((r.path, frozenset(r.methods or set())))
+    return out
+
+
+def test_empty_handlers_register_no_routes() -> None:
+    """A handler bundle with everything ``None`` mounts zero routes."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(),
+        handlers=SessionRouteHandlers(),
+    )
+    assert routes == []
+
+
+def test_coord_shape_mounts_expected_verbs() -> None:
+    """Coord wiring exposes list / saved / new / detail + the
+    per-``{ws_id}`` interaction verbs at the unified prefix."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(),
+        handlers=SessionRouteHandlers(
+            list_workstreams=_stub,
+            list_saved=_stub,
+            create=_stub,
+            detail=_stub,
+            open=_stub,
+            close=_stub,
+            send=_stub,
+            approve=_stub,
+            cancel=_stub,
+            events=_stub,
+            history=_stub,
+        ),
+    )
+    paths = _route_paths(routes)
+    expected = {
+        ("/api/workstreams", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/saved", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/new", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/open", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/close", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/send", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/approve", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/cancel", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/events", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/{ws_id}/history", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/{ws_id}", frozenset({"GET", "HEAD"})),
+    }
+    assert set(paths) == expected
+
+
+def test_interactive_shape_mounts_legacy_close_and_attachments() -> None:
+    """Interactive wiring exposes legacy body-keyed close + the
+    full attachments quartet under the unified prefix."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(supports_legacy_close=True),
+        handlers=SessionRouteHandlers(
+            list_workstreams=_stub,
+            list_saved=_stub,
+            create=_stub,
+            close_legacy=_stub,
+            delete=_stub,
+            open=_stub,
+            refresh_title=_stub,
+            set_title=_stub,
+            upload_attachment=_stub,
+            list_attachments=_stub,
+            get_attachment_content=_stub,
+            delete_attachment=_stub,
+        ),
+    )
+    paths = {(p, m) for p, m in _route_paths(routes)}
+    assert ("/api/workstreams/close", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/delete", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/refresh-title", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/title", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"POST"})) in paths
+    assert ("/api/workstreams/{ws_id}/attachments", frozenset({"GET", "HEAD"})) in paths
+    assert (
+        "/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
+        frozenset({"GET", "HEAD"}),
+    ) in paths
+    assert (
+        "/api/workstreams/{ws_id}/attachments/{attachment_id}",
+        frozenset({"DELETE"}),
+    ) in paths
+
+
+def test_supports_legacy_close_without_handler_raises() -> None:
+    routes: list[Any] = []
+    with pytest.raises(ValueError, match="close_legacy"):
+        register_session_routes(
+            routes,
+            prefix="/api/workstreams",
+            config=SessionRouteConfig(supports_legacy_close=True),
+            handlers=SessionRouteHandlers(),
+        )
+
+
+def test_partial_attachment_handlers_raise() -> None:
+    """Setting one or two attachment handlers without all four is a
+    config error — partial surfaces leave broken frontend flows."""
+    routes: list[Any] = []
+    with pytest.raises(ValueError, match="attachment handlers"):
+        register_session_routes(
+            routes,
+            prefix="/api/workstreams",
+            config=SessionRouteConfig(),
+            handlers=SessionRouteHandlers(
+                upload_attachment=_stub,
+                list_attachments=_stub,
+                # missing get_attachment_content + delete_attachment
+            ),
+        )
+
+
+def test_saved_registers_before_detail() -> None:
+    """Literal ``saved`` must register before bare ``{ws_id}`` so
+    Starlette doesn't match "saved" as a ws_id path param."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(),
+        handlers=SessionRouteHandlers(
+            list_saved=_stub,
+            detail=_stub,
+        ),
+    )
+    paths = [r.path for r in routes if isinstance(r, Route)]
+    assert paths.index("/api/workstreams/saved") < paths.index("/api/workstreams/{ws_id}")
+
+
+def test_specific_verbs_register_before_bare_detail() -> None:
+    """Per-verb ``{ws_id}/{verb}`` patterns must register before the
+    bare ``{ws_id}`` GET so Starlette routes verb requests to the
+    right handler."""
+    routes: list[Any] = []
+    register_session_routes(
+        routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(),
+        handlers=SessionRouteHandlers(
+            detail=_stub,
+            close=_stub,
+            send=_stub,
+            events=_stub,
+        ),
+    )
+    paths = [r.path for r in routes if isinstance(r, Route)]
+    detail_idx = paths.index("/api/workstreams/{ws_id}")
+    assert paths.index("/api/workstreams/{ws_id}/close") < detail_idx
+    assert paths.index("/api/workstreams/{ws_id}/send") < detail_idx
+    assert paths.index("/api/workstreams/{ws_id}/events") < detail_idx
+
+
+def test_console_create_app_exposes_unified_workstream_paths() -> None:
+    """The console's ``create_app`` mounts coord verbs at both the
+    legacy ``/api/coordinator/`` shape and the unified
+    ``/api/workstreams/`` shape so SDK consumers can migrate
+    incrementally before the legacy paths delete in Step 0.4.
+    """
+    from tests.test_console import MockStorage
+    from turnstone.console.collector import ClusterCollector
+    from turnstone.console.server import create_app
+
+    collector = ClusterCollector(storage=MockStorage(), discovery_interval=999)
+    app = create_app(collector=collector)
+    # Walk the route tree to collect every mounted path.
+    paths: set[str] = set()
+
+    def _walk(routes: Any) -> None:
+        for r in routes:
+            if hasattr(r, "path"):
+                paths.add(r.path)
+            sub = getattr(r, "routes", None)
+            if sub:
+                _walk(sub)
+
+    _walk(app.routes)
+    # Legacy shape still present (Step 0.2 transition; Step 0.4 deletes).
+    assert any("/api/coordinator/" in p or p.endswith("/api/coordinator") for p in paths)
+    # Unified shape is now also present.
+    assert "/v1/api/workstreams" in paths or "/api/workstreams" in paths
+    assert any(p.endswith("/api/workstreams/{ws_id}/send") for p in paths)
+    assert any(p.endswith("/api/workstreams/{ws_id}/approve") for p in paths)
+    assert any(p.endswith("/api/workstreams/{ws_id}/events") for p in paths)
+    assert any(p.endswith("/api/workstreams/{ws_id}") for p in paths)
+
+
+def test_console_unified_paths_route_to_legacy_handlers() -> None:
+    """Each unified ``/api/workstreams/{verb}`` route on the console
+    points at the SAME handler function as the legacy
+    ``/api/coordinator/{verb}`` route — the transition is a pure
+    URL alias, not a fork.
+    """
+    from tests.test_console import MockStorage
+    from turnstone.console.collector import ClusterCollector
+    from turnstone.console.server import create_app
+
+    collector = ClusterCollector(storage=MockStorage(), discovery_interval=999)
+    app = create_app(collector=collector)
+
+    endpoint_by_path: dict[str, Any] = {}
+
+    def _walk(routes: Any) -> None:
+        for r in routes:
+            if isinstance(r, Route):
+                endpoint_by_path[r.path] = r.endpoint
+            sub = getattr(r, "routes", None)
+            if sub:
+                _walk(sub)
+
+    _walk(app.routes)
+
+    # Spot-check the verb pairs whose handlers must remain identical.
+    aliases = {
+        "/api/coordinator": "/api/workstreams",
+        "/api/coordinator/saved": "/api/workstreams/saved",
+        "/api/coordinator/new": "/api/workstreams/new",
+        "/api/coordinator/{ws_id}/send": "/api/workstreams/{ws_id}/send",
+        "/api/coordinator/{ws_id}/approve": "/api/workstreams/{ws_id}/approve",
+        "/api/coordinator/{ws_id}/cancel": "/api/workstreams/{ws_id}/cancel",
+        "/api/coordinator/{ws_id}/close": "/api/workstreams/{ws_id}/close",
+        "/api/coordinator/{ws_id}/open": "/api/workstreams/{ws_id}/open",
+        "/api/coordinator/{ws_id}/events": "/api/workstreams/{ws_id}/events",
+        "/api/coordinator/{ws_id}/history": "/api/workstreams/{ws_id}/history",
+        "/api/coordinator/{ws_id}": "/api/workstreams/{ws_id}",
+    }
+    # Walked Route paths are relative to their parent Mount; the
+    # ``/v1`` prefix is applied at request time, not stored on the
+    # nested Route object.
+    for legacy, unified in aliases.items():
+        assert legacy in endpoint_by_path, f"missing legacy path {legacy}"
+        assert unified in endpoint_by_path, f"missing unified path {unified}"
+        assert endpoint_by_path[legacy] is endpoint_by_path[unified], (
+            f"{unified} routes to a different handler than {legacy}"
+        )

--- a/tests/test_session_routes.py
+++ b/tests/test_session_routes.py
@@ -22,8 +22,10 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from turnstone.core.session_routes import (
+    CoordVerbHandlers,
     SessionRouteConfig,
     SessionRouteHandlers,
+    register_coord_verbs,
     register_session_routes,
 )
 
@@ -202,6 +204,35 @@ def test_specific_verbs_register_before_bare_detail() -> None:
     assert paths.index("/api/workstreams/{ws_id}/events") < detail_idx
 
 
+def test_register_coord_verbs_mounts_expected_paths() -> None:
+    """``register_coord_verbs`` mounts the seven coord-only verbs
+    at the unified prefix."""
+    routes: list[Any] = []
+    register_coord_verbs(
+        routes,
+        prefix="/api/workstreams",
+        handlers=CoordVerbHandlers(
+            children=_stub,
+            tasks=_stub,
+            metrics=_stub,
+            trust=_stub,
+            restrict=_stub,
+            stop_cascade=_stub,
+            close_all_children=_stub,
+        ),
+    )
+    paths = {(p, m) for p, m in _route_paths(routes)}
+    assert paths == {
+        ("/api/workstreams/{ws_id}/children", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/{ws_id}/tasks", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/{ws_id}/metrics", frozenset({"GET", "HEAD"})),
+        ("/api/workstreams/{ws_id}/trust", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/restrict", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/stop_cascade", frozenset({"POST"})),
+        ("/api/workstreams/{ws_id}/close_all_children", frozenset({"POST"})),
+    }
+
+
 def test_console_create_app_exposes_unified_workstream_paths() -> None:
     """The console's ``create_app`` mounts coord verbs at both the
     legacy ``/api/coordinator/`` shape and the unified
@@ -274,6 +305,16 @@ def test_console_unified_paths_route_to_legacy_handlers() -> None:
         "/api/coordinator/{ws_id}/events": "/api/workstreams/{ws_id}/events",
         "/api/coordinator/{ws_id}/history": "/api/workstreams/{ws_id}/history",
         "/api/coordinator/{ws_id}": "/api/workstreams/{ws_id}",
+        # Step 0.3: coord-only verbs.
+        "/api/coordinator/{ws_id}/children": "/api/workstreams/{ws_id}/children",
+        "/api/coordinator/{ws_id}/tasks": "/api/workstreams/{ws_id}/tasks",
+        "/api/coordinator/{ws_id}/metrics": "/api/workstreams/{ws_id}/metrics",
+        "/api/coordinator/{ws_id}/trust": "/api/workstreams/{ws_id}/trust",
+        "/api/coordinator/{ws_id}/restrict": "/api/workstreams/{ws_id}/restrict",
+        "/api/coordinator/{ws_id}/stop_cascade": "/api/workstreams/{ws_id}/stop_cascade",
+        "/api/coordinator/{ws_id}/close_all_children": (
+            "/api/workstreams/{ws_id}/close_all_children"
+        ),
     }
     # Walked Route paths are relative to their parent Mount; the
     # ``/v1`` prefix is applied at request time, not stored on the

--- a/tests/test_session_routes.py
+++ b/tests/test_session_routes.py
@@ -234,11 +234,9 @@ def test_register_coord_verbs_mounts_expected_paths() -> None:
 
 
 def test_console_create_app_exposes_unified_workstream_paths() -> None:
-    """The console's ``create_app`` mounts coord verbs at both the
-    legacy ``/api/coordinator/`` shape and the unified
-    ``/api/workstreams/`` shape so SDK consumers can migrate
-    incrementally before the legacy paths delete in Step 0.4.
-    """
+    """The console's ``create_app`` mounts coord verbs at the unified
+    ``/api/workstreams/`` shape and no longer mounts the legacy
+    ``/api/coordinator/`` shape (deleted in Step 0.4)."""
     from tests.test_console import MockStorage
     from turnstone.console.collector import ClusterCollector
     from turnstone.console.server import create_app
@@ -257,71 +255,19 @@ def test_console_create_app_exposes_unified_workstream_paths() -> None:
                 _walk(sub)
 
     _walk(app.routes)
-    # Legacy shape still present (Step 0.2 transition; Step 0.4 deletes).
-    assert any("/api/coordinator/" in p or p.endswith("/api/coordinator") for p in paths)
-    # Unified shape is now also present.
-    assert "/v1/api/workstreams" in paths or "/api/workstreams" in paths
+    # Legacy shape is gone — no path under ``/api/coordinator/`` should
+    # remain (the bare ``/api/coordinator`` literal is also gone).
+    assert not any("/api/coordinator" in p for p in paths), (
+        f"legacy /api/coordinator paths still mounted: "
+        f"{sorted(p for p in paths if '/api/coordinator' in p)}"
+    )
+    # Unified shape carries the workstream verb tree.
+    assert any(p.endswith("/api/workstreams") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}/send") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}/approve") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}/events") for p in paths)
     assert any(p.endswith("/api/workstreams/{ws_id}") for p in paths)
-
-
-def test_console_unified_paths_route_to_legacy_handlers() -> None:
-    """Each unified ``/api/workstreams/{verb}`` route on the console
-    points at the SAME handler function as the legacy
-    ``/api/coordinator/{verb}`` route — the transition is a pure
-    URL alias, not a fork.
-    """
-    from tests.test_console import MockStorage
-    from turnstone.console.collector import ClusterCollector
-    from turnstone.console.server import create_app
-
-    collector = ClusterCollector(storage=MockStorage(), discovery_interval=999)
-    app = create_app(collector=collector)
-
-    endpoint_by_path: dict[str, Any] = {}
-
-    def _walk(routes: Any) -> None:
-        for r in routes:
-            if isinstance(r, Route):
-                endpoint_by_path[r.path] = r.endpoint
-            sub = getattr(r, "routes", None)
-            if sub:
-                _walk(sub)
-
-    _walk(app.routes)
-
-    # Spot-check the verb pairs whose handlers must remain identical.
-    aliases = {
-        "/api/coordinator": "/api/workstreams",
-        "/api/coordinator/saved": "/api/workstreams/saved",
-        "/api/coordinator/new": "/api/workstreams/new",
-        "/api/coordinator/{ws_id}/send": "/api/workstreams/{ws_id}/send",
-        "/api/coordinator/{ws_id}/approve": "/api/workstreams/{ws_id}/approve",
-        "/api/coordinator/{ws_id}/cancel": "/api/workstreams/{ws_id}/cancel",
-        "/api/coordinator/{ws_id}/close": "/api/workstreams/{ws_id}/close",
-        "/api/coordinator/{ws_id}/open": "/api/workstreams/{ws_id}/open",
-        "/api/coordinator/{ws_id}/events": "/api/workstreams/{ws_id}/events",
-        "/api/coordinator/{ws_id}/history": "/api/workstreams/{ws_id}/history",
-        "/api/coordinator/{ws_id}": "/api/workstreams/{ws_id}",
-        # Step 0.3: coord-only verbs.
-        "/api/coordinator/{ws_id}/children": "/api/workstreams/{ws_id}/children",
-        "/api/coordinator/{ws_id}/tasks": "/api/workstreams/{ws_id}/tasks",
-        "/api/coordinator/{ws_id}/metrics": "/api/workstreams/{ws_id}/metrics",
-        "/api/coordinator/{ws_id}/trust": "/api/workstreams/{ws_id}/trust",
-        "/api/coordinator/{ws_id}/restrict": "/api/workstreams/{ws_id}/restrict",
-        "/api/coordinator/{ws_id}/stop_cascade": "/api/workstreams/{ws_id}/stop_cascade",
-        "/api/coordinator/{ws_id}/close_all_children": (
-            "/api/workstreams/{ws_id}/close_all_children"
-        ),
-    }
-    # Walked Route paths are relative to their parent Mount; the
-    # ``/v1`` prefix is applied at request time, not stored on the
-    # nested Route object.
-    for legacy, unified in aliases.items():
-        assert legacy in endpoint_by_path, f"missing legacy path {legacy}"
-        assert unified in endpoint_by_path, f"missing unified path {unified}"
-        assert endpoint_by_path[legacy] is endpoint_by_path[unified], (
-            f"{unified} routes to a different handler than {legacy}"
-        )
+    # Coord-only verbs from Step 0.3 are also present at the unified prefix.
+    assert any(p.endswith("/api/workstreams/{ws_id}/trust") for p in paths)
+    assert any(p.endswith("/api/workstreams/{ws_id}/children") for p in paths)
+    assert any(p.endswith("/api/workstreams/{ws_id}/close_all_children") for p in paths)

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -985,7 +985,7 @@ class BulkSetNodeMetadataRequest(BaseModel):
 
 
 class CoordinatorOpenResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/{ws_id}/open."""
+    """Response body for POST /v1/api/workstreams/{ws_id}/open."""
 
     ws_id: str
     name: str
@@ -996,7 +996,7 @@ class CoordinatorOpenResponse(BaseModel):
 
 
 class CoordinatorCreateRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/new."""
+    """Body for POST /v1/api/workstreams/new."""
 
     name: str = Field(default="", description="Optional display name; auto-generated when empty.")
     skill: str | None = Field(
@@ -1010,7 +1010,7 @@ class CoordinatorCreateRequest(BaseModel):
 
 
 class CoordinatorCreateResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/new (201)."""
+    """Response body for POST /v1/api/workstreams/new (201)."""
 
     ws_id: str
     name: str
@@ -1026,13 +1026,13 @@ class CoordinatorInfo(BaseModel):
 
 
 class CoordinatorListResponse(BaseModel):
-    """Response body for GET /v1/api/coordinator."""
+    """Response body for GET /v1/api/workstreams."""
 
     coordinators: list[CoordinatorInfo] = Field(default_factory=list)
 
 
 class CoordinatorDetailResponse(BaseModel):
-    """Response body for GET /v1/api/coordinator/{ws_id}."""
+    """Response body for GET /v1/api/workstreams/{ws_id}."""
 
     ws_id: str
     name: str
@@ -1042,13 +1042,13 @@ class CoordinatorDetailResponse(BaseModel):
 
 
 class CoordinatorSendRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/{ws_id}/send."""
+    """Body for POST /v1/api/workstreams/{ws_id}/send."""
 
     message: str = Field(description="User message to queue onto the coordinator's worker.")
 
 
 class CoordinatorApproveRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/{ws_id}/approve."""
+    """Body for POST /v1/api/workstreams/{ws_id}/approve."""
 
     approved: bool = Field(description="True approves the pending tool call(s); False denies.")
     feedback: str | None = Field(
@@ -1065,7 +1065,7 @@ class CoordinatorApproveRequest(BaseModel):
 
 
 class CoordinatorHistoryResponse(BaseModel):
-    """Response body for GET /v1/api/coordinator/{ws_id}/history."""
+    """Response body for GET /v1/api/workstreams/{ws_id}/history."""
 
     ws_id: str
     messages: list[dict[str, Any]] = Field(
@@ -1094,7 +1094,7 @@ class CoordinatorChildInfo(BaseModel):
 
 
 class CoordinatorChildrenResponse(BaseModel):
-    """Response body for GET /v1/api/coordinator/{ws_id}/children."""
+    """Response body for GET /v1/api/workstreams/{ws_id}/children."""
 
     items: list[CoordinatorChildInfo] = Field(default_factory=list)
     truncated: bool = Field(
@@ -1115,7 +1115,7 @@ class CoordinatorTaskInfo(BaseModel):
 
 
 class CoordinatorTasksResponse(BaseModel):
-    """Response body for GET /v1/api/coordinator/{ws_id}/tasks.
+    """Response body for GET /v1/api/workstreams/{ws_id}/tasks.
 
     Mirrors the envelope the ``task_list(action='list')`` model tool returns.
     """
@@ -1125,7 +1125,7 @@ class CoordinatorTasksResponse(BaseModel):
 
 
 class CoordinatorTrustRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/{ws_id}/trust."""
+    """Body for POST /v1/api/workstreams/{ws_id}/trust."""
 
     send: bool = Field(
         description=(
@@ -1138,14 +1138,14 @@ class CoordinatorTrustRequest(BaseModel):
 
 
 class CoordinatorTrustResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/{ws_id}/trust."""
+    """Response body for POST /v1/api/workstreams/{ws_id}/trust."""
 
     status: str = Field(default="ok")
     trust_send: bool = Field(description="Post-toggle value of the flag.")
 
 
 class CoordinatorRestrictRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/{ws_id}/restrict."""
+    """Body for POST /v1/api/workstreams/{ws_id}/restrict."""
 
     revoke: list[str] = Field(
         description=(
@@ -1157,14 +1157,14 @@ class CoordinatorRestrictRequest(BaseModel):
 
 
 class CoordinatorRestrictResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/{ws_id}/restrict."""
+    """Response body for POST /v1/api/workstreams/{ws_id}/restrict."""
 
     status: str = Field(default="ok")
     revoked_tools: list[str] = Field(description="Full post-revocation set of revoked tool names.")
 
 
 class CoordinatorStopCascadeResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/{ws_id}/stop_cascade."""
+    """Response body for POST /v1/api/workstreams/{ws_id}/stop_cascade."""
 
     status: str = Field(default="ok")
     cancelled: list[str] = Field(
@@ -1191,7 +1191,7 @@ class CoordinatorStopCascadeResponse(BaseModel):
 
 
 class CoordinatorCloseAllChildrenRequest(BaseModel):
-    """Body for POST /v1/api/coordinator/{ws_id}/close_all_children."""
+    """Body for POST /v1/api/workstreams/{ws_id}/close_all_children."""
 
     reason: str = Field(
         default="",
@@ -1205,7 +1205,7 @@ class CoordinatorCloseAllChildrenRequest(BaseModel):
 
 
 class CoordinatorCloseAllChildrenResponse(BaseModel):
-    """Response body for POST /v1/api/coordinator/{ws_id}/close_all_children."""
+    """Response body for POST /v1/api/workstreams/{ws_id}/close_all_children."""
 
     status: str = Field(default="ok")
     closed: list[str] = Field(

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1132,7 +1132,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
     # enforced per-row (callers without ``admin.system`` see only their
     # own coordinators); cross-tenant misses 404-mask.
     EndpointSpec(
-        "/v1/api/coordinator/new",
+        "/v1/api/workstreams/new",
         "POST",
         "Create a new coordinator workstream",
         description=(
@@ -1147,7 +1147,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator",
+        "/v1/api/workstreams",
         "GET",
         "List coordinator workstreams visible to the caller",
         description=(
@@ -1159,7 +1159,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}",
+        "/v1/api/workstreams/{ws_id}",
         "GET",
         "Get coordinator detail (rehydrates lazily on miss)",
         description=(
@@ -1173,7 +1173,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/open",
+        "/v1/api/workstreams/{ws_id}/open",
         "POST",
         "Open (rehydrate) a coordinator workstream by ws_id",
         description=(
@@ -1187,7 +1187,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/send",
+        "/v1/api/workstreams/{ws_id}/send",
         "POST",
         "Queue a user message onto the coordinator session",
         description=(
@@ -1200,7 +1200,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/approve",
+        "/v1/api/workstreams/{ws_id}/approve",
         "POST",
         "Resolve a pending tool approval on the coordinator session",
         description=(
@@ -1215,7 +1215,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/cancel",
+        "/v1/api/workstreams/{ws_id}/cancel",
         "POST",
         "Cancel in-flight generation on the coordinator session",
         description=(
@@ -1228,7 +1228,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/close",
+        "/v1/api/workstreams/{ws_id}/close",
         "POST",
         "Soft-close the coordinator (unload from memory; storage preserved)",
         description=(
@@ -1242,7 +1242,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/events",
+        "/v1/api/workstreams/{ws_id}/events",
         "GET",
         "Subscribe to the coordinator's SSE event stream",
         description=(
@@ -1257,7 +1257,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/history",
+        "/v1/api/workstreams/{ws_id}/history",
         "GET",
         "Read the coordinator's reconstructed message history",
         description=(
@@ -1278,7 +1278,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/children",
+        "/v1/api/workstreams/{ws_id}/children",
         "GET",
         "List the coordinator's spawned child workstreams",
         description=(
@@ -1291,7 +1291,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/tasks",
+        "/v1/api/workstreams/{ws_id}/tasks",
         "GET",
         "Read the coordinator's task list envelope",
         description=(
@@ -1304,7 +1304,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/trust",
+        "/v1/api/workstreams/{ws_id}/trust",
         "POST",
         "Toggle trusted-session mode for send_to_workstream",
         description=(
@@ -1325,7 +1325,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/restrict",
+        "/v1/api/workstreams/{ws_id}/restrict",
         "POST",
         "Revoke tool access on a live coordinator session",
         description=(
@@ -1344,7 +1344,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/stop_cascade",
+        "/v1/api/workstreams/{ws_id}/stop_cascade",
         "POST",
         "Cancel the coordinator and every direct child",
         description=(
@@ -1362,7 +1362,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/coordinator/{ws_id}/close_all_children",
+        "/v1/api/workstreams/{ws_id}/close_all_children",
         "POST",
         "Soft-close every direct child of the coordinator",
         description=(

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -147,7 +147,7 @@ class CreateWorkstreamRequest(BaseModel):
         description=(
             "Workstream kind — 'interactive' (default) or 'coordinator'. "
             "Coordinator workstreams are created by the console's own "
-            "/v1/api/coordinator/new endpoint; clients hitting "
+            "/v1/api/workstreams/new endpoint; clients hitting "
             "/v1/api/workstreams/new should leave this at the default."
         ),
     )

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -248,7 +248,7 @@ _ROUTE_PATHS: dict[str, str] = {
     # routing-proxy prefix.  ``_post`` still formats against
     # ``_base_url``; formatting of the ``{ws_id}`` slot happens at call
     # time in ``close_all_children``.
-    "close_all_children": "/v1/api/coordinator/{ws_id}/close_all_children",
+    "close_all_children": "/v1/api/workstreams/{ws_id}/close_all_children",
 }
 
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2388,6 +2388,33 @@ def _auth_scopes(request: Request) -> set[str]:
     return set(getattr(auth, "scopes", []) or [])
 
 
+def _audit_close_coordinator(
+    request: Request,
+    ws_id: str,
+    ws_before: Workstream,  # noqa: ARG001 — coord audit detail doesn't use it yet
+    reason: str,  # noqa: ARG001 — coord doesn't expose close_reason yet
+) -> None:
+    """Record the ``coordinator.close`` audit event.
+
+    Passed to :func:`make_close_handler` as the ``audit_emit``
+    callable. ``storage`` is guaranteed non-``None`` by the lifted
+    handler's upstream gate; the ``getattr`` fallback is defensive
+    consistency with the rest of the storage access pattern.
+    """
+    storage = getattr(request.app.state, "auth_storage", None)
+    if storage is None:
+        return
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "coordinator.close",
+        "workstream",
+        ws_id,
+        {"coord_ws_id": ws_id, "src": "coordinator"},
+        request.client.host if request.client else "",
+    )
+
+
 async def coordinator_create(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/new — create a new coordinator session."""
     from turnstone.core.audit import record_audit
@@ -10093,24 +10120,6 @@ def create_app(
         not_found_label="coordinator not found",
         audit_action_prefix="coordinator",
     )
-
-    def _audit_close_coordinator(
-        request: Request,
-        ws_id: str,
-        ws_before: Workstream,
-        reason: str,  # noqa: ARG001 — coord doesn't expose close_reason yet
-    ) -> None:
-        storage = request.app.state.auth_storage
-        record_audit(
-            storage,
-            _auth_user_id(request),
-            "coordinator.close",
-            "workstream",
-            ws_id,
-            {"coord_ws_id": ws_id, "src": "coordinator"},
-            request.client.host if request.client else "",
-        )
-
     coord_workstream_routes: list[Any] = []
     register_session_routes(
         coord_workstream_routes,
@@ -10122,11 +10131,12 @@ def create_app(
             detail=coordinator_detail,
             open=coordinator_open,
             close=make_close_handler(  # lifted: shared body
+                coord_endpoint_config,
                 audit_emit=_audit_close_coordinator,
                 supports_close_reason=False,
             ),
             send=coordinator_send,
-            approve=make_approve_handler(),  # lifted: shared body
+            approve=make_approve_handler(coord_endpoint_config),  # lifted: shared body
             cancel=coordinator_cancel,
             events=coordinator_events,
             history=coordinator_history,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -56,7 +56,9 @@ from turnstone.core.auth import (
 from turnstone.core.rendezvous import NoAvailableNodeError
 from turnstone.core.session_routes import (
     CoordOnlyVerbHandlers,
+    SessionEndpointConfig,
     SharedSessionVerbHandlers,
+    make_approve_handler,
     register_coord_verbs,
     register_session_routes,
 )
@@ -2520,44 +2522,6 @@ async def coordinator_send(request: Request) -> JSONResponse:
         if ws_now is not None and ws_now.session is not None:
             return JSONResponse({"error": "worker queue full; retry shortly"}, status_code=429)
         return JSONResponse({"error": "send failed"}, status_code=500)
-    return JSONResponse({"status": "ok"})
-
-
-async def coordinator_approve(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/approve — unblock pending approval."""
-    from turnstone.core.web_helpers import read_json_or_400
-
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    approved = bool(body.get("approved", False))
-    feedback = body.get("feedback")
-    always = bool(body.get("always", False))
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    ui = ws.ui
-    if ui is None or not hasattr(ui, "resolve_approval"):
-        return JSONResponse(
-            {"error": "coordinator UI does not support approval"},
-            status_code=409,
-        )
-    if always and approved and getattr(ui, "_pending_approval", None):
-        tool_names = {
-            it.get("approval_label", "") or it.get("func_name", "")
-            for it in ui._pending_approval.get("items", [])
-            if it.get("needs_approval") and it.get("func_name") and not it.get("error")
-        }
-        tool_names.discard("")
-        ui.auto_approve_tools.update(tool_names)
-    ui.resolve_approval(approved, feedback)
     return JSONResponse({"status": "ok"})
 
 
@@ -10149,9 +10113,20 @@ def create_app(
     _docs_handler = make_docs_handler()
 
     # Coord workstream HTTP tree mounts under the unified
-    # ``/api/workstreams/`` shape. Handlers look the coord manager up
-    # via ``request.app.state.coord_mgr`` because the manager is built
-    # in the lifespan, after app construction.
+    # ``/api/workstreams/`` shape. Lifted handlers (e.g. ``approve``)
+    # consult ``app.state.session_endpoint_config`` for the kind's
+    # auth + manager-lookup policies. Per-kind handlers
+    # (``coordinator_*``) still look the coord manager up via
+    # ``request.app.state.coord_mgr`` because the manager is built in
+    # the lifespan, after this app construction; future verb lifts
+    # carry that lookup into the config callable.
+    coord_endpoint_config = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=_require_coord_mgr,
+        tenant_check=None,  # cluster-wide admin.coordinator gate covers it
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
     coord_workstream_routes: list[Any] = []
     register_session_routes(
         coord_workstream_routes,
@@ -10164,7 +10139,7 @@ def create_app(
             open=coordinator_open,
             close=coordinator_close,
             send=coordinator_send,
-            approve=coordinator_approve,
+            approve=make_approve_handler(),  # lifted: shared body
             cancel=coordinator_cancel,
             events=coordinator_events,
             history=coordinator_history,
@@ -10621,6 +10596,7 @@ def create_app(
         lifespan=_lifespan,
     )
     app.state.collector = collector
+    app.state.session_endpoint_config = coord_endpoint_config
     app.state.jwt_secret = jwt_secret
     app.state.auth_storage = auth_storage
     app.state.proxy_token_mgr = proxy_token_mgr

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -10106,13 +10106,13 @@ def create_app(
     _docs_handler = make_docs_handler()
 
     # Coord workstream HTTP tree mounts under the unified
-    # ``/api/workstreams/`` shape. Lifted handlers (e.g. ``approve``)
-    # consult ``app.state.session_endpoint_config`` for the kind's
-    # auth + manager-lookup policies. Per-kind handlers
-    # (``coordinator_*``) still look the coord manager up via
-    # ``request.app.state.coord_mgr`` because the manager is built in
-    # the lifespan, after this app construction; future verb lifts
-    # carry that lookup into the config callable.
+    # ``/api/workstreams/`` shape. Lifted handlers (e.g. ``approve``,
+    # ``close``) capture the kind-specific ``SessionEndpointConfig``
+    # via the factory closure. Per-kind handlers (``coordinator_*``)
+    # still look the coord manager up via ``request.app.state.coord_mgr``
+    # at request time because the manager is built in the lifespan,
+    # after this app construction; future verb lifts carry that lookup
+    # into the config callable.
     coord_endpoint_config = SessionEndpointConfig(
         permission_gate=_require_admin_coordinator,
         manager_lookup=_require_coord_mgr,
@@ -10593,7 +10593,6 @@ def create_app(
         lifespan=_lifespan,
     )
     app.state.collector = collector
-    app.state.session_endpoint_config = coord_endpoint_config
     app.state.jwt_secret = jwt_secret
     app.state.auth_storage = auth_storage
     app.state.proxy_token_mgr = proxy_token_mgr

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2265,7 +2265,10 @@ async def _proxy_sse(
 
 
 # ---------------------------------------------------------------------------
-# Coordinator workstream endpoints — POST /v1/api/coordinator/*
+# Coordinator workstream endpoints — mounted under /v1/api/workstreams/*
+# via register_session_routes + register_coord_verbs. Handler bodies stay
+# named ``coordinator_*`` for now; the body-convergence follow-on lifts
+# them into turnstone.core.session_routes with kind branching.
 # ---------------------------------------------------------------------------
 
 
@@ -2384,7 +2387,7 @@ def _auth_scopes(request: Request) -> set[str]:
 
 
 async def coordinator_create(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/new — create a new coordinator session."""
+    """POST /v1/api/workstreams/new — create a new coordinator session."""
     from turnstone.core.audit import record_audit
     from turnstone.core.web_helpers import read_json_or_400
 
@@ -2490,7 +2493,7 @@ async def coordinator_create(request: Request) -> JSONResponse:
 
 
 async def coordinator_send(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/send — queue a user message."""
+    """POST /v1/api/workstreams/{ws_id}/send — queue a user message."""
     from turnstone.core.web_helpers import read_json_or_400
 
     err = _require_admin_coordinator(request)
@@ -2522,7 +2525,7 @@ async def coordinator_send(request: Request) -> JSONResponse:
 
 
 async def coordinator_approve(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/approve — unblock pending approval."""
+    """POST /v1/api/workstreams/{ws_id}/approve — unblock pending approval."""
     from turnstone.core.web_helpers import read_json_or_400
 
     err = _require_admin_coordinator(request)
@@ -2560,7 +2563,7 @@ async def coordinator_approve(request: Request) -> JSONResponse:
 
 
 async def coordinator_cancel(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/cancel — cancel in-flight generation."""
+    """POST /v1/api/workstreams/{ws_id}/cancel — cancel in-flight generation."""
     from turnstone.core.audit import record_audit
 
     err = _require_admin_coordinator(request)
@@ -2593,7 +2596,7 @@ async def coordinator_cancel(request: Request) -> JSONResponse:
 
 
 async def coordinator_close(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/close — unload the session."""
+    """POST /v1/api/workstreams/{ws_id}/close — unload the session."""
     from turnstone.core.audit import record_audit
 
     err = _require_admin_coordinator(request)
@@ -2627,7 +2630,7 @@ async def coordinator_close(request: Request) -> JSONResponse:
 
 
 async def coordinator_events(request: Request) -> Response:
-    """GET /v1/api/coordinator/{ws_id}/events — SSE event stream."""
+    """GET /v1/api/workstreams/{ws_id}/events — SSE event stream."""
     err = _require_admin_coordinator(request)
     if err is not None:
         return err
@@ -2670,7 +2673,7 @@ async def coordinator_events(request: Request) -> Response:
 
 
 async def coordinator_history(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/{ws_id}/history — message history for page load.
+    """GET /v1/api/workstreams/{ws_id}/history — message history for page load.
 
     Supports a ``?limit=`` query param (default 100, max 500) bounding
     how many conversation rows are fetched from storage.  Long-lived
@@ -2706,7 +2709,7 @@ async def coordinator_history(request: Request) -> JSONResponse:
 
 
 async def coordinator_list(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator — list active coordinator sessions for the caller."""
+    """GET /v1/api/workstreams — list active coordinator sessions for the caller."""
     err = _require_admin_coordinator(request)
     if err is not None:
         return err
@@ -2733,7 +2736,7 @@ async def coordinator_list(request: Request) -> JSONResponse:
 
 
 async def coordinator_saved(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/saved — list saved (closed-but-persisted) coordinator
+    """GET /v1/api/workstreams/saved — list saved (closed-but-persisted) coordinator
     sessions for the caller.
 
     Mirrors :func:`turnstone.server.list_saved_workstreams` for the
@@ -2838,7 +2841,7 @@ async def coordinator_page(request: Request) -> Response:
 
 
 async def coordinator_detail(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/{ws_id} — detail + lazy rehydrate on miss."""
+    """GET /v1/api/workstreams/{ws_id} — detail + lazy rehydrate on miss."""
     err = _require_admin_coordinator(request)
     if err is not None:
         return err
@@ -2887,7 +2890,7 @@ async def coordinator_detail(request: Request) -> JSONResponse:
 
 
 async def coordinator_open(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/open — explicit rehydration.
+    """POST /v1/api/workstreams/{ws_id}/open — explicit rehydration.
 
     Parity with the server's ``POST /v1/api/workstreams/{ws_id}/open``.
     ``coordinator_detail`` already rehydrates lazily on a GET miss; this
@@ -2972,7 +2975,7 @@ def _coord_children_row(row: Any) -> dict[str, Any]:
 
 
 async def coordinator_children(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/{ws_id}/children — list direct children.
+    """GET /v1/api/workstreams/{ws_id}/children — list direct children.
 
     Returns ``{items, truncated}`` with one row per interactive workstream
     whose ``parent_ws_id`` is the coordinator.  Matches the shape of the
@@ -3076,7 +3079,7 @@ def _coordinator_metrics_payload(
 
 
 async def coordinator_metrics(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/{ws_id}/metrics — per-coordinator health snapshot.
+    """GET /v1/api/workstreams/{ws_id}/metrics — per-coordinator health snapshot.
 
     Aggregates cheap, already-persisted signals into a one-shot "is
     this coordinator healthy?" answer for operators (#16).  No new
@@ -3371,7 +3374,7 @@ def _set_audit_executor(executor: ThreadPoolExecutor | None) -> None:
 
 
 async def coordinator_trust(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/trust — toggle trusted-session mode."""
+    """POST /v1/api/workstreams/{ws_id}/trust — toggle trusted-session mode."""
     trust_err = require_permission(request, "coordinator.trust.send", allow_service_bypass=False)
     if trust_err is not None:
         return trust_err
@@ -3401,7 +3404,7 @@ async def coordinator_trust(request: Request) -> JSONResponse:
 
 
 async def coordinator_restrict(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/restrict — revoke tool access mid-session."""
+    """POST /v1/api/workstreams/{ws_id}/restrict — revoke tool access mid-session."""
     resolved = await _resolve_coord_session(request, allow_service_bypass=False)
     if isinstance(resolved, JSONResponse):
         return resolved
@@ -3445,7 +3448,7 @@ async def coordinator_restrict(request: Request) -> JSONResponse:
 
 
 async def coordinator_stop_cascade(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/stop_cascade — cancel the subtree."""
+    """POST /v1/api/workstreams/{ws_id}/stop_cascade — cancel the subtree."""
     resolved = await _resolve_coord_session(request, allow_service_bypass=False)
     if isinstance(resolved, JSONResponse):
         return resolved
@@ -3496,7 +3499,7 @@ _CLOSE_ALL_CHILDREN_MAX_REASON_LEN = 512
 
 
 async def coordinator_close_all_children(request: Request) -> JSONResponse:
-    """POST /v1/api/coordinator/{ws_id}/close_all_children — soft-close the direct children.
+    """POST /v1/api/workstreams/{ws_id}/close_all_children — soft-close the direct children.
 
     Near-twin of ``coordinator_stop_cascade`` — both fan out over
     ``children_snapshot`` via ``_fanout_on_children``.  Returns
@@ -3567,7 +3570,7 @@ async def coordinator_close_all_children(request: Request) -> JSONResponse:
 
 
 async def coordinator_tasks(request: Request) -> JSONResponse:
-    """GET /v1/api/coordinator/{ws_id}/tasks — read task list envelope.
+    """GET /v1/api/workstreams/{ws_id}/tasks — read task list envelope.
 
     Returns ``{"version": 1, "tasks": [...]}`` — the same shape the
     ``task_list(action="list")`` tool returns (less the list-tool's
@@ -10237,96 +10240,12 @@ def create_app(
                         methods=["GET"],
                     ),
                     Route("/api/route", route_lookup, methods=["GET"]),
-                    # Coordinator workstream API — console-hosted sessions.
-                    # All require admin.coordinator permission.
-                    Route(
-                        "/api/coordinator/new",
-                        coordinator_create,
-                        methods=["POST"],
-                    ),
-                    Route("/api/coordinator", coordinator_list, methods=["GET"]),
-                    # Literal path BEFORE the /{ws_id} routes below so
-                    # Starlette doesn't match "saved" as a ws_id.
-                    Route(
-                        "/api/coordinator/saved",
-                        coordinator_saved,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/send",
-                        coordinator_send,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/approve",
-                        coordinator_approve,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/cancel",
-                        coordinator_cancel,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/close",
-                        coordinator_close,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/open",
-                        coordinator_open,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/events",
-                        coordinator_events,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/history",
-                        coordinator_history,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/children",
-                        coordinator_children,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/tasks",
-                        coordinator_tasks,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/metrics",
-                        coordinator_metrics,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/trust",
-                        coordinator_trust,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/restrict",
-                        coordinator_restrict,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/stop_cascade",
-                        coordinator_stop_cascade,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}/close_all_children",
-                        coordinator_close_all_children,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/coordinator/{ws_id}",
-                        coordinator_detail,
-                        methods=["GET"],
-                    ),
+                    # Coordinator workstream API mounts above via
+                    # ``register_session_routes`` + ``register_coord_verbs``
+                    # at the unified ``/api/workstreams/`` prefix. The
+                    # legacy ``/api/coordinator/`` shape was deleted in
+                    # Stage 2 Priority 0 Step 0.4 — it never shipped in
+                    # a stable release, so no compat carry-forward.
                     Route("/api/models", list_available_models),
                     Route("/api/skills", list_skills_summary),
                     Route("/api/auth/login", auth_login, methods=["POST"]),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -55,8 +55,10 @@ from turnstone.core.auth import (
 )
 from turnstone.core.rendezvous import NoAvailableNodeError
 from turnstone.core.session_routes import (
+    CoordVerbHandlers,
     SessionRouteConfig,
     SessionRouteHandlers,
+    register_coord_verbs,
     register_session_routes,
 )
 from turnstone.core.skill_kind import SkillKind
@@ -10169,6 +10171,22 @@ def create_app(
             cancel=coordinator_cancel,
             events=coordinator_events,
             history=coordinator_history,
+        ),
+    )
+    # Step 0.3: coord-only verbs (children registry, quotas, trust /
+    # restrict policy, cascade controls) mount alongside under the
+    # same unified prefix.
+    register_coord_verbs(
+        coord_workstream_routes,
+        prefix="/api/workstreams",
+        handlers=CoordVerbHandlers(
+            children=coordinator_children,
+            tasks=coordinator_tasks,
+            metrics=coordinator_metrics,
+            trust=coordinator_trust,
+            restrict=coordinator_restrict,
+            stop_cascade=coordinator_stop_cascade,
+            close_all_children=coordinator_close_all_children,
         ),
     )
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -54,6 +54,11 @@ from turnstone.core.auth import (
     require_permission,
 )
 from turnstone.core.rendezvous import NoAvailableNodeError
+from turnstone.core.session_routes import (
+    SessionRouteConfig,
+    SessionRouteHandlers,
+    register_session_routes,
+)
 from turnstone.core.skill_kind import SkillKind
 from turnstone.core.web_helpers import (
     read_json_or_400,
@@ -10139,12 +10144,41 @@ def create_app(
     _openapi_handler = make_openapi_handler(_spec)
     _docs_handler = make_docs_handler()
 
+    # Coord verbs mounted under the unified ``/api/workstreams/`` shape
+    # via the shared registrar. The legacy ``/api/coordinator/...`` routes
+    # below stay live during the Step 0.2 transition; Step 0.4 deletes
+    # them once the frontend (Step 0.6) and tests (Step 0.7) move off.
+    # ``mgr`` / ``adapter`` are built in the lifespan (after this app
+    # construction), so handlers continue to look them up via
+    # ``request.app.state.coord_mgr`` for now — they only become
+    # registrar-arguments in the body-convergence follow-on.
+    coord_workstream_routes: list[Any] = []
+    register_session_routes(
+        coord_workstream_routes,
+        prefix="/api/workstreams",
+        config=SessionRouteConfig(),
+        handlers=SessionRouteHandlers(
+            list_workstreams=coordinator_list,
+            list_saved=coordinator_saved,
+            create=coordinator_create,
+            detail=coordinator_detail,
+            open=coordinator_open,
+            close=coordinator_close,
+            send=coordinator_send,
+            approve=coordinator_approve,
+            cancel=coordinator_cancel,
+            events=coordinator_events,
+            history=coordinator_history,
+        ),
+    )
+
     app = Starlette(
         routes=[
             Route("/", index),
             Mount(
                 "/v1",
                 routes=[
+                    *coord_workstream_routes,
                     Route("/api/cluster/overview", cluster_overview),
                     Route("/api/cluster/nodes", cluster_nodes),
                     Route("/api/cluster/workstreams", cluster_workstreams),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -59,6 +59,7 @@ from turnstone.core.session_routes import (
     SessionEndpointConfig,
     SharedSessionVerbHandlers,
     make_approve_handler,
+    make_close_handler,
     register_coord_verbs,
     register_session_routes,
 )
@@ -67,7 +68,7 @@ from turnstone.core.web_helpers import (
     read_json_or_400,
     require_storage_or_503,
 )
-from turnstone.core.workstream import WorkstreamKind
+from turnstone.core.workstream import Workstream, WorkstreamKind
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
@@ -2558,40 +2559,6 @@ async def coordinator_cancel(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
-async def coordinator_close(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/close — unload the session."""
-    from turnstone.core.audit import record_audit
-
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    user_id = _auth_user_id(request)
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    if not coord_mgr.close(ws_id):
-        return JSONResponse({"error": "close failed"}, status_code=500)
-    storage = getattr(request.app.state, "auth_storage", None)
-    if storage is not None:
-        try:
-            record_audit(
-                storage,
-                user_id,
-                "coordinator.close",
-                "workstream",
-                ws_id,
-                {"coord_ws_id": ws_id, "src": "coordinator"},
-                request.client.host if request.client else "",
-            )
-        except Exception:
-            log.debug("coordinator_close.audit_failed", exc_info=True)
-    return JSONResponse({"status": "ok"})
-
-
 async def coordinator_events(request: Request) -> Response:
     """GET /v1/api/workstreams/{ws_id}/events — SSE event stream."""
     err = _require_admin_coordinator(request)
@@ -3930,7 +3897,6 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     build_console_session_factory,
                 )
                 from turnstone.core.session_manager import SessionManager
-                from turnstone.core.workstream import Workstream
 
                 jwt_secret: str = getattr(app.state, "jwt_secret", "")
                 console_bind_url: str = getattr(app.state, "console_url", "") or (
@@ -10127,6 +10093,24 @@ def create_app(
         not_found_label="coordinator not found",
         audit_action_prefix="coordinator",
     )
+
+    def _audit_close_coordinator(
+        request: Request,
+        ws_id: str,
+        ws_before: Workstream,
+        reason: str,  # noqa: ARG001 — coord doesn't expose close_reason yet
+    ) -> None:
+        storage = request.app.state.auth_storage
+        record_audit(
+            storage,
+            _auth_user_id(request),
+            "coordinator.close",
+            "workstream",
+            ws_id,
+            {"coord_ws_id": ws_id, "src": "coordinator"},
+            request.client.host if request.client else "",
+        )
+
     coord_workstream_routes: list[Any] = []
     register_session_routes(
         coord_workstream_routes,
@@ -10137,7 +10121,10 @@ def create_app(
             create=coordinator_create,
             detail=coordinator_detail,
             open=coordinator_open,
-            close=coordinator_close,
+            close=make_close_handler(  # lifted: shared body
+                audit_emit=_audit_close_coordinator,
+                supports_close_reason=False,
+            ),
             send=coordinator_send,
             approve=make_approve_handler(),  # lifted: shared body
             cancel=coordinator_cancel,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -55,9 +55,8 @@ from turnstone.core.auth import (
 )
 from turnstone.core.rendezvous import NoAvailableNodeError
 from turnstone.core.session_routes import (
-    CoordVerbHandlers,
-    SessionRouteConfig,
-    SessionRouteHandlers,
+    CoordOnlyVerbHandlers,
+    SharedSessionVerbHandlers,
     register_coord_verbs,
     register_session_routes,
 )
@@ -10149,20 +10148,15 @@ def create_app(
     _openapi_handler = make_openapi_handler(_spec)
     _docs_handler = make_docs_handler()
 
-    # Coord verbs mounted under the unified ``/api/workstreams/`` shape
-    # via the shared registrar. The legacy ``/api/coordinator/...`` routes
-    # below stay live during the Step 0.2 transition; Step 0.4 deletes
-    # them once the frontend (Step 0.6) and tests (Step 0.7) move off.
-    # ``mgr`` / ``adapter`` are built in the lifespan (after this app
-    # construction), so handlers continue to look them up via
-    # ``request.app.state.coord_mgr`` for now — they only become
-    # registrar-arguments in the body-convergence follow-on.
+    # Coord workstream HTTP tree mounts under the unified
+    # ``/api/workstreams/`` shape. Handlers look the coord manager up
+    # via ``request.app.state.coord_mgr`` because the manager is built
+    # in the lifespan, after app construction.
     coord_workstream_routes: list[Any] = []
     register_session_routes(
         coord_workstream_routes,
         prefix="/api/workstreams",
-        config=SessionRouteConfig(),
-        handlers=SessionRouteHandlers(
+        handlers=SharedSessionVerbHandlers(
             list_workstreams=coordinator_list,
             list_saved=coordinator_saved,
             create=coordinator_create,
@@ -10176,13 +10170,10 @@ def create_app(
             history=coordinator_history,
         ),
     )
-    # Step 0.3: coord-only verbs (children registry, quotas, trust /
-    # restrict policy, cascade controls) mount alongside under the
-    # same unified prefix.
     register_coord_verbs(
         coord_workstream_routes,
         prefix="/api/workstreams",
-        handlers=CoordVerbHandlers(
+        handlers=CoordOnlyVerbHandlers(
             children=coordinator_children,
             tasks=coordinator_tasks,
             metrics=coordinator_metrics,
@@ -10240,12 +10231,6 @@ def create_app(
                         methods=["GET"],
                     ),
                     Route("/api/route", route_lookup, methods=["GET"]),
-                    # Coordinator workstream API mounts above via
-                    # ``register_session_routes`` + ``register_coord_verbs``
-                    # at the unified ``/api/workstreams/`` prefix. The
-                    # legacy ``/api/coordinator/`` shape was deleted in
-                    # Stage 2 Priority 0 Step 0.4 — it never shipped in
-                    # a stable release, so no compat carry-forward.
                     Route("/api/models", list_available_models),
                     Route("/api/skills", list_skills_summary),
                     Route("/api/auth/login", auth_login, methods=["POST"]),

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -8,7 +8,7 @@ window.onLoginSuccess = function () {
   // Re-populate the home-composer skill dropdown and re-probe the
   // coordinator subsystem now that auth has landed.  The initial
   // page-load pass runs before login completes, so /v1/api/skills
-  // and /v1/api/coordinator both 401; without this re-run the
+  // and /v1/api/workstreams both 401; without this re-run the
   // dropdown stays empty and the 503 banner never flips correctly.
   if (typeof _populateHomeSkillDropdown === "function") {
     _populateHomeSkillDropdown();
@@ -150,7 +150,7 @@ function patchClusterState(data) {
     // real-node interactive closes don't carry kind on the wire, but
     // they're already typed in clusterState from the matching ws_created
     // event.  Skipping interactive closes avoids per-close fan-out into
-    // /v1/api/coordinator/saved on busy clusters.
+    // /v1/api/workstreams/saved on busy clusters.
     var wasCoordinator = false;
     Object.keys(clusterState.nodes).forEach(function (nid) {
       (clusterState.nodes[nid].workstreams || []).forEach(function (ws) {
@@ -1826,7 +1826,7 @@ function _hasCoordPermission() {
   return perms.split(",").indexOf("admin.coordinator") !== -1;
 }
 
-// POST /v1/api/coordinator/new.  Accepts the three request fields
+// POST /v1/api/workstreams/new.  Accepts the three request fields
 // directly + an errEl / setBusy callback so the caller owns the
 // loading-state UX (button label swap, composer disabled flag, etc.).
 // On success redirects to /coordinator/{ws_id}; on 503 invokes on503
@@ -1849,7 +1849,7 @@ function _createCoordinator(opts) {
   if (skill) body.skill = skill;
   if (task) body.initial_message = task;
 
-  authFetch("/v1/api/coordinator/new", {
+  authFetch("/v1/api/workstreams/new", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -1983,7 +1983,7 @@ function _populateHomeSkillDropdown() {
     });
 }
 
-// Probe GET /v1/api/coordinator — 200 = subsystem ready; 503 = no model
+// Probe GET /v1/api/workstreams — 200 = subsystem ready; 503 = no model
 // alias resolvable, show remediation banner.  4xx (auth / permission) is
 // treated as "unknown, don't flip the banner" because the probe cannot
 // actually tell us anything about subsystem readiness in that case —
@@ -1998,7 +1998,7 @@ function _populateHomeSkillDropdown() {
 // round-trip on every login.
 function _probeCoordSubsystem() {
   if (!_hasCoordPermission()) return;
-  authFetch("/v1/api/coordinator")
+  authFetch("/v1/api/workstreams")
     .then(function (r) {
       if (r.status === 503) {
         _homeCoordReady = false;
@@ -2224,7 +2224,7 @@ function _renderHomeView() {
 // Saved coordinators — closed sessions persisted on disk.  Mirrors the
 // interactive UI's "Saved Workstreams" card grid (same /shared/cards.css
 // primitives, same /shared/cards.js renderSessionCard helper, same
-// response item shape from /v1/api/coordinator/saved).  Click a card →
+// response item shape from /v1/api/workstreams/saved).  Click a card →
 // POST /open then /coordinator/{ws_id}; coordinator_detail lazily
 // rehydrates from storage on the GET miss.
 // ---------------------------------------------------------------------------
@@ -2244,7 +2244,7 @@ function loadSavedCoordinators() {
     return;
   }
   _savedCoordsInFlight = true;
-  authFetch("/v1/api/coordinator/saved")
+  authFetch("/v1/api/workstreams/saved")
     .then(function (r) {
       return r.ok ? r.json() : { coordinators: [] };
     })
@@ -2295,7 +2295,7 @@ function renderSavedCoordinators(items) {
         // "all slots in use" instead of staring at a 404.
         cardEl.classList.add("is-busy");
         authFetch(
-          "/v1/api/coordinator/" + encodeURIComponent(s.ws_id) + "/open",
+          "/v1/api/workstreams/" + encodeURIComponent(s.ws_id) + "/open",
           { method: "POST" },
         )
           .then(function (r) {

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1,12 +1,12 @@
 /* coordinator.js — one-pane UI for console-hosted coordinator sessions.
  *
  * Connects to:
- *   GET  /v1/api/coordinator/{ws_id}/events  (SSE)
- *   GET  /v1/api/coordinator/{ws_id}/history (initial history)
- *   POST /v1/api/coordinator/{ws_id}/send
- *   POST /v1/api/coordinator/{ws_id}/approve
- *   POST /v1/api/coordinator/{ws_id}/cancel
- *   POST /v1/api/coordinator/{ws_id}/close
+ *   GET  /v1/api/workstreams/{ws_id}/events  (SSE)
+ *   GET  /v1/api/workstreams/{ws_id}/history (initial history)
+ *   POST /v1/api/workstreams/{ws_id}/send
+ *   POST /v1/api/workstreams/{ws_id}/approve
+ *   POST /v1/api/workstreams/{ws_id}/cancel
+ *   POST /v1/api/workstreams/{ws_id}/close
  *
  * Depends on shared/auth.js (authFetch, fetchWithCreds), shared/theme.js
  * (toggleTheme), shared/toast.js (toast.info / toast.error),
@@ -516,7 +516,7 @@
     setApprovalButtonsDisabled(true);
     try {
       const resp = await postJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/approve",
+        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/approve",
         body,
       );
       if (!resp.ok) throw new Error("approve failed: HTTP " + resp.status);
@@ -538,7 +538,7 @@
     if (!msg) return false;
     composer.clear();
     composer.setBusy(true);
-    postJSON("/v1/api/coordinator/" + encodeURIComponent(wsId) + "/send", {
+    postJSON("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send", {
       message: msg,
     })
       .then((resp) => {
@@ -561,7 +561,7 @@
 
   window.coordCancel = function () {
     postJSON(
-      "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/cancel",
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/cancel",
       {},
     ).catch((e) => console.error(e));
   };
@@ -575,7 +575,7 @@
       return;
     try {
       const resp = await postJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/close",
+        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/close",
         {},
       );
       if (!resp.ok) throw new Error("close failed: HTTP " + resp.status);
@@ -649,7 +649,7 @@
     // we were disconnected aren't replayed by coordinator_events, so
     // the client has to pull authoritative state after any gap.
     const wasReconnecting = reconnectAttempts > 0;
-    const url = "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/events";
+    const url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
     evtSource = new EventSource(url, { withCredentials: true });
     evtSource.onopen = function () {
       reconnectAttempts = 0;
@@ -686,7 +686,7 @@
       // On any other outcome, fall through to the normal reconnect
       // schedule.
       var probe = typeof authFetch === "function" ? authFetch : fetch;
-      probe("/v1/api/coordinator/" + encodeURIComponent(wsId))
+      probe("/v1/api/workstreams/" + encodeURIComponent(wsId))
         .then(function (r) {
           if (r.status === 401 && typeof showLogin === "function") {
             showLogin("Session expired. Please sign in to reconnect.");
@@ -1242,7 +1242,7 @@
     childrenTreeEl.setAttribute("aria-busy", "true");
     try {
       const body = await getJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/children",
+        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/children",
       );
       // Default (initial page load): merge rather than clear.  SSE
       // events may have arrived during the in-flight fetch and
@@ -1274,7 +1274,7 @@
   async function loadTasks() {
     try {
       const body = await getJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/tasks",
+        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/tasks",
       );
       tasksState = body || { version: 1, tasks: [] };
     } catch (e) {
@@ -1559,7 +1559,7 @@
   async function init() {
     try {
       const data = await getJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId),
+        "/v1/api/workstreams/" + encodeURIComponent(wsId),
       );
       nameEl.textContent = data.name || "";
       statusEl.textContent = data.state || "";
@@ -1569,7 +1569,7 @@
     }
     try {
       const hist = await getJSON(
-        "/v1/api/coordinator/" + encodeURIComponent(wsId) + "/history",
+        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/history",
       );
       (hist.messages || []).forEach((m) => {
         const role = m.role || "tool";

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -162,7 +162,7 @@
         <!-- Saved coordinators — closed sessions that persist on disk.
          Mirrors the interactive UI's "Saved Workstreams" card grid
          (same /shared/cards.css primitives, same response item shape
-         from /v1/api/coordinator/saved).  Click a card →
+         from /v1/api/workstreams/saved).  Click a card →
          /coordinator/{ws_id} → coordinator_detail lazy-rehydrates from
          storage.  Hidden until at least one saved coordinator loads. -->
         <section

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -154,6 +154,16 @@ class SessionManager:
         return self._adapter.kind
 
     @property
+    def adapter(self) -> SessionKindAdapter:
+        """The kind adapter this manager was constructed with.
+
+        Exposed so callers (e.g. the HTTP route registrar) that already
+        hold a manager don't have to re-thread the adapter through every
+        construction layer.
+        """
+        return self._adapter
+
+    @property
     def count(self) -> int:
         with self._lock:
             return len(self._workstreams)

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -154,16 +154,6 @@ class SessionManager:
         return self._adapter.kind
 
     @property
-    def adapter(self) -> SessionKindAdapter:
-        """The kind adapter this manager was constructed with.
-
-        Exposed so callers (e.g. the HTTP route registrar) that already
-        hold a manager don't have to re-thread the adapter through every
-        construction layer.
-        """
-        return self._adapter
-
-    @property
     def count(self) -> int:
         with self._lock:
             return len(self._workstreams)

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -4,24 +4,30 @@ Stage 2 Priority 0 of the SessionManager unification — collapses the
 parallel ``/v1/api/workstreams/*`` (interactive) and
 ``/v1/api/coordinator/*`` (coordinator) handler trees into one.
 
-Step 0.1 (this commit): scaffold the registrar. Handler bodies still
-live in ``turnstone/server.py`` and ``turnstone/console/server.py``
-and are passed in via :class:`SessionRouteHandlers`. The registrar
-owns the URL shape; the next step lifts bodies into this module so
-both kinds share them.
+Step 0.1: scaffolded the registrar; interactive ``server.py`` mounts
+through it.
 
-Step 0.2: coord migrates into the registrar; per-kind branching moves
-behind :class:`SessionRouteConfig` flags so each kind's call site is
-localized rather than spread across two server files.
+Step 0.2 (this commit): grow the registrar to cover the coord-side
+verbs (``send`` / ``approve`` / ``plan`` / ``cancel`` / ``close`` /
+``events`` / ``history`` / ``detail``) and have ``console/server.py``
+mount coord at ``/v1/api/workstreams/`` alongside its existing
+``/v1/api/coordinator/`` paths. Both URL shapes point at the same
+handler functions during the transition; Step 0.4 deletes the
+``/coordinator/`` shape outright once the frontend (Step 0.6) and
+tests (Step 0.7) move off it.
+
+Handler bodies still live in their server modules and are passed in
+via :class:`SessionRouteHandlers` — body convergence is the next
+Step 0.2 follow-on (kind branching behind config flags). Splitting
+"URL surface unified" from "handler bodies converged" keeps the
+soak-able diffs small.
 
 Step 0.3: coord-only verbs (``/trust``, ``/restrict``,
 ``/stop_cascade``, ``/close_all_children``, ``/children``,
 ``/metrics``, ``/tasks``) migrate via :func:`register_coord_verbs`,
 404-ing on non-coord ws_ids via the manager's kind check.
 
-Step 0.4: ``/v1/api/coordinator/*`` deletes outright. The window is
-open precisely because that prefix never shipped in a stable release;
-once 1.5.0 stable tags it becomes a committed surface.
+Step 0.4: ``/v1/api/coordinator/*`` deletes outright.
 
 See ``1.5.0-session-manager-stage-2.md`` for the full sequencing.
 """
@@ -49,26 +55,47 @@ Handler = Callable[["Request"], Awaitable["Response"]]
 class SessionRouteHandlers:
     """Bundle of HTTP handler callables the registrar mounts.
 
-    Step 0.1 placeholder: handlers live in their server modules and
-    are passed in here. Step 0.2 lifts the bodies into
-    ``session_routes`` and switches kind branching to live behind
-    :class:`SessionRouteConfig` flags, at which point this struct
-    deletes.
+    All handlers are optional; ``None`` skips that route. Lets one
+    bundle describe both the interactive shape (no per-``{ws_id}``
+    ``send`` / ``approve`` etc. yet — those use legacy body-keyed
+    paths) and the coord shape (no attachments, no
+    ``refresh-title``).
 
-    Attachment + send-family handlers are ``None``-able because
-    interactive currently exposes ``/api/send`` etc. without a path
-    ``ws_id`` (legacy URL shape) and coord doesn't expose attachments
-    at all yet. Step 0.2 normalizes those gaps.
+    Step 0.2 placeholder: handlers live in their server modules and
+    are passed in here. The next Step 0.2 follow-on lifts the
+    bodies into ``session_routes`` and switches kind branching to
+    live behind :class:`SessionRouteConfig` flags, at which point
+    this struct deletes.
     """
 
-    list_workstreams: Handler
-    list_saved: Handler
-    create: Handler
-    close_legacy: Handler  # POST /workstreams/close — ws_id in body, interactive only
-    delete: Handler
-    open: Handler
-    refresh_title: Handler
-    set_title: Handler
+    # Listing
+    list_workstreams: Handler | None = None  # GET  {prefix}
+    list_saved: Handler | None = None  # GET  {prefix}/saved
+
+    # Create
+    create: Handler | None = None  # POST {prefix}/new
+
+    # Per-``{ws_id}`` lifecycle
+    detail: Handler | None = None  # GET  {prefix}/{ws_id}
+    delete: Handler | None = None  # POST {prefix}/{ws_id}/delete
+    open: Handler | None = None  # POST {prefix}/{ws_id}/open
+    close: Handler | None = None  # POST {prefix}/{ws_id}/close
+    refresh_title: Handler | None = None  # POST {prefix}/{ws_id}/refresh-title
+    set_title: Handler | None = None  # POST {prefix}/{ws_id}/title
+
+    # Legacy interactive close (``ws_id`` in body, not path)
+    close_legacy: Handler | None = None  # POST {prefix}/close
+
+    # Per-``{ws_id}`` interaction (coord shape today; interactive
+    # adopts these in Priority 1's worker dispatch unification)
+    send: Handler | None = None  # POST {prefix}/{ws_id}/send
+    approve: Handler | None = None  # POST {prefix}/{ws_id}/approve
+    plan: Handler | None = None  # POST {prefix}/{ws_id}/plan
+    cancel: Handler | None = None  # POST {prefix}/{ws_id}/cancel
+    events: Handler | None = None  # GET  {prefix}/{ws_id}/events (SSE)
+    history: Handler | None = None  # GET  {prefix}/{ws_id}/history
+
+    # Attachments (interactive only today; coord parity is post-1.5)
     upload_attachment: Handler | None = None
     list_attachments: Handler | None = None
     get_attachment_content: Handler | None = None
@@ -79,90 +106,122 @@ class SessionRouteHandlers:
 class SessionRouteConfig:
     """Per-kind feature flags for the session HTTP route registrar.
 
-    Step 0.1 carries only the flags the current registrar branches
-    on; Step 0.2 grows the flag set as kind-specific handler bodies
-    are lifted in (e.g. ``supports_initial_message_worker`` for
-    interactive ``/new``, ``supports_parent_ws_id`` for coord
-    ``/new``, kind-aware permission scope for the auth gate).
+    Step 0.2 carries one flag — whether the legacy body-keyed
+    ``close`` verb is mounted. Step 0.2's body-convergence follow-on
+    grows this with the per-kind branching flags handler bodies
+    consult (e.g. ``permission_scope``, ``audit_action_prefix``,
+    ``not_found_label``).
     """
 
-    supports_attachments: bool = False
-    supports_legacy_close: bool = False  # interactive: POST /workstreams/close — ws_id in body
+    supports_legacy_close: bool = False  # POST {prefix}/close — ws_id in body
 
 
 def register_session_routes(
     routes: list[BaseRoute],
     *,
     prefix: str,
-    mgr: SessionManager,
-    adapter: SessionKindAdapter,
+    mgr: SessionManager | None = None,
+    adapter: SessionKindAdapter | None = None,
     config: SessionRouteConfig,
     handlers: SessionRouteHandlers,
 ) -> None:
     """Append the workstream HTTP route table to ``routes`` at ``prefix``.
 
-    Mounts the per-workstream verbs (``new``, ``close``, ``open``,
-    ``delete``, ``title``, ``refresh-title``, attachments) plus the
-    list/saved listing endpoints under ``prefix``. Routes that are
-    not workstream-prefixed in the current interactive surface
-    (``/api/dashboard``, ``/api/send``, ``/api/approve``,
-    ``/api/plan``, ``/api/cancel``, ``/api/command``, ``/api/events``)
-    stay at their existing paths in ``server.py`` for Step 0.1 — the
-    next step migrates them into a unified ``{prefix}/{ws_id}/...``
-    shape so coord can share the handlers.
+    Mounts every verb whose handler is non-``None``. Routes register
+    in an order that respects Starlette's first-match semantics:
+    literal subpaths (``saved``, ``new``, ``close``) before the
+    per-``{ws_id}`` patterns; per-``{ws_id}/{verb}`` patterns before
+    the bare ``{ws_id}`` detail GET.
 
     Args:
         routes: list to extend; typically the inner ``Mount`` route
             list a Starlette app uses.
         prefix: URL prefix relative to the mount, e.g.
             ``"/api/workstreams"``.
-        mgr: the session manager owning the workstream kind. Wired
-            through now so Step 0.2's lifted handler bodies can read
-            it without further plumbing.
+        mgr: the session manager owning the workstream kind, when
+            available at app-construction time. Optional today
+            because the console builds its coord manager in the
+            lifespan (after routes), and current handler bodies
+            look the manager up via ``request.app.state``. Becomes
+            required in the body-convergence follow-on once handlers
+            move into this module and read ``mgr`` directly.
         adapter: the kind's adapter. Same forward-wiring rationale.
         config: per-kind feature flags.
         handlers: bundle of handler callables for the routes the
-            registrar mounts. Step 0.2 deletes this argument.
+            registrar mounts. The body-convergence follow-on
+            deletes this argument.
     """
-    # ``mgr`` and ``adapter`` are unused in Step 0.1; declared in the
-    # signature so handler bodies can pick them up directly in 0.2
-    # without a callsite churn. Suppress the lint locally.
+    # ``mgr`` and ``adapter`` are unused this commit; declared in the
+    # signature so handler bodies can pick them up directly in the
+    # body-convergence follow-on without a callsite churn.
     _ = (mgr, adapter)
 
     p = prefix.rstrip("/")
 
     # --- Listing endpoints ----------------------------------------------
-    routes.append(Route(p, handlers.list_workstreams))
-    # ``saved`` literal must register BEFORE the ``{ws_id}`` routes
-    # below so Starlette doesn't match "saved" as a ws_id path param.
-    routes.append(Route(f"{p}/saved", handlers.list_saved))
+    if handlers.list_workstreams is not None:
+        routes.append(Route(p, handlers.list_workstreams))
+    # Literal ``saved`` must register BEFORE the bare ``{ws_id}``
+    # detail GET below so Starlette doesn't match "saved" as a ws_id.
+    if handlers.list_saved is not None:
+        routes.append(Route(f"{p}/saved", handlers.list_saved))
 
     # --- Lifecycle: create + legacy close (ws_id in body) ---------------
-    routes.append(Route(f"{p}/new", handlers.create, methods=["POST"]))
+    if handlers.create is not None:
+        routes.append(Route(f"{p}/new", handlers.create, methods=["POST"]))
     if config.supports_legacy_close:
+        if handlers.close_legacy is None:
+            raise ValueError("supports_legacy_close=True requires handlers.close_legacy")
         routes.append(Route(f"{p}/close", handlers.close_legacy, methods=["POST"]))
 
-    # --- Per-{ws_id} verbs ----------------------------------------------
-    routes.append(Route(f"{p}/{{ws_id}}/delete", handlers.delete, methods=["POST"]))
-    routes.append(Route(f"{p}/{{ws_id}}/open", handlers.open, methods=["POST"]))
-    routes.append(
-        Route(
-            f"{p}/{{ws_id}}/refresh-title",
-            handlers.refresh_title,
-            methods=["POST"],
+    # --- Per-``{ws_id}`` verbs (specific verbs first) -------------------
+    if handlers.delete is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/delete", handlers.delete, methods=["POST"]))
+    if handlers.open is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/open", handlers.open, methods=["POST"]))
+    if handlers.close is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/close", handlers.close, methods=["POST"]))
+    if handlers.refresh_title is not None:
+        routes.append(
+            Route(
+                f"{p}/{{ws_id}}/refresh-title",
+                handlers.refresh_title,
+                methods=["POST"],
+            )
         )
-    )
-    routes.append(Route(f"{p}/{{ws_id}}/title", handlers.set_title, methods=["POST"]))
+    if handlers.set_title is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/title", handlers.set_title, methods=["POST"]))
+    if handlers.send is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/send", handlers.send, methods=["POST"]))
+    if handlers.approve is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/approve", handlers.approve, methods=["POST"]))
+    if handlers.plan is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/plan", handlers.plan, methods=["POST"]))
+    if handlers.cancel is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/cancel", handlers.cancel, methods=["POST"]))
+    if handlers.events is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/events", handlers.events, methods=["GET"]))
+    if handlers.history is not None:
+        routes.append(Route(f"{p}/{{ws_id}}/history", handlers.history, methods=["GET"]))
 
-    # --- Attachments (interactive-only today; coord parity is post-1.5) -
-    if config.supports_attachments:
+    # --- Attachments ----------------------------------------------------
+    has_any_attachment_handler = (
+        handlers.upload_attachment is not None
+        or handlers.list_attachments is not None
+        or handlers.get_attachment_content is not None
+        or handlers.delete_attachment is not None
+    )
+    if has_any_attachment_handler:
+        # Either all four come together or it's a config error — partial
+        # attachment surfaces (e.g. upload without delete) leave broken
+        # frontend flows.
         if (
             handlers.upload_attachment is None
             or handlers.list_attachments is None
             or handlers.get_attachment_content is None
             or handlers.delete_attachment is None
         ):
-            raise ValueError("supports_attachments=True requires all four attachment handlers")
+            raise ValueError("attachment handlers must be set as a complete set of four")
         routes.append(
             Route(
                 f"{p}/{{ws_id}}/attachments",
@@ -191,3 +250,8 @@ def register_session_routes(
                 methods=["DELETE"],
             )
         )
+
+    # --- Bare ``{ws_id}`` detail (GET) registers LAST so the verb-
+    #     suffixed patterns above win for ``{ws_id}/...`` paths.
+    if handlers.detail is not None:
+        routes.append(Route(f"{p}/{{ws_id}}", handlers.detail, methods=["GET"]))

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -4,9 +4,10 @@ Both node and console processes mount the workstream HTTP tree at
 ``/v1/api/workstreams/`` via this registrar against their own
 :class:`~turnstone.core.session_manager.SessionManager` (interactive
 on the node, coordinator on the console). One URL shape, two
-processes, kind-specific handler bodies wired in by the caller.
+processes, kind-specific policy in :class:`SessionEndpointConfig`
+that handlers consult at request time via ``app.state``.
 
-Two registrar functions:
+Three registrar functions:
 
 - :func:`register_session_routes` — verbs both kinds expose
   (``new``, ``close``, ``open``, ``delete``, ``send``, ``approve``,
@@ -17,14 +18,21 @@ Two registrar functions:
   ``restrict``, ``stop_cascade``, ``close_all_children``,
   ``children``, ``tasks``, ``metrics``) that read or mutate state
   that doesn't exist on interactive workstreams.
+
+Some verbs in :class:`SharedSessionVerbHandlers` ship as factory-
+returned closures (e.g. :func:`make_approve_handler`) that bake the
+:class:`SessionEndpointConfig` in at app-construction time. Both
+node and console call the factory during startup and pass the
+result as ``handlers.approve``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 if TYPE_CHECKING:
@@ -32,8 +40,56 @@ if TYPE_CHECKING:
     from starlette.responses import Response
     from starlette.routing import BaseRoute
 
+    from turnstone.core.session_manager import SessionManager
+
 
 Handler = Callable[["Request"], Awaitable["Response"]]
+PermissionGate = Callable[["Request"], "JSONResponse | None"]
+ManagerLookup = Callable[["Request"], tuple["SessionManager | None", "JSONResponse | None"]]
+TenantCheck = Callable[
+    ["Request", str, "SessionManager"],
+    "JSONResponse | None",
+]
+
+
+@dataclass(frozen=True)
+class SessionEndpointConfig:
+    """Per-kind policy the lifted handler bodies consult at request time.
+
+    Instantiated once per process during app construction and stored
+    on ``app.state.session_endpoint_config``. The unified handler
+    bodies pull this config + the kind manager from ``app.state``
+    rather than taking either as a per-request parameter — keeps the
+    handler signatures uniform (``Handler = Request -> Response``)
+    so the registrar mounts them like any other route.
+
+    - ``permission_gate``: kind's pre-handler permission check
+      (e.g. ``admin.coordinator`` for coord, ``None`` for interactive
+      which has no per-handler scope check beyond auth middleware).
+      Returns the rejection response when the gate fails, ``None``
+      when the request passes.
+    - ``manager_lookup``: returns ``(SessionManager, None)`` when the
+      kind's manager is loaded, or ``(None, JSONResponse)`` with a
+      503 when the subsystem isn't available (coord on a console
+      without configured models). For interactive the lookup just
+      returns ``(app.state.workstreams, None)``.
+    - ``tenant_check``: per-``ws_id`` cross-tenant guard. Interactive
+      uses ``_require_ws_access`` (404 on owner mismatch); coord
+      relies on the cluster-wide ``admin.coordinator`` scope from
+      ``permission_gate`` and sets this to ``None``.
+    - ``not_found_label``: the message body for the 404 returned when
+      the manager has no such ws_id ("Workstream not found" for
+      interactive; "coordinator not found" for coord).
+    - ``audit_action_prefix``: the dot-namespaced prefix the kind
+      uses for its audit actions ("workstream" → ``workstream.cancel``;
+      "coordinator" → ``coordinator.cancel``).
+    """
+
+    permission_gate: PermissionGate | None
+    manager_lookup: ManagerLookup
+    tenant_check: TenantCheck | None
+    not_found_label: str
+    audit_action_prefix: str
 
 
 @dataclass(frozen=True)
@@ -236,3 +292,125 @@ def register_coord_verbs(
             methods=["POST"],
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# Lifted handler bodies — Stage 2 Priority 0 body-convergence
+#
+# Each verb here was previously implemented twice (once in
+# ``turnstone/server.py`` for interactive, once in
+# ``turnstone/console/server.py`` for coord). The lifted body uses
+# the kind-specific :class:`SessionEndpointConfig` from
+# ``app.state.session_endpoint_config`` to branch on the few places
+# the kinds legitimately differ.
+#
+# Verbs not lifted yet (intentional — bodies have substantive
+# behavior divergence that needs SessionManager-side refactoring,
+# not just kind branching): send (worker dispatch — Priority 1
+# territory), cancel (interactive does inline forensics + force-cancel
+# ws._lock manipulation), close (interactive caps + redacts +
+# persists close_reason), open (interactive resume vs coord rehydrate),
+# events (different SSE replay shapes), create (interactive
+# attachments vs coord initial_message), list / saved (different
+# response keys: ``workstreams`` vs ``coordinators``).
+# ---------------------------------------------------------------------------
+
+
+def make_approve_handler() -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/approve``.
+
+    Resolves a pending tool approval on the workstream's UI. Both
+    kinds expose the same approve / feedback / always body shape and
+    the same ``ui.resolve_approval(approved, feedback)`` mechanic;
+    differences are auth scope, manager lookup, and the
+    ``__budget_override__`` filter (interactive-only — coord workstreams
+    don't have the budget-override pseudo-tool).
+    """
+    from turnstone.core.web_helpers import read_json_or_400
+
+    async def approve(request: Request) -> Response:
+        cfg: SessionEndpointConfig = request.app.state.session_endpoint_config
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        assert mgr is not None  # narrowed by the err503 None-check
+        body = await read_json_or_400(request)
+        if isinstance(body, JSONResponse):
+            return body
+        ws_id = request.path_params.get("ws_id", "")
+        approved = bool(body.get("approved", False))
+        feedback = body.get("feedback")
+        always = bool(body.get("always", False))
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        ui = ws.ui
+        if ui is None or not hasattr(ui, "resolve_approval"):
+            return JSONResponse(
+                {"error": "session UI does not support approval"},
+                status_code=409,
+            )
+        # ``_pending_approval`` and ``auto_approve_tools`` aren't on the
+        # ``SessionUI`` Protocol — both interactive ``WebUI`` and
+        # ``ConsoleCoordinatorUI`` add them, but a kind-agnostic body
+        # has to look them up dynamically. The CLI ``CliUI`` wouldn't
+        # have either, so accessing through ``getattr`` is also safer.
+        pending = getattr(ui, "_pending_approval", None)
+        auto_approve_tools = getattr(ui, "auto_approve_tools", None)
+        if always and approved and pending and auto_approve_tools is not None:
+            tool_names: set[str] = {
+                it.get("approval_label", "") or it.get("func_name", "")
+                for it in pending.get("items", [])
+                if it.get("needs_approval") and it.get("func_name") and not it.get("error")
+            }
+            tool_names.discard("")
+            # Budget-override is an interactive-only pseudo-tool that
+            # must never be added to the auto-approve set — discarding
+            # unconditionally is safe (no-op for coord).
+            tool_names.discard("__budget_override__")
+            if tool_names:
+                auto_approve_tools.update(tool_names)
+        ui.resolve_approval(approved, feedback)
+        return JSONResponse({"status": "ok"})
+
+    return approve
+
+
+def make_legacy_body_keyed_adapter(handler: Handler) -> Handler:
+    """Wrap a path-keyed handler so it can be mounted at a body-keyed URL.
+
+    Pre-1.5 interactive handlers (``/api/approve``, ``/api/cancel``,
+    ``/api/plan``, etc.) take ``ws_id`` from the JSON body. The
+    lifted bodies in this module read ``ws_id`` from the path. This
+    adapter peeks the body for ``ws_id``, copies it into
+    ``request.path_params``, and forwards. Starlette caches the
+    request body so the lifted handler's own body read is a hash-map
+    lookup, not a second network read.
+    """
+
+    async def adapter(request: Request) -> Response:
+        from turnstone.core.web_helpers import read_json_or_400
+
+        body = await read_json_or_400(request)
+        if isinstance(body, JSONResponse):
+            return body
+        ws_id = str(body.get("ws_id") or "")
+        # ``request.path_params`` is normally populated by Starlette
+        # at Route match time; since this adapter is mounted on a
+        # body-keyed URL with no ``{ws_id}`` slot, we splice it into
+        # the scope so the lifted handler's ``request.path_params.get(...)``
+        # finds it.
+        path_params: dict[str, Any] = dict(request.path_params)
+        path_params["ws_id"] = ws_id
+        request.scope["path_params"] = path_params
+        return await handler(request)
+
+    return adapter

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2,32 +2,29 @@
 
 Stage 2 Priority 0 of the SessionManager unification — collapses the
 parallel ``/v1/api/workstreams/*`` (interactive) and
-``/v1/api/coordinator/*`` (coordinator) handler trees into one.
+``/v1/api/coordinator/*`` (coordinator, never shipped stable) handler
+trees into one. The legacy coord URL prefix has been removed; both
+node and console processes mount the same shape against their own
+manager via this registrar.
 
 Step 0.1: scaffolded the registrar; interactive ``server.py`` mounts
 through it.
 
-Step 0.2 (this commit): grow the registrar to cover the coord-side
-verbs (``send`` / ``approve`` / ``plan`` / ``cancel`` / ``close`` /
-``events`` / ``history`` / ``detail``) and have ``console/server.py``
-mount coord at ``/v1/api/workstreams/`` alongside its existing
-``/v1/api/coordinator/`` paths. Both URL shapes point at the same
-handler functions during the transition; Step 0.4 deletes the
-``/coordinator/`` shape outright once the frontend (Step 0.6) and
-tests (Step 0.7) move off it.
-
-Handler bodies still live in their server modules and are passed in
-via :class:`SessionRouteHandlers` — body convergence is the next
-Step 0.2 follow-on (kind branching behind config flags). Splitting
-"URL surface unified" from "handler bodies converged" keeps the
-soak-able diffs small.
+Step 0.2: grew the registrar to cover the coord-side verbs (``send``
+/ ``approve`` / ``plan`` / ``cancel`` / ``close`` / ``events`` /
+``history`` / ``detail``); console mounted coord through it
+alongside the legacy ``/v1/api/coordinator/`` paths.
 
 Step 0.3: coord-only verbs (``/trust``, ``/restrict``,
 ``/stop_cascade``, ``/close_all_children``, ``/children``,
-``/metrics``, ``/tasks``) migrate via :func:`register_coord_verbs`,
-404-ing on non-coord ws_ids via the manager's kind check.
+``/metrics``, ``/tasks``) migrated via :func:`register_coord_verbs`.
 
-Step 0.4: ``/v1/api/coordinator/*`` deletes outright.
+Step 0.4: legacy ``/v1/api/coordinator/*`` Route entries deleted from
+``console/server.py`` — alongside the URL sweep across the OpenAPI
+spec, frontend JS, server-side coord client, and test suite (Steps
+0.5–0.7). The handler functions stay named ``coordinator_*`` until
+the body-convergence follow-on lifts them into this module with
+kind branching behind :class:`SessionRouteConfig` flags.
 
 See ``1.5.0-session-manager-stage-2.md`` for the full sequencing.
 """

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -5,7 +5,8 @@ Both node and console processes mount the workstream HTTP tree at
 :class:`~turnstone.core.session_manager.SessionManager` (interactive
 on the node, coordinator on the console). One URL shape, two
 processes, kind-specific policy in :class:`SessionEndpointConfig`
-that handlers consult at request time via ``app.state``.
+captured by closure when the handler factory is called at app
+construction.
 
 Three registrar functions:
 
@@ -20,10 +21,12 @@ Three registrar functions:
   that doesn't exist on interactive workstreams.
 
 Some verbs in :class:`SharedSessionVerbHandlers` ship as factory-
-returned closures (e.g. :func:`make_approve_handler`) that bake the
-:class:`SessionEndpointConfig` in at app-construction time. Both
-node and console call the factory during startup and pass the
-result as ``handlers.approve``.
+returned closures (e.g. :func:`make_approve_handler`,
+:func:`make_close_handler`) that bake their
+:class:`SessionEndpointConfig` (and any verb-specific args like
+``audit_emit``) in at app-construction time. Both node and console
+call the factory during startup and pass the result as
+``handlers.approve`` / ``handlers.close``.
 """
 
 from __future__ import annotations
@@ -61,12 +64,11 @@ TenantCheck = Callable[
 class SessionEndpointConfig:
     """Per-kind policy the lifted handler bodies consult at request time.
 
-    Instantiated once per process during app construction and stored
-    on ``app.state.session_endpoint_config``. The unified handler
-    bodies pull this config + the kind manager from ``app.state``
-    rather than taking either as a per-request parameter — keeps the
-    handler signatures uniform (``Handler = Request -> Response``)
-    so the registrar mounts them like any other route.
+    Instantiated once per process during app construction and passed
+    to the verb factory (e.g. :func:`make_approve_handler`,
+    :func:`make_close_handler`), which captures it via closure. The
+    request-time handler reads ``cfg`` from the closure rather than
+    ``app.state`` so the dependency is visible at the wire-up site.
 
     - ``permission_gate``: kind's pre-handler permission check
       (e.g. ``admin.coordinator`` for coord, ``None`` for interactive
@@ -304,20 +306,18 @@ def register_coord_verbs(
 #
 # Each verb here was previously implemented twice (once in
 # ``turnstone/server.py`` for interactive, once in
-# ``turnstone/console/server.py`` for coord). The lifted body uses
-# the kind-specific :class:`SessionEndpointConfig` from
-# ``app.state.session_endpoint_config`` to branch on the few places
-# the kinds legitimately differ.
+# ``turnstone/console/server.py`` for coord). The lifted body
+# branches on the kind-specific :class:`SessionEndpointConfig` the
+# factory captured at app-construction time.
 #
 # Verbs not lifted yet (intentional — bodies have substantive
 # behavior divergence that needs SessionManager-side refactoring,
 # not just kind branching): send (worker dispatch — Priority 1
-# territory), cancel (interactive does inline forensics + force-cancel
-# ws._lock manipulation), close (interactive caps + redacts +
-# persists close_reason), open (interactive resume vs coord rehydrate),
-# events (different SSE replay shapes), create (interactive
-# attachments vs coord initial_message), list / saved (different
-# response keys: ``workstreams`` vs ``coordinators``).
+# territory), cancel (interactive does inline forensics + force-
+# cancel ws._lock manipulation), open (interactive resume vs coord
+# rehydrate), events (different SSE replay shapes), create
+# (interactive attachments vs coord initial_message), list / saved
+# (different response keys: ``workstreams`` vs ``coordinators``).
 # ---------------------------------------------------------------------------
 
 

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -255,3 +255,80 @@ def register_session_routes(
     #     suffixed patterns above win for ``{ws_id}/...`` paths.
     if handlers.detail is not None:
         routes.append(Route(f"{p}/{{ws_id}}", handlers.detail, methods=["GET"]))
+
+
+@dataclass(frozen=True)
+class CoordVerbHandlers:
+    """Bundle of coord-only HTTP handler callables.
+
+    These verbs are legitimately kind-specific (they read or mutate
+    coord-only state — children registry, parent quota, trust /
+    restrict policy, cascade controls) so they live on a separate
+    Protocol from :class:`SessionRouteHandlers`. Mounted alongside
+    the shared session verbs at the same ``/api/workstreams/{ws_id}/``
+    prefix so the URL surface stays unified, but registered through
+    a distinct call so the kind separation is explicit at the wiring
+    site.
+
+    Step 0.3 placeholder: handlers live in
+    ``turnstone/console/server.py`` and are passed in here; the
+    body-convergence follow-on lifts them into a coord-specific
+    module.
+    """
+
+    children: Handler  # GET  {prefix}/{ws_id}/children
+    tasks: Handler  # GET  {prefix}/{ws_id}/tasks
+    metrics: Handler  # GET  {prefix}/{ws_id}/metrics
+    trust: Handler  # POST {prefix}/{ws_id}/trust
+    restrict: Handler  # POST {prefix}/{ws_id}/restrict
+    stop_cascade: Handler  # POST {prefix}/{ws_id}/stop_cascade
+    close_all_children: Handler  # POST {prefix}/{ws_id}/close_all_children
+
+
+def register_coord_verbs(
+    routes: list[BaseRoute],
+    *,
+    prefix: str,
+    mgr: SessionManager | None = None,
+    handlers: CoordVerbHandlers,
+) -> None:
+    """Mount coord-only verbs at the unified ``{prefix}/{ws_id}/...`` shape.
+
+    Call ordering vs :func:`register_session_routes` doesn't matter
+    in practice — Starlette's default ``str`` path converter is
+    single-segment, so ``{ws_id}/{verb}`` patterns can never collide
+    with the bare ``{ws_id}`` detail GET registered by
+    ``register_session_routes``. The body-convergence follow-on will
+    additionally have these handlers 404 on non-coord ws_ids via the
+    manager's kind check; today the legacy ``admin.coordinator``
+    permission gate and ``_require_coord_mgr`` 503 are the
+    enforcement.
+
+    Args:
+        routes: list to extend; typically the inner ``Mount`` route
+            list a Starlette app uses.
+        prefix: URL prefix relative to the mount, e.g.
+            ``"/api/workstreams"``.
+        mgr: the coord session manager when available at
+            app-construction time. Optional today because the console
+            builds its coord manager in the lifespan; becomes required
+            in the body-convergence follow-on.
+        handlers: bundle of handler callables for the coord-only
+            verbs.
+    """
+    _ = mgr  # forward-wired; see :func:`register_session_routes`
+
+    p = prefix.rstrip("/")
+    routes.append(Route(f"{p}/{{ws_id}}/children", handlers.children, methods=["GET"]))
+    routes.append(Route(f"{p}/{{ws_id}}/tasks", handlers.tasks, methods=["GET"]))
+    routes.append(Route(f"{p}/{{ws_id}}/metrics", handlers.metrics, methods=["GET"]))
+    routes.append(Route(f"{p}/{{ws_id}}/trust", handlers.trust, methods=["POST"]))
+    routes.append(Route(f"{p}/{{ws_id}}/restrict", handlers.restrict, methods=["POST"]))
+    routes.append(Route(f"{p}/{{ws_id}}/stop_cascade", handlers.stop_cascade, methods=["POST"]))
+    routes.append(
+        Route(
+            f"{p}/{{ws_id}}/close_all_children",
+            handlers.close_all_children,
+            methods=["POST"],
+        )
+    )

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -414,3 +414,119 @@ def make_legacy_body_keyed_adapter(handler: Handler) -> Handler:
         return await handler(request)
 
     return adapter
+
+
+CloseAuditEmitter = Callable[
+    ["Request", str, "Workstream", str],
+    None,
+]
+
+
+def make_close_handler(
+    *,
+    audit_emit: CloseAuditEmitter | None = None,
+    supports_close_reason: bool = False,
+) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/close``.
+
+    Closes the workstream's session (unloads from memory; storage row
+    survives so the session can be re-opened later). Both kinds share
+    the same auth → mgr → ws-lookup → ``mgr.close()`` → audit
+    sequence; per-kind divergence is in the audit detail shape and
+    whether a request body ``reason`` is read / capped / persisted on
+    the workstream's config row.
+
+    Args:
+        audit_emit: kind's audit emitter for the close event.
+            Receives ``(request, ws_id, ws_before, reason)``; ``reason``
+            is the empty string when ``supports_close_reason`` is
+            ``False`` or no reason was provided. ``None`` skips the
+            audit entirely (only valid when neither kind cares).
+        supports_close_reason: when ``True``, the handler reads a
+            ``reason`` field from the JSON body, caps it at 512 UTF-8
+            bytes, redacts credentials, persists it via
+            ``storage.save_workstream_config(ws_id, {"close_reason": ...})``,
+            and threads it through to ``audit_emit``. The cap protects
+            ``workstream_config`` from unbounded growth on a model-
+            generated dump; the redact protects audit logs from
+            captured-secret leakage under prompt injection.
+    """
+
+    async def close(request: Request) -> Response:
+        cfg: SessionEndpointConfig = request.app.state.session_endpoint_config
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        assert mgr is not None
+        ws_id = request.path_params.get("ws_id", "")
+
+        reason = ""
+        if supports_close_reason:
+            from turnstone.core.output_guard import redact_credentials
+            from turnstone.core.web_helpers import read_json_or_400
+
+            body = await read_json_or_400(request)
+            if isinstance(body, JSONResponse):
+                return body
+            raw_reason = body.get("reason", "")
+            if isinstance(raw_reason, str):
+                # Cap on UTF-8 bytes (not code points) so a CJK / emoji
+                # payload can't sneak past at 3-4x the documented budget.
+                # ``errors="ignore"`` drops any partial code point left
+                # at the truncation boundary.
+                capped = raw_reason.strip().encode("utf-8")[:512].decode(
+                    "utf-8", errors="ignore"
+                )
+                reason = redact_credentials(capped)
+
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws_before = mgr.get(ws_id)
+        if ws_before is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        if not mgr.close(ws_id):
+            # Standardized to 404 (was 500 on the legacy coord path —
+            # overly pessimistic; close-failure here means the ws was
+            # popped between the .get() check and the .close() call,
+            # which is a "not found" semantic).
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        storage = getattr(request.app.state, "auth_storage", None)
+        if supports_close_reason and reason and storage is not None:
+            try:
+                storage.save_workstream_config(ws_id, {"close_reason": reason})
+            except Exception:
+                from turnstone.core.log import get_logger as _gl
+
+                _gl(__name__).debug(
+                    "ws.close.reason_persist_failed ws=%s",
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+
+        if audit_emit is not None and storage is not None:
+            try:
+                audit_emit(request, ws_id, ws_before, reason)
+            except Exception:
+                from turnstone.core.log import get_logger as _gl
+
+                _gl(__name__).debug(
+                    "ws.close.audit_failed ws=%s",
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+
+        return JSONResponse({"status": "ok"})
+
+    return close
+
+
+if TYPE_CHECKING:
+    from turnstone.core.workstream import Workstream  # noqa: F401 — used in type alias above

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1,32 +1,22 @@
 """Shared HTTP route registrar for workstream-shaped sessions.
 
-Stage 2 Priority 0 of the SessionManager unification — collapses the
-parallel ``/v1/api/workstreams/*`` (interactive) and
-``/v1/api/coordinator/*`` (coordinator, never shipped stable) handler
-trees into one. The legacy coord URL prefix has been removed; both
-node and console processes mount the same shape against their own
-manager via this registrar.
+Both node and console processes mount the workstream HTTP tree at
+``/v1/api/workstreams/`` via this registrar against their own
+:class:`~turnstone.core.session_manager.SessionManager` (interactive
+on the node, coordinator on the console). One URL shape, two
+processes, kind-specific handler bodies wired in by the caller.
 
-Step 0.1: scaffolded the registrar; interactive ``server.py`` mounts
-through it.
+Two registrar functions:
 
-Step 0.2: grew the registrar to cover the coord-side verbs (``send``
-/ ``approve`` / ``plan`` / ``cancel`` / ``close`` / ``events`` /
-``history`` / ``detail``); console mounted coord through it
-alongside the legacy ``/v1/api/coordinator/`` paths.
-
-Step 0.3: coord-only verbs (``/trust``, ``/restrict``,
-``/stop_cascade``, ``/close_all_children``, ``/children``,
-``/metrics``, ``/tasks``) migrated via :func:`register_coord_verbs`.
-
-Step 0.4: legacy ``/v1/api/coordinator/*`` Route entries deleted from
-``console/server.py`` — alongside the URL sweep across the OpenAPI
-spec, frontend JS, server-side coord client, and test suite (Steps
-0.5–0.7). The handler functions stay named ``coordinator_*`` until
-the body-convergence follow-on lifts them into this module with
-kind branching behind :class:`SessionRouteConfig` flags.
-
-See ``1.5.0-session-manager-stage-2.md`` for the full sequencing.
+- :func:`register_session_routes` — verbs both kinds expose
+  (``new``, ``close``, ``open``, ``delete``, ``send``, ``approve``,
+  ``cancel``, ``events``, ``history``, ``detail``, ...).
+  All handlers in :class:`SharedSessionVerbHandlers` are optional;
+  ``None`` skips the route, so one bundle describes either kind.
+- :func:`register_coord_verbs` — coord-only verbs (``trust``,
+  ``restrict``, ``stop_cascade``, ``close_all_children``,
+  ``children``, ``tasks``, ``metrics``) that read or mutate state
+  that doesn't exist on interactive workstreams.
 """
 
 from __future__ import annotations
@@ -42,27 +32,37 @@ if TYPE_CHECKING:
     from starlette.responses import Response
     from starlette.routing import BaseRoute
 
-    from turnstone.core.session_manager import SessionKindAdapter, SessionManager
-
 
 Handler = Callable[["Request"], Awaitable["Response"]]
 
 
 @dataclass(frozen=True)
-class SessionRouteHandlers:
-    """Bundle of HTTP handler callables the registrar mounts.
+class AttachmentHandlers:
+    """The four-handler quartet for the per-workstream attachment surface.
 
-    All handlers are optional; ``None`` skips that route. Lets one
-    bundle describe both the interactive shape (no per-``{ws_id}``
-    ``send`` / ``approve`` etc. yet — those use legacy body-keyed
-    paths) and the coord shape (no attachments, no
-    ``refresh-title``).
+    Grouped so the type system enforces that you can't mount
+    upload-without-delete or list-without-content (a half-mounted
+    surface leaves broken frontend flows). Set
+    :attr:`SharedSessionVerbHandlers.attachments` to ``None`` for
+    kinds that don't expose attachments yet.
+    """
 
-    Step 0.2 placeholder: handlers live in their server modules and
-    are passed in here. The next Step 0.2 follow-on lifts the
-    bodies into ``session_routes`` and switches kind branching to
-    live behind :class:`SessionRouteConfig` flags, at which point
-    this struct deletes.
+    upload: Handler  # POST   {prefix}/{ws_id}/attachments
+    list: Handler  # GET    {prefix}/{ws_id}/attachments
+    get_content: Handler  # GET    {prefix}/{ws_id}/attachments/{attachment_id}/content
+    delete: Handler  # DELETE {prefix}/{ws_id}/attachments/{attachment_id}
+
+
+@dataclass(frozen=True)
+class SharedSessionVerbHandlers:
+    """Bundle of HTTP handler callables for verbs both kinds expose.
+
+    All handlers are optional; ``None`` skips that route. One bundle
+    describes either kind — interactive omits the per-``{ws_id}``
+    interaction verbs (``send`` / ``approve`` / ``plan`` / ``cancel``
+    / ``events`` / ``history`` / ``detail``) until Priority 1's
+    worker dispatch unification; coord omits ``delete`` /
+    ``refresh_title`` / ``set_title`` / attachments.
     """
 
     # Listing
@@ -80,8 +80,9 @@ class SessionRouteHandlers:
     refresh_title: Handler | None = None  # POST {prefix}/{ws_id}/refresh-title
     set_title: Handler | None = None  # POST {prefix}/{ws_id}/title
 
-    # Legacy interactive close (``ws_id`` in body, not path)
-    close_legacy: Handler | None = None  # POST {prefix}/close
+    # Legacy interactive close (``ws_id`` in body, not path) — the only
+    # surviving body-keyed verb. Set non-``None`` to mount POST {prefix}/close.
+    close_legacy: Handler | None = None
 
     # Per-``{ws_id}`` interaction (coord shape today; interactive
     # adopts these in Priority 1's worker dispatch unification)
@@ -92,37 +93,39 @@ class SessionRouteHandlers:
     events: Handler | None = None  # GET  {prefix}/{ws_id}/events (SSE)
     history: Handler | None = None  # GET  {prefix}/{ws_id}/history
 
-    # Attachments (interactive only today; coord parity is post-1.5)
-    upload_attachment: Handler | None = None
-    list_attachments: Handler | None = None
-    get_attachment_content: Handler | None = None
-    delete_attachment: Handler | None = None
+    # Attachments — the four handlers come together or not at all.
+    attachments: AttachmentHandlers | None = None
 
 
 @dataclass(frozen=True)
-class SessionRouteConfig:
-    """Per-kind feature flags for the session HTTP route registrar.
+class CoordOnlyVerbHandlers:
+    """Bundle of coord-only HTTP handler callables.
 
-    Step 0.2 carries one flag — whether the legacy body-keyed
-    ``close`` verb is mounted. Step 0.2's body-convergence follow-on
-    grows this with the per-kind branching flags handler bodies
-    consult (e.g. ``permission_scope``, ``audit_action_prefix``,
-    ``not_found_label``).
+    These verbs read or mutate state that doesn't exist on interactive
+    workstreams — children registry, parent quota, trust / restrict
+    policy, cascade controls — so they live on a Protocol distinct
+    from :class:`SharedSessionVerbHandlers`. Mounted at the same
+    ``/api/workstreams/{ws_id}/`` prefix so the URL surface stays
+    unified, but registered through a separate call so the kind
+    separation is explicit at the wiring site.
     """
 
-    supports_legacy_close: bool = False  # POST {prefix}/close — ws_id in body
+    children: Handler  # GET  {prefix}/{ws_id}/children
+    tasks: Handler  # GET  {prefix}/{ws_id}/tasks
+    metrics: Handler  # GET  {prefix}/{ws_id}/metrics
+    trust: Handler  # POST {prefix}/{ws_id}/trust
+    restrict: Handler  # POST {prefix}/{ws_id}/restrict
+    stop_cascade: Handler  # POST {prefix}/{ws_id}/stop_cascade
+    close_all_children: Handler  # POST {prefix}/{ws_id}/close_all_children
 
 
 def register_session_routes(
     routes: list[BaseRoute],
     *,
     prefix: str,
-    mgr: SessionManager | None = None,
-    adapter: SessionKindAdapter | None = None,
-    config: SessionRouteConfig,
-    handlers: SessionRouteHandlers,
+    handlers: SharedSessionVerbHandlers,
 ) -> None:
-    """Append the workstream HTTP route table to ``routes`` at ``prefix``.
+    """Append the shared workstream HTTP route table to ``routes`` at ``prefix``.
 
     Mounts every verb whose handler is non-``None``. Routes register
     in an order that respects Starlette's first-match semantics:
@@ -130,29 +133,9 @@ def register_session_routes(
     per-``{ws_id}`` patterns; per-``{ws_id}/{verb}`` patterns before
     the bare ``{ws_id}`` detail GET.
 
-    Args:
-        routes: list to extend; typically the inner ``Mount`` route
-            list a Starlette app uses.
-        prefix: URL prefix relative to the mount, e.g.
-            ``"/api/workstreams"``.
-        mgr: the session manager owning the workstream kind, when
-            available at app-construction time. Optional today
-            because the console builds its coord manager in the
-            lifespan (after routes), and current handler bodies
-            look the manager up via ``request.app.state``. Becomes
-            required in the body-convergence follow-on once handlers
-            move into this module and read ``mgr`` directly.
-        adapter: the kind's adapter. Same forward-wiring rationale.
-        config: per-kind feature flags.
-        handlers: bundle of handler callables for the routes the
-            registrar mounts. The body-convergence follow-on
-            deletes this argument.
+    ``prefix`` is the URL prefix relative to the mount, e.g.
+    ``"/api/workstreams"``.
     """
-    # ``mgr`` and ``adapter`` are unused this commit; declared in the
-    # signature so handler bodies can pick them up directly in the
-    # body-convergence follow-on without a callsite churn.
-    _ = (mgr, adapter)
-
     p = prefix.rstrip("/")
 
     # --- Listing endpoints ----------------------------------------------
@@ -166,9 +149,7 @@ def register_session_routes(
     # --- Lifecycle: create + legacy close (ws_id in body) ---------------
     if handlers.create is not None:
         routes.append(Route(f"{p}/new", handlers.create, methods=["POST"]))
-    if config.supports_legacy_close:
-        if handlers.close_legacy is None:
-            raise ValueError("supports_legacy_close=True requires handlers.close_legacy")
+    if handlers.close_legacy is not None:
         routes.append(Route(f"{p}/close", handlers.close_legacy, methods=["POST"]))
 
     # --- Per-``{ws_id}`` verbs (specific verbs first) -------------------
@@ -201,49 +182,22 @@ def register_session_routes(
     if handlers.history is not None:
         routes.append(Route(f"{p}/{{ws_id}}/history", handlers.history, methods=["GET"]))
 
-    # --- Attachments ----------------------------------------------------
-    has_any_attachment_handler = (
-        handlers.upload_attachment is not None
-        or handlers.list_attachments is not None
-        or handlers.get_attachment_content is not None
-        or handlers.delete_attachment is not None
-    )
-    if has_any_attachment_handler:
-        # Either all four come together or it's a config error — partial
-        # attachment surfaces (e.g. upload without delete) leave broken
-        # frontend flows.
-        if (
-            handlers.upload_attachment is None
-            or handlers.list_attachments is None
-            or handlers.get_attachment_content is None
-            or handlers.delete_attachment is None
-        ):
-            raise ValueError("attachment handlers must be set as a complete set of four")
-        routes.append(
-            Route(
-                f"{p}/{{ws_id}}/attachments",
-                handlers.upload_attachment,
-                methods=["POST"],
-            )
-        )
-        routes.append(
-            Route(
-                f"{p}/{{ws_id}}/attachments",
-                handlers.list_attachments,
-                methods=["GET"],
-            )
-        )
+    # --- Attachments (the quartet comes together or not at all) ---------
+    if handlers.attachments is not None:
+        a = handlers.attachments
+        routes.append(Route(f"{p}/{{ws_id}}/attachments", a.upload, methods=["POST"]))
+        routes.append(Route(f"{p}/{{ws_id}}/attachments", a.list, methods=["GET"]))
         routes.append(
             Route(
                 f"{p}/{{ws_id}}/attachments/{{attachment_id}}/content",
-                handlers.get_attachment_content,
+                a.get_content,
                 methods=["GET"],
             )
         )
         routes.append(
             Route(
                 f"{p}/{{ws_id}}/attachments/{{attachment_id}}",
-                handlers.delete_attachment,
+                a.delete,
                 methods=["DELETE"],
             )
         )
@@ -254,40 +208,11 @@ def register_session_routes(
         routes.append(Route(f"{p}/{{ws_id}}", handlers.detail, methods=["GET"]))
 
 
-@dataclass(frozen=True)
-class CoordVerbHandlers:
-    """Bundle of coord-only HTTP handler callables.
-
-    These verbs are legitimately kind-specific (they read or mutate
-    coord-only state — children registry, parent quota, trust /
-    restrict policy, cascade controls) so they live on a separate
-    Protocol from :class:`SessionRouteHandlers`. Mounted alongside
-    the shared session verbs at the same ``/api/workstreams/{ws_id}/``
-    prefix so the URL surface stays unified, but registered through
-    a distinct call so the kind separation is explicit at the wiring
-    site.
-
-    Step 0.3 placeholder: handlers live in
-    ``turnstone/console/server.py`` and are passed in here; the
-    body-convergence follow-on lifts them into a coord-specific
-    module.
-    """
-
-    children: Handler  # GET  {prefix}/{ws_id}/children
-    tasks: Handler  # GET  {prefix}/{ws_id}/tasks
-    metrics: Handler  # GET  {prefix}/{ws_id}/metrics
-    trust: Handler  # POST {prefix}/{ws_id}/trust
-    restrict: Handler  # POST {prefix}/{ws_id}/restrict
-    stop_cascade: Handler  # POST {prefix}/{ws_id}/stop_cascade
-    close_all_children: Handler  # POST {prefix}/{ws_id}/close_all_children
-
-
 def register_coord_verbs(
     routes: list[BaseRoute],
     *,
     prefix: str,
-    mgr: SessionManager | None = None,
-    handlers: CoordVerbHandlers,
+    handlers: CoordOnlyVerbHandlers,
 ) -> None:
     """Mount coord-only verbs at the unified ``{prefix}/{ws_id}/...`` shape.
 
@@ -295,26 +220,8 @@ def register_coord_verbs(
     in practice — Starlette's default ``str`` path converter is
     single-segment, so ``{ws_id}/{verb}`` patterns can never collide
     with the bare ``{ws_id}`` detail GET registered by
-    ``register_session_routes``. The body-convergence follow-on will
-    additionally have these handlers 404 on non-coord ws_ids via the
-    manager's kind check; today the legacy ``admin.coordinator``
-    permission gate and ``_require_coord_mgr`` 503 are the
-    enforcement.
-
-    Args:
-        routes: list to extend; typically the inner ``Mount`` route
-            list a Starlette app uses.
-        prefix: URL prefix relative to the mount, e.g.
-            ``"/api/workstreams"``.
-        mgr: the coord session manager when available at
-            app-construction time. Optional today because the console
-            builds its coord manager in the lifespan; becomes required
-            in the body-convergence follow-on.
-        handlers: bundle of handler callables for the coord-only
-            verbs.
+    ``register_session_routes``.
     """
-    _ = mgr  # forward-wired; see :func:`register_session_routes`
-
     p = prefix.rstrip("/")
     routes.append(Route(f"{p}/{{ws_id}}/children", handlers.children, methods=["GET"]))
     routes.append(Route(f"{p}/{{ws_id}}/tasks", handlers.tasks, methods=["GET"]))

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from starlette.responses import JSONResponse
 from starlette.routing import Route
+
+from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -41,6 +43,9 @@ if TYPE_CHECKING:
     from starlette.routing import BaseRoute
 
     from turnstone.core.session_manager import SessionManager
+    from turnstone.core.workstream import Workstream
+
+log = get_logger(__name__)
 
 
 Handler = Callable[["Request"], Awaitable["Response"]]
@@ -316,7 +321,7 @@ def register_coord_verbs(
 # ---------------------------------------------------------------------------
 
 
-def make_approve_handler() -> Handler:
+def make_approve_handler(cfg: SessionEndpointConfig) -> Handler:
     """Lifted body for ``POST {prefix}/{ws_id}/approve``.
 
     Resolves a pending tool approval on the workstream's UI. Both
@@ -329,15 +334,18 @@ def make_approve_handler() -> Handler:
     from turnstone.core.web_helpers import read_json_or_400
 
     async def approve(request: Request) -> Response:
-        cfg: SessionEndpointConfig = request.app.state.session_endpoint_config
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
                 return err
-        mgr, err503 = cfg.manager_lookup(request)
+        mgr_opt, err503 = cfg.manager_lookup(request)
         if err503 is not None:
             return err503
-        assert mgr is not None  # narrowed by the err503 None-check
+        # ``manager_lookup`` returns ``(None, JSONResponse)`` when the
+        # subsystem is unavailable (returned above) or
+        # ``(SessionManager, None)`` otherwise; ``cast`` makes the
+        # type-checker-only narrowing explicit and survives ``python -O``.
+        mgr = cast("SessionManager", mgr_opt)
         body = await read_json_or_400(request)
         if isinstance(body, JSONResponse):
             return body
@@ -423,6 +431,7 @@ CloseAuditEmitter = Callable[
 
 
 def make_close_handler(
+    cfg: SessionEndpointConfig,
     *,
     audit_emit: CloseAuditEmitter | None = None,
     supports_close_reason: bool = False,
@@ -437,6 +446,9 @@ def make_close_handler(
     the workstream's config row.
 
     Args:
+        cfg: per-kind policy bundle (auth, manager lookup, tenant
+            check, error labels). Captured by closure so the request-
+            time handler doesn't reach into ``app.state``.
         audit_emit: kind's audit emitter for the close event.
             Receives ``(request, ws_id, ws_before, reason)``; ``reason``
             is the empty string when ``supports_close_reason`` is
@@ -450,18 +462,30 @@ def make_close_handler(
             ``workstream_config`` from unbounded growth on a model-
             generated dump; the redact protects audit logs from
             captured-secret leakage under prompt injection.
+
+    Behavior change vs the pre-lift handlers:
+
+    - The interactive handler previously let ``record_audit`` failures
+      surface as HTTP 500 (no try/except). The lifted body wraps
+      ``audit_emit`` in try/except and demotes failures to a
+      ``warning`` log, returning 200 to the caller. Coord previously
+      already swallowed; convergence is intentional — operators
+      monitor the audit-fail log line in both kinds the same way.
+    - The coord ``mgr.close()`` race-loss returned 500; standardized
+      to 404 ("popped between ``.get()`` and ``.close()``" is a
+      not-found semantic, not a server error).
     """
 
     async def close(request: Request) -> Response:
-        cfg: SessionEndpointConfig = request.app.state.session_endpoint_config
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
                 return err
-        mgr, err503 = cfg.manager_lookup(request)
+        mgr_opt, err503 = cfg.manager_lookup(request)
         if err503 is not None:
             return err503
-        assert mgr is not None
+        # See ``make_approve_handler`` for the cast rationale.
+        mgr = cast("SessionManager", mgr_opt)
         ws_id = request.path_params.get("ws_id", "")
 
         reason = ""
@@ -478,9 +502,7 @@ def make_close_handler(
                 # payload can't sneak past at 3-4x the documented budget.
                 # ``errors="ignore"`` drops any partial code point left
                 # at the truncation boundary.
-                capped = raw_reason.strip().encode("utf-8")[:512].decode(
-                    "utf-8", errors="ignore"
-                )
+                capped = raw_reason.strip().encode("utf-8")[:512].decode("utf-8", errors="ignore")
                 reason = redact_credentials(capped)
 
         if cfg.tenant_check is not None:
@@ -492,10 +514,6 @@ def make_close_handler(
         if ws_before is None:
             return JSONResponse({"error": cfg.not_found_label}, status_code=404)
         if not mgr.close(ws_id):
-            # Standardized to 404 (was 500 on the legacy coord path —
-            # overly pessimistic; close-failure here means the ws was
-            # popped between the .get() check and the .close() call,
-            # which is a "not found" semantic).
             return JSONResponse({"error": cfg.not_found_label}, status_code=404)
 
         storage = getattr(request.app.state, "auth_storage", None)
@@ -503,9 +521,7 @@ def make_close_handler(
             try:
                 storage.save_workstream_config(ws_id, {"close_reason": reason})
             except Exception:
-                from turnstone.core.log import get_logger as _gl
-
-                _gl(__name__).debug(
+                log.warning(
                     "ws.close.reason_persist_failed ws=%s",
                     ws_id[:8] if ws_id else "",
                     exc_info=True,
@@ -515,9 +531,11 @@ def make_close_handler(
             try:
                 audit_emit(request, ws_id, ws_before, reason)
             except Exception:
-                from turnstone.core.log import get_logger as _gl
-
-                _gl(__name__).debug(
+                # Audit-write failure is a compliance signal —
+                # ``warning`` so it surfaces in ops logs. Behavior change
+                # vs the original interactive handler (which would have
+                # 500'd here); see the function docstring.
+                log.warning(
                     "ws.close.audit_failed ws=%s",
                     ws_id[:8] if ws_id else "",
                     exc_info=True,
@@ -526,7 +544,3 @@ def make_close_handler(
         return JSONResponse({"status": "ok"})
 
     return close
-
-
-if TYPE_CHECKING:
-    from turnstone.core.workstream import Workstream  # noqa: F401 — used in type alias above

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1,0 +1,193 @@
+"""Shared HTTP route registrar for workstream-shaped sessions.
+
+Stage 2 Priority 0 of the SessionManager unification — collapses the
+parallel ``/v1/api/workstreams/*`` (interactive) and
+``/v1/api/coordinator/*`` (coordinator) handler trees into one.
+
+Step 0.1 (this commit): scaffold the registrar. Handler bodies still
+live in ``turnstone/server.py`` and ``turnstone/console/server.py``
+and are passed in via :class:`SessionRouteHandlers`. The registrar
+owns the URL shape; the next step lifts bodies into this module so
+both kinds share them.
+
+Step 0.2: coord migrates into the registrar; per-kind branching moves
+behind :class:`SessionRouteConfig` flags so each kind's call site is
+localized rather than spread across two server files.
+
+Step 0.3: coord-only verbs (``/trust``, ``/restrict``,
+``/stop_cascade``, ``/close_all_children``, ``/children``,
+``/metrics``, ``/tasks``) migrate via :func:`register_coord_verbs`,
+404-ing on non-coord ws_ids via the manager's kind check.
+
+Step 0.4: ``/v1/api/coordinator/*`` deletes outright. The window is
+open precisely because that prefix never shipped in a stable release;
+once 1.5.0 stable tags it becomes a committed surface.
+
+See ``1.5.0-session-manager-stage-2.md`` for the full sequencing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from starlette.routing import Route
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.routing import BaseRoute
+
+    from turnstone.core.session_manager import SessionKindAdapter, SessionManager
+
+
+Handler = Callable[["Request"], Awaitable["Response"]]
+
+
+@dataclass(frozen=True)
+class SessionRouteHandlers:
+    """Bundle of HTTP handler callables the registrar mounts.
+
+    Step 0.1 placeholder: handlers live in their server modules and
+    are passed in here. Step 0.2 lifts the bodies into
+    ``session_routes`` and switches kind branching to live behind
+    :class:`SessionRouteConfig` flags, at which point this struct
+    deletes.
+
+    Attachment + send-family handlers are ``None``-able because
+    interactive currently exposes ``/api/send`` etc. without a path
+    ``ws_id`` (legacy URL shape) and coord doesn't expose attachments
+    at all yet. Step 0.2 normalizes those gaps.
+    """
+
+    list_workstreams: Handler
+    list_saved: Handler
+    create: Handler
+    close_legacy: Handler  # POST /workstreams/close — ws_id in body, interactive only
+    delete: Handler
+    open: Handler
+    refresh_title: Handler
+    set_title: Handler
+    upload_attachment: Handler | None = None
+    list_attachments: Handler | None = None
+    get_attachment_content: Handler | None = None
+    delete_attachment: Handler | None = None
+
+
+@dataclass(frozen=True)
+class SessionRouteConfig:
+    """Per-kind feature flags for the session HTTP route registrar.
+
+    Step 0.1 carries only the flags the current registrar branches
+    on; Step 0.2 grows the flag set as kind-specific handler bodies
+    are lifted in (e.g. ``supports_initial_message_worker`` for
+    interactive ``/new``, ``supports_parent_ws_id`` for coord
+    ``/new``, kind-aware permission scope for the auth gate).
+    """
+
+    supports_attachments: bool = False
+    supports_legacy_close: bool = False  # interactive: POST /workstreams/close — ws_id in body
+
+
+def register_session_routes(
+    routes: list[BaseRoute],
+    *,
+    prefix: str,
+    mgr: SessionManager,
+    adapter: SessionKindAdapter,
+    config: SessionRouteConfig,
+    handlers: SessionRouteHandlers,
+) -> None:
+    """Append the workstream HTTP route table to ``routes`` at ``prefix``.
+
+    Mounts the per-workstream verbs (``new``, ``close``, ``open``,
+    ``delete``, ``title``, ``refresh-title``, attachments) plus the
+    list/saved listing endpoints under ``prefix``. Routes that are
+    not workstream-prefixed in the current interactive surface
+    (``/api/dashboard``, ``/api/send``, ``/api/approve``,
+    ``/api/plan``, ``/api/cancel``, ``/api/command``, ``/api/events``)
+    stay at their existing paths in ``server.py`` for Step 0.1 — the
+    next step migrates them into a unified ``{prefix}/{ws_id}/...``
+    shape so coord can share the handlers.
+
+    Args:
+        routes: list to extend; typically the inner ``Mount`` route
+            list a Starlette app uses.
+        prefix: URL prefix relative to the mount, e.g.
+            ``"/api/workstreams"``.
+        mgr: the session manager owning the workstream kind. Wired
+            through now so Step 0.2's lifted handler bodies can read
+            it without further plumbing.
+        adapter: the kind's adapter. Same forward-wiring rationale.
+        config: per-kind feature flags.
+        handlers: bundle of handler callables for the routes the
+            registrar mounts. Step 0.2 deletes this argument.
+    """
+    # ``mgr`` and ``adapter`` are unused in Step 0.1; declared in the
+    # signature so handler bodies can pick them up directly in 0.2
+    # without a callsite churn. Suppress the lint locally.
+    _ = (mgr, adapter)
+
+    p = prefix.rstrip("/")
+
+    # --- Listing endpoints ----------------------------------------------
+    routes.append(Route(p, handlers.list_workstreams))
+    # ``saved`` literal must register BEFORE the ``{ws_id}`` routes
+    # below so Starlette doesn't match "saved" as a ws_id path param.
+    routes.append(Route(f"{p}/saved", handlers.list_saved))
+
+    # --- Lifecycle: create + legacy close (ws_id in body) ---------------
+    routes.append(Route(f"{p}/new", handlers.create, methods=["POST"]))
+    if config.supports_legacy_close:
+        routes.append(Route(f"{p}/close", handlers.close_legacy, methods=["POST"]))
+
+    # --- Per-{ws_id} verbs ----------------------------------------------
+    routes.append(Route(f"{p}/{{ws_id}}/delete", handlers.delete, methods=["POST"]))
+    routes.append(Route(f"{p}/{{ws_id}}/open", handlers.open, methods=["POST"]))
+    routes.append(
+        Route(
+            f"{p}/{{ws_id}}/refresh-title",
+            handlers.refresh_title,
+            methods=["POST"],
+        )
+    )
+    routes.append(Route(f"{p}/{{ws_id}}/title", handlers.set_title, methods=["POST"]))
+
+    # --- Attachments (interactive-only today; coord parity is post-1.5) -
+    if config.supports_attachments:
+        if (
+            handlers.upload_attachment is None
+            or handlers.list_attachments is None
+            or handlers.get_attachment_content is None
+            or handlers.delete_attachment is None
+        ):
+            raise ValueError("supports_attachments=True requires all four attachment handlers")
+        routes.append(
+            Route(
+                f"{p}/{{ws_id}}/attachments",
+                handlers.upload_attachment,
+                methods=["POST"],
+            )
+        )
+        routes.append(
+            Route(
+                f"{p}/{{ws_id}}/attachments",
+                handlers.list_attachments,
+                methods=["GET"],
+            )
+        )
+        routes.append(
+            Route(
+                f"{p}/{{ws_id}}/attachments/{{attachment_id}}/content",
+                handlers.get_attachment_content,
+                methods=["GET"],
+            )
+        )
+        routes.append(
+            Route(
+                f"{p}/{{ws_id}}/attachments/{{attachment_id}}",
+                handlers.delete_attachment,
+                methods=["DELETE"],
+            )
+        )

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -636,7 +636,7 @@ def _build_registry() -> dict[str, SettingDef]:
             "Must match an entry in the Models tab. Coordinator sessions create and "
             "drive child workstreams on your server nodes; point this at a capable "
             "model so the orchestration reasoning is solid. When empty, "
-            "POST /v1/api/coordinator/new returns 503 with a remediation message.",
+            "POST /v1/api/workstreams/new returns 503 with a remediation message.",
         ),
         SettingDef(
             "coordinator.reasoning_effort",
@@ -659,7 +659,7 @@ def _build_registry() -> dict[str, SettingDef]:
             min_value=1,
             max_value=100,
             help="Cap on how many coordinator workstreams can run at once on this "
-            "console. When the limit is reached, POST /v1/api/coordinator/new either "
+            "console. When the limit is reached, POST /v1/api/workstreams/new either "
             "evicts the oldest idle coordinator (matching SessionManager.close_idle "
             "semantics) or returns 429 if every slot is non-idle.",
         ),

--- a/turnstone/core/storage/migrations/versions/042_coord_trust_send_perm.py
+++ b/turnstone/core/storage/migrations/versions/042_coord_trust_send_perm.py
@@ -1,6 +1,6 @@
 """Add ``coordinator.trust.send`` permission to the builtin-admin role.
 
-Gates the trusted-session mode on ``POST /v1/api/coordinator/{ws_id}/trust``:
+Gates the trusted-session mode on ``POST /v1/api/workstreams/{ws_id}/trust``:
 when set on a coordinator session, sends to the coordinator's own
 children skip the approval prompt.  Foreign ws_ids still go through
 approval regardless — the permission only unlocks the toggle, it does

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -804,6 +804,72 @@ def _audit_context(request: Request) -> tuple[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Per-kind policies passed to the lifted session_routes handlers
+# ---------------------------------------------------------------------------
+
+
+def _interactive_manager_lookup(
+    request: Request,
+) -> tuple[SessionManager | None, JSONResponse | None]:
+    """Return the interactive ``SessionManager`` from app.state.
+
+    Interactive always has the manager loaded (it's constructed
+    synchronously at server startup), so the 503 branch is unused
+    on this side. Match the :data:`SessionRouteHandlers` signature
+    so the lifted handler bodies can call it uniformly.
+    """
+    return request.app.state.workstreams, None
+
+
+def _interactive_tenant_check(
+    request: Request, ws_id: str, mgr: SessionManager
+) -> JSONResponse | None:
+    """Cross-tenant gate for the lifted session handlers.
+
+    Forwards to :func:`_require_ws_access`, which returns 404 on
+    owner mismatch (the interactive trusted-team model).
+    """
+    _owner, err = _require_ws_access(request, ws_id, mgr=mgr)
+    return err
+
+
+def _audit_close_workstream(
+    request: Request,
+    ws_id: str,
+    ws_before: Workstream,
+    reason: str,
+) -> None:
+    """Record the ``workstream.closed`` audit event for interactive close.
+
+    Passed to :func:`make_close_handler` as the ``audit_emit``
+    callable. ``storage`` is guaranteed non-``None`` by the lifted
+    handler's upstream gate; the ``getattr`` fallback is defensive
+    consistency with the rest of the storage access pattern.
+    """
+    from turnstone.core.audit import record_audit
+
+    storage = getattr(request.app.state, "auth_storage", None)
+    if storage is None:
+        return
+    _, ip = _audit_context(request)
+    detail: dict[str, Any] = {
+        "kind": str(ws_before.kind),
+        "parent_ws_id": ws_before.parent_ws_id,
+    }
+    if reason:
+        detail["reason"] = reason
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "workstream.closed",
+        "workstream",
+        ws_id,
+        detail,
+        ip,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Route handlers — all async
 # ---------------------------------------------------------------------------
 
@@ -4305,51 +4371,17 @@ def create_app(
     # ``turnstone.core.session_routes`` so the console mounts the same
     # shape against its coord manager. ``session_endpoint_config``
     # carries the kind-specific policy (auth, manager lookup, audit
-    # prefix) the lifted handler bodies consult at request time.
-    def _interactive_tenant_check(
-        request: Request, ws_id: str, mgr: SessionManager
-    ) -> JSONResponse | None:
-        # ``_require_ws_access`` returns ``(owner_uid, err)``; only the
-        # err matters for the gate.
-        _owner, err = _require_ws_access(request, ws_id, mgr=mgr)
-        return err
-
+    # prefix) the lifted handler bodies consult.
     interactive_endpoint_config = SessionEndpointConfig(
         permission_gate=None,  # interactive auth is enforced at the middleware layer
-        manager_lookup=lambda r: (r.app.state.workstreams, None),
+        manager_lookup=_interactive_manager_lookup,
         tenant_check=_interactive_tenant_check,
         not_found_label="Workstream not found",
         audit_action_prefix="workstream",
     )
-    approve_handler = make_approve_handler()
-
-    def _audit_close_workstream(
-        request: Request,
-        ws_id: str,
-        ws_before: Workstream,
-        reason: str,
-    ) -> None:
-        from turnstone.core.audit import record_audit
-
-        storage = request.app.state.auth_storage
-        _, ip = _audit_context(request)
-        detail: dict[str, Any] = {
-            "kind": str(ws_before.kind),
-            "parent_ws_id": ws_before.parent_ws_id,
-        }
-        if reason:
-            detail["reason"] = reason
-        record_audit(
-            storage,
-            _auth_user_id(request),
-            "workstream.closed",
-            "workstream",
-            ws_id,
-            detail,
-            ip,
-        )
-
+    approve_handler = make_approve_handler(interactive_endpoint_config)
     close_handler = make_close_handler(
+        interactive_endpoint_config,
         audit_emit=_audit_close_workstream,
         supports_close_reason=True,
     )

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -54,7 +54,12 @@ from turnstone.core.log import get_logger
 from turnstone.core.metrics import metrics as _metrics
 from turnstone.core.ratelimit import resolve_client_ip
 from turnstone.core.session import ChatSession, GenerationCancelled, SessionUI  # noqa: F401
-from turnstone.core.session_manager import SessionManager
+from turnstone.core.session_manager import SessionKindAdapter, SessionManager
+from turnstone.core.session_routes import (
+    SessionRouteConfig,
+    SessionRouteHandlers,
+    register_session_routes,
+)
 from turnstone.core.session_ui_base import SessionUIBase
 from turnstone.core.tools import TOOLS  # noqa: F401 — available for introspection
 from turnstone.core.web_helpers import version_html as _version_html
@@ -4387,6 +4392,7 @@ def _build_middleware(cors_origins: list[str] | None = None) -> list[Middleware]
 def create_app(
     *,
     workstreams: SessionManager,
+    adapter: SessionKindAdapter | None = None,
     global_queue: queue.Queue[dict[str, Any]],
     global_listeners: list[queue.Queue[dict[str, Any]]],
     global_listeners_lock: threading.Lock,
@@ -4411,51 +4417,53 @@ def create_app(
     _openapi_handler = make_openapi_handler(_spec)
     _docs_handler = make_docs_handler()
 
+    # Workstream HTTP tree — owned by the shared registrar in
+    # turnstone.core.session_routes so the coord side can mount the
+    # same shape against its own manager in Stage 2 Step 0.2. The
+    # ``adapter`` param defaults off the manager so existing test
+    # call sites that build a manager + app directly don't have to
+    # thread the adapter through.
+    if adapter is None:
+        adapter = workstreams.adapter
+    v1_routes: list[Any] = [
+        Route("/api/events", events_sse),
+        Route("/api/events/global", global_events_sse),
+    ]
+    register_session_routes(
+        v1_routes,
+        prefix="/api/workstreams",
+        mgr=workstreams,
+        adapter=adapter,
+        config=SessionRouteConfig(
+            supports_attachments=True,
+            supports_legacy_close=True,
+        ),
+        handlers=SessionRouteHandlers(
+            list_workstreams=list_workstreams,
+            list_saved=list_saved_workstreams,
+            create=create_workstream,
+            close_legacy=close_workstream,
+            delete=delete_workstream_endpoint,
+            open=open_workstream,
+            refresh_title=refresh_workstream_title,
+            set_title=set_workstream_title,
+            upload_attachment=upload_attachment,
+            list_attachments=list_attachments,
+            get_attachment_content=get_attachment_content,
+            delete_attachment=delete_attachment,
+        ),
+    )
+    # Dashboard sits outside the /workstreams prefix today; Step 0.2
+    # decides whether to fold it in alongside the unified verbs.
+    v1_routes.append(Route("/api/dashboard", dashboard))
+
     app = Starlette(
         routes=[
             Route("/", index),
             Mount(
                 "/v1",
                 routes=[
-                    Route("/api/events", events_sse),
-                    Route("/api/events/global", global_events_sse),
-                    Route("/api/workstreams", list_workstreams),
-                    Route("/api/dashboard", dashboard),
-                    Route("/api/workstreams/saved", list_saved_workstreams),
-                    Route("/api/workstreams/new", create_workstream, methods=["POST"]),
-                    Route("/api/workstreams/close", close_workstream, methods=["POST"]),
-                    Route(
-                        "/api/workstreams/{ws_id}/delete",
-                        delete_workstream_endpoint,
-                        methods=["POST"],
-                    ),
-                    Route("/api/workstreams/{ws_id}/open", open_workstream, methods=["POST"]),
-                    Route(
-                        "/api/workstreams/{ws_id}/refresh-title",
-                        refresh_workstream_title,
-                        methods=["POST"],
-                    ),
-                    Route("/api/workstreams/{ws_id}/title", set_workstream_title, methods=["POST"]),
-                    Route(
-                        "/api/workstreams/{ws_id}/attachments",
-                        upload_attachment,
-                        methods=["POST"],
-                    ),
-                    Route(
-                        "/api/workstreams/{ws_id}/attachments",
-                        list_attachments,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
-                        get_attachment_content,
-                        methods=["GET"],
-                    ),
-                    Route(
-                        "/api/workstreams/{ws_id}/attachments/{attachment_id}",
-                        delete_attachment,
-                        methods=["DELETE"],
-                    ),
+                    *v1_routes,
                     Route("/api/skills", list_skills_summary),
                     Route("/api/models", list_available_models),
                     Route("/api/send", send_message, methods=["POST", "DELETE"]),
@@ -5056,6 +5064,7 @@ def main() -> None:
     _skip_perms = config_store.get("tools.skip_permissions")
     app = create_app(
         workstreams=manager,
+        adapter=interactive_adapter,
         global_queue=global_queue,
         global_listeners=global_listeners,
         global_listeners_lock=global_listeners_lock,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -815,8 +815,8 @@ def _interactive_manager_lookup(
 
     Interactive always has the manager loaded (it's constructed
     synchronously at server startup), so the 503 branch is unused
-    on this side. Match the :data:`SessionRouteHandlers` signature
-    so the lifted handler bodies can call it uniformly.
+    on this side. Matches the :attr:`SessionEndpointConfig.manager_lookup`
+    callable shape so the lifted handler bodies can call it uniformly.
     """
     return request.app.state.workstreams, None
 
@@ -4369,9 +4369,9 @@ def create_app(
 
     # Workstream HTTP tree — owned by the shared registrar in
     # ``turnstone.core.session_routes`` so the console mounts the same
-    # shape against its coord manager. ``session_endpoint_config``
-    # carries the kind-specific policy (auth, manager lookup, audit
-    # prefix) the lifted handler bodies consult.
+    # shape against its coord manager. The lifted handler factories
+    # (``make_approve_handler``, ``make_close_handler``) capture the
+    # kind-specific ``SessionEndpointConfig`` via closure.
     interactive_endpoint_config = SessionEndpointConfig(
         permission_gate=None,  # interactive auth is enforced at the middleware layer
         manager_lookup=_interactive_manager_lookup,
@@ -4473,7 +4473,6 @@ def create_app(
         lifespan=_lifespan,
     )
     app.state.workstreams = workstreams
-    app.state.session_endpoint_config = interactive_endpoint_config
     app.state.global_queue = global_queue
     app.state.global_listeners = global_listeners
     app.state.global_listeners_lock = global_listeners_lock

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2392,7 +2392,12 @@ async def create_workstream(request: Request) -> JSONResponse:
         )
     if body_kind != WorkstreamKind.INTERACTIVE:
         return JSONResponse(
-            {"error": "coordinator workstreams must be created via /v1/api/coordinator/new"},
+            {
+                "error": (
+                    "coordinator workstreams must be created on the console via "
+                    "POST /v1/api/workstreams/new (with admin.coordinator scope)"
+                )
+            },
             status_code=400,
         )
     body_parent = body.get("parent_ws_id") or None

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -60,6 +60,7 @@ from turnstone.core.session_routes import (
     SessionEndpointConfig,
     SharedSessionVerbHandlers,
     make_approve_handler,
+    make_close_handler,
     make_legacy_body_keyed_adapter,
     register_session_routes,
 )
@@ -2630,93 +2631,6 @@ async def create_workstream(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(e)}, status_code=400)
 
 
-async def close_workstream(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/close — close a workstream.
-
-    Optional ``reason`` from the request body is persisted on the
-    workstream's config row so post-mortem tooling (and the coordinator's
-    ``inspect_workstream``) can surface why the workstream was retired
-    without scraping the audit log.
-    """
-    from turnstone.core.audit import record_audit
-    from turnstone.core.output_guard import redact_credentials
-    from turnstone.core.web_helpers import read_json_or_400
-
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    ws_id = str(body.get("ws_id", ""))
-    raw_reason = body.get("reason", "")
-    # Cap reason length so a model that accidentally / maliciously dumps
-    # a multi-KB blob (or a captured secret) can't grow workstream_config
-    # rows without bound.  512 BYTES is enough for any human-readable
-    # close reason; anything longer is suspicious.  Slice on UTF-8 bytes
-    # (not code points) so a CJK / emoji-heavy payload can't sneak past
-    # the cap at 3-4x the documented budget.  ``errors="ignore"`` drops
-    # any partial code point left at the truncation boundary.  Then run
-    # the same credential-redaction the output guard applies to tool
-    # output — a model under prompt injection that dumps a captured
-    # secret in ``reason`` doesn't get to plant it in plaintext audit
-    # logs / workstream_config.
-    if isinstance(raw_reason, str):
-        capped = raw_reason.strip().encode("utf-8")[:512].decode("utf-8", errors="ignore")
-        reason = redact_credentials(capped)
-    else:
-        reason = ""
-    mgr = request.app.state.workstreams
-    # Cross-tenant close would abort another tenant's running generation.
-    # _require_ws_access returns 404 on non-owner — same shape as the
-    # "last workstream" (400) / "not found" (404) branches below.
-    _owner_uid, err = _require_ws_access(request, ws_id, mgr=mgr)
-    if err:
-        return err
-    ws_before = mgr.get(ws_id)
-    if not ws_before:
-        return JSONResponse({"error": "Workstream not found"}, status_code=404)
-    if mgr.close(ws_id):
-        storage = getattr(request.app.state, "auth_storage", None)
-        # Persist before the ws_closed event reaches consumers so any
-        # downstream reader sees the close_reason in the same
-        # observation window as the state change. The adapter-level
-        # emit_closed fires inside mgr.close() which already returned
-        # — strictly speaking the event beat us here, but the
-        # close_reason is advisory UI metadata, not a sync barrier.
-        if reason and storage is not None:
-            try:
-                storage.save_workstream_config(ws_id, {"close_reason": reason})
-            except Exception:
-                log.debug(
-                    "ws.close.reason_persist_failed ws=%s",
-                    ws_id[:8] if ws_id else "",
-                    exc_info=True,
-                )
-        if storage is not None:
-            _, ip = _audit_context(request)
-            audit_detail: dict[str, Any] = {
-                "kind": str(ws_before.kind),
-                "parent_ws_id": ws_before.parent_ws_id,
-            }
-            if reason:
-                audit_detail["reason"] = reason
-            record_audit(
-                storage,
-                _auth_user_id(request),
-                "workstream.closed",
-                "workstream",
-                ws_id,
-                audit_detail,
-                ip,
-            )
-        return JSONResponse({"status": "ok"})
-    # close() returned False — the ws was popped between the mgr.get()
-    # check above and our mgr.close() call (another close racing in).
-    # Return 404 so the API contract matches a "not found" caller
-    # experience; the old "Cannot close last workstream" 400 went away
-    # with the default-startup workstream and there's no scenario where
-    # this branch means anything other than "the ws isn't tracked here".
-    return JSONResponse({"error": "Workstream not found"}, status_code=404)
-
-
 async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/{ws_id}/delete — permanently delete a saved workstream."""
     from turnstone.core.audit import record_audit
@@ -4408,6 +4322,37 @@ def create_app(
         audit_action_prefix="workstream",
     )
     approve_handler = make_approve_handler()
+
+    def _audit_close_workstream(
+        request: Request,
+        ws_id: str,
+        ws_before: Workstream,
+        reason: str,
+    ) -> None:
+        from turnstone.core.audit import record_audit
+
+        storage = request.app.state.auth_storage
+        _, ip = _audit_context(request)
+        detail: dict[str, Any] = {
+            "kind": str(ws_before.kind),
+            "parent_ws_id": ws_before.parent_ws_id,
+        }
+        if reason:
+            detail["reason"] = reason
+        record_audit(
+            storage,
+            _auth_user_id(request),
+            "workstream.closed",
+            "workstream",
+            ws_id,
+            detail,
+            ip,
+        )
+
+    close_handler = make_close_handler(
+        audit_emit=_audit_close_workstream,
+        supports_close_reason=True,
+    )
     v1_routes: list[Any] = [
         Route("/api/events", events_sse),
         Route("/api/events/global", global_events_sse),
@@ -4419,9 +4364,10 @@ def create_app(
             list_workstreams=list_workstreams,
             list_saved=list_saved_workstreams,
             create=create_workstream,
-            close_legacy=close_workstream,
+            close_legacy=make_legacy_body_keyed_adapter(close_handler),
             delete=delete_workstream_endpoint,
             open=open_workstream,
+            close=close_handler,  # lifted: shared body
             refresh_title=refresh_workstream_title,
             set_title=set_workstream_title,
             approve=approve_handler,  # lifted: shared body

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4434,10 +4434,7 @@ def create_app(
         prefix="/api/workstreams",
         mgr=workstreams,
         adapter=adapter,
-        config=SessionRouteConfig(
-            supports_attachments=True,
-            supports_legacy_close=True,
-        ),
+        config=SessionRouteConfig(supports_legacy_close=True),
         handlers=SessionRouteHandlers(
             list_workstreams=list_workstreams,
             list_saved=list_saved_workstreams,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -57,7 +57,10 @@ from turnstone.core.session import ChatSession, GenerationCancelled, SessionUI  
 from turnstone.core.session_manager import SessionManager
 from turnstone.core.session_routes import (
     AttachmentHandlers,
+    SessionEndpointConfig,
     SharedSessionVerbHandlers,
+    make_approve_handler,
+    make_legacy_body_keyed_adapter,
     register_session_routes,
 )
 from turnstone.core.session_ui_base import SessionUIBase
@@ -1670,43 +1673,6 @@ async def send_message(request: Request) -> JSONResponse:
             "dropped_attachment_ids": dropped,
         }
     )
-
-
-async def approve(request: Request) -> JSONResponse:
-    """POST /v1/api/approve — approve or deny a tool call."""
-    from turnstone.core.web_helpers import read_json_or_400
-
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    approved = body.get("approved", False)
-    feedback = body.get("feedback")
-    always = body.get("always", False)
-    ws_id = body.get("ws_id")
-    mgr = request.app.state.workstreams
-    # Cross-tenant guard: resolving a pending tool approval on another
-    # tenant's workstream is RCE-adjacent (the victim queued a command
-    # expecting to decide themselves).  Gate before touching the UI.
-    # Pass mgr= so the check uses the in-memory ws.user_id and survives
-    # transient storage outages.
-    _owner, err = _require_ws_access(request, str(ws_id or ""), mgr=mgr)
-    if err:
-        return err
-    ws, ui = _get_ws(mgr, ws_id)
-    if not ws or not ui:
-        return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-    if always and approved and ui._pending_approval:
-        tool_names = {
-            it.get("approval_label", "") or it.get("func_name", "")
-            for it in ui._pending_approval.get("items", [])
-            if it.get("needs_approval") and it.get("func_name") and not it.get("error")
-        }
-        tool_names.discard("")
-        tool_names.discard("__budget_override__")
-        if tool_names:
-            ui.auto_approve_tools.update(tool_names)
-    ui.resolve_approval(approved, feedback)
-    return JSONResponse({"status": "ok"})
 
 
 async def plan_feedback(request: Request) -> JSONResponse:
@@ -4423,7 +4389,25 @@ def create_app(
 
     # Workstream HTTP tree — owned by the shared registrar in
     # ``turnstone.core.session_routes`` so the console mounts the same
-    # shape against its coord manager.
+    # shape against its coord manager. ``session_endpoint_config``
+    # carries the kind-specific policy (auth, manager lookup, audit
+    # prefix) the lifted handler bodies consult at request time.
+    def _interactive_tenant_check(
+        request: Request, ws_id: str, mgr: SessionManager
+    ) -> JSONResponse | None:
+        # ``_require_ws_access`` returns ``(owner_uid, err)``; only the
+        # err matters for the gate.
+        _owner, err = _require_ws_access(request, ws_id, mgr=mgr)
+        return err
+
+    interactive_endpoint_config = SessionEndpointConfig(
+        permission_gate=None,  # interactive auth is enforced at the middleware layer
+        manager_lookup=lambda r: (r.app.state.workstreams, None),
+        tenant_check=_interactive_tenant_check,
+        not_found_label="Workstream not found",
+        audit_action_prefix="workstream",
+    )
+    approve_handler = make_approve_handler()
     v1_routes: list[Any] = [
         Route("/api/events", events_sse),
         Route("/api/events/global", global_events_sse),
@@ -4440,6 +4424,7 @@ def create_app(
             open=open_workstream,
             refresh_title=refresh_workstream_title,
             set_title=set_workstream_title,
+            approve=approve_handler,  # lifted: shared body
             attachments=AttachmentHandlers(
                 upload=upload_attachment,
                 list=list_attachments,
@@ -4460,7 +4445,11 @@ def create_app(
                     Route("/api/skills", list_skills_summary),
                     Route("/api/models", list_available_models),
                     Route("/api/send", send_message, methods=["POST", "DELETE"]),
-                    Route("/api/approve", approve, methods=["POST"]),
+                    Route(
+                        "/api/approve",
+                        make_legacy_body_keyed_adapter(approve_handler),
+                        methods=["POST"],
+                    ),
                     Route("/api/plan", plan_feedback, methods=["POST"]),
                     Route("/api/command", command, methods=["POST"]),
                     Route("/api/cancel", cancel_generation, methods=["POST"]),
@@ -4506,6 +4495,7 @@ def create_app(
         lifespan=_lifespan,
     )
     app.state.workstreams = workstreams
+    app.state.session_endpoint_config = interactive_endpoint_config
     app.state.global_queue = global_queue
     app.state.global_listeners = global_listeners
     app.state.global_listeners_lock = global_listeners_lock

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -54,10 +54,10 @@ from turnstone.core.log import get_logger
 from turnstone.core.metrics import metrics as _metrics
 from turnstone.core.ratelimit import resolve_client_ip
 from turnstone.core.session import ChatSession, GenerationCancelled, SessionUI  # noqa: F401
-from turnstone.core.session_manager import SessionKindAdapter, SessionManager
+from turnstone.core.session_manager import SessionManager
 from turnstone.core.session_routes import (
-    SessionRouteConfig,
-    SessionRouteHandlers,
+    AttachmentHandlers,
+    SharedSessionVerbHandlers,
     register_session_routes,
 )
 from turnstone.core.session_ui_base import SessionUIBase
@@ -4397,7 +4397,6 @@ def _build_middleware(cors_origins: list[str] | None = None) -> list[Middleware]
 def create_app(
     *,
     workstreams: SessionManager,
-    adapter: SessionKindAdapter | None = None,
     global_queue: queue.Queue[dict[str, Any]],
     global_listeners: list[queue.Queue[dict[str, Any]]],
     global_listeners_lock: threading.Lock,
@@ -4423,13 +4422,8 @@ def create_app(
     _docs_handler = make_docs_handler()
 
     # Workstream HTTP tree — owned by the shared registrar in
-    # turnstone.core.session_routes so the coord side can mount the
-    # same shape against its own manager in Stage 2 Step 0.2. The
-    # ``adapter`` param defaults off the manager so existing test
-    # call sites that build a manager + app directly don't have to
-    # thread the adapter through.
-    if adapter is None:
-        adapter = workstreams.adapter
+    # ``turnstone.core.session_routes`` so the console mounts the same
+    # shape against its coord manager.
     v1_routes: list[Any] = [
         Route("/api/events", events_sse),
         Route("/api/events/global", global_events_sse),
@@ -4437,10 +4431,7 @@ def create_app(
     register_session_routes(
         v1_routes,
         prefix="/api/workstreams",
-        mgr=workstreams,
-        adapter=adapter,
-        config=SessionRouteConfig(supports_legacy_close=True),
-        handlers=SessionRouteHandlers(
+        handlers=SharedSessionVerbHandlers(
             list_workstreams=list_workstreams,
             list_saved=list_saved_workstreams,
             create=create_workstream,
@@ -4449,14 +4440,14 @@ def create_app(
             open=open_workstream,
             refresh_title=refresh_workstream_title,
             set_title=set_workstream_title,
-            upload_attachment=upload_attachment,
-            list_attachments=list_attachments,
-            get_attachment_content=get_attachment_content,
-            delete_attachment=delete_attachment,
+            attachments=AttachmentHandlers(
+                upload=upload_attachment,
+                list=list_attachments,
+                get_content=get_attachment_content,
+                delete=delete_attachment,
+            ),
         ),
     )
-    # Dashboard sits outside the /workstreams prefix today; Step 0.2
-    # decides whether to fold it in alongside the unified verbs.
     v1_routes.append(Route("/api/dashboard", dashboard))
 
     app = Starlette(
@@ -5066,7 +5057,6 @@ def main() -> None:
     _skip_perms = config_store.get("tools.skip_permissions")
     app = create_app(
         workstreams=manager,
-        adapter=interactive_adapter,
         global_queue=global_queue,
         global_listeners=global_listeners,
         global_listeners_lock=global_listeners_lock,


### PR DESCRIPTION
## Summary

Stage 2 Priority 0 of the SessionManager unification — collapses the parallel `/v1/api/workstreams/*` (interactive) and `/v1/api/coordinator/*` (coordinator, never shipped stable) HTTP handler trees into one URL shape mounted by both processes via a shared registrar in `turnstone.core.session_routes`. Two handler bodies (`approve`, `close`) lifted into the registrar with kind branching behind `SessionEndpointConfig`.

**Net: 27 files, +1371 / −668 LOC.** Smaller than the plan's −1500 to −2000 LOC target — most of that delta lives in the seven verbs whose body convergence is genuinely blocked on Priority 1 (worker dispatch) or coordinated frontend changes (response-shape unification). What's here is the URL surface unification + the two cleanly-mergeable verbs + everything that has to land alongside (frontend, SDK, tests, OpenAPI spec).

## What ships

**HTTP surface**

- New `turnstone/core/session_routes.py` — `SharedSessionVerbHandlers` (all-Optional bundle) + `CoordOnlyVerbHandlers` + `AttachmentHandlers` quartet + `SessionEndpointConfig` (per-kind policy: auth gate, manager lookup, tenant check, audit prefix, error label).
- `register_session_routes(routes, *, prefix, handlers)` and `register_coord_verbs(routes, *, prefix, handlers)` — both processes mount the same shape against their own `SessionManager`.
- `make_approve_handler(cfg)` and `make_close_handler(cfg, *, audit_emit, supports_close_reason)` — factory closures returning the lifted bodies. Each kind passes its own `SessionEndpointConfig` + (for close) its own `audit_emit` callable. No app.state lookup at request time; config captured by closure at app construction.
- `make_legacy_body_keyed_adapter(handler)` — wraps a path-keyed lifted handler so the legacy `POST /v1/api/approve` / `POST /v1/api/workstreams/close` URLs forward to the same lifted body. Frontend / SDK keep the legacy URLs; both shapes resolve to the same code.
- The eighteen legacy `Route("/api/coordinator/...")` entries deleted from `console/server.py`. Coord traffic flows exclusively through `/v1/api/workstreams/{ws_id}/{verb}`.

**Mechanical sweep `/v1/api/coordinator` → `/v1/api/workstreams` across:**

- Frontend JS — `coordinator.js` (16 sites), `app.js` (9 sites), `index.html`
- OpenAPI spec — `console_spec.py`, `console_schemas.py`, `server_schemas.py`
- TypeScript SDK — `openapi-{server,console}.json` regenerated via `scripts/generate-types.py`; package bumped 0.3.0 → 0.4.0
- Server-side coord HTTP client — `coordinator_client.py:251`
- Six coord test files
- Settings descriptions, migration 042 docstring
- Handler docstrings in `console/server.py`

**Tests**

- New `tests/test_session_routes.py` (7 tests) — registrar mounting rules + console route-walk asserting the legacy paths are gone.
- Coord test fixtures (`test_coordinator_endpoints._make_client`, `test_coordinator_end_to_end._make_client`) wire through `make_approve_handler(cfg)` / `make_close_handler(cfg, ...)` against the same `SessionEndpointConfig` + `_audit_close_coordinator` the live console uses.
- `MockStorage` moved from `test_console.py` into `tests/_coord_test_helpers.py`; `test_console.py` re-imports.
- `test_phase6_endpoints.py` drops its duplicated `_AuthMiddleware` / `_FakeConfigStore` / `_fake_registry` / `_build_mgr` and imports from the shared helpers.

## Behavior changes (CHANGELOG-flagged)

Two on the close path:

1. **`mgr.close()` race-loss returns 404** (was 500 on the legacy coord path). "Popped between `.get()` and `.close()`" is a not-found semantic, not a server error.
2. **Audit-write failures are now caught and logged at `warning`**; the close still returns 200. Previously the interactive path let `record_audit` exceptions propagate as HTTP 500. Coord previously already swallowed; convergence is intentional — operators monitor the `ws.close.audit_failed` log line in both kinds the same way.

URL change: any 1.5.0aN-era SDK consumer of `/v1/api/coordinator/*` must swap to `/v1/api/workstreams/*`. Stable releases (1.0 / 1.3 / 1.4) never exposed `/v1/api/coordinator/`, so this is a no-op for stable upgraders.

## What's deferred and why

Seven shared verbs keep their per-kind handlers — body convergence isn't a clean fit:

- `send` — inline worker dispatch on interactive vs `adapter.send` on coord; convergence depends on Priority 1's worker-dispatch unification.
- `cancel` — interactive does forensics + `force` flag + inline `ws._lock` manipulation that coord doesn't need; merging would be more branching than savings.
- `close` is the boundary case — the audit shape (different detail dict) factored cleanly via `audit_emit`; cancel's inline mechanics don't.
- `open` — interactive `resume` vs coord `rehydrate`.
- `events` — different SSE replay shapes per kind.
- `create` — interactive attachments vs coord `initial_message` + plan/task model knobs.
- `list` / `saved` — different response keys (`workstreams` vs `coordinators`); convergence is a coordinated frontend change.
- `history` / `detail` — coord-only currently; lifting is pure relocation, no LOC win.

The `SessionEndpointConfig` + factory pattern makes future verb lifts cheap (~10 LOC factory + 5 LOC wiring per kind) once the upstream blockers (Priority 1, response-shape unification) lift.

## Review

Two `/review` rounds run on this branch:

- **Round 1** (after URL surface unification, before body convergence): 0 critical / major, 5 minor + 5 nit quality findings — all addressed in `a769b73` (trim docstring narrative, drop unused `mgr`/`adapter` placeholder kwargs, group attachment quartet into nested dataclass, drop tombstone comment, rename for symmetry).
- **Round 2** (after `approve` + `close` lift): 0 critical / major, 6 minor + 3 nit findings (1 bug-flagged behavior change, the rest quality). All addressed in `869142a` except q-6 (`request.scope[\"path_params\"]` mutation in the legacy adapter) — documented in the adapter docstring; restructuring lifted-handler signatures to take ws_id explicitly is bigger than this PR's scope.

## Test plan

- [ ] CI: ruff + mypy + 4366 pytest pass
- [ ] CI: TypeScript SDK `npm run typecheck` + 32 vitest pass
- [ ] Manual: spin up `turnstone-console`, hit `/v1/api/workstreams/{ws_id}/{verb}` with `admin.coordinator` JWT — already verified locally returns 503 (no coord_mgr in smoke env) which proves the lifted handlers are reachable + manager_lookup fires.
- [ ] Manual: load the coord browser surface (`/coordinator/{ws_id}`) and confirm the new URLs work end-to-end. Cannot do this autonomously; needs a human pass.
- [ ] CHANGELOG `[Unreleased]` entry covers the URL move + the two close-path behavior changes + the SDK bump.