### PR TITLE
refactor(core): defer emit_created on SessionManager.create + commit_create / discard pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,47 @@ Three release tracks are maintained:
 
 ### Changed
 
+- **`SessionManager.create` gains a deferred-emit option; lifted
+  ``create`` HTTP handler eliminates the phantom create→close
+  pair on coord rollback.** ``SessionManager.create`` now accepts
+  ``defer_emit_created: bool = False`` (default preserves the
+  legacy "advertise immediately" contract for direct callers); two
+  new methods complete the deferred-create bracket:
+  - ``SessionManager.commit_create(ws)`` fires the deferred
+    ``emit_created`` event after the caller's post-create work
+    confirms the workstream should be advertised.
+  - ``SessionManager.discard(ws_id)`` releases the in-memory slot
+    + cleans up the UI WITHOUT firing ``emit_closed`` — the
+    workstream's existence was never advertised, so there's
+    nothing to advertise on rollback. Storage-row deletion stays
+    a separate concern (caller invokes ``delete_workstream`` for
+    a complete rollback), mirroring ``mgr.create``'s split between
+    slot reservation and ``register_workstream``. Logs a
+    ``warning`` (``session_mgr.discard.after_emit_created``) when
+    invoked on a workstream that's already been advertised
+    (non-deferred create or post-``commit_create``); the slot is
+    still released so capacity isn't stranded, but the warning
+    surfaces the caller-bug case where ``close`` would have been
+    the right call.
+
+  The lifted ``make_create_handler`` now uses this bracket: pass
+  ``defer_emit_created=True``, validate uploaded attachments, then
+  ``mgr.commit_create(ws)`` on success / ``mgr.discard(ws.id)`` on
+  failure. Pre-fix, coord's ``mgr.create`` fired ``emit_created``
+  synchronously — a rollback then called ``mgr.close`` which
+  fired ``emit_closed``, surfacing a quick create→close pair on
+  the cluster events stream that the collector's diff-reconcile
+  had to handle. Post-fix, a rejected upload produces zero
+  events. Interactive's ``emit_created`` is a documented no-op
+  stub so the deferral is observably a no-op there; the
+  ``ws_created`` broadcast on the global SSE queue continues to
+  fire from the kind's post_install callback after attachment
+  validation passes (unchanged).
+
+  Direct callers of ``mgr.create`` (test fixtures, the CLI REPL,
+  channel adapters) keep the default ``defer_emit_created=False``
+  and see no behaviour change.
+
 - **Coordinator HTTP surface unified under `/v1/api/workstreams/`**
   ([Stage 2 Priority 0]). The experimental `/v1/api/coordinator/*`
   URL tree from 1.5.0aN is removed; coord verbs now mount at the

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -451,6 +451,48 @@ def test_create_with_multipart_attachments_and_initial_message_reserves(storage)
         _reg._storage = _old_storage
 
 
+def test_create_attachment_failure_no_phantom_create_close_pair(storage):
+    """Regression for the ``defer_emit_created`` follow-up — when a
+    multipart create rolls back on attachment validation failure,
+    the cluster collector sees zero events: no phantom
+    ``ws_created``, no orphan ``ws_closed``. Pre-fix, coord's
+    ``mgr.create`` fired ``emit_created`` synchronously and the
+    rollback path called ``mgr.close`` which fired ``emit_closed``,
+    surfacing a quick create→close pair on the cluster events
+    stream."""
+    mgr = _build_mgr(storage)
+    # Pull the collector MagicMock out of the adapter so we can
+    # introspect call counts after the failed create.
+    coord_collector = mgr._adapter._collector  # type: ignore[attr-defined]
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+    import turnstone.core.storage._registry as _reg
+
+    _old_storage = _reg._storage
+    _reg._storage = storage
+    try:
+        # Empty file body → ``validate_and_save_uploaded_files``
+        # returns the 400 "Empty file" path which the lifted body
+        # surfaces directly. The rollback path runs after.
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            data={"meta": '{"name": "rollback-target"}'},
+            files={"file": ("blank.bin", b"", "application/octet-stream")},
+            headers=_COORD_HEADERS,
+        )
+        assert resp.status_code == 400, resp.text
+        # Manager is empty — slot was discarded.
+        assert mgr.count == 0
+        # The collector saw NEITHER create nor close events for any
+        # ws_id. ``MagicMock`` records every method call, so an empty
+        # list of calls to these specific methods is the regression
+        # check.
+        assert coord_collector.emit_console_ws_created.call_count == 0
+        assert coord_collector.emit_console_ws_closed.call_count == 0
+    finally:
+        _reg._storage = _old_storage
+
+
 def test_create_rejects_disabled_skill(storage):
     """Coord parity gain — disabled skills now rejected at the lift,
     matching interactive's pre-lift behaviour. Pre-lift coord silently

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -347,7 +347,8 @@ def test_discard_releases_slot_without_emit_closed() -> None:
     ws = mgr.create(user_id="u1", name="will-be-discarded", defer_emit_created=True)
     ws_id = ws.id
 
-    assert mgr.discard(ws_id) is True
+    discarded = mgr.discard(ws_id)
+    assert discarded is True
 
     # In-memory slot released — capacity restored.
     assert mgr.get(ws_id) is None
@@ -369,36 +370,61 @@ def test_discard_returns_false_for_unknown_ws_id() -> None:
     safely call discard inside ``contextlib.suppress`` without
     spurious failures swallowing real errors."""
     mgr, _, _ = _make_manager()
-    assert mgr.discard("nonexistent-ws-id") is False
+    result = mgr.discard("nonexistent-ws-id")
+    assert result is False
 
 
-def test_commit_create_after_discard_is_caller_bug_no_op(caplog) -> None:
-    """Caller-bug case: ``commit_create`` after ``discard`` must
-    not crash and must not re-emit the created event for a
-    workstream that's no longer tracked by the manager. The
-    workstream object still exists in the caller's scope (the
-    discard only removed it from the manager's slot map), so
-    forwarding it to ``commit_create`` would fire a phantom
+def test_commit_create_after_discard_is_no_op(caplog) -> None:
+    """Caller-bug case: ``commit_create`` after ``discard`` must not
+    fire ``emit_created`` for a workstream that's no longer tracked
+    by the manager. The workstream object still exists in the
+    caller's scope (discard only removed it from the manager's slot
+    map), so forwarding it to ``commit_create`` would fire a phantom
     ``ws_created`` for an id the cluster collector / children
-    registry will then never see ``ws_closed`` for.
+    registry will then never see ``ws_closed`` for. The guard logs
+    ``session_mgr.commit_create.untracked`` and returns without
+    emitting."""
+    import logging
 
-    Pinning current behaviour: ``commit_create`` does NOT verify
-    the workstream is still tracked — it forwards to
-    ``event_emitter.emit_created(ws)`` unconditionally. This is
-    surprising but matches the docstring's "trust the caller"
-    contract; the regression test exists so a future refactor
-    that adds the guard makes a deliberate choice instead of an
-    accident."""
     mgr, adapter, _ = _make_manager()
     ws = mgr.create(user_id="u1", defer_emit_created=True)
-    assert mgr.discard(ws.id) is True
+    discarded = mgr.discard(ws.id)
+    assert discarded is True
     assert adapter.events_of("created") == []
 
-    # Caller-bug: commit_create after discard. Re-fires the event
-    # because no guard exists. Pinning the behaviour.
-    mgr.commit_create(ws)
+    with caplog.at_level(logging.WARNING, logger="turnstone.core.session_manager"):
+        mgr.commit_create(ws)
 
+    # No event emitted — the tracked-ws check failed.
+    assert adapter.events_of("created") == []
+    # Warning surfaced for operator triage.
+    assert any("commit_create.untracked" in record.message for record in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+def test_commit_create_is_idempotent_on_duplicate_call(caplog) -> None:
+    """Caller-bug case: calling ``commit_create`` twice on the same
+    workstream must fire ``emit_created`` exactly once. The second
+    call hits the ``_emit_created_fired`` guard, logs
+    ``session_mgr.commit_create.already_fired``, and returns without
+    re-emitting."""
+    import logging
+
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", defer_emit_created=True)
+    mgr.commit_create(ws)
     assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+
+    with caplog.at_level(logging.WARNING, logger="turnstone.core.session_manager"):
+        mgr.commit_create(ws)
+
+    # Still exactly one created event — the guard short-circuited
+    # the second call.
+    assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+    assert any("commit_create.already_fired" in record.message for record in caplog.records), [
+        r.message for r in caplog.records
+    ]
 
 
 def test_discard_after_emit_created_warns_but_releases_slot(caplog) -> None:

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -219,22 +219,33 @@ class FakeStorage:
         return 0
 
 
+_EMITTER_DEFAULT = object()
+
+
 def _make_manager(
     adapter: FakeAdapter | None = None,
     *,
     max_active: int = 5,
     storage: FakeStorage | None = None,
+    event_emitter: Any = _EMITTER_DEFAULT,
 ) -> tuple[SessionManager, FakeAdapter, FakeStorage]:
+    """Build a SessionManager wired to a FakeAdapter for both Protocols.
+
+    ``event_emitter`` defaults to the adapter (production wiring shape);
+    pass ``None`` explicitly to disable the lifecycle-event side
+    channel for tests that care about no-emitter behaviour.
+    """
     adapter = adapter or FakeAdapter()
     storage = storage or FakeStorage()
     # FakeAdapter implements both Protocols (the production adapters
     # do too — wire as both so the emit_* assertions in this file
     # still see the events the manager fires).
+    emitter = adapter if event_emitter is _EMITTER_DEFAULT else event_emitter
     mgr = SessionManager(
         adapter,
         storage=storage,
         max_active=max_active,
-        event_emitter=adapter,
+        event_emitter=emitter,
     )
     return mgr, adapter, storage
 
@@ -275,6 +286,155 @@ def test_create_persists_and_emits_created() -> None:
     assert ws.id in storage.rows
     assert storage.rows[ws.id].kind == WorkstreamKind.INTERACTIVE.value
     assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+
+
+def test_create_with_defer_emit_created_skips_emit() -> None:
+    """``defer_emit_created=True`` returns the workstream but skips
+    the ``emit_created`` call. The slot, storage row, and built
+    session all exist — only the lifecycle event is held back.
+    Caller takes ownership of advertising the workstream via
+    :meth:`SessionManager.commit_create` (success) or
+    :meth:`SessionManager.discard` (rollback)."""
+    mgr, adapter, storage = _make_manager()
+    ws = mgr.create(user_id="u1", name="deferred", defer_emit_created=True)
+    # Workstream is fully constructed — only the broadcast is deferred.
+    assert ws.session is not None
+    assert ws.ui is not None
+    assert ws.id in storage.rows
+    assert mgr.get(ws.id) is ws
+    # No created event fired.
+    assert adapter.events_of("created") == []
+
+
+def test_commit_create_fires_deferred_emit_created() -> None:
+    """``commit_create`` is the deferred counterpart that fires the
+    pending ``emit_created`` event after the caller's post-create
+    work (e.g. attachment validation in the lifted HTTP handler)
+    confirms the workstream should be advertised."""
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", defer_emit_created=True)
+    assert adapter.events_of("created") == []
+
+    mgr.commit_create(ws)
+
+    assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+
+
+def test_commit_create_is_noop_without_event_emitter() -> None:
+    """``commit_create`` must tolerate a manager constructed without
+    an event emitter — the deferred-create + commit pair has to
+    work the same shape regardless of whether transport fan-out is
+    wired (test fixtures, future kinds without an emitter)."""
+    mgr, adapter, _ = _make_manager(event_emitter=None)
+    ws = mgr.create(user_id="u1", defer_emit_created=True)
+    # Must not raise; nothing observable should happen.
+    mgr.commit_create(ws)
+    assert adapter.events_of("created") == []
+
+
+def test_discard_releases_slot_without_emit_closed() -> None:
+    """``discard`` is the rollback counterpart to ``commit_create``.
+    Releases the in-memory slot + cleans up the UI, but does NOT
+    fire ``emit_closed`` because the workstream's existence was
+    never advertised (caller used ``defer_emit_created=True``).
+
+    Distinct from ``close`` which DOES fire ``emit_closed`` to
+    advertise the transition. Pre-fix, the lifted create handler's
+    rollback path called ``close`` and produced a phantom
+    create→close pair on the cluster events stream when attachment
+    validation failed; ``discard`` is the surgical fix."""
+    mgr, adapter, storage = _make_manager(max_active=2)
+    ws = mgr.create(user_id="u1", name="will-be-discarded", defer_emit_created=True)
+    ws_id = ws.id
+
+    assert mgr.discard(ws_id) is True
+
+    # In-memory slot released — capacity restored.
+    assert mgr.get(ws_id) is None
+    assert mgr.count == 0
+    # UI cleanup ran (cleanup_ui is part of discard's contract).
+    assert ws_id in adapter.cleaned_up
+    # No advertisement at any point: no created event, no closed event.
+    assert adapter.events_of("created") == []
+    assert adapter.events_of("closed") == []
+    # Storage row survives — caller is responsible for
+    # ``delete_workstream`` if they want a complete rollback. Mirrors
+    # mgr.create's own session-build-failure path.
+    assert ws_id in storage.rows
+
+
+def test_discard_returns_false_for_unknown_ws_id() -> None:
+    """``discard`` is idempotent on an absent ws_id — returns False
+    instead of raising so the lifted handler's rollback path can
+    safely call discard inside ``contextlib.suppress`` without
+    spurious failures swallowing real errors."""
+    mgr, _, _ = _make_manager()
+    assert mgr.discard("nonexistent-ws-id") is False
+
+
+def test_commit_create_after_discard_is_caller_bug_no_op(caplog) -> None:
+    """Caller-bug case: ``commit_create`` after ``discard`` must
+    not crash and must not re-emit the created event for a
+    workstream that's no longer tracked by the manager. The
+    workstream object still exists in the caller's scope (the
+    discard only removed it from the manager's slot map), so
+    forwarding it to ``commit_create`` would fire a phantom
+    ``ws_created`` for an id the cluster collector / children
+    registry will then never see ``ws_closed`` for.
+
+    Pinning current behaviour: ``commit_create`` does NOT verify
+    the workstream is still tracked — it forwards to
+    ``event_emitter.emit_created(ws)`` unconditionally. This is
+    surprising but matches the docstring's "trust the caller"
+    contract; the regression test exists so a future refactor
+    that adds the guard makes a deliberate choice instead of an
+    accident."""
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", defer_emit_created=True)
+    assert mgr.discard(ws.id) is True
+    assert adapter.events_of("created") == []
+
+    # Caller-bug: commit_create after discard. Re-fires the event
+    # because no guard exists. Pinning the behaviour.
+    mgr.commit_create(ws)
+
+    assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+
+
+def test_discard_after_emit_created_warns_but_releases_slot(caplog) -> None:
+    """Caller-bug case: ``discard`` on a workstream where
+    ``emit_created`` has already fired (either via the non-deferred
+    create path or via ``commit_create``). The intended retraction
+    path is ``close`` (which fires ``emit_closed``); ``discard``
+    leaves a stale ``ws_created`` on the wire with no matching
+    ``ws_closed``, which is exactly the phantom-event bug
+    ``defer_emit_created`` was added to fix.
+
+    ``discard`` still releases the in-memory slot (so capacity is
+    freed even when the caller misuses the API) but logs a
+    ``warning`` so the misuse surfaces in ops logs.
+    """
+    import logging
+
+    mgr, adapter, _ = _make_manager()
+    # Non-deferred create — emit_created fires inside mgr.create.
+    ws = mgr.create(user_id="u1", name="created-then-discarded")
+    assert [e.ws_id for e in adapter.events_of("created")] == [ws.id]
+
+    with caplog.at_level(logging.WARNING, logger="turnstone.core.session_manager"):
+        result = mgr.discard(ws.id)
+
+    # Slot released (caller-bug doesn't strand capacity).
+    assert result is True
+    assert mgr.get(ws.id) is None
+    # Warning surfaced for operator triage.
+    assert any("discard.after_emit_created" in record.message for record in caplog.records), [
+        r.message for r in caplog.records
+    ]
+    # No ws_closed was fired — the bug being warned about is exactly
+    # this asymmetry (created without close on the wire). Operators
+    # who actually want a clean retraction should call close instead.
+    assert adapter.events_of("closed") == []
 
 
 def test_create_evicts_oldest_idle_at_capacity() -> None:

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -284,6 +284,7 @@ class SessionManager:
         model: str | None = None,
         client_type: str = "",
         parent_ws_id: str | None = None,
+        defer_emit_created: bool = False,
         **extra_session_kwargs: Any,
     ) -> Workstream:
         """Construct a new workstream, persist, and register.
@@ -298,6 +299,26 @@ class SessionManager:
         Raises ``RuntimeError`` when the manager is at capacity with
         no idle workstream to evict — callers (HTTP handlers) translate
         this to 429.
+
+        ``defer_emit_created``: when ``True``, the ``emit_created`` call
+        on the configured event emitter is skipped. The caller takes
+        ownership of advertising the new workstream — typically by
+        calling :meth:`commit_create` after running additional
+        post-create work that might roll the create back (e.g. the
+        Stage 2 ``create`` HTTP handler runs uploaded-attachment
+        validation post-create and rolls the workstream back via
+        :meth:`discard` on validation failure; deferring the emit
+        means a rolled-back create produces no phantom create→close
+        pair on the cluster events stream).
+
+        Default ``False`` preserves the legacy "advertise immediately"
+        contract for direct callers (test fixtures, the CLI REPL,
+        anything that doesn't have a post-create gate).
+
+        Caller-bug if ``defer_emit_created=True`` is set but neither
+        :meth:`commit_create` nor :meth:`discard` is ever called: the
+        slot is held forever (capacity leak). The HTTP handler bracket
+        runs both terminations within a single request lifecycle.
         """
         ws_id = ws_id or uuid.uuid4().hex
         effective_name = name or f"ws-{ws_id[:4]}"
@@ -350,9 +371,110 @@ class SessionManager:
                 self._remove_locked(ws_id)
             raise
 
+        if not defer_emit_created:
+            # Mark fired BEFORE the actual emit so a concurrent
+            # ``discard`` can't observe ``False`` after the event
+            # already fanned out. The flag is observational (powers
+            # the discard warning); strict ordering relative to the
+            # event isn't load-bearing for fan-out correctness.
+            ws._emit_created_fired = True
+            if self._event_emitter is not None:
+                self._event_emitter.emit_created(ws)
+        return ws
+
+    def commit_create(self, ws: Workstream) -> None:
+        """Fire the deferred ``emit_created`` event for ``ws``.
+
+        Pairs with :meth:`create` called with
+        ``defer_emit_created=True``. The caller is responsible for
+        invoking ``commit_create`` exactly once per deferred ``create``,
+        before any state-change events flow (so subscribers see the
+        ``ws_created`` event before the first ``ws_state``). On the
+        rollback branch the caller invokes :meth:`discard` instead.
+
+        Idempotent against a missing emitter — when ``event_emitter`` is
+        ``None`` (test fixtures, future kinds without an emitter wired)
+        the lifecycle event is skipped but ``ws._emit_created_fired``
+        is still set so a subsequent :meth:`discard` correctly
+        identifies the workstream as committed (the warning path
+        treats "committed" as a contract assertion, not as "actually
+        broadcast somewhere").
+        """
+        # See the matching comment in ``create`` re: ordering. Flag
+        # set before the emit so a racing discard sees True even if
+        # it observes us mid-fanout.
+        ws._emit_created_fired = True
         if self._event_emitter is not None:
             self._event_emitter.emit_created(ws)
-        return ws
+
+    def discard(self, ws_id: str) -> bool:
+        """Release a workstream's in-memory slot WITHOUT firing ``emit_closed``.
+
+        Use after :meth:`create` was called with
+        ``defer_emit_created=True`` and a post-create check determined
+        the workstream should not be advertised at all. Callers that
+        also want to remove the persisted storage row should call
+        ``turnstone.core.memory.delete_workstream(ws_id)`` separately
+        — :meth:`discard` only owns the in-memory side, mirroring the
+        split between ``mgr.create``'s slot reservation and
+        ``self._storage.register_workstream``'s row write.
+
+        Distinct from :meth:`close`:
+
+        - ``close`` advertises the transition (``emit_closed``) and
+          writes ``state='closed'`` to storage so the workstream is
+          re-openable later.
+        - ``discard`` does neither — the workstream's existence was
+          never advertised (caller deferred ``emit_created``) so there
+          is no transition to advertise, and the row should be
+          deleted (not soft-closed) since the create is being
+          unwound.
+
+        Returns ``True`` when a workstream was removed, ``False`` if
+        the id wasn't tracked. The method is safe to call from the
+        HTTP handler's rollback path under
+        ``contextlib.suppress(Exception)`` even if ``cleanup_ui``
+        raises — the in-memory slot release runs first under the
+        lock, so capacity is freed before any UI-cleanup error
+        surfaces.
+
+        Logs a ``warning`` when the workstream's
+        ``_emit_created_fired`` flag is set — that means the
+        workstream was already advertised to lifecycle subscribers
+        (either created without ``defer_emit_created`` or committed
+        via :meth:`commit_create`), and discarding now leaves a stale
+        ``ws_created`` on the wire with no matching ``ws_closed``.
+        Discard still completes (returns ``True``) so the slot is
+        freed, but the warning surfaces the caller-bug for triage.
+        Use :meth:`close` instead when the workstream's lifecycle
+        was advertised and now needs to be retracted.
+        """
+        with self._lock:
+            ws = self._workstreams.pop(ws_id, None)
+            if ws is None:
+                return False
+            if ws_id in self._order:
+                self._order.remove(ws_id)
+            if self._active_id == ws_id:
+                self._active_id = self._order[0] if self._order else None
+        if ws._emit_created_fired:
+            # Caller-bug path: the workstream was already advertised
+            # via ``emit_created`` — a clean rollback would need
+            # ``close`` (which fires ``emit_closed``) to retract the
+            # advertisement, not ``discard``. Surface the misuse so
+            # operators / future contributors can find the call site
+            # via the log line; we still complete the in-memory
+            # release so the slot is freed.
+            log.warning(
+                "session_mgr.discard.after_emit_created ws=%s",
+                ws_id[:8] if ws_id else "",
+            )
+        # cleanup_ui runs OUTSIDE the manager lock to match
+        # ``close``'s ordering — UI cleanup may join worker threads
+        # or do other potentially-blocking work that must not hold
+        # the slot-accounting mutex.
+        self._adapter.cleanup_ui(ws)
+        return True
 
     # ------------------------------------------------------------------
     # open — lazy rehydrate for a persisted workstream

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -399,11 +399,47 @@ class SessionManager:
         identifies the workstream as committed (the warning path
         treats "committed" as a contract assertion, not as "actually
         broadcast somewhere").
+
+        Caller-bug guard: under the manager lock, check that ``ws`` is
+        still tracked by this manager and that ``_emit_created_fired``
+        is not already set. Either failure logs a warning and returns
+        without firing the event — duplicate calls and calls after
+        :meth:`discard` become safe no-ops. Symmetric to
+        :meth:`discard`'s warning when invoked on an already-
+        advertised workstream; together the two methods make the
+        deferred-create bracket robust against the obvious caller-
+        bug shapes.
         """
-        # See the matching comment in ``create`` re: ordering. Flag
-        # set before the emit so a racing discard sees True even if
-        # it observes us mid-fanout.
-        ws._emit_created_fired = True
+        with self._lock:
+            if ws._emit_created_fired:
+                # Duplicate commit_create call. Could surface as a
+                # double ``ws_created`` on the wire if we proceeded;
+                # warn instead and bail.
+                log.warning(
+                    "session_mgr.commit_create.already_fired ws=%s",
+                    ws.id[:8] if ws.id else "",
+                )
+                return
+            tracked = self._workstreams.get(ws.id)
+            if tracked is not ws:
+                # Workstream was discarded (or never tracked, or
+                # replaced by a same-id reuse — which would be a
+                # different ws object). Firing emit_created for an
+                # untracked ws_id leaks a phantom ``ws_created`` to
+                # subscribers with no matching close. Warn + bail.
+                log.warning(
+                    "session_mgr.commit_create.untracked ws=%s",
+                    ws.id[:8] if ws.id else "",
+                )
+                return
+            # Both checks passed — flip the flag under the lock so a
+            # racing discard sees True before our emit completes
+            # outside the lock. (Manager lock is not held during the
+            # emit itself: emit_created on coord acquires its own
+            # locks for collector + children-registry updates and
+            # holding the manager lock during fan-out would couple
+            # the two unnecessarily.)
+            ws._emit_created_fired = True
         if self._event_emitter is not None:
             self._event_emitter.emit_created(ws)
 

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1421,10 +1421,12 @@ def make_create_handler(
 ) -> Handler:
     """Lifted body for ``POST {prefix}/new`` — workstream creation.
 
-    Both kinds share the create sequence (parse body → resolve uid →
-    resolve skill → kind-specific validate → ``mgr.create`` → save
-    attachments → audit → kind-specific post-install → respond).
-    Per-kind divergence captured by the cfg + ``audit_emit``:
+    Both kinds share the create sequence (parse body → resolve uid
+    → kind-specific validate → resolve skill → ``mgr.create`` (with
+    ``defer_emit_created=True``) → save attachments → ``mgr.discard``
+    on validation failure / ``mgr.commit_create`` on success → audit
+    → kind-specific post-install → respond). Per-kind divergence
+    captured by the cfg + ``audit_emit``:
 
     - ``cfg.create_supports_attachments`` — when ``True``, the body
       may arrive as ``multipart/form-data`` with a ``meta`` JSON
@@ -1447,6 +1449,22 @@ def make_create_handler(
     - ``audit_emit`` — ``workstream.created`` on interactive,
       ``coordinator.create`` on coord.
 
+    Ordering invariants (load-bearing — easy to break in a refactor):
+
+    1. ``mgr.create(defer_emit_created=True)`` runs FIRST so the
+       slot + storage row + session exist before any post-create
+       work touches them.
+    2. Attachment validation runs BEFORE ``commit_create`` so a
+       rejected upload produces zero lifecycle events. Failure path
+       is ``mgr.discard`` + ``delete_workstream``; success path
+       falls through.
+    3. ``mgr.commit_create(ws)`` runs BEFORE ``audit_emit`` and
+       ``post_install`` so any state-change events ``post_install``
+       triggers (e.g. a worker dispatched on ``initial_message``)
+       reach the cluster collector for an already-known ws_id.
+       Reordering this commit after the worker dispatch puts
+       ``emit_state`` on the wire ahead of ``emit_created``.
+
     Behavior changes vs the pre-lift handlers (documented in
     CHANGELOG, mostly coord-up-to-interactive parity gains):
 
@@ -1454,12 +1472,25 @@ def make_create_handler(
       ``coordinator_create`` accepted JSON only and ignored uploads;
       the lifted body parses multipart bodies on coord and saves
       attachments through the kind-agnostic storage layer (§ Post-P3
-      reckoning item #1). Coord's initial_message dispatch does NOT
-      yet reserve those attachments onto the first turn (coord
-      adapter's ``send`` doesn't take attachments) — the rows save
-      as pending and the first ``/send`` picks them up via the
-      standard send-with-attachments path. Initial-message + create-
-      time attachments coordination is a follow-up.
+      reckoning item #1). When the same request supplies an
+      ``initial_message``, the uploads are reserved onto the
+      dispatched first turn via ``CoordinatorAdapter.send`` (which
+      gained ``attachments`` + ``send_id`` kwargs in the same
+      release).
+    - **No phantom create→close pair on coord rollback.** The lifted
+      body now passes ``defer_emit_created=True`` to ``mgr.create``
+      and explicitly fires ``mgr.commit_create(ws)`` only after
+      attachment validation passes. On failure ``mgr.discard(ws.id)``
+      releases the slot WITHOUT firing ``emit_closed`` (because the
+      create was never advertised). Pre-fix, coord's ``mgr.create``
+      fired ``emit_created`` synchronously and a rollback then
+      called ``mgr.close``, surfacing a quick create→close pair on
+      the cluster events stream that consumers had to reconcile via
+      the collector's diff path. Post-fix, a rejected upload
+      produces zero events. Interactive's ``emit_created`` is a
+      documented no-op stub so the deferral is observably a no-op
+      there; the ``ws_created`` broadcast on the global SSE queue
+      continues to fire from the kind's post_install callback.
     - **Coord gains the disabled-skill rejection.** Pre-lift
       ``coordinator_create`` silently allowed disabled skills to
       flow through to ``mgr.create``; the lifted body returns 400
@@ -1691,7 +1722,9 @@ def make_create_handler(
             kwargs = cfg.create_build_kwargs(
                 request, body, uid, skill_data, skill_id_resolved, applied_skill_version
             )
-            ws = await asyncio.to_thread(mgr.create, **kwargs)
+            # Deferred emit — committed below post-attachment-
+            # validation. See handler docstring's Ordering invariants.
+            ws = await asyncio.to_thread(mgr.create, defer_emit_created=True, **kwargs)
         except RuntimeError as exc:
             # ``SessionManager.create`` documents RuntimeError as
             # "manager at capacity" — translate to 429 (rate-limit /
@@ -1727,18 +1760,10 @@ def make_create_handler(
             )
 
         # --- Attachment validation + save + rollback --------------------
-        # Interactive's pre-lift pattern: validate post-create so
-        # ``ws_id`` is bound (the storage layer scopes attachments by
-        # ws_id). On any failure, mgr.close + delete_workstream the
-        # workstream so the caller doesn't see a half-built phantom.
-        # On coord this is a brand-new path — pre-lift coord_create
-        # had no attachments support. Note: coord's mgr.create already
-        # fired ``emit_created`` (cluster collector fan-out) by this
-        # point, so a rollback here produces a phantom create→close
-        # pair on the cluster events stream. Cluster consumers handle
-        # this gracefully (same shape as any quick-create-close), and
-        # the alternative (decoupling emit_created from mgr.create)
-        # is a bigger refactor that doesn't belong in the verb lift.
+        # Validate post-create so ``ws_id`` is bound. Rollback uses
+        # ``mgr.discard`` (no ``emit_closed`` because the create was
+        # deferred) + ``delete_workstream`` for the storage row. See
+        # handler docstring's Ordering invariants for the rationale.
         attachment_ids: list[str] = []
         if uploaded_files:
             saved_ids, save_err = await asyncio.to_thread(
@@ -1748,11 +1773,16 @@ def make_create_handler(
                 from turnstone.core.memory import delete_workstream as _delete_ws
 
                 with contextlib.suppress(Exception):
-                    await asyncio.to_thread(mgr.close, ws.id)
+                    await asyncio.to_thread(mgr.discard, ws.id)
                 with contextlib.suppress(Exception):
                     await asyncio.to_thread(_delete_ws, ws.id)
                 return save_err
             attachment_ids = saved_ids
+
+        # --- Commit the deferred emit_created ----------------------------
+        # Synchronous: in-memory non-blocking work on every kind
+        # (interactive: no-op stub; coord: dict + ``queue.put_nowait``).
+        mgr.commit_create(ws)
 
         # --- Audit emit --------------------------------------------------
         if audit_emit is not None:

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -116,14 +116,16 @@ class Workstream:
     # True once ``SessionManager.commit_create`` (or the non-deferred
     # path through ``SessionManager.create``) has fired the lifecycle
     # ``emit_created`` event for this workstream. Used by
-    # :meth:`SessionManager.discard` to detect the caller-bug case
-    # where a workstream is being abandoned AFTER its existence was
-    # already advertised — the silent path through ``discard`` would
-    # leave a stale ``ws_created`` on the wire with no matching
-    # ``ws_closed``, reproducing the exact phantom-pair bug
-    # ``defer_emit_created`` was added to fix. Set under the manager's
-    # `_lock`-protected emit; read without locking (the warning path
-    # is observational, not a correctness gate).
+    # :meth:`SessionManager.discard` (warns when set — abandoning an
+    # already-advertised ws leaves a stale ``ws_created`` on the wire
+    # with no matching ``ws_closed``) and by
+    # :meth:`SessionManager.commit_create` itself (no-ops when set,
+    # to make the idempotent-second-call and the
+    # commit-after-discard caller-bug paths safe). The non-deferred
+    # ``create`` sets this immediately before calling
+    # ``emit_created``; ``commit_create`` sets it under the manager
+    # lock alongside the tracked-ws check so a racing ``discard`` can
+    # never see it without also seeing the slot already popped.
     _emit_created_fired: bool = field(default=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -113,6 +113,18 @@ class Workstream:
     # racing ``Thread.is_alive()``. Used by both interactive and
     # coordinator paths since Stage 2 P1.
     _worker_running: bool = field(default=False, repr=False)
+    # True once ``SessionManager.commit_create`` (or the non-deferred
+    # path through ``SessionManager.create``) has fired the lifecycle
+    # ``emit_created`` event for this workstream. Used by
+    # :meth:`SessionManager.discard` to detect the caller-bug case
+    # where a workstream is being abandoned AFTER its existence was
+    # already advertised — the silent path through ``discard`` would
+    # leave a stale ``ws_created`` on the wire with no matching
+    # ``ws_closed``, reproducing the exact phantom-pair bug
+    # ``defer_emit_created`` was added to fix. Set under the manager's
+    # `_lock`-protected emit; read without locking (the warning path
+    # is observational, not a correctness gate).
+    _emit_created_fired: bool = field(default=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Summary

Eliminates the phantom create→close pair on coord rollback that was documented as a known limitation in PR #416.

The pair surfaced on the cluster events stream when a multipart workstream-create request failed attachment validation: coord's `mgr.create` fired `emit_created` synchronously, then the rollback called `mgr.close` which fired `emit_closed`. Cluster consumers had to reconcile via the collector's diff path. **Post-fix, a rejected upload produces zero events.**

## API additions

`SessionManager` gets one new kwarg + two new methods, all additive:

- `create(..., defer_emit_created: bool = False)` — skip the trailing `emit_created`. Default preserves the existing "advertise immediately" contract; direct callers (test fixtures, CLI REPL, channel adapters) see no behavior change.
- `commit_create(ws)` — fires the deferred `emit_created` event. Synchronous; in-memory non-blocking on every kind.
- `discard(ws_id)` — releases the in-memory slot + cleans up the UI WITHOUT firing `emit_closed`. Distinct from `close` which advertises the transition.

## Caller-bug detection

`Workstream._emit_created_fired` is set inside `create` (non-deferred path) and `commit_create`. `discard` logs `session_mgr.discard.after_emit_created` warning when invoked on an already-advertised workstream — slot is still released so capacity isn't stranded, but the warning surfaces the misuse for triage.

## Lifted handler bracket

`make_create_handler` now uses the deferred-create bracket:

1. `mgr.create(defer_emit_created=True)` — slot + storage row + session built, no emit
2. attachment validation → `mgr.discard(ws.id)` + `delete_workstream(ws.id)` on failure
3. `mgr.commit_create(ws)` — advertises the workstream
4. `audit_emit`
5. `post_install` (worker dispatch may fire state events to a now-known ws_id)

The "commit BEFORE audit_emit and post_install" ordering is documented as a numbered invariant in the handler docstring.

## What's tested

- 5 unit tests on the new SessionManager API (defer skips emit, commit fires it, commit no-ops without emitter, discard releases without emit_closed, discard returns False on unknown id)
- 2 caller-bug regression tests (commit_create after discard pins behaviour; discard after non-deferred create asserts warning fires + slot releases)
- 1 coord regression test asserting the cluster collector sees zero events on attachment-validation failure

## /review feedback addressed

Multi-stage `/review` pipeline ran on the initial draft and flagged:
- **M1** (major) test gap on caller-bug paths → 2 new regression tests
- **Mi1** (minor) no runtime guard for already-advertised workstream → `_emit_created_fired` flag + warning
- **Mi2** (minor) `_make_manager` inconsistency → added `event_emitter` override
- **Mi3 / N2** (minor / nit) duplicated comments + buried ordering invariant → trimmed to one-line pointers + numbered invariants in the docstring
- **N1** (nit) wasteful `asyncio.to_thread` on `commit_create` → synchronous

## Test plan

- [x] 4509 tests passing (was 4501 pre-PR; +8 new)
- [x] `ruff check turnstone/ tests/` clean
- [x] `mypy turnstone/` clean
- [x] No public API removed; all changes additive
- [x] Default `defer_emit_created=False` preserves existing behaviour for direct callers
- [ ] Manual smoke against running server: coord create + multipart with bad uploads → confirm cluster events stream stays clean
- [ ] Soak on main; revert if anything regresses

## Behavior changes

All in CHANGELOG `[Unreleased]`:

- `SessionManager.create` accepts `defer_emit_created: bool = False`. Default preserves existing behavior.
- `SessionManager.commit_create(ws)` and `SessionManager.discard(ws_id)` added.
- Lifted create handler now passes `defer_emit_created=True`, calls `commit_create` after attachment validation passes, calls `discard` instead of `close` on rollback.
- Coord rollback path now produces zero cluster events (was: phantom create→close pair).
- `discard` warns on already-advertised workstreams via `session_mgr.discard.after_emit_created` log line.