### PR TITLE
refactor(core): lift cancel verb body across both kinds (Stage 2 verb lift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,68 @@ Three release tracks are maintained:
   ``ws_state``); ``emit_closed`` stays load-bearing as the sole
   transport path for ``ws_closed`` onto the global SSE queue.
 
+- **`cancel` verb body lifted across both kinds** ([Stage 2 Verb
+  Lift — `cancel`]). The interactive ``/v1/api/cancel`` and coord
+  ``/v1/api/workstreams/{ws_id}/cancel`` handlers now share one
+  body via ``make_cancel_handler(cfg, *, audit_emit=None)``;
+  per-kind divergence captured by a new
+  ``cancel_forensics: CancelForensics | None`` field on
+  ``SessionEndpointConfig`` (interactive wires
+  ``_capture_cancel_forensics``; coord wires ``None``).
+  Three observable behaviour changes for coord callers:
+
+  - **Coord cancel now accepts a ``force`` flag.** Same shape as
+    interactive: posting ``{"force": true}`` abandons the worker
+    thread and emits ``stream_end`` so a stuck coord generation
+    can be recovered without waiting for the daemon thread to
+    exit. Pre-lift coord ignored ``force``.
+  - **Coord cancel response always includes ``"dropped"``.**
+    Pre-lift coord returned bare ``{"status": "ok"}``; the lifted
+    body returns ``{"status": "ok", "dropped": {}}`` (always-include
+    parity with interactive). SDK consumers don't need to branch
+    on kind to read ``dropped``.
+  - **Coord cancel returns 400 when the workstream's session is
+    ``None``.** Pre-lift coord called ``coord_mgr.cancel`` which
+    silently no-op'd on a placeholder/build-failed workstream; the
+    lifted body 400s with ``{"error": "No session"}`` for parity
+    with interactive's pre-existing branch.
+
+  One observable change for interactive: ``resolve_approval`` /
+  ``resolve_plan`` now run on every cancel (previously gated on
+  ``was_running``). Lifts coord's pre-lift behaviour onto interactive
+  — a stuck approval-pending state from a crashed worker can now
+  be cleared via ``cancel`` instead of requiring a workstream
+  close + rehydrate. The calls are idempotent and no-op when
+  nothing is blocked.
+
+  Coord ``coordinator.cancel`` audit detail now includes ``force``
+  so operator-driven recovery is distinguishable from a routine
+  cancel in the audit log.
+
+  Three /review fixes folded into the same commit:
+
+  - **No more stale ``approval_resolved`` SSE event on idle cancel.**
+    The lifted body's ``resolve_approval`` call is now gated on
+    ``ui._pending_approval is not None``. Pre-fix, the unconditional
+    call would broadcast a phantom ``approval_resolved`` to every
+    SSE listener even when no prompt was pending — listener UIs
+    that key on the event would dismiss prompts they didn't have.
+  - **Force-cancel now clears ``_worker_running`` alongside
+    ``worker_thread``.** Previously the force path left the half-
+    state ``(_worker_running=True, worker_thread=None)``, which
+    routed any follow-up ``send`` through the queue-enqueue path
+    onto the abandoned worker (where the cancel flag short-circuits
+    the queue-drain seam, leaving the message orphaned until the
+    next spawn). Restores the
+    ``(worker_thread, _worker_running)`` invariant
+    ``session_worker.send`` documents.
+  - **``coordinator_stop_cascade`` now treats child cancel
+    ``400 + "No session"`` as ``skipped``** (was previously
+    ``failed``). Lifted coord cancel returns 400 on placeholder /
+    build-failed children — matching the pre-lift outcome where
+    those children were silently no-op'd, so the cascade response's
+    ``failed`` bucket no longer fires spurious operator alerts.
+
 ### Security
 
 - **Coord attachment endpoints are now kind-strict**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,13 +188,23 @@ Three release tracks are maintained:
     lifted body 400s with ``{"error": "No session"}`` for parity
     with interactive's pre-existing branch.
 
-  One observable change for interactive: ``resolve_approval`` /
-  ``resolve_plan`` now run on every cancel (previously gated on
-  ``was_running``). Lifts coord's pre-lift behaviour onto interactive
-  — a stuck approval-pending state from a crashed worker can now
-  be cleared via ``cancel`` instead of requiring a workstream
-  close + rehydrate. The calls are idempotent and no-op when
-  nothing is blocked.
+  Two observable changes for interactive (asymmetric — coord
+  pre-lift already had this behaviour):
+
+  - ``resolve_plan`` now runs on every cancel (previously gated
+    on ``was_running``). ``resolve_plan`` has an internal
+    ``_pending_plan_review is None`` guard, so the call is no-op
+    when no plan review is pending. Lift gives interactive coord's
+    pre-lift recovery path: a stuck plan-pending state from a
+    crashed worker can be cleared via ``cancel`` instead of
+    requiring a workstream close + rehydrate.
+  - ``resolve_approval`` runs on every cancel **only when
+    ``ui._pending_approval is not None``** (the lifted body gates
+    the call). ``resolve_approval`` is not idempotent — it always
+    broadcasts ``approval_resolved`` and overwrites
+    ``_approval_result`` — so the gate prevents a stale resolution
+    event from leaking on idle cancels while preserving the recovery
+    path when an approval really is pending.
 
   Coord ``coordinator.cancel`` audit detail now includes ``force``
   so operator-driven recovery is distinguishable from a routine

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -31,11 +31,11 @@ from tests._coord_test_helpers import (
 )
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
+    _audit_cancel_coordinator,
     _audit_close_coordinator,
     _require_admin_coordinator,
     _require_coord_mgr,
     cluster_ws_detail,
-    coordinator_cancel,
     coordinator_children,
     coordinator_create,
     coordinator_detail,
@@ -60,6 +60,7 @@ from turnstone.core.session_routes import (
     SessionEndpointConfig,
     make_approve_handler,
     make_attachment_handlers,
+    make_cancel_handler,
     make_close_handler,
     make_send_handler,
 )
@@ -149,7 +150,10 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/cancel",
-                coordinator_cancel,
+                make_cancel_handler(
+                    _coord_endpoint_config,
+                    audit_emit=_audit_cancel_coordinator,
+                ),
                 methods=["POST"],
             ),
             Route(
@@ -624,6 +628,166 @@ def test_cancel_resolves_pending_approval(storage):
     resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
     assert resp.status_code == 200
     assert ws.ui._approval_event.is_set()
+
+
+def test_cancel_response_always_includes_dropped_key(storage):
+    """Always-include shape parity: post-P3 verb lift, coord cancel
+    returns ``{"status": "ok", "dropped": {}}`` regardless of whether
+    a forensics callable is wired (coord wires ``None``). SDK
+    consumers don't have to branch on kind to read ``dropped``."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["dropped"] == {}
+
+
+def test_cancel_force_flag_abandons_worker_thread_and_emits_stream_end(storage):
+    """Parity gain from the verb lift: coord now honours the ``force``
+    flag the same way interactive does (pre-lift coord ignored it).
+    Stuck-worker recovery: the abandoned thread is cleared, an
+    ``idle`` state-change is dispatched via the UI, and a
+    ``stream_end`` event lands on the listener queue so the dashboard
+    recovers without waiting for the daemon thread to exit."""
+    import threading
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    assert isinstance(ws.ui, ConsoleCoordinatorUI)
+    # Simulate an in-flight worker the UI is still waiting on.
+    ws._worker_running = True
+    ws.worker_thread = threading.Thread(target=lambda: None, daemon=True)
+    listener = ws.ui._register_listener()
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/cancel",
+        headers=_COORD_HEADERS,
+        json={"force": True},
+    )
+    assert resp.status_code == 200
+    # Worker thread reference cleared so a follow-up send doesn't
+    # think a generation is still in flight.
+    assert ws.worker_thread is None
+    # ``stream_end`` lands on the listener so SDK consumers bail out
+    # of the SSE loop instead of hanging on the daemon thread.
+    seen = []
+    while not listener.empty():
+        seen.append(listener.get_nowait().get("type"))
+    assert "stream_end" in seen
+
+
+def test_cancel_returns_400_when_session_missing(storage):
+    """Pre-lift coord called ``coord_mgr.cancel`` which silently
+    no-op'd on a placeholder workstream (session=None). The lifted
+    body 400s for parity with interactive's existing
+    ``"No session"`` branch — surfaces the build-failure state to
+    the operator instead of swallowing it."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    # Force the placeholder/build-failed shape.
+    ws.session = None
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 400
+
+
+def test_cancel_swallows_forensics_exception(storage):
+    """``cancel_forensics`` is observational — a bug in the snapshot
+    callable must NOT block the actual cancel. The lifted body wraps
+    the call in try/except + log.debug and falls through with an
+    empty ``dropped`` dict so the response shape stays consistent."""
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.core.session_routes import (
+        SessionEndpointConfig,
+        make_cancel_handler,
+    )
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+
+    def _raises_forensics(session, ui, *, was_running):  # noqa: ARG001
+        raise RuntimeError("forensics blew up")
+
+    cfg = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=lambda r: (mgr, None),
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+        cancel_forensics=_raises_forensics,
+    )
+    handler = make_cancel_handler(cfg)
+    app = Starlette(routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])])
+    app.add_middleware(_AuthMiddleware)
+    client = TestClient(app)
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["dropped"] == {}
+
+
+def test_cancel_swallows_audit_emit_exception(storage):
+    """``audit_emit`` failures are demoted to ``log.warning`` and the
+    cancel returns 200. Mirrors the same pattern in ``make_close_handler``
+    — telemetry bugs must not block recovery verbs."""
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.core.session_routes import (
+        SessionEndpointConfig,
+        make_cancel_handler,
+    )
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+
+    def _raises_audit(request, ws_id, ws_obj, force):  # noqa: ARG001
+        raise RuntimeError("audit blew up")
+
+    cfg = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=lambda r: (mgr, None),
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
+    handler = make_cancel_handler(cfg, audit_emit=_raises_audit)
+    app = Starlette(routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])])
+    app.add_middleware(_AuthMiddleware)
+    client = TestClient(app)
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_cancel_idle_workstream_does_not_broadcast_approval_resolved(storage):
+    """Bug-1 from /review: the unconditional resolve_approval lift
+    leaked a stale ``approval_resolved`` SSE event on every idle
+    cancel. The fix gates the call on ``_pending_approval is not None``
+    so listeners don't see a phantom resolution. Asserts the
+    ``approval_resolved`` event does NOT land on the listener queue
+    when no approval is pending."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    assert isinstance(ws.ui, ConsoleCoordinatorUI)
+    assert ws.ui._pending_approval is None  # idle baseline
+    listener = ws.ui._register_listener()
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+
+    seen_types = []
+    while not listener.empty():
+        seen_types.append(listener.get_nowait().get("type"))
+    assert "approval_resolved" not in seen_types
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -608,3 +608,87 @@ class TestAuditEventsOnMutations:
         assert matching, "audit row absent for newly created workstream"
         detail = json.loads(matching[0]["detail"])
         assert detail["kind"] == "interactive"
+
+
+class TestInteractiveCancelLifted:
+    """HTTP-level coverage for the post-lift interactive ``/api/cancel``
+    handler. The lifted ``make_cancel_handler`` body is shared with
+    coord but interactive routes through ``make_legacy_body_keyed_adapter``
+    (ws_id in body, not path). Pre-lift ``cancel_generation`` was
+    untested at the HTTP layer; coord exercised the lifted body via
+    ``test_coordinator_endpoints.py``. This class adds the missing
+    interactive-side parity."""
+
+    def _create_ws(self, client) -> str:
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "cancel-target"},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        return resp.json()["ws_id"]
+
+    def test_cancel_returns_dropped_shape(self, app_client):
+        """Always-include shape: response carries ``dropped`` (the
+        forensic snapshot) regardless of whether anything was running."""
+        client, _mgr = app_client
+        ws_id = self._create_ws(client)
+        resp = client.post(
+            "/v1/api/cancel",
+            json={"ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert "dropped" in body
+        assert body["dropped"]["was_running"] is False
+
+    def test_cancel_force_clears_worker_thread_and_running_flag(self, app_client):
+        """Force-cancel parity with coord: clears ``worker_thread`` AND
+        ``_worker_running`` so a follow-up send doesn't route through
+        ``enqueue()`` to the abandoned worker's queue (bug-2 from the
+        cancel-lift /review). Mirrors
+        ``test_cancel_force_flag_abandons_worker_thread_and_emits_stream_end``
+        on the coord side."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        # Simulate an in-flight worker the lifted cancel needs to
+        # abandon. The fake session's cancel() is a no-op, so the
+        # cancel flag side-effect doesn't matter — what matters is
+        # the (worker_thread, _worker_running) pair after force-cancel.
+        ws._worker_running = True
+        ws.worker_thread = threading.Thread(target=lambda: None, daemon=True)
+
+        resp = client.post(
+            "/v1/api/cancel",
+            json={"ws_id": ws_id, "force": True},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        # Both fields cleared together — invariant from session_worker
+        # ("readers gating on either flag see a coherent
+        # (worker_thread, _worker_running) pair").
+        assert ws.worker_thread is None
+        assert ws._worker_running is False
+
+    def test_cancel_returns_400_when_session_missing(self, app_client):
+        """Parity with coord: a placeholder workstream (session=None)
+        gets a 400 ``"No session"`` rather than a silent no-op 200.
+        Pre-lift interactive already returned 400 here; the lift
+        preserves the behaviour and propagates it to coord."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        ws.session = None  # force the build-failed shape
+
+        resp = client.post(
+            "/v1/api/cancel",
+            json={"ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "No session"

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -61,6 +61,7 @@ from turnstone.core.session_routes import (
     SharedSessionVerbHandlers,
     make_approve_handler,
     make_attachment_handlers,
+    make_cancel_handler,
     make_close_handler,
     make_send_handler,
     register_coord_verbs,
@@ -2425,6 +2426,33 @@ def _audit_close_coordinator(
     )
 
 
+def _audit_cancel_coordinator(
+    request: Request,
+    ws_id: str,
+    ws_before: Workstream,  # noqa: ARG001 — coord audit detail doesn't use it yet
+    force: bool,
+) -> None:
+    """Record the ``coordinator.cancel`` audit event.
+
+    Passed to :func:`make_cancel_handler` as the ``audit_emit``
+    callable. Mirrors :func:`_audit_close_coordinator`. The ``force``
+    flag rides into the audit detail so an operator-driven recovery
+    is distinguishable from a routine cancel.
+    """
+    storage = getattr(request.app.state, "auth_storage", None)
+    if storage is None:
+        return
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "coordinator.cancel",
+        "workstream",
+        ws_id,
+        {"coord_ws_id": ws_id, "src": "coordinator", "force": force},
+        request.client.host if request.client else "",
+    )
+
+
 async def coordinator_create(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/new — create a new coordinator session."""
     from turnstone.core.audit import record_audit
@@ -2529,39 +2557,6 @@ async def coordinator_create(request: Request) -> JSONResponse:
         except Exception:
             log.debug("coordinator_create.audit_failed", exc_info=True)
     return JSONResponse({"ws_id": ws.id, "name": ws.name}, status_code=201)
-
-
-async def coordinator_cancel(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/cancel — cancel in-flight generation."""
-    from turnstone.core.audit import record_audit
-
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    user_id = _auth_user_id(request)
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    coord_mgr.cancel(ws_id)
-    storage = getattr(request.app.state, "auth_storage", None)
-    if storage is not None:
-        try:
-            record_audit(
-                storage,
-                user_id,
-                "coordinator.cancel",
-                "workstream",
-                ws_id,
-                {"coord_ws_id": ws_id, "src": "coordinator"},
-                request.client.host if request.client else "",
-            )
-        except Exception:
-            log.debug("coordinator_cancel.audit_failed", exc_info=True)
-    return JSONResponse({"status": "ok"})
 
 
 async def coordinator_events(request: Request) -> Response:
@@ -3184,6 +3179,16 @@ async def _fanout_on_children(
                 # 404 both mean "already gone".  Route to skipped so
                 # operators can distinguish from dispatch failures.
                 if result.get("status") == 404:
+                    return cid, "skipped"
+                # Lifted ``cancel`` returns 400 with "No session" for
+                # placeholder / build-failed workstreams (the in-memory
+                # row exists but its ChatSession was never constructed,
+                # so there's nothing to cancel). Treat the same as
+                # 404 — the child has no work to stop, not a dispatch
+                # failure that should fire alerts. Pre-lift coord
+                # silently no-op'd on placeholders; this keeps cascade
+                # behaviour parity with the pre-lift outcome.
+                if result.get("status") == 400 and result.get("error") == "No session":
                     return cid, "skipped"
                 return cid, "failed"
             except Exception:
@@ -10180,7 +10185,10 @@ def create_app(
             ),
             send=make_send_handler(coord_endpoint_config),  # lifted: shared body (P1.5)
             approve=make_approve_handler(coord_endpoint_config),  # lifted: shared body
-            cancel=coordinator_cancel,
+            cancel=make_cancel_handler(  # lifted: shared body
+                coord_endpoint_config,
+                audit_emit=_audit_cancel_coordinator,
+            ),
             events=coordinator_events,
             history=coordinator_history,
             attachments=make_attachment_handlers(

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -686,13 +686,20 @@ def make_cancel_handler(
       ``coord_mgr.cancel`` which silently no-op'd on a placeholder;
       the lifted body 400s for parity with interactive's existing
       "No session" branch.
-    - **Interactive resolve_approval / resolve_plan now run
-      unconditionally** (was gated on ``was_running``). Lifts coord's
-      always-resolve behaviour onto interactive — a stuck
-      approval-pending state from a crashed worker thread can now
-      be cleared via ``cancel`` on interactive, matching coord's
-      pre-lift recovery path. The calls are idempotent and no-op
-      when nothing is blocked, so the new path is strictly safer.
+    - **Interactive ``resolve_plan`` now runs on every cancel** (was
+      gated on ``was_running``). Lifts coord's always-resolve
+      behaviour onto interactive — a stuck plan-pending state from
+      a crashed worker thread can now be cleared via ``cancel``,
+      matching coord's pre-lift recovery path. ``resolve_plan`` has
+      its own internal ``_pending_plan_review is None`` guard, so
+      the call is genuinely no-op when nothing is blocked.
+      ``resolve_approval`` is **gated on ``ui._pending_approval is not None``**
+      because :meth:`SessionUIBase.resolve_approval` is *not*
+      idempotent — it always broadcasts ``approval_resolved`` and
+      overwrites ``_approval_result``. Without the gate, every idle
+      cancel would leak a stale resolution event to SSE listeners.
+      The gate preserves the recovery semantics for the genuine
+      stuck case while skipping the broadcast on idle cancels.
     """
 
     async def cancel(request: Request) -> Response:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -69,6 +69,17 @@ AttachmentOwnerResolver = Callable[
 # ``_metrics.record_message_sent`` + per-UI message counters; coord
 # has no analog and wires ``None``.
 SpawnMetricsHook = Callable[["Request", Any], None]
+
+
+# (session, ui, *, was_running) — pure read; returns the ``dropped``
+# dict surfaced in the cancel response (pending-approval tool names,
+# queued-message count + preview, etc.). Kinds that don't need a
+# forensic snapshot wire ``None`` and the lifted body returns an
+# empty ``dropped`` dict in the response. Protocol-typed because
+# ``Callable`` can't express the keyword-only ``was_running`` arg
+# the lifted body passes.
+class CancelForensics(Protocol):
+    def __call__(self, session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]: ...
 
 
 @dataclass(frozen=True)
@@ -161,6 +172,15 @@ class SessionEndpointConfig:
     attachment_helpers: AttachmentUploadHelpers | None = None
     spawn_metrics: SpawnMetricsHook | None = None
     emit_message_queued: bool = True
+    # (session, ui, *, was_running) -> dict. When set, the lifted
+    # ``cancel`` body calls this and surfaces the result as the
+    # ``dropped`` key on the response. Interactive wires
+    # ``_capture_cancel_forensics`` so the model-invoked
+    # ``cancel_workstream`` tool can tell operators what got killed
+    # (pending-approval tool names, queued-message count + preview).
+    # Coord wires ``None`` — no forensic surface today; the lifted
+    # body still returns ``dropped: {}`` for response-shape parity.
+    cancel_forensics: CancelForensics | None = None
 
 
 @dataclass(frozen=True)
@@ -608,6 +628,229 @@ def make_close_handler(
         return JSONResponse({"status": "ok"})
 
     return close
+
+
+CancelAuditEmitter = Callable[
+    ["Request", str, "Workstream", bool],
+    None,
+]
+
+
+def make_cancel_handler(
+    cfg: SessionEndpointConfig,
+    *,
+    audit_emit: CancelAuditEmitter | None = None,
+) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/cancel``.
+
+    Cancels in-flight generation on a workstream. Sets the cooperative
+    cancel flag on the session, unblocks any pending approval / plan
+    waits, and (when the request body asks for it) force-abandons a
+    stuck worker thread so the UI recovers immediately.
+
+    Both kinds share the cancel sequence (``session.cancel`` →
+    ``ui.resolve_approval(False)`` → ``ui.resolve_plan("reject")``).
+    Per-kind divergence captured via the cfg + ``audit_emit``:
+
+    - ``cancel_forensics`` (cfg) — when set, the lifted body calls
+      it with ``(session, ui, was_running=...)`` and surfaces the
+      result as the response's ``dropped`` key. Interactive wires
+      ``_capture_cancel_forensics`` so the model-invoked
+      ``cancel_workstream`` tool can tell operators what got killed
+      (pending-approval tool names, queued-message preview); coord
+      wires ``None`` and the response's ``dropped`` is ``{}``.
+    - ``audit_emit`` — receives ``(request, ws_id, ws, force)``.
+      Coord wires its ``coordinator.cancel`` audit hook; interactive
+      wires ``None`` (cancel isn't audited on interactive today —
+      preserved for behavioural parity with the pre-lift handler).
+
+    Args:
+        cfg: per-kind policy bundle (auth, manager lookup, tenant
+            check, error labels, ``cancel_forensics``).
+        audit_emit: kind's audit emitter for the cancel event.
+            ``None`` skips the audit entirely.
+
+    Behavior changes vs the pre-lift handlers:
+
+    - **Coord gains the ``force`` flag.** Pre-lift coord ignored
+      ``force``; the lifted body honours it on both kinds (parity
+      gain — coord workers can hang the same way interactive's can,
+      and operators benefit from the same recovery path).
+    - **Coord response shape now includes ``dropped: {}``.**
+      Pre-lift coord returned bare ``{"status": "ok"}``; the unified
+      shape always carries ``dropped`` so SDK consumers don't have
+      to branch on kind. Coord's ``dropped`` is ``{}`` until coord
+      grows its own forensic capture.
+    - **Coord cancel returns 400 when ``ws.session is None``** (the
+      placeholder/build-failed path). Pre-lift coord called
+      ``coord_mgr.cancel`` which silently no-op'd on a placeholder;
+      the lifted body 400s for parity with interactive's existing
+      "No session" branch.
+    - **Interactive resolve_approval / resolve_plan now run
+      unconditionally** (was gated on ``was_running``). Lifts coord's
+      always-resolve behaviour onto interactive — a stuck
+      approval-pending state from a crashed worker thread can now
+      be cleared via ``cancel`` on interactive, matching coord's
+      pre-lift recovery path. The calls are idempotent and no-op
+      when nothing is blocked, so the new path is strictly safer.
+    """
+
+    async def cancel(request: Request) -> Response:
+        from turnstone.core.web_helpers import read_json_or_400
+
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        # See ``make_approve_handler`` for the cast rationale.
+        mgr = cast("SessionManager", mgr_opt)
+        ws_id = request.path_params.get("ws_id", "")
+
+        # Body is optional — only ``force`` is read. An empty body is
+        # a valid cancel request (the original coord URL took no body
+        # at all; preserve that ergonomic). Malformed JSON is treated
+        # as no body rather than 400'd: cancel is a recovery verb and
+        # should work even when the caller's JSON is junk.
+        force = False
+        try:
+            body = await read_json_or_400(request)
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            force = body.get("force", False) is True
+
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        session = ws.session
+        ui = ws.ui
+        if session is None or ui is None:
+            return JSONResponse({"error": "No session"}, status_code=400)
+
+        was_running = bool(getattr(ws, "_worker_running", False))
+        dropped: dict[str, Any] = {}
+        if cfg.cancel_forensics is not None:
+            try:
+                dropped = cfg.cancel_forensics(session, ui, was_running=was_running)
+            except Exception:
+                # Forensics is observational — never let a snapshot
+                # bug block the actual cancel. Log and proceed with
+                # an empty dropped dict.
+                log.debug("ws.cancel.forensics_failed ws=%s", ws_id[:8], exc_info=True)
+                dropped = {}
+
+        # Always set the cooperative cancel flag — cheap, no harm if
+        # nothing's running. resolve_approval / resolve_plan are
+        # gated by their respective ``_pending_*`` slots: pre-lift
+        # coord called them unconditionally via ``mgr.cancel`` (which
+        # is recovery-friendly: a stuck approval-pending state from a
+        # crashed worker can still be cleared), but ``resolve_approval``
+        # is NOT idempotent — calling it with no pending approval
+        # broadcasts a stale ``approval_resolved`` SSE event and
+        # overwrites ``_approval_result``. Gating on the pending slot
+        # preserves the recovery semantics for the actual stuck case
+        # while skipping the broadcast on idle cancels. ``resolve_plan``
+        # has its own internal no-pending guard, so the call is
+        # already safe to make unconditionally.
+        try:
+            session.cancel()
+        except Exception:
+            log.debug("ws.cancel.session_failed ws=%s", ws_id[:8], exc_info=True)
+        if hasattr(ui, "resolve_approval") and getattr(ui, "_pending_approval", None) is not None:
+            try:
+                ui.resolve_approval(False, "Cancelled by user")
+            except Exception:
+                log.debug(
+                    "ws.cancel.resolve_approval_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
+        if hasattr(ui, "resolve_plan"):
+            try:
+                ui.resolve_plan("reject")
+            except Exception:
+                log.debug(
+                    "ws.cancel.resolve_plan_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
+
+        # The remaining steps only matter when a worker is actually
+        # running: force-recovery has nothing to recover otherwise,
+        # and the SSE ``cancelled`` event would mislead consumers that
+        # have no in-flight generation to cancel.
+        if was_running:
+            if force:
+                # Force cancel: abandon the stuck worker thread (daemon,
+                # will die on process exit or stream timeout) and emit
+                # stream_end so the UI and session recover immediately.
+                # The per-generation cancel flag stays set so the
+                # abandoned thread still kills subprocesses at its next
+                # checkpoint. Clear ``_worker_running`` alongside
+                # ``worker_thread`` so a follow-up send doesn't see the
+                # ``(_worker_running=True, worker_thread=None)``
+                # half-state and route through ``enqueue()`` to the
+                # abandoned worker's queue (which won't drain — the
+                # cancel flag short-circuits the abandoned thread
+                # before it reaches the queue-drain seam, leaving the
+                # queued message orphaned until the next spawn).
+                # ``session_worker.send`` documents this invariant:
+                # "readers gating on either flag see a coherent
+                # (worker_thread, _worker_running) pair."
+                with ws._lock:
+                    ws.worker_thread = None
+                    ws._worker_running = False
+                if hasattr(ui, "_enqueue"):
+                    try:
+                        ui._enqueue({"type": "stream_end"})
+                    except Exception:
+                        log.debug(
+                            "ws.cancel.stream_end_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
+                if hasattr(ui, "on_state_change"):
+                    try:
+                        ui.on_state_change("idle")
+                    except Exception:
+                        log.debug(
+                            "ws.cancel.idle_state_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
+            elif hasattr(ui, "_enqueue"):
+                try:
+                    ui._enqueue({"type": "cancelled"})
+                except Exception:
+                    log.debug(
+                        "ws.cancel.cancelled_event_failed ws=%s",
+                        ws_id[:8],
+                        exc_info=True,
+                    )
+
+        if audit_emit is not None:
+            try:
+                audit_emit(request, ws_id, ws, force)
+            except Exception:
+                # Mirrors make_close_handler — audit-write failures
+                # shouldn't surface as HTTP 500. Log + continue.
+                log.warning(
+                    "ws.cancel.audit_failed ws=%s",
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+
+        return JSONResponse({"status": "ok", "dropped": dropped})
+
+    return cancel
 
 
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -71,15 +71,22 @@ AttachmentOwnerResolver = Callable[
 SpawnMetricsHook = Callable[["Request", Any], None]
 
 
-# (session, ui, *, was_running) — pure read; returns the ``dropped``
-# dict surfaced in the cancel response (pending-approval tool names,
-# queued-message count + preview, etc.). Kinds that don't need a
-# forensic snapshot wire ``None`` and the lifted body returns an
-# empty ``dropped`` dict in the response. Protocol-typed because
-# ``Callable`` can't express the keyword-only ``was_running`` arg
-# the lifted body passes.
 class CancelForensics(Protocol):
-    def __call__(self, session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]: ...
+    """Pure-read snapshot the lifted ``cancel`` body surfaces as ``dropped``.
+
+    Returns a dict with whatever in-flight session / UI state the
+    kind wants to expose to the caller (pending-approval tool names,
+    queued-message count + preview, etc.). Kinds that don't need a
+    forensic snapshot wire ``None`` on the cfg and the lifted body
+    returns an empty ``dropped`` dict in the response.
+
+    Protocol-typed (rather than ``Callable``) because the keyword-only
+    ``was_running`` argument the lifted body passes can't be expressed
+    by a plain ``Callable`` type alias.
+    """
+
+    def __call__(self, session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]:
+        """Return the ``dropped`` snapshot for the cancel response."""
 
 
 @dataclass(frozen=True)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -61,6 +61,7 @@ from turnstone.core.session_routes import (
     SharedSessionVerbHandlers,
     make_approve_handler,
     make_attachment_handlers,
+    make_cancel_handler,
     make_close_handler,
     make_dequeue_handler,
     make_legacy_body_keyed_adapter,
@@ -1523,59 +1524,6 @@ async def plan_feedback(request: Request) -> JSONResponse:
         return JSONResponse({"error": "Unknown workstream"}, status_code=404)
     ui.resolve_plan(feedback)
     return JSONResponse({"status": "ok"})
-
-
-async def cancel_generation(request: Request) -> JSONResponse:
-    """POST /v1/api/cancel — cancel the active generation in a workstream.
-
-    Returns ``{status, dropped}`` where ``dropped`` captures a forensic
-    snapshot of what was in flight at cancel time: any pending approval's
-    tool names, queued-message count and a short preview, and whether a
-    worker thread was actively generating.  The model-invoked
-    ``cancel_workstream`` tool passes this through so a coordinator can
-    tell operators what it just killed instead of a bare ``{cancelled:
-    true}``.  Absent keys mean "nothing observable in that lane".
-    """
-    from turnstone.core.web_helpers import read_json_or_400
-
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    ws_id = body.get("ws_id")
-    mgr = request.app.state.workstreams
-    _owner, err = _require_ws_access(request, str(ws_id or ""), mgr=mgr)
-    if err:
-        return err
-    ws, ui = _get_ws(mgr, ws_id)
-    if not ws or not ui:
-        return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-    session = ws.session
-    if session is None:
-        return JSONResponse({"error": "No session"}, status_code=400)
-    force = body.get("force", False) is True
-    was_running = ws._worker_running
-    dropped = _capture_cancel_forensics(session, ui, was_running=was_running)
-    # Only act if generation is actually in progress
-    if was_running:
-        # Set the cooperative cancel flag (worker thread checks at checkpoints)
-        session.cancel()
-        # Unblock any pending approval/plan review waits
-        ui.resolve_approval(False, "Cancelled by user")
-        ui.resolve_plan("reject")
-        if force:
-            # Force cancel: abandon the stuck worker thread (daemon, will
-            # die on process exit or stream timeout) and emit stream_end
-            # so the UI and session recover immediately.  The per-generation
-            # cancel event stays set so the abandoned thread still kills
-            # subprocesses at its next checkpoint.
-            with ws._lock:
-                ws.worker_thread = None
-            ui._enqueue({"type": "stream_end"})
-            ui.on_state_change("idle")
-        else:
-            # Emit cancelled SSE event so SDK consumers get a typed signal
-            ui._enqueue({"type": "cancelled"})
-    return JSONResponse({"status": "ok", "dropped": dropped})
 
 
 def _capture_cancel_forensics(session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]:
@@ -3896,6 +3844,7 @@ def create_app(
         attachment_helpers=interactive_attachment_helpers,
         spawn_metrics=_interactive_spawn_metrics,
         emit_message_queued=True,
+        cancel_forensics=_capture_cancel_forensics,
     )
     approve_handler = make_approve_handler(interactive_endpoint_config)
     close_handler = make_close_handler(
@@ -3903,6 +3852,7 @@ def create_app(
         audit_emit=_audit_close_workstream,
         supports_close_reason=True,
     )
+    cancel_handler = make_cancel_handler(interactive_endpoint_config)
     send_handler = make_send_handler(interactive_endpoint_config)
     dequeue_handler = make_dequeue_handler(interactive_endpoint_config)
     attachment_handlers = make_attachment_handlers(interactive_endpoint_config)
@@ -3925,6 +3875,7 @@ def create_app(
             set_title=set_workstream_title,
             send=send_handler,  # lifted: shared body (P1.5)
             approve=approve_handler,  # lifted: shared body
+            cancel=cancel_handler,  # lifted: shared body
             attachments=attachment_handlers,  # lifted: shared body (P1.5)
         ),
     )
@@ -3958,7 +3909,11 @@ def create_app(
                     ),
                     Route("/api/plan", plan_feedback, methods=["POST"]),
                     Route("/api/command", command, methods=["POST"]),
-                    Route("/api/cancel", cancel_generation, methods=["POST"]),
+                    Route(
+                        "/api/cancel",
+                        make_legacy_body_keyed_adapter(cancel_handler),
+                        methods=["POST"],
+                    ),
                     Route("/api/watches", list_watches),
                     Route("/api/watches/{watch_id}/cancel", cancel_watch, methods=["POST"]),
                     Route("/api/memories", list_memories),


### PR DESCRIPTION
## Summary

Stage 2 verb lift on the 1.5.0 SessionManager unification track. Lifts the `cancel` verb body into one shared factory (`make_cancel_handler`) used by both interactive and coord, following the same capability-flag pattern P1.5 established for `send` + attachments.

- **Factory**: `make_cancel_handler(cfg, *, audit_emit=None)` in `turnstone/core/session_routes.py`. New `cancel_forensics: CancelForensics | None` field on `SessionEndpointConfig` captures kind-specific divergence (interactive wires `_capture_cancel_forensics`; coord wires None).
- **Wiring**: interactive at the unified registrar slot + legacy `/api/cancel` URL via `make_legacy_body_keyed_adapter`. Coord at the registrar slot with `_audit_cancel_coordinator` audit emit.
- **Old bodies deleted**: `cancel_generation` (interactive) + `coordinator_cancel` (coord).
- **Bundled fixes**: 3 /review findings folded into the same commit (stale `approval_resolved` SSE leak on idle cancel, `_worker_running` half-state in force-cancel, cascade misclassifying placeholder-child cancels as `failed`).

Behaviour changes (documented in CHANGELOG):
- Coord gains the `force` flag (parity gain — pre-lift ignored it).
- Coord cancel response always includes `"dropped"` (was bare `{"status": "ok"}`).
- Coord cancel returns 400 `"No session"` on placeholder workstreams (was silent 200 no-op).
- Coord `coordinator.cancel` audit detail now includes `force`.
- Interactive `resolve_approval` / `resolve_plan` now run on every cancel regardless of `was_running` (lifts coord's recovery-friendly behaviour onto interactive).

## Test plan

- [x] Lint (ruff) + mypy clean on touched files
- [x] 4484 tests passing (was 4475; +9 new cancel tests, -0 removed)
- [x] Multi-stage `/review` pipeline (4 finders → verify → dedupe): 3 bug findings, 5 quality findings; all 8 confirmed by verifier; all addressed in the commit
- [x] Coord HTTP-level cancel tests: always-include shape, force-flag worker abandon, 400-on-null-session, forensics-raises swallowed, audit-raises swallowed, no-stale-approval-resolved-on-idle
- [x] Interactive HTTP-level cancel tests (new — pre-lift had no HTTP coverage): dropped shape, force-flag clears worker_thread + _worker_running, 400-on-null-session
- [ ] Manual smoke on a running console with both kinds is recommended before merge