### PR TITLE
refactor(core): split SessionKindAdapter Protocol into construction +…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,26 @@ Three release tracks are maintained:
   coord workers should switch to monitoring ``stream_end`` /
   ``state=idle`` together.
 
+- **`SessionKindAdapter` Protocol split into construction +
+  emission** ([Stage 2 Priority 3]). The adapter Protocol now covers
+  only what every kind must implement (``kind`` / ``build_ui`` /
+  ``build_session`` / ``cleanup_ui``); the four lifecycle emit
+  methods (``emit_created`` / ``emit_state`` / ``emit_rehydrated`` /
+  ``emit_closed``) move to a separate ``SessionEventEmitter``
+  Protocol wired through a new optional
+  ``event_emitter: SessionEventEmitter | None`` kwarg on
+  ``SessionManager``. Both production adapters (interactive on
+  ``server.py``, coordinator on ``console/server.py``) implement
+  both Protocols and are passed as both ``adapter`` and
+  ``event_emitter`` at lifespan-construction time, so production
+  behavior is unchanged. The interactive adapter's three
+  ``emit_created`` / ``emit_state`` / ``emit_rehydrated`` methods
+  remain documented no-op stubs (those events fire from out-of-band
+  paths — the create handler enqueues ``ws_created`` after
+  attachment validation, ``WebUI._broadcast_state`` emits
+  ``ws_state``); ``emit_closed`` stays load-bearing as the sole
+  transport path for ``ws_closed`` onto the global SSE queue.
+
 ### Security
 
 - **Coord attachment endpoints are now kind-strict**

--- a/tests/_coord_test_helpers.py
+++ b/tests/_coord_test_helpers.py
@@ -97,6 +97,7 @@ def _build_mgr(storage: Any) -> SessionManager:
         storage=storage,
         max_active=3,
         node_id=ClusterCollector.CONSOLE_PSEUDO_NODE_ID,
+        event_emitter=adapter,
     )
     adapter.attach(mgr)
     return mgr

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -118,6 +118,7 @@ def _build_mgr(storage: SQLiteBackend) -> SessionManager:
         storage=storage,
         max_active=5,
         node_id=ClusterCollector.CONSOLE_PSEUDO_NODE_ID,
+        event_emitter=adapter,
     )
     adapter.attach(mgr)
     return mgr

--- a/tests/test_interactive_adapter.py
+++ b/tests/test_interactive_adapter.py
@@ -1,10 +1,18 @@
 """Tests for InteractiveAdapter.
 
-Focus: the transport contract (what gets pushed onto the global
-queue) and cleanup_ui behavior (unblock pending events, broadcast
-ws_closed to per-UI listeners, cancel + close session). The
-SessionManager-level tests in ``test_session_manager.py`` cover the
-adapter-agnostic lifecycle.
+Focus: the ``emit_closed`` transport contract (sole path for
+``ws_closed`` onto the process-wide queue) and ``cleanup_ui``
+behavior (unblock pending events, broadcast ``ws_closed`` to per-UI
+listeners, cancel + close session). The SessionManager-level tests
+in ``test_session_manager.py`` cover the adapter-agnostic lifecycle.
+
+The other three :class:`SessionEventEmitter` methods
+(``emit_created`` / ``emit_state`` / ``emit_rehydrated``) are
+documented no-op stubs — ``ws_created`` is fired by the create HTTP
+handler after attachment validation, and ``ws_state`` is fired by
+``WebUI._broadcast_state`` with the full payload. No-op assertions
+on those methods would be tautological given the class docstring,
+so they're not retested here.
 """
 
 from __future__ import annotations
@@ -15,7 +23,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
-from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
+from turnstone.core.workstream import Workstream, WorkstreamKind
 
 
 class _StubUI:
@@ -71,36 +79,9 @@ def _make_ws(**overrides: Any) -> Workstream:
 
 
 # ---------------------------------------------------------------------------
-# Transport — emit_created / emit_state / emit_closed
+# Transport — emit_closed (the only emit_* with real behavior on interactive;
+# emit_created / emit_state / emit_rehydrated are documented no-op stubs)
 # ---------------------------------------------------------------------------
-
-
-def test_emit_created_is_noop_on_interactive() -> None:
-    """The create_workstream HTTP handler fires ws_created after
-    attachment validation; the adapter intentionally no-ops so the
-    event isn't duplicated (and so failed-attachment creates don't
-    surface a phantom create→close pair)."""
-    adapter, gq = _make_adapter()
-    ws = _make_ws()
-    adapter.emit_created(ws)
-    assert gq.empty()
-
-
-def test_emit_rehydrated_is_noop_on_interactive() -> None:
-    adapter, gq = _make_adapter()
-    ws = _make_ws()
-    adapter.emit_rehydrated(ws)
-    assert gq.empty()
-
-
-def test_emit_state_is_noop_on_interactive() -> None:
-    """WebUI._broadcast_state emits the full ws_state payload (tokens,
-    context_ratio, activity). The adapter no-ops to avoid duplicating
-    that with a thinner payload."""
-    adapter, gq = _make_adapter()
-    ws = _make_ws()
-    adapter.emit_state(ws, WorkstreamState.RUNNING)
-    assert gq.empty()
 
 
 def test_emit_closed_defaults_to_closed_reason() -> None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1219,7 +1219,7 @@ def _make_manager(session_factory: Any) -> Any:
         ui_factory=lambda ws: MagicMock(),
         session_factory=session_factory,
     )
-    return SessionManager(adapter, storage=MagicMock(), max_active=10)
+    return SessionManager(adapter, storage=MagicMock(), max_active=10, event_emitter=adapter)
 
 
 class TestWorkstreamModelParam:

--- a/tests/test_prompt_templates_runtime.py
+++ b/tests/test_prompt_templates_runtime.py
@@ -463,7 +463,7 @@ class TestSkillFactoryPassthrough:
             ui_factory=lambda ws: NullUI(),
             session_factory=factory,
         )
-        mgr = SessionManager(adapter, storage=MagicMock(), max_active=10)
+        mgr = SessionManager(adapter, storage=MagicMock(), max_active=10, event_emitter=adapter)
         ws = mgr.create(user_id="", name="test", skill="factory-tpl")
         assert captured_skill == "factory-tpl"
         assert ws.session is not None
@@ -490,7 +490,7 @@ class TestSkillFactoryPassthrough:
             ui_factory=lambda ws: NullUI(),
             session_factory=factory,
         )
-        mgr = SessionManager(adapter, storage=MagicMock(), max_active=10)
+        mgr = SessionManager(adapter, storage=MagicMock(), max_active=10, event_emitter=adapter)
         mgr.create(user_id="", name="test")
         assert captured_skill is None
 

--- a/tests/test_server_attachments_on_create.py
+++ b/tests/test_server_attachments_on_create.py
@@ -289,7 +289,9 @@ def app_client(tmp_path, monkeypatch):
         ),
         session_factory=_factory,
     )
-    mgr = SessionManager(adapter, storage=get_storage(), max_active=10, node_id="node-test")
+    mgr = SessionManager(
+        adapter, storage=get_storage(), max_active=10, node_id="node-test", event_emitter=adapter
+    )
 
     app = create_app(
         workstreams=mgr,

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -159,7 +159,9 @@ def app_client(tmp_path, monkeypatch):
         ),
         session_factory=_factory,
     )
-    mgr = SessionManager(adapter, storage=get_storage(), max_active=10, node_id="node-test")
+    mgr = SessionManager(
+        adapter, storage=get_storage(), max_active=10, node_id="node-test", event_emitter=adapter
+    )
     app = create_app(
         workstreams=mgr,
         global_queue=gq,

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -6,7 +6,11 @@ reservation, eviction, per-ws lock serialization on lazy rehydrate,
 state flips, close-unblocks-UI. All exercised through a
 ``FakeAdapter`` that records ``emit_*`` / ``cleanup_ui`` calls so
 tests can assert the transport contract without spinning up real
-WebUI / ClusterCollector pipelines.
+WebUI / ClusterCollector pipelines. The adapter is wired as both the
+manager's ``adapter`` (for ``cleanup_ui`` / ``build_*``) and its
+``event_emitter`` (for the ``emit_*`` lifecycle calls); production
+adapters do the same — interactive on ``server.py``, coordinator on
+``console/server.py``.
 """
 
 from __future__ import annotations
@@ -29,7 +33,7 @@ from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamStat
 
 @dataclass
 class _Event:
-    kind: str  # "created" | "state" | "closed"
+    kind: str  # "created" | "rehydrated" | "state" | "closed"
     ws_id: str
     state: WorkstreamState | None = None
     reason: str | None = None
@@ -96,13 +100,14 @@ class FakeAdapter:
             self.events.append(_Event("created", ws.id))
 
     def emit_rehydrated(self, ws: Workstream) -> None:
-        # Record as a plain "created" event — the test suite treats
-        # create + rehydrate as indistinguishable on the interactive
-        # transport. The coord-side adapter uses emit_rehydrated for
-        # its storage-seeded subtree rebuild; the fake doesn't need a
-        # separate event type.
+        # Distinct from "created" so a regression where the manager
+        # fires emit_created on the rehydrate path (or emit_rehydrated
+        # on the create path) actually fails a test. The
+        # SessionEventEmitter Protocol carves these out as semantically
+        # different — coord uses emit_rehydrated for the storage-seeded
+        # subtree rebuild that emit_created skips.
         with self._events_lock:
-            self.events.append(_Event("created", ws.id))
+            self.events.append(_Event("rehydrated", ws.id))
 
     def emit_state(self, ws: Workstream, state: WorkstreamState) -> None:
         with self._events_lock:
@@ -222,7 +227,15 @@ def _make_manager(
 ) -> tuple[SessionManager, FakeAdapter, FakeStorage]:
     adapter = adapter or FakeAdapter()
     storage = storage or FakeStorage()
-    mgr = SessionManager(adapter, storage=storage, max_active=max_active)
+    # FakeAdapter implements both Protocols (the production adapters
+    # do too — wire as both so the emit_* assertions in this file
+    # still see the events the manager fires).
+    mgr = SessionManager(
+        adapter,
+        storage=storage,
+        max_active=max_active,
+        event_emitter=adapter,
+    )
     return mgr, adapter, storage
 
 
@@ -374,8 +387,10 @@ def test_open_resurrects_closed_state() -> None:
     assert reopened.id == ws_id
     assert reopened.session is not None
     assert reopened.session.resumed is True  # type: ignore[attr-defined]
-    # Open fires a fresh emit_created so observers see the rehydrate.
-    assert ws_id in [e.ws_id for e in adapter.events_of("created")]
+    # Open fires emit_rehydrated (NOT emit_created) so observers can
+    # gate any extra resurrect-only setup on it (e.g. coord's
+    # storage-seeded children rebuild).
+    assert ws_id in [e.ws_id for e in adapter.events_of("rehydrated")]
 
 
 def test_open_ignores_owner_mismatch() -> None:
@@ -659,7 +674,10 @@ def test_eviction_count_tracks_evictions() -> None:
 
 def test_create_uses_configured_node_id() -> None:
     storage = MagicMock()
-    mgr = SessionManager(FakeAdapter(), storage=storage, max_active=3, node_id="node-xyz")
+    adapter = FakeAdapter()
+    mgr = SessionManager(
+        adapter, storage=storage, max_active=3, node_id="node-xyz", event_emitter=adapter
+    )
     mgr.create(user_id="u1")
     assert storage.register_workstream.call_args.kwargs["node_id"] == "node-xyz"
 
@@ -682,11 +700,13 @@ class TestSessionManagerWithStateWriter:
 
         storage = FakeStorage()
         writer = StateWriter(storage, flush_interval=flush_interval)
+        adapter = FakeAdapter()
         mgr = SessionManager(
-            FakeAdapter(),
+            adapter,
             storage=storage,
             max_active=3,
             state_writer=writer,
+            event_emitter=adapter,
         )
         return mgr, storage, writer
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1767,7 +1767,7 @@ class TestSkillConfigAppliedToWorkstream:
             ),
             session_factory=_session_factory,
         )
-        mgr = SessionManager(adapter, storage=storage, max_active=10)
+        mgr = SessionManager(adapter, storage=storage, max_active=10, event_emitter=adapter)
 
         routes = [
             Mount(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3954,6 +3954,11 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                     max_active=int(config_store.get("coordinator.max_active")),
                     node_id=ClusterCollector.CONSOLE_PSEUDO_NODE_ID,
                     state_writer=coord_state_writer,
+                    # CoordinatorAdapter implements SessionEventEmitter
+                    # in full — every lifecycle transition fans out to
+                    # the cluster collector's pseudo-node so the
+                    # dashboard tree mirrors child state.
+                    event_emitter=coord_adapter,
                 )
                 # Late-bind the manager onto the adapter so
                 # ``_rebuild_children_registry`` / ``send`` /

--- a/turnstone/core/adapters/interactive_adapter.py
+++ b/turnstone/core/adapters/interactive_adapter.py
@@ -1,9 +1,12 @@
 """InteractiveAdapter — SessionManager bridge for interactive workstreams.
 
-Emits lifecycle events onto the process-wide ``global_queue`` the SSE
-fan-out thread copies to every connected browser tab. Uses
-``WebUI``'s per-UI listener set for ``cleanup_ui`` — the same hooks
-(``_approval_event`` / ``_plan_event`` / ``_fg_event`` + the
+Implements both :class:`SessionKindAdapter` (construction + cleanup)
+and :class:`SessionEventEmitter` (lifecycle emission). The emission
+surface is asymmetric on the interactive side and the asymmetry is
+load-bearing — see ``InteractiveAdapter`` docstring.
+
+Uses ``WebUI``'s per-UI listener set for ``cleanup_ui`` — the same
+hooks (``_approval_event`` / ``_plan_event`` / ``_fg_event`` + the
 ``ws_closed`` broadcast) the old ``WorkstreamManager._cleanup_ui``
 touched.
 """
@@ -28,7 +31,29 @@ log = get_logger(__name__)
 
 
 class InteractiveAdapter:
-    """Bridges SessionManager to the interactive node's transport."""
+    """Bridges SessionManager to the interactive node's transport.
+
+    Lifecycle emission asymmetry:
+
+    - :meth:`emit_closed` is the **sole** transport path for
+      ``ws_closed`` onto the process-wide ``global_queue`` the SSE
+      fan-out thread copies to every connected browser tab. Stage 1
+      consolidated the old inline emission from the create handler
+      (``reason="evicted"``) here so there's exactly one emission point;
+      ``name`` powers the frontend's eviction toast.
+
+    - :meth:`emit_created` / :meth:`emit_state` / :meth:`emit_rehydrated`
+      are no-ops. The corresponding events fire from out-of-band paths:
+      the create HTTP handler enqueues ``ws_created`` directly onto
+      ``global_queue`` *after* attachment validation (so a rejected
+      upload doesn't surface a phantom create→close pair), and
+      ``WebUI._broadcast_state`` emits the full ``ws_state`` payload
+      (tokens + context_ratio + activity) via the
+      ``SessionUI.on_state_change`` callback chain. The stubs exist
+      solely to satisfy :class:`SessionEventEmitter` Protocol so the
+      adapter can be wired as the manager's ``event_emitter`` for the
+      ``emit_closed`` path.
+    """
 
     kind: WorkstreamKind = WorkstreamKind.INTERACTIVE
 
@@ -69,27 +94,17 @@ class InteractiveAdapter:
         return mgr
 
     # ------------------------------------------------------------------
-    # Lifecycle events — push onto the process-wide SSE queue
+    # SessionEventEmitter — see class docstring for the asymmetry
     # ------------------------------------------------------------------
 
     def emit_created(self, ws: Workstream) -> None:
-        # No-op on interactive. The create_workstream HTTP handler
-        # (turnstone/server.py) fires ws_created to the global queue
-        # AFTER attachment validation so a rejected upload doesn't
-        # surface a phantom create→close pair. Firing here would
-        # duplicate the event and reintroduce the phantom.
-        pass
+        del ws  # no-op — ws_created fires from the create HTTP handler
 
     def emit_state(self, ws: Workstream, state: WorkstreamState) -> None:
-        # No-op on interactive. WebUI._broadcast_state emits the full
-        # ws_state payload (tokens + context_ratio + activity) via the
-        # SessionUI.on_state_change callback chain; firing here would
-        # duplicate the event with a thinner payload.
-        pass
+        del ws, state  # no-op — ws_state fires from WebUI._broadcast_state
 
     def emit_rehydrated(self, ws: Workstream) -> None:
-        # No-op on interactive (mirrors emit_created).
-        pass
+        del ws  # no-op — mirrors emit_created (handler-side ws_created)
 
     def emit_closed(
         self,
@@ -98,23 +113,15 @@ class InteractiveAdapter:
         reason: str = "closed",
         name: str = "",
     ) -> None:
-        # Sole transport path for ws_closed on interactive. The old
-        # create_workstream HTTP handler used to fire this inline (with
-        # name + reason="evicted" on the eviction path) — Stage 1
-        # consolidated that here so there's exactly one emission point.
-        # ``name`` powers the frontend eviction toast.
-        self._enqueue(
-            {
-                "type": "ws_closed",
-                "ws_id": ws_id,
-                "reason": reason,
-                "name": name,
-            }
-        )
-
-    def _enqueue(self, event: dict[str, Any]) -> None:
         with contextlib.suppress(queue.Full):
-            self._global_queue.put_nowait(event)
+            self._global_queue.put_nowait(
+                {
+                    "type": "ws_closed",
+                    "ws_id": ws_id,
+                    "reason": reason,
+                    "name": name,
+                }
+            )
 
     # ------------------------------------------------------------------
     # UI cleanup — unblock pending events + broadcast ws_closed to listeners

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -39,14 +39,28 @@ class SessionKindAdapter(Protocol):
       events when a workstream closes.
 
     Lifecycle event fan-out (``ws_created`` / ``ws_state`` /
-    ``ws_closed``) is a *separate* Protocol — :class:`SessionEventEmitter`
-    — and is opt-in. Interactive emits its lifecycle events out-of-band
-    (``WebUI._broadcast_state`` for state, the create handler for
-    create), so the interactive adapter doesn't implement
-    ``SessionEventEmitter`` and the manager skips the emit calls when no
-    emitter is wired. Coordinator implements both: the construction
-    Protocol here AND the emitter Protocol so the cluster collector's
-    pseudo-node sees lifecycle transitions.
+    ``ws_closed``) lives on a *separate* Protocol —
+    :class:`SessionEventEmitter` — wired through the manager's
+    optional ``event_emitter`` kwarg. Both production adapters
+    implement *both* Protocols. The asymmetry is in *which* emit
+    methods carry real bodies:
+
+    - Coordinator: all four ``emit_*`` are real — every transition
+      fans out via the cluster collector's pseudo-node.
+    - Interactive: only ``emit_closed`` is load-bearing (it's the
+      sole transport path for ``ws_closed`` onto the global SSE
+      queue); ``emit_created`` / ``emit_state`` / ``emit_rehydrated``
+      are documented no-op stubs because those events fire from
+      out-of-band paths (the create HTTP handler enqueues
+      ``ws_created`` after attachment validation;
+      ``WebUI._broadcast_state`` enqueues a richer ``ws_state``
+      payload than this Protocol carries).
+
+    The manager's ``if self._event_emitter is not None`` guard
+    handles the case where no emitter is wired at all — used by
+    tests that don't care about the event side effects, and reserved
+    for future kinds whose lifecycle transitions don't fan out
+    anywhere.
 
     Intentionally NOT on the Protocol (see design brief's "Decisions
     settled during the pruning pass"): per-kind permission scope
@@ -85,13 +99,19 @@ class SessionEventEmitter(Protocol):
     """Optional transport fan-out for lifecycle events.
 
     Wired into :class:`SessionManager` via the ``event_emitter`` kwarg.
-    Kinds whose lifecycle events flow through out-of-band channels
-    (interactive's ``WebUI._broadcast_state`` for state and its
-    HTTP create handler's ``ws_created`` enqueue for create / rehydrate)
-    don't implement this Protocol and the manager simply skips the
-    emit calls. Coordinator implements both this Protocol and
-    :class:`SessionKindAdapter` so the cluster collector's pseudo-node
-    sees every transition.
+    Both production adapters implement this Protocol; the manager's
+    ``if self._event_emitter is not None`` guard exists for kinds /
+    tests that omit an emitter entirely.
+
+    Implementing the Protocol does not commit a kind to wiring every
+    method — interactive's ``emit_created`` / ``emit_state`` /
+    ``emit_rehydrated`` are documented no-op stubs because those
+    events fire from out-of-band channels (``WebUI._broadcast_state``
+    for state, the create HTTP handler for ``ws_created`` after
+    attachment validation). Only ``emit_closed`` carries a real body
+    on interactive. Coordinator's four methods are all real (cluster
+    collector's pseudo-node sees every transition). See
+    :class:`SessionKindAdapter` docstring for the asymmetry rationale.
     """
 
     def emit_created(self, ws: Workstream) -> None:

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -29,16 +29,24 @@ log = get_logger(__name__)
 
 
 class SessionKindAdapter(Protocol):
-    """Per-kind policies the shared ``SessionManager`` delegates to.
+    """Per-kind construction + cleanup policies the shared ``SessionManager`` delegates to.
 
     The manager owns invariant mechanics. The adapter owns:
 
-    - **Transport**: how lifecycle events (``ws_created`` /
-      ``ws_state`` / ``ws_closed``) fan out. Interactive pushes onto a
-      per-UI listener queue + global event queue; coordinator emits on
-      the cluster collector's pseudo-node.
     - **Session construction**: what UI class wraps the workstream,
       what ``ChatSession`` factory signature applies.
+    - **UI cleanup**: unblocking pending approval / plan / foreground
+      events when a workstream closes.
+
+    Lifecycle event fan-out (``ws_created`` / ``ws_state`` /
+    ``ws_closed``) is a *separate* Protocol — :class:`SessionEventEmitter`
+    — and is opt-in. Interactive emits its lifecycle events out-of-band
+    (``WebUI._broadcast_state`` for state, the create handler for
+    create), so the interactive adapter doesn't implement
+    ``SessionEventEmitter`` and the manager skips the emit calls when no
+    emitter is wired. Coordinator implements both: the construction
+    Protocol here AND the emitter Protocol so the cluster collector's
+    pseudo-node sees lifecycle transitions.
 
     Intentionally NOT on the Protocol (see design brief's "Decisions
     settled during the pruning pass"): per-kind permission scope
@@ -48,31 +56,6 @@ class SessionKindAdapter(Protocol):
     """
 
     kind: WorkstreamKind
-
-    def emit_created(self, ws: Workstream) -> None: ...
-    def emit_rehydrated(self, ws: Workstream) -> None:
-        """Fire the lifecycle event for a lazy-rehydrated workstream.
-
-        Distinct from ``emit_created`` so coord-side adapters can
-        perform storage-seeded registry rebuilds only on the resurrect
-        path. A freshly-created workstream provably has zero children,
-        so the rebuild query is wasted. Interactive adapters with no
-        such registry just delegate to ``emit_created``.
-        """
-
-    def emit_state(self, ws: Workstream, state: WorkstreamState) -> None: ...
-    def emit_closed(
-        self,
-        ws_id: str,
-        *,
-        reason: str = "closed",
-        name: str = "",
-    ) -> None:
-        """Fire the close event. ``reason`` is "closed" for manual
-        close, "evicted" for capacity eviction (frontend shows a
-        distinct toast). ``name`` is the workstream's display name —
-        the frontend eviction toast includes it so the user sees
-        which workstream was evicted."""
 
     def cleanup_ui(self, ws: Workstream) -> None:
         """Unblock per-UI events on close; cancel + close the session."""
@@ -98,6 +81,51 @@ class SessionKindAdapter(Protocol):
         """
 
 
+class SessionEventEmitter(Protocol):
+    """Optional transport fan-out for lifecycle events.
+
+    Wired into :class:`SessionManager` via the ``event_emitter`` kwarg.
+    Kinds whose lifecycle events flow through out-of-band channels
+    (interactive's ``WebUI._broadcast_state`` for state and its
+    HTTP create handler's ``ws_created`` enqueue for create / rehydrate)
+    don't implement this Protocol and the manager simply skips the
+    emit calls. Coordinator implements both this Protocol and
+    :class:`SessionKindAdapter` so the cluster collector's pseudo-node
+    sees every transition.
+    """
+
+    def emit_created(self, ws: Workstream) -> None:
+        """Fire the lifecycle event for a freshly created workstream."""
+
+    def emit_rehydrated(self, ws: Workstream) -> None:
+        """Fire the lifecycle event for a lazy-rehydrated workstream.
+
+        Distinct from ``emit_created`` so emitters can do extra setup
+        only on the resurrect path (the coordinator emitter rebuilds
+        its children registry from storage on rehydrate; a fresh
+        ``create`` provably has zero children, so the rebuild query is
+        skipped).
+        """
+
+    def emit_state(self, ws: Workstream, state: WorkstreamState) -> None:
+        """Fire the state-transition event."""
+
+    def emit_closed(
+        self,
+        ws_id: str,
+        *,
+        reason: str = "closed",
+        name: str = "",
+    ) -> None:
+        """Fire the close event.
+
+        ``reason`` is ``"closed"`` for manual close, ``"evicted"`` for
+        capacity eviction (frontend shows a distinct toast). ``name``
+        is the workstream's display name — the eviction toast
+        includes it so the user sees which workstream was evicted.
+        """
+
+
 class SessionManager:
     """Unified lifecycle manager for a single workstream kind.
 
@@ -114,6 +142,7 @@ class SessionManager:
         max_active: int,
         node_id: str | None = None,
         state_writer: StateWriter | None = None,
+        event_emitter: SessionEventEmitter | None = None,
     ) -> None:
         if max_active < 1:
             raise ValueError(f"max_active must be >= 1, got {max_active}")
@@ -125,6 +154,14 @@ class SessionManager:
         # ``ws._lock`` across a sync DB UPDATE. Tests can leave it
         # None and get the legacy direct-write behaviour.
         self._state_writer = state_writer
+        # Optional lifecycle-event emitter. Wired by both production
+        # lifespans (interactive's emitter is the adapter itself, which
+        # also satisfies the Protocol; coord wires its own adapter the
+        # same way). When ``None``, the manager skips every emit_*
+        # call — used by tests that don't care about the event side
+        # effects, and reserved for future kinds whose lifecycle
+        # transitions don't fan out anywhere.
+        self._event_emitter = event_emitter
         self._node_id = node_id
         self._workstreams: dict[str, Workstream] = {}
         self._order: list[str] = []
@@ -143,8 +180,8 @@ class SessionManager:
         # Optional state-change observer. The CLI sets this to a
         # callback that prints a background-attention notification
         # when a non-focused workstream transitions to ATTENTION.
-        # Web/coord paths use the adapter's emit_state for their own
-        # fan-out; this is a second, manager-level hook for callers
+        # Web/coord paths use the event_emitter's emit_state for their
+        # own fan-out; this is a second, manager-level hook for callers
         # that don't consume SSE.
         self._on_state_change: Callable[[str, WorkstreamState], None] | None = None
 
@@ -252,7 +289,8 @@ class SessionManager:
 
         if evicted is not None:
             self._adapter.cleanup_ui(evicted)
-            self._adapter.emit_closed(evicted.id, reason="evicted", name=evicted.name)
+            if self._event_emitter is not None:
+                self._event_emitter.emit_closed(evicted.id, reason="evicted", name=evicted.name)
 
         # Persist before session construction. Fail-closed: if the row
         # can't be written, the in-memory session would be invisible to
@@ -292,7 +330,8 @@ class SessionManager:
                 self._remove_locked(ws_id)
             raise
 
-        self._adapter.emit_created(ws)
+        if self._event_emitter is not None:
+            self._event_emitter.emit_created(ws)
         return ws
 
     # ------------------------------------------------------------------
@@ -346,7 +385,10 @@ class SessionManager:
 
                 if evicted is not None:
                     self._adapter.cleanup_ui(evicted)
-                    self._adapter.emit_closed(evicted.id, reason="evicted", name=evicted.name)
+                    if self._event_emitter is not None:
+                        self._event_emitter.emit_closed(
+                            evicted.id, reason="evicted", name=evicted.name
+                        )
 
                 try:
                     ws.session = self._adapter.build_session(ws)
@@ -369,7 +411,8 @@ class SessionManager:
                 # last close(). The next set_state() call syncs it
                 # naturally; writing 'idle' here could race a concurrent
                 # close() that writes 'closed' under self._lock.
-                self._adapter.emit_rehydrated(ws)
+                if self._event_emitter is not None:
+                    self._event_emitter.emit_rehydrated(ws)
                 return ws
         finally:
             self._release_open_lock(ws_id)
@@ -437,7 +480,8 @@ class SessionManager:
                 self._storage.delete_workstream_override(ws_id)
             except Exception:
                 log.debug("session_mgr.override_delete_failed ws=%s", ws_id[:8], exc_info=True)
-        self._adapter.emit_closed(ws_id, name=ws.name)
+        if self._event_emitter is not None:
+            self._event_emitter.emit_closed(ws_id, name=ws.name)
         return True
 
     def set_state(
@@ -481,7 +525,8 @@ class SessionManager:
                     self._storage.update_workstream_state(ws_id, state.value)
                 except Exception:
                     log.debug("session_mgr.state_update_failed ws=%s", ws_id[:8], exc_info=True)
-        self._adapter.emit_state(ws, state)
+        if self._event_emitter is not None:
+            self._event_emitter.emit_state(ws, state)
         if self._on_state_change is not None:
             with contextlib.suppress(Exception):
                 self._on_state_change(ws_id, state)
@@ -559,7 +604,8 @@ class SessionManager:
                     self._storage.delete_workstream_override(ws.id)
                 except Exception:
                     log.debug("session_mgr.override_delete_failed ws=%s", ws.id[:8], exc_info=True)
-            self._adapter.emit_closed(ws.id, name=ws.name)
+            if self._event_emitter is not None:
+                self._event_emitter.emit_closed(ws.id, name=ws.name)
             closed_ids.append(ws.id)
         return closed_ids
 
@@ -666,7 +712,8 @@ class SessionManager:
             # subscribers.
             if evicted is not None:
                 self._adapter.cleanup_ui(evicted)
-                self._adapter.emit_closed(evicted.id, reason="evicted", name=evicted.name)
+                if self._event_emitter is not None:
+                    self._event_emitter.emit_closed(evicted.id, reason="evicted", name=evicted.name)
             raise
         self._workstreams[ws_id] = ws
         self._order.append(ws_id)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4468,6 +4468,11 @@ def main() -> None:
         max_active=config_store.get("server.max_workstreams"),
         node_id=_node_id,
         state_writer=state_writer,
+        # InteractiveAdapter satisfies SessionEventEmitter for the
+        # ``ws_closed`` transport path; emit_created / emit_state /
+        # emit_rehydrated are no-ops because those events fire from
+        # out-of-band paths (create handler + WebUI._broadcast_state).
+        event_emitter=interactive_adapter,
     )
     interactive_adapter.attach(manager)
     WebUI._workstream_mgr = manager


### PR DESCRIPTION
… emission (Stage 2 P3)

The single ``SessionKindAdapter`` Protocol that ``SessionManager`` takes is split into two:

* ``SessionKindAdapter`` — kind / build_ui / build_session / cleanup_ui. Required for every kind. The shared lifecycle manager always delegates here for construction + cleanup.
* ``SessionEventEmitter`` — emit_created / emit_state / emit_rehydrated / emit_closed. **Optional**, wired through a new ``event_emitter: SessionEventEmitter | None = None`` kwarg on ``SessionManager``. Reserved for future kinds whose lifecycle transitions don't fan out anywhere; both production kinds wire one today.

Both production adapters implement both Protocols. The interactive lifespan (``server.py``) and console lifespan
(``console/server.py``) pass their adapter as both ``adapter`` and ``event_emitter`` — production behaviour is unchanged. Six lifecycle sites in ``SessionManager`` (create / open eviction / open rehydrate / close / set_state / close_idle / _reserve_and_install_locked unwind) now call ``self._event_emitter.emit_*(...)`` guarded by ``if self._event_emitter is not None``.

InteractiveAdapter asymmetry preserved + documented:

* ``emit_closed`` stays load-bearing — it's the **sole** transport path for ``ws_closed`` onto the process-wide global SSE queue (Stage 1 consolidated emission from the create handler here so there's exactly one emission point; ``name`` powers the frontend's eviction toast).
* ``emit_created`` / ``emit_state`` / ``emit_rehydrated`` are documented no-op stubs (``del ws[, state]``). Those events fire from out-of-band paths — the create HTTP handler enqueues ``ws_created`` directly onto ``global_queue`` *after* attachment validation (so a rejected upload doesn't surface a phantom create→close pair); ``WebUI._broadcast_state`` emits the full ``ws_state`` payload (tokens + context_ratio + activity) via the ``SessionUI.on_state_change`` callback chain. The stubs exist solely to satisfy ``SessionEventEmitter`` Protocol so the adapter can be wired as the manager's ``event_emitter`` for the ``emit_closed`` path. Each stub has a 1-line inline rationale to match the in-repo convention (``coordinator_adapter.py:210``).

Test scaffolding:

* ``tests/test_session_manager.py`` — ``_make_manager`` and ``_make_with_writer`` wire ``FakeAdapter`` as both ``adapter`` and ``event_emitter`` for production parity; the standalone ``test_create_uses_configured_node_id`` does the same. ``FakeAdapter.emit_rehydrated`` now records as ``_Event("rehydrated", ...)`` rather than conflating with ``"created"``, and ``test_open_resurrects_closed_state`` asserts against ``events_of("rehydrated")`` so a regression where the manager fires the wrong call on the open path actually fails.
* ``tests/_coord_test_helpers.py`` and ``tests/test_coordinator_end_to_end.py`` — wire ``CoordinatorAdapter`` as both args.
* Six interactive test fixtures (``test_skills.py``, ``test_prompt_templates_runtime.py`` x2, ``test_model_registry.py``, ``test_server_authz.py``, ``test_server_attachments_on_create.py``) — wire ``event_emitter=adapter`` so they match the production wiring, removing the footgun where a future contributor adds a ``gq.get_nowait()`` assertion and silently loses the only ``ws_closed`` transport.
* ``tests/test_interactive_adapter.py`` — drops the three tautological no-op-emit_* tests (``test_emit_created_is_noop``, ``test_emit_state_is_noop``, ``test_emit_rehydrated_is_noop``); keeps the four ``emit_closed`` tests (real behaviour).

Lint + mypy clean. 4475 tests passing.