### PR TITLE
refactor(core): lift events verb body across both kinds (Stage 2 verb lift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,84 @@ Three release tracks are maintained:
     handler body keeps a future contributor from narrowing it
     incorrectly.
 
+- **`events` verb body lifted across both kinds** ([Stage 2 Verb
+  Lift — `events`]). The interactive
+  ``GET /v1/api/events?ws_id=...`` and coord
+  ``GET /v1/api/workstreams/{ws_id}/events`` SSE handlers now
+  share one body via ``make_events_handler(cfg)``. Per-kind
+  divergence captured by a new
+  ``events_replay: EventsReplay | None`` cfg field — a Protocol-
+  typed callback yielding the kind-specific initial replay
+  payload that the lifted body iterates and sends as ``data:``
+  lines before starting the live event loop. Interactive's
+  ``_interactive_events_replay`` yields the pre-lift sequence
+  (``connected`` + ``status`` + ``history`` + ``pending_approval``
+  + cached intent verdicts + ``pending_plan_review``); coord's
+  ``_coord_events_replay`` yields just ``pending_approval`` +
+  ``pending_plan_review`` (matches pre-lift coord behaviour).
+
+  The legacy interactive query-keyed URL is preserved via a new
+  ``make_legacy_query_keyed_adapter`` helper (sister to
+  ``make_legacy_body_keyed_adapter`` from earlier lifts) — it
+  reads ``ws_id`` from the query string and splices into
+  ``request.path_params`` before delegating to the lifted body.
+  ``GET /v1/api/events?ws_id=...`` continues to work for any 1.x
+  SDK consumer.
+
+  Two convergence wins:
+
+  - **Coord gains SSE connect/disconnect metrics.** Pre-lift
+    coord didn't record per-stream metrics; the lifted body
+    always calls ``metrics.record_sse_connect()`` /
+    ``...disconnect()``, giving the cluster dashboard the same
+    per-stream observability interactive's had since 1.0.
+  - **Both kinds now check ``request.is_disconnected()`` AND
+    the ``ws_closed`` event** to terminate. Pre-lift interactive
+    relied solely on ``ws_closed`` (which never fires if the
+    client just goes away without closing the workstream);
+    pre-lift coord relied solely on ``is_disconnected``. The
+    lifted body uses both — whichever fires first wins.
+
+  One observable shape change for coord callers: the lifted body
+  returns 409 ``"session has no UI"`` when ``ws.ui`` is missing
+  (placeholder / build-failed UI), matching pre-lift coord.
+  Pre-lift interactive returned 404 in this case; the lift
+  converges on 409 across kinds because the workstream EXISTS
+  (404 would imply it doesn't).
+
+  **Item #2 from § Post-P3 reckoning split out** of this lift
+  during scoping (rich ``ws_state`` payload parity for coord —
+  lifting coord's ``ConsoleCoordinatorUI`` to broadcast
+  ``tokens + context_ratio + activity + content`` like
+  ``WebUI._broadcast_state`` does). The body lift touches
+  ``session_routes.py`` + ``server.py`` + ``console/server.py``;
+  the rich-payload work touches ``coordinator_ui.py`` +
+  ``collector.py`` + ``session_ui_base.py`` (different files,
+  different reviewer concern). Tracked as standalone follow-up
+  ``feat/coord-rich-ws-state-payload``.
+
+  Two /review fixes folded into the same commit:
+
+  - **Restored interactive's dedicated SSE thread pool.** The
+    initial draft of ``make_events_handler`` used
+    ``asyncio.to_thread`` (default executor, capped at
+    ``min(32, cpu_count + 4)``) for the per-connection
+    ``client_queue.get`` blocking wait. Pre-lift interactive used
+    a dedicated 200-thread ``sse_executor`` (created in the
+    lifespan with ``thread_name_prefix="sse"``) precisely to
+    avoid this — under high concurrent SSE counts the default
+    pool starves and SSE polling contends with every other
+    ``asyncio.to_thread`` caller in the process (storage, router,
+    audit). Restored isolation via a new
+    ``sse_executor_lookup: SseExecutorLookup | None`` cfg field;
+    interactive returns ``request.app.state.sse_executor``, coord
+    wires ``None`` and falls through to the default executor.
+  - **Restored 5s queue.get poll** (was shortened to 1s in the
+    initial draft). The 5x wakeup-rate bump compounded the thread-
+    pool starvation; the ``request.is_disconnected()`` probe
+    between polls already covers cancel-detection latency the
+    timeout would otherwise gate.
+
 ### Security
 
 - **Coord attachment endpoints are now kind-strict**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,20 @@ Three release tracks are maintained:
     pool starvation; the ``request.is_disconnected()`` probe
     between polls already covers cancel-detection latency the
     timeout would otherwise gate.
+  - **Replay phase streams events directly from the generator
+    instead of pre-building into a list.** The initial draft
+    materialised the entire kind-specific replay payload
+    (``connected`` + ``status`` + ``history`` + pending prompts)
+    into a list before constructing the ``EventSourceResponse``,
+    delaying time-to-first-byte until the heaviest replay event
+    (``_build_history`` for long-running interactive workstreams)
+    finished serialising AND letting the per-UI listener queue
+    accumulate over its 500-slot cap on a chatty mid-generation
+    workstream. The lifted body now iterates ``cfg.events_replay``
+    inside the async generator so each event ships as soon as the
+    callback yields it; the existing observational-failure swallow
+    semantics are preserved by wrapping the iteration in the same
+    try/except.
 
 ### Security
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -791,6 +791,58 @@ def test_cancel_idle_workstream_does_not_broadcast_approval_resolved(storage):
 
 
 # ---------------------------------------------------------------------------
+# Events (SSE replay shape)
+# ---------------------------------------------------------------------------
+
+
+def test_coord_events_replay_yields_pending_approval_then_pending_plan():
+    """The lifted coord ``events_replay`` callback yields two things
+    on a fresh SSE connect: pending approval (if any) + pending plan
+    review (if any). Pre-lift coord pushed both onto the listener
+    queue via ``put_nowait``; the lift restructures as a generator
+    the lifted body iterates and yields as ``data:`` lines, but the
+    payload identity is preserved. Pure-read — never mutates ``ui``."""
+    from turnstone.console.server import _coord_events_replay
+
+    ui = MagicMock()
+    ui._pending_approval = {"type": "approve_request", "items": []}
+    ui._pending_plan_review = {"type": "plan_review", "content": "..."}
+    ws = MagicMock()
+    request = MagicMock()
+
+    out = list(_coord_events_replay(ws, ui, request))
+    # Order matters — the pre-lift body re-injected approval first.
+    assert out[0]["type"] == "approve_request"
+    assert out[1]["type"] == "plan_review"
+
+
+def test_coord_events_replay_yields_nothing_when_no_pending():
+    """A workstream with no pending approval / plan review yields
+    an empty replay. The lifted body falls through to the live loop
+    immediately."""
+    from turnstone.console.server import _coord_events_replay
+
+    ui = MagicMock()
+    ui._pending_approval = None
+    ui._pending_plan_review = None
+    ws = MagicMock()
+    request = MagicMock()
+
+    out = list(_coord_events_replay(ws, ui, request))
+    assert out == []
+
+
+def test_coord_events_returns_404_on_missing_ws(storage):
+    """Cross-kind / missing ws_id surfaces as 404 with
+    ``cfg.not_found_label`` ("coordinator not found") via the lifted
+    body's ``mgr.get`` None-return contract."""
+    mgr = _build_mgr(storage)
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get("/v1/api/workstreams/nonexistent-id/events", headers=_COORD_HEADERS)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Open (explicit rehydration)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -13,6 +13,7 @@ import json
 import queue
 import threading
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from starlette.testclient import TestClient
@@ -704,3 +705,150 @@ class TestInteractiveCancelLifted:
         )
         assert resp.status_code == 400
         assert resp.json()["error"] == "No session"
+
+
+def _make_interactive_replay_mocks(**overrides: Any) -> tuple[Any, Any, Any]:
+    """Build (ws, ui, request) MagicMock triples for
+    ``_interactive_events_replay`` tests.
+
+    Defaults match a fresh workstream that hasn't completed a turn
+    (no last_usage, no pending prompts). Per-test overrides come in
+    as kwargs and are applied via setattr on the returned mocks.
+
+    Why a fixture: each test exercises 1-2 attribute variations
+    while the rest of the mock surface (model, model_alias,
+    auto_approve, _pending_approval, _pending_plan_review,
+    _ws_lock, etc.) stays uniform. Helper isolates the per-test
+    intent from the boilerplate.
+    """
+    import threading
+
+    session = MagicMock()
+    session.model = "gpt-5"
+    session.model_alias = "default"
+    session._last_usage = None
+    session.context_window = 100000
+    session.reasoning_effort = "medium"
+    session.messages = []
+    ui = MagicMock()
+    ui.auto_approve = False
+    ui._pending_approval = None
+    ui._pending_plan_review = None
+    ui._llm_verdicts = {}
+    ui._ws_lock = threading.Lock()
+    ui._ws_turn_tool_calls = 0
+    ui._ws_messages = 0
+    ws = MagicMock()
+    ws.session = session
+    request = MagicMock()
+
+    for key, value in overrides.items():
+        # Dotted keys ("session.model_alias") drill into the nested
+        # MagicMock; bare keys set on the ws/ui directly.
+        if "." in key:
+            head, tail = key.split(".", 1)
+            target = {"session": session, "ui": ui, "ws": ws, "request": request}[head]
+            setattr(target, tail, value)
+        elif hasattr(ui, key) or key.startswith(("_", "auto_")):
+            setattr(ui, key, value)
+        else:
+            setattr(ws, key, value)
+    return ws, ui, request
+
+
+class TestInteractiveEventsLifted:
+    """Unit + HTTP coverage for the lifted ``events`` SSE handler.
+
+    Substantive coverage targets the ``_interactive_events_replay``
+    callback (the kind-specific initial-replay generator the lifted
+    body iterates before the live loop) and the legacy URL shim.
+    The live SSE loop itself (``ws_closed`` exit + ``is_disconnected``
+    check) is hard to assert against ``TestClient`` because each
+    event arrives as a separate ``data:`` line and the stream runs
+    forever; the loop is the same shape used by every other lifted
+    SSE-shaped path (cancel / close / open / send), so a regression
+    in the loop body would surface across many test files. Live-loop
+    smoke coverage is a deferred follow-up tracked in
+    ``1.5.0-stable-handoff.md``'s "Risk flags for the next session"
+    section.
+    """
+
+    def test_events_replay_yields_connected_first(self):
+        """Pre-lift ``events_sse`` yielded a ``connected`` event
+        first (model + skip_permissions). The lifted callback
+        preserves the order so client SSE handlers that key on
+        the connected event for state setup keep working."""
+        from turnstone.server import _interactive_events_replay
+
+        ws, ui, request = _make_interactive_replay_mocks()
+        out = list(_interactive_events_replay(ws, ui, request))
+        assert out[0]["type"] == "connected"
+        assert out[0]["model"] == "gpt-5"
+        assert out[0]["model_alias"] == "default"
+        assert out[0]["skip_permissions"] is False
+
+    def test_events_replay_includes_status_only_when_last_usage_present(self):
+        """The ``status`` event populates the per-tab token-usage
+        bar on resume. Skipped when ``session._last_usage`` is None
+        (a freshly-created workstream that hasn't completed a turn)."""
+        from turnstone.server import _interactive_events_replay
+
+        ws, ui, request = _make_interactive_replay_mocks()
+        out = list(_interactive_events_replay(ws, ui, request))
+        assert "status" not in {ev["type"] for ev in out}
+
+    def test_events_replay_yields_pending_approval_then_verdicts_then_plan(self):
+        """When both prompts are pending, the order is approval +
+        cached verdicts (so the client renders the prompt and then
+        the LLM-judge intent verdicts that fired during it), then
+        plan-review. Pre-lift ordering preserved."""
+        from turnstone.server import _interactive_events_replay
+
+        ws, ui, request = _make_interactive_replay_mocks(
+            _pending_approval={"type": "approve_request", "items": []},
+            _pending_plan_review={"type": "plan_review", "content": "..."},
+            _llm_verdicts={"v1": {"verdict_id": "v1", "tier": "judge"}},
+        )
+
+        out = list(_interactive_events_replay(ws, ui, request))
+        types = [ev["type"] for ev in out]
+        # The approve_request, then the intent_verdict, then the plan_review.
+        approve_idx = types.index("approve_request")
+        verdict_idx = types.index("intent_verdict")
+        plan_idx = types.index("plan_review")
+        assert approve_idx < verdict_idx < plan_idx
+
+    def test_events_replay_skips_when_session_missing(self):
+        """Defensive: a placeholder workstream whose session is
+        ``None`` (close-then-reopen race) yields an empty replay
+        rather than NPE'ing on ``session.model``. The lifted body
+        already 409s for missing UI; this guards the rare case
+        where UI exists but session was detached."""
+        from turnstone.server import _interactive_events_replay
+
+        ws = MagicMock()
+        ws.session = None
+        ui = MagicMock()
+        request = MagicMock()
+        out = list(_interactive_events_replay(ws, ui, request))
+        assert out == []
+
+    def test_events_legacy_query_keyed_url_still_resolves_to_404_for_unknown_ws(self, app_client):
+        """The legacy ``GET /api/events?ws_id=...`` URL (interactive
+        stable surface since 1.0) routes through the
+        ``make_legacy_query_keyed_adapter`` shim into the lifted
+        body. Pinning a 404 response confirms the shim wires
+        ``ws_id`` from query into ``path_params`` correctly — if the
+        shim were broken, the lifted body's
+        ``request.path_params.get('ws_id', '')`` would return empty
+        and we'd see a 400 (``ws_id is required``) instead."""
+        client, _mgr = app_client
+        resp = client.get(
+            "/v1/api/events?ws_id=does-not-exist",
+            headers=_auth("user-1"),
+        )
+        # 404 because the workstream isn't loaded; NOT 400 (which
+        # would indicate the shim failed to splice ws_id into
+        # path_params).
+        assert resp.status_code == 404
+        assert "ws_id" not in resp.json().get("error", "").lower()

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -63,6 +63,7 @@ from turnstone.core.session_routes import (
     make_attachment_handlers,
     make_cancel_handler,
     make_close_handler,
+    make_events_handler,
     make_open_handler,
     make_send_handler,
     register_coord_verbs,
@@ -76,7 +77,7 @@ from turnstone.core.web_helpers import (
 from turnstone.core.workstream import Workstream, WorkstreamKind
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable
+    from collections.abc import AsyncGenerator, Callable, Iterable
 
     from starlette.requests import Request
 
@@ -2454,6 +2455,32 @@ def _audit_cancel_coordinator(
     )
 
 
+def _coord_events_replay(
+    ws: Workstream,  # noqa: ARG001 — coord replay reads ui only
+    ui: Any,
+    request: Request,  # noqa: ARG001 — coord replay doesn't need request context
+) -> Iterable[dict[str, Any]]:
+    """Initial SSE replay payload for coord ``events`` connections.
+
+    Pre-lift ``coordinator_events`` re-injected just two things on
+    connect: the pending approval prompt (if any) and the pending
+    plan-review (if any). The lifted ``make_events_handler`` body
+    delegates to this callback so the kind-specific shape stays in
+    this module. Coord doesn't replay ``connected``/``status``/
+    ``history`` because its dashboard fetches conversation history
+    via a separate ``/history`` endpoint and doesn't render the
+    per-tab status bar (those are interactive-UX-specific).
+
+    Pure read — never mutates ``ui``.
+    """
+    pending_approval = getattr(ui, "_pending_approval", None)
+    if pending_approval is not None:
+        yield pending_approval
+    pending_plan = getattr(ui, "_pending_plan_review", None)
+    if pending_plan is not None:
+        yield pending_plan
+
+
 async def coordinator_create(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/new — create a new coordinator session."""
     from turnstone.core.audit import record_audit
@@ -2558,49 +2585,6 @@ async def coordinator_create(request: Request) -> JSONResponse:
         except Exception:
             log.debug("coordinator_create.audit_failed", exc_info=True)
     return JSONResponse({"ws_id": ws.id, "name": ws.name}, status_code=201)
-
-
-async def coordinator_events(request: Request) -> Response:
-    """GET /v1/api/workstreams/{ws_id}/events — SSE event stream."""
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    ui = ws.ui
-    if ui is None or not hasattr(ui, "_register_listener"):
-        return JSONResponse({"error": "coordinator has no UI"}, status_code=409)
-
-    client_queue = ui._register_listener()
-    # Replay any pending approval so a reconnecting tab sees the prompt.
-    pending = getattr(ui, "_pending_approval", None)
-    if pending is not None:
-        with contextlib.suppress(queue.Full):
-            client_queue.put_nowait(pending)
-    pending_plan = getattr(ui, "_pending_plan_review", None)
-    if pending_plan is not None:
-        with contextlib.suppress(queue.Full):
-            client_queue.put_nowait(pending_plan)
-
-    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
-        try:
-            while True:
-                if await request.is_disconnected():
-                    break
-                try:
-                    event = await asyncio.to_thread(client_queue.get, True, 1.0)
-                    yield {"data": json.dumps(event)}
-                except queue.Empty:
-                    pass  # ping keeps the connection alive
-        finally:
-            ui._unregister_listener(client_queue)
-
-    return EventSourceResponse(event_generator(), ping=5)
 
 
 async def coordinator_history(request: Request) -> JSONResponse:
@@ -5594,7 +5578,6 @@ def _parse_skill_session_config(body: dict[str, Any]) -> tuple[dict[str, Any], J
 
 def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, Any]:
     """Convert a storage skill dict to a JSON-safe response dict."""
-    import contextlib
     import json as _json
 
     tags: list[str] = []
@@ -5994,7 +5977,6 @@ async def admin_list_skill_versions(request: Request) -> JSONResponse:
 
 async def list_skills_summary(request: Request) -> JSONResponse:
     """GET /v1/api/skills — list available skills (summary)."""
-    import contextlib
     import json as _json
 
     from turnstone.core.web_helpers import require_storage_or_503
@@ -10122,6 +10104,7 @@ def create_app(
         # dashboard. Cluster-level metrics fan out via the collector.
         spawn_metrics=None,
         emit_message_queued=True,
+        events_replay=_coord_events_replay,
     )
     coord_workstream_routes: list[Any] = []
     register_session_routes(
@@ -10144,7 +10127,7 @@ def create_app(
                 coord_endpoint_config,
                 audit_emit=_audit_cancel_coordinator,
             ),
-            events=coordinator_events,
+            events=make_events_handler(coord_endpoint_config),  # lifted: shared body
             history=coordinator_history,
             attachments=make_attachment_handlers(
                 coord_endpoint_config

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -646,8 +646,8 @@
     setSseStatus("connecting…", "");
     // Snapshot whether this is a reconnect BEFORE resetting
     // reconnectAttempts in onopen — child_ws_* events dispatched while
-    // we were disconnected aren't replayed by coordinator_events, so
-    // the client has to pull authoritative state after any gap.
+    // we were disconnected aren't replayed by the events SSE handler,
+    // so the client has to pull authoritative state after any gap.
     const wasReconnecting = reconnectAttempts > 0;
     const url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
     evtSource = new EventSource(url, { withCredentials: true });
@@ -750,9 +750,9 @@
       case "approve_request":
         showApproval(ev.items);
         // Surface each tool for context.  Dedupe by call_id: the console
-        // replays _pending_approval into every new SSE subscriber (see
-        // coordinator_events handler), so without this check an SSE
-        // reconnect would render each tool row a second time.
+        // replays _pending_approval into every new SSE subscriber (the
+        // events SSE handler's coord-side replay), so without this check
+        // an SSE reconnect would render each tool row a second time.
         (ev.items || []).forEach((it) => {
           if (!it.needs_approval) return;
           if (

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1244,26 +1244,6 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
 
         client_queue = register()
 
-        # Pre-build the replay payload while we still hold the
-        # request context. The kind-specific callback can read
-        # ``ws.session._last_usage`` / ``ui._pending_approval`` etc.
-        # synchronously; we don't need to keep the request alive
-        # for the iteration.
-        replay_events: list[dict[str, Any]] = []
-        if cfg.events_replay is not None:
-            try:
-                for ev in cfg.events_replay(ws, ui, request):
-                    replay_events.append(ev)
-            except Exception:
-                # Replay is observational — never let a snapshot bug
-                # block the live stream. Log and start the loop with
-                # whatever partial replay we managed to build.
-                log.debug(
-                    "ws.events.replay_failed ws=%s",
-                    ws_id[:8],
-                    exc_info=True,
-                )
-
         # Per-kind executor for the blocking ``client_queue.get``
         # wait. Interactive returns its dedicated 200-thread
         # ``sse_executor`` so SSE polling stays isolated from every
@@ -1275,6 +1255,9 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
         live_executor = (
             cfg.sse_executor_lookup(request) if cfg.sse_executor_lookup is not None else None
         )
+        # Capture the replay callback in a local so the inner
+        # generator's closure doesn't have to re-read the cfg field.
+        replay_cb = cfg.events_replay
 
         async def event_generator() -> Any:
             import functools
@@ -1282,10 +1265,30 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
             _metrics.record_sse_connect()
             loop = asyncio.get_running_loop()
             try:
-                # Replay phase — yield the kind-specific initial
-                # payload before the live loop starts.
-                for ev in replay_events:
-                    yield {"data": json.dumps(ev)}
+                # Replay phase — stream the kind-specific initial
+                # payload one event at a time so the client sees the
+                # first byte immediately (interactive's ``connected``
+                # event is the very first yield, before the heavier
+                # ``status`` / ``history`` work runs). Pre-building
+                # the replay into a list would block time-to-first-
+                # byte until the entire replay materialized AND let
+                # the listener queue accumulate (potentially over its
+                # 500-slot cap on a chatty mid-generation workstream)
+                # while replay was being built.
+                if replay_cb is not None:
+                    try:
+                        for ev in replay_cb(ws, ui, request):
+                            yield {"data": json.dumps(ev)}
+                    except Exception:
+                        # Replay is observational — never let a
+                        # snapshot bug block the live stream. Log
+                        # and continue with whatever partial replay
+                        # was already yielded.
+                        log.debug(
+                            "ws.events.replay_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
                 # Live phase — drain the per-UI listener queue
                 # until either the workstream closes or the client
                 # disconnects. 5s poll matches pre-lift interactive

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -31,7 +31,7 @@ call the factory during startup and pass the result as
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -110,6 +110,42 @@ OpenPostLoad = Callable[["Request", "Workstream"], None]
 # event. Same shape as ``CloseAuditEmitter``'s leading args. Coord
 # wires ``None`` (coord doesn't audit open today).
 OpenAuditEmitter = Callable[["Request", "Workstream"], None]
+
+
+class EventsReplay(Protocol):
+    """Pure-read generator of the per-kind initial SSE replay payload.
+
+    The lifted ``events`` body calls this once per SSE connection
+    *after* the per-UI listener queue is registered, but *before* the
+    live event loop starts. Each yielded dict gets JSON-serialised
+    and sent as a single ``data:`` line to the client.
+
+    Interactive yields five things on connect: ``connected`` (model +
+    skip_permissions), ``status`` (token usage + context %, only when
+    ``session._last_usage`` exists), ``history`` (replayed conversation),
+    ``pending_approval`` + cached intent verdicts, and
+    ``pending_plan_review``. Coord yields just two: ``pending_approval``
+    and ``pending_plan_review`` (the rest aren't needed because coord's
+    dashboard fetches history via a separate ``/history`` endpoint
+    and doesn't render the per-tab status bar). Kinds that don't
+    need any pre-replay wire ``None`` and the live loop starts
+    immediately.
+    """
+
+    def __call__(self, ws: Workstream, ui: Any, request: Request) -> Iterable[dict[str, Any]]:
+        """Return the iterable of initial replay events."""
+
+
+# (request) -> Executor for the SSE live-loop's blocking `queue.get`
+# wait. Interactive returns the dedicated ``sse_executor``
+# (200-thread pool created at lifespan setup) so the SSE poll path
+# stays isolated from every other ``asyncio.to_thread`` caller in
+# the process (storage, router, audit). Coord returns ``None`` and
+# the lifted body falls through to ``asyncio.to_thread`` (default
+# executor, capped at ``min(32, os.cpu_count() + 4)`` workers) —
+# coord's per-process SSE concurrency stays well under that ceiling
+# and adding a dedicated pool would over-engineer for the LOC win.
+SseExecutorLookup = Callable[["Request"], Any]
 
 
 @dataclass(frozen=True)
@@ -228,6 +264,24 @@ class SessionEndpointConfig:
     # wires ``None`` and lets the cluster collector handle the
     # transition via ``CoordinatorAdapter.emit_rehydrated``.
     open_post_load: OpenPostLoad | None = None
+    # (ws, ui, request) -> Iterable[dict]. Kind-specific initial
+    # SSE replay payload the lifted ``events`` body yields after
+    # registering the per-UI listener queue but before the live
+    # event loop. Interactive replays connected + status + history
+    # + pending_approval (with cached intent verdicts) +
+    # pending_plan_review. Coord replays just pending_approval +
+    # pending_plan_review (its dashboard fetches history via a
+    # separate ``/history`` endpoint and doesn't render the per-tab
+    # status bar). Kinds that don't need pre-replay wire ``None``.
+    events_replay: EventsReplay | None = None
+    # (request) -> Executor for the SSE live-loop's blocking
+    # ``queue.get`` wait. Interactive returns the dedicated
+    # ``request.app.state.sse_executor`` (200-thread pool) so SSE
+    # polling stays isolated from every other ``asyncio.to_thread``
+    # caller in the process; coord wires ``None`` and the lifted
+    # body falls through to the default executor. See
+    # :data:`SseExecutorLookup` docstring above.
+    sse_executor_lookup: SseExecutorLookup | None = None
 
 
 @dataclass(frozen=True)
@@ -547,6 +601,29 @@ def make_legacy_body_keyed_adapter(handler: Handler) -> Handler:
         # body-keyed URL with no ``{ws_id}`` slot, we splice it into
         # the scope so the lifted handler's ``request.path_params.get(...)``
         # finds it.
+        path_params: dict[str, Any] = dict(request.path_params)
+        path_params["ws_id"] = ws_id
+        request.scope["path_params"] = path_params
+        return await handler(request)
+
+    return adapter
+
+
+def make_legacy_query_keyed_adapter(handler: Handler) -> Handler:
+    """Wrap a path-keyed handler so it can be mounted at a query-keyed URL.
+
+    Pre-1.5 interactive ``GET /api/events?ws_id=...`` takes ``ws_id``
+    from the query string. The lifted ``events`` body reads it from
+    the path. This adapter mirrors :func:`make_legacy_body_keyed_adapter`
+    for the query-param case: read ``ws_id`` from the query, splice
+    into path_params, forward.
+
+    SSE-friendly: no body read involved (events is GET); the handler
+    stays streaming.
+    """
+
+    async def adapter(request: Request) -> Response:
+        ws_id = request.query_params.get("ws_id", "")
         path_params: dict[str, Any] = dict(request.path_params)
         path_params["ws_id"] = ws_id
         request.scope["path_params"] = path_params
@@ -1075,6 +1152,167 @@ def make_open_handler(
         return JSONResponse({"ws_id": ws.id, "name": ws.name})
 
     return open_ws
+
+
+def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``GET {prefix}/{ws_id}/events`` — per-workstream SSE.
+
+    Both kinds share the SSE plumbing: register the per-UI listener
+    queue, run the kind-specific initial replay (``cfg.events_replay``,
+    typically ``connected`` + ``status`` + ``history`` + pending
+    approval / plan on interactive; just pending approval / plan on
+    coord), then drain the queue forever until either the workstream
+    closes (``ws_closed`` event) or the client disconnects.
+
+    The kind-specific divergence is captured entirely by
+    ``cfg.events_replay``. The live-loop body, the listener
+    registration, the ``ws_closed`` exit, the disconnect detection,
+    and the SSE-connect/disconnect metric recording are uniform.
+
+    Pre-lift behaviour preserved on both kinds with two small
+    convergence wins:
+
+    - **Coord gains SSE connect/disconnect metrics.** Pre-lift coord
+      did no metric recording on its events stream; the lifted body
+      always calls ``metrics.record_sse_connect()`` / ``...disconnect()``,
+      which gives the cluster dashboard the same per-stream
+      observability interactive's had since 1.0.
+    - **Both kinds now check ``request.is_disconnected()`` between
+      polls AND the ``ws_closed`` event.** Pre-lift interactive
+      relied solely on ``ws_closed`` to terminate (which never fires
+      if the client just goes away without a proper close); pre-lift
+      coord relied solely on ``is_disconnected``. The lifted body
+      uses both — whichever fires first wins.
+
+    Args:
+        cfg: per-kind policy bundle. ``events_replay`` is the only
+             field the events body reads beyond the standard
+             permission_gate / manager_lookup / tenant_check prelude.
+    """
+    # Lazy-imported at factory call time so the metrics module isn't
+    # dragged into ``session_routes.py``'s top-level import graph
+    # (which is consumed by the ``client_type="chat"`` channel
+    # gateway, where the metrics collector is irrelevant).
+    from turnstone.core.metrics import metrics as _metrics
+
+    async def events(request: Request) -> Response:
+        import asyncio
+        import json
+        import queue
+
+        from sse_starlette import EventSourceResponse
+
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        # See ``make_approve_handler`` for the cast rationale.
+        mgr = cast("SessionManager", mgr_opt)
+
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        if cfg.tenant_check is not None:
+            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws = mgr.get(ws_id)
+        if ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+        ui = ws.ui
+        # The listener-queue methods aren't on the ``SessionUI``
+        # Protocol surface (they live on ``SessionUIBase``), so
+        # extract via ``getattr`` after presence checks. Both kinds'
+        # production UIs subclass ``SessionUIBase``; the placeholder /
+        # build-failed UI path may have neither.
+        register = getattr(ui, "_register_listener", None) if ui is not None else None
+        unregister = getattr(ui, "_unregister_listener", None) if ui is not None else None
+        if ui is None or register is None or unregister is None:
+            # Placeholder / build-failed UI — there's no listener
+            # queue to attach to. 409 (not 404) because the
+            # workstream EXISTS in the manager but its UI is half-built.
+            # Pre-lift coord returned 409 for this case; pre-lift
+            # interactive 404'd. Lifted converges on 409 across
+            # kinds — more accurate for the workstream-exists-but-
+            # half-built shape.
+            return JSONResponse({"error": "session has no UI"}, status_code=409)
+
+        client_queue = register()
+
+        # Pre-build the replay payload while we still hold the
+        # request context. The kind-specific callback can read
+        # ``ws.session._last_usage`` / ``ui._pending_approval`` etc.
+        # synchronously; we don't need to keep the request alive
+        # for the iteration.
+        replay_events: list[dict[str, Any]] = []
+        if cfg.events_replay is not None:
+            try:
+                for ev in cfg.events_replay(ws, ui, request):
+                    replay_events.append(ev)
+            except Exception:
+                # Replay is observational — never let a snapshot bug
+                # block the live stream. Log and start the loop with
+                # whatever partial replay we managed to build.
+                log.debug(
+                    "ws.events.replay_failed ws=%s",
+                    ws_id[:8],
+                    exc_info=True,
+                )
+
+        # Per-kind executor for the blocking ``client_queue.get``
+        # wait. Interactive returns its dedicated 200-thread
+        # ``sse_executor`` so SSE polling stays isolated from every
+        # other ``asyncio.to_thread`` caller in the process; coord
+        # returns ``None`` and the lifted body falls back to the
+        # default executor (capped at ``min(32, cpu+4)``). Pre-lift
+        # interactive used the dedicated pool too — the lookup
+        # restores that isolation under the lifted contract.
+        live_executor = (
+            cfg.sse_executor_lookup(request) if cfg.sse_executor_lookup is not None else None
+        )
+
+        async def event_generator() -> Any:
+            import functools
+
+            _metrics.record_sse_connect()
+            loop = asyncio.get_running_loop()
+            try:
+                # Replay phase — yield the kind-specific initial
+                # payload before the live loop starts.
+                for ev in replay_events:
+                    yield {"data": json.dumps(ev)}
+                # Live phase — drain the per-UI listener queue
+                # until either the workstream closes or the client
+                # disconnects. 5s poll matches pre-lift interactive
+                # (the ``is_disconnected`` probe between polls covers
+                # cancel-detection latency the timeout would otherwise
+                # gate; shortening to 1s 5x'd the wakeup rate without
+                # any client-observable benefit).
+                while True:
+                    if await request.is_disconnected():
+                        return
+                    try:
+                        event = await loop.run_in_executor(
+                            live_executor,
+                            functools.partial(client_queue.get, timeout=5),
+                        )
+                    except queue.Empty:
+                        continue  # ping keeps the connection alive
+                    if event.get("type") == "ws_closed":
+                        return
+                    yield {"data": json.dumps(event)}
+            finally:
+                _metrics.record_sse_disconnect()
+                unregister(client_queue)
+
+        return EventSourceResponse(event_generator(), ping=5)
+
+    return events
 
 
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -30,6 +30,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 from sse_starlette import EventSourceResponse
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -64,7 +67,9 @@ from turnstone.core.session_routes import (
     make_cancel_handler,
     make_close_handler,
     make_dequeue_handler,
+    make_events_handler,
     make_legacy_body_keyed_adapter,
+    make_legacy_query_keyed_adapter,
     make_open_handler,
     make_send_handler,
     register_session_routes,
@@ -895,6 +900,88 @@ def _audit_close_workstream(
     )
 
 
+def _interactive_events_replay(
+    ws: Workstream, ui: Any, request: Request
+) -> Iterable[dict[str, Any]]:
+    """Initial SSE replay payload for interactive ``events`` connections.
+
+    Pre-lift ``events_sse`` yielded five things on connect: a
+    ``connected`` event with model + skip_permissions; a ``status``
+    event with the workstream's last token usage + context %; the
+    full conversation ``history`` (with pending-approval flagging on
+    the last assistant entry's tool calls); the pending approval
+    prompt + cached intent verdicts (if a prompt is pending); the
+    pending plan-review (if a review is pending). The lifted
+    ``make_events_handler`` body delegates that yield sequence to
+    this callback so the kind-specific shape stays in this module.
+
+    Pure read — never mutates ``ws`` / ``ui`` / ``session``.
+    """
+    del request  # not needed; replay reads ws/ui/session state
+    session = ws.session
+    if session is None:
+        # Defensive — the lifted body's UI presence check guarantees
+        # the workstream made it past placeholder state, but the
+        # session can still be detached on the close-then-reopen path.
+        return
+
+    # Connected event — model + skip-permissions ride here so the
+    # client can populate the per-tab status bar before any history
+    # arrives.
+    yield {
+        "type": "connected",
+        "model": session.model,
+        "model_alias": session.model_alias or "",
+        "skip_permissions": getattr(ui, "auto_approve", False),
+    }
+
+    # Status replay — only when last_usage exists so the client can
+    # populate the token / context-window bar on resume.
+    last_usage = session._last_usage
+    if last_usage is not None:
+        total_tok = last_usage["prompt_tokens"] + last_usage["completion_tokens"]
+        cw = session.context_window
+        pct = total_tok / cw * 100 if cw > 0 else 0
+        with ui._ws_lock:
+            turn_tool_calls = ui._ws_turn_tool_calls
+            turn_count = ui._ws_messages
+        yield {
+            "type": "status",
+            "prompt_tokens": last_usage["prompt_tokens"],
+            "completion_tokens": last_usage["completion_tokens"],
+            "total_tokens": total_tok,
+            "context_window": cw,
+            "pct": round(pct, 1),
+            "effort": session.reasoning_effort,
+            "cache_creation_tokens": last_usage.get("cache_creation_tokens", 0),
+            "cache_read_tokens": last_usage.get("cache_read_tokens", 0),
+            "tool_calls_this_turn": turn_tool_calls,
+            "turn_count": turn_count,
+        }
+
+    # History replay — pending-approval flag rides on the last
+    # assistant entry's tool_calls so the client renders them as
+    # awaiting approval rather than already approved.
+    pending_approval = getattr(ui, "_pending_approval", None)
+    history = _build_history(session, has_pending_approval=pending_approval is not None)
+    if history:
+        yield {"type": "history", "messages": history}
+
+    # Pending approval re-injection (so a reconnecting tab sees the
+    # prompt) + cached LLM verdicts received since the prompt fired.
+    if pending_approval is not None:
+        yield pending_approval
+        with ui._ws_lock:
+            cached_verdicts = list(ui._llm_verdicts.values())
+        for v in cached_verdicts:
+            yield {"type": "intent_verdict", **v}
+
+    # Pending plan-review re-injection.
+    pending_plan = getattr(ui, "_pending_plan_review", None)
+    if pending_plan is not None:
+        yield pending_plan
+
+
 def _interactive_open_post_load(request: Request, ws: Workstream) -> None:
     """Post-load hook for the lifted interactive ``open`` body.
 
@@ -985,100 +1072,6 @@ async def index(request: Request) -> Response:
     resp.headers["Cache-Control"] = "no-cache"
     resp.headers["ETag"] = _HTML_ETAG
     return resp
-
-
-async def events_sse(request: Request) -> Response:
-    """GET /v1/api/events — per-workstream SSE event stream."""
-    mgr = request.app.state.workstreams
-    ws_id = request.query_params.get("ws_id")
-    # Subscribing to another tenant's stream would leak their messages,
-    # tool calls, and pending approvals in real time.  Gate before
-    # _register_listener so non-owners get a flat 404 (no enumeration).
-    # In-memory fast path via mgr= keeps SSE resilient to DB blips.
-    _owner, err = _require_ws_access(request, ws_id or "", mgr=mgr)
-    if err:
-        return err
-    ws, ui = _get_ws(mgr, ws_id)
-    if not ws or not ui:
-        return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-
-    # Each client gets its own queue — no drain needed.
-    client_queue = ui._register_listener()
-
-    async def event_generator() -> AsyncGenerator[dict[str, str], None]:
-        assert ws.session is not None
-        session: ChatSession = ws.session
-        # Connected event
-        yield {
-            "data": json.dumps(
-                {
-                    "type": "connected",
-                    "model": session.model,
-                    "model_alias": session.model_alias or "",
-                    "skip_permissions": ui.auto_approve,
-                }
-            )
-        }
-        # Replay last status so the per-pane status bar populates on resume
-        if session._last_usage is not None:
-            u = session._last_usage
-            total_tok = u["prompt_tokens"] + u["completion_tokens"]
-            cw = session.context_window
-            pct = total_tok / cw * 100 if cw > 0 else 0
-            with ui._ws_lock:
-                turn_tool_calls = ui._ws_turn_tool_calls
-                turn_count = ui._ws_messages
-            yield {
-                "data": json.dumps(
-                    {
-                        "type": "status",
-                        "prompt_tokens": u["prompt_tokens"],
-                        "completion_tokens": u["completion_tokens"],
-                        "total_tokens": total_tok,
-                        "context_window": cw,
-                        "pct": round(pct, 1),
-                        "effort": session.reasoning_effort,
-                        "cache_creation_tokens": u.get("cache_creation_tokens", 0),
-                        "cache_read_tokens": u.get("cache_read_tokens", 0),
-                        "tool_calls_this_turn": turn_tool_calls,
-                        "turn_count": turn_count,
-                    }
-                )
-            }
-        # History replay
-        history = _build_history(session, has_pending_approval=ui._pending_approval is not None)
-        if history:
-            yield {"data": json.dumps({"type": "history", "messages": history})}
-        # Re-inject pending approval or plan review
-        if ui._pending_approval is not None:
-            yield {"data": json.dumps(ui._pending_approval)}
-            # Replay any LLM verdicts received since the approval was sent
-            with ui._ws_lock:
-                cached_verdicts = list(ui._llm_verdicts.values())
-            for v in cached_verdicts:
-                yield {"data": json.dumps({"type": "intent_verdict", **v})}
-        if ui._pending_plan_review is not None:
-            yield {"data": json.dumps(ui._pending_plan_review)}
-
-        _metrics.record_sse_connect()
-        try:
-            loop = asyncio.get_running_loop()
-            executor = request.app.state.sse_executor
-            while True:
-                try:
-                    event = await loop.run_in_executor(
-                        executor, functools.partial(client_queue.get, timeout=5)
-                    )
-                    if event.get("type") == "ws_closed":
-                        return
-                    yield {"data": json.dumps(event)}
-                except queue.Empty:
-                    pass  # poll timeout, retry
-        finally:
-            _metrics.record_sse_disconnect()
-            ui._unregister_listener(client_queue)
-
-    return EventSourceResponse(event_generator(), ping=5)
 
 
 def _build_node_snapshot(app_state: Any) -> dict[str, Any]:
@@ -3813,6 +3806,14 @@ def create_app(
         cancel_forensics=_capture_cancel_forensics,
         open_resolve_alias=_resolve_workstream_alias,
         open_post_load=_interactive_open_post_load,
+        events_replay=_interactive_events_replay,
+        # Pre-lift ``events_sse`` used the dedicated 200-thread
+        # ``sse_executor`` so SSE polling stayed isolated from
+        # every other ``asyncio.to_thread`` caller in the process
+        # (storage, router, audit). Restore that isolation under
+        # the lifted contract — coord wires ``None`` and falls
+        # back to the default executor.
+        sse_executor_lookup=lambda request: request.app.state.sse_executor,
     )
     approve_handler = make_approve_handler(interactive_endpoint_config)
     close_handler = make_close_handler(
@@ -3825,11 +3826,12 @@ def create_app(
         interactive_endpoint_config,
         audit_emit=_audit_workstream_opened,
     )
+    events_handler = make_events_handler(interactive_endpoint_config)
     send_handler = make_send_handler(interactive_endpoint_config)
     dequeue_handler = make_dequeue_handler(interactive_endpoint_config)
     attachment_handlers = make_attachment_handlers(interactive_endpoint_config)
     v1_routes: list[Any] = [
-        Route("/api/events", events_sse),
+        Route("/api/events", make_legacy_query_keyed_adapter(events_handler)),
         Route("/api/events/global", global_events_sse),
     ]
     register_session_routes(
@@ -3848,6 +3850,7 @@ def create_app(
             send=send_handler,  # lifted: shared body (P1.5)
             approve=approve_handler,  # lifted: shared body
             cancel=cancel_handler,  # lifted: shared body
+            events=events_handler,  # lifted: shared body
             attachments=attachment_handlers,  # lifted: shared body (P1.5)
         ),
     )


### PR DESCRIPTION
## Summary

Stage 2 verb lift on the 1.5.0 SessionManager unification track. Lifts the `events` SSE handler body into `make_events_handler(cfg)` shared by both kinds. Same factory + capability-flag pattern as the merged cancel/open/close/send/approve/attachment lifts.

**New cfg fields**:
- `events_replay: EventsReplay | None` — Protocol-typed callback yielding the kind-specific initial replay payload. Interactive: connected + status + history + pending_approval + intent_verdicts + pending_plan_review. Coord: just pending_approval + pending_plan_review.
- `sse_executor_lookup: SseExecutorLookup | None` — per-kind executor for the live loop's blocking `client_queue.get`. Interactive returns the dedicated 200-thread `sse_executor`; coord returns None (default).

**New helper**: `make_legacy_query_keyed_adapter(handler)` — sister to the body-keyed adapter, splices `?ws_id=...` from query into `path_params`. Preserves the legacy `GET /v1/api/events?ws_id=...` URL.

**Coord parity gains**:
- SSE connect/disconnect metrics (was a gap pre-lift)
- Both kinds now check `is_disconnected()` AND `ws_closed` to terminate (pre-lift each kind only checked one)

**Behavior change for coord**: cross-kind / missing-UI now returns 409 `"session has no UI"` (matched pre-lift coord; pre-lift interactive 404'd). Security boundary unchanged.

**Item #2 from § Post-P3 reckoning split out** — rich `ws_state` payload parity for coord touches different files (coordinator_ui.py + collector.py + session_ui_base.py). Tracked as `feat/coord-rich-ws-state-payload` follow-up.

**Bundled /review fixes**:
- Restored dedicated 200-thread SSE executor (initial draft regressed to default ~32-thread pool)
- Restored 5s poll timeout (initial draft shortened to 1s)

## Test plan

- [x] Lint (ruff) + mypy clean
- [x] 4497 tests passing (was 4489; +8 new events tests)
- [x] Multi-stage `/review` pipeline: 1 major (thread pool starvation, fixed) + 1 minor perf (poll timeout, fixed) + 4 quality (3 addressed, 1 nit deferred)
- [x] New tests pin: connected event first; status only when last_usage present; ordering of approval/verdicts/plan; skip when session missing; legacy `/api/events?ws_id=` shim still routes correctly
- [ ] Manual smoke on a running console with both kinds is recommended before merge