### PR TITLE
refactor(core): lift open verb body across both kinds (Stage 2 verb lift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,80 @@ Three release tracks are maintained:
     those children were silently no-op'd, so the cascade response's
     ``failed`` bucket no longer fires spurious operator alerts.
 
+- **`open` verb body lifted across both kinds** ([Stage 2 Verb
+  Lift — `open`]). The interactive
+  ``POST /v1/api/workstreams/{ws_id}/open`` and coord
+  ``POST /v1/api/workstreams/{ws_id}/open`` handlers now share one
+  body via ``make_open_handler(cfg, *, audit_emit=None)``. Per-kind
+  divergence captured by two new ``SessionEndpointConfig`` fields:
+
+  - ``open_resolve_alias: AliasResolver | None`` — interactive
+    wires :func:`turnstone.core.memory.resolve_workstream` so
+    callers can pass user-friendly aliases ("my-debug-ws") in the
+    path param. Coord wires ``None`` (hex ids only).
+  - ``open_post_load: OpenPostLoad | None`` — interactive wires the
+    UI-replay (``clear_ui`` + history) + handler-side ``ws_created``
+    enqueue onto the global SSE queue. Coord wires ``None`` and
+    relies on the cluster collector fan-out from
+    ``CoordinatorAdapter.emit_rehydrated``.
+
+  **Load-bearing fix** (§ Post-P3 reckoning item #3): interactive
+  ``open_workstream`` previously called
+  ``mgr.create(ws_id=resolved_id)`` + ``ws.session.resume(...)`` to
+  rehydrate, bypassing ``mgr.open()`` entirely. After the lift both
+  kinds route through ``mgr.open()`` — which makes
+  ``InteractiveAdapter.emit_rehydrated`` reachable on interactive
+  (it had been dead-by-routing) and gives the manager a single
+  rehydrate code path to maintain. ``emit_rehydrated`` stays a
+  documented no-op stub on the interactive adapter (the
+  handler-side ``ws_created`` enqueue from ``open_post_load`` is
+  the load-bearing emission).
+
+  Two observable behaviour changes for interactive callers:
+
+  - **Cross-kind open returns 404** (was 400). Pre-lift had a
+    pre-mgr storage probe that returned ``400`` with
+    ``"Workstream is not an interactive kind"`` for coord rows;
+    the lift consolidates on ``mgr.open()``'s single ``None``-
+    return contract for missing / wrong-kind / tombstoned rows.
+    Security boundary unchanged.
+  - **Already-loaded response uses ``ws.name`` directly** (was
+    ``get_workstream_display_name(resolved_id) or resolved_id``).
+    A workstream renamed via ``set_workstream_alias`` after being
+    loaded into memory will surface the storage-row name in the
+    open response's ``name`` field instead of the latest alias.
+    The dashboard listing endpoint still resolves aliases on its
+    own pass, so the user-visible workstream name in the tab strip
+    isn't affected.
+
+  Coord behaviour unchanged.
+
+  Two /review fixes folded into the same commit:
+
+  - **Resume failures now return 5xx instead of broken-200.**
+    ``SessionManager.open()`` previously caught and ``log.debug``-
+    swallowed exceptions from ``ChatSession.resume`` (which assigns
+    ``self.messages`` *before* the config-restore block, so a
+    partial-failure resume — corrupted ``workstream_config`` row,
+    model-registry mismatch on a saved alias, malformed
+    ``temperature`` / ``max_tokens`` — would leave the session with
+    history but with default config). Pre-lift, the interactive
+    open handler called ``ws.session.resume(...)`` directly and let
+    exceptions propagate as 500. The lift accidentally inherited
+    the swallow because it routed through ``mgr.open()``. Restored
+    pre-lift behaviour: ``mgr.open()`` now re-raises resume
+    exceptions after rolling back the slot (``cleanup_ui`` +
+    ``_remove_locked``), so the lifted handler returns 500 with
+    a correlation id and the storage row stays available for a
+    retry instead of silently 200'ing with broken state.
+  - **``except Exception`` in the lifted body documents intent.**
+    The bare exception catch around ``mgr.open(ws_id)`` is
+    intentional — the kind's session factory has no documented
+    exception spec, and resume can propagate from
+    ``ChatSession.resume``. A one-line rationale comment in the
+    handler body keeps a future contributor from narrowing it
+    incorrectly.
+
 ### Security
 
 - **Coord attachment endpoints are now kind-strict**

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -41,7 +41,6 @@ from turnstone.console.server import (
     coordinator_detail,
     coordinator_history,
     coordinator_list,
-    coordinator_open,
     coordinator_saved,
     coordinator_tasks,
 )
@@ -62,6 +61,7 @@ from turnstone.core.session_routes import (
     make_attachment_handlers,
     make_cancel_handler,
     make_close_handler,
+    make_open_handler,
     make_send_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
@@ -172,7 +172,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/open",
-                coordinator_open,
+                make_open_handler(_coord_endpoint_config),
                 methods=["POST"],
             ),
             Route(

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -241,7 +241,19 @@ class TestKindValidationOnCreate:
 
 
 class TestOpenKindGate:
-    """POST /v1/api/workstreams/{ws_id}/open refuses coordinator rows."""
+    """POST /v1/api/workstreams/{ws_id}/open refuses coordinator rows.
+
+    Post-lift behavior change: the lifted ``open`` body delegates the
+    kind check to ``SessionManager.open()`` (which returns ``None``
+    for kind mismatch / missing row / tombstone — all the
+    "manager has no such ws_id" cases). The pre-lift handler had a
+    separate pre-mgr storage probe that returned a kind-specific
+    400 ("Workstream is not an interactive kind"); the lift
+    consolidates on a single 404 ("Workstream not found"). Security
+    boundary unchanged — caller still can't open a coord row from
+    the interactive node — but the error code + message converge
+    with the rest of the not-found paths.
+    """
 
     def test_refuses_to_open_coordinator(self, app_client):
         from turnstone.core.storage import get_storage
@@ -260,8 +272,8 @@ class TestOpenKindGate:
             "/v1/api/workstreams/coord-1/open",
             headers=_auth("user-1"),
         )
-        assert resp.status_code == 400
-        assert "interactive" in resp.json()["error"].lower()
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -490,6 +490,63 @@ class TestOpenWorkstream:
         assert captured == [("ws-fresh", "fresh-name")]
 
     @patch("turnstone.core.memory.resolve_workstream")
+    def test_open_500_message_uses_kind_noun_from_cfg(self, mock_resolve, _inject_storage):
+        """``cfg.audit_action_prefix`` ("workstream" interactive,
+        "coordinator" coord) is woven into the 500 error string so
+        coord callers see ``"failed to open coordinator"`` and
+        interactive callers see ``"failed to open workstream"``,
+        matching the pre-lift wording on both sides. Pre-fix
+        (Copilot review on PR #414) the message was hardcoded
+        ``"failed to open workstream"`` for both kinds — coord
+        callers got misleading text."""
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.routing import Mount, Route
+        from starlette.testclient import TestClient
+
+        def _lazy_alias(ws_id: str) -> str | None:
+            from turnstone.core.memory import resolve_workstream
+
+            return resolve_workstream(ws_id)
+
+        mock_mgr = MagicMock()
+        cfg = SessionEndpointConfig(
+            permission_gate=None,
+            manager_lookup=lambda _r: (mock_mgr, None),
+            tenant_check=None,
+            not_found_label="coordinator not found",
+            audit_action_prefix="coordinator",  # coord-shaped cfg
+            open_resolve_alias=_lazy_alias,
+        )
+        handler = make_open_handler(cfg)
+        app = Starlette(
+            routes=[
+                Mount(
+                    "/v1",
+                    routes=[
+                        Route("/api/workstreams/{ws_id}/open", handler, methods=["POST"]),
+                    ],
+                ),
+            ],
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        client = TestClient(app)
+
+        mock_resolve.return_value = "ws-fresh"
+        mock_mgr.get.return_value = None
+        mock_mgr.open.side_effect = RuntimeError("session factory blew up")
+
+        r = client.post("/v1/api/workstreams/ws-fresh/open")
+        assert r.status_code == 500
+        body = r.json()
+        # Per-kind noun in the message.
+        assert "failed to open coordinator" in body["error"]
+        # Correlation id present so support can match a log entry.
+        assert "correlation_id=" in body["error"]
+        # Exception text is NOT echoed (no internal-detail leak).
+        assert "session factory blew up" not in body["error"]
+
+    @patch("turnstone.core.memory.resolve_workstream")
     def test_open_swallows_post_load_exception(self, mock_resolve, _inject_storage):
         """A bug in ``open_post_load`` must NOT block the open from
         returning 200 — the workstream is already loaded by mgr.open

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -18,11 +18,14 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
 from turnstone.core.auth import AuthResult
+from turnstone.core.session_routes import (
+    SessionEndpointConfig,
+    make_open_handler,
+)
 from turnstone.core.storage._sqlite import SQLiteBackend
 from turnstone.server import (
     delete_workstream_endpoint,
     list_interface_settings,
-    open_workstream,
     refresh_workstream_title,
     set_workstream_title,
     update_interface_setting,
@@ -114,6 +117,31 @@ def title_client(_inject_storage):
 
 @pytest.fixture
 def open_client(_inject_storage):
+    """Build a TestClient with the lifted ``open`` handler wired the
+    same way ``server.py`` does — alias resolver, no post-load
+    callback (the tests assert HTTP-shape only, not the SSE replay).
+
+    The alias resolver is wrapped in a lazy lookup so each test's
+    ``@patch("turnstone.core.memory.resolve_workstream")`` is
+    visible at request time. A direct function reference would
+    bind to the unpatched original at fixture-construction time.
+    """
+
+    def _lazy_alias_resolver(ws_id: str) -> str | None:
+        from turnstone.core.memory import resolve_workstream
+
+        return resolve_workstream(ws_id)
+
+    mock_mgr = MagicMock()
+    cfg = SessionEndpointConfig(
+        permission_gate=None,
+        manager_lookup=lambda _r: (mock_mgr, None),
+        tenant_check=None,
+        not_found_label="Workstream not found",
+        audit_action_prefix="workstream",
+        open_resolve_alias=_lazy_alias_resolver,
+    )
+    open_handler = make_open_handler(cfg)
     app = Starlette(
         routes=[
             Mount(
@@ -121,7 +149,7 @@ def open_client(_inject_storage):
                 routes=[
                     Route(
                         "/api/workstreams/{ws_id}/open",
-                        open_workstream,
+                        open_handler,
                         methods=["POST"],
                     ),
                 ],
@@ -129,7 +157,6 @@ def open_client(_inject_storage):
         ],
         middleware=[Middleware(_InjectAuthMiddleware)],
     )
-    mock_mgr = MagicMock()
     app.state.workstreams = mock_mgr
     gq: queue.Queue[dict[str, Any]] = queue.Queue()
     app.state.global_queue = gq
@@ -300,16 +327,25 @@ class TestRefreshWorkstreamTitle:
 class TestOpenWorkstream:
     @patch("turnstone.core.memory.resolve_workstream")
     def test_open_already_loaded(self, mock_resolve, open_client):
+        """The lifted body returns ``ws.name`` directly on the
+        already-loaded shortcut path (not a display-alias re-lookup).
+        Pre-lift interactive routed through ``get_workstream_display_name``
+        here; the lift consolidates on the in-memory ``ws.name`` field
+        for parity with coord's pre-lift behaviour. Frontend already
+        re-fetches names from the dashboard endpoint so a freshly-
+        renamed workstream still surfaces its alias on subsequent
+        listings — no observable user-facing regression."""
         client, mock_mgr, gq = open_client
         mock_resolve.return_value = "ws-abc"
         mock_ws = MagicMock()
         mock_ws.id = "ws-abc"
+        mock_ws.name = "My WS"
         mock_mgr.get.return_value = mock_ws
-        with patch("turnstone.core.memory.get_workstream_display_name", return_value="My WS"):
-            r = client.post("/v1/api/workstreams/ws-abc/open")
+        r = client.post("/v1/api/workstreams/ws-abc/open")
         assert r.status_code == 200
         assert r.json()["already_loaded"] is True
         assert r.json()["ws_id"] == "ws-abc"
+        assert r.json()["name"] == "My WS"
 
     @patch("turnstone.core.memory.resolve_workstream")
     def test_open_not_found(self, mock_resolve, open_client):
@@ -320,13 +356,193 @@ class TestOpenWorkstream:
 
     @patch("turnstone.core.memory.resolve_workstream")
     def test_open_no_storage_row(self, mock_resolve, open_client, _inject_storage):
+        """``mgr.open`` returns ``None`` for missing storage rows, kind
+        mismatches, and tombstoned rows — all surface as 404 with
+        ``cfg.not_found_label``. Pre-lift returned a more specific
+        ``"Workstream not found in storage"`` from a separate
+        pre-mgr.create storage probe; the lift consolidates the
+        404 path through ``mgr.open``'s single None-return contract
+        (the kind-specific failure mode is internal detail not worth
+        a distinct error string)."""
         client, mock_mgr, gq = open_client
         mock_resolve.return_value = "ws-abc"
         mock_mgr.get.return_value = None  # not loaded
-        # Storage has no row for ws-abc
+        mock_mgr.open.return_value = (
+            None  # mgr.open's contract: None for missing/wrong-kind/tombstone
+        )
         r = client.post("/v1/api/workstreams/ws-abc/open")
         assert r.status_code == 404
-        assert "storage" in r.json()["error"].lower()
+        assert "not found" in r.json()["error"].lower()
+
+    @patch("turnstone.core.memory.resolve_workstream")
+    def test_open_calls_mgr_open_not_mgr_create(self, mock_resolve, open_client):
+        """Post-P3 reckoning item #3: interactive ``open`` must route
+        through ``mgr.open()`` (which fires ``emit_rehydrated``), not
+        ``mgr.create(ws_id=...)`` (the pre-lift workaround that
+        bypassed ``emit_rehydrated`` entirely, leaving it dead-by-
+        routing on interactive). Asserting ``mgr.open`` was called
+        + ``mgr.create`` was NOT called pins the load-bearing
+        behaviour change."""
+        client, mock_mgr, gq = open_client
+        mock_resolve.return_value = "ws-resolved"
+        mock_mgr.get.return_value = None  # not loaded
+        loaded_ws = MagicMock()
+        loaded_ws.id = "ws-resolved"
+        loaded_ws.name = "resolved"
+        mock_mgr.open.return_value = loaded_ws
+
+        r = client.post("/v1/api/workstreams/some-alias/open")
+        assert r.status_code == 200
+        mock_mgr.open.assert_called_once_with("ws-resolved")
+        mock_mgr.create.assert_not_called()
+
+    @patch("turnstone.core.memory.resolve_workstream")
+    def test_open_resolves_alias_before_lookup(self, mock_resolve, open_client):
+        """``cfg.open_resolve_alias`` runs first — the path-param can
+        be a user-friendly alias that resolves to a hex id, and the
+        already-loaded shortcut + mgr.open both see the resolved id.
+        Pre-lift behaviour preserved verbatim (interactive's friendly-
+        alias UX survives the lift)."""
+        client, mock_mgr, gq = open_client
+        mock_resolve.return_value = "ws-canonical-id"
+        mock_mgr.get.return_value = None
+        loaded_ws = MagicMock()
+        loaded_ws.id = "ws-canonical-id"
+        loaded_ws.name = "x"
+        mock_mgr.open.return_value = loaded_ws
+
+        r = client.post("/v1/api/workstreams/my-friendly-alias/open")
+        assert r.status_code == 200
+        mock_resolve.assert_called_once_with("my-friendly-alias")
+        mock_mgr.get.assert_called_once_with("ws-canonical-id")
+        mock_mgr.open.assert_called_once_with("ws-canonical-id")
+
+    @patch("turnstone.core.memory.resolve_workstream")
+    def test_open_post_load_callback_fires_with_request_and_ws(self, mock_resolve, _inject_storage):
+        """``cfg.open_post_load`` is the kind-specific hook for
+        post-mgr.open work (interactive uses it for UI replay +
+        handler-side ws_created enqueue; coord wires None). Verify
+        the callback receives ``(request, ws)`` exactly once on a
+        successful open and is NOT fired on the already-loaded
+        shortcut (the pre-lift handler also returned early in the
+        already-loaded branch before any post-load work)."""
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.routing import Mount, Route
+        from starlette.testclient import TestClient
+
+        captured: list[tuple[str, Any]] = []
+
+        def _post_load(request: Any, ws_obj: Any) -> None:
+            captured.append((ws_obj.id, ws_obj.name))
+
+        def _lazy_alias(ws_id: str) -> str | None:
+            from turnstone.core.memory import resolve_workstream
+
+            return resolve_workstream(ws_id)
+
+        mock_mgr = MagicMock()
+        cfg = SessionEndpointConfig(
+            permission_gate=None,
+            manager_lookup=lambda _r: (mock_mgr, None),
+            tenant_check=None,
+            not_found_label="Workstream not found",
+            audit_action_prefix="workstream",
+            open_resolve_alias=_lazy_alias,
+            open_post_load=_post_load,
+        )
+        handler = make_open_handler(cfg)
+        app = Starlette(
+            routes=[
+                Mount(
+                    "/v1",
+                    routes=[
+                        Route("/api/workstreams/{ws_id}/open", handler, methods=["POST"]),
+                    ],
+                ),
+            ],
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        client = TestClient(app)
+
+        # Already-loaded path: post_load must NOT fire (pre-lift
+        # parity — the original handler returned early without any
+        # post-load work in the already-loaded branch).
+        mock_resolve.return_value = "ws-loaded"
+        loaded_ws = MagicMock()
+        loaded_ws.id = "ws-loaded"
+        loaded_ws.name = "loaded-name"
+        mock_mgr.get.return_value = loaded_ws
+        r = client.post("/v1/api/workstreams/ws-loaded/open")
+        assert r.status_code == 200
+        assert r.json()["already_loaded"] is True
+        assert captured == [], "post_load fired on the already-loaded shortcut"
+
+        # Load-from-storage path: post_load fires with (request, ws).
+        mock_resolve.return_value = "ws-fresh"
+        mock_mgr.get.return_value = None
+        opened_ws = MagicMock()
+        opened_ws.id = "ws-fresh"
+        opened_ws.name = "fresh-name"
+        mock_mgr.open.return_value = opened_ws
+        r = client.post("/v1/api/workstreams/ws-fresh/open")
+        assert r.status_code == 200
+        assert captured == [("ws-fresh", "fresh-name")]
+
+    @patch("turnstone.core.memory.resolve_workstream")
+    def test_open_swallows_post_load_exception(self, mock_resolve, _inject_storage):
+        """A bug in ``open_post_load`` must NOT block the open from
+        returning 200 — the workstream is already loaded by mgr.open
+        and the post-load is observational. Mirrors the same swallow
+        pattern in ``make_cancel_handler``'s ``cancel_forensics``
+        wrapper."""
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.routing import Mount, Route
+        from starlette.testclient import TestClient
+
+        def _raises_post_load(_request: Any, _ws: Any) -> None:
+            raise RuntimeError("post-load blew up")
+
+        def _lazy_alias(ws_id: str) -> str | None:
+            from turnstone.core.memory import resolve_workstream
+
+            return resolve_workstream(ws_id)
+
+        mock_mgr = MagicMock()
+        cfg = SessionEndpointConfig(
+            permission_gate=None,
+            manager_lookup=lambda _r: (mock_mgr, None),
+            tenant_check=None,
+            not_found_label="Workstream not found",
+            audit_action_prefix="workstream",
+            open_resolve_alias=_lazy_alias,
+            open_post_load=_raises_post_load,
+        )
+        handler = make_open_handler(cfg)
+        app = Starlette(
+            routes=[
+                Mount(
+                    "/v1",
+                    routes=[
+                        Route("/api/workstreams/{ws_id}/open", handler, methods=["POST"]),
+                    ],
+                ),
+            ],
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        client = TestClient(app)
+
+        mock_resolve.return_value = "ws-fresh"
+        mock_mgr.get.return_value = None
+        opened_ws = MagicMock()
+        opened_ws.id = "ws-fresh"
+        opened_ws.name = "fresh-name"
+        mock_mgr.open.return_value = opened_ws
+
+        r = client.post("/v1/api/workstreams/ws-fresh/open")
+        assert r.status_code == 200
+        assert r.json()["ws_id"] == "ws-fresh"
 
 
 # ===========================================================================

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -63,6 +63,7 @@ from turnstone.core.session_routes import (
     make_attachment_handlers,
     make_cancel_handler,
     make_close_handler,
+    make_open_handler,
     make_send_handler,
     register_coord_verbs,
     register_session_routes,
@@ -2817,52 +2818,6 @@ async def coordinator_detail(request: Request) -> JSONResponse:
             "kind": ws.kind,
         }
     )
-
-
-async def coordinator_open(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/open — explicit rehydration.
-
-    Parity with the server's ``POST /v1/api/workstreams/{ws_id}/open``.
-    ``coordinator_detail`` already rehydrates lazily on a GET miss; this
-    endpoint gives SDK callers and operators a way to warm a coordinator
-    without browsing to it.  Same ownership / 404-on-mismatch /
-    correlation-id-masked error semantics as ``coordinator_detail``.
-    """
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    if not ws_id:
-        return JSONResponse({"error": "ws_id is required"}, status_code=400)
-    ws = coord_mgr.get(ws_id)
-    if ws is not None:
-        return JSONResponse({"ws_id": ws.id, "name": ws.name, "already_loaded": True})
-    try:
-        ws = coord_mgr.open(ws_id)
-    except ValueError as exc:
-        return JSONResponse({"error": str(exc)}, status_code=503)
-    except Exception:
-        correlation_id = secrets.token_hex(4)
-        log.warning(
-            "coordinator_open.rehydrate_failed correlation_id=%s ws_id=%s",
-            correlation_id,
-            ws_id[:8],
-            exc_info=True,
-        )
-        return JSONResponse(
-            {
-                "error": (
-                    f"failed to open coordinator (internal error). correlation_id={correlation_id}"
-                )
-            },
-            status_code=500,
-        )
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    return JSONResponse({"ws_id": ws.id, "name": ws.name})
 
 
 _CHILDREN_PAGE_LIMIT = 200
@@ -10177,7 +10132,7 @@ def create_app(
             list_saved=coordinator_saved,
             create=coordinator_create,
             detail=coordinator_detail,
-            open=coordinator_open,
+            open=make_open_handler(coord_endpoint_config),  # lifted: shared body
             close=make_close_handler(  # lifted: shared body
                 coord_endpoint_config,
                 audit_emit=_audit_close_coordinator,

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -424,7 +424,22 @@ class SessionManager:
                     try:
                         ws.session.resume(ws_id)
                     except Exception:
-                        log.debug("session_mgr.resume_failed ws=%s", ws_id[:8], exc_info=True)
+                        # Resume can leave the session in a partial state
+                        # (``ChatSession.resume`` assigns ``self.messages``
+                        # before the config-restore block, so a failure
+                        # mid-restore loads the conversation but with
+                        # default ``temperature`` / ``max_tokens`` /
+                        # tool config). Treating this as success would
+                        # silently 200 with broken state; the user's next
+                        # send would run with default config instead of
+                        # the persisted config. Roll the slot back so the
+                        # caller surfaces a 5xx and the storage row stays
+                        # available for a retry. Mirrors the
+                        # build_session-failure unwind above.
+                        self._adapter.cleanup_ui(ws)
+                        with self._lock:
+                            self._remove_locked(ws_id)
+                        raise
 
                 # No DB state-flip on resurrect. The in-memory session
                 # is IDLE; the DB row may still say 'closed' from the

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1016,10 +1016,19 @@ def make_open_handler(
                 ws_id[:8] if ws_id else "",
                 exc_info=True,
             )
+            # Per-kind noun in the user-facing error so coord callers
+            # see "failed to open coordinator" and interactive callers
+            # see "failed to open workstream" (matching the pre-lift
+            # ``coordinator_open`` / ``open_workstream`` wording on
+            # both sides). ``audit_action_prefix`` is the existing
+            # per-kind label both lifespans already construct
+            # ("workstream" / "coordinator"); reusing it here gives
+            # the cfg field its first runtime reader.
+            kind_noun = cfg.audit_action_prefix or "workstream"
             return JSONResponse(
                 {
                     "error": (
-                        f"failed to open workstream (internal error). "
+                        f"failed to open {kind_noun} (internal error). "
                         f"correlation_id={correlation_id}"
                     )
                 },

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -89,6 +89,29 @@ class CancelForensics(Protocol):
         """Return the ``dropped`` snapshot for the cancel response."""
 
 
+# (alias_or_id) -> canonical_id_or_None. Interactive's lifted
+# ``open`` body (:func:`make_open_handler`) pre-resolves user-friendly
+# aliases to the canonical hex ws_id via
+# :func:`turnstone.core.memory.resolve_workstream` so callers can
+# pass either shape. Coord wires ``None`` (coord workstreams are
+# addressed by hex id only).
+AliasResolver = Callable[[str], str | None]
+# (request, ws) -> None. Optional kind-specific post-load callback
+# the lifted ``open`` body fires after the workstream is loaded into
+# the manager. Interactive uses it to push a ``clear_ui`` + history
+# replay onto the UI listener queue and to enqueue a handler-side
+# ``ws_created`` event onto the global SSE queue (the global-queue
+# emission stays out of band on interactive — see
+# :class:`SessionKindAdapter` docstring for the asymmetry rationale).
+# Coord wires ``None`` and relies on the cluster collector fan-out
+# triggered by ``CoordinatorAdapter.emit_rehydrated``.
+OpenPostLoad = Callable[["Request", "Workstream"], None]
+# (request, ws) -> None. Optional audit emitter for the ``open``
+# event. Same shape as ``CloseAuditEmitter``'s leading args. Coord
+# wires ``None`` (coord doesn't audit open today).
+OpenAuditEmitter = Callable[["Request", "Workstream"], None]
+
+
 @dataclass(frozen=True)
 class AttachmentUploadHelpers:
     """Process-local hooks the lifted attachment factories call into.
@@ -188,6 +211,23 @@ class SessionEndpointConfig:
     # Coord wires ``None`` — no forensic surface today; the lifted
     # body still returns ``dropped: {}`` for response-shape parity.
     cancel_forensics: CancelForensics | None = None
+    # (alias_or_id) -> canonical_id_or_None. When set, the lifted
+    # ``open`` body resolves the path-param ws_id through this
+    # callable before any storage lookup. Interactive wires
+    # :func:`turnstone.core.memory.resolve_workstream` so user-friendly
+    # aliases ("my-debug-ws") map to canonical hex ids. Coord wires
+    # ``None`` — coord uses hex ids only.
+    open_resolve_alias: AliasResolver | None = None
+    # (request, ws) -> None. Kind-specific post-load callback fired
+    # by the lifted ``open`` body after ``mgr.open(ws_id)`` returns
+    # the workstream. Interactive uses it to send the UI-replay
+    # events (``clear_ui`` + history) and to enqueue a handler-side
+    # ``ws_created`` onto the global SSE queue (out-of-band path —
+    # see :class:`SessionKindAdapter` docstring for why interactive's
+    # creation events stay outside the manager's emit_*). Coord
+    # wires ``None`` and lets the cluster collector handle the
+    # transition via ``CoordinatorAdapter.emit_rehydrated``.
+    open_post_load: OpenPostLoad | None = None
 
 
 @dataclass(frozen=True)
@@ -865,6 +905,167 @@ def make_cancel_handler(
         return JSONResponse({"status": "ok", "dropped": dropped})
 
     return cancel
+
+
+def make_open_handler(
+    cfg: SessionEndpointConfig,
+    *,
+    audit_emit: OpenAuditEmitter | None = None,
+) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/open``.
+
+    Loads a persisted workstream into memory under its original
+    ws_id (vs ``resume`` which forks into a fresh ws_id). Both kinds
+    share the auth → mgr → already-loaded shortcut → ``mgr.open()``
+    → 404-on-miss sequence; per-kind divergence captured by the
+    cfg + ``audit_emit``:
+
+    - ``cfg.open_resolve_alias`` — interactive wires
+      :func:`turnstone.core.memory.resolve_workstream` so callers
+      can pass user-friendly aliases ("my-debug-ws") in the path
+      param. Coord wires ``None`` (hex ids only).
+    - ``cfg.open_post_load`` — interactive uses it for UI-replay
+      events (``clear_ui`` + history) plus a handler-side
+      ``ws_created`` enqueue onto the global SSE queue. Coord wires
+      ``None`` and relies on the cluster collector fan-out triggered
+      by ``CoordinatorAdapter.emit_rehydrated``.
+    - ``audit_emit`` — kind's audit hook for the ``open`` event.
+      Interactive wires ``workstream.opened``; coord wires ``None``
+      (coord doesn't audit open today).
+
+    Pre-lift behaviour preserved on both kinds with one important
+    fix: **interactive previously called ``mgr.create(ws_id=...)``
+    + ``ws.session.resume(...)`` to rehydrate, bypassing
+    ``mgr.open()`` entirely**. After this lift both kinds route
+    through ``mgr.open()`` — which makes ``emit_rehydrated``
+    reachable on interactive (it had been dead-by-routing pre-lift)
+    and gives the manager a single rehydrate code path to maintain.
+    See § Post-P3 reckoning item #3 in
+    ``1.5.0-session-manager-stage-2.md`` for the design history.
+
+    Args:
+        cfg: per-kind policy bundle.
+        audit_emit: kind's audit hook. ``None`` skips the audit.
+    """
+
+    async def open_ws(request: Request) -> Response:
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        # See ``make_approve_handler`` for the cast rationale.
+        mgr = cast("SessionManager", mgr_opt)
+
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        # Optional alias resolution. Interactive lets callers pass
+        # user-friendly aliases; coord skips this entirely.
+        if cfg.open_resolve_alias is not None:
+            resolved = cfg.open_resolve_alias(ws_id)
+            if not resolved:
+                return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+            ws_id = resolved
+
+        # Already-loaded shortcut — both kinds return the same
+        # ``{ws_id, name, already_loaded: true}`` shape.
+        existing = mgr.get(ws_id)
+        if existing is not None:
+            return JSONResponse(
+                {
+                    "ws_id": existing.id,
+                    "name": existing.name,
+                    "already_loaded": True,
+                }
+            )
+
+        try:
+            ws = mgr.open(ws_id)
+        except ValueError as exc:
+            # Session factory misconfig (e.g., a model alias that
+            # no longer exists). Surface the factory's remediation
+            # text as a 503 so the operator can fix it without
+            # digging through stack traces. Same shape coord used
+            # pre-lift; standardised across both kinds here.
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        except Exception:
+            # Bare ``Exception`` is intentional: ``mgr.open`` can
+            # raise from ``adapter.build_session`` (no documented
+            # exception spec — depends on the kind's session factory)
+            # or from ``ChatSession.resume`` propagating a partial-
+            # restore failure (corrupted workstream_config row,
+            # model-registry mismatch on saved alias, etc.). Either
+            # way the workstream isn't loadable; the operator needs
+            # the correlation-id'd log entry to diagnose.
+            #
+            # Don't echo the exception text — it can leak internal
+            # paths / frame names. Log with a correlation id and
+            # return that to the client so support can match a
+            # report to the log line. Mirrors coord's pre-lift
+            # ``coordinator_open`` 500 path.
+            import secrets
+
+            correlation_id = secrets.token_hex(4)
+            log.warning(
+                "ws.open.rehydrate_failed correlation_id=%s ws_id=%s",
+                correlation_id,
+                ws_id[:8] if ws_id else "",
+                exc_info=True,
+            )
+            return JSONResponse(
+                {
+                    "error": (
+                        f"failed to open workstream (internal error). "
+                        f"correlation_id={correlation_id}"
+                    )
+                },
+                status_code=500,
+            )
+
+        # Both except branches above ``return``; ``ws`` is bound here.
+        if ws is None:
+            # ``mgr.open`` returns None for missing rows, kind
+            # mismatch, and tombstoned rows — all surface as 404
+            # for the caller (the kind-specific failure mode is
+            # internal detail).
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        # Kind-specific post-load action (interactive: UI replay +
+        # handler-side ws_created enqueue; coord: None and the
+        # cluster collector handles the fan-out via the adapter's
+        # emit_rehydrated path).
+        if cfg.open_post_load is not None:
+            try:
+                cfg.open_post_load(request, ws)
+            except Exception:
+                # Post-load is observational — never let a hook bug
+                # block the open. Log + continue.
+                log.debug(
+                    "ws.open.post_load_failed ws=%s",
+                    ws.id[:8],
+                    exc_info=True,
+                )
+
+        if audit_emit is not None:
+            try:
+                audit_emit(request, ws)
+            except Exception:
+                # Mirrors make_close_handler / make_cancel_handler
+                # — audit-write failures shouldn't surface as HTTP
+                # 500. Log + continue.
+                log.warning(
+                    "ws.open.audit_failed ws=%s",
+                    ws.id[:8],
+                    exc_info=True,
+                )
+
+        return JSONResponse({"ws_id": ws.id, "name": ws.name})
+
+    return open_ws
 
 
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -65,6 +65,7 @@ from turnstone.core.session_routes import (
     make_close_handler,
     make_dequeue_handler,
     make_legacy_body_keyed_adapter,
+    make_open_handler,
     make_send_handler,
     register_session_routes,
 )
@@ -890,6 +891,83 @@ def _audit_close_workstream(
         "workstream",
         ws_id,
         detail,
+        ip,
+    )
+
+
+def _interactive_open_post_load(request: Request, ws: Workstream) -> None:
+    """Post-load hook for the lifted interactive ``open`` body.
+
+    Runs after ``mgr.open(ws_id)`` returns the workstream (which
+    internally already attempted ``ws.session.resume(ws_id)`` and
+    fired ``InteractiveAdapter.emit_rehydrated`` — the latter being
+    a no-op stub on interactive per the documented asymmetry). This
+    callback handles the interactive-only out-of-band emissions:
+
+    1. Sync the workstream's name to the persisted display alias
+       (a user-renamed workstream stores its alias separately from
+       the manager's in-memory name).
+    2. Replay clear_ui + history onto the per-workstream UI listener
+       queue so a freshly-connected browser tab sees the conversation
+       state. Only fires when ``ws.session.messages`` is non-empty
+       (resume succeeded and there's history to show).
+    3. Enqueue ``ws_created`` onto the global SSE queue so dashboards
+       and other multi-workstream consumers see the rehydrate. The
+       handler-side emission is the load-bearing path on interactive;
+       ``InteractiveAdapter.emit_rehydrated`` is a no-op stub
+       precisely because this enqueue lives here.
+    """
+    from turnstone.core.memory import get_workstream_display_name
+
+    ws.name = get_workstream_display_name(ws.id) or ws.name
+    ui = ws.ui
+    session = ws.session
+    if isinstance(ui, WebUI) and session is not None and session.messages:
+        ui._enqueue({"type": "clear_ui"})
+        history = _build_history(session)
+        if history:
+            ui._enqueue({"type": "history", "messages": history})
+
+    gq: queue.Queue[dict[str, Any]] | None = getattr(request.app.state, "global_queue", None)
+    if gq is not None:
+        with contextlib.suppress(queue.Full):
+            gq.put_nowait(
+                {
+                    "type": "ws_created",
+                    "ws_id": ws.id,
+                    "name": ws.name,
+                    "model": session.model if session else "",
+                    "model_alias": session.model_alias if session else "",
+                    "kind": ws.kind,
+                    "parent_ws_id": ws.parent_ws_id,
+                    "user_id": ws.user_id,
+                }
+            )
+
+
+def _audit_workstream_opened(request: Request, ws: Workstream) -> None:
+    """Record the ``workstream.opened`` audit event.
+
+    Passed to :func:`make_open_handler` as the ``audit_emit``
+    callable. Mirrors :func:`_audit_close_workstream`'s shape.
+    Distinguishing rehydrate from fresh-create in the audit trail
+    (same ``ws_created`` SSE shape on the wire; the audit action
+    name is the disambiguator) is the original justification for
+    this row.
+    """
+    from turnstone.core.audit import record_audit
+
+    storage = getattr(request.app.state, "auth_storage", None)
+    if storage is None:
+        return
+    _, ip = _audit_context(request)
+    record_audit(
+        storage,
+        _auth_user_id(request),
+        "workstream.opened",
+        "workstream",
+        ws.id,
+        {"kind": str(ws.kind), "parent_ws_id": ws.parent_ws_id},
         ip,
     )
 
@@ -2623,120 +2701,6 @@ def _require_ws_access(
     return resolve_workstream_owner(request, ws_id, mgr=mgr, not_found_label="Workstream not found")
 
 
-async def open_workstream(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/open — load a saved workstream into memory.
-
-    Unlike resume (which creates a NEW workstream and forks), this endpoint
-    loads the existing workstream into memory with its original ws_id preserved.
-    """
-    from turnstone.core.log import get_logger
-    from turnstone.core.memory import get_workstream_display_name, resolve_workstream
-    from turnstone.core.storage import get_storage as _get_storage
-
-    log = get_logger(__name__)
-    ws_id = request.path_params.get("ws_id", "")
-    if not ws_id:
-        return JSONResponse({"error": "ws_id is required"}, status_code=400)
-
-    resolved_id = resolve_workstream(ws_id)
-    if not resolved_id:
-        return JSONResponse({"error": "Workstream not found"}, status_code=404)
-
-    mgr: SessionManager = request.app.state.workstreams
-
-    if mgr.get(resolved_id):
-        return JSONResponse(
-            {
-                "ws_id": resolved_id,
-                "name": get_workstream_display_name(resolved_id) or resolved_id,
-                "already_loaded": True,
-            }
-        )
-
-    _st = _get_storage()
-    ws_row = _st.get_workstream(resolved_id)
-    if not ws_row:
-        return JSONResponse({"error": "Workstream not found in storage"}, status_code=404)
-
-    # Coordinator workstreams live on the console process, not on server
-    # nodes.  Refuse to rehydrate one here so we don't silently build a
-    # coordinator-kind ChatSession with coord_client=None (A/S1 guard).
-    if ws_row.get("kind") != WorkstreamKind.INTERACTIVE:
-        return JSONResponse(
-            {"error": "Workstream is not an interactive kind"},
-            status_code=400,
-        )
-
-    uid: str = _auth_user_id(request)
-
-    # Trusted-team model: scope-level auth (already enforced by the
-    # middleware) is the only gate.  ``user_id`` is metadata for audit
-    # + display, not an access boundary, so any authenticated caller
-    # can rehydrate any persisted workstream.  Fall back to the
-    # caller's uid when the row has no recorded owner.
-    stored_owner = (ws_row.get("user_id") or "").strip()
-    owner_uid = stored_owner or uid
-
-    try:
-        ws = mgr.create(
-            user_id=owner_uid,
-            name=ws_row.get("name", ""),
-            ws_id=resolved_id,
-            parent_ws_id=ws_row.get("parent_ws_id"),
-        )
-    except Exception as e:
-        log.warning("ws.open.create_failed", ws_id=resolved_id[:8], error=str(e))
-        return JSONResponse({"error": f"Failed to load workstream: {e}"}, status_code=500)
-
-    if not isinstance(ws.ui, WebUI):
-        msg = f"Expected WebUI, got {type(ws.ui).__name__}"
-        raise TypeError(msg)
-
-    if ws.session is not None and ws.session.resume(resolved_id):
-        ws.name = get_workstream_display_name(resolved_id) or ws.name
-        ui = ws.ui
-        ui._enqueue({"type": "clear_ui"})
-        history = _build_history(ws.session)
-        if history:
-            ui._enqueue({"type": "history", "messages": history})
-
-    gq: queue.Queue[dict[str, Any]] = request.app.state.global_queue
-    with contextlib.suppress(queue.Full):
-        gq.put_nowait(
-            {
-                "type": "ws_created",
-                "ws_id": ws.id,
-                "name": ws.name,
-                "model": ws.session.model if ws.session else "",
-                "model_alias": ws.session.model_alias if ws.session else "",
-                "kind": ws.kind,
-                "parent_ws_id": ws.parent_ws_id,
-                "user_id": ws.user_id,
-            }
-        )
-
-    # Audit the rehydration so console-side forensic review can distinguish
-    # rehydrated workstreams from fresh creates (same broadcast shape; the
-    # audit action name is the disambiguator).
-    _audit_storage = getattr(request.app.state, "auth_storage", None)
-    if _audit_storage is not None:
-        from turnstone.core.audit import record_audit as _record_audit
-
-        _, _audit_ip = _audit_context(request)
-        _record_audit(
-            _audit_storage,
-            _auth_user_id(request),
-            "workstream.opened",
-            "workstream",
-            ws.id,
-            {"kind": str(ws.kind), "parent_ws_id": ws.parent_ws_id},
-            _audit_ip,
-        )
-
-    log.info("ws.opened", ws_id=resolved_id[:8])
-    return JSONResponse({"ws_id": ws.id, "name": ws.name})
-
-
 async def list_watches(request: Request) -> JSONResponse:
     """GET /v1/api/watches — list active watches, optionally filtered by ws_id."""
     from turnstone.core.storage._registry import get_storage
@@ -3833,6 +3797,8 @@ def create_app(
         classify_text_attachment=_classify_text_attachment,
         upload_lock=_attachment_upload_lock,
     )
+    from turnstone.core.memory import resolve_workstream as _resolve_workstream_alias
+
     interactive_endpoint_config = SessionEndpointConfig(
         permission_gate=None,  # interactive auth is enforced at the middleware layer
         manager_lookup=_interactive_manager_lookup,
@@ -3845,6 +3811,8 @@ def create_app(
         spawn_metrics=_interactive_spawn_metrics,
         emit_message_queued=True,
         cancel_forensics=_capture_cancel_forensics,
+        open_resolve_alias=_resolve_workstream_alias,
+        open_post_load=_interactive_open_post_load,
     )
     approve_handler = make_approve_handler(interactive_endpoint_config)
     close_handler = make_close_handler(
@@ -3853,6 +3821,10 @@ def create_app(
         supports_close_reason=True,
     )
     cancel_handler = make_cancel_handler(interactive_endpoint_config)
+    open_handler = make_open_handler(
+        interactive_endpoint_config,
+        audit_emit=_audit_workstream_opened,
+    )
     send_handler = make_send_handler(interactive_endpoint_config)
     dequeue_handler = make_dequeue_handler(interactive_endpoint_config)
     attachment_handlers = make_attachment_handlers(interactive_endpoint_config)
@@ -3869,7 +3841,7 @@ def create_app(
             create=create_workstream,
             close_legacy=make_legacy_body_keyed_adapter(close_handler),
             delete=delete_workstream_endpoint,
-            open=open_workstream,
+            open=open_handler,  # lifted: shared body
             close=close_handler,  # lifted: shared body
             refresh_title=refresh_workstream_title,
             set_title=set_workstream_title,


### PR DESCRIPTION
## Summary

Stage 2 verb lift on the 1.5.0 SessionManager unification track. Lifts the `open` verb body into `make_open_handler(cfg, *, audit_emit=None)` shared by both kinds. Same factory + capability-flag pattern as the merged cancel/send/close/approve/attachment lifts.

**Key behavioral fix** (§ Post-P3 reckoning item #3 from `1.5.0-session-manager-stage-2.md`): pre-lift interactive's `open_workstream` called `mgr.create(ws_id=resolved_id)` + `ws.session.resume(...)` to rehydrate, bypassing `mgr.open()` entirely. The lift routes both kinds through `mgr.open()` — making `InteractiveAdapter.emit_rehydrated` reachable on interactive (it was dead-by-routing) and consolidating the rehydrate code path.

**New cfg fields**:
- `open_resolve_alias: AliasResolver | None` — interactive wires `resolve_workstream` for the user-friendly alias UX; coord wires None.
- `open_post_load: OpenPostLoad | None` — interactive wires `_interactive_open_post_load` (display-name sync, UI replay, handler-side `ws_created`); coord wires None and uses cluster-collector fan-out from `emit_rehydrated`.

**Behavior changes for interactive callers** (in CHANGELOG):
- Cross-kind open returns 404 (was 400 with kind-specific error). Security boundary unchanged.
- Already-loaded response uses `ws.name` directly (was alias re-lookup). Dashboard listing endpoint still resolves aliases on its own pass.

**Bundled /review fixes**:
- bug-1: resume failures now surface as 5xx with correlation id (pre-lift behavior). `mgr.open()` was silently swallowing resume exceptions, leaving sessions in partial state. Fix in `SessionManager.open()` rolls back the slot and re-raises.
- q-3: bare `except Exception` documents intent in a comment.
- q-2 + q-4: doc-comment cleanup, dropped a redundant `import secrets as _secrets` alias.

## Test plan

- [x] Lint (ruff) + mypy clean
- [x] 4488 tests passing (was 4475; +13 new open tests, -0 removed)
- [x] Multi-stage `/review` pipeline: 1 bug + 6 quality findings; all 7 confirmed by verifier; bug-1 + q-1 + q-3 + nits q-2/q-4 addressed in same commit; q-5 (factory-prelude DRY) deferred to Stage 3
- [x] New tests pin: alias resolution runs first, `mgr.open` is called (NOT `mgr.create`), post-load callback fires only on load-from-storage path, post-load exception swallowed → 200
- [ ] Manual smoke on a running console with both kinds is recommended before merge