### PR TITLE
Stage 2 P1.5 — send body lift + coord attachments + queues parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,29 @@ Three release tracks are maintained:
   for parity with interactive. Existing callers checking for ``429``
   should switch to the status-code shape.
 
+  Coord ``GenerationCancelled`` now emits ``state=idle`` +
+  ``stream_end`` (parity with interactive); pre-P1.5 a cancel-killed
+  coord worker would have terminated silently with no state event.
+  Cluster fanout / alerting keyed on ``state=error`` for cancelled
+  coord workers should switch to monitoring ``stream_end`` /
+  ``state=idle`` together.
+
+### Security
+
+- **Coord attachment endpoints are now kind-strict**
+  ([Stage 2 P1.5]). The coord ``attachment_owner_resolver``
+  resolves through the in-memory ``coord_mgr`` only — it does NOT
+  fall back to storage. Without this, an
+  ``admin.coordinator``-scoped caller could pass an *interactive*
+  workstream ws_id to the new coord attachment endpoints; the
+  generic ``get_workstream_owner`` storage call (kind-agnostic)
+  would resolve cleanly and grant cross-kind read / write access
+  to interactive attachments. The kind-strict resolver returns
+  404 for any ws_id not currently held by the coord manager,
+  closing the cross-kind path. Persisted-but-not-loaded
+  coordinators must be ``open``ed before their attachment endpoints
+  respond. Caught by /review pre-merge; no exploit observed.
+
 - **Workstream state writes are now buffered through ``StateWriter``.**
   ``SessionManager.set_state`` no longer holds ``ws._lock`` across a
   synchronous Postgres ``UPDATE`` for non-terminal transitions;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,56 @@ Three release tracks are maintained:
   fork ship into the stable line bakes the duplication in for the
   lifetime of the 1.5 track.
 
+- **`/send` body lift + coordinator attachments + queue surface
+  parity** ([Stage 2 Priority 1.5]). The ``/send`` HTTP handler is
+  now ONE factory body (``make_send_handler(cfg)``) wired with
+  capability flags on both kinds; the four attachment endpoints
+  (``upload`` / ``list`` / ``get_content`` / ``delete``) are also
+  unified via ``make_attachment_handlers(cfg)``. Coord workstreams
+  light up:
+
+  - ``POST/GET /v1/api/workstreams/{ws_id}/attachments``,
+    ``GET .../attachments/{aid}/content``,
+    ``DELETE .../attachments/{aid}`` — same shape, same caps, same
+    reservation flow as interactive.
+  - ``POST /v1/api/workstreams/{ws_id}/send`` accepts
+    ``attachment_ids`` (or auto-consumes pending) and returns
+    ``attached_ids`` / ``dropped_attachment_ids`` for surfacing
+    partial reservations. Live-worker reuse path also returns
+    ``priority`` / ``msg_id`` (parity with the interactive
+    ``status: queued`` shape).
+
+  Backend parity is end-to-end: storage layer was already
+  kind-agnostic; the route registrar's ``AttachmentHandlers`` slot
+  has been there since Stage 2 P0; the multi-node attachment
+  routing-proxy on the console (``route_attachment_proxy``) was
+  already shipping. P1.5 is the wiring + verb-shape lift that lets
+  these primitives surface on the coord side.
+
+  Coord dashboard rendering surfaces an attachment-count badge on
+  past messages with attachments; full chip rendering with
+  click-to-view is deferred (the coord dashboard is
+  diagnostic-leaning and chip parity isn't on the critical path
+  for the unification thesis). Python SDK adds
+  ``coordinator_send`` / ``coordinator_upload_attachment`` /
+  ``coordinator_list_attachments`` /
+  ``coordinator_get_attachment_content`` /
+  ``coordinator_delete_attachment`` on
+  ``AsyncTurnstoneConsole`` + ``TurnstoneConsole``. TS SDK
+  regenerated; bumped to 0.5.0.
+
+  Three lifted helpers (``sniff_image_mime``,
+  ``classify_text_attachment``, ``upload_lock``) moved from
+  ``turnstone/server.py`` to ``turnstone/core/attachments.py`` so
+  both processes use the canonical implementation. The interactive
+  surface keeps the same behaviour; the helpers are simply
+  imported from their new home.
+
+  ``coordinator_send`` no longer returns ``429`` on a full worker
+  queue — the unified body returns ``200 {"status": "queue_full"}``
+  for parity with interactive. Existing callers checking for ``429``
+  should switch to the status-code shape.
+
 - **Workstream state writes are now buffered through ``StateWriter``.**
   ``SessionManager.set_state`` no longer holds ``ws._lock`` across a
   synchronous Postgres ``UPDATE`` for non-terminal transitions;

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -4864,6 +4864,16 @@
               }
             }
           },
+          "409": {
+            "description": "Error 409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Error 500",
             "content": {

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -4802,7 +4802,7 @@
         "tags": [
           "Coordinator"
         ],
-        "description": "Worker thread picks up the message via the session's queue.  ``429`` when the worker queue is full \u2014 caller should back off.",
+        "description": "Worker thread picks up the message via the session's queue. Optional ``attachment_ids`` reserve attachments under the message's send_id token (parity with the interactive surface). Response carries ``attached_ids`` / ``dropped_attachment_ids`` so callers can detect partial reservations and ``priority`` / ``msg_id`` on the queued path. ``status: queue_full`` when the worker queue is full \u2014 caller should back off.",
         "parameters": [
           {
             "name": "ws_id",
@@ -4829,7 +4829,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
+                  "$ref": "#/components/schemas/CoordinatorSendResponse"
                 }
               }
             }
@@ -4864,8 +4864,8 @@
               }
             }
           },
-          "429": {
-            "description": "Error 429",
+          "500": {
+            "description": "Error 500",
             "content": {
               "application/json": {
                 "schema": {
@@ -4874,8 +4874,282 @@
               }
             }
           },
-          "500": {
-            "description": "Error 500",
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/api/workstreams/{ws_id}/attachments": {
+      "post": {
+        "summary": "Upload a file attachment to a coordinator workstream",
+        "operationId": "v1_api_workstreams_{ws_id}_attachments_post",
+        "tags": [
+          "Coordinator"
+        ],
+        "description": "Multipart upload (field ``file``). Same validation rules as the interactive surface: magic-byte image sniff, UTF-8 text decode, per-kind size cap, per-(ws,user) pending cap. Attachments stay pending until a subsequent ``/send`` reserves them under its ``send_id`` token.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadAttachmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Error 413",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List the caller's pending coordinator attachments",
+        "operationId": "v1_api_workstreams_{ws_id}_attachments_get",
+        "tags": [
+          "Coordinator"
+        ],
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAttachmentsResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}/content": {
+      "get": {
+        "summary": "Return raw bytes of a coordinator attachment",
+        "operationId": "v1_api_workstreams_{ws_id}_attachments_{attachment_id}_content_get",
+        "tags": [
+          "Coordinator"
+        ],
+        "description": "Same byte-stream + headers as the interactive surface. Text kinds are forced to ``text/plain`` so an HTML-shaped text upload can't render same-origin.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}": {
+      "delete": {
+        "summary": "Remove a pending coordinator attachment",
+        "operationId": "v1_api_workstreams_{ws_id}_attachments_{attachment_id}_delete",
+        "tags": [
+          "Coordinator"
+        ],
+        "description": "Consumed attachments return 404.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
             "content": {
               "application/json": {
                 "schema": {
@@ -7372,12 +7646,90 @@
             "description": "User message to queue onto the coordinator's worker.",
             "title": "Message",
             "type": "string"
+          },
+          "attachment_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Explicit list of attachment ids to inject into this turn. When omitted, any pending attachments for the caller on this coordinator are auto-consumed. An empty list disables auto-consumption for this send.",
+            "title": "Attachment Ids"
           }
         },
         "required": [
           "message"
         ],
         "title": "CoordinatorSendRequest",
+        "type": "object"
+      },
+      "CoordinatorSendResponse": {
+        "description": "Response shape for POST /v1/api/workstreams/{ws_id}/send (coord).",
+        "properties": {
+          "status": {
+            "description": "'ok' (fresh worker spawned), 'queued' (live worker reuse), or 'queue_full'.",
+            "examples": [
+              "ok",
+              "queued",
+              "queue_full"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "attached_ids": {
+            "description": "Attachment ids actually reserved onto this turn. Subset of the request's `attachment_ids` (or the auto-consumed pending set). Empty when the send carries no attachments.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Attached Ids",
+            "type": "array"
+          },
+          "dropped_attachment_ids": {
+            "description": "Attachment ids the caller requested that the server could not reserve (lost a race, already consumed, or cross-scope). The request still proceeds with whatever was reserved.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Dropped Attachment Ids",
+            "type": "array"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Set on `queued` responses: relative priority of the queued message.",
+            "title": "Priority"
+          },
+          "msg_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Set on `queued` responses: id used to dequeue the message.",
+            "title": "Msg Id"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "CoordinatorSendResponse",
         "type": "object"
       },
       "CoordinatorStopCascadeResponse": {

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -64,7 +64,6 @@ from turnstone.core.session_routes import (
     make_send_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
-from turnstone.core.web_helpers import resolve_workstream_owner
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -72,10 +71,20 @@ from turnstone.core.web_helpers import resolve_workstream_owner
 
 
 def _coord_attach_owner(request, ws_id, mgr):
-    """Coord attachment owner resolver mirroring production wiring."""
-    return resolve_workstream_owner(
-        request, ws_id, mgr=mgr, not_found_label="coordinator not found"
-    )
+    """Coord attachment owner resolver mirroring production wiring.
+
+    Kind-strict — coord attachments can only be accessed for
+    workstreams currently held by ``coord_mgr``; no storage fallback
+    so cross-kind ws_ids 404 instead of leaking through storage.
+    """
+    from starlette.responses import JSONResponse
+
+    from turnstone.core.web_helpers import auth_user_id
+
+    ws = mgr.get(ws_id)
+    if ws is None:
+        return "", JSONResponse({"error": "coordinator not found"}, status_code=404)
+    return ws.user_id or auth_user_id(request), None
 
 
 # Per-kind config the lifted handler factories capture by closure.
@@ -1371,3 +1380,51 @@ class TestCoordinatorAttachments:
         assert body["status"] == "ok"
         assert body["attached_ids"] == []
         assert body["dropped_attachment_ids"] == []
+
+    def test_coord_attachment_endpoints_404_on_interactive_ws_id(self, storage):
+        """Security regression: an ``admin.coordinator``-scoped caller
+        must NOT be able to read or mutate attachments on
+        **interactive** workstreams via the coord attachment surface.
+        The kind-strict resolver returns 404 (no storage fallback) so
+        a cross-kind ws_id never resolves to its owner."""
+        from turnstone.core.workstream import WorkstreamKind
+
+        # Persist an interactive workstream row directly — never loaded
+        # into the coord_mgr.
+        interactive_ws_id = "i" * 32
+        storage.register_workstream(
+            interactive_ws_id,
+            node_id="some-node",
+            user_id="alice",
+            name="alice-interactive",
+            kind=WorkstreamKind.INTERACTIVE,
+            parent_ws_id=None,
+        )
+        mgr = _build_mgr(storage)
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        # Upload attempt — must 404, not 200.
+        files = {"file": ("note.md", b"sneaky", "text/markdown")}
+        resp = client.post(
+            f"/v1/api/workstreams/{interactive_ws_id}/attachments",
+            files=files,
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 404, resp.text
+
+        # List, get-content, delete — same kind-strict 404 behaviour.
+        resp = client.get(
+            f"/v1/api/workstreams/{interactive_ws_id}/attachments",
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 404
+        resp = client.get(
+            f"/v1/api/workstreams/{interactive_ws_id}/attachments/anything/content",
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 404
+        resp = client.delete(
+            f"/v1/api/workstreams/{interactive_ws_id}/attachments/anything",
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 404

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -43,20 +43,39 @@ from turnstone.console.server import (
     coordinator_list,
     coordinator_open,
     coordinator_saved,
-    coordinator_send,
     coordinator_tasks,
+)
+from turnstone.core.attachments import (
+    classify_text_attachment as _coord_test_classify_text,
+)
+from turnstone.core.attachments import (
+    sniff_image_mime as _coord_test_sniff_image,
+)
+from turnstone.core.attachments import (
+    upload_lock as _coord_test_upload_lock,
 )
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_routes import (
+    AttachmentUploadHelpers,
     SessionEndpointConfig,
     make_approve_handler,
+    make_attachment_handlers,
     make_close_handler,
+    make_send_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
+from turnstone.core.web_helpers import resolve_workstream_owner
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+def _coord_attach_owner(request, ws_id, mgr):
+    """Coord attachment owner resolver mirroring production wiring."""
+    return resolve_workstream_owner(
+        request, ws_id, mgr=mgr, not_found_label="coordinator not found"
+    )
 
 
 # Per-kind config the lifted handler factories capture by closure.
@@ -68,6 +87,15 @@ _coord_endpoint_config = SessionEndpointConfig(
     tenant_check=None,
     not_found_label="coordinator not found",
     audit_action_prefix="coordinator",
+    supports_attachments=True,
+    attachment_owner_resolver=_coord_attach_owner,
+    attachment_helpers=AttachmentUploadHelpers(
+        sniff_image_mime=_coord_test_sniff_image,
+        classify_text_attachment=_coord_test_classify_text,
+        upload_lock=_coord_test_upload_lock,
+    ),
+    spawn_metrics=None,
+    emit_message_queued=True,
 )
 
 
@@ -84,6 +112,7 @@ def _make_client(
     registry=None,
 ) -> TestClient:
     """Build a TestClient exposing just the coordinator routes."""
+    coord_attachments = make_attachment_handlers(_coord_endpoint_config)
     app = Starlette(
         routes=[
             Route(
@@ -101,7 +130,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/send",
-                coordinator_send,
+                make_send_handler(_coord_endpoint_config),
                 methods=["POST"],
             ),
             Route(
@@ -142,6 +171,26 @@ def _make_client(
                 "/v1/api/workstreams/{ws_id}/tasks",
                 coordinator_tasks,
                 methods=["GET"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/attachments",
+                coord_attachments.upload,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/attachments",
+                coord_attachments.list,
+                methods=["GET"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
+                coord_attachments.get_content,
+                methods=["GET"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}",
+                coord_attachments.delete,
+                methods=["DELETE"],
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}",
@@ -1210,3 +1259,115 @@ def test_coordinator_rows_persisted_cluster_wide(storage):
         request = _persisted_rows_request(storage, mgr, caller, perms)
         rows = _coordinator_rows(request)
         assert {r["name"] for r in rows} == {"alice-closed", "bob-closed", "orphan-closed"}
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 P1.5 — coord attachment surface parity with interactive
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorAttachments:
+    """The lifted ``make_attachment_handlers`` factory exposes
+    upload / list / get_content / delete on coord workstreams using
+    the same kind-agnostic storage layer interactive uses. These
+    tests exercise the surface end-to-end via TestClient."""
+
+    def _upload(self, client, ws_id, *, name="hello.md", body=b"hi", mime="text/markdown"):
+        files = {"file": (name, body, mime)}
+        resp = client.post(
+            f"/v1/api/workstreams/{ws_id}/attachments",
+            files=files,
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_upload_round_trip_lists_pending(self, storage):
+        mgr = _build_mgr(storage)
+        ws = mgr.create(user_id="user-1", name="c1")
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        info = self._upload(client, ws.id, name="note.md", body=b"hello world")
+        assert info["filename"] == "note.md"
+        assert info["kind"] == "text"
+        assert info["size_bytes"] == len(b"hello world")
+
+        listing = client.get(f"/v1/api/workstreams/{ws.id}/attachments", headers=_COORD_HEADERS)
+        assert listing.status_code == 200
+        ids = [a["attachment_id"] for a in listing.json()["attachments"]]
+        assert info["attachment_id"] in ids
+
+    def test_get_content_returns_raw_bytes(self, storage):
+        mgr = _build_mgr(storage)
+        ws = mgr.create(user_id="user-1", name="c1")
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        info = self._upload(
+            client, ws.id, name="data.json", body=b'{"k":1}', mime="application/json"
+        )
+        resp = client.get(
+            f"/v1/api/workstreams/{ws.id}/attachments/{info['attachment_id']}/content",
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 200
+        # Text kinds force text/plain to avoid same-origin HTML/SVG rendering.
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert resp.content == b'{"k":1}'
+
+    def test_delete_removes_pending(self, storage):
+        mgr = _build_mgr(storage)
+        ws = mgr.create(user_id="user-1", name="c1")
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        info = self._upload(client, ws.id)
+        resp = client.delete(
+            f"/v1/api/workstreams/{ws.id}/attachments/{info['attachment_id']}",
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "deleted"}
+
+        listing = client.get(f"/v1/api/workstreams/{ws.id}/attachments", headers=_COORD_HEADERS)
+        ids = [a["attachment_id"] for a in listing.json()["attachments"]]
+        assert info["attachment_id"] not in ids
+
+    def test_send_with_attachment_ids_consumes_pending(self, storage):
+        """End-to-end: upload an attachment, then ``coord_send`` it. The
+        reservation flips ``reserved_for_msg_id`` to the send_id, so the
+        attachment is no longer in the pending listing."""
+        mgr = _build_mgr(storage)
+        ws = mgr.create(user_id="user-1", name="c1")
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        info = self._upload(client, ws.id)
+        resp = client.post(
+            f"/v1/api/workstreams/{ws.id}/send",
+            json={"message": "hi", "attachment_ids": [info["attachment_id"]]},
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        # Surfacing parity with interactive: response carries the
+        # attached / dropped lists even when no drops occurred.
+        assert body["attached_ids"] == [info["attachment_id"]]
+        assert body["dropped_attachment_ids"] == []
+
+    def test_send_response_includes_attached_ids_field_when_no_attachments(self, storage):
+        """The unified response shape always carries ``attached_ids`` /
+        ``dropped_attachment_ids`` so SDK consumers don't have to
+        branch on whether attachments were involved."""
+        mgr = _build_mgr(storage)
+        ws = mgr.create(user_id="user-1", name="c1")
+        client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+        resp = client.post(
+            f"/v1/api/workstreams/{ws.id}/send",
+            json={"message": "no attachments here"},
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["attached_ids"] == []
+        assert body["dropped_attachment_ids"] == []

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1045,6 +1045,48 @@ class CoordinatorSendRequest(BaseModel):
     """Body for POST /v1/api/workstreams/{ws_id}/send."""
 
     message: str = Field(description="User message to queue onto the coordinator's worker.")
+    attachment_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Explicit list of attachment ids to inject into this turn. "
+            "When omitted, any pending attachments for the caller on "
+            "this coordinator are auto-consumed. An empty list disables "
+            "auto-consumption for this send."
+        ),
+    )
+
+
+class CoordinatorSendResponse(BaseModel):
+    """Response shape for POST /v1/api/workstreams/{ws_id}/send (coord)."""
+
+    status: str = Field(
+        description="'ok' (fresh worker spawned), 'queued' (live worker reuse), or 'queue_full'.",
+        examples=["ok", "queued", "queue_full"],
+    )
+    attached_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Attachment ids actually reserved onto this turn. Subset of "
+            "the request's `attachment_ids` (or the auto-consumed pending "
+            "set). Empty when the send carries no attachments."
+        ),
+    )
+    dropped_attachment_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Attachment ids the caller requested that the server could "
+            "not reserve (lost a race, already consumed, or cross-scope). "
+            "The request still proceeds with whatever was reserved."
+        ),
+    )
+    priority: str | None = Field(
+        default=None,
+        description="Set on `queued` responses: relative priority of the queued message.",
+    )
+    msg_id: str | None = Field(
+        default=None,
+        description="Set on `queued` responses: id used to dequeue the message.",
+    )
 
 
 class CoordinatorApproveRequest(BaseModel):

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1205,7 +1205,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         ),
         request_model=CoordinatorSendRequest,
         response_model=CoordinatorSendResponse,
-        error_codes=[400, 403, 404, 500, 503],
+        error_codes=[400, 403, 404, 409, 500, 503],
         tags=["Coordinator"],
     ),
     # --- Coordinator attachments (P1.5: parity with interactive) ---

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -37,6 +37,7 @@ from turnstone.api.console_schemas import (
     CoordinatorRestrictRequest,
     CoordinatorRestrictResponse,
     CoordinatorSendRequest,
+    CoordinatorSendResponse,
     CoordinatorStopCascadeResponse,
     CoordinatorTaskInfo,
     CoordinatorTasksResponse,
@@ -131,8 +132,10 @@ from turnstone.api.schemas import (
     UserInfo,
 )
 from turnstone.api.server_schemas import (
+    ListAttachmentsResponse,
     ListSkillSummaryResponse,
     SkillSummary,
+    UploadAttachmentResponse,
 )
 
 CONSOLE_ENDPOINTS: list[EndpointSpec] = [
@@ -1191,12 +1194,63 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "POST",
         "Queue a user message onto the coordinator session",
         description=(
-            "Worker thread picks up the message via the session's queue.  "
-            "``429`` when the worker queue is full — caller should back off."
+            "Worker thread picks up the message via the session's queue. "
+            "Optional ``attachment_ids`` reserve attachments under the "
+            "message's send_id token (parity with the interactive surface). "
+            "Response carries ``attached_ids`` / ``dropped_attachment_ids`` "
+            "so callers can detect partial reservations and ``priority`` / "
+            "``msg_id`` on the queued path. "
+            "``status: queue_full`` when the worker queue is full — caller "
+            "should back off."
         ),
         request_model=CoordinatorSendRequest,
+        response_model=CoordinatorSendResponse,
+        error_codes=[400, 403, 404, 500, 503],
+        tags=["Coordinator"],
+    ),
+    # --- Coordinator attachments (P1.5: parity with interactive) ---
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}/attachments",
+        "POST",
+        "Upload a file attachment to a coordinator workstream",
+        description=(
+            "Multipart upload (field ``file``). Same validation rules as "
+            "the interactive surface: magic-byte image sniff, UTF-8 text "
+            "decode, per-kind size cap, per-(ws,user) pending cap. "
+            "Attachments stay pending until a subsequent ``/send`` "
+            "reserves them under its ``send_id`` token."
+        ),
+        response_model=UploadAttachmentResponse,
+        error_codes=[400, 403, 404, 409, 413, 503],
+        tags=["Coordinator"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}/attachments",
+        "GET",
+        "List the caller's pending coordinator attachments",
+        response_model=ListAttachmentsResponse,
+        error_codes=[403, 404, 503],
+        tags=["Coordinator"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
+        "GET",
+        "Return raw bytes of a coordinator attachment",
+        description=(
+            "Same byte-stream + headers as the interactive surface. Text "
+            "kinds are forced to ``text/plain`` so an HTML-shaped text "
+            "upload can't render same-origin."
+        ),
+        error_codes=[403, 404, 503],
+        tags=["Coordinator"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}/attachments/{attachment_id}",
+        "DELETE",
+        "Remove a pending coordinator attachment",
+        description="Consumed attachments return 404.",
         response_model=StatusResponse,
-        error_codes=[400, 403, 404, 429, 500, 503],
+        error_codes=[403, 404, 503],
         tags=["Coordinator"],
     ),
     EndpointSpec(
@@ -1460,6 +1514,7 @@ _ALL_MODELS: list[type[BaseModel]] = [
     CoordinatorRestrictRequest,
     CoordinatorRestrictResponse,
     CoordinatorSendRequest,
+    CoordinatorSendResponse,
     CoordinatorStopCascadeResponse,
     CoordinatorTaskInfo,
     CoordinatorTasksResponse,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -55,11 +55,14 @@ from turnstone.core.auth import (
 )
 from turnstone.core.rendezvous import NoAvailableNodeError
 from turnstone.core.session_routes import (
+    AttachmentUploadHelpers,
     CoordOnlyVerbHandlers,
     SessionEndpointConfig,
     SharedSessionVerbHandlers,
     make_approve_handler,
+    make_attachment_handlers,
     make_close_handler,
+    make_send_handler,
     register_coord_verbs,
     register_session_routes,
 )
@@ -2519,38 +2522,6 @@ async def coordinator_create(request: Request) -> JSONResponse:
         except Exception:
             log.debug("coordinator_create.audit_failed", exc_info=True)
     return JSONResponse({"ws_id": ws.id, "name": ws.name}, status_code=201)
-
-
-async def coordinator_send(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/send — queue a user message."""
-    from turnstone.core.web_helpers import read_json_or_400
-
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    message = (body.get("message") or "").strip()
-    if not message:
-        return JSONResponse({"error": "message is required"}, status_code=400)
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    coord_adapter = getattr(request.app.state, "coord_adapter", None)
-    if coord_adapter is None or not coord_adapter.send(ws_id, message):
-        # Distinguish "worker busy + queue full" from "ws not loaded".
-        # If ws is loaded and session exists, the worker queue is full —
-        # tell the client to back off rather than retry blindly.
-        ws_now = coord_mgr.get(ws_id)
-        if ws_now is not None and ws_now.session is not None:
-            return JSONResponse({"error": "worker queue full; retry shortly"}, status_code=429)
-        return JSONResponse({"error": "send failed"}, status_code=500)
-    return JSONResponse({"status": "ok"})
 
 
 async def coordinator_cancel(request: Request) -> JSONResponse:
@@ -10127,12 +10098,50 @@ def create_app(
     # at request time because the manager is built in the lifespan,
     # after this app construction; future verb lifts carry that lookup
     # into the config callable.
+    def _coord_attachment_owner(
+        request: Request, ws_id: str, mgr: Any
+    ) -> tuple[str, JSONResponse | None]:
+        """Resolve the attachment owner for a coord ws_id.
+
+        Mirrors interactive's resolver: prefers the in-memory ws's
+        ``user_id`` (the operator who created the coord), falls back
+        to the persisted row owner, returns 404 when neither is found.
+        """
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        return resolve_workstream_owner(
+            request, ws_id, mgr=mgr, not_found_label="coordinator not found"
+        )
+
+    from turnstone.core.attachments import (
+        classify_text_attachment as _coord_classify_text,
+    )
+    from turnstone.core.attachments import (
+        sniff_image_mime as _coord_sniff_image,
+    )
+    from turnstone.core.attachments import (
+        upload_lock as _coord_upload_lock,
+    )
+
+    coord_attachment_helpers = AttachmentUploadHelpers(
+        sniff_image_mime=_coord_sniff_image,
+        classify_text_attachment=_coord_classify_text,
+        upload_lock=_coord_upload_lock,
+    )
     coord_endpoint_config = SessionEndpointConfig(
         permission_gate=_require_admin_coordinator,
         manager_lookup=_require_coord_mgr,
         tenant_check=None,  # cluster-wide admin.coordinator gate covers it
         not_found_label="coordinator not found",
         audit_action_prefix="coordinator",
+        supports_attachments=True,
+        attachment_owner_resolver=_coord_attachment_owner,
+        attachment_helpers=coord_attachment_helpers,
+        # No per-conversation metrics on coord — the per-UI counters
+        # interactive maintains don't have an analog on the coord
+        # dashboard. Cluster-level metrics fan out via the collector.
+        spawn_metrics=None,
+        emit_message_queued=True,
     )
     coord_workstream_routes: list[Any] = []
     register_session_routes(
@@ -10149,11 +10158,14 @@ def create_app(
                 audit_emit=_audit_close_coordinator,
                 supports_close_reason=False,
             ),
-            send=coordinator_send,
+            send=make_send_handler(coord_endpoint_config),  # lifted: shared body (P1.5)
             approve=make_approve_handler(coord_endpoint_config),  # lifted: shared body
             cancel=coordinator_cancel,
             events=coordinator_events,
             history=coordinator_history,
+            attachments=make_attachment_handlers(
+                coord_endpoint_config
+            ),  # lifted: shared body (P1.5)
         ),
     )
     register_coord_verbs(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2382,8 +2382,15 @@ def _resolve_coordinator_or_404(
 
 
 def _auth_user_id(request: Request) -> str:
-    auth = getattr(getattr(request, "state", None), "auth_result", None)
-    return getattr(auth, "user_id", "") or ""
+    """Thin shim over :func:`turnstone.core.web_helpers.auth_user_id`.
+
+    Kept as a module-level alias so existing call sites don't need a
+    sweeping rename; the lifted helper is the canonical version
+    (shared with the node side since P1.5).
+    """
+    from turnstone.core.web_helpers import auth_user_id
+
+    return auth_user_id(request)
 
 
 def _auth_scopes(request: Request) -> set[str]:
@@ -10103,15 +10110,23 @@ def create_app(
     ) -> tuple[str, JSONResponse | None]:
         """Resolve the attachment owner for a coord ws_id.
 
-        Mirrors interactive's resolver: prefers the in-memory ws's
-        ``user_id`` (the operator who created the coord), falls back
-        to the persisted row owner, returns 404 when neither is found.
+        Kind-strict — only resolves through ``coord_mgr.get(ws_id)``
+        and DOES NOT fall back to storage. This keeps an
+        ``admin.coordinator``-scoped caller from reading or mutating
+        attachments on **interactive** workstreams via the coord
+        attachment endpoints: the storage row for an interactive ws
+        would otherwise resolve cleanly through the generic
+        ``get_workstream_owner`` storage call (which doesn't filter
+        by kind), granting cross-kind access. Persisted-but-not-loaded
+        coordinators must be ``open``ed before they can accept
+        attachment operations.
         """
-        from turnstone.core.web_helpers import resolve_workstream_owner
+        from turnstone.core.web_helpers import auth_user_id
 
-        return resolve_workstream_owner(
-            request, ws_id, mgr=mgr, not_found_label="coordinator not found"
-        )
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return "", JSONResponse({"error": "coordinator not found"}, status_code=404)
+        return ws.user_id or auth_user_id(request), None
 
     from turnstone.core.attachments import (
         classify_text_attachment as _coord_classify_text,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -838,6 +838,17 @@
       case "rename":
         nameEl.textContent = ev.name || "";
         break;
+      case "message_queued":
+        // Live-worker reuse path: send appended to the running
+        // worker's pending queue rather than spawning a new one.
+        // Surface as an info row so operators see queueing happen
+        // instead of dropping the event silently.
+        appendText(
+          "info",
+          "Queued (priority: " + (ev.priority || "normal") + ")",
+          { label: "queued" },
+        );
+        break;
       case "tools_auto_approved":
         (ev.items || []).forEach((it) => appendToolCall(it));
         break;

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1573,10 +1573,48 @@
       );
       (hist.messages || []).forEach((m) => {
         const role = m.role || "tool";
-        const content =
-          typeof m.content === "string"
-            ? m.content
-            : JSON.stringify(m.content || "");
+        // User messages with attachments arrive as multipart list
+        // content (text + image_url/document parts) and may carry an
+        // ``_attachments_meta`` side-channel with display metadata.
+        // Extract the text portion + attachment count for a readable
+        // history replay; chip-rendering parity with the interactive
+        // pane is deferred (the coord dashboard is diagnostic-leaning
+        // — primary use is monitoring, not authoring).
+        let content;
+        let attachmentCount = 0;
+        if (typeof m.content === "string") {
+          content = m.content;
+        } else if (Array.isArray(m.content)) {
+          const textParts = [];
+          for (const part of m.content) {
+            if (!part || typeof part !== "object") continue;
+            if (part.type === "text") {
+              textParts.push(String(part.text || ""));
+            } else if (part.type === "image_url" || part.type === "document") {
+              attachmentCount += 1;
+            }
+          }
+          content = textParts.join("\n");
+        } else {
+          content = JSON.stringify(m.content || "");
+        }
+        const meta = Array.isArray(m._attachments_meta)
+          ? m._attachments_meta
+          : null;
+        if (meta && meta.length > attachmentCount) {
+          // Prefer the side-channel count when present — it covers
+          // attachments whose multipart parts couldn't be reconstructed.
+          attachmentCount = meta.length;
+        }
+        if (attachmentCount > 0) {
+          const noun = attachmentCount === 1 ? "attachment" : "attachments";
+          content =
+            (content ? content + "\n\n" : "") +
+            "📎 " +
+            attachmentCount +
+            " " +
+            noun;
+        }
         if (!content) return;
         if (role === "tool") {
           appendToolResult(

--- a/turnstone/core/attachments.py
+++ b/turnstone/core/attachments.py
@@ -1,7 +1,19 @@
-"""Attachment data types for user-uploaded files bound to a workstream turn."""
+"""Attachment data types + upload-classification helpers for user-uploaded files
+bound to a workstream turn.
+
+The image-sniff / text-classify / per-(ws,user) upload-lock helpers
+live here (rather than in ``turnstone/server.py``) so the console
+process can wire them into the lifted attachment endpoints for the
+coordinator surface without depending on the node-side server module.
+The classification policy is intentionally kind-agnostic — the same
+type allowlist applies on both processes.
+"""
 
 from __future__ import annotations
 
+import collections
+import os
+import threading
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,6 +54,138 @@ class Attachment:
     @property
     def is_text(self) -> bool:
         return self.kind == "text"
+
+
+# ---------------------------------------------------------------------------
+# Per-(ws, user) upload lock cache
+# ---------------------------------------------------------------------------
+# Soft cap on the upload-lock cache. Locks are evicted opportunistically
+# when an upload completes (see ``upload_lock``); a held lock means an
+# upload is in flight, never evicted.
+_ATTACHMENT_UPLOAD_LOCKS_MAX: int = 1024
+_attachment_upload_locks: collections.OrderedDict[tuple[str, str], threading.Lock] = (
+    collections.OrderedDict()
+)
+_attachment_upload_locks_mx: threading.Lock = threading.Lock()
+
+
+def upload_lock(ws_id: str, user_id: str) -> threading.Lock:
+    """Return (and track) the per-(ws, user) upload mutex.
+
+    Called at the start of every attachment upload to serialize the
+    pending-cap check + save sequence per (ws, user) — concurrent
+    uploads can't both pass a check that sees ``count == cap-1``.
+    Process-local cache; bounded eviction skips held locks.
+    """
+    key = (ws_id, user_id)
+    with _attachment_upload_locks_mx:
+        lock = _attachment_upload_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _attachment_upload_locks[key] = lock
+        else:
+            # Touch for LRU
+            _attachment_upload_locks.move_to_end(key)
+        # Opportunistic eviction once we exceed the soft cap. Skip
+        # held locks (an upload is in flight under that key).
+        if len(_attachment_upload_locks) > _ATTACHMENT_UPLOAD_LOCKS_MAX:
+            for stale_key in list(_attachment_upload_locks):
+                if len(_attachment_upload_locks) <= _ATTACHMENT_UPLOAD_LOCKS_MAX:
+                    break
+                if stale_key == key:
+                    continue  # never evict the lock we're handing out
+                stale = _attachment_upload_locks[stale_key]
+                # threading.Lock has no public locked() — use the
+                # non-blocking acquire-and-release probe instead.
+                if stale.acquire(blocking=False):
+                    stale.release()
+                    del _attachment_upload_locks[stale_key]
+        return lock
+
+
+# ---------------------------------------------------------------------------
+# Upload classification
+# ---------------------------------------------------------------------------
+_TEXT_ATTACHMENT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".c",
+        ".conf",
+        ".cpp",
+        ".css",
+        ".go",
+        ".h",
+        ".hpp",
+        ".html",
+        ".ini",
+        ".java",
+        ".js",
+        ".json",
+        ".jsx",
+        ".md",
+        ".py",
+        ".rs",
+        ".sh",
+        ".sql",
+        ".toml",
+        ".ts",
+        ".tsx",
+        ".txt",
+        ".xml",
+        ".yaml",
+        ".yml",
+    }
+)
+
+
+def sniff_image_mime(data: bytes) -> str | None:
+    """Return a canonical image MIME type by inspecting magic bytes.
+
+    Returns ``None`` if the bytes don't match any supported image
+    format. Do not trust the client-provided ``Content-Type`` alone.
+    """
+    if len(data) < 12:
+        return None
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def classify_text_attachment(
+    filename: str, claimed_mime: str, data: bytes
+) -> tuple[str | None, str | None]:
+    """Return ``(canonical_mime, error)`` for a candidate text upload.
+
+    Accepts MIMEs starting with ``text/`` or in an application allowlist,
+    OR a filename with a known text-file extension. The payload must
+    decode as UTF-8. Returns ``(None, error_message)`` on rejection.
+    """
+    allowed_app_mimes = {
+        "application/json",
+        "application/xml",
+        "application/x-yaml",
+        "application/yaml",
+        "application/toml",
+    }
+    mime_ok = claimed_mime.startswith("text/") or claimed_mime in allowed_app_mimes
+    ext_ok = os.path.splitext(filename)[1].lower() in _TEXT_ATTACHMENT_EXTENSIONS
+    if not (mime_ok or ext_ok):
+        return None, (
+            f"Unsupported file type: {claimed_mime or 'unknown'} (filename: {filename!r})"
+        )
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None, "Text attachment is not valid UTF-8"
+    # Normalize MIME — prefer the claimed one if sensible, else text/plain.
+    if mime_ok and claimed_mime:
+        return claimed_mime, None
+    return "text/plain", None
 
 
 def unreadable_placeholder(filename: str) -> dict[str, Any]:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -819,6 +819,29 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             queue_outcome["priority"] = priority
             queue_outcome["msg_id"] = msg_id
 
+        def _emit_ui(hook_name: str, *args: Any) -> None:
+            """Best-effort UI hook dispatch.
+
+            Each call is wrapped in try/except so a failure in one
+            hook (e.g. listener-queue full → on_error raises) doesn't
+            suppress the others. Mirrors the pre-P1.5
+            coord_adapter.send per-hook defense.
+            """
+            if ui is None:
+                return
+            method = getattr(ui, hook_name, None)
+            if method is None:
+                return
+            try:
+                method(*args)
+            except Exception:
+                log.debug(
+                    "ws.send.ui_hook_failed ws=%s hook=%s",
+                    ws.id[:8] if ws.id else "",
+                    hook_name,
+                    exc_info=True,
+                )
+
         def _run() -> None:
             me = threading.current_thread()
             try:
@@ -833,19 +856,23 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 # If this thread was force-abandoned, ws.worker_thread
                 # was set to None — don't emit spurious events.
                 _release_reservation_on_fail()
-                if ws.worker_thread is me and ui is not None:
-                    ui.on_stream_end()
-                    ui.on_state_change("idle")
-            except Exception as e:
+                if ws.worker_thread is me:
+                    _emit_ui("on_stream_end")
+                    _emit_ui("on_state_change", "idle")
+            except Exception as exc:
                 # Release the reservation so attachments don't stay
                 # soft-locked forever on a worker crash before the
                 # consume step. Idempotent: once consume cleared the
                 # token, a follow-up unreserve is a no-op.
                 _release_reservation_on_fail()
-                if ws.worker_thread is me and ui is not None:
-                    ui.on_error(f"Error: {e}")
-                    ui.on_stream_end()
-                    ui.on_state_change("error")
+                if ws.worker_thread is me:
+                    # ``type(exc).__name__: msg`` carries the exception
+                    # class — coord operators triaging worker failures
+                    # rely on the class name to disambiguate (model-
+                    # alias misconfig vs. tool-policy reject vs. etc.).
+                    _emit_ui("on_error", f"{type(exc).__name__}: {exc}")
+                    _emit_ui("on_stream_end")
+                    _emit_ui("on_state_change", "error")
 
         ok = session_worker.send(
             ws,
@@ -1150,7 +1177,11 @@ def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
                 return err_tenant
 
         ws = mgr.get(ws_id)
-        if ws is None:
+        if ws is None or ws.ui is None:
+            # ``ws.ui is None`` mirrors the pre-P1.5 ``_get_ws`` check —
+            # a workstream observed during a partial-construction or
+            # close window can have no UI; dequeue would otherwise
+            # answer for a session whose listener queues are gone.
             return JSONResponse({"error": cfg.not_found_label}, status_code=404)
         if ws.session is None:
             return JSONResponse({"error": "No session"}, status_code=400)

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -114,10 +114,13 @@ class SessionEndpointConfig:
       503 when the subsystem isn't available (coord on a console
       without configured models). For interactive the lookup just
       returns ``(app.state.workstreams, None)``.
-    - ``tenant_check``: per-``ws_id`` cross-tenant guard. Interactive
-      uses ``_require_ws_access`` (404 on owner mismatch); coord
-      relies on the cluster-wide ``admin.coordinator`` scope from
-      ``permission_gate`` and sets this to ``None``.
+    - ``tenant_check``: per-``ws_id`` existence + access gate.
+      Interactive wires :func:`_require_ws_access` (which 404s when
+      the workstream doesn't exist; row-level ownership is NOT
+      enforced — turnstone is a trusted-team tool, ``admin.workstreams``
+      scope is the cluster-wide gate). Coord sets this to ``None``
+      and relies on ``admin.coordinator`` from ``permission_gate``
+      plus an in-memory ``coord_mgr`` lookup at handler time.
     - ``not_found_label``: the message body for the 404 returned when
       the manager has no such ws_id ("Workstream not found" for
       interactive; "coordinator not found" for coord).
@@ -619,16 +622,23 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
 
     Capability flags on ``cfg`` toggle the kind-specific behaviour:
 
-    - ``supports_attachments``: when ``False``, attachment-resolution
-      logic short-circuits and the handler accepts only
-      ``{"message": ...}``.
+    - ``supports_attachments``: when ``False``, the entire
+      attachment-resolution block (reservation, fetch, scope-check)
+      short-circuits and any ``attachment_ids`` in the body are
+      silently ignored — no reservation, no error. Both kinds wire
+      ``True`` post-P1.5; the flag exists so a kind that hasn't
+      lit up its UI surface yet can defer.
     - ``spawn_metrics``: when set, fires once on the spawn path with
       ``(request, ui)``. Interactive wires its WebUI per-conversation
       counters here; coord wires ``None``.
     - ``emit_message_queued``: when ``True``, the queue-reuse path
       pushes a ``message_queued`` event onto the listener queue.
 
-    Response shape (both kinds, P1.5 onwards):
+    Response shape (both kinds, P1.5 onwards). Every successful
+    response carries ``attached_ids`` and ``dropped_attachment_ids``
+    (empty lists when no attachments are involved), so SDK
+    consumers don't have to branch on whether the request had
+    attachments:
 
     - 200 ``{"status": "ok", "attached_ids", "dropped_attachment_ids"}``
       — fresh worker spawned. ``attached_ids`` is the subset of
@@ -637,8 +647,11 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     - 200 ``{"status": "queued", "priority", "msg_id", "attached_ids",
       "dropped_attachment_ids"}`` — reused live worker; queued for
       injection at the next tool-result seam.
-    - 200 ``{"status": "queue_full"}`` — live worker's queue at
-      capacity. Caller should retry.
+    - 200 ``{"status": "queue_full", "attached_ids",
+      "dropped_attachment_ids"}`` — live worker's queue at
+      capacity; reservations released. Caller should retry. The
+      ``attached_ids`` list is always empty here (the dispatch
+      didn't take ownership of any reservations).
     - 4xx / 500 — auth / not-found / no-session per the usual
       :class:`SessionEndpointConfig` semantics.
     """
@@ -882,9 +895,19 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         )
         if not ok:
             # queue.Full or session-disappeared race — surface as
-            # queue_full so clients retry rather than 500.
+            # queue_full so clients retry rather than 500. Reservations
+            # released above; ``attached_ids`` is always empty on this
+            # path (the dispatch never took ownership). The empty
+            # arrays preserve the response-shape guarantee so SDK
+            # consumers don't branch on status.
             _release_reservation_on_fail()
-            return JSONResponse({"status": "queue_full"})
+            return JSONResponse(
+                {
+                    "status": "queue_full",
+                    "attached_ids": [],
+                    "dropped_attachment_ids": list(requested_ids),
+                }
+            )
 
         dropped = [aid for aid in requested_ids if aid not in reserved_set]
         if queue_outcome:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -58,6 +58,39 @@ TenantCheck = Callable[
     ["Request", str, "SessionManager"],
     "JSONResponse | None",
 ]
+# (request, ws_id, mgr) -> (owner_user_id, error_response). Owner is
+# the user_id attachments are filed under; error is a 404 when the ws
+# doesn't exist anywhere (memory or storage).
+AttachmentOwnerResolver = Callable[
+    ["Request", str, "SessionManager"],
+    tuple[str, "JSONResponse | None"],
+]
+# (request, ui) — kind's spawn-time bookkeeping. Interactive bumps
+# ``_metrics.record_message_sent`` + per-UI message counters; coord
+# has no analog and wires ``None``.
+SpawnMetricsHook = Callable[["Request", Any], None]
+
+
+@dataclass(frozen=True)
+class AttachmentUploadHelpers:
+    """Process-local hooks the lifted attachment factories call into.
+
+    The classification + per-(ws,user) lock are stateful concerns that
+    don't belong on the (frozen) :class:`SessionEndpointConfig`
+    directly: ``sniff_image_mime`` and ``classify_text_attachment``
+    are pure but defined in the kind's owning module;
+    ``upload_lock`` returns a process-local cached lock. Bundling
+    them on a separate dataclass keeps the cfg declarative and lets
+    callers share one helper instance across kinds if the policies
+    converge later.
+    """
+
+    sniff_image_mime: Callable[[bytes], str | None]
+    classify_text_attachment: Callable[
+        [str, str, bytes],
+        tuple[str | None, str | None],
+    ]
+    upload_lock: Callable[[str, str], Any]
 
 
 @dataclass(frozen=True)
@@ -66,9 +99,10 @@ class SessionEndpointConfig:
 
     Instantiated once per process during app construction and passed
     to the verb factory (e.g. :func:`make_approve_handler`,
-    :func:`make_close_handler`), which captures it via closure. The
-    request-time handler reads ``cfg`` from the closure rather than
-    ``app.state`` so the dependency is visible at the wire-up site.
+    :func:`make_close_handler`, :func:`make_send_handler`), which
+    captures it via closure. The request-time handler reads ``cfg``
+    from the closure rather than ``app.state`` so the dependency is
+    visible at the wire-up site.
 
     - ``permission_gate``: kind's pre-handler permission check
       (e.g. ``admin.coordinator`` for coord, ``None`` for interactive
@@ -90,6 +124,28 @@ class SessionEndpointConfig:
     - ``audit_action_prefix``: the dot-namespaced prefix the kind
       uses for its audit actions ("workstream" → ``workstream.cancel``;
       "coordinator" → ``coordinator.cancel``).
+
+    Capability flags (added with the P1.5 ``send`` body lift):
+
+    - ``supports_attachments``: when ``True``, the lifted ``send``
+      handler resolves attachment_ids, reserves under a send_id token,
+      and threads them through ``ChatSession.send`` /
+      ``ChatSession.queue_message``. Both kinds wire ``True`` post-P1.5
+      (the storage layer was always kind-agnostic; the gate stays
+      around so a kind that hasn't lit up its UI surface yet can
+      defer the verb body changes).
+    - ``attachment_owner_resolver``: resolves the ``user_id`` to scope
+      attachments under for a given request + ws_id. Required when
+      ``supports_attachments`` is ``True``.
+    - ``spawn_metrics``: optional bookkeeping hook fired once per
+      ``send`` that spawns a fresh worker (queue-reuse path skips it).
+      Interactive wires its WebUI per-conversation counters; coord
+      wires ``None``.
+    - ``emit_message_queued``: when ``True`` and the dispatcher takes
+      the live-worker enqueue path, the lifted body emits a
+      ``message_queued`` event onto the workstream's listener queue
+      via ``ui._enqueue``. Both kinds wire ``True`` since both UIs
+      have a listener queue.
     """
 
     permission_gate: PermissionGate | None
@@ -97,6 +153,11 @@ class SessionEndpointConfig:
     tenant_check: TenantCheck | None
     not_found_label: str
     audit_action_prefix: str
+    supports_attachments: bool = False
+    attachment_owner_resolver: AttachmentOwnerResolver | None = None
+    attachment_helpers: AttachmentUploadHelpers | None = None
+    spawn_metrics: SpawnMetricsHook | None = None
+    emit_message_queued: bool = True
 
 
 @dataclass(frozen=True)
@@ -544,3 +605,556 @@ def make_close_handler(
         return JSONResponse({"status": "ok"})
 
     return close
+
+
+def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/send`` — message dispatch.
+
+    Reserves any attachment ids the request carries, captures a
+    ``send_id`` token for end-to-end tracking, then dispatches via
+    :func:`turnstone.core.session_worker.send` (atomic
+    spawn-or-enqueue under ``ws._lock``). Both queue-reuse and
+    spawn paths reserve so the eventual ``mark_attachments_consumed``
+    can match on ``reserved_for_msg_id``.
+
+    Capability flags on ``cfg`` toggle the kind-specific behaviour:
+
+    - ``supports_attachments``: when ``False``, attachment-resolution
+      logic short-circuits and the handler accepts only
+      ``{"message": ...}``.
+    - ``spawn_metrics``: when set, fires once on the spawn path with
+      ``(request, ui)``. Interactive wires its WebUI per-conversation
+      counters here; coord wires ``None``.
+    - ``emit_message_queued``: when ``True``, the queue-reuse path
+      pushes a ``message_queued`` event onto the listener queue.
+
+    Response shape (both kinds, P1.5 onwards):
+
+    - 200 ``{"status": "ok", "attached_ids", "dropped_attachment_ids"}``
+      — fresh worker spawned. ``attached_ids`` is the subset of
+      requested attachments that landed (may be a strict subset on
+      reservation race losses).
+    - 200 ``{"status": "queued", "priority", "msg_id", "attached_ids",
+      "dropped_attachment_ids"}`` — reused live worker; queued for
+      injection at the next tool-result seam.
+    - 200 ``{"status": "queue_full"}`` — live worker's queue at
+      capacity. Caller should retry.
+    - 4xx / 500 — auth / not-found / no-session per the usual
+      :class:`SessionEndpointConfig` semantics.
+    """
+    import asyncio
+    import threading
+    import uuid
+
+    from turnstone.core import session_worker
+    from turnstone.core.session import GenerationCancelled
+    from turnstone.core.web_helpers import read_json_or_400
+
+    async def send(request: Request) -> Response:
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        mgr = cast("SessionManager", mgr_opt)
+
+        body = await read_json_or_400(request)
+        if isinstance(body, JSONResponse):
+            return body
+
+        ws_id = request.path_params.get("ws_id", "")
+        message = (body.get("message") or "").strip()
+        if not message:
+            return JSONResponse({"error": "message is required"}, status_code=400)
+
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        ui = ws.ui
+        if ui is None:
+            return JSONResponse({"error": "session UI not available"}, status_code=409)
+
+        # ----- Attachment reservation (atomic reserve-then-dispatch) -----
+        send_id = ""
+        requested_ids: list[str] = []
+        ordered_reserved: list[str] = []
+        reserved_set: set[str] = set()
+        reserved_ids: list[str] = []
+        resolved_atts: list[Any] = []
+        attach_user_id = ""
+
+        if cfg.supports_attachments:
+            from turnstone.core.attachments import (
+                MAX_PENDING_ATTACHMENTS_PER_USER_WS,
+                Attachment,
+            )
+            from turnstone.core.memory import (
+                get_attachments as _get_attachments,
+            )
+            from turnstone.core.memory import (
+                get_pending_attachments_with_content as _get_pending_with_content,
+            )
+            from turnstone.core.memory import (
+                reserve_attachments as _reserve,
+            )
+
+            if cfg.attachment_owner_resolver is None:
+                # Mis-wired config — the resolver is mandatory when
+                # attachments are enabled. Fail loudly rather than
+                # silently filing under the wrong owner.
+                return JSONResponse({"error": "attachment_owner_resolver missing"}, status_code=500)
+            attach_user_id, owner_err = cfg.attachment_owner_resolver(request, ws_id, mgr)
+            if owner_err is not None:
+                return owner_err
+
+            send_id = uuid.uuid4().hex
+            raw_ids = body.get("attachment_ids")
+            auto_consume_rows: list[dict[str, Any]] = []
+            if raw_ids is None:
+                # Auto-consume: pull the caller's pending (unreserved)
+                # rows in creation order — bytes included so we skip
+                # a second fetch below.
+                auto_consume_rows = _get_pending_with_content(ws_id, attach_user_id)
+                requested_ids = [str(r["attachment_id"]) for r in auto_consume_rows]
+            elif isinstance(raw_ids, list) and raw_ids:
+                if len(raw_ids) > MAX_PENDING_ATTACHMENTS_PER_USER_WS:
+                    return JSONResponse(
+                        {
+                            "error": (
+                                f"Too many attachment_ids "
+                                f"(max {MAX_PENDING_ATTACHMENTS_PER_USER_WS})"
+                            ),
+                            "code": "too_many",
+                        },
+                        status_code=400,
+                    )
+                requested_ids = [str(x) for x in raw_ids if x]
+
+            reserved_ids = (
+                _reserve(requested_ids, send_id, ws_id, attach_user_id) if requested_ids else []
+            )
+            reserved_set = set(reserved_ids)
+            ordered_reserved = [aid for aid in requested_ids if aid in reserved_set]
+
+            if ordered_reserved:
+                if auto_consume_rows and all(
+                    str(r["attachment_id"]) in reserved_set for r in auto_consume_rows
+                ):
+                    rows_by_id = {str(r["attachment_id"]): r for r in auto_consume_rows}
+                    # reserved_for_msg_id was None at pre-fetch; patch
+                    # in the token so the scope check below admits the
+                    # rows we just reserved.
+                    for r in rows_by_id.values():
+                        r["reserved_for_msg_id"] = send_id
+                else:
+                    rows = _get_attachments(ordered_reserved)
+                    rows_by_id = {str(r["attachment_id"]): r for r in rows}
+                for aid in ordered_reserved:
+                    row = rows_by_id.get(aid)
+                    if not row:
+                        continue
+                    # Belt-and-braces scope check on top of the reservation.
+                    if (
+                        row.get("ws_id") != ws_id
+                        or row.get("user_id") != attach_user_id
+                        or row.get("message_id") is not None
+                        or row.get("reserved_for_msg_id") != send_id
+                    ):
+                        continue
+                    content = row.get("content")
+                    if not isinstance(content, bytes):
+                        continue
+                    resolved_atts.append(
+                        Attachment(
+                            attachment_id=str(row["attachment_id"]),
+                            filename=str(row.get("filename") or ""),
+                            mime_type=str(row.get("mime_type") or "application/octet-stream"),
+                            kind=str(row.get("kind") or ""),
+                            content=content,
+                        )
+                    )
+
+        def _release_reservation_on_fail() -> None:
+            """Unreserve if we bail before the dispatcher takes ownership."""
+            if reserved_ids:
+                from turnstone.core.memory import (
+                    unreserve_attachments as _unreserve,
+                )
+
+                _unreserve(send_id, ws_id, attach_user_id)
+
+        # If a cancel was just issued, briefly poll for the worker to
+        # exit before dispatching — avoids spawning into a stale
+        # worker. ``_worker_running`` flips False under ws._lock when
+        # the thread reaches its finally block (same gate the
+        # dispatcher uses). Async sleep keeps the event loop free.
+        if ws._worker_running and ws.session and ws.session._cancel_event.is_set():
+            for _ in range(30):  # up to 3s in 100ms steps
+                await asyncio.sleep(0.1)
+                if not ws._worker_running:
+                    break
+        if ws.session is None:
+            _release_reservation_on_fail()
+            return JSONResponse({"error": "No session"}, status_code=500)
+
+        session = ws.session
+        # Captured by ``_enqueue`` only when the dispatcher takes the
+        # live-worker reuse path. Empty after a fresh-spawn dispatch.
+        queue_outcome: dict[str, Any] = {}
+
+        def _enqueue() -> None:
+            cleaned, priority, msg_id = session.queue_message(
+                message,
+                attachment_ids=list(ordered_reserved),
+                queue_msg_id=send_id or None,
+            )
+            queue_outcome["cleaned"] = cleaned
+            queue_outcome["priority"] = priority
+            queue_outcome["msg_id"] = msg_id
+
+        def _run() -> None:
+            me = threading.current_thread()
+            try:
+                kwargs: dict[str, Any] = {}
+                if resolved_atts:
+                    kwargs["attachments"] = resolved_atts
+                if send_id:
+                    kwargs["send_id"] = send_id
+                session.send(message, **kwargs)
+            except GenerationCancelled:
+                # Safety net — send() normally handles this internally.
+                # If this thread was force-abandoned, ws.worker_thread
+                # was set to None — don't emit spurious events.
+                _release_reservation_on_fail()
+                if ws.worker_thread is me and ui is not None:
+                    ui.on_stream_end()
+                    ui.on_state_change("idle")
+            except Exception as e:
+                # Release the reservation so attachments don't stay
+                # soft-locked forever on a worker crash before the
+                # consume step. Idempotent: once consume cleared the
+                # token, a follow-up unreserve is a no-op.
+                _release_reservation_on_fail()
+                if ws.worker_thread is me and ui is not None:
+                    ui.on_error(f"Error: {e}")
+                    ui.on_stream_end()
+                    ui.on_state_change("error")
+
+        ok = session_worker.send(
+            ws,
+            enqueue=_enqueue,
+            run=_run,
+            thread_name=f"send-worker-{ws.id[:8]}",
+        )
+        if not ok:
+            # queue.Full or session-disappeared race — surface as
+            # queue_full so clients retry rather than 500.
+            _release_reservation_on_fail()
+            return JSONResponse({"status": "queue_full"})
+
+        dropped = [aid for aid in requested_ids if aid not in reserved_set]
+        if queue_outcome:
+            # Reused a live worker; ``queue_message`` succeeded.
+            if cfg.emit_message_queued and hasattr(ui, "_enqueue"):
+                ui._enqueue(
+                    {
+                        "type": "message_queued",
+                        "message": queue_outcome["cleaned"],
+                        "priority": queue_outcome["priority"],
+                        "msg_id": queue_outcome["msg_id"],
+                    }
+                )
+            return JSONResponse(
+                {
+                    "status": "queued",
+                    "priority": queue_outcome["priority"],
+                    "msg_id": queue_outcome["msg_id"],
+                    "attached_ids": list(ordered_reserved),
+                    "dropped_attachment_ids": dropped,
+                }
+            )
+
+        # Spawned a fresh worker — kind's metrics fire once per turn.
+        if cfg.spawn_metrics is not None:
+            try:
+                cfg.spawn_metrics(request, ui)
+            except Exception:
+                log.debug(
+                    "ws.send.spawn_metrics_failed ws=%s",
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+        return JSONResponse(
+            {
+                "status": "ok",
+                "attached_ids": list(ordered_reserved),
+                "dropped_attachment_ids": dropped,
+            }
+        )
+
+    return send
+
+
+def make_attachment_handlers(cfg: SessionEndpointConfig) -> AttachmentHandlers:
+    """Lifted bodies for the four per-workstream attachment endpoints.
+
+    Both kinds share the storage layer
+    (:mod:`turnstone.core.memory` calls are kind-agnostic) and the
+    same per-(``ws_id``, ``user_id``) scope semantics. Differences
+    factor into ``cfg.permission_gate`` (auth) and
+    ``cfg.attachment_owner_resolver`` (scope + 404 mask).
+
+    ``cfg.supports_attachments`` is checked at registration time —
+    callers should only invoke this factory when it's ``True``. The
+    factory still returns four working handlers if you call it
+    otherwise; they'll just no-op-with-500 when
+    ``attachment_owner_resolver`` is unset.
+    """
+    import uuid
+
+    async def _gate(request: Request) -> JSONResponse | None:
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        return None
+
+    async def _resolve_owner(request: Request, ws_id: str) -> tuple[str, JSONResponse | None]:
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return "", err503
+        mgr = cast("SessionManager", mgr_opt)
+        if cfg.attachment_owner_resolver is None:
+            return "", JSONResponse({"error": "attachment_owner_resolver missing"}, status_code=500)
+        return cfg.attachment_owner_resolver(request, ws_id, mgr)
+
+    async def upload(request: Request) -> Response:
+        from turnstone.core.attachments import (
+            IMAGE_SIZE_CAP,
+            MAX_PENDING_ATTACHMENTS_PER_USER_WS,
+            TEXT_DOC_SIZE_CAP,
+        )
+        from turnstone.core.memory import list_pending_attachments, save_attachment
+        from turnstone.core.web_helpers import read_multipart_file_or_400
+
+        # Sniffing helpers stay kind-specific because they're tied to
+        # the file-classification policy table; defer to the cfg's
+        # owning module via the upload-helper hook.
+        if cfg.attachment_helpers is None:
+            return JSONResponse({"error": "attachment_helpers missing"}, status_code=500)
+        sniff_image = cfg.attachment_helpers.sniff_image_mime
+        classify_text = cfg.attachment_helpers.classify_text_attachment
+        upload_lock = cfg.attachment_helpers.upload_lock
+
+        err_gate = await _gate(request)
+        if err_gate is not None:
+            return err_gate
+
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        user_id, err = await _resolve_owner(request, ws_id)
+        if err:
+            return err
+
+        got = await read_multipart_file_or_400(request, field="file", max_bytes=IMAGE_SIZE_CAP)
+        if isinstance(got, JSONResponse):
+            return got
+        filename, claimed_mime, data = got
+        if not data:
+            return JSONResponse({"error": "Empty file"}, status_code=400)
+
+        sniffed_image = sniff_image(data)
+        if sniffed_image is not None:
+            if len(data) > IMAGE_SIZE_CAP:
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Image too large ({len(data):,} bytes); "
+                            f"cap is {IMAGE_SIZE_CAP:,} bytes."
+                        ),
+                        "code": "too_large",
+                    },
+                    status_code=413,
+                )
+            kind = "image"
+            mime = sniffed_image
+        else:
+            if len(data) > TEXT_DOC_SIZE_CAP:
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Text document too large ({len(data):,} bytes); "
+                            f"cap is {TEXT_DOC_SIZE_CAP:,} bytes."
+                        ),
+                        "code": "too_large",
+                    },
+                    status_code=413,
+                )
+            mime_or_err = classify_text(filename, claimed_mime, data)
+            if mime_or_err[0] is None:
+                return JSONResponse(
+                    {"error": mime_or_err[1], "code": "unsupported"}, status_code=400
+                )
+            kind = "text"
+            mime = mime_or_err[0]
+
+        # Serialize count-check + save per (ws, user) so concurrent
+        # uploads can't both pass a check that sees count == cap-1.
+        lock = upload_lock(ws_id, user_id)
+        with lock:
+            if len(list_pending_attachments(ws_id, user_id)) >= MAX_PENDING_ATTACHMENTS_PER_USER_WS:
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Too many pending attachments "
+                            f"(max {MAX_PENDING_ATTACHMENTS_PER_USER_WS} pending per workstream)"
+                        ),
+                        "code": "too_many",
+                    },
+                    status_code=409,
+                )
+            attachment_id = uuid.uuid4().hex
+            save_attachment(attachment_id, ws_id, user_id, filename, mime, len(data), kind, data)
+        return JSONResponse(
+            {
+                "attachment_id": attachment_id,
+                "filename": filename,
+                "mime_type": mime,
+                "size_bytes": len(data),
+                "kind": kind,
+            }
+        )
+
+    async def list_pending(request: Request) -> Response:
+        from turnstone.core.memory import list_pending_attachments
+
+        err_gate = await _gate(request)
+        if err_gate is not None:
+            return err_gate
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+        user_id, err = await _resolve_owner(request, ws_id)
+        if err:
+            return err
+        rows = list_pending_attachments(ws_id, user_id)
+        return JSONResponse({"attachments": rows})
+
+    async def get_content(request: Request) -> Response:
+        from starlette.responses import Response as _Response
+
+        from turnstone.core.memory import get_attachment
+
+        err_gate = await _gate(request)
+        if err_gate is not None:
+            return err_gate
+        ws_id = request.path_params.get("ws_id", "")
+        attachment_id = request.path_params.get("attachment_id", "")
+        if not ws_id or not attachment_id:
+            return JSONResponse({"error": "ws_id and attachment_id are required"}, status_code=400)
+        user_id, err = await _resolve_owner(request, ws_id)
+        if err:
+            return err
+        row = get_attachment(attachment_id)
+        # Scope on user_id too — id-guessing across users in an
+        # unowned workstream would otherwise leak blobs. Mask
+        # cross-user / cross-ws as 404 to avoid leaking existence.
+        if not row or row.get("ws_id") != ws_id or row.get("user_id") != user_id:
+            return JSONResponse({"error": "Not found"}, status_code=404)
+        body = row.get("content") or b""
+        kind = row.get("kind") or ""
+        stored_mime = row.get("mime_type") or "application/octet-stream"
+        filename = str(row.get("filename") or "attachment")
+        # Force text/plain for text kinds — avoids same-origin HTML/SVG
+        # rendering if a user uploaded an HTML-ish text file. Images
+        # keep their sniffed MIME (allowlist is strict: png/jpeg/gif/webp).
+        response_mime = "text/plain; charset=utf-8" if kind == "text" else stored_mime
+        safe_name = filename.replace('"', "").replace("\r", "").replace("\n", "")
+        headers = {
+            "X-Content-Type-Options": "nosniff",
+            "Content-Security-Policy": "default-src 'none'; sandbox",
+            "Content-Disposition": f'inline; filename="{safe_name}"',
+            "Cache-Control": "private, no-store",
+        }
+        return _Response(body, media_type=response_mime, headers=headers)
+
+    async def delete_(request: Request) -> Response:
+        from turnstone.core.memory import delete_attachment as _delete
+
+        err_gate = await _gate(request)
+        if err_gate is not None:
+            return err_gate
+        ws_id = request.path_params.get("ws_id", "")
+        attachment_id = request.path_params.get("attachment_id", "")
+        if not ws_id or not attachment_id:
+            return JSONResponse({"error": "ws_id and attachment_id are required"}, status_code=400)
+        user_id, err = await _resolve_owner(request, ws_id)
+        if err:
+            return err
+        deleted = _delete(attachment_id, ws_id, user_id)
+        if not deleted:
+            return JSONResponse({"error": "Not found"}, status_code=404)
+        return JSONResponse({"status": "deleted"})
+
+    return AttachmentHandlers(
+        upload=upload,
+        list=list_pending,
+        get_content=get_content,
+        delete=delete_,
+    )
+
+
+def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``DELETE {prefix}/{ws_id}/send`` — cancel a queued message.
+
+    Removes a previously-queued message identified by ``msg_id`` from
+    the workstream's pending queue. Returns ``status: removed`` when
+    the queue had the entry and ``status: not_found`` otherwise.
+    Reservations attached to the dequeued message are released by
+    ``ChatSession.dequeue_message`` so attachments can be reused.
+    """
+    from turnstone.core.web_helpers import read_json_or_400
+
+    async def dequeue(request: Request) -> Response:
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        mgr = cast("SessionManager", mgr_opt)
+
+        body = await read_json_or_400(request)
+        if isinstance(body, JSONResponse):
+            return body
+        msg_id = body.get("msg_id")
+        if not msg_id:
+            return JSONResponse({"error": "msg_id required"}, status_code=400)
+
+        # ws_id may come from path (new path-keyed shape) or body
+        # (legacy /v1/api/send DELETE under the body-keyed adapter).
+        ws_id = request.path_params.get("ws_id", "") or str(body.get("ws_id") or "")
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        if ws.session is None:
+            return JSONResponse({"error": "No session"}, status_code=400)
+        removed = ws.session.dequeue_message(msg_id)
+        return JSONResponse({"status": "removed" if removed else "not_found"})
+
+    return dequeue

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -246,6 +246,63 @@ def require_storage_or_503(
     return storage, None
 
 
+def auth_user_id(request: Request) -> str:
+    """Return the authenticated user's id (empty string when absent).
+
+    Reads ``request.state.auth_result.user_id`` set by
+    :class:`AuthMiddleware`. Both node and console processes carry the
+    same ``AuthResult`` shape, so this helper is kind-agnostic — useful
+    for handlers lifted into :mod:`turnstone.core.session_routes`.
+    """
+    auth = getattr(getattr(request, "state", None), "auth_result", None)
+    return str(getattr(auth, "user_id", "") or "")
+
+
+def resolve_workstream_owner(
+    request: Request,
+    ws_id: str,
+    *,
+    mgr: Any | None = None,
+    not_found_label: str = "Workstream not found",
+) -> tuple[str, JSONResponse | None]:
+    """Resolve ``ws_id`` to its owner; 404 when the row doesn't exist.
+
+    Turnstone is a trusted-team tool: scope-level auth (e.g.
+    ``admin.workstreams`` / ``admin.coordinator``) is the only gate;
+    row-level ownership is not enforced here. Returns
+    ``(owner_user_id, None)`` on success — the persisted owner id,
+    which attachments should be filed under so existing storage shape
+    is preserved. Falls back to the caller's own uid when the row has
+    no recorded owner.
+
+    When ``mgr`` is provided and the workstream is live in memory,
+    trust its cached ``user_id`` instead of round-tripping storage —
+    keeps in-memory-only handlers functional during transient DB
+    outages and trims the hot-path by one query.
+
+    ``not_found_label`` is the message body the 404 carries — the
+    interactive surface uses "Workstream not found"; coord uses
+    "coordinator not found" so error strings stay readable per kind.
+    """
+    from starlette.responses import JSONResponse as _JSONResponse
+
+    caller = auth_user_id(request)
+
+    if mgr is not None:
+        ws_mem = mgr.get(ws_id)
+        if ws_mem is not None:
+            return ws_mem.user_id or caller, None
+        # Not in memory — fall through to storage so persisted-but-not-
+        # loaded rows still resolve.
+
+    from turnstone.core.memory import get_workstream_owner
+
+    owner = get_workstream_owner(ws_id)
+    if owner is None:
+        return "", _JSONResponse({"error": not_found_label}, status_code=404)
+    return owner or caller, None
+
+
 def parse_cors_origins() -> list[str] | None:
     """Parse ``TURNSTONE_CORS_ORIGINS`` env var into a list of origin strings.
 

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -330,6 +330,75 @@ class AsyncTurnstoneConsole(_BaseClient):
             response_model=StatusResponse,
         )
 
+    # -- coordinator workstreams (P1.5: parity with interactive) -------------
+    #
+    # These hit the console directly — coordinator workstreams live on
+    # the console process, no routing-proxy hop. URL shape mirrors
+    # interactive (``/v1/api/workstreams/{ws_id}/*``) since Stage 2 P0.
+
+    async def coordinator_send(
+        self,
+        ws_id: str,
+        message: str,
+        *,
+        attachment_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Send a message to a coordinator workstream.
+
+        ``attachment_ids`` reserves attachments under the message's
+        ``send_id`` token; pass ``None`` to auto-consume the caller's
+        pending attachments, or ``[]`` to disable auto-consume.
+        """
+        body: dict[str, Any] = {"message": message}
+        if attachment_ids is not None:
+            body["attachment_ids"] = attachment_ids
+        return await self._request("POST", f"/v1/api/workstreams/{ws_id}/send", json_body=body)
+
+    async def coordinator_upload_attachment(
+        self,
+        ws_id: str,
+        filename: str,
+        data: bytes,
+        *,
+        mime_type: str | None = None,
+    ) -> UploadAttachmentResponse:
+        """Upload a file attachment to a coordinator workstream."""
+        files: list[tuple[str, tuple[str, bytes, str]]] = [
+            (
+                "file",
+                (filename, data, mime_type or "application/octet-stream"),
+            )
+        ]
+        return await self._request(
+            "POST",
+            f"/v1/api/workstreams/{ws_id}/attachments",
+            files=files,
+            response_model=UploadAttachmentResponse,
+        )
+
+    async def coordinator_list_attachments(self, ws_id: str) -> ListAttachmentsResponse:
+        """List the caller's pending attachments for a coordinator workstream."""
+        return await self._request(
+            "GET",
+            f"/v1/api/workstreams/{ws_id}/attachments",
+            response_model=ListAttachmentsResponse,
+        )
+
+    async def coordinator_get_attachment_content(self, ws_id: str, attachment_id: str) -> bytes:
+        """Fetch the raw bytes of a coordinator attachment."""
+        return await self._request_bytes(
+            "GET",
+            f"/v1/api/workstreams/{ws_id}/attachments/{attachment_id}/content",
+        )
+
+    async def coordinator_delete_attachment(self, ws_id: str, attachment_id: str) -> StatusResponse:
+        """Delete a pending coordinator attachment."""
+        return await self._request(
+            "DELETE",
+            f"/v1/api/workstreams/{ws_id}/attachments/{attachment_id}",
+            response_model=StatusResponse,
+        )
+
     async def route_send(self, message: str, ws_id: str) -> dict[str, Any]:
         """Send a message via the routing proxy."""
         return await self._request(
@@ -1193,6 +1262,42 @@ class TurnstoneConsole:
 
     def route_send(self, message: str, ws_id: str) -> dict[str, Any]:
         return self._runner.run(self._async.route_send(message, ws_id))
+
+    # -- coordinator workstreams (P1.5: parity with interactive) -------------
+
+    def coordinator_send(
+        self,
+        ws_id: str,
+        message: str,
+        *,
+        attachment_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        return self._runner.run(
+            self._async.coordinator_send(ws_id, message, attachment_ids=attachment_ids)
+        )
+
+    def coordinator_upload_attachment(
+        self,
+        ws_id: str,
+        filename: str,
+        data: bytes,
+        *,
+        mime_type: str | None = None,
+    ) -> UploadAttachmentResponse:
+        return self._runner.run(
+            self._async.coordinator_upload_attachment(ws_id, filename, data, mime_type=mime_type)
+        )
+
+    def coordinator_list_attachments(self, ws_id: str) -> ListAttachmentsResponse:
+        return self._runner.run(self._async.coordinator_list_attachments(ws_id))
+
+    def coordinator_get_attachment_content(self, ws_id: str, attachment_id: str) -> bytes:
+        return self._runner.run(
+            self._async.coordinator_get_attachment_content(ws_id, attachment_id)
+        )
+
+    def coordinator_delete_attachment(self, ws_id: str, attachment_id: str) -> StatusResponse:
+        return self._runner.run(self._async.coordinator_delete_attachment(ws_id, attachment_id))
 
     # -- routing proxy: attachments -----------------------------------------
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2609,9 +2609,16 @@ async def set_workstream_title(request: Request, ws_id: str = "") -> JSONRespons
 
 
 def _auth_user_id(request: Request) -> str:
-    """Return the authenticated user's id (empty string when absent)."""
-    auth = getattr(getattr(request, "state", None), "auth_result", None)
-    return str(getattr(auth, "user_id", "") or "")
+    """Return the authenticated user's id (empty string when absent).
+
+    Thin shim over :func:`turnstone.core.web_helpers.auth_user_id` —
+    kept as a module-level alias so existing call sites don't need a
+    sweeping rename. The lifted helper is the canonical version
+    (shared by both kinds since P1.5).
+    """
+    from turnstone.core.web_helpers import auth_user_id
+
+    return auth_user_id(request)
 
 
 def _auth_scopes(request: Request) -> set[str]:
@@ -2656,36 +2663,16 @@ def _require_ws_access(
 ) -> tuple[str, JSONResponse | None]:
     """Resolve ``ws_id`` to its owner, 404-ing when the row doesn't exist.
 
-    Turnstone is a trusted-team tool: scope-level auth (e.g.
-    ``admin.workstreams``) is the only gate; row-level ownership is not
-    enforced here.  Returns ``(owner_user_id, None)`` on success — the
-    persisted owner id, which attachments should be filed under so
-    existing storage shape is preserved.  Falls back to the caller's
-    own uid when the row has no recorded owner.
-
-    When ``mgr`` is provided and the workstream is live in the manager,
-    trust its cached ``user_id`` instead of round-tripping storage —
-    keeps in-memory-only handlers (approve / plan / cancel / command /
-    close / SSE / title) functional during transient DB outages and
-    trims the hot-path by one query.  Handlers that act on
-    persisted-but-not-loaded workstreams (``/delete``, ``/open``) omit
-    ``mgr`` and fall through to the storage path.
+    Thin shim over :func:`turnstone.core.web_helpers.resolve_workstream_owner` —
+    kept as a module-level alias for the many existing callers.
+    Both helpers preserve the same trusted-team semantics: any
+    authenticated caller resolves to the row's recorded owner (with
+    fallback to caller uid on unowned rows). The lifted version is
+    the canonical implementation post-P1.5.
     """
-    caller = _auth_user_id(request)
+    from turnstone.core.web_helpers import resolve_workstream_owner
 
-    if mgr is not None:
-        ws_mem = mgr.get(ws_id)
-        if ws_mem is not None:
-            return ws_mem.user_id or caller, None
-        # Not in memory — fall through to storage so /delete etc.
-        # still resolve persisted-but-not-loaded rows.
-
-    from turnstone.core.memory import get_workstream_owner
-
-    owner = get_workstream_owner(ws_id)
-    if owner is None:
-        return "", JSONResponse({"error": "Workstream not found"}, status_code=404)
-    return owner or caller, None
+    return resolve_workstream_owner(request, ws_id, mgr=mgr, not_found_label="Workstream not found")
 
 
 async def open_workstream(request: Request) -> JSONResponse:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3854,9 +3854,18 @@ def create_app(
 
     def _interactive_spawn_metrics(_request: Request, ui: Any) -> None:
         """Per-conversation metrics fired once per send that spawns a
-        fresh worker. Coord wires ``None`` for this hook."""
+        fresh worker. Coord wires ``None`` for this hook.
+
+        The per-UI counters live on ``WebUI`` only — guard all three
+        attributes so a future ``SessionUI`` subclass without the
+        full counter set doesn't trip on the assignment.
+        """
         _metrics.record_message_sent()
-        if hasattr(ui, "_ws_lock") and hasattr(ui, "_ws_messages"):
+        if (
+            hasattr(ui, "_ws_lock")
+            and hasattr(ui, "_ws_messages")
+            and hasattr(ui, "_ws_turn_tool_calls")
+        ):
             with ui._ws_lock:
                 ui._ws_messages += 1
                 ui._ws_turn_tool_calls = 0

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import collections
 import contextlib
 import functools
 import hashlib
@@ -57,12 +56,15 @@ from turnstone.core.ratelimit import resolve_client_ip
 from turnstone.core.session import ChatSession, GenerationCancelled, SessionUI  # noqa: F401
 from turnstone.core.session_manager import SessionManager
 from turnstone.core.session_routes import (
-    AttachmentHandlers,
+    AttachmentUploadHelpers,
     SessionEndpointConfig,
     SharedSessionVerbHandlers,
     make_approve_handler,
+    make_attachment_handlers,
     make_close_handler,
+    make_dequeue_handler,
     make_legacy_body_keyed_adapter,
+    make_send_handler,
     register_session_routes,
 )
 from turnstone.core.session_ui_base import SessionUIBase
@@ -834,6 +836,27 @@ def _interactive_tenant_check(
     return err
 
 
+def _make_method_dispatch(
+    handlers: dict[str, Any],
+) -> Any:
+    """Mount one URL with different bodies per HTTP method.
+
+    Starlette's ``Route`` accepts a single handler; the legacy
+    ``/v1/api/send`` URL serves both POST (send) and DELETE (dequeue)
+    via the same path. The shared registrar mounts these as two
+    separate path-keyed verbs (``send`` / ``DELETE``); this helper
+    bridges so the legacy body-keyed URL can keep its single Route.
+    """
+
+    async def dispatch(request: Request) -> Any:
+        handler = handlers.get(request.method)
+        if handler is None:
+            return JSONResponse({"error": f"method {request.method} not allowed"}, status_code=405)
+        return await handler(request)
+
+    return dispatch
+
+
 def _audit_close_workstream(
     request: Request,
     ws_id: str,
@@ -1482,275 +1505,6 @@ def _make_watch_dispatch(ws: Workstream, session: ChatSession, ui: Any) -> Any:
     return dispatch
 
 
-async def send_message(request: Request) -> JSONResponse:
-    """POST /v1/api/send — send or queue a user message.
-
-    DELETE /v1/api/send — remove a queued message by ``msg_id``.
-    """
-    from turnstone.core.web_helpers import read_json_or_400
-
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-
-    # DELETE — remove a queued message
-    if request.method == "DELETE":
-        ws_id = body.get("ws_id")
-        msg_id = body.get("msg_id")
-        if not msg_id:
-            return JSONResponse({"error": "msg_id required"}, status_code=400)
-        mgr = request.app.state.workstreams
-        ws, ui = _get_ws(mgr, ws_id)
-        if not ws or not ui:
-            return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-        session = ws.session
-        if session is None:
-            return JSONResponse({"error": "No session"}, status_code=400)
-        removed = session.dequeue_message(msg_id)
-        return JSONResponse({"status": "removed" if removed else "not_found"})
-
-    # POST — send or queue
-    message = body.get("message", "").strip()
-    ws_id = body.get("ws_id")
-    if not message:
-        return JSONResponse({"error": "Empty message"}, status_code=400)
-    mgr = request.app.state.workstreams
-    ws, ui = _get_ws(mgr, ws_id)
-    if not ws or not ui:
-        return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-
-    # --- Atomic reserve-then-dispatch for attachments ---------------------
-    # Generate a send token up front and reserve attachments BEFORE we
-    # commit to queueing or starting a worker.  The reserved set is the
-    # source of truth — overlapping requests can't select the same row.
-    # Idle path and busy path both reserve, so session.send / dequeue can
-    # consume with defense-in-depth (matching reserved_for_msg_id).
-    from turnstone.core.attachments import Attachment
-    from turnstone.core.memory import (
-        get_attachments as _get_attachments,
-    )
-    from turnstone.core.memory import (
-        get_pending_attachments_with_content as _get_pending_with_content,
-    )
-    from turnstone.core.memory import (
-        reserve_attachments as _reserve,
-    )
-
-    # Actor resolution: service-scoped callers file attachments under the
-    # workstream owner (matches upload/list/delete semantics).  Returns
-    # 404 on missing/foreign workstreams.
-    attach_user_id, err = _require_ws_access(request, ws_id or "")
-    if err:
-        return err
-    # _require_ws_access already 404'd on missing ws_id; the explicit
-    # check keeps the type-checker happy without a bare assert.
-    if not isinstance(ws_id, str):
-        return JSONResponse({"error": "ws_id required"}, status_code=400)
-
-    # Full UUID hex — this token scopes both the attachment reservation
-    # and the eventual consume, so keep the full 128 bits.
-    send_id = uuid.uuid4().hex
-    raw_ids = body.get("attachment_ids")
-    auto_consume_rows: list[dict[str, Any]] = []
-    if raw_ids is None:
-        # Auto-consume: pull the current user's pending (unreserved)
-        # rows in creation order IN ONE QUERY (bytes included) — we'll
-        # reserve them below and skip the second fetch.  The reserve
-        # call is scoped to message_id IS NULL AND reserved_for_msg_id
-        # IS NULL so a concurrent reservation can't double-book.
-        auto_consume_rows = _get_pending_with_content(ws_id, attach_user_id)
-        requested_ids = [str(r["attachment_id"]) for r in auto_consume_rows]
-    elif isinstance(raw_ids, list) and raw_ids:
-        # Cap inbound id-list length so a hostile client can't blow up
-        # the storage IN (...) clause with millions of bogus ids.
-        from turnstone.core.attachments import MAX_PENDING_ATTACHMENTS_PER_USER_WS
-
-        if len(raw_ids) > MAX_PENDING_ATTACHMENTS_PER_USER_WS:
-            return JSONResponse(
-                {
-                    "error": (
-                        f"Too many attachment_ids (max {MAX_PENDING_ATTACHMENTS_PER_USER_WS})"
-                    ),
-                    "code": "too_many",
-                },
-                status_code=400,
-            )
-        requested_ids = [str(x) for x in raw_ids if x]
-    else:
-        requested_ids = []
-
-    reserved_ids: list[str] = (
-        _reserve(requested_ids, send_id, ws_id, attach_user_id) if requested_ids else []
-    )
-    # Preserve request order; reserve returned a set that may be a
-    # strict subset (lost a race, already consumed, etc.).  Silently
-    # drop losers — the user can re-upload if needed and sees the
-    # partial outcome via the UI's chip-clearing on success.
-    reserved_set = set(reserved_ids)
-    ordered_reserved: list[str] = [aid for aid in requested_ids if aid in reserved_set]
-
-    resolved_atts: list[Attachment] = []
-    if ordered_reserved:
-        # Prefer the bytes we already fetched on the auto-consume path.
-        # Bytes were pre-reserve-call though, so reserved_for_msg_id
-        # needs refresh from the authoritative row.  Re-fetch if the
-        # auto-fetch is stale or empty.
-        if auto_consume_rows and all(
-            str(r["attachment_id"]) in set(ordered_reserved) for r in auto_consume_rows
-        ):
-            rows_by_id = {str(r["attachment_id"]): r for r in auto_consume_rows}
-            # reserved_for_msg_id was None at pre-fetch; patch in the token
-            # so the belt-and-braces scope check below doesn't reject the
-            # rows we just reserved.
-            for r in rows_by_id.values():
-                r["reserved_for_msg_id"] = send_id
-        else:
-            rows = _get_attachments(ordered_reserved)
-            rows_by_id = {str(r["attachment_id"]): r for r in rows}
-        for aid in ordered_reserved:
-            row = rows_by_id.get(aid)
-            if not row:
-                continue
-            r = row
-            # Scope check — belt and braces on top of the reservation.
-            if (
-                r.get("ws_id") != ws_id
-                or r.get("user_id") != attach_user_id
-                or r.get("message_id") is not None
-                or r.get("reserved_for_msg_id") != send_id
-            ):
-                continue
-            content = r.get("content")
-            if not isinstance(content, bytes):
-                continue
-            resolved_atts.append(
-                Attachment(
-                    attachment_id=str(r["attachment_id"]),
-                    filename=str(r.get("filename") or ""),
-                    mime_type=str(r.get("mime_type") or "application/octet-stream"),
-                    kind=str(r.get("kind") or ""),
-                    content=content,
-                )
-            )
-
-    def _release_reservation_on_fail() -> None:
-        """Unreserve if we bail out before dispatching."""
-        if reserved_ids:
-            from turnstone.core.memory import unreserve_attachments as _unreserve
-
-            _unreserve(send_id, ws_id, attach_user_id)
-
-    # If cancel was requested, poll briefly for the worker to exit before
-    # dispatching.  ``_worker_running`` flips to False atomically under
-    # ws._lock when the worker thread reaches its finally block — gates
-    # the dispatch on the same flag the shared dispatcher uses.  Uses
-    # async sleep to avoid blocking the event loop.
-    if ws._worker_running and ws.session and ws.session._cancel_event.is_set():
-        for _ in range(30):  # up to 3s in 100ms steps
-            await asyncio.sleep(0.1)
-            if not ws._worker_running:
-                break
-    if ws.session is None:
-        _release_reservation_on_fail()
-        return JSONResponse({"error": "No session"}, status_code=500)
-
-    session = ws.session
-
-    # Pre-allocate the queue-path outcome dict; populated by ``_enqueue``
-    # only when the shared dispatcher routes us onto a live worker.
-    queue_outcome: dict[str, Any] = {}
-
-    def _enqueue() -> None:
-        # Reuse path: append to the live worker's pending queue. The
-        # ``send_id`` token threads through ``queue_msg_id`` so the
-        # queue entry, the attachment reservation, and the eventual
-        # consume all share one token.
-        cleaned, priority, msg_id = session.queue_message(
-            message,
-            attachment_ids=list(ordered_reserved),
-            queue_msg_id=send_id,
-        )
-        queue_outcome["cleaned"] = cleaned
-        queue_outcome["priority"] = priority
-        queue_outcome["msg_id"] = msg_id
-
-    def _run() -> None:
-        assert ui is not None
-        me = threading.current_thread()
-        try:
-            session.send(
-                message,
-                attachments=resolved_atts or None,
-                send_id=send_id,
-            )
-        except GenerationCancelled:
-            # Safety net — send() normally handles this internally.
-            # If this thread was force-abandoned, ws.worker_thread will
-            # have been set to None — don't emit spurious events.
-            _release_reservation_on_fail()
-            if ws.worker_thread is me:
-                ui.on_stream_end()
-                ui.on_state_change("idle")
-        except Exception as e:
-            # Release the reservation so the attachments don't stay
-            # soft-locked forever when the worker crashes before
-            # reaching the consume step.  Safe-by-idempotency: once
-            # mark_attachments_consumed has cleared the token, a
-            # follow-up unreserve is a no-op.
-            _release_reservation_on_fail()
-            if ws.worker_thread is me:
-                ui.on_error(f"Error: {e}")
-                ui.on_stream_end()
-                ui.on_state_change("error")
-
-    ok = session_worker.send(
-        ws,
-        enqueue=_enqueue,
-        run=_run,
-        thread_name=f"send-worker-{ws.id[:8]}",
-    )
-    if not ok:
-        # Returns False on queue.Full (live worker, queue at capacity)
-        # or session-disappeared race. Either way the message couldn't
-        # land — surface as queue_full so the client can retry.
-        _release_reservation_on_fail()
-        return JSONResponse({"status": "queue_full"})
-
-    dropped = [aid for aid in requested_ids if aid not in reserved_set]
-    if queue_outcome:
-        # Reused a live worker; queue_message succeeded.
-        ui._enqueue(
-            {
-                "type": "message_queued",
-                "message": queue_outcome["cleaned"],
-                "priority": queue_outcome["priority"],
-                "msg_id": queue_outcome["msg_id"],
-            }
-        )
-        return JSONResponse(
-            {
-                "status": "queued",
-                "priority": queue_outcome["priority"],
-                "msg_id": queue_outcome["msg_id"],
-                "attached_ids": list(ordered_reserved),
-                "dropped_attachment_ids": dropped,
-            }
-        )
-
-    # Spawned a fresh worker — count this as a new turn.
-    _metrics.record_message_sent()
-    with ui._ws_lock:
-        ui._ws_messages += 1
-        ui._ws_turn_tool_calls = 0
-    return JSONResponse(
-        {
-            "status": "ok",
-            "attached_ids": list(ordered_reserved),
-            "dropped_attachment_ids": dropped,
-        }
-    )
-
-
 async def plan_feedback(request: Request) -> JSONResponse:
     """POST /v1/api/plan — respond to a plan review."""
     from turnstone.core.web_helpers import read_json_or_400
@@ -2259,6 +2013,9 @@ def _validate_and_save_uploaded_files(
         IMAGE_SIZE_CAP,
         MAX_PENDING_ATTACHMENTS_PER_USER_WS,
         TEXT_DOC_SIZE_CAP,
+        classify_text_attachment,
+        sniff_image_mime,
+        upload_lock,
     )
     from turnstone.core.memory import list_pending_attachments, save_attachment
 
@@ -2266,13 +2023,13 @@ def _validate_and_save_uploaded_files(
     if not files:
         return saved_ids, None
 
-    lock = _attachment_upload_lock(ws_id, user_id)
+    lock = upload_lock(ws_id, user_id)
     with lock:
         pending_count = len(list_pending_attachments(ws_id, user_id))
         for filename, claimed_mime, data in files:
             if not data:
                 return saved_ids, JSONResponse({"error": "Empty file"}, status_code=400)
-            sniffed_image = _sniff_image_mime(data)
+            sniffed_image = sniff_image_mime(data)
             if sniffed_image is not None:
                 if len(data) > IMAGE_SIZE_CAP:
                     return saved_ids, JSONResponse(
@@ -2299,7 +2056,7 @@ def _validate_and_save_uploaded_files(
                         },
                         status_code=413,
                     )
-                mime_or_err = _classify_text_attachment(filename, claimed_mime, data)
+                mime_or_err = classify_text_attachment(filename, claimed_mime, data)
                 if mime_or_err[0] is None:
                     return saved_ids, JSONResponse(
                         {"error": mime_or_err[1], "code": "unsupported"},
@@ -2851,145 +2608,6 @@ async def set_workstream_title(request: Request, ws_id: str = "") -> JSONRespons
     return JSONResponse({"status": "ok", "title": title})
 
 
-# ---------------------------------------------------------------------------
-# Workstream attachments
-# ---------------------------------------------------------------------------
-
-
-# Per-(ws_id, user_id) lock serializing the count-check → insert on
-# upload.  Guards the pending-cap against a concurrent-upload TOCTOU race
-# within a single process.  Multi-process deployments would need an
-# additional DB-side check, but turnstone-server runs one process per node.
-#
-# Uses ``threading.Lock`` (not ``asyncio.Lock``) on purpose: Starlette's
-# TestClient — and any framework that runs each request on a fresh
-# anyio task — can leave a cached ``asyncio.Lock`` bound to a stale,
-# closed event loop, and the next acquire deadlocks silently.  A
-# threading.Lock is loop-agnostic, and the critical section here is
-# short (one COUNT, one INSERT) so blocking the event loop briefly is
-# acceptable.
-#
-# Bounded LRU eviction prevents unbounded growth on long-running nodes:
-# when the map exceeds the soft cap we drop the oldest *unlocked* entries
-# (a held lock means an upload is in flight — never evict those).
-_ATTACHMENT_UPLOAD_LOCKS_MAX = 1024
-_attachment_upload_locks: collections.OrderedDict[tuple[str, str], threading.Lock] = (
-    collections.OrderedDict()
-)
-_attachment_upload_locks_mx = threading.Lock()
-
-
-def _attachment_upload_lock(ws_id: str, user_id: str) -> threading.Lock:
-    key = (ws_id, user_id)
-    with _attachment_upload_locks_mx:
-        lock = _attachment_upload_locks.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _attachment_upload_locks[key] = lock
-        else:
-            # Touch for LRU
-            _attachment_upload_locks.move_to_end(key)
-        # Opportunistic eviction once we exceed the soft cap.  Skip
-        # held locks (an upload is in flight under that key).
-        if len(_attachment_upload_locks) > _ATTACHMENT_UPLOAD_LOCKS_MAX:
-            for stale_key in list(_attachment_upload_locks):
-                if len(_attachment_upload_locks) <= _ATTACHMENT_UPLOAD_LOCKS_MAX:
-                    break
-                if stale_key == key:
-                    continue  # never evict the lock we're handing out
-                stale = _attachment_upload_locks[stale_key]
-                # threading.Lock has no public locked() — use the
-                # non-blocking acquire-and-release probe instead.
-                if stale.acquire(blocking=False):
-                    stale.release()
-                    del _attachment_upload_locks[stale_key]
-        return lock
-
-
-_TEXT_ATTACHMENT_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".c",
-        ".conf",
-        ".cpp",
-        ".css",
-        ".go",
-        ".h",
-        ".hpp",
-        ".html",
-        ".ini",
-        ".java",
-        ".js",
-        ".json",
-        ".jsx",
-        ".md",
-        ".py",
-        ".rs",
-        ".sh",
-        ".sql",
-        ".toml",
-        ".ts",
-        ".tsx",
-        ".txt",
-        ".xml",
-        ".yaml",
-        ".yml",
-    }
-)
-
-
-def _sniff_image_mime(data: bytes) -> str | None:
-    """Return a canonical image MIME type by inspecting magic bytes.
-
-    Returns ``None`` if the bytes don't match any supported image
-    format.  Do not trust the client-provided ``Content-Type`` alone.
-    """
-    if len(data) < 12:
-        return None
-    if data.startswith(b"\x89PNG\r\n\x1a\n"):
-        return "image/png"
-    if data.startswith(b"\xff\xd8\xff"):
-        return "image/jpeg"
-    if data[:6] in (b"GIF87a", b"GIF89a"):
-        return "image/gif"
-    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
-        return "image/webp"
-    return None
-
-
-def _classify_text_attachment(
-    filename: str, claimed_mime: str, data: bytes
-) -> tuple[str | None, str | None]:
-    """Return ``(canonical_mime, error)`` for a candidate text upload.
-
-    Accepts MIMEs starting with ``text/`` or in an application allowlist,
-    OR a filename with a known text-file extension.  The payload must
-    decode as UTF-8.  Returns ``(None, error_message)`` on rejection.
-    """
-    import os
-
-    allowed_app_mimes = {
-        "application/json",
-        "application/xml",
-        "application/x-yaml",
-        "application/yaml",
-        "application/toml",
-    }
-    mime_ok = claimed_mime.startswith("text/") or claimed_mime in allowed_app_mimes
-    ext_ok = os.path.splitext(filename)[1].lower() in _TEXT_ATTACHMENT_EXTENSIONS
-    if not (mime_ok or ext_ok):
-        return None, (
-            f"Unsupported file type: {claimed_mime or 'unknown'} (filename: {filename!r})"
-        )
-    try:
-        data.decode("utf-8")
-    except UnicodeDecodeError:
-        return None, "Text attachment is not valid UTF-8"
-    # Normalize MIME — prefer the claimed one if sensible, else text/plain.
-    if mime_ok and claimed_mime:
-        return claimed_mime, None
-    return "text/plain", None
-
-
 def _auth_user_id(request: Request) -> str:
     """Return the authenticated user's id (empty string when absent)."""
     auth = getattr(getattr(request, "state", None), "auth_result", None)
@@ -3068,189 +2686,6 @@ def _require_ws_access(
     if owner is None:
         return "", JSONResponse({"error": "Workstream not found"}, status_code=404)
     return owner or caller, None
-
-
-async def upload_attachment(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/attachments — upload one file.
-
-    Multipart body with a single ``file`` field.  Validates size + MIME
-    + magic bytes, enforces per-(ws,user) pending cap, then stores.
-    """
-    from turnstone.core.attachments import (
-        IMAGE_SIZE_CAP,
-        MAX_PENDING_ATTACHMENTS_PER_USER_WS,
-        TEXT_DOC_SIZE_CAP,
-    )
-    from turnstone.core.memory import list_pending_attachments, save_attachment
-    from turnstone.core.web_helpers import read_multipart_file_or_400
-
-    ws_id = request.path_params.get("ws_id", "")
-    if not ws_id:
-        return JSONResponse({"error": "ws_id is required"}, status_code=400)
-
-    user_id, err = _require_ws_access(request, ws_id)
-    if err:
-        return err
-
-    # Cap at image size (largest permitted type) — per-kind cap enforced below.
-    got = await read_multipart_file_or_400(request, field="file", max_bytes=IMAGE_SIZE_CAP)
-    if isinstance(got, JSONResponse):
-        return got
-    filename, claimed_mime, data = got
-
-    if not data:
-        return JSONResponse({"error": "Empty file"}, status_code=400)
-
-    # Classify: image (magic-byte sniff) vs text (mime/ext + UTF-8 decode)
-    sniffed_image = _sniff_image_mime(data)
-    if sniffed_image is not None:
-        if len(data) > IMAGE_SIZE_CAP:
-            return JSONResponse(
-                {
-                    "error": (
-                        f"Image too large ({len(data):,} bytes); cap is {IMAGE_SIZE_CAP:,} bytes."
-                    ),
-                    "code": "too_large",
-                },
-                status_code=413,
-            )
-        kind = "image"
-        mime = sniffed_image
-    else:
-        if len(data) > TEXT_DOC_SIZE_CAP:
-            return JSONResponse(
-                {
-                    "error": (
-                        f"Text document too large ({len(data):,} bytes); "
-                        f"cap is {TEXT_DOC_SIZE_CAP:,} bytes."
-                    ),
-                    "code": "too_large",
-                },
-                status_code=413,
-            )
-        mime_or_err = _classify_text_attachment(filename, claimed_mime, data)
-        if mime_or_err[0] is None:
-            return JSONResponse({"error": mime_or_err[1], "code": "unsupported"}, status_code=400)
-        kind = "text"
-        mime = mime_or_err[0]
-
-    # Serialize count-check + save per (ws, user) so concurrent uploads
-    # can't both pass a check that sees count == cap-1.  Plain
-    # threading.Lock (not asyncio.Lock) — see _attachment_upload_lock
-    # for why.  The critical section is short, so blocking the event
-    # loop briefly is acceptable.
-    lock = _attachment_upload_lock(ws_id, user_id)
-    with lock:
-        if len(list_pending_attachments(ws_id, user_id)) >= MAX_PENDING_ATTACHMENTS_PER_USER_WS:
-            return JSONResponse(
-                {
-                    "error": (
-                        f"Too many pending attachments "
-                        f"(max {MAX_PENDING_ATTACHMENTS_PER_USER_WS} pending per workstream)"
-                    ),
-                    "code": "too_many",
-                },
-                status_code=409,
-            )
-        attachment_id = uuid.uuid4().hex
-        save_attachment(
-            attachment_id,
-            ws_id,
-            user_id,
-            filename,
-            mime,
-            len(data),
-            kind,
-            data,
-        )
-    return JSONResponse(
-        {
-            "attachment_id": attachment_id,
-            "filename": filename,
-            "mime_type": mime,
-            "size_bytes": len(data),
-            "kind": kind,
-        }
-    )
-
-
-async def list_attachments(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams/{ws_id}/attachments — list current user's
-    pending (unconsumed) attachments for this workstream.
-    """
-    from turnstone.core.memory import list_pending_attachments
-
-    ws_id = request.path_params.get("ws_id", "")
-    if not ws_id:
-        return JSONResponse({"error": "ws_id is required"}, status_code=400)
-    user_id, err = _require_ws_access(request, ws_id)
-    if err:
-        return err
-    rows = list_pending_attachments(ws_id, user_id)
-    return JSONResponse({"attachments": rows})
-
-
-async def get_attachment_content(request: Request) -> Response:
-    """GET /v1/api/workstreams/{ws_id}/attachments/{attachment_id}/content —
-    raw bytes of the attachment with its stored ``Content-Type``.
-
-    The caller must own the workstream (or hold service scope).
-    Unknown / cross-workstream ids return 404 to avoid leaking existence.
-    """
-    from turnstone.core.memory import get_attachment
-
-    ws_id = request.path_params.get("ws_id", "")
-    attachment_id = request.path_params.get("attachment_id", "")
-    if not ws_id or not attachment_id:
-        return JSONResponse({"error": "ws_id and attachment_id are required"}, status_code=400)
-    user_id, err = _require_ws_access(request, ws_id)
-    if err:
-        return err
-    row = get_attachment(attachment_id)
-    # Scope on user_id too — in an unowned workstream different users
-    # could otherwise fetch each other's blobs via id-guessing.  Mask
-    # cross-user / cross-ws as 404 to avoid leaking existence.
-    if not row or row.get("ws_id") != ws_id or row.get("user_id") != user_id:
-        return JSONResponse({"error": "Not found"}, status_code=404)
-    body = row.get("content") or b""
-    kind = row.get("kind") or ""
-    stored_mime = row.get("mime_type") or "application/octet-stream"
-    filename = str(row.get("filename") or "attachment")
-    # Force text/plain for text kinds — avoids same-origin HTML/SVG
-    # rendering if a user uploaded an HTML-ish text file.  Images keep
-    # their sniffed MIME (the allowlist is strict: png/jpeg/gif/webp).
-    response_mime = "text/plain; charset=utf-8" if kind == "text" else stored_mime
-    # Sanitize filename for Content-Disposition (quotes / CRLF only —
-    # browsers tolerate most other characters).  RFC 6266 filename*=
-    # would be more complete but isn't needed for the inline-attachment
-    # use case here.
-    safe_name = filename.replace('"', "").replace("\r", "").replace("\n", "")
-    headers = {
-        "X-Content-Type-Options": "nosniff",
-        "Content-Security-Policy": "default-src 'none'; sandbox",
-        "Content-Disposition": f'inline; filename="{safe_name}"',
-        "Cache-Control": "private, no-store",
-    }
-    return Response(body, media_type=response_mime, headers=headers)
-
-
-async def delete_attachment(request: Request) -> JSONResponse:
-    """DELETE /v1/api/workstreams/{ws_id}/attachments/{attachment_id} —
-    remove a pending attachment.  Consumed attachments return 404.
-    """
-    from turnstone.core.memory import delete_attachment as _delete
-
-    ws_id = request.path_params.get("ws_id", "")
-    attachment_id = request.path_params.get("attachment_id", "")
-    if not ws_id or not attachment_id:
-        return JSONResponse({"error": "ws_id and attachment_id are required"}, status_code=400)
-    user_id, err = _require_ws_access(request, ws_id)
-    if err:
-        return err
-    deleted = _delete(attachment_id, ws_id, user_id)
-    if not deleted:
-        return JSONResponse({"error": "Not found"}, status_code=404)
-    return JSONResponse({"status": "deleted"})
 
 
 async def open_workstream(request: Request) -> JSONResponse:
@@ -4420,12 +3855,51 @@ def create_app(
     # shape against its coord manager. The lifted handler factories
     # (``make_approve_handler``, ``make_close_handler``) capture the
     # kind-specific ``SessionEndpointConfig`` via closure.
+    def _interactive_attachment_owner(
+        request: Request, ws_id: str, _mgr: SessionManager
+    ) -> tuple[str, JSONResponse | None]:
+        """Resolve attachment owner for interactive workstreams via
+        :func:`_require_ws_access`. Mirrors the pre-P1.5 inline logic
+        in ``send_message`` — uses the storage path (``mgr`` not
+        passed) so tests with MagicMock managers don't trip on a
+        magic-mocked ``ws.user_id``."""
+        return _require_ws_access(request, ws_id)
+
+    def _interactive_spawn_metrics(_request: Request, ui: Any) -> None:
+        """Per-conversation metrics fired once per send that spawns a
+        fresh worker. Coord wires ``None`` for this hook."""
+        _metrics.record_message_sent()
+        if hasattr(ui, "_ws_lock") and hasattr(ui, "_ws_messages"):
+            with ui._ws_lock:
+                ui._ws_messages += 1
+                ui._ws_turn_tool_calls = 0
+
+    from turnstone.core.attachments import (
+        classify_text_attachment as _classify_text_attachment,
+    )
+    from turnstone.core.attachments import (
+        sniff_image_mime as _sniff_image_mime,
+    )
+    from turnstone.core.attachments import (
+        upload_lock as _attachment_upload_lock,
+    )
+
+    interactive_attachment_helpers = AttachmentUploadHelpers(
+        sniff_image_mime=_sniff_image_mime,
+        classify_text_attachment=_classify_text_attachment,
+        upload_lock=_attachment_upload_lock,
+    )
     interactive_endpoint_config = SessionEndpointConfig(
         permission_gate=None,  # interactive auth is enforced at the middleware layer
         manager_lookup=_interactive_manager_lookup,
         tenant_check=_interactive_tenant_check,
         not_found_label="Workstream not found",
         audit_action_prefix="workstream",
+        supports_attachments=True,
+        attachment_owner_resolver=_interactive_attachment_owner,
+        attachment_helpers=interactive_attachment_helpers,
+        spawn_metrics=_interactive_spawn_metrics,
+        emit_message_queued=True,
     )
     approve_handler = make_approve_handler(interactive_endpoint_config)
     close_handler = make_close_handler(
@@ -4433,6 +3907,9 @@ def create_app(
         audit_emit=_audit_close_workstream,
         supports_close_reason=True,
     )
+    send_handler = make_send_handler(interactive_endpoint_config)
+    dequeue_handler = make_dequeue_handler(interactive_endpoint_config)
+    attachment_handlers = make_attachment_handlers(interactive_endpoint_config)
     v1_routes: list[Any] = [
         Route("/api/events", events_sse),
         Route("/api/events/global", global_events_sse),
@@ -4450,13 +3927,9 @@ def create_app(
             close=close_handler,  # lifted: shared body
             refresh_title=refresh_workstream_title,
             set_title=set_workstream_title,
+            send=send_handler,  # lifted: shared body (P1.5)
             approve=approve_handler,  # lifted: shared body
-            attachments=AttachmentHandlers(
-                upload=upload_attachment,
-                list=list_attachments,
-                get_content=get_attachment_content,
-                delete=delete_attachment,
-            ),
+            attachments=attachment_handlers,  # lifted: shared body (P1.5)
         ),
     )
     v1_routes.append(Route("/api/dashboard", dashboard))
@@ -4470,7 +3943,18 @@ def create_app(
                     *v1_routes,
                     Route("/api/skills", list_skills_summary),
                     Route("/api/models", list_available_models),
-                    Route("/api/send", send_message, methods=["POST", "DELETE"]),
+                    Route(
+                        "/api/send",
+                        make_legacy_body_keyed_adapter(
+                            _make_method_dispatch(
+                                {
+                                    "POST": send_handler,
+                                    "DELETE": dequeue_handler,
+                                }
+                            )
+                        ),
+                        methods=["POST", "DELETE"],
+                    ),
                     Route(
                         "/api/approve",
                         make_legacy_body_keyed_adapter(approve_handler),


### PR DESCRIPTION
## Summary

Stage 2 Priority 1.5 of the SessionManager unification (1.5.0aN experimental track). Lifts `/send` body and the four attachment endpoints to shared factories AND ships full coordinator parity for attachments + queue-priority surfacing — closing the cognitive-dissonance loop from PR #410's review.

- **Verb shape unified.** New `make_send_handler(cfg)` and `make_attachment_handlers(cfg)` factories in `turnstone/core/session_routes.py`. Capability flags on `SessionEndpointConfig` (`supports_attachments`, `attachment_owner_resolver`, `attachment_helpers`, `spawn_metrics`, `emit_message_queued`) toggle per-kind behaviour without forking the body.
- **Coord lit up.** Console mounts the shared factories with `supports_attachments=True`. Browser dashboard, Python SDK, OpenAPI spec, and TS SDK regen all updated.
- **Three pure helpers** (`sniff_image_mime`, `classify_text_attachment`, `upload_lock`) moved from `turnstone/server.py` to `turnstone/core/attachments.py` so both processes use the canonical implementation.
- **`auth_user_id` / `resolve_workstream_owner`** lifted to `turnstone/core/web_helpers.py`; existing private helpers in `server.py` + `console/server.py` now delegate.

Net: 12 files changed, +1924 / −686 LOC. Most of the delta is the lifted factory bodies + tests + spec entries; `server.py` shrinks by ~735 LOC.

## Behaviour changes (callouts in CHANGELOG)

- **`coordinator_send` queue-full response**: was `429 {"error": "..."}`, now `200 {"status": "queue_full"}` for parity with interactive. SDK consumers checking for 429 should switch to the status-code shape.
- **Coord `GenerationCancelled`**: now emits `state=idle` + `stream_end` (parity with interactive). Pre-P1.5 a cancel-killed coord worker terminated silently with no state event.
- **Send response shape**: now always carries `attached_ids` / `dropped_attachment_ids` (empty arrays on plain text sends); the live-worker reuse path also surfaces `priority` / `msg_id`.

## Why bundle attachments parity with the verb-shape lift?

Tonight's investigation (after the cognitive-dissonance correction in PR #410) confirmed: the storage layer is already kind-agnostic, the registrar's `AttachmentHandlers | None` slot has been there since Stage 2 P0, the console already had `route_attachment_proxy` for multi-node attachment routing, and the verb-shape lift was going to do most of the work either way. Splitting them ships a half-done feature surface for no benefit. Bundle. (See `1.5.0-session-manager-stage-2.md` § Priority 1.5.)

## /review pipeline pass

Local `/review` (4 finders → verify → fix-up commit). Six high-leverage findings addressed in `2825fc1`:

- **sec-1 (major)**: coord `attachment_owner_resolver` is now kind-strict — resolves through `coord_mgr.get(ws_id)` only, no storage fallback. Without this, an `admin.coordinator`-scoped caller could read or mutate interactive attachments via the new coord endpoints (the generic `get_workstream_owner` storage call is kind-agnostic; storage-fallback granted cross-kind access). New regression test `test_coord_attachment_endpoints_404_on_interactive_ws_id` pins the surface.
- **bug-1 (minor)**: UI hook calls in the spawn-path `_run` closure are now wrapped per-hook (via `_emit_ui`) so a failure in `ui.on_error` doesn't suppress the subsequent `on_stream_end` / `on_state_change` calls.
- **bug-2 (minor)**: `make_dequeue_handler` now 404s when `ws.ui is None` (preserves the pre-P1.5 `_get_ws` contract).
- **bug-3 (minor)**: `coordinator.js` gains a `case "message_queued":` handler so the events coord wires aren't silently dropped client-side.
- **bug-4 (minor)**: error-message format on coord regressed from `f"{type(exc).__name__}: {exc}"` to `f"Error: {e}"` — restored.
- **q-1 (major)**: duplicate `_auth_user_id` and `_require_ws_access` helpers in `server.py` and `console/server.py` now delegate to the lifted versions in `web_helpers.py`.

## Test plan

- [x] Full pytest green: 4440 tests pass (excluding `tests/live`). +6 new coord-attachment tests including the cross-kind 404 security regression.
- [x] `ruff check turnstone/ tests/` clean.
- [x] `mypy turnstone/` clean across 175 source files.
- [x] OpenAPI specs regenerated (`openapi-server.json`, `openapi-console.json`); TS SDK bumped to 0.5.0.
- [ ] Manual smoke on coord dashboard (attachment upload via browser flow, send-with-attachment, history-replay attachment-count badge).
- [ ] Soak on `main` after merge — no more alpha tags pre-`v1.5.0` per the unification plan.

## Risk flags

- **`coordinator_send` 429 → 200**: callers polling for 429 will misread queue-full as success. Documented in CHANGELOG.
- **Coord cancel-state emission**: cluster fanout / alerting that keyed on `state=error` for cancelled coord workers should switch to monitoring `stream_end` / `state=idle` together. Documented.
- **Persisted-but-not-loaded coord attachments**: the kind-strict resolver requires the coord to be in `coord_mgr`. Saved coords don't expose attachment UI today, so this is fine in practice; uploading to a saved coord requires `open` first.
- **Interactive `_require_ws_access` storage fallback** is unchanged. The interactive surface gates on per-row `user_id`, not a dedicated kind scope, so the same cross-kind read concern doesn't apply (interactive callers don't gain new privileges via cross-kind ws_ids — they'd just be filing attachments they own). If a follow-up wants symmetric kind-strict resolution, that's an additive hardening.