### PR TITLE
refactor(core): lift history + detail verb bodies (Stage 2 verb lift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,62 @@ Three release tracks are maintained:
 
 ### Changed
 
+- **`history` / `detail` verb bodies lifted across both kinds**
+  ([Stage 2 Verb Lift — `history` / `detail`]). The coord
+  ``GET /v1/api/workstreams/{ws_id}/history`` and
+  ``GET /v1/api/workstreams/{ws_id}`` handlers now share two factory
+  bodies via ``make_history_handler(cfg)`` and
+  ``make_detail_handler(cfg)``. The lift adds both endpoints to the
+  interactive surface as a feature gain (pre-lift only coord exposed
+  them; interactive consumers had to subscribe to ``/events`` SSE
+  just to read history rows or display fields). No new
+  ``SessionEndpointConfig`` fields — the factories reuse
+  ``permission_gate``, ``manager_lookup``, ``not_found_label``,
+  ``audit_action_prefix``, and (for history's storage-fallback kind
+  check) ``list_kind`` — all already wired by both production
+  lifespans.
+
+  Three observable behaviour changes (all documented per kind):
+
+  - **Interactive gains ``GET /v1/api/workstreams/{ws_id}``.** Pre-lift
+    interactive had no detail endpoint — SDK consumers had to read
+    display fields from the SSE replay on ``/events`` or scrape the
+    active list. The lifted body lazy-rehydrates a closed/evicted
+    workstream via ``mgr.open()`` so the response shape is stable
+    across loaded / persisted-only states. Same
+    ``{ws_id, name, state, user_id, kind}`` shape coord exposed
+    pre-lift, now available on both surfaces.
+  - **Interactive gains ``GET /v1/api/workstreams/{ws_id}/history``.**
+    Same ``?limit=`` query param contract as coord (default 100, max
+    500, malformed values fall back to 100, out-of-range clamps to
+    [1, 500]). Persisted-but-not-loaded interactives serve history
+    without rehydrating — the lifted body falls back to a storage-row
+    + kind check (via ``cfg.list_kind``) when ``mgr.get`` returns
+    ``None``, mirroring coord's pre-lift
+    ``_resolve_coordinator_or_404`` ladder.
+  - **Storage / manager-lock work moved off the event loop on coord.**
+    The lifted ``history`` body always runs ``storage.get_workstream``
+    (storage-fallback path) and ``storage.load_messages`` through
+    ``asyncio.to_thread``; pre-lift coord ran them inline on the
+    event loop. Long-tail message reads on a saturated console no
+    longer stall every other async handler for the duration of the
+    SQL.
+
+  Pydantic schemas: ``CoordinatorDetailResponse`` and
+  ``CoordinatorHistoryResponse`` removed; both folded into
+  ``WorkstreamDetailResponse`` / ``WorkstreamHistoryResponse`` on
+  the shared ``server_schemas.py`` (mirrors the list lift's pattern
+  for ``WorkstreamInfo``). Both server and console OpenAPI specs
+  reference the unified schemas; ``server_spec.py`` gains
+  ``EndpointSpec`` entries for the new interactive endpoints. TS
+  SDK gains ``WorkstreamDetailResponse`` / ``WorkstreamHistoryResponse``
+  interfaces in ``sdk/typescript/src/types.ts``;
+  ``openapi-{server,console}.json`` regenerated.
+  ``GET /v1/api/workstreams/{ws_id}/history`` is the only verb
+  whose lifted body keeps a kind-aware storage fallback (via
+  ``cfg.list_kind``); ``detail`` defers cross-kind isolation to
+  ``mgr.open()`` itself.
+
 - **`list` / `saved` verb bodies lifted across both kinds** ([Stage 2
   Verb Lift — `list` / `saved`]). The interactive
   ``GET /v1/api/workstreams`` + ``GET /v1/api/workstreams/saved``

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -4655,7 +4655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CoordinatorDetailResponse"
+                  "$ref": "#/components/schemas/WorkstreamDetailResponse"
                 }
               }
             }
@@ -5506,7 +5506,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CoordinatorHistoryResponse"
+                  "$ref": "#/components/schemas/WorkstreamHistoryResponse"
                 }
               }
             }
@@ -7491,63 +7491,6 @@
           "name"
         ],
         "title": "CoordinatorCreateResponse",
-        "type": "object"
-      },
-      "CoordinatorDetailResponse": {
-        "description": "Response body for GET /v1/api/workstreams/{ws_id}.",
-        "properties": {
-          "ws_id": {
-            "title": "Ws Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "state": {
-            "title": "State",
-            "type": "string"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "string"
-          },
-          "kind": {
-            "default": "coordinator",
-            "title": "Kind",
-            "type": "string"
-          }
-        },
-        "required": [
-          "ws_id",
-          "name",
-          "state",
-          "user_id"
-        ],
-        "title": "CoordinatorDetailResponse",
-        "type": "object"
-      },
-      "CoordinatorHistoryResponse": {
-        "description": "Response body for GET /v1/api/workstreams/{ws_id}/history.",
-        "properties": {
-          "ws_id": {
-            "title": "Ws Id",
-            "type": "string"
-          },
-          "messages": {
-            "description": "Tail of the coordinator's reconstructed message history (provider-fidelity OpenAI-like shape).  Bounded by the ``limit`` query parameter (default 100, max 500).",
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Messages",
-            "type": "array"
-          }
-        },
-        "required": [
-          "ws_id"
-        ],
-        "title": "CoordinatorHistoryResponse",
         "type": "object"
       },
       "CoordinatorOpenResponse": {
@@ -11692,6 +11635,71 @@
           "skills"
         ],
         "title": "ListSkillSummaryResponse",
+        "type": "object"
+      },
+      "WorkstreamDetailResponse": {
+        "description": "Response body for ``GET /v1/api/workstreams/{ws_id}``.\n\nRenamed and relocated from ``CoordinatorDetailResponse`` in the\nStage 2 history/detail verb lift. Both kinds populate every field;\nSDK consumers don't branch on kind to read them. The lift adds the\nendpoint to interactive as a feature gain (pre-lift only coord\nexposed it).",
+        "properties": {
+          "ws_id": {
+            "title": "Ws Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/WorkstreamKind",
+            "default": "interactive"
+          }
+        },
+        "required": [
+          "ws_id",
+          "name",
+          "state",
+          "user_id"
+        ],
+        "title": "WorkstreamDetailResponse",
+        "type": "object"
+      },
+      "WorkstreamKind": {
+        "description": "Classifier for which manager hosts a workstream.\n\nStrEnum so members are drop-in ``str`` replacements for the DB column,\nJSON payloads, and existing ``==`` comparisons against raw strings.\nNarrow internal annotations to this type; wide boundaries (HTTP body,\nDB row) stay ``str`` and parse via ``WorkstreamKind(raw)`` / ``from_raw``\nat the edge.",
+        "enum": [
+          "interactive",
+          "coordinator"
+        ],
+        "title": "WorkstreamKind",
+        "type": "string"
+      },
+      "WorkstreamHistoryResponse": {
+        "description": "Response body for ``GET /v1/api/workstreams/{ws_id}/history``.\n\nRenamed and relocated from ``CoordinatorHistoryResponse`` in the\nStage 2 history/detail verb lift. Same OpenAI-like message-row\nshape on both kinds; the lift adds the endpoint to interactive as\na feature gain (pre-lift interactive only exposed history through\nthe SSE replay on ``/events``).",
+        "properties": {
+          "ws_id": {
+            "title": "Ws Id",
+            "type": "string"
+          },
+          "messages": {
+            "description": "Tail of the workstream's reconstructed message history (provider-fidelity OpenAI-like shape). Bounded by the ``limit`` query parameter (default 100, max 500).",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Messages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ws_id"
+        ],
+        "title": "WorkstreamHistoryResponse",
         "type": "object"
       }
     }

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -5511,6 +5511,16 @@
               }
             }
           },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Error 403",
             "content": {
@@ -5523,6 +5533,16 @@
           },
           "404": {
             "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error 500",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -623,6 +623,130 @@
         }
       }
     },
+    "/v1/api/workstreams/{ws_id}": {
+      "get": {
+        "summary": "Get workstream detail (rehydrates lazily on miss)",
+        "operationId": "v1_api_workstreams_{ws_id}_get",
+        "tags": [
+          "Workstreams"
+        ],
+        "description": "Returns the persisted workstream's display fields. If the session isn't currently in memory the manager rehydrates it before responding; ``500`` on rehydrate failure carries a correlation id matching the server log line. Lifted from the coord-only surface in the Stage 2 history/detail verb lift \u2014 interactive previously had no detail endpoint.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkstreamDetailResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error 500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/api/workstreams/{ws_id}/history": {
+      "get": {
+        "summary": "Read the workstream's reconstructed message history",
+        "operationId": "v1_api_workstreams_{ws_id}_history_get",
+        "tags": [
+          "Workstreams"
+        ],
+        "description": "Returns the tail of the conversation in OpenAI-like message format. Persisted-but-not-loaded workstreams (closed / evicted) serve history without rehydrating. Lifted from the coord-only surface in the Stage 2 history/detail verb lift \u2014 interactive previously only exposed history through the SSE replay on ``/events``.",
+        "parameters": [
+          {
+            "name": "ws_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100
+            },
+            "description": "Max conversation rows to fetch from storage (default 100, max 500)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkstreamHistoryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/api/workstreams/{ws_id}/attachments": {
       "post": {
         "summary": "Upload a file (multipart/form-data, field 'file') and attach it to the caller's next user turn on this workstream.  Validates size, MIME, and UTF-8 for text; magic-byte sniff for images.  Ownership failures are masked as 404 so non-owners cannot enumerate workstream existence; a 403 indicates a scope/auth failure from the middleware layer.",
@@ -2073,6 +2197,62 @@
           "state"
         ],
         "title": "WorkstreamInfo",
+        "type": "object"
+      },
+      "WorkstreamDetailResponse": {
+        "description": "Response body for ``GET /v1/api/workstreams/{ws_id}``.\n\nRenamed and relocated from ``CoordinatorDetailResponse`` in the\nStage 2 history/detail verb lift. Both kinds populate every field;\nSDK consumers don't branch on kind to read them. The lift adds the\nendpoint to interactive as a feature gain (pre-lift only coord\nexposed it).",
+        "properties": {
+          "ws_id": {
+            "title": "Ws Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/WorkstreamKind",
+            "default": "interactive"
+          }
+        },
+        "required": [
+          "ws_id",
+          "name",
+          "state",
+          "user_id"
+        ],
+        "title": "WorkstreamDetailResponse",
+        "type": "object"
+      },
+      "WorkstreamHistoryResponse": {
+        "description": "Response body for ``GET /v1/api/workstreams/{ws_id}/history``.\n\nRenamed and relocated from ``CoordinatorHistoryResponse`` in the\nStage 2 history/detail verb lift. Same OpenAI-like message-row\nshape on both kinds; the lift adds the endpoint to interactive as\na feature gain (pre-lift interactive only exposed history through\nthe SSE replay on ``/events``).",
+        "properties": {
+          "ws_id": {
+            "title": "Ws Id",
+            "type": "string"
+          },
+          "messages": {
+            "description": "Tail of the workstream's reconstructed message history (provider-fidelity OpenAI-like shape). Bounded by the ``limit`` query parameter (default 100, max 500).",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Messages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ws_id"
+        ],
+        "title": "WorkstreamHistoryResponse",
         "type": "object"
       },
       "DashboardResponse": {

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -734,8 +734,38 @@
               }
             }
           },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error 500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -181,6 +181,25 @@ export interface ListWorkstreamsResponse {
   workstreams: WorkstreamInfo[];
 }
 
+export interface WorkstreamDetailResponse {
+  // Lifted from coord-only into a shared verb in the Stage 2
+  // history/detail verb lift. Both kinds populate every field; SDK
+  // consumers don't branch on kind.
+  ws_id: string;
+  name: string;
+  state: string;
+  user_id: string;
+  kind: string;
+}
+
+export interface WorkstreamHistoryResponse {
+  ws_id: string;
+  // Tail of the workstream's reconstructed message history
+  // (provider-fidelity OpenAI-like shape). Bounded by the ?limit=
+  // query param (default 100, max 500).
+  messages: Record<string, unknown>[];
+}
+
 export interface DashboardWorkstream {
   id: string;
   name: string;

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -38,7 +38,6 @@ from turnstone.console.server import (
     _coord_create_validate_request,
     _require_admin_coordinator,
     _require_coord_mgr,
-    coordinator_detail,
 )
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_manager import SessionManager
@@ -46,6 +45,7 @@ from turnstone.core.session_routes import (
     SessionEndpointConfig,
     make_close_handler,
     make_create_handler,
+    make_detail_handler,
     make_list_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
@@ -164,7 +164,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}",
-                coordinator_detail,
+                make_detail_handler(_coord_endpoint_config),
                 methods=["GET"],
             ),
         ],

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -42,8 +42,6 @@ from turnstone.console.server import (
     _require_coord_mgr,
     cluster_ws_detail,
     coordinator_children,
-    coordinator_detail,
-    coordinator_history,
     coordinator_tasks,
 )
 from turnstone.core.attachments import (
@@ -64,6 +62,8 @@ from turnstone.core.session_routes import (
     make_cancel_handler,
     make_close_handler,
     make_create_handler,
+    make_detail_handler,
+    make_history_handler,
     make_list_handler,
     make_open_handler,
     make_saved_handler,
@@ -189,7 +189,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}/history",
-                coordinator_history,
+                make_history_handler(_coord_endpoint_config),
                 methods=["GET"],
             ),
             Route(
@@ -229,7 +229,7 @@ def _make_client(
             ),
             Route(
                 "/v1/api/workstreams/{ws_id}",
-                coordinator_detail,
+                make_detail_handler(_coord_endpoint_config),
                 methods=["GET"],
             ),
             Route(
@@ -829,6 +829,42 @@ def test_detail_404_when_kind_interactive(storage):
     assert resp.status_code == 404
 
 
+def test_detail_503_on_session_factory_misconfig(storage):
+    """``ValueError`` from ``mgr.open`` (e.g. a model alias that no longer
+    resolves) surfaces as 503 with the factory's remediation text — not
+    a correlation-id'd 500. Mirrors the open verb lift's contract so
+    operators can fix the misconfig without grepping logs."""
+    from unittest.mock import patch
+
+    mgr = _build_mgr(storage)
+    storage.register_workstream("misconfig-coord", kind="coordinator", user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    with patch.object(mgr, "open", side_effect=ValueError("no such model alias")):
+        resp = client.get("/v1/api/workstreams/misconfig-coord", headers=_COORD_HEADERS)
+    assert resp.status_code == 503
+    assert "no such model alias" in resp.json()["error"]
+
+
+def test_detail_correlation_id_on_unexpected_rehydrate_failure(storage):
+    """Bare ``Exception`` from ``mgr.open`` (build_session / resume failure
+    with no documented spec) surfaces as a correlation-id'd 500 with the
+    per-kind noun in the user-facing message — not the raw exception
+    text. Mirrors :func:`make_open_handler`'s leak-prevention contract."""
+    from unittest.mock import patch
+
+    mgr = _build_mgr(storage)
+    storage.register_workstream("broken-coord", kind="coordinator", user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    with patch.object(mgr, "open", side_effect=RuntimeError("internal stack frame leak")):
+        resp = client.get("/v1/api/workstreams/broken-coord", headers=_COORD_HEADERS)
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "internal stack frame leak" not in body["error"]
+    assert "correlation_id=" in body["error"]
+    # Per-kind noun via cfg.audit_action_prefix — coord wires "coordinator".
+    assert "coordinator" in body["error"]
+
+
 # ---------------------------------------------------------------------------
 # History
 # ---------------------------------------------------------------------------
@@ -860,6 +896,107 @@ def test_history_any_admin_coordinator_caller_can_read(storage):
     )
     assert resp.status_code == 200
     assert resp.json()["ws_id"] == ws.id
+
+
+def test_history_serves_storage_only_workstream(storage):
+    """Persisted-but-not-loaded coordinators (closed / evicted) are still
+    readable via /history without rehydrating. Mirrors the pre-lift
+    ``_resolve_coordinator_or_404`` ladder: storage-row + kind check
+    is sufficient when ``mgr.get`` returns None."""
+    mgr = _build_mgr(storage)
+    storage.register_workstream("storage-only-coord", kind="coordinator", user_id="user-1")
+    storage.save_message("storage-only-coord", "user", "from cold storage")
+    # Confirm precondition: row is in storage, NOT in the manager's pool.
+    assert mgr.get("storage-only-coord") is None
+
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get(
+        "/v1/api/workstreams/storage-only-coord/history",
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert any(m.get("content") == "from cold storage" for m in resp.json()["messages"])
+    # History does NOT rehydrate (unlike detail) — pool stays cold.
+    assert mgr.get("storage-only-coord") is None
+
+
+def test_history_404_when_kind_interactive(storage):
+    """Cross-kind isolation on the storage fallback path: an interactive
+    ws_id that exists in storage 404s on the coord history endpoint
+    (mirrors :func:`test_detail_404_when_kind_interactive`). The lifted
+    factory uses ``cfg.list_kind`` for the kind check; pre-lift coord
+    used :func:`_resolve_coordinator_or_404`'s explicit kind compare."""
+    mgr = _build_mgr(storage)
+    storage.register_workstream("ws-int", kind="interactive", user_id="user-1")
+    storage.save_message("ws-int", "user", "interactive content")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.get("/v1/api/workstreams/ws-int/history", headers=_COORD_HEADERS)
+    assert resp.status_code == 404
+    assert "interactive content" not in resp.text
+
+
+def test_history_swallows_load_messages_exception_returns_empty(storage):
+    """``storage.load_messages`` raising mid-call (transient DB outage,
+    corrupted row, etc.) must not 5xx the page-load handshake — coord
+    pre-lift logged at debug and returned 200 with ``messages == []``.
+    The lifted body preserves that contract on both kinds; pin it
+    explicitly so a future reader doesn't remove the bare-except as
+    dead code."""
+    from unittest.mock import patch
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+    with patch.object(storage, "load_messages", side_effect=RuntimeError("db gone")):
+        resp = client.get(f"/v1/api/workstreams/{ws.id}/history", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ws_id"] == ws.id
+    assert body["messages"] == []
+
+
+def test_history_clamps_limit_query_param(storage):
+    """Pre-lift coord clamped ``?limit=`` to [1, 500]. The lifted factory
+    preserves the same bounds. Out-of-range / unparseable values
+    fall back to defaults instead of erroring — coord's page-load
+    handshake should never 4xx on a malformed limit param."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    # Seed enough messages to exercise the upper bound. SQLite's INSERT
+    # is fast enough that 6 inserts in a tight loop is fine.
+    for i in range(6):
+        storage.save_message(ws.id, "user", f"msg-{i}")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    base = f"/v1/api/workstreams/{ws.id}/history"
+
+    # No limit → default 100 (returns all 6).
+    resp = client.get(base, headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 6
+
+    # limit=2 → only 2 messages returned (storage owns the row
+    # ordering contract; the factory just threads ``limit`` through).
+    resp = client.get(base, params={"limit": 2}, headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 2
+
+    # Negative / zero → clamp to 1 (factory: ``max(1, min(limit, 500))``).
+    resp = client.get(base, params={"limit": 0}, headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 1
+
+    # Garbage → falls back to default 100 (still 200, returns all 6).
+    resp = client.get(base, params={"limit": "garbage"}, headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 6
+
+    # Above-cap → clamps to 500 (page-load handshake never 4xx's).
+    resp = client.get(base, params={"limit": 999}, headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    # We only have 6 messages but the response is still 200 — the cap
+    # is enforced on the SQL LIMIT, not on the row count.
+    assert len(resp.json()["messages"]) == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -26,6 +26,8 @@ class TestServerSpec:
         paths = set(spec["paths"].keys())
         expected = {
             "/v1/api/workstreams",
+            "/v1/api/workstreams/{ws_id}",
+            "/v1/api/workstreams/{ws_id}/history",
             "/v1/api/dashboard",
             "/v1/api/workstreams/saved",
             "/v1/api/send",
@@ -41,6 +43,17 @@ class TestServerSpec:
             "/health",
         }
         assert expected.issubset(paths), f"Missing: {expected - paths}"
+
+    def test_workstream_history_has_limit_query_param(self):
+        """Mirror of the coord-side history limit param test — server now
+        exposes the same endpoint via the lifted factory."""
+        from turnstone.api.server_spec import build_server_spec
+
+        spec = build_server_spec()
+        op = spec["paths"]["/v1/api/workstreams/{ws_id}/history"]["get"]
+        param_names = [p["name"] for p in op.get("parameters", [])]
+        assert "ws_id" in param_names
+        assert "limit" in param_names
 
     def test_schemas_not_empty(self):
         from turnstone.api.server_spec import build_server_spec

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -20,9 +20,12 @@ if TYPE_CHECKING:
 from turnstone.core.auth import AuthResult
 from turnstone.core.session_routes import (
     SessionEndpointConfig,
+    make_detail_handler,
+    make_history_handler,
     make_open_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
+from turnstone.core.workstream import WorkstreamKind
 from turnstone.server import (
     delete_workstream_endpoint,
     list_interface_settings,
@@ -678,3 +681,262 @@ class TestUpdateInterfaceSetting:
             json={"value": "neon-pink"},
         )
         assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# History / detail — interactive parity with the lifted factories
+# ---------------------------------------------------------------------------
+#
+# Stage 2 ``history`` / ``detail`` verb lift adds these endpoints to the
+# interactive surface as a feature gain (pre-lift only coord exposed
+# them). The lifted factories live in :mod:`turnstone.core.session_routes`;
+# coord parity coverage lives in :mod:`tests.test_coordinator_endpoints`.
+# These tests pin the interactive wiring against the same factory.
+
+
+def _interactive_endpoint_cfg(mock_mgr: Any) -> SessionEndpointConfig:
+    """Interactive-shaped cfg wired the same way ``server.py`` does.
+
+    Shared by both :func:`_build_history_app` and :func:`_build_detail_app`
+    — every field both factories actually read is present (the detail
+    factory ignores ``list_kind`` since it relies on ``mgr.open()`` for
+    cross-kind isolation, but the field is harmless to set).
+    """
+    return SessionEndpointConfig(
+        permission_gate=None,  # auth middleware covers it
+        manager_lookup=lambda _r: (mock_mgr, None),
+        tenant_check=None,
+        not_found_label="Workstream not found",
+        audit_action_prefix="workstream",
+        list_kind=WorkstreamKind.INTERACTIVE,
+    )
+
+
+def _build_history_app(mock_mgr: Any, storage: Any) -> TestClient:
+    cfg = _interactive_endpoint_cfg(mock_mgr)
+    handler = make_history_handler(cfg)
+    app = Starlette(
+        routes=[
+            Mount(
+                "/v1",
+                routes=[
+                    Route("/api/workstreams/{ws_id}/history", handler, methods=["GET"]),
+                ],
+            ),
+        ],
+        middleware=[Middleware(_InjectAuthMiddleware)],
+    )
+    app.state.workstreams = mock_mgr
+    app.state.auth_storage = storage
+    return TestClient(app)
+
+
+def _build_detail_app(mock_mgr: Any) -> TestClient:
+    cfg = _interactive_endpoint_cfg(mock_mgr)
+    handler = make_detail_handler(cfg)
+    app = Starlette(
+        routes=[
+            Mount(
+                "/v1",
+                routes=[Route("/api/workstreams/{ws_id}", handler, methods=["GET"])],
+            ),
+        ],
+        middleware=[Middleware(_InjectAuthMiddleware)],
+    )
+    app.state.workstreams = mock_mgr
+    return TestClient(app)
+
+
+class TestHistoryInteractive:
+    """Interactive parity for the lifted ``GET /v1/api/workstreams/{ws_id}/history``."""
+
+    def test_returns_messages_for_in_memory_workstream(self, _inject_storage):
+        ws_id = "ws-int-1"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        _inject_storage.save_message(ws_id, "user", "hello interactive")
+        mock_ws = MagicMock()
+        mock_ws.id = ws_id
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = mock_ws
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ws_id"] == ws_id
+        assert any(
+            m.get("role") == "user" and m.get("content") == "hello interactive"
+            for m in body["messages"]
+        )
+
+    def test_serves_storage_only_workstream(self, _inject_storage):
+        """Persisted-but-not-loaded interactives serve history without
+        rehydrating — same shape as coord. Pre-lift interactive had no
+        history endpoint at all, so this is a feature gain."""
+        ws_id = "ws-cold"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        _inject_storage.save_message(ws_id, "assistant", "from cold storage")
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None  # not loaded
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        assert any(m.get("content") == "from cold storage" for m in r.json()["messages"])
+
+    def test_404_on_missing_ws_id(self, _inject_storage):
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get("/v1/api/workstreams/no-such-ws/history")
+        assert r.status_code == 404
+        assert r.json()["error"] == "Workstream not found"
+
+    def test_404_on_cross_kind_coord_ws_id(self, _inject_storage):
+        """Cross-kind isolation on the storage fallback: a coord ws_id
+        in shared storage 404s on the interactive history endpoint.
+        Mirrors :func:`test_history_404_when_kind_interactive` in
+        ``tests.test_coordinator_endpoints``."""
+        ws_id = "ws-coord-1"
+        _inject_storage.register_workstream(ws_id, kind="coordinator", user_id="test-user")
+        _inject_storage.save_message(ws_id, "user", "coord-only content")
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 404
+        assert "coord-only content" not in r.text
+
+    def test_clamps_limit_query_param(self, _inject_storage):
+        """Same [1, 500] clamp as coord — pre-lift interactive had no
+        history endpoint to enforce a clamp, so this is the
+        first-time bound. Out-of-range / unparseable values fall
+        back to defaults instead of erroring."""
+        ws_id = "ws-clamp"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        for i in range(4):
+            _inject_storage.save_message(ws_id, "user", f"msg-{i}")
+        mock_ws = MagicMock()
+        mock_ws.id = ws_id
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = mock_ws
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        base = f"/v1/api/workstreams/{ws_id}/history"
+        # No limit → default 100 returns all 4.
+        assert len(client.get(base).json()["messages"]) == 4
+        # limit=2 → only 2.
+        assert len(client.get(base, params={"limit": 2}).json()["messages"]) == 2
+        # 0 → clamps to 1.
+        assert len(client.get(base, params={"limit": 0}).json()["messages"]) == 1
+        # Garbage → falls back to 100.
+        assert client.get(base, params={"limit": "garbage"}).status_code == 200
+        # Above-cap → clamps to 500 (response is still 200; we have 4 rows).
+        assert client.get(base, params={"limit": 999}).status_code == 200
+
+
+class TestDetailInteractive:
+    """Interactive parity for the lifted ``GET /v1/api/workstreams/{ws_id}``.
+
+    The lifted ``make_detail_handler`` factory never reads storage —
+    cross-kind isolation is enforced inside ``mgr.open()`` and the
+    response is built from in-memory ``Workstream`` fields. The
+    ``mgr.open`` calls are mocked via ``MagicMock`` here, so the
+    storage-registry side effect that ``_inject_storage`` would
+    otherwise provide is irrelevant; the fixture is intentionally
+    omitted from these methods (unlike :class:`TestHistoryInteractive`
+    where the storage backend serves the message rows).
+    """
+
+    def test_returns_workstream_fields(self):
+        ws_id = "ws-detail-1"
+        ws_state = MagicMock()
+        ws_state.value = "idle"
+        loaded_ws = MagicMock()
+        loaded_ws.id = ws_id
+        loaded_ws.name = "my-interactive"
+        loaded_ws.state = ws_state
+        loaded_ws.user_id = "test-user"
+        loaded_ws.kind = "interactive"
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = loaded_ws
+        client = _build_detail_app(mock_mgr)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {
+            "ws_id": ws_id,
+            "name": "my-interactive",
+            "state": "idle",
+            "user_id": "test-user",
+            "kind": "interactive",
+        }
+
+    def test_lazy_rehydrates_on_miss(self):
+        """``mgr.get`` miss → ``mgr.open`` rehydrate. Same flow as coord;
+        pre-lift interactive had no detail endpoint so this is the
+        first time the rehydrate path is exercised on this surface."""
+        ws_id = "ws-cold-detail"
+        ws_state = MagicMock()
+        ws_state.value = "closed"
+        rehydrated = MagicMock()
+        rehydrated.id = ws_id
+        rehydrated.name = "rehydrated"
+        rehydrated.state = ws_state
+        rehydrated.user_id = "owner"
+        rehydrated.kind = "interactive"
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        mock_mgr.open.return_value = rehydrated
+        client = _build_detail_app(mock_mgr)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}")
+        assert r.status_code == 200
+        assert r.json()["name"] == "rehydrated"
+        mock_mgr.open.assert_called_once_with(ws_id)
+
+    def test_404_on_missing_ws_id(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        # ``mgr.open`` returns None for missing rows / kind mismatch /
+        # tombstoned rows — all 404 with the per-kind label.
+        mock_mgr.open.return_value = None
+        client = _build_detail_app(mock_mgr)
+
+        r = client.get("/v1/api/workstreams/no-such-ws")
+        assert r.status_code == 404
+        assert r.json()["error"] == "Workstream not found"
+
+    def test_503_on_session_factory_misconfig(self):
+        """``ValueError`` from ``mgr.open`` (e.g. a model alias that no
+        longer resolves) surfaces as 503 with the factory's
+        remediation text — not a correlation-id'd 500. Mirrors
+        :func:`make_open_handler`."""
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        mock_mgr.open.side_effect = ValueError("alias 'gone' no longer resolves")
+        client = _build_detail_app(mock_mgr)
+
+        r = client.get("/v1/api/workstreams/ws-misconfig")
+        assert r.status_code == 503
+        assert "alias 'gone' no longer resolves" in r.json()["error"]
+
+    def test_correlation_id_on_unexpected_rehydrate_failure(self):
+        """Bare ``Exception`` from ``mgr.open`` → 500 + correlation_id +
+        per-kind noun in user-facing message. Exception text is NOT
+        echoed (no internal-detail leak)."""
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        mock_mgr.open.side_effect = RuntimeError("internal stack frame leak")
+        client = _build_detail_app(mock_mgr)
+
+        r = client.get("/v1/api/workstreams/ws-broken")
+        assert r.status_code == 500
+        body = r.json()
+        assert "internal stack frame leak" not in body["error"]
+        assert "correlation_id=" in body["error"]
+        # Per-kind noun via cfg.audit_action_prefix.
+        assert "workstream" in body["error"]

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1024,16 +1024,6 @@ class CoordinatorCreateResponse(BaseModel):
     attachment_ids: list[str] = Field(default_factory=list)
 
 
-class CoordinatorDetailResponse(BaseModel):
-    """Response body for GET /v1/api/workstreams/{ws_id}."""
-
-    ws_id: str
-    name: str
-    state: str
-    user_id: str
-    kind: str = Field(default="coordinator")
-
-
 class CoordinatorSendRequest(BaseModel):
     """Body for POST /v1/api/workstreams/{ws_id}/send."""
 
@@ -1095,20 +1085,6 @@ class CoordinatorApproveRequest(BaseModel):
         description=(
             "When approved=True, also adds the pending tool name(s) to the session's "
             "auto-approve set so subsequent calls of the same tool skip the prompt."
-        ),
-    )
-
-
-class CoordinatorHistoryResponse(BaseModel):
-    """Response body for GET /v1/api/workstreams/{ws_id}/history."""
-
-    ws_id: str
-    messages: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description=(
-            "Tail of the coordinator's reconstructed message history "
-            "(provider-fidelity OpenAI-like shape).  Bounded by the ``limit`` "
-            "query parameter (default 100, max 500)."
         ),
     )
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -29,8 +29,6 @@ from turnstone.api.console_schemas import (
     CoordinatorCloseAllChildrenResponse,
     CoordinatorCreateRequest,
     CoordinatorCreateResponse,
-    CoordinatorDetailResponse,
-    CoordinatorHistoryResponse,
     CoordinatorOpenResponse,
     CoordinatorRestrictRequest,
     CoordinatorRestrictResponse,
@@ -135,6 +133,8 @@ from turnstone.api.server_schemas import (
     ListWorkstreamsResponse,
     SkillSummary,
     UploadAttachmentResponse,
+    WorkstreamDetailResponse,
+    WorkstreamHistoryResponse,
 )
 
 CONSOLE_ENDPOINTS: list[EndpointSpec] = [
@@ -1172,7 +1172,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
             "before responding; ``500`` on rehydrate failure carries a "
             "correlation id matching the server log line."
         ),
-        response_model=CoordinatorDetailResponse,
+        response_model=WorkstreamDetailResponse,
         error_codes=[400, 403, 404, 500, 503],
         tags=["Coordinator"],
     ),
@@ -1320,7 +1320,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
             "format.  Used by the page-load handshake; SSE handles updates "
             "after that.  Bounded by the ``limit`` query parameter."
         ),
-        response_model=CoordinatorHistoryResponse,
+        response_model=WorkstreamHistoryResponse,
         query_params=[
             QueryParam(
                 "limit",
@@ -1507,8 +1507,6 @@ _ALL_MODELS: list[type[BaseModel]] = [
     CoordinatorCloseAllChildrenResponse,
     CoordinatorCreateRequest,
     CoordinatorCreateResponse,
-    CoordinatorDetailResponse,
-    CoordinatorHistoryResponse,
     CoordinatorOpenResponse,
     CoordinatorRestrictRequest,
     CoordinatorRestrictResponse,
@@ -1589,6 +1587,8 @@ _ALL_MODELS: list[type[BaseModel]] = [
     RouteCreateResponse,
     SkillSummary,
     ListSkillSummaryResponse,
+    WorkstreamDetailResponse,
+    WorkstreamHistoryResponse,
 ]
 
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1329,7 +1329,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
                 default=100,
             ),
         ],
-        error_codes=[403, 404, 503],
+        error_codes=[400, 403, 404, 500, 503],
         tags=["Coordinator"],
     ),
     EndpointSpec(

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -267,6 +267,49 @@ class SavedWorkstreamInfo(BaseModel):
 
 class ListSavedWorkstreamsResponse(BaseModel):
     workstreams: list[SavedWorkstreamInfo]
+
+
+# ---------------------------------------------------------------------------
+# Detail / history (Stage 2 verb lift — both kinds expose these)
+# ---------------------------------------------------------------------------
+
+
+class WorkstreamDetailResponse(BaseModel):
+    """Response body for ``GET /v1/api/workstreams/{ws_id}``.
+
+    Renamed and relocated from ``CoordinatorDetailResponse`` in the
+    Stage 2 history/detail verb lift. Both kinds populate every field;
+    SDK consumers don't branch on kind to read them. The lift adds the
+    endpoint to interactive as a feature gain (pre-lift only coord
+    exposed it).
+    """
+
+    ws_id: str
+    name: str
+    state: str
+    user_id: str
+    kind: WorkstreamKind = WorkstreamKind.INTERACTIVE
+
+
+class WorkstreamHistoryResponse(BaseModel):
+    """Response body for ``GET /v1/api/workstreams/{ws_id}/history``.
+
+    Renamed and relocated from ``CoordinatorHistoryResponse`` in the
+    Stage 2 history/detail verb lift. Same OpenAI-like message-row
+    shape on both kinds; the lift adds the endpoint to interactive as
+    a feature gain (pre-lift interactive only exposed history through
+    the SSE replay on ``/events``).
+    """
+
+    ws_id: str
+    messages: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Tail of the workstream's reconstructed message history "
+            "(provider-fidelity OpenAI-like shape). Bounded by the "
+            "``limit`` query parameter (default 100, max 500)."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -42,6 +42,8 @@ from turnstone.api.server_schemas import (
     SendResponse,
     SkillSummary,
     UploadAttachmentResponse,
+    WorkstreamDetailResponse,
+    WorkstreamHistoryResponse,
 )
 
 SERVER_ENDPOINTS: list[EndpointSpec] = [
@@ -181,6 +183,46 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "/v1/api/workstreams/{ws_id}/refresh-title",
         "POST",
         "Regenerate workstream title via LLM",
+        error_codes=[404],
+        tags=["Workstreams"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}",
+        "GET",
+        "Get workstream detail (rehydrates lazily on miss)",
+        description=(
+            "Returns the persisted workstream's display fields. If the "
+            "session isn't currently in memory the manager rehydrates it "
+            "before responding; ``500`` on rehydrate failure carries a "
+            "correlation id matching the server log line. Lifted from "
+            "the coord-only surface in the Stage 2 history/detail verb "
+            "lift — interactive previously had no detail endpoint."
+        ),
+        response_model=WorkstreamDetailResponse,
+        error_codes=[400, 404, 500, 503],
+        tags=["Workstreams"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/{ws_id}/history",
+        "GET",
+        "Read the workstream's reconstructed message history",
+        description=(
+            "Returns the tail of the conversation in OpenAI-like message "
+            "format. Persisted-but-not-loaded workstreams (closed / "
+            "evicted) serve history without rehydrating. Lifted from "
+            "the coord-only surface in the Stage 2 history/detail verb "
+            "lift — interactive previously only exposed history through "
+            "the SSE replay on ``/events``."
+        ),
+        response_model=WorkstreamHistoryResponse,
+        query_params=[
+            QueryParam(
+                "limit",
+                "Max conversation rows to fetch from storage (default 100, max 500).",
+                schema_type="integer",
+                default=100,
+            ),
+        ],
         error_codes=[404],
         tags=["Workstreams"],
     ),
@@ -397,6 +439,8 @@ _ALL_MODELS: list[type[BaseModel]] = [
     CreateWorkstreamResponse,
     CloseWorkstreamRequest,
     ListWorkstreamsResponse,
+    WorkstreamDetailResponse,
+    WorkstreamHistoryResponse,
     DashboardResponse,
     ListSavedWorkstreamsResponse,
     UploadAttachmentResponse,

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -223,7 +223,7 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
                 default=100,
             ),
         ],
-        error_codes=[404],
+        error_codes=[400, 404, 500, 503],
         tags=["Workstreams"],
     ),
     # --- Workstream attachments ---

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -64,7 +64,9 @@ from turnstone.core.session_routes import (
     make_cancel_handler,
     make_close_handler,
     make_create_handler,
+    make_detail_handler,
     make_events_handler,
+    make_history_handler,
     make_list_handler,
     make_open_handler,
     make_saved_handler,
@@ -835,7 +837,7 @@ async def cluster_ws_detail(request: Request) -> JSONResponse:
       ``live=null`` rather than an error status.
     - ``messages`` — tail-N conversation messages, default 20, capped at 200.
 
-    404 masks ownership failures (match ``coordinator_detail``).
+    404 masks ownership failures (match :func:`make_detail_handler`).
     Correlation-id masks unexpected exceptions in the merge path.
     """
     from turnstone.core.auth import require_permission
@@ -853,7 +855,7 @@ async def cluster_ws_detail(request: Request) -> JSONResponse:
         return JSONResponse({"error": "invalid ws_id"}, status_code=400)
 
     # Accept either ``?limit=`` (the canonical name used by
-    # coordinator_history and the list_workstreams tool) or the
+    # the lifted history factory and the list_workstreams tool) or the
     # transitional ``?message_limit=`` from earlier phase-3 drafts.
     # ``?limit`` wins when both are set so callers migrating from the
     # older name can overlap without surprise.
@@ -2364,8 +2366,10 @@ def _resolve_coordinator_or_404(
     ``(None, 404)`` on missing row / wrong kind / storage unavailable.
 
     Centralises the manager-first, storage-fallback, 404-mask ladder
-    previously duplicated across ``coordinator_children`` /
-    ``coordinator_tasks`` / ``coordinator_history``.  Turnstone is a
+    used by the coord-only verbs (``coordinator_children`` /
+    ``coordinator_tasks``).  The shared verbs (history, detail, ...)
+    inline the same ladder via :func:`make_history_handler` /
+    :func:`make_detail_handler`.  Turnstone is a
     trusted-team tool — ``user_id`` is metadata, not an access
     boundary, so this helper no longer gates on row ownership; scope
     auth (``admin.coordinator``) upstream is the gate.
@@ -2652,42 +2656,6 @@ async def _coord_saved_loaded_lookup(request: Request) -> set[str]:
     )
 
 
-async def coordinator_history(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams/{ws_id}/history — message history for page load.
-
-    Supports a ``?limit=`` query param (default 100, max 500) bounding
-    how many conversation rows are fetched from storage.  Long-lived
-    coordinators can accumulate thousands of messages — the page load
-    only needs the tail.
-    """
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    user_id = _auth_user_id(request)
-    storage = getattr(request.app.state, "auth_storage", None)
-    _ws, err404 = _resolve_coordinator_or_404(request, coord_mgr, storage, ws_id, user_id)
-    if err404 is not None:
-        return err404
-
-    try:
-        limit = int(request.query_params.get("limit", "100"))
-    except (TypeError, ValueError):
-        limit = 100
-    limit = max(1, min(limit, 500))
-
-    messages: list[dict[str, Any]] = []
-    if storage is not None:
-        try:
-            messages = storage.load_messages(ws_id, limit=limit)
-        except Exception:
-            log.debug("coordinator_history.load_failed ws=%s", ws_id[:8], exc_info=True)
-    return JSONResponse({"ws_id": ws_id, "messages": messages})
-
-
 async def coordinator_page(request: Request) -> Response:
     """GET /coordinator/{ws_id} — serve the one-pane coordinator HTML.
 
@@ -2711,55 +2679,6 @@ async def coordinator_page(request: Request) -> Response:
     # to HTML-escape; leave the replacement simple.
     body = body.replace("{{WS_ID}}", ws_id)
     return Response(body, media_type="text/html; charset=utf-8")
-
-
-async def coordinator_detail(request: Request) -> JSONResponse:
-    """GET /v1/api/workstreams/{ws_id} — detail + lazy rehydrate on miss."""
-    err = _require_admin_coordinator(request)
-    if err is not None:
-        return err
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503
-    ws_id = request.path_params.get("ws_id", "")
-    ws = coord_mgr.get(ws_id)
-    if ws is None:
-        # Lazy rehydration goes through the session factory, which can
-        # raise the same exceptions coordinator_create handles — match
-        # the correlation-id mask so stack traces don't leak through
-        # the detail endpoint either.
-        try:
-            ws = coord_mgr.open(ws_id)
-        except ValueError as exc:
-            return JSONResponse({"error": str(exc)}, status_code=503)
-        except Exception:
-            correlation_id = secrets.token_hex(4)
-            log.warning(
-                "coordinator_detail.rehydrate_failed correlation_id=%s ws_id=%s",
-                correlation_id,
-                ws_id[:8],
-                exc_info=True,
-            )
-            return JSONResponse(
-                {
-                    "error": (
-                        "failed to rehydrate coordinator (internal error). "
-                        f"correlation_id={correlation_id}"
-                    )
-                },
-                status_code=500,
-            )
-        if ws is None:
-            return JSONResponse({"error": "coordinator not found"}, status_code=404)
-    return JSONResponse(
-        {
-            "ws_id": ws.id,
-            "name": ws.name,
-            "state": ws.state.value,
-            "user_id": ws.user_id,
-            "kind": ws.kind,
-        }
-    )
 
 
 _CHILDREN_PAGE_LIMIT = 200
@@ -2810,7 +2729,7 @@ async def coordinator_children(request: Request) -> JSONResponse:
     the same rows.
 
     Same ownership / 404-on-mismatch / admin-bypass semantics as
-    ``coordinator_detail``.  Reads don't audit.
+    :func:`make_detail_handler`.  Reads don't audit.
     """
     from turnstone.core.web_helpers import require_storage_or_503
 
@@ -2932,8 +2851,8 @@ async def coordinator_metrics(request: Request) -> JSONResponse:
       wait-tool instrumentation (future work — the SSE events from
       #14 carry the data live but aren't persisted yet).
 
-    Ownership / authz: same gate as ``coordinator_detail`` — 404-mask
-    rows the caller doesn't own (no existence-oracle leak).
+    Ownership / authz: same gate as :func:`make_detail_handler` —
+    404-mask rows the caller doesn't own (no existence-oracle leak).
     """
     from turnstone.core.web_helpers import require_storage_or_503
 
@@ -10093,7 +10012,7 @@ def create_app(
                 coord_endpoint_config,
                 audit_emit=_audit_coordinator_create,
             ),
-            detail=coordinator_detail,
+            detail=make_detail_handler(coord_endpoint_config),  # lifted: shared body
             open=make_open_handler(coord_endpoint_config),  # lifted: shared body
             close=make_close_handler(  # lifted: shared body
                 coord_endpoint_config,
@@ -10107,7 +10026,7 @@ def create_app(
                 audit_emit=_audit_cancel_coordinator,
             ),
             events=make_events_handler(coord_endpoint_config),  # lifted: shared body
-            history=coordinator_history,
+            history=make_history_handler(coord_endpoint_config),  # lifted: shared body
             attachments=make_attachment_handlers(
                 coord_endpoint_config
             ),  # lifted: shared body (P1.5)

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -2225,8 +2225,8 @@ function _renderHomeView() {
 // interactive UI's "Saved Workstreams" card grid (same /shared/cards.css
 // primitives, same /shared/cards.js renderSessionCard helper, same
 // response item shape from /v1/api/workstreams/saved).  Click a card →
-// POST /open then /coordinator/{ws_id}; coordinator_detail lazily
-// rehydrates from storage on the GET miss.
+// POST /open then /coordinator/{ws_id}; the lifted detail factory
+// lazily rehydrates from storage on the GET miss.
 // ---------------------------------------------------------------------------
 
 // In-flight de-dup for loadSavedCoordinators.  ws_closed events can

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -163,8 +163,8 @@
          Mirrors the interactive UI's "Saved Workstreams" card grid
          (same /shared/cards.css primitives, same response item shape
          from /v1/api/workstreams/saved).  Click a card →
-         /coordinator/{ws_id} → coordinator_detail lazy-rehydrates from
-         storage.  Hidden until at least one saved coordinator loads. -->
+         /coordinator/{ws_id} → the lifted detail factory lazy-rehydrates
+         from storage.  Hidden until at least one saved coordinator loads. -->
         <section
           id="saved-coordinators"
           class="home-section"

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2087,6 +2087,215 @@ def make_saved_handler(cfg: SessionEndpointConfig) -> Handler:
     return saved_workstreams_handler
 
 
+def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``GET {prefix}/{ws_id}/history`` — message history.
+
+    Returns the tail of the workstream's reconstructed conversation as
+    OpenAI-like message dicts. Used by coord's page-load handshake (the
+    dashboard fetches history once, then SSE handles updates). The lift
+    also adds the endpoint to interactive as a feature gain — pre-lift
+    interactive only exposed history through the SSE replay on
+    ``/events``, so SDK consumers had to subscribe to a stream just to
+    read message rows.
+
+    Per-kind divergence captured by:
+
+    - ``cfg.permission_gate`` — coord's ``admin.coordinator`` check;
+      interactive ``None``.
+    - ``cfg.manager_lookup`` — already used by every other lifted verb.
+    - ``cfg.list_kind`` — required for the storage-fallback kind check
+      so an interactive ws_id can't read history through the coord
+      process and vice versa. Pre-lift coord went through
+      :func:`_resolve_coordinator_or_404` for the same isolation; the
+      lifted body uses ``cfg.list_kind`` (already wired by both
+      production lifespans for the list/saved factories) instead of
+      adding a new cfg field. **Required when this handler is mounted**
+      — a missing value fails loud (500 + ``log.error``) rather than
+      silently leaking cross-kind history through the storage
+      fallback. Mirrors :func:`make_saved_handler`'s same gate.
+    - ``cfg.not_found_label`` — per-kind 404 wording.
+
+    Pre-lift coord behaviour preserved with one performance lift:
+    both the storage-row kind check and the ``load_messages`` call now
+    run through ``asyncio.to_thread`` (matched to the rest of the
+    lifted verbs' storage offload pattern; pre-lift coord ran them
+    inline on the event loop).
+
+    Args:
+        cfg: per-kind policy bundle.
+    """
+
+    async def history(request: Request) -> Response:
+        import asyncio
+
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+
+        # Fail-closed misconfig gate. Without ``cfg.list_kind`` the
+        # storage-fallback path below has no way to enforce cross-kind
+        # isolation — an interactive ws_id requested through a coord
+        # process would silently serve coord history from storage (and
+        # vice versa). Mirrors :func:`make_saved_handler`'s same gate
+        # for the same reason; a future kind / hand-rolled test cfg
+        # that drops the field fails loud instead of leaking rows.
+        if cfg.list_kind is None:
+            log.error("ws.history.misconfigured_no_list_kind")
+            return JSONResponse(
+                {"error": "history handler misconfigured"},
+                status_code=500,
+            )
+
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        mgr = cast("SessionManager", mgr_opt)
+
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        # Existence + kind check. The workstream may live only in
+        # storage (closed coordinators are still readable via /history
+        # without rehydrating; persisted-but-not-loaded interactives
+        # are likewise readable). Mirrors the pre-lift coord
+        # ``_resolve_coordinator_or_404`` ladder: in-memory mgr.get →
+        # storage row + kind check → 404. Falling back to storage
+        # without the kind check would leak interactive rows through
+        # the coord endpoint (and vice versa) on a process that
+        # shares storage with the other kind. ``cfg.list_kind`` is
+        # guaranteed non-None by the misconfig gate above.
+        storage = getattr(request.app.state, "auth_storage", None)
+        if mgr.get(ws_id) is None:
+            if storage is None:
+                return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+            try:
+                row = await asyncio.to_thread(storage.get_workstream, ws_id)
+            except Exception:
+                log.debug("ws.history.lookup_failed ws=%s", ws_id[:8], exc_info=True)
+                return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+            if row is None or row.get("kind") != cfg.list_kind:
+                return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        # Bound the row count. Pre-lift coord clamped to [1, 500].
+        try:
+            limit = int(request.query_params.get("limit", "100"))
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 500))
+
+        messages: list[dict[str, Any]] = []
+        if storage is not None:
+            try:
+                messages = await asyncio.to_thread(storage.load_messages, ws_id, limit=limit)
+            except Exception:
+                log.debug("ws.history.load_failed ws=%s", ws_id[:8], exc_info=True)
+        return JSONResponse({"ws_id": ws_id, "messages": messages})
+
+    return history
+
+
+def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``GET {prefix}/{ws_id}`` — workstream display fields.
+
+    Returns ``{ws_id, name, state, user_id, kind}`` for the workstream.
+    Lazy-rehydrates on miss via ``mgr.open(ws_id)`` so a closed/evicted
+    workstream comes back into memory before the response. Mirrors the
+    error-handling pattern from :func:`make_open_handler`: ``ValueError``
+    from the session factory surfaces as 503 with the factory's
+    remediation text; any other rehydrate failure surfaces as a
+    correlation-id'd 500 with the per-kind noun in the user-facing
+    message.
+
+    Cross-kind isolation is enforced inside ``mgr.open()`` itself —
+    it returns ``None`` for missing rows, kind mismatches, and
+    tombstoned rows; all surface as 404 with ``cfg.not_found_label``.
+    No inline storage check needed (unlike :func:`make_history_handler`)
+    because rehydrate is the existence proof.
+
+    Per-kind divergence:
+
+    - ``cfg.permission_gate`` — coord's ``admin.coordinator`` check;
+      interactive ``None``.
+    - ``cfg.manager_lookup`` — already used by every other lifted verb.
+    - ``cfg.not_found_label`` — per-kind 404 wording.
+    - ``cfg.audit_action_prefix`` — per-kind noun in the 500 error.
+
+    Pre-lift coord behaviour preserved verbatim. The lift adds the
+    endpoint to interactive as a feature gain — pre-lift interactive
+    had no HTTP detail endpoint (SDK consumers had to subscribe to
+    SSE just to read display fields).
+
+    Args:
+        cfg: per-kind policy bundle.
+    """
+
+    async def detail(request: Request) -> Response:
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        mgr = cast("SessionManager", mgr_opt)
+
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        ws = mgr.get(ws_id)
+        if ws is None:
+            try:
+                ws = mgr.open(ws_id)
+            except ValueError as exc:
+                # Session factory misconfig (e.g. a model alias that no
+                # longer resolves). Surface remediation text as 503
+                # mirroring :func:`make_open_handler`.
+                return JSONResponse({"error": str(exc)}, status_code=503)
+            except Exception:
+                # Bare ``Exception`` is intentional — see
+                # :func:`make_open_handler` for the rationale
+                # (``adapter.build_session`` / ``ChatSession.resume``
+                # have no documented exception spec).
+                import secrets
+
+                correlation_id = secrets.token_hex(4)
+                log.warning(
+                    "ws.detail.rehydrate_failed correlation_id=%s ws_id=%s",
+                    correlation_id,
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+                kind_noun = cfg.audit_action_prefix or "workstream"
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"failed to rehydrate {kind_noun} (internal error). "
+                            f"correlation_id={correlation_id}"
+                        )
+                    },
+                    status_code=500,
+                )
+            if ws is None:
+                # ``mgr.open`` returns None for missing rows, kind
+                # mismatch, and tombstoned rows — all surface as 404.
+                return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        return JSONResponse(
+            {
+                "ws_id": ws.id,
+                "name": ws.name,
+                "state": ws.state.value,
+                "user_id": ws.user_id,
+                "kind": ws.kind,
+            }
+        )
+
+    return detail
+
+
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     """Lifted body for ``POST {prefix}/{ws_id}/send`` — message dispatch.
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -68,7 +68,9 @@ from turnstone.core.session_routes import (
     make_close_handler,
     make_create_handler,
     make_dequeue_handler,
+    make_detail_handler,
     make_events_handler,
+    make_history_handler,
     make_legacy_body_keyed_adapter,
     make_legacy_query_keyed_adapter,
     make_list_handler,
@@ -3615,6 +3617,8 @@ def create_app(
     )
     list_handler = make_list_handler(interactive_endpoint_config)
     saved_handler = make_saved_handler(interactive_endpoint_config)
+    history_handler = make_history_handler(interactive_endpoint_config)
+    detail_handler = make_detail_handler(interactive_endpoint_config)
     v1_routes: list[Any] = [
         Route("/api/events", make_legacy_query_keyed_adapter(events_handler)),
         Route("/api/events/global", global_events_sse),
@@ -3628,6 +3632,7 @@ def create_app(
             create=create_handler,  # lifted: shared body
             close_legacy=make_legacy_body_keyed_adapter(close_handler),
             delete=delete_workstream_endpoint,
+            detail=detail_handler,  # lifted: shared body (interactive feature gain)
             open=open_handler,  # lifted: shared body
             close=close_handler,  # lifted: shared body
             refresh_title=refresh_workstream_title,
@@ -3636,6 +3641,7 @@ def create_app(
             approve=approve_handler,  # lifted: shared body
             cancel=cancel_handler,  # lifted: shared body
             events=events_handler,  # lifted: shared body
+            history=history_handler,  # lifted: shared body (interactive feature gain)
             attachments=attachment_handlers,  # lifted: shared body (P1.5)
         ),
     )


### PR DESCRIPTION
Last verb-shape lift before v1.5.0 stable can tag. Adds two new
factories to ``turnstone/core/session_routes.py``:

- ``make_history_handler(cfg)`` — body lifted from coord's
  ``coordinator_history`` near-verbatim. ``?limit=`` query param
  defaults to 100, clamps to [1, 500], malformed values fall back
  to 100. Storage operations (``get_workstream`` on the
  storage-fallback path, ``load_messages`` for the row read) now
  run via ``asyncio.to_thread`` (was inline pre-lift on coord).
- ``make_detail_handler(cfg)`` — body lifted from coord's
  ``coordinator_detail``. Lazy-rehydrates a closed/evicted
  workstream via ``mgr.open()`` on miss; mirrors
  :func:`make_open_handler`'s exception envelope (``ValueError``
  → 503 with the session-factory's remediation text; bare
  ``Exception`` → correlation_id'd 500 with the per-kind noun
  via ``cfg.audit_action_prefix``).

NO new ``SessionEndpointConfig`` fields — the factories reuse
``permission_gate``, ``manager_lookup``, ``not_found_label``,
``audit_action_prefix``, and (for history's storage-fallback
kind check) ``list_kind`` — all already wired by both production
lifespans for the list/saved factories.

Coord side: ``coordinator_history`` and ``coordinator_detail``
standalone handler bodies removed from ``console/server.py``;
``register_session_routes`` now wires
``history=make_history_handler(coord_endpoint_config)`` and
``detail=make_detail_handler(coord_endpoint_config)``.

Interactive side: GAINS both endpoints as a feature gain. Pre-lift
interactive had no ``GET /v1/api/workstreams/{ws_id}`` and no
``GET /v1/api/workstreams/{ws_id}/history`` — SDK consumers had to
subscribe to ``/events`` SSE just to read display fields or
message rows. The same lifted factories are wired with the
interactive endpoint config; cross-kind isolation is preserved on
both sides (history via ``cfg.list_kind`` storage-fallback gate
+ fail-loud-on-misconfig 500; detail via ``mgr.open()``'s internal
kind check).

Pydantic schemas: ``CoordinatorDetailResponse`` /
``CoordinatorHistoryResponse`` removed from ``console_schemas.py``;
``WorkstreamDetailResponse`` / ``WorkstreamHistoryResponse`` added
to ``server_schemas.py`` (mirrors the list lift's pattern for
``WorkstreamInfo``). Both server and console OpenAPI specs
reference the unified schemas; ``server_spec.py`` gains
``EndpointSpec`` entries for the new interactive endpoints. TS
SDK gains both interfaces in ``sdk/typescript/src/types.ts``;
``openapi-{server,console}.json`` regenerated.

Tests: 6 new coord regression/parity tests in
``test_coordinator_endpoints.py`` (limit clamping, cross-kind 404
on storage fallback, storage-only history, detail 503 on
session-factory misconfig, detail 500 with correlation_id on
unexpected rehydrate failure, history swallows
``load_messages`` exception → 200 with empty messages). 10 new
interactive parity tests in ``test_workstream_endpoints.py``
(``TestHistoryInteractive`` + ``TestDetailInteractive``). 1 new
openapi spec test pinning the server-side ``?limit=`` query param.
Total: ``4490 → 4491`` after the new exception-swallow
regression test landed. ``ruff check`` clean, ``mypy`` clean on
touched files.

/review pipeline (4 finders → verify → dedupe) caught 1 Minor
defense-in-depth (bug-1/sec-1, merged: ``make_history_handler``
fail-closed gate when ``cfg.list_kind is None``, mirroring
``make_saved_handler``'s same gate) + 1 Minor test-helper rename
(q-1: ``_interactive_history_cfg`` → ``_interactive_endpoint_cfg``)
+ 4 Nits (q-2 unused fixture parameter, q-3 CHANGELOG TS SDK
mention, q-4 missing exception-swallow regression test, q-5
misleading test comment) — all addressed in the same commit.