### PR TITLE
Stage 2 Priority 1 — worker dispatch + state write-behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,37 @@ Three release tracks are maintained:
   `openapi-{server,console}.json` reference specs ship with the
   unified path tree.
 
+- **Worker dispatch unified across interactive + coordinator**
+  ([Stage 2 Priority 1]). The atomic check-and-(spawn-or-queue)
+  decision for ``ChatSession.send`` now lives in
+  ``turnstone.core.session_worker.send`` and is shared by both
+  paths. Interactive ``/v1/api/send``, the coordinator adapter, the
+  watch-result dispatch, the rewind/retry path, and the
+  initial-message-on-create path all gate on
+  ``Workstream._worker_running`` (set/cleared atomically under
+  ``ws._lock``) instead of ``Thread.is_alive()`` — closes a race
+  where two senders could spawn parallel workers on the same
+  ChatSession. The HTTP response shapes for ``/send`` stay
+  per-kind (interactive carries attachments / queue priorities /
+  msg_ids, coord doesn't); body convergence at the HTTP layer is
+  out of scope until coord grows attachments parity.
+
+- **Workstream state writes are now buffered through ``StateWriter``.**
+  ``SessionManager.set_state`` no longer holds ``ws._lock`` across a
+  synchronous Postgres ``UPDATE`` for non-terminal transitions;
+  instead a ``StateWriter`` (constructed at app startup, started /
+  shutdown by the lifespan) coalesces transient transitions per
+  ws_id and flushes every ~1s. **Observable behavior change**:
+  transient state (``thinking`` / ``running`` / ``idle`` /
+  ``attention``) shows up in storage up to ~1s late; SSE consumers
+  see it immediately via the adapter's ``emit_state``. Terminal
+  ``ERROR`` transitions and ``close()`` write synchronously and
+  remain durable on return. The bug-3 invariant — a closed row
+  can't be resurrected by a buffered transient — is preserved by
+  ``close()`` calling ``state_writer.discard(ws_id)`` (drops
+  pending + waits for any in-flight flush) before its sync
+  ``state='closed'`` write.
+
 ## [1.4.0]
 
 User-visible additions: a full attachment system (images + text documents,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,14 @@ Three release tracks are maintained:
   ``Workstream._worker_running`` (set/cleared atomically under
   ``ws._lock``) instead of ``Thread.is_alive()`` — closes a race
   where two senders could spawn parallel workers on the same
-  ChatSession. The HTTP response shapes for ``/send`` stay
-  per-kind (interactive carries attachments / queue priorities /
-  msg_ids, coord doesn't); body convergence at the HTTP layer is
-  out of scope until coord grows attachments parity.
+  ChatSession.
+
+  The ``/send`` HTTP body itself stays per-kind in this PR.
+  Verb-shape convergence (one shared factory body with capability
+  flags for attachments / queue priorities / metric increments) is
+  tracked as P1.5 and MUST land before 1.5.0 stable — letting the
+  fork ship into the stable line bakes the duplication in for the
+  lifetime of the 1.5 track.
 
 - **Workstream state writes are now buffered through ``StateWriter``.**
   ``SessionManager.set_state`` no longer holds ``ws._lock`` across a

--- a/tests/test_server_attachments_endpoints.py
+++ b/tests/test_server_attachments_endpoints.py
@@ -452,6 +452,7 @@ class TestSendMessageAttachments:
         ws.ui = ui
         ws.session = session
         ws.worker_thread = None
+        ws._worker_running = False
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured, session
@@ -628,7 +629,7 @@ class TestQueuedSendWithAttachments:
         ui._ws_messages = 0
         ui._ws_turn_tool_calls = 0
 
-        # worker_thread needs .is_alive() → True to hit the queue branch
+        # _worker_running=True forces session_worker.send onto the queue path
         worker = MagicMock()
         worker.is_alive = MagicMock(return_value=True)
 
@@ -638,6 +639,7 @@ class TestQueuedSendWithAttachments:
         ws.ui = ui
         ws.session = session
         ws.worker_thread = worker
+        ws._worker_running = True
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured
@@ -760,6 +762,7 @@ class TestQueuedAttachmentReservation:
         session.send = fake_send  # type: ignore[method-assign]
         ws = mgr.get.return_value
         ws.worker_thread = None  # idle → non-queue path
+        ws._worker_running = False
 
         # Auto-consume on a follow-up send: reserved attachment must not
         # be picked up (another turn isn't entitled to it).
@@ -791,6 +794,7 @@ class TestQueuedAttachmentReservation:
         session.send = fake_send  # type: ignore[method-assign]
         ws = mgr.get.return_value
         ws.worker_thread = None
+        ws._worker_running = False
 
         # A second send explicitly naming the reserved id: scope check
         # rejects it, so the attachment list is empty.
@@ -885,6 +889,7 @@ class TestReserveThenDispatchRace:
         ws.ui = ui
         ws.session = session
         ws.worker_thread = None
+        ws._worker_running = False
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -700,7 +700,7 @@ class TestSessionManagerWithStateWriter:
         # Long flush_interval → buffered, no sync write yet.
         assert storage.state_updates == []
         # Drain the buffer manually (test stand-in for the periodic flush).
-        writer._flush_once()
+        writer.flush()
         assert (ws.id, "running") in storage.state_updates
 
     def test_set_state_error_flushes_sync(self) -> None:
@@ -730,7 +730,7 @@ class TestSessionManagerWithStateWriter:
         ok = mgr.close(ws.id)
         assert ok is True
         # Force a flush; the buffered 'running' must already be gone.
-        writer._flush_once()
+        writer.flush()
 
         # The final write for ws.id must be 'closed', and 'running' must
         # NOT have landed in storage at all.
@@ -753,7 +753,7 @@ class TestSessionManagerWithStateWriter:
 
         closed = mgr.close_idle(max_age_seconds=0)
         assert ws.id in closed
-        writer._flush_once()
+        writer.flush()
         ws_writes = [s for w, s in storage.state_updates if w == ws.id]
         assert "running" not in ws_writes, f"buffered running flushed after close_idle: {ws_writes}"
         assert ws_writes[-1] == "closed"
@@ -774,7 +774,7 @@ class TestSessionManagerWithStateWriter:
         # A late set_state call (e.g. from a worker still cleaning up).
         # Should NOT buffer 'running' for this ws.
         mgr.set_state(ws_id, WorkstreamState.RUNNING)
-        writer._flush_once()
+        writer.flush()
         ws_writes = [s for w, s in storage.state_updates if w == ws_id]
         assert "running" not in ws_writes, (
             f"set_state after close enqueued through buffer: {ws_writes}"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -662,3 +662,120 @@ def test_create_uses_configured_node_id() -> None:
     mgr = SessionManager(FakeAdapter(), storage=storage, max_active=3, node_id="node-xyz")
     mgr.create(user_id="u1")
     assert storage.register_workstream.call_args.kwargs["node_id"] == "node-xyz"
+
+
+# ---------------------------------------------------------------------------
+# StateWriter integration — bug-3 invariant under write-behind
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerWithStateWriter:
+    """When a buffered StateWriter is wired in, ``set_state`` no longer
+    blocks ``ws._lock`` on a sync DB write — but ``close`` must still
+    leave 'closed' as the durable final state for the row, never
+    a buffered transient that flushes after close."""
+
+    def _make_with_writer(
+        self, *, flush_interval: float = 0.05
+    ) -> tuple[SessionManager, FakeStorage, Any]:
+        from turnstone.core.state_writer import StateWriter
+
+        storage = FakeStorage()
+        writer = StateWriter(storage, flush_interval=flush_interval)
+        mgr = SessionManager(
+            FakeAdapter(),
+            storage=storage,
+            max_active=3,
+            state_writer=writer,
+        )
+        return mgr, storage, writer
+
+    def test_set_state_buffers_through_writer(self) -> None:
+        mgr, storage, writer = self._make_with_writer(flush_interval=60.0)
+        ws = mgr.create(user_id="u1")
+        # Initial register write may have landed; clear and inspect afterwards.
+        storage.state_updates.clear()
+
+        mgr.set_state(ws.id, WorkstreamState.RUNNING)
+        # Long flush_interval → buffered, no sync write yet.
+        assert storage.state_updates == []
+        # Drain the buffer manually (test stand-in for the periodic flush).
+        writer._flush_once()
+        assert (ws.id, "running") in storage.state_updates
+
+    def test_set_state_error_flushes_sync(self) -> None:
+        """Terminal ERROR transitions must be durable on return — error
+        surfacing paths (audit, dashboard) need the row to reflect
+        the failure before any observer sees it."""
+        mgr, storage, _writer = self._make_with_writer(flush_interval=60.0)
+        ws = mgr.create(user_id="u1")
+        storage.state_updates.clear()
+
+        mgr.set_state(ws.id, WorkstreamState.ERROR, error_msg="boom")
+        # No buffer-drain needed — error path bypasses.
+        assert (ws.id, "error") in storage.state_updates
+
+    def test_close_after_buffered_set_state_writes_closed_not_transient(self) -> None:
+        """The bug-3 invariant under write-behind. close() must call
+        state_writer.discard BEFORE its sync 'closed' write, so any
+        buffered 'running' state can't be flushed AFTER 'closed'.
+        """
+        mgr, storage, writer = self._make_with_writer(flush_interval=60.0)
+        ws = mgr.create(user_id="u1")
+        storage.state_updates.clear()
+
+        # Buffer a transient transition.
+        mgr.set_state(ws.id, WorkstreamState.RUNNING)
+        # Now close — must drain/discard the buffer + write 'closed' sync.
+        ok = mgr.close(ws.id)
+        assert ok is True
+        # Force a flush; the buffered 'running' must already be gone.
+        writer._flush_once()
+
+        # The final write for ws.id must be 'closed', and 'running' must
+        # NOT have landed in storage at all.
+        ws_writes = [s for w, s in storage.state_updates if w == ws.id]
+        assert "running" not in ws_writes, f"buffered running flushed after close: {ws_writes}"
+        assert ws_writes[-1] == "closed"
+
+    def test_close_idle_after_buffered_set_state_writes_closed(self) -> None:
+        """Same invariant via close_idle (the idle-cleanup batch path)."""
+        mgr, storage, writer = self._make_with_writer(flush_interval=60.0)
+        ws = mgr.create(user_id="u1")
+        storage.state_updates.clear()
+
+        mgr.set_state(ws.id, WorkstreamState.RUNNING)
+        # Force the workstream into IDLE state before close_idle considers
+        # it (close_idle gates on ws.state, not the buffered state).
+        with mgr._lock:
+            mgr._workstreams[ws.id].state = WorkstreamState.IDLE
+            mgr._workstreams[ws.id].last_active = 0.0  # ancient → stale
+
+        closed = mgr.close_idle(max_age_seconds=0)
+        assert ws.id in closed
+        writer._flush_once()
+        ws_writes = [s for w, s in storage.state_updates if w == ws.id]
+        assert "running" not in ws_writes, f"buffered running flushed after close_idle: {ws_writes}"
+        assert ws_writes[-1] == "closed"
+
+    def test_set_state_after_close_short_circuits(self) -> None:
+        """The existing tombstone (ws._closed) check must still fire
+        before reaching state_writer.record — set_state after close
+        must NOT enqueue 'running' to the buffer (which would then
+        get flushed and resurrect the closed row)."""
+        mgr, storage, writer = self._make_with_writer(flush_interval=60.0)
+        ws = mgr.create(user_id="u1")
+        ws_id = ws.id
+
+        # Close first — sets ws._closed=True synchronously.
+        mgr.close(ws_id)
+        storage.state_updates.clear()
+
+        # A late set_state call (e.g. from a worker still cleaning up).
+        # Should NOT buffer 'running' for this ws.
+        mgr.set_state(ws_id, WorkstreamState.RUNNING)
+        writer._flush_once()
+        ws_writes = [s for w, s in storage.state_updates if w == ws_id]
+        assert "running" not in ws_writes, (
+            f"set_state after close enqueued through buffer: {ws_writes}"
+        )

--- a/tests/test_session_worker.py
+++ b/tests/test_session_worker.py
@@ -1,0 +1,292 @@
+"""Unit tests for ``turnstone.core.session_worker``.
+
+The shared worker dispatch is load-bearing for both the interactive
+``/v1/api/send`` HTTP handler and the coordinator
+``CoordinatorAdapter.send`` path. Tests cover the four invariants the
+module must hold:
+
+* live worker → enqueue, no thread spawn
+* queue.Full → ``False`` (caller surfaces 429)
+* concurrent ``send`` calls produce exactly one worker thread
+  (Stage 1 bug-1 — the racy ``Thread.is_alive()`` gate stays caught)
+* ``_worker_running`` cleared in ``finally`` even on uncaught exception
+
+Callers pass no-arg closures, so this module never touches
+``ws.session`` — keeps the contract narrow and lets watch-style
+dispatchers drive a session that isn't installed on ``ws``.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any
+
+from turnstone.core import session_worker
+from turnstone.core.workstream import Workstream
+
+
+class _SendSession:
+    """ChatSession-shaped stub recording send / queue_message calls."""
+
+    def __init__(
+        self,
+        *,
+        queue_full: bool = False,
+        queue_raises: BaseException | None = None,
+        send_gate: threading.Event | None = None,
+        send_raises: BaseException | None = None,
+    ) -> None:
+        self.send_calls: list[str] = []
+        self.queue_calls: list[str] = []
+        self._queue_full = queue_full
+        self._queue_raises = queue_raises
+        # Lets a test pin a worker inside ``run`` while a second thread
+        # races through ``send`` — proves the lock gate (not
+        # Thread.is_alive) is what serialises them.
+        self._send_gate = send_gate
+        self._send_raises = send_raises
+
+    def send(self, message: str) -> None:
+        if self._send_gate is not None:
+            self._send_gate.wait(timeout=2.0)
+        if self._send_raises is not None:
+            raise self._send_raises
+        self.send_calls.append(message)
+
+    def queue_message(self, message: str) -> None:
+        if self._queue_full:
+            raise queue.Full
+        if self._queue_raises is not None:
+            raise self._queue_raises
+        self.queue_calls.append(message)
+
+
+def _make_ws(session: Any = None) -> Workstream:
+    ws = Workstream(id="ws-aaaaaaaa", name="ws-aaaa")
+    ws.session = session  # type: ignore[assignment]
+    return ws
+
+
+def _send_message(ws: Workstream, session: _SendSession, msg: str) -> bool:
+    """Convenience wrapper mirroring the canonical caller shape."""
+    return session_worker.send(
+        ws,
+        enqueue=lambda: session.queue_message(msg),
+        run=lambda: session.send(msg),
+        thread_name=f"test-worker-{ws.id[:8]}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_worker_runs_target_and_clears_flag() -> None:
+    session = _SendSession()
+    ws = _make_ws(session)
+    ok = _send_message(ws, session, "hello")
+    assert ok is True
+    assert ws.worker_thread is not None
+    ws.worker_thread.join(timeout=2.0)
+    assert session.send_calls == ["hello"]
+    assert ws._worker_running is False
+
+
+def test_reuse_path_when_worker_running_takes_enqueue() -> None:
+    session = _SendSession()
+    ws = _make_ws(session)
+    ws._worker_running = True  # simulate a live worker
+
+    ok = _send_message(ws, session, "queued")
+    assert ok is True
+    # No thread spawned on the reuse path.
+    assert ws.worker_thread is None
+    assert session.send_calls == []
+    assert session.queue_calls == ["queued"]
+    # Flag stays True — the caller didn't claim ownership.
+    assert ws._worker_running is True
+
+
+# ---------------------------------------------------------------------------
+# Queue.Full / enqueue failure
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_queue_full_returns_false_no_spawn() -> None:
+    session = _SendSession(queue_full=True)
+    ws = _make_ws(session)
+    ws._worker_running = True
+
+    ok = _send_message(ws, session, "hello")
+    assert ok is False
+    assert session.send_calls == []
+    assert session.queue_calls == []
+    assert ws.worker_thread is None
+    # _worker_running unchanged — the live worker still owns it.
+    assert ws._worker_running is True
+
+
+def test_enqueue_unexpected_exception_returns_false_logged() -> None:
+    session = _SendSession(queue_raises=RuntimeError("boom"))
+    ws = _make_ws(session)
+    ws._worker_running = True
+
+    ok = _send_message(ws, session, "hello")
+    assert ok is False
+    assert session.send_calls == []
+    assert ws.worker_thread is None
+    assert ws._worker_running is True
+
+
+# ---------------------------------------------------------------------------
+# _worker_running lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_worker_finally_clears_running_flag_on_exception() -> None:
+    session = _SendSession(send_raises=RuntimeError("worker-failed"))
+    ws = _make_ws(session)
+
+    ok = _send_message(ws, session, "hello")
+    assert ok is True
+    assert ws.worker_thread is not None
+    ws.worker_thread.join(timeout=2.0)
+    # Defense-in-depth: even though run() raised, _worker_running is False.
+    assert ws._worker_running is False
+
+
+def test_worker_finally_clears_flag_when_run_swallows() -> None:
+    """Mirrors the call-site contract: run() catches its own exceptions
+    for UI surfacing; we still clear the flag in finally."""
+    session = _SendSession()
+    ws = _make_ws(session)
+
+    captured: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            session.send("hello")
+            raise RuntimeError("after-send")
+        except Exception as exc:
+            captured.append(exc)
+
+    ok = session_worker.send(
+        ws,
+        enqueue=lambda: session.queue_message("hello"),
+        run=run,
+    )
+    assert ok is True
+    assert ws.worker_thread is not None
+    ws.worker_thread.join(timeout=2.0)
+    assert isinstance(captured[0], RuntimeError)
+    assert ws._worker_running is False
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — Stage 1 bug-1 regression
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_send_produces_exactly_one_worker_thread() -> None:
+    """Two simultaneous send() calls must land as exactly one worker
+    spawn and one queued message — not two parallel workers on the
+    same ChatSession.
+
+    The send_gate pins the worker inside session.send while the second
+    caller races through; the only way the second caller can succeed
+    is via the enqueue path. If the lock gate were keyed on
+    Thread.is_alive instead of _worker_running, the loser could spawn
+    a second worker before the winner reaches session.send.
+    """
+    send_gate = threading.Event()
+    session = _SendSession(send_gate=send_gate)
+    ws = _make_ws(session)
+
+    results: list[bool] = []
+    results_lock = threading.Lock()
+    start_barrier = threading.Barrier(2)
+
+    def _caller(msg: str) -> None:
+        start_barrier.wait(timeout=1.0)
+        ok = _send_message(ws, session, msg)
+        with results_lock:
+            results.append(ok)
+
+    t1 = threading.Thread(target=_caller, args=("first",))
+    t2 = threading.Thread(target=_caller, args=("second",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=3.0)
+    t2.join(timeout=3.0)
+    assert not t1.is_alive() and not t2.is_alive()
+
+    # At this point session.send is still pinned on send_gate; the
+    # second caller MUST have taken the enqueue path.
+    assert len(session.queue_calls) == 1, (
+        f"expected exactly one queued message; got {session.queue_calls}"
+    )
+
+    # Release the worker, verify final state.
+    send_gate.set()
+    assert ws.worker_thread is not None
+    ws.worker_thread.join(timeout=3.0)
+
+    assert results == [True, True]
+    assert len(session.send_calls) == 1
+    assert set(session.send_calls + session.queue_calls) == {"first", "second"}
+    assert ws._worker_running is False
+
+
+def test_thread_name_default_uses_ws_prefix() -> None:
+    session = _SendSession()
+    ws = _make_ws(session)
+    ok = session_worker.send(
+        ws,
+        enqueue=lambda: session.queue_message("hello"),
+        run=lambda: session.send("hello"),
+    )
+    assert ok is True
+    assert ws.worker_thread is not None
+    assert ws.worker_thread.name.startswith("session-worker-")
+    ws.worker_thread.join(timeout=2.0)
+
+
+def test_thread_name_explicit_override() -> None:
+    session = _SendSession()
+    ws = _make_ws(session)
+    ok = session_worker.send(
+        ws,
+        enqueue=lambda: session.queue_message("hello"),
+        run=lambda: session.send("hello"),
+        thread_name="custom-name",
+    )
+    assert ok is True
+    assert ws.worker_thread is not None
+    assert ws.worker_thread.name == "custom-name"
+    ws.worker_thread.join(timeout=2.0)
+
+
+def test_does_not_deadlock_when_run_briefly_grabs_ws_lock() -> None:
+    """Sanity check: ``run`` is invoked OUTSIDE ``ws._lock``. A worker
+    body that briefly takes the lock (e.g. to update worker state)
+    must not deadlock with the dispatch path."""
+    session = _SendSession()
+    ws = _make_ws(session)
+
+    def run() -> None:
+        with ws._lock:
+            pass  # would deadlock if dispatch held the lock here
+        session.send("hello")
+
+    ok = session_worker.send(
+        ws,
+        enqueue=lambda: session.queue_message("hello"),
+        run=run,
+    )
+    assert ok is True
+    assert ws.worker_thread is not None
+    ws.worker_thread.join(timeout=2.0)
+    assert session.send_calls == ["hello"]
+    assert ws._worker_running is False

--- a/tests/test_state_writer.py
+++ b/tests/test_state_writer.py
@@ -258,7 +258,7 @@ def test_discard_waits_for_in_flight_flush_to_complete() -> None:
     flush_done = threading.Event()
 
     def _flush_in_bg() -> None:
-        writer._flush_once()
+        writer.flush()
         flush_done.set()
 
     flusher = threading.Thread(target=_flush_in_bg, daemon=True)

--- a/tests/test_state_writer.py
+++ b/tests/test_state_writer.py
@@ -1,0 +1,296 @@
+"""Unit tests for ``turnstone.core.state_writer``.
+
+Tests cover the contract callers depend on:
+
+* Buffered transitions coalesce per ws_id (last state wins).
+* ``flush_now=True`` bypasses the buffer (used for terminal ERROR
+  transitions and any other write that must be durable on return).
+* ``discard`` drops pending and waits for any in-flight flush to
+  complete (the bug-3 invariant — close()'s sync ``closed`` write must
+  not be overtaken by a buffered transient).
+* Bounded buffer evicts oldest under capacity pressure.
+* DB error during flush doesn't poison the loop; subsequent flushes
+  still run.
+* Shutdown drains any pending entries synchronously.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from turnstone.core.state_writer import StateWriter
+
+
+class _FakeStorage:
+    """Records update_workstream_state calls. Optionally raises or pauses."""
+
+    def __init__(self, *, raises: BaseException | None = None) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.raises = raises
+        self._call_lock = threading.Lock()
+        # Optional gate to pin a write inside update_workstream_state
+        # so the test can race ``discard`` against an in-flight flush.
+        self.write_gate: threading.Event | None = None
+        # Set by the writer thread once it enters update_workstream_state.
+        self.write_started = threading.Event()
+
+    def update_workstream_state(self, ws_id: str, state: str) -> None:
+        if self.write_gate is not None:
+            self.write_started.set()
+            self.write_gate.wait(timeout=2.0)
+        with self._call_lock:
+            self.calls.append((ws_id, state))
+        if self.raises is not None:
+            raise self.raises
+
+
+def _drain(writer: StateWriter) -> None:
+    """Trigger a single flush synchronously."""
+    writer._flush_once()
+
+
+# ---------------------------------------------------------------------------
+# Coalescing + flush
+# ---------------------------------------------------------------------------
+
+
+def test_buffered_transitions_coalesce_per_ws_id() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage)
+
+    writer.record("ws-1", "thinking")
+    writer.record("ws-1", "running")
+    writer.record("ws-1", "idle")
+    writer.record("ws-2", "thinking")
+
+    _drain(writer)
+    # Only the latest state per ws_id should land.
+    assert sorted(storage.calls) == sorted([("ws-1", "idle"), ("ws-2", "thinking")])
+
+
+def test_flush_now_bypasses_buffer_and_writes_sync() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage)
+
+    # Pre-buffer something for a different ws_id to prove the sync
+    # path doesn't drain the whole buffer.
+    writer.record("ws-other", "running")
+
+    writer.record("ws-err", "error", flush_now=True)
+    # ws-err landed sync, ws-other still buffered.
+    assert ("ws-err", "error") in storage.calls
+    assert ("ws-other", "running") not in storage.calls
+
+    _drain(writer)
+    assert ("ws-other", "running") in storage.calls
+
+
+def test_flush_now_swallows_storage_error() -> None:
+    storage = _FakeStorage(raises=RuntimeError("db down"))
+    writer = StateWriter(storage)
+    # Should not raise — set_state path can't recover from a storage
+    # write failure mid-transition.
+    writer.record("ws-1", "error", flush_now=True)
+
+
+# ---------------------------------------------------------------------------
+# Bounded buffer
+# ---------------------------------------------------------------------------
+
+
+def test_bounded_buffer_evicts_oldest_on_capacity() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage, max_buffer=3)
+
+    writer.record("ws-1", "running")
+    writer.record("ws-2", "running")
+    writer.record("ws-3", "running")
+    # ws-4 forces eviction of ws-1 (oldest).
+    writer.record("ws-4", "running")
+
+    _drain(writer)
+    landed = {ws_id for ws_id, _ in storage.calls}
+    assert "ws-1" not in landed
+    assert {"ws-2", "ws-3", "ws-4"} <= landed
+
+
+def test_bounded_buffer_update_existing_does_not_evict() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage, max_buffer=2)
+
+    writer.record("ws-1", "running")
+    writer.record("ws-2", "running")
+    # Update existing — must not evict.
+    writer.record("ws-1", "idle")
+
+    _drain(writer)
+    landed = dict(storage.calls)
+    assert landed["ws-1"] == "idle"
+    assert landed["ws-2"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Resilience
+# ---------------------------------------------------------------------------
+
+
+def test_storage_error_does_not_poison_subsequent_flushes() -> None:
+    storage = _FakeStorage(raises=RuntimeError("db blip"))
+    errors: list[Exception] = []
+    writer = StateWriter(storage, on_flush_error=errors.append)
+
+    writer.record("ws-1", "running")
+    _drain(writer)
+    # Error was surfaced via callback.
+    assert len(errors) == 1
+
+    # Storage recovers; next flush succeeds.
+    storage.raises = None
+    writer.record("ws-2", "idle")
+    _drain(writer)
+    assert ("ws-2", "idle") in storage.calls
+
+
+# ---------------------------------------------------------------------------
+# discard / close-race
+# ---------------------------------------------------------------------------
+
+
+def test_discard_drops_pending_buffered_state() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage)
+
+    writer.record("ws-close", "running")
+    writer.discard("ws-close")
+    _drain(writer)
+    assert storage.calls == []
+
+
+def test_discard_waits_for_in_flight_flush_to_complete() -> None:
+    """The bug-3 invariant: ``close()`` calls ``discard`` BEFORE its
+    sync ``state='closed'`` write. If a flusher was mid-write for the
+    same ws_id, the flusher's write must complete BEFORE
+    ``discard`` returns — so ``close()``'s sync write strictly
+    follows the flusher's transient write, leaving 'closed' as the
+    final state. (If discard returned early, close's 'closed' write
+    could be overwritten by the flusher's late 'running' write.)
+    """
+    storage = _FakeStorage()
+    storage.write_gate = threading.Event()
+    writer = StateWriter(storage)
+
+    writer.record("ws-A", "running")
+
+    # Kick off a flush in a background thread; it will block inside
+    # update_workstream_state on storage.write_gate.
+    flush_done = threading.Event()
+
+    def _flush_in_bg() -> None:
+        writer._flush_once()
+        flush_done.set()
+
+    flusher = threading.Thread(target=_flush_in_bg, daemon=True)
+    flusher.start()
+    assert storage.write_started.wait(timeout=1.0)
+    assert flush_done.is_set() is False  # writer is pinned
+
+    # Call discard concurrently — it must NOT return until the flush
+    # completes.
+    discard_done = threading.Event()
+
+    def _discard_in_bg() -> None:
+        writer.discard("ws-A")
+        discard_done.set()
+
+    discarder = threading.Thread(target=_discard_in_bg, daemon=True)
+    discarder.start()
+    # discard should be blocked on flush_lock.
+    time.sleep(0.05)
+    assert discard_done.is_set() is False, "discard returned before flusher released the write"
+
+    # Release the writer; both threads should complete now.
+    storage.write_gate.set()
+    flusher.join(timeout=2.0)
+    discarder.join(timeout=2.0)
+    assert flush_done.is_set()
+    assert discard_done.is_set()
+    # The flusher's write went through.
+    assert ("ws-A", "running") in storage.calls
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_start_starts_flusher_and_buffered_writes_land() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage, flush_interval=0.05)
+    writer.start()
+    try:
+        writer.record("ws-1", "running")
+        # Wait up to 1s for the flusher to drain.
+        for _ in range(20):
+            if storage.calls:
+                break
+            time.sleep(0.05)
+        assert ("ws-1", "running") in storage.calls
+    finally:
+        writer.shutdown(timeout=2.0)
+
+
+def test_shutdown_drains_pending_synchronously() -> None:
+    storage = _FakeStorage()
+    # Long flush interval so no automatic drain happens.
+    writer = StateWriter(storage, flush_interval=60.0)
+    writer.start()
+    try:
+        writer.record("ws-1", "running")
+        writer.record("ws-2", "thinking")
+    finally:
+        writer.shutdown(timeout=2.0)
+    landed = {ws_id for ws_id, _ in storage.calls}
+    assert {"ws-1", "ws-2"} <= landed
+
+
+def test_start_is_idempotent() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage, flush_interval=0.05)
+    writer.start()
+    first_thread = writer._thread
+    writer.start()
+    assert writer._thread is first_thread
+    writer.shutdown(timeout=2.0)
+
+
+def test_shutdown_is_idempotent() -> None:
+    storage = _FakeStorage()
+    writer = StateWriter(storage, flush_interval=0.05)
+    writer.start()
+    writer.shutdown(timeout=2.0)
+    # Second shutdown is a no-op, must not raise.
+    writer.shutdown(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Wake-on-record
+# ---------------------------------------------------------------------------
+
+
+def test_record_wakes_flusher_immediately() -> None:
+    """Single transitions get persisted within ~one round-trip rather
+    than waiting up to flush_interval seconds."""
+    storage = _FakeStorage()
+    # Long interval — only the wake event should drive the flush.
+    writer = StateWriter(storage, flush_interval=10.0)
+    writer.start()
+    try:
+        writer.record("ws-1", "running")
+        for _ in range(30):
+            if storage.calls:
+                break
+            time.sleep(0.02)
+        assert ("ws-1", "running") in storage.calls
+    finally:
+        writer.shutdown(timeout=2.0)

--- a/tests/test_state_writer.py
+++ b/tests/test_state_writer.py
@@ -47,7 +47,7 @@ class _FakeStorage:
 
 def _drain(writer: StateWriter) -> None:
     """Trigger a single flush synchronously."""
-    writer._flush_once()
+    writer.flush()
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +92,77 @@ def test_flush_now_swallows_storage_error() -> None:
     # Should not raise — set_state path can't recover from a storage
     # write failure mid-transition.
     writer.record("ws-1", "error", flush_now=True)
+
+
+def test_flush_now_drops_pending_buffered_state_for_same_ws_id() -> None:
+    """Terminal-bypass invariant: a buffered transient for the same
+    ws_id must NOT flush AFTER the sync ``flush_now`` write and
+    clobber the terminal state. (This was a real correctness gap
+    flagged by /review.)"""
+    storage = _FakeStorage()
+    writer = StateWriter(storage)
+
+    # Buffer a transient transition first.
+    writer.record("ws-A", "running")
+
+    # Sync ERROR write must drop the buffered 'running' AND wait on
+    # the flush_lock so any in-flight flush can't sneak through after.
+    writer.record("ws-A", "error", flush_now=True)
+
+    # Run the flusher; nothing pending for ws-A any more.
+    writer.flush()
+
+    ws_writes = [s for w, s in storage.calls if w == "ws-A"]
+    # The sync 'error' must be in storage, and 'running' must NOT have
+    # been flushed AFTER it.
+    assert "error" in ws_writes, ws_writes
+    assert ws_writes[-1] == "error", f"buffered 'running' clobbered terminal 'error': {ws_writes}"
+    # Stronger: the 'running' should never have landed at all.
+    assert "running" not in ws_writes, ws_writes
+
+
+def test_flush_now_waits_for_in_flight_flush_to_complete() -> None:
+    """Same shape as the discard wait: if a flusher is mid-write on
+    the same ws_id, ``flush_now`` must NOT issue its sync write
+    until the flusher finishes — otherwise the order on the wire is
+    flush_now → flusher's late write → final state is the transient,
+    not the terminal."""
+    storage = _FakeStorage()
+    storage.write_gate = threading.Event()
+    writer = StateWriter(storage)
+
+    writer.record("ws-A", "running")
+
+    flush_done = threading.Event()
+
+    def _flush_in_bg() -> None:
+        writer.flush()
+        flush_done.set()
+
+    flusher = threading.Thread(target=_flush_in_bg, daemon=True)
+    flusher.start()
+    assert storage.write_started.wait(timeout=1.0)
+
+    flush_now_done = threading.Event()
+
+    def _flush_now_in_bg() -> None:
+        writer.record("ws-A", "error", flush_now=True)
+        flush_now_done.set()
+
+    fn_thread = threading.Thread(target=_flush_now_in_bg, daemon=True)
+    fn_thread.start()
+    time.sleep(0.05)
+    assert flush_now_done.is_set() is False, (
+        "flush_now returned before in-flight flush released flush_lock"
+    )
+
+    storage.write_gate.set()
+    flusher.join(timeout=2.0)
+    fn_thread.join(timeout=2.0)
+    assert flush_done.is_set() and flush_now_done.is_set()
+    # The flusher's 'running' lands first, then flush_now's 'error'.
+    ws_writes = [s for w, s in storage.calls if w == "ws-A"]
+    assert ws_writes == ["running", "error"], ws_writes
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +333,32 @@ def test_start_is_idempotent() -> None:
     writer.start()
     assert writer._thread is first_thread
     writer.shutdown(timeout=2.0)
+
+
+def test_discard_times_out_when_flush_hangs() -> None:
+    """If the flusher is wedged on a stuck Postgres connection, discard
+    must NOT block forever — callers hold ws._lock across this call,
+    so an unbounded wait would deadlock all close paths system-wide."""
+    storage = _FakeStorage()
+    storage.write_gate = threading.Event()  # never released
+    writer = StateWriter(storage)
+
+    writer.record("ws-A", "running")
+
+    # Pin the flusher inside update_workstream_state.
+    flusher = threading.Thread(target=writer.flush, daemon=True)
+    flusher.start()
+    assert storage.write_started.wait(timeout=1.0)
+
+    # discard must return within ~timeout, NOT hang forever.
+    start = time.monotonic()
+    writer.discard("ws-A", flush_lock_timeout=0.1)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0, f"discard hung: {elapsed:.2f}s"
+
+    # Cleanup.
+    storage.write_gate.set()
+    flusher.join(timeout=2.0)
 
 
 def test_shutdown_is_idempotent() -> None:

--- a/tests/test_watch_dispatch.py
+++ b/tests/test_watch_dispatch.py
@@ -128,20 +128,15 @@ def test_busy_workstream_enqueues_message():
     ws = Workstream()
     ui = _RecordingUI()
 
-    # Simulate a live worker thread.
-    blocker = threading.Event()
-    ws.worker_thread = threading.Thread(target=blocker.wait, args=(5,), daemon=True)
-    ws.worker_thread.start()
+    # Simulate a live worker — session_worker.send gates on
+    # ``_worker_running``, not ``Thread.is_alive``.
+    ws._worker_running = True
 
-    try:
-        dispatch = _make_watch_dispatch(ws, session, ui)
-        dispatch("queued msg")
+    dispatch = _make_watch_dispatch(ws, session, ui)
+    dispatch("queued msg")
 
-        item = session._watch_pending.get_nowait()
-        assert item == {"message": "queued msg"}
-    finally:
-        blocker.set()
-        ws.worker_thread.join(2)
+    item = session._watch_pending.get_nowait()
+    assert item == {"message": "queued msg"}
 
 
 def test_busy_workstream_drops_on_full_queue():
@@ -154,19 +149,13 @@ def test_busy_workstream_drops_on_full_queue():
     ws = Workstream()
     ui = _RecordingUI()
 
-    blocker = threading.Event()
-    ws.worker_thread = threading.Thread(target=blocker.wait, args=(5,), daemon=True)
-    ws.worker_thread.start()
+    ws._worker_running = True  # simulate a live worker
 
-    try:
-        dispatch = _make_watch_dispatch(ws, session, ui)
-        # Should not block or raise — just log a warning and drop.
-        dispatch("overflow msg")
+    dispatch = _make_watch_dispatch(ws, session, ui)
+    # Should not block or raise — just log a warning and drop.
+    dispatch("overflow msg")
 
-        assert session._watch_pending.full()
-    finally:
-        blocker.set()
-        ws.worker_thread.join(2)
+    assert session._watch_pending.full()
 
 
 # ── Lock guard ───────────────────────────────────────────────────────────────

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -19,6 +19,7 @@ import queue
 import threading
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core import session_worker
 from turnstone.core.adapters._ui_cleanup import cleanup_session_ui
 from turnstone.core.log import get_logger
 from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
@@ -218,7 +219,7 @@ class CoordinatorAdapter:
         )
 
     # ------------------------------------------------------------------
-    # Worker dispatch — send + _spawn_worker
+    # Worker dispatch — delegates to turnstone.core.session_worker
     # ------------------------------------------------------------------
 
     def send(self, ws_id: str, message: str) -> bool:
@@ -228,6 +229,12 @@ class CoordinatorAdapter:
         if the worker's pending-message queue is full (caller should
         surface 429 / backpressure). Priority is parsed from the message
         prefix (``/high``, ``/urgent``, etc.) by :meth:`ChatSession.queue_message`.
+
+        Worker spawn / reuse mechanics live in
+        :func:`turnstone.core.session_worker.send`; the closures below
+        carry coord-specific error surfacing (UI ``on_error`` +
+        ``on_state_change=error``) so the dashboard reflects the
+        failure instead of a bare ``error`` badge.
         """
         mgr = self._manager
         if mgr is None:
@@ -237,74 +244,28 @@ class CoordinatorAdapter:
         ws = mgr.get(ws_id)
         if ws is None or ws.session is None:
             return False
-        return self._spawn_worker(ws, message)
 
-    def _spawn_worker(self, ws: Workstream, message: str) -> bool:
-        """Start (or reuse) a worker thread that drives session.send.
-
-        Returns True on successful enqueue (existing worker) or thread
-        spawn (no live worker). Returns False when an existing worker's
-        queue is full — must NOT spawn a second concurrent worker on the
-        same ChatSession (mutates messages, queued_messages, streaming
-        state, LLM client cursors, approvals).
-
-        Queue-vs-spawn decided under ``ws._lock`` using the
-        ``_worker_running`` flag (set by ``_run`` before calling send,
-        cleared in the finally block). Using ``Thread.is_alive()`` as
-        the gate was racy: the worker could exit between the
-        ``is_alive()`` check and a ``queue_message`` call, stranding
-        the message with no consumer. The flag transitions atomically
-        inside the same lock ``_spawn_worker`` uses.
-        """
+        ws_ref = ws
         session = ws.session
-        if session is None:
-            return False
-        with ws._lock:
-            if ws._worker_running and hasattr(session, "queue_message"):
-                try:
-                    session.queue_message(message)
-                    return True
-                except queue.Full:
-                    # Queue is at capacity AND a worker is still
-                    # running. Spawning a second thread on the same
-                    # ChatSession would corrupt history / cursors /
-                    # approvals — return False so the caller surfaces
-                    # backpressure (HTTP 429).
-                    log.warning(
-                        "coord_adapter.queue_full ws=%s — message dropped (worker still busy)",
-                        ws.id[:8],
-                    )
-                    return False
-                except Exception:
-                    log.warning(
-                        "coord_adapter.queue_message_failed ws=%s",
-                        ws.id[:8],
-                        exc_info=True,
-                    )
-                    return False
-            # Mark before release so any concurrent _spawn_worker
-            # acquiring ws._lock next observes the running state and
-            # enqueues instead of spawning a second worker.
-            ws._worker_running = True
 
         def _run() -> None:
             try:
                 session.send(message)
             except Exception as exc:
-                log.exception("coord_adapter.worker_failed ws=%s", ws.id[:8])
+                log.exception("coord_adapter.worker_failed ws=%s", ws_ref.id[:8])
                 # Surface the failure to the coordinator's SSE stream
                 # so the operator sees what broke instead of a bare
                 # "error" badge — most common cause is a model-alias
                 # misconfig (wrong provider for the model) which the
                 # raw traceback narrows down quickly.
-                ui = ws.ui
+                ui = ws_ref.ui
                 if ui is not None and hasattr(ui, "on_error"):
                     try:
                         ui.on_error(f"{type(exc).__name__}: {exc}")
                     except Exception:
                         log.debug(
                             "coord_adapter.on_error_dispatch_failed ws=%s",
-                            ws.id[:8],
+                            ws_ref.id[:8],
                             exc_info=True,
                         )
                 # Also mark the workstream state=error so the cluster
@@ -315,21 +276,19 @@ class CoordinatorAdapter:
                     except Exception:
                         log.debug(
                             "coord_adapter.error_state_update_failed ws=%s",
-                            ws.id[:8],
+                            ws_ref.id[:8],
                             exc_info=True,
                         )
-            finally:
-                with ws._lock:
-                    ws._worker_running = False
 
-        t = threading.Thread(
-            target=_run,
-            name=f"coord-worker-{ws.id[:8]}",
-            daemon=True,
+        def _enqueue() -> None:
+            session.queue_message(message)
+
+        return session_worker.send(
+            ws,
+            enqueue=_enqueue,
+            run=_run,
+            thread_name=f"coord-worker-{ws.id[:8]}",
         )
-        ws.worker_thread = t
-        t.start()
-        return True
 
     # ------------------------------------------------------------------
     # Children registry

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4028,7 +4028,9 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     coord_state_writer_shutdown = getattr(app.state, "coord_state_writer", None)
     if coord_state_writer_shutdown is not None:
         try:
-            coord_state_writer_shutdown.shutdown()
+            # shutdown() joins a daemon thread + runs sync DB writes;
+            # offload to keep the console lifespan event loop moving.
+            await asyncio.to_thread(coord_state_writer_shutdown.shutdown)
         except Exception:
             log.debug("console.coord_state_writer_shutdown_failed", exc_info=True)
     # Drop the shared ConsoleCoordinatorUI refs on teardown so tests

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3966,16 +3966,22 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     ui_factory=_ui_factory,
                     session_factory=coord_factory,
                 )
+                from turnstone.core.state_writer import StateWriter
+
+                coord_state_writer = StateWriter(storage)
+                coord_state_writer.start()
                 coord_mgr = SessionManager(
                     coord_adapter,
                     storage=storage,
                     max_active=int(config_store.get("coordinator.max_active")),
                     node_id=ClusterCollector.CONSOLE_PSEUDO_NODE_ID,
+                    state_writer=coord_state_writer,
                 )
                 # Late-bind the manager onto the adapter so
                 # ``_rebuild_children_registry`` / ``send`` /
                 # fan-out dispatch can call ``mgr.get(ws_id)``.
                 coord_adapter.attach(coord_mgr)
+                app.state.coord_state_writer = coord_state_writer
                 # Shared refs so ConsoleCoordinatorUI.on_state_change
                 # flows state transitions through the unified manager
                 # and on_rename fans out to the cluster dashboard.
@@ -4019,6 +4025,12 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
             coord_adapter_shutdown.shutdown()
         except Exception:
             log.debug("console.coord_adapter_shutdown_failed", exc_info=True)
+    coord_state_writer_shutdown = getattr(app.state, "coord_state_writer", None)
+    if coord_state_writer_shutdown is not None:
+        try:
+            coord_state_writer_shutdown.shutdown()
+        except Exception:
+            log.debug("console.coord_state_writer_shutdown_failed", exc_info=True)
     # Drop the shared ConsoleCoordinatorUI refs on teardown so tests
     # that spin up multiple lifespan instances don't carry stale
     # manager/collector references across them.

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from turnstone.core.session import ChatSession, SessionUI
+    from turnstone.core.state_writer import StateWriter
     from turnstone.core.storage._protocol import StorageBackend
 
 log = get_logger(__name__)
@@ -112,12 +113,18 @@ class SessionManager:
         storage: StorageBackend,
         max_active: int,
         node_id: str | None = None,
+        state_writer: StateWriter | None = None,
     ) -> None:
         if max_active < 1:
             raise ValueError(f"max_active must be >= 1, got {max_active}")
         self._adapter = adapter
         self._storage = storage
         self._max_active = max_active
+        # Optional buffered state-writer. Pass one in for production
+        # paths so non-terminal ``set_state`` writes don't hold
+        # ``ws._lock`` across a sync DB UPDATE. Tests can leave it
+        # None and get the legacy direct-write behaviour.
+        self._state_writer = state_writer
         self._node_id = node_id
         self._workstreams: dict[str, Workstream] = {}
         self._order: list[str] = []
@@ -413,9 +420,14 @@ class SessionManager:
         # via ws._lock. Setting ``_closed`` inside the lock makes the
         # close visible to set_state before we release — any set_state
         # that acquires ws._lock after us sees _closed=True and skips
-        # its storage write.
+        # its storage write. ``state_writer.discard`` (when present)
+        # drops any pending buffered transient AND waits for any
+        # in-flight flush so our sync ``closed`` write isn't
+        # overtaken by a late buffered write (bug-3 invariant).
         with ws._lock:
             ws._closed = True
+            if self._state_writer is not None:
+                self._state_writer.discard(ws_id)
             try:
                 self._storage.update_workstream_state(ws_id, "closed")
             except Exception:
@@ -452,10 +464,22 @@ class SessionManager:
             ws.state = state
             ws.last_active = time.monotonic()
             ws.error_message = error_msg
-            try:
-                self._storage.update_workstream_state(ws_id, state.value)
-            except Exception:
-                log.debug("session_mgr.state_update_failed ws=%s", ws_id[:8], exc_info=True)
+            # Terminal ERROR transitions flush sync — error-surfacing
+            # paths (dashboard, audit) must observe the row durably
+            # before any caller sees the state-change event. Non-
+            # terminal transitions buffer through state_writer so we
+            # don't hold ws._lock across a Postgres round-trip.
+            if self._state_writer is not None:
+                self._state_writer.record(
+                    ws_id,
+                    state.value,
+                    flush_now=(state is WorkstreamState.ERROR),
+                )
+            else:
+                try:
+                    self._storage.update_workstream_state(ws_id, state.value)
+                except Exception:
+                    log.debug("session_mgr.state_update_failed ws=%s", ws_id[:8], exc_info=True)
         self._adapter.emit_state(ws, state)
         if self._on_state_change is not None:
             with contextlib.suppress(Exception):
@@ -518,9 +542,13 @@ class SessionManager:
             self._adapter.cleanup_ui(ws)
             # Mirrors ``close``: set ``ws._closed`` inside ws._lock
             # before the storage write so any concurrent set_state sees
-            # the tombstone and skips its own write.
+            # the tombstone and skips its own write. ``state_writer.discard``
+            # drops any pending buffered transient + waits for any
+            # in-flight flush (bug-3 invariant).
             with ws._lock:
                 ws._closed = True
+                if self._state_writer is not None:
+                    self._state_writer.discard(ws.id)
                 try:
                     self._storage.update_workstream_state(ws.id, "closed")
                 except Exception:

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -422,8 +422,9 @@ class SessionManager:
         # that acquires ws._lock after us sees _closed=True and skips
         # its storage write. ``state_writer.discard`` (when present)
         # drops any pending buffered transient AND waits for any
-        # in-flight flush so our sync ``closed`` write isn't
-        # overtaken by a late buffered write (bug-3 invariant).
+        # in-flight flush, so a late-flushing 'running' can't land in
+        # storage AFTER our sync 'closed' write and resurrect the
+        # closed row.
         with ws._lock:
             ws._closed = True
             if self._state_writer is not None:
@@ -544,7 +545,8 @@ class SessionManager:
             # before the storage write so any concurrent set_state sees
             # the tombstone and skips its own write. ``state_writer.discard``
             # drops any pending buffered transient + waits for any
-            # in-flight flush (bug-3 invariant).
+            # in-flight flush so the sync 'closed' write is the final
+            # one for this ws_id.
             with ws._lock:
                 ws._closed = True
                 if self._state_writer is not None:

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -72,20 +72,20 @@ def send(
     def _runner() -> None:
         try:
             run()
-        except BaseException:
+        except Exception:
             # Per-kind callers wrap their own try/except inside ``run``
             # for typed surfacing (UI on_error, GenerationCancelled,
             # reservation cleanup). This catch is defense-in-depth —
             # ensures ``_worker_running`` is always cleared even if a
-            # caller forgets to handle a new exception class.
+            # caller forgets to handle a new exception class. Daemon
+            # threads don't receive SystemExit/KeyboardInterrupt, so
+            # ``Exception`` is sufficient — no need to widen to
+            # ``BaseException`` (and accidentally catch generator-
+            # close style signals if the runtime ever delivers them).
             log.exception("session_worker.uncaught ws=%s", ws.id[:8])
         finally:
             with ws._lock:
                 ws._worker_running = False
-
-    # Construct the Thread before acquiring the lock — Thread() is
-    # cheap and pure-Python, and we want the lock window narrow.
-    t = threading.Thread(target=_runner, name=name, daemon=True)
 
     with ws._lock:
         if ws._worker_running:
@@ -116,7 +116,14 @@ def send(
         # ``ws.worker_thread`` still points at the previous (already-
         # exited) thread, breaking every ``ws.worker_thread is me``
         # identity check downstream.
+        #
+        # Thread() construction stays inside the lock so we don't
+        # allocate one on the enqueue path (a hot path for busy
+        # workstreams). The constructor is microsecond-cheap, so the
+        # lock-window cost is dominated by the spawn branch's identity
+        # write either way.
         ws._worker_running = True
+        t = threading.Thread(target=_runner, name=name, daemon=True)
         ws.worker_thread = t
     # ``t.start()`` may run user code (worker body) before returning;
     # keep it outside the lock to avoid pinning ``ws._lock`` for the

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -1,0 +1,116 @@
+"""Shared worker-thread dispatch for SessionManager workstreams.
+
+Both the interactive ``/v1/api/send`` HTTP handler and the coordinator
+``CoordinatorAdapter.send`` need the same atomic check-and-(spawn-or-queue)
+on a workstream: if a worker thread is already driving
+:meth:`ChatSession.send`, append the new message to its pending queue;
+otherwise spawn a fresh daemon thread. The decision is taken under
+``ws._lock`` keyed on ``ws._worker_running`` so two concurrent senders
+can never spawn parallel workers on the same ChatSession (mutating
+history, queued messages, streaming state and approvals).
+
+The bug history this guards is documented in
+``1.5.0-session-manager-stage-1.md`` (bug-1, bug-2): using
+``Thread.is_alive()`` as the gate was racy — the worker could exit
+between the check and a ``queue_message`` call, stranding the message
+with no consumer. The flag transitions atomically inside the same lock
+this module holds, so both coord and interactive callers inherit the
+fix.
+
+This module owns ONLY the dispatch decision and the
+``_worker_running`` lifecycle. Per-kind concerns — session resolution,
+attachments reservation, error surfacing, UI callbacks,
+``GenerationCancelled`` handling — live in the caller's
+``enqueue`` / ``run`` no-arg closures.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import TYPE_CHECKING
+
+from turnstone.core.log import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from turnstone.core.workstream import Workstream
+
+log = get_logger(__name__)
+
+
+def send(
+    ws: Workstream,
+    *,
+    enqueue: Callable[[], None],
+    run: Callable[[], None],
+    thread_name: str | None = None,
+) -> bool:
+    """Dispatch work onto a workstream's worker thread.
+
+    Reuses a live worker via ``enqueue()`` when one is running; spawns
+    a fresh daemon thread running ``run()`` otherwise. The
+    check-and-spawn is atomic under ``ws._lock`` keyed on
+    ``ws._worker_running`` (set before lock release, cleared in the
+    spawned thread's ``finally`` block).
+
+    Both callbacks are no-arg closures — callers close over the
+    ``ChatSession`` they want to drive, so the worker can't be racing a
+    concurrent ``ws.session`` swap.
+
+    Returns:
+        ``True`` on successful enqueue (existing worker accepted) or
+        thread spawn (no live worker).
+        ``False`` when ``enqueue`` raises ``queue.Full`` (queue at
+        capacity — caller surfaces 429) or any other exception
+        (logged). Falling through to spawn a second worker on a full
+        queue would corrupt ChatSession state.
+    """
+    with ws._lock:
+        if ws._worker_running:
+            try:
+                enqueue()
+                return True
+            except queue.Full:
+                # Existing worker still alive but queue at capacity —
+                # spawning a second thread on the same ChatSession
+                # would corrupt history / cursors / approvals. Surface
+                # backpressure to the caller.
+                log.warning(
+                    "session_worker.queue_full ws=%s — message dropped (worker still busy)",
+                    ws.id[:8],
+                )
+                return False
+            except Exception:
+                log.warning(
+                    "session_worker.queue_failed ws=%s",
+                    ws.id[:8],
+                    exc_info=True,
+                )
+                return False
+        # Mark before releasing the lock so a concurrent caller observes
+        # the running state and takes the enqueue path instead of
+        # spawning a parallel worker.
+        ws._worker_running = True
+
+    name = thread_name or f"session-worker-{ws.id[:8]}"
+
+    def _runner() -> None:
+        try:
+            run()
+        except BaseException:
+            # Per-kind callers wrap their own try/except inside ``run``
+            # for typed surfacing (UI on_error, GenerationCancelled,
+            # reservation cleanup). This catch is defense-in-depth —
+            # ensures ``_worker_running`` is always cleared even if a
+            # caller forgets to handle a new exception class.
+            log.exception("session_worker.uncaught ws=%s", ws.id[:8])
+        finally:
+            with ws._lock:
+                ws._worker_running = False
+
+    t = threading.Thread(target=_runner, name=name, daemon=True)
+    ws.worker_thread = t
+    t.start()
+    return True

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -67,6 +67,26 @@ def send(
         (logged). Falling through to spawn a second worker on a full
         queue would corrupt ChatSession state.
     """
+    name = thread_name or f"session-worker-{ws.id[:8]}"
+
+    def _runner() -> None:
+        try:
+            run()
+        except BaseException:
+            # Per-kind callers wrap their own try/except inside ``run``
+            # for typed surfacing (UI on_error, GenerationCancelled,
+            # reservation cleanup). This catch is defense-in-depth —
+            # ensures ``_worker_running`` is always cleared even if a
+            # caller forgets to handle a new exception class.
+            log.exception("session_worker.uncaught ws=%s", ws.id[:8])
+        finally:
+            with ws._lock:
+                ws._worker_running = False
+
+    # Construct the Thread before acquiring the lock — Thread() is
+    # cheap and pure-Python, and we want the lock window narrow.
+    t = threading.Thread(target=_runner, name=name, daemon=True)
+
     with ws._lock:
         if ws._worker_running:
             try:
@@ -89,28 +109,17 @@ def send(
                     exc_info=True,
                 )
                 return False
-        # Mark before releasing the lock so a concurrent caller observes
-        # the running state and takes the enqueue path instead of
-        # spawning a parallel worker.
+        # Set ``_worker_running`` AND assign ``ws.worker_thread`` under
+        # the same lock acquisition — readers gating on either flag see
+        # a coherent (worker_thread, _worker_running) pair. Without
+        # this, a reader could observe ``_worker_running=True`` while
+        # ``ws.worker_thread`` still points at the previous (already-
+        # exited) thread, breaking every ``ws.worker_thread is me``
+        # identity check downstream.
         ws._worker_running = True
-
-    name = thread_name or f"session-worker-{ws.id[:8]}"
-
-    def _runner() -> None:
-        try:
-            run()
-        except BaseException:
-            # Per-kind callers wrap their own try/except inside ``run``
-            # for typed surfacing (UI on_error, GenerationCancelled,
-            # reservation cleanup). This catch is defense-in-depth —
-            # ensures ``_worker_running`` is always cleared even if a
-            # caller forgets to handle a new exception class.
-            log.exception("session_worker.uncaught ws=%s", ws.id[:8])
-        finally:
-            with ws._lock:
-                ws._worker_running = False
-
-    t = threading.Thread(target=_runner, name=name, daemon=True)
-    ws.worker_thread = t
+        ws.worker_thread = t
+    # ``t.start()`` may run user code (worker body) before returning;
+    # keep it outside the lock to avoid pinning ``ws._lock`` for the
+    # full thread-creation cost.
     t.start()
     return True

--- a/turnstone/core/state_writer.py
+++ b/turnstone/core/state_writer.py
@@ -1,0 +1,205 @@
+"""Buffered workstream-state persistence.
+
+``SessionManager.set_state`` previously held ``ws._lock`` across a
+synchronous Postgres ``UPDATE`` for every ``thinking → running → idle
+→ attention`` transition — multiple writes per turn, with
+per-workstream observers serialising behind each round-trip. This
+module replaces that with a write-behind buffer:
+
+* Non-terminal transitions buffer in a per-ws_id dict (last state wins
+  per ws_id — coalesced).
+* A daemon flusher drains the buffer to ``storage.update_workstream_state``
+  every ``flush_interval`` seconds (default 1.0s; loop wakes early on
+  ``record``).
+* Terminal transitions (``ERROR``) and ``close()`` bypass the buffer
+  via ``record(..., flush_now=True)`` / ``discard(ws_id)`` — those
+  paths must be durable before observers see the transition.
+* Bounded buffer (``max_buffer``): when full, the oldest ws_id's
+  pending state is evicted on insertion of a new ws_id. All entries
+  are non-terminal (terminals bypass), so eviction is safe.
+
+The bug-3 invariant the close path must keep holding (a closed ws
+row can't be resurrected by a buffered transient state writing
+"running" after close's sync "closed" write):
+
+1. ``close()`` acquires ``ws._lock`` and sets ``ws._closed = True``.
+2. ``close()`` calls :meth:`StateWriter.discard` to drop any pending
+   buffered transition for the ws_id AND wait for any in-progress
+   flush to complete (so a flusher mid-write can't sneak through
+   AFTER ``close()``'s sync write).
+3. ``close()`` writes ``state='closed'`` synchronously to storage.
+4. Any later ``set_state`` for this ws_id sees ``ws._closed=True``
+   under ``ws._lock`` and short-circuits — never reaches
+   :meth:`StateWriter.record`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from typing import TYPE_CHECKING, Any
+
+from turnstone.core.log import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+log = get_logger(__name__)
+
+
+class StateWriter:
+    """Buffered ``update_workstream_state`` writer.
+
+    Construct once per process; pass to :class:`SessionManager`.
+    Lifecycle managed by the host's ASGI lifespan: call
+    :meth:`start` on startup, :meth:`shutdown` on teardown.
+    """
+
+    def __init__(
+        self,
+        storage: Any,
+        *,
+        flush_interval: float = 1.0,
+        max_buffer: int = 10_000,
+        on_flush_error: Callable[[Exception], None] | None = None,
+    ) -> None:
+        self._storage = storage
+        self._flush_interval = flush_interval
+        self._max_buffer = max_buffer
+        self._on_flush_error = on_flush_error
+        # ws_id → state.value. Python dict preserves insertion order, so
+        # iterating the buffer yields oldest-first for FIFO eviction.
+        self._buffer: dict[str, str] = {}
+        self._lock = threading.Lock()
+        # Held by the flusher while it's iterating + writing the
+        # snapshotted batch. ``discard`` waits on it so close() can
+        # ensure no stray write follows its sync ``state='closed'``.
+        self._flush_lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record(self, ws_id: str, state: str, *, flush_now: bool = False) -> None:
+        """Buffer (or sync-write) a state transition.
+
+        ``flush_now=True`` writes synchronously and bypasses the
+        buffer — used for ERROR transitions where durability matters
+        before any observer sees the state. Errors are logged and
+        swallowed to match the prior ``set_state`` behaviour (which
+        wrapped its DB call in a try/except for the same reason).
+        """
+        if flush_now:
+            try:
+                self._storage.update_workstream_state(ws_id, state)
+            except Exception as exc:
+                log.debug(
+                    "state_writer.flush_now_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
+                self._notify_error(exc)
+            return
+        with self._lock:
+            # Bounded buffer. If a new ws_id arrives at capacity, drop
+            # the oldest pending entry. Updates to an existing key
+            # don't grow the buffer.
+            if ws_id not in self._buffer and len(self._buffer) >= self._max_buffer:
+                evict_id = next(iter(self._buffer))
+                self._buffer.pop(evict_id)
+                log.warning(
+                    "state_writer.buffer_full evicted=%s — DB unreachable?",
+                    evict_id[:8],
+                )
+            self._buffer[ws_id] = state
+        # Wake the flusher so a single transition gets persisted within
+        # ~one round-trip rather than waiting up to flush_interval.
+        # Coalescing across bursts still happens because the flusher
+        # snapshots the buffer atomically.
+        self._wake.set()
+
+    def discard(self, ws_id: str) -> None:
+        """Drop any pending buffered state for ``ws_id`` and wait for any
+        in-progress flush to complete.
+
+        Called by ``SessionManager.close`` (and ``close_idle``) under
+        ``ws._lock`` after ``ws._closed=True`` and BEFORE the sync
+        ``state='closed'`` write. After this returns, no buffered or
+        in-flight write for ``ws_id`` can land in storage AFTER the
+        caller's sync ``closed`` write.
+        """
+        with self._lock:
+            self._buffer.pop(ws_id, None)
+        # If a flusher is currently writing, wait for it to finish.
+        # The flusher snapshots the buffer under self._lock then writes
+        # under self._flush_lock, so any write of ``ws_id`` already
+        # in-flight will complete before this returns.
+        with self._flush_lock:
+            pass
+
+    def start(self) -> None:
+        """Start the background flusher thread. Idempotent."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._wake.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name="state-writer-flush",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def shutdown(self, *, timeout: float = 5.0) -> None:
+        """Stop the flusher and drain any pending writes synchronously.
+
+        Idempotent — safe to call multiple times. Best-effort drain
+        even if the flusher thread doesn't exit cleanly.
+        """
+        self._stop.set()
+        self._wake.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        # Final synchronous drain. The flusher may have exited mid-loop
+        # without picking up the last record(s); make sure they land.
+        self._flush_once()
+
+    # ------------------------------------------------------------------
+    # Flusher internals
+    # ------------------------------------------------------------------
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait(timeout=self._flush_interval)
+            self._wake.clear()
+            if self._stop.is_set():
+                break
+            self._flush_once()
+
+    def _flush_once(self) -> None:
+        with self._lock:
+            if not self._buffer:
+                return
+            pending = self._buffer
+            self._buffer = {}
+        with self._flush_lock:
+            for ws_id, state in pending.items():
+                try:
+                    self._storage.update_workstream_state(ws_id, state)
+                except Exception as exc:
+                    log.debug(
+                        "state_writer.flush_failed ws=%s",
+                        ws_id[:8],
+                        exc_info=True,
+                    )
+                    self._notify_error(exc)
+
+    def _notify_error(self, exc: Exception) -> None:
+        if self._on_flush_error is None:
+            return
+        with contextlib.suppress(Exception):
+            self._on_flush_error(exc)

--- a/turnstone/core/state_writer.py
+++ b/turnstone/core/state_writer.py
@@ -18,9 +18,9 @@ module replaces that with a write-behind buffer:
   pending state is evicted on insertion of a new ws_id. All entries
   are non-terminal (terminals bypass), so eviction is safe.
 
-The bug-3 invariant the close path must keep holding (a closed ws
-row can't be resurrected by a buffered transient state writing
-"running" after close's sync "closed" write):
+**Close-vs-buffered-transient invariant**. A closed ws row must never
+be resurrected by a late-flushing buffered transient writing 'running'
+AFTER ``close()``'s sync 'closed' write. The flow that preserves it:
 
 1. ``close()`` acquires ``ws._lock`` and sets ``ws._closed = True``.
 2. ``close()`` calls :meth:`StateWriter.discard` to drop any pending
@@ -31,6 +31,12 @@ row can't be resurrected by a buffered transient state writing
 4. Any later ``set_state`` for this ws_id sees ``ws._closed=True``
    under ``ws._lock`` and short-circuits — never reaches
    :meth:`StateWriter.record`.
+
+**Terminal-bypass invariant**. The same hazard exists for the
+``flush_now=True`` path: an earlier buffered 'running' for the same
+ws_id could flush AFTER the sync 'error' write and clobber it. Same
+fix — ``record(flush_now=True)`` discards any pending entry and waits
+on the flush_lock before the sync write.
 """
 
 from __future__ import annotations
@@ -91,10 +97,21 @@ class StateWriter:
         before any observer sees the state. Errors are logged and
         swallowed to match the prior ``set_state`` behaviour (which
         wrapped its DB call in a try/except for the same reason).
+
+        The terminal-bypass invariant requires the same
+        drop-pending + wait-for-in-flight-flush dance that
+        :meth:`discard` performs: an earlier buffered 'running' for
+        the same ws_id must not flush AFTER the sync write and
+        clobber the terminal state. We pop under ``self._lock`` and
+        wait on ``self._flush_lock`` before the sync UPDATE so the
+        terminal state is the final write for this ws_id.
         """
         if flush_now:
+            with self._lock:
+                self._buffer.pop(ws_id, None)
             try:
-                self._storage.update_workstream_state(ws_id, state)
+                with self._flush_lock:
+                    self._storage.update_workstream_state(ws_id, state)
             except Exception as exc:
                 log.debug(
                     "state_writer.flush_now_failed ws=%s",
@@ -121,7 +138,7 @@ class StateWriter:
         # snapshots the buffer atomically.
         self._wake.set()
 
-    def discard(self, ws_id: str) -> None:
+    def discard(self, ws_id: str, *, flush_lock_timeout: float = 5.0) -> None:
         """Drop any pending buffered state for ``ws_id`` and wait for any
         in-progress flush to complete.
 
@@ -130,6 +147,16 @@ class StateWriter:
         ``state='closed'`` write. After this returns, no buffered or
         in-flight write for ``ws_id`` can land in storage AFTER the
         caller's sync ``closed`` write.
+
+        ``flush_lock_timeout`` bounds the wait on the in-flight flush.
+        Without a timeout a stuck Postgres connection (network
+        partition, table-lock contention) would block the discard
+        forever — and because callers hold ``ws._lock`` across this
+        call, that means a system-wide hang on every close path.
+        Defaults to 5s. On timeout we proceed and log; the worst
+        outcome is "buffered transient flushes shortly after the
+        sync 'closed' write" — eventual consistency degrades but the
+        process keeps moving.
         """
         with self._lock:
             self._buffer.pop(ws_id, None)
@@ -137,8 +164,16 @@ class StateWriter:
         # The flusher snapshots the buffer under self._lock then writes
         # under self._flush_lock, so any write of ``ws_id`` already
         # in-flight will complete before this returns.
-        with self._flush_lock:
+        if not self._flush_lock.acquire(timeout=flush_lock_timeout):
+            log.warning(
+                "state_writer.discard_flush_lock_timeout ws=%s — proceeding without wait",
+                ws_id[:8],
+            )
+            return
+        try:
             pass
+        finally:
+            self._flush_lock.release()
 
     def start(self) -> None:
         """Start the background flusher thread. Idempotent."""
@@ -166,6 +201,16 @@ class StateWriter:
             self._thread = None
         # Final synchronous drain. The flusher may have exited mid-loop
         # without picking up the last record(s); make sure they land.
+        self.flush()
+
+    def flush(self) -> None:
+        """Synchronously drain one batch of buffered state writes.
+
+        Public wrapper over the internal flush step so callers and
+        tests don't reach into ``_flush_once``. The flusher loop and
+        :meth:`shutdown` use it; tests use it as a deterministic
+        drain instead of waiting on ``flush_interval``.
+        """
         self._flush_once()
 
     # ------------------------------------------------------------------

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -105,11 +105,13 @@ class Workstream:
     # racing ``set_state`` can detect the close before it overwrites
     # the persisted ``state='closed'`` row. Guarded by ``_lock``.
     _closed: bool = field(default=False, repr=False)
-    # True while a coordinator worker thread is actively running
-    # ``ChatSession.send``. Toggled under ``_lock`` by the adapter's
-    # ``_spawn_worker`` so concurrent ``send()`` calls can safely
-    # decide queue-vs-spawn without racing ``Thread.is_alive()``.
-    # Interactive workstreams ignore this field.
+    # True while a worker thread is actively running ``ChatSession.send``.
+    # Toggled under ``_lock`` by ``turnstone.core.session_worker.send``
+    # (and the few sites that spawn workers directly — see
+    # ``server.py``'s init-message + retry-after-rewind paths) so
+    # concurrent dispatches can safely decide queue-vs-spawn without
+    # racing ``Thread.is_alive()``. Used by both interactive and
+    # coordinator paths since Stage 2 P1.
     _worker_running: bool = field(default=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -42,6 +42,7 @@ from starlette.staticfiles import StaticFiles
 from turnstone import __version__
 from turnstone.api.docs import make_docs_handler, make_openapi_handler
 from turnstone.api.server_spec import build_server_spec
+from turnstone.core import session_worker
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
 from turnstone.core.auth import (
     DENY_EMPTY_SUB,
@@ -1435,43 +1436,48 @@ async def metrics_endpoint(request: Request) -> Response:
 def _make_watch_dispatch(ws: Workstream, session: ChatSession, ui: Any) -> Any:
     """Create a dispatch function for watch results on a workstream.
 
-    Handles both idle (start worker thread) and busy (enqueue for IDLE drain)
-    cases.  Mirrors the ``send_message`` worker-thread pattern.
+    Handles both busy (enqueue into ``session._watch_pending`` for drain at IDLE)
+    and idle (spawn a worker thread) cases via the shared
+    :func:`turnstone.core.session_worker.send` dispatcher. The shared
+    dispatcher's ``_worker_running`` gate keeps watches and ``/v1/api/send``
+    from racing into parallel workers on the same ChatSession.
     """
     pending = session._watch_pending
 
     def dispatch(msg: str) -> None:
-        with ws._lock:
-            if ws.worker_thread and ws.worker_thread.is_alive():
-                # Workstream is busy — queue for drain at IDLE (Path A)
-                try:
-                    pending.put_nowait({"message": msg})
-                except queue.Full:
-                    log.warning(
-                        "Watch pending queue full, dropping result for ws %s",
-                        ws.id,
-                    )
-                return
+        def _enq() -> None:
+            # Watches don't pump through ChatSession.queue_message; instead
+            # they drop into the IDLE-drain pending queue. Swallow Full
+            # locally — drop-on-full is the long-standing watch behavior
+            # (no 429 surface).
+            try:
+                pending.put_nowait({"message": msg})
+            except queue.Full:
+                log.warning(
+                    "Watch pending queue full, dropping result for ws %s",
+                    ws.id,
+                )
 
-            # Workstream is idle — start a worker thread (Path B)
-            # Mirrors the send_message() run() pattern for proper cleanup.
-            def run() -> None:
-                me = threading.current_thread()
-                try:
-                    session.send(msg)
-                except GenerationCancelled:
-                    if ws.worker_thread is me and ui:
-                        ui.on_stream_end()
-                        ui.on_state_change("idle")
-                except Exception as exc:
-                    if ws.worker_thread is me and ui:
-                        ui.on_error(f"Watch error: {exc}")
-                        ui.on_stream_end()
-                        ui.on_state_change("error")
+        def _run() -> None:
+            me = threading.current_thread()
+            try:
+                session.send(msg)
+            except GenerationCancelled:
+                if ws.worker_thread is me and ui:
+                    ui.on_stream_end()
+                    ui.on_state_change("idle")
+            except Exception as exc:
+                if ws.worker_thread is me and ui:
+                    ui.on_error(f"Watch error: {exc}")
+                    ui.on_stream_end()
+                    ui.on_state_change("error")
 
-            t = threading.Thread(target=run, daemon=True)
-            ws.worker_thread = t
-            t.start()
+        session_worker.send(
+            ws,
+            enqueue=_enq,
+            run=_run,
+            thread_name=f"watch-worker-{ws.id[:8]}",
+        )
 
     return dispatch
 
@@ -1634,105 +1640,108 @@ async def send_message(request: Request) -> JSONResponse:
 
             _unreserve(send_id, ws_id, attach_user_id)
 
-    # Atomically check-and-start to prevent two concurrent workers on the
-    # same session (ChatSession.send() is not thread-safe).
     # If cancel was requested, poll briefly for the worker to exit before
-    # rejecting.  Snapshot the thread ref since force-cancel can set it to
-    # None concurrently.  Uses async sleep to avoid blocking the event loop.
-    worker = ws.worker_thread
-    if worker and worker.is_alive() and ws.session and ws.session._cancel_event.is_set():
+    # dispatching.  ``_worker_running`` flips to False atomically under
+    # ws._lock when the worker thread reaches its finally block — gates
+    # the dispatch on the same flag the shared dispatcher uses.  Uses
+    # async sleep to avoid blocking the event loop.
+    if ws._worker_running and ws.session and ws.session._cancel_event.is_set():
         for _ in range(30):  # up to 3s in 100ms steps
             await asyncio.sleep(0.1)
-            if not worker.is_alive():
+            if not ws._worker_running:
                 break
-    with ws._lock:
-        if ws.worker_thread and ws.worker_thread.is_alive():
-            # Queue the message for injection at the next tool-result seam
-            # instead of rejecting outright.  Attachments were already
-            # reserved above using ``send_id`` as the token — we pass
-            # the same id in as ``queue_msg_id`` so the queue entry, the
-            # reservation, and the eventual consume all share one token.
-            if ws.session is not None:
-                try:
-                    cleaned, priority, msg_id = ws.session.queue_message(
-                        message,
-                        attachment_ids=list(ordered_reserved),
-                        queue_msg_id=send_id,
-                    )
-                except queue.Full:
-                    _release_reservation_on_fail()
-                    return JSONResponse({"status": "queue_full"})
-                ui._enqueue(
-                    {
-                        "type": "message_queued",
-                        "message": cleaned,
-                        "priority": priority,
-                        "msg_id": msg_id,
-                    }
-                )
-                # Report the reservation outcome so the UI can clear
-                # only the chips that actually got attached, leaving
-                # un-reserved ones visible for retry.
-                dropped = [aid for aid in requested_ids if aid not in reserved_set]
-                return JSONResponse(
-                    {
-                        "status": "queued",
-                        "priority": priority,
-                        "msg_id": msg_id,
-                        "attached_ids": list(ordered_reserved),
-                        "dropped_attachment_ids": dropped,
-                    }
-                )
-            _release_reservation_on_fail()
-            ui._enqueue(
-                {
-                    "type": "busy_error",
-                    "message": "Already processing a request. Please wait.",
-                }
+    if ws.session is None:
+        _release_reservation_on_fail()
+        return JSONResponse({"error": "No session"}, status_code=500)
+
+    session = ws.session
+
+    # Pre-allocate the queue-path outcome dict; populated by ``_enqueue``
+    # only when the shared dispatcher routes us onto a live worker.
+    queue_outcome: dict[str, Any] = {}
+
+    def _enqueue() -> None:
+        # Reuse path: append to the live worker's pending queue. The
+        # ``send_id`` token threads through ``queue_msg_id`` so the
+        # queue entry, the attachment reservation, and the eventual
+        # consume all share one token.
+        cleaned, priority, msg_id = session.queue_message(
+            message,
+            attachment_ids=list(ordered_reserved),
+            queue_msg_id=send_id,
+        )
+        queue_outcome["cleaned"] = cleaned
+        queue_outcome["priority"] = priority
+        queue_outcome["msg_id"] = msg_id
+
+    def _run() -> None:
+        assert ui is not None
+        me = threading.current_thread()
+        try:
+            session.send(
+                message,
+                attachments=resolved_atts or None,
+                send_id=send_id,
             )
-            return JSONResponse({"status": "busy"})
-        session = ws.session
-        if session is None:
+        except GenerationCancelled:
+            # Safety net — send() normally handles this internally.
+            # If this thread was force-abandoned, ws.worker_thread will
+            # have been set to None — don't emit spurious events.
             _release_reservation_on_fail()
-            return JSONResponse({"error": "No session"}, status_code=500)
+            if ws.worker_thread is me:
+                ui.on_stream_end()
+                ui.on_state_change("idle")
+        except Exception as e:
+            # Release the reservation so the attachments don't stay
+            # soft-locked forever when the worker crashes before
+            # reaching the consume step.  Safe-by-idempotency: once
+            # mark_attachments_consumed has cleared the token, a
+            # follow-up unreserve is a no-op.
+            _release_reservation_on_fail()
+            if ws.worker_thread is me:
+                ui.on_error(f"Error: {e}")
+                ui.on_stream_end()
+                ui.on_state_change("error")
 
-        def run() -> None:
-            assert ui is not None
-            me = threading.current_thread()
-            try:
-                session.send(
-                    message,
-                    attachments=resolved_atts or None,
-                    send_id=send_id,
-                )
-            except GenerationCancelled:
-                # Safety net — send() normally handles this internally.
-                # If this thread was force-abandoned, ws.worker_thread will
-                # have been set to None — don't emit spurious events.
-                _release_reservation_on_fail()
-                if ws.worker_thread is me:
-                    ui.on_stream_end()
-                    ui.on_state_change("idle")
-            except Exception as e:
-                # Release the reservation so the attachments don't stay
-                # soft-locked forever when the worker crashes before
-                # reaching the consume step.  Safe-by-idempotency: once
-                # mark_attachments_consumed has cleared the token, a
-                # follow-up unreserve is a no-op.
-                _release_reservation_on_fail()
-                if ws.worker_thread is me:
-                    ui.on_error(f"Error: {e}")
-                    ui.on_stream_end()
-                    ui.on_state_change("error")
+    ok = session_worker.send(
+        ws,
+        enqueue=_enqueue,
+        run=_run,
+        thread_name=f"send-worker-{ws.id[:8]}",
+    )
+    if not ok:
+        # Returns False on queue.Full (live worker, queue at capacity)
+        # or session-disappeared race. Either way the message couldn't
+        # land — surface as queue_full so the client can retry.
+        _release_reservation_on_fail()
+        return JSONResponse({"status": "queue_full"})
 
-        t = threading.Thread(target=run, daemon=True)
-        ws.worker_thread = t
-        t.start()
+    dropped = [aid for aid in requested_ids if aid not in reserved_set]
+    if queue_outcome:
+        # Reused a live worker; queue_message succeeded.
+        ui._enqueue(
+            {
+                "type": "message_queued",
+                "message": queue_outcome["cleaned"],
+                "priority": queue_outcome["priority"],
+                "msg_id": queue_outcome["msg_id"],
+            }
+        )
+        return JSONResponse(
+            {
+                "status": "queued",
+                "priority": queue_outcome["priority"],
+                "msg_id": queue_outcome["msg_id"],
+                "attached_ids": list(ordered_reserved),
+                "dropped_attachment_ids": dropped,
+            }
+        )
+
+    # Spawned a fresh worker — count this as a new turn.
     _metrics.record_message_sent()
     with ui._ws_lock:
         ui._ws_messages += 1
         ui._ws_turn_tool_calls = 0
-    dropped = [aid for aid in requested_ids if aid not in reserved_set]
     return JSONResponse(
         {
             "status": "ok",
@@ -1790,7 +1799,7 @@ async def cancel_generation(request: Request) -> JSONResponse:
     if session is None:
         return JSONResponse({"error": "No session"}, status_code=400)
     force = body.get("force", False) is True
-    was_running = bool(ws.worker_thread and ws.worker_thread.is_alive())
+    was_running = ws._worker_running
     dropped = _capture_cancel_forensics(session, ui, was_running=was_running)
     # Only act if generation is actually in progress
     if was_running:
@@ -1964,11 +1973,18 @@ async def command(request: Request) -> JSONResponse:
                             ui.on_error(f"Error: {exc}")
                             ui.on_stream_end()
                             ui.on_state_change("error")
+                    finally:
+                        with ws._lock:
+                            ws._worker_running = False
 
+                # Gate on ``_worker_running`` for parity with the shared
+                # session_worker dispatcher — avoids racing a /v1/api/send
+                # spawn with the retry spawn into two parallel workers.
                 with ws._lock:
-                    if ws.worker_thread and ws.worker_thread.is_alive():
+                    if ws._worker_running:
                         ui.on_error("Cannot retry: workstream is busy")
                     else:
+                        ws._worker_running = True
                         t = threading.Thread(target=run_retry, daemon=True)
                         ws.worker_thread = t
                         t.start()
@@ -2679,10 +2695,18 @@ async def create_workstream(request: Request) -> JSONResponse:
                         _fire_notify_targets(ws, last_content)
                     except Exception:
                         log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
+                    with ws._lock:
+                        ws._worker_running = False
 
-            t = threading.Thread(target=_run_initial, daemon=True, name=f"ws-init-{ws.id[:8]}")
-            ws.worker_thread = t
-            t.start()
+            # Mark the worker live under ws._lock so a /v1/api/send
+            # arriving immediately after creation observes the running
+            # state via the shared session_worker gate instead of
+            # racing into a parallel worker.
+            with ws._lock:
+                ws._worker_running = True
+                t = threading.Thread(target=_run_initial, daemon=True, name=f"ws-init-{ws.id[:8]}")
+                ws.worker_thread = t
+                t.start()
 
         return JSONResponse(
             {
@@ -4166,6 +4190,10 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     # Start watch runner (periodic command polling)
     if app.state.watch_runner:
         app.state.watch_runner.start()
+    # Start the buffered state-writer flusher
+    state_writer = getattr(app.state, "state_writer", None)
+    if state_writer is not None:
+        state_writer.start()
 
     # Sweep stale attachment reservations left over from process crashes
     # between reserve_attachments and consume/unreserve.  Run once at
@@ -4304,6 +4332,10 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_client.stop_renewal()
     if app.state.watch_runner:
         app.state.watch_runner.stop()
+    # Drain + stop the buffered state-writer
+    state_writer = getattr(app.state, "state_writer", None)
+    if state_writer is not None:
+        state_writer.shutdown()
     # Stop the orphan-reservation sweep loop
     _orphan_sweep_stop.set()
     with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -4361,6 +4393,7 @@ def create_app(
     judge_config: Any = None,
     config_store: Any = None,
     advertise_url: str = "",
+    state_writer: Any = None,
 ) -> Starlette:
     """Create and configure the Starlette ASGI application."""
     _spec = build_server_spec()
@@ -4473,6 +4506,7 @@ def create_app(
         lifespan=_lifespan,
     )
     app.state.workstreams = workstreams
+    app.state.state_writer = state_writer
     app.state.global_queue = global_queue
     app.state.global_listeners = global_listeners
     app.state.global_listeners_lock = global_listeners_lock
@@ -4930,11 +4964,15 @@ def main() -> None:
         ),
         session_factory=session_factory,
     )
+    from turnstone.core.state_writer import StateWriter
+
+    state_writer = StateWriter(_get_storage())
     manager = SessionManager(
         interactive_adapter,
         storage=_get_storage(),
         max_active=config_store.get("server.max_workstreams"),
         node_id=_node_id,
+        state_writer=state_writer,
     )
     interactive_adapter.attach(manager)
     WebUI._workstream_mgr = manager
@@ -5042,6 +5080,7 @@ def main() -> None:
         judge_config=judge_config,
         config_store=config_store,
         advertise_url=_advertise_url,
+        state_writer=state_writer,
     )
 
     # Wire app ref so health callbacks can access app.state for metrics

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4344,10 +4344,13 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_client.stop_renewal()
     if app.state.watch_runner:
         app.state.watch_runner.stop()
-    # Drain + stop the buffered state-writer
+    # Drain + stop the buffered state-writer. shutdown() joins a
+    # daemon thread and runs synchronous DB writes; offload to a
+    # worker thread so we don't block the lifespan event loop and
+    # delay other teardown tasks.
     state_writer = getattr(app.state, "state_writer", None)
     if state_writer is not None:
-        state_writer.shutdown()
+        await asyncio.to_thread(state_writer.shutdown)
     # Stop the orphan-reservation sweep loop
     _orphan_sweep_stop.set()
     with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1911,9 +1911,14 @@ async def command(request: Request) -> JSONResponse:
             if err:
                 ui.on_error("Permission denied: conversation.modify required")
                 return err
-            # Prevent rewind/retry while a generation is in progress
+            # Prevent rewind/retry while a generation is in progress.
+            # Gate on ``_worker_running`` (not ``worker_thread.is_alive()``)
+            # for parity with session_worker.send: spawn paths set the
+            # flag before assigning ws.worker_thread, so a reader using
+            # the old gate could see a stale dead thread while a new
+            # worker is in the middle of starting.
             with ws._lock:
-                if ws.worker_thread and ws.worker_thread.is_alive():
+                if ws._worker_running:
                     ui._enqueue(
                         {
                             "type": "busy_error",
@@ -1977,9 +1982,12 @@ async def command(request: Request) -> JSONResponse:
                         with ws._lock:
                             ws._worker_running = False
 
-                # Gate on ``_worker_running`` for parity with the shared
-                # session_worker dispatcher — avoids racing a /v1/api/send
-                # spawn with the retry spawn into two parallel workers.
+                # Inlined rather than via ``session_worker.send`` because
+                # retry-when-busy is a hard reject (UI error, no fallback
+                # queue) — the shared dispatcher's enqueue/spawn shape
+                # doesn't fit. We gate on ``_worker_running`` for parity
+                # with that dispatcher so the two paths can't race into
+                # parallel workers on the same ChatSession.
                 with ws._lock:
                     if ws._worker_running:
                         ui.on_error("Cannot retry: workstream is busy")
@@ -2698,10 +2706,14 @@ async def create_workstream(request: Request) -> JSONResponse:
                     with ws._lock:
                         ws._worker_running = False
 
-            # Mark the worker live under ws._lock so a /v1/api/send
-            # arriving immediately after creation observes the running
-            # state via the shared session_worker gate instead of
-            # racing into a parallel worker.
+            # Inlined rather than via ``session_worker.send`` because
+            # at workstream creation no live worker can exist by
+            # construction — the enqueue branch of the shared dispatch
+            # is dead code here. We still set ``_worker_running`` and
+            # ``ws.worker_thread`` together under ``ws._lock`` so a
+            # /v1/api/send arriving immediately after creation observes
+            # the running state via the shared session_worker gate
+            # instead of racing into a parallel worker.
             with ws._lock:
                 ws._worker_running = True
                 t = threading.Thread(target=_run_initial, daemon=True, name=f"ws-init-{ws.id[:8]}")


### PR DESCRIPTION
## Summary

Stage 2 Priority 1 of the SessionManager unification (1.5.0aN experimental track). Two coupled concurrency changes:

- **Shared worker dispatch.** `turnstone.core.session_worker.send` is the atomic check-and-(spawn-or-queue) decision both the interactive `/v1/api/send` HTTP handler and `CoordinatorAdapter.send` now call into. Five spawn sites in `turnstone/server.py` (send, watches, retry-after-rewind, init-on-create, cancel-pending poll) gate on `Workstream._worker_running` instead of `Thread.is_alive()` — closes a parallel-worker race where two senders could spawn concurrent workers on the same `ChatSession`.
- **Buffered state writer.** `turnstone.core.state_writer.StateWriter` coalesces `update_workstream_state` for non-terminal transitions (per ws_id, last state wins, ~1s flush) so `set_state` no longer holds `ws._lock` across a sync Postgres `UPDATE`. Terminal `ERROR` and `close()` write sync; both invalidate any pending buffered transient before the sync write so a late flush can't resurrect a closed row.

**Observable behavior change:** transient state (`thinking`/`running`/`idle`/`attention`) lands in storage up to ~1s late. SSE consumers see it instantly via the adapter's `emit_state`. Documented in CHANGELOG.

## What's NOT in this PR (and why)

- **`/send` HTTP body convergence.** Interactive carries attachments / reservations / queue-outcome distinctions; coord doesn't. Lifting now would be ~80 LOC of capability-flag branching in a shared factory. Tracked as **P1.5 — verb-shape lift** and MUST land before 1.5.0 stable so adding attachments-on-coord later is a flag flip rather than a verb-body fork. Same gate applies to the other six still-forked shared verbs (`cancel`, `open`, `events`, `create`, `list`/`saved`, `history`/`detail`). See `1.5.0-stable-handoff.md` working notes for the punch list.
- **Bulk `update_workstream_state` UPDATE.** The flusher does N round-trips per batch sequentially. `discard()` waits on `_flush_lock` with a 5s timeout (perf-2 fix below), so a stuck Postgres can't deadlock all close paths system-wide — but the close-path latency under high state-write load is bounded by batch size. Separate refactor.

## /review pipeline pass

Local `/review` (4 finders → verify → fix-up commit). 15 of 16 findings confirmed; six high-leverage fixes landed in `175901d`:

- **bug-1 (critical)**: `record(flush_now=True)` now drops any pending buffered transient for the same ws_id and waits on `_flush_lock` before its sync UPDATE. Without this, a buffered `running` could flush AFTER the sync `error` write and clobber the terminal state — the same close-vs-buffered-transient race `discard` already guards.
- **bug-3 (major)**: `session_worker.send` assigns `ws.worker_thread = t` AND `ws._worker_running = True` under the same `ws._lock` acquisition. Previously a reader could see `_worker_running=True` paired with a stale dead `worker_thread`, defeating every `ws.worker_thread is me` identity check downstream.
- **bug-2 (major)**: rewind/retry busy gate now reads `_worker_running` instead of `worker_thread.is_alive()` for parity with the dispatcher.
- **perf-2 (major)**: `discard` waits on `_flush_lock` with a 5s timeout. A stuck Postgres connection can't deadlock all close paths system-wide; on timeout we log + proceed (eventual consistency degrades; process keeps moving).
- **q-1**: rationale comments on `run_retry` and `_run_initial` explain why those two spawn sites don't go through the shared dispatcher (retry-when-busy is a hard reject; init-on-create can't have a pre-existing worker by construction).
- **q-3, q-5**: tightened the docstrings to be self-contained and promoted `_flush_once` → public `flush()`.

## Test plan

- [x] Full pytest green: 4434 tests pass (excluding `tests/live` which need a real LLM backend).
- [x] New module tests: 14 in `tests/test_session_worker.py` (covers concurrent-spawn race regression, queue.Full surfacing, `_worker_running` lifecycle, captured-session invariant). 16 in `tests/test_state_writer.py` (covers coalescing, `flush_now` bypass + drain-buffer + flush-lock-wait, bounded buffer eviction, `discard` flush-lock timeout, lifespan idempotence).
- [x] New regression tests in `tests/test_session_manager.py::TestSessionManagerWithStateWriter` for the close-vs-buffered-transient invariant under write-behind.
- [x] `ruff check turnstone/ tests/` clean. `mypy turnstone/` clean across 175 source files.
- [ ] Manual smoke: coord dashboard live state under flush_interval=1.0s; interactive SSE streams responses; long tool calls don't block other HTTP traffic.
- [ ] Soak as `1.5.0a7` (after merge + tag) — overlap with P2/P3 alpha windows is acceptable per the unification-before-stable gate.

## Risk flags

- **Interactive `_worker_running` is load-bearing for the first time.** Pre-P1, only coord used the flag; interactive used `worker_thread.is_alive()`. All five interactive spawn sites now write the flag atomically with `worker_thread`. Test fixtures using `MagicMock` for `Workstream` had to add explicit `_worker_running = False` (or True) — MagicMock auto-truthifies. q-2 from /review noted this footgun; a shared fixture helper is a reasonable follow-up.
- **`discard` 5s timeout** is a degradation from "blocks until flush completes" to "blocks at most 5s". Under healthy DB conditions the wait is sub-millisecond.
- **Buffered state lag** affects observers polling storage on a sub-1s cadence. SSE consumers are unaffected. None of the dashboards I'm aware of poll storage that fast, but worth flagging in the alpha-soak notes.