### PR TITLE
feat(console): coord rich ws_state payload + live activity broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,16 @@ Three release tracks are maintained:
     ``usage_event`` by ``ws_id`` will see coord rows for the first
     time.
   - **Coord broadcasts live activity transitions.** New
-    ``collector.emit_console_ws_activity(ws_id, *, activity,
-    activity_state)`` method. The cluster dashboard's per-ws
-    polling reads the in-memory pseudo-node row, so activity ticks
-    land on the next snapshot fetch (matches WebUI's behaviour
-    where activity events are observational; not fanned out
-    through the cluster SSE stream).
+    ``ClusterCollector.update_console_ws_activity(ws_id, *,
+    activity, activity_state)`` method (named ``update_*`` rather
+    than ``emit_*`` to flag the no-fan-out asymmetry vs. the rest
+    of the ``emit_console_ws_*`` family — it updates the in-memory
+    pseudo-node row but intentionally does NOT fan out a separate
+    SSE event). The cluster dashboard's per-ws polling reads the
+    in-memory pseudo-node row, so activity ticks land on the next
+    snapshot fetch (matches WebUI's behaviour where activity
+    events are observational; not fanned out through the cluster
+    SSE stream).
   - **Cluster ``cluster_state`` events for coord rows now carry
     non-zero ``tokens`` / ``content`` fields.** Frontend rendering
     that conditionally hid these on coord rows can drop the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,107 @@ Three release tracks are maintained:
 
 ### Changed
 
+- **Coordinator gains rich `ws_state` payload + live activity broadcast**
+  ([§ Post-P3 reckoning item #2 follow-up]). Pre-lift coord's
+  cluster broadcast was state-only — the dashboard's coord rows
+  showed the state column flipping but the ``tokens``,
+  ``context_ratio``, ``activity``, and per-turn ``content`` fields
+  were all hardcoded to zero / empty. The lift turns
+  ``on_status`` / ``on_content_token`` / ``on_thinking_start`` /
+  ``on_thinking_stop`` / ``on_stream_end`` / ``on_tool_result``
+  into shared bodies on :class:`SessionUIBase` so coord populates
+  the same per-ws metric fields interactive does (the fields were
+  already declared on the base; only the writes were
+  WebUI-specific). ``coord_adapter.emit_state`` now reads the UI's
+  snapshot under ``_ws_lock`` via the new
+  :meth:`SessionUIBase.snapshot_and_consume_state_payload` helper
+  and passes the rich kwargs through to
+  ``collector.emit_console_ws_state``; the cluster dashboard's
+  coord rows now render with the same tokens / activity / content /
+  context_ratio fields interactive rows do.
+
+  Three observable behaviour changes (all CHANGELOG-callout-worthy):
+
+  - **Coord persists ``usage_event`` storage rows.** Pre-lift only
+    WebUI did. The lifted ``on_status`` body unifies usage tracking
+    so governance dashboards / token-spend queries see coordinator
+    consumption alongside interactive. Operators querying
+    ``usage_event`` by ``ws_id`` will see coord rows for the first
+    time.
+  - **Coord broadcasts live activity transitions.** New
+    ``collector.emit_console_ws_activity(ws_id, *, activity,
+    activity_state)`` method. The cluster dashboard's per-ws
+    polling reads the in-memory pseudo-node row, so activity ticks
+    land on the next snapshot fetch (matches WebUI's behaviour
+    where activity events are observational; not fanned out
+    through the cluster SSE stream).
+  - **Cluster ``cluster_state`` events for coord rows now carry
+    non-zero ``tokens`` / ``content`` fields.** Frontend rendering
+    that conditionally hid these on coord rows can drop the
+    branch.
+
+  Architecture changes:
+
+  - ``_MAX_TURN_CONTENT_CHARS`` moved from ``turnstone.server`` to
+    ``turnstone.core.session_ui_base`` so coord enforces the same
+    per-turn content cap interactive does.
+  - WebUI keeps ``on_status`` / ``on_tool_result`` / ``on_error``
+    overrides that layer Prometheus ``_metrics.record_*`` calls
+    (node-only) on top of the shared body via ``super()`` — the
+    Prometheus surface stays node-scoped (the console isn't a
+    node and has no /metrics endpoint).
+  - ``ConsoleCoordinatorUI`` adds a ``_broadcast_activity``
+    override that fans out via the cluster collector instead of
+    the global SSE queue (which is node-only on interactive).
+  - ``coord_endpoint_config`` wires a new ``_coord_spawn_metrics``
+    hook (mirrors interactive's) so the per-spawn ``_ws_messages``
+    increment + ``_ws_turn_tool_calls`` reset happen on coord too.
+
+  Test additions: 23 new tests in ``tests/test_coord_rich_ws_state_payload.py``
+  pin the per-ws metric writes (status, content accumulation,
+  activity tracking, tool-result counters, stream-end activity
+  clear), the snapshot helper's IDLE/ERROR drain semantics +
+  single-lock-acquisition guarantee, the adapter's rich-payload
+  pass-through + defensive None-UI handling, the activity
+  broadcast (collector wire + failure swallow + no-op-when-
+  collector-unset + dedup against last-emitted state), the
+  spawn_metrics hook, and a concurrent-writes-during-snapshot
+  stress case (cycles through running / idle / error so the
+  drain branches actually run against a concurrent writer).
+  Plus WebUI-override regression tests confirming
+  ``_metrics.record_*`` still fires on top of the lifted bodies.
+  Existing ``tests/test_webui_content.py`` updated to import
+  ``_MAX_TURN_CONTENT_CHARS`` from its new home in
+  ``turnstone.core.session_ui_base``;
+  ``tests/test_coordinator_adapter.py`` updated to expect the
+  rich-payload kwargs (``tokens=0`` defaults) on
+  ``emit_console_ws_state``.
+
+  Two deferred follow-ups (out-of-scope for this lift,
+  flagged for tracking):
+
+  - **Synchronous ``record_usage_event`` INSERT on coord worker
+    thread.** The lifted ``on_status`` body persists usage rows on
+    every provider response — same shape WebUI uses, but coord
+    workers can fire multi-step plan/task agent loops where each
+    response blocks the worker for a write transaction. Parity
+    with WebUI is the explicit goal here; if coord throughput
+    becomes a concern, batch usage_event writes onto a background
+    flusher thread (one batch INSERT per N events / per K ms) on
+    both kinds.
+  - **Coord assistant turn content now flows on the cluster SSE
+    stream (``/v1/api/cluster/events``).** Pre-lift the broadcast
+    was ``content=""``; post-lift it carries the joined assistant
+    output. The cluster SSE stream has no per-user filter today —
+    extends an existing cross-tenant exposure (interactive
+    ``cluster_state`` events already carry content) to a
+    previously-empty channel (coord rows). Proper fix needs the
+    SSE endpoint gated on ``admin.cluster.inspect`` (matching
+    ``/v1/api/cluster/ws/{ws_id}/detail``) or per-listener
+    user_id filtering. Tracked as a separate security-tightening
+    project; not gating this lift since it inherits an existing
+    exposure rather than introducing a new mechanism.
+
 - **`history` / `detail` verb bodies lifted across both kinds**
   ([Stage 2 Verb Lift — `history` / `detail`]). The coord
   ``GET /v1/api/workstreams/{ws_id}/history`` and

--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -1,0 +1,542 @@
+"""Tests for the rich ``ws_state`` payload on coord (Stage 2 follow-up).
+
+Pre-lift coord's ``ConsoleCoordinatorUI`` populated none of the per-ws
+metric fields ``SessionUIBase`` defines (``_ws_prompt_tokens`` /
+``_ws_context_ratio`` / ``_ws_current_activity`` / ``_ws_turn_content``)
+and the ``coord_adapter.emit_state`` broadcast was state-only —
+``tokens=0`` / ``content=""`` were hardcoded into
+``collector.emit_console_ws_state``. The lift turned ``on_status`` /
+``on_content_token`` / ``on_thinking_*`` / ``on_tool_result`` into
+shared bodies on :class:`SessionUIBase` so coord populates the same
+fields, then enriched ``coord_adapter.emit_state`` to read them under
+lock and pass through to the cluster collector with the rich kwargs.
+The cluster dashboard's coord rows now render with the same
+tokens / activity / content / context_ratio fields interactive rows do.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
+from turnstone.core.session_ui_base import _MAX_TURN_CONTENT_CHARS
+from turnstone.core.workstream import WorkstreamState
+
+# ---------------------------------------------------------------------------
+# Per-ws metric writes — lifted to SessionUIBase, both subclasses inherit
+# ---------------------------------------------------------------------------
+
+
+def _patch_get_storage(storage: Any):
+    return patch("turnstone.core.storage._registry.get_storage", return_value=storage)
+
+
+def test_coord_on_status_writes_per_ws_metrics() -> None:
+    """Pre-lift coord ``on_status`` was an enqueue-only stub — ``_ws_*``
+    fields stayed at their initial zero values regardless of token usage.
+    Post-lift coord inherits SessionUIBase's body, so token counters and
+    context ratio populate just like interactive."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    with _patch_get_storage(MagicMock()):
+        ui.on_status(
+            {"prompt_tokens": 100, "completion_tokens": 50},
+            context_window=1000,
+            effort="medium",
+        )
+    assert ui._ws_prompt_tokens == 100
+    assert ui._ws_completion_tokens == 50
+    assert ui._ws_context_ratio == pytest.approx(0.15)
+
+
+def test_coord_on_status_persists_usage_event() -> None:
+    """Pre-lift coord didn't persist usage_event rows — only WebUI did.
+    Lift extends usage tracking to coord so governance dashboards see
+    coordinator token consumption alongside interactive."""
+    storage = MagicMock()
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    with _patch_get_storage(storage):
+        ui.on_status(
+            {"prompt_tokens": 7, "completion_tokens": 3, "model": "gpt-x"},
+            context_window=200,
+            effort="low",
+        )
+    storage.record_usage_event.assert_called_once()
+    kwargs = storage.record_usage_event.call_args.kwargs
+    assert kwargs["ws_id"] == "coord-ws"
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["model"] == "gpt-x"
+    assert kwargs["prompt_tokens"] == 7
+    assert kwargs["completion_tokens"] == 3
+
+
+def test_coord_on_content_token_accumulates() -> None:
+    """Pre-lift coord ``on_content_token`` only enqueued; lift turns it
+    into the same per-ws accumulator WebUI uses so the collector
+    broadcast can piggyback the joined turn content on the IDLE
+    state-change event."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui.on_content_token("Hello ")
+    ui.on_content_token("world")
+    assert ui._ws_turn_content == ["Hello ", "world"]
+    assert ui._ws_turn_content_size == len("Hello world")
+
+
+def test_coord_on_content_token_caps_at_ceiling() -> None:
+    """Same content cap interactive enforces — keeps a runaway turn from
+    ballooning the cluster broadcast event past listener queue size."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    chunk = "x" * 1024
+    rounds = (_MAX_TURN_CONTENT_CHARS // 1024) + 50
+    for _ in range(rounds):
+        ui.on_content_token(chunk)
+    # Cap is enforced at the size check; one over-cap chunk still
+    # gets in (per the original ``< _MAX``-not-``<=`` semantics) but
+    # nothing past that lands.
+    assert ui._ws_turn_content_size <= _MAX_TURN_CONTENT_CHARS + 1024
+
+
+def test_coord_on_thinking_start_sets_activity() -> None:
+    """Live activity tracking — coord's dashboard row now flips
+    ``activity_state`` to ``"thinking"`` when the model starts."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui.on_thinking_start()
+    assert ui._ws_current_activity == "Thinking…"
+    assert ui._ws_activity_state == "thinking"
+
+
+def test_coord_on_tool_result_clears_activity_and_increments_counters() -> None:
+    """Lifted ``on_tool_result`` body increments ``_ws_tool_calls`` /
+    ``_ws_turn_tool_calls`` and clears the activity. Pre-lift coord
+    just enqueued without touching counters."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui._ws_current_activity = "⚙ bash: ls -la"
+    ui._ws_activity_state = "tool"
+    ui.on_tool_result("call-1", "bash", "output")
+    assert ui._ws_tool_calls == {"bash": 1}
+    assert ui._ws_turn_tool_calls == 1
+    assert ui._ws_current_activity == ""
+    assert ui._ws_activity_state == ""
+
+
+# ---------------------------------------------------------------------------
+# Snapshot helper — drains turn content on IDLE/ERROR
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_idle_returns_content_and_clears_accumulator() -> None:
+    """IDLE snapshot piggybacks the joined assistant content onto the
+    state-change broadcast (so the dashboard renders the turn without
+    a storage round-trip), then clears the accumulator for the next
+    turn."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui.on_content_token("Here's ")
+    ui.on_content_token("the result.")
+    payload = ui.snapshot_and_consume_state_payload("idle")
+    assert payload["content"] == "Here's the result."
+    assert ui._ws_turn_content == []
+    assert ui._ws_turn_content_size == 0
+
+
+def test_snapshot_error_clears_accumulator_without_emitting_content() -> None:
+    """ERROR clears the partial content (the turn's broken; nothing to
+    render) but the broadcast itself doesn't carry it — the state
+    transition is what matters."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui.on_content_token("partial...")
+    payload = ui.snapshot_and_consume_state_payload("error")
+    assert payload["content"] == ""
+    assert ui._ws_turn_content == []
+
+
+def test_snapshot_thinking_does_not_touch_accumulator() -> None:
+    """Mid-turn state transitions (running / thinking / attention)
+    don't drain the accumulator — only IDLE / ERROR are terminal."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui.on_content_token("partial mid-turn")
+    payload = ui.snapshot_and_consume_state_payload("thinking")
+    assert payload["content"] == ""
+    # Accumulator preserved.
+    assert ui._ws_turn_content == ["partial mid-turn"]
+
+
+def test_snapshot_carries_token_and_activity_snapshot() -> None:
+    """Snapshot reads tokens / context_ratio / activity under one lock
+    acquisition so concurrent on_status / on_thinking_start writes
+    don't tear the snapshot."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    with _patch_get_storage(MagicMock()):
+        ui.on_status(
+            {"prompt_tokens": 80, "completion_tokens": 20},
+            context_window=400,
+            effort="medium",
+        )
+    ui.on_thinking_start()  # sets activity = "Thinking…"
+    payload = ui.snapshot_and_consume_state_payload("running")
+    assert payload["tokens"] == 100
+    assert payload["context_ratio"] == pytest.approx(0.25)
+    assert payload["activity"] == "Thinking…"
+    assert payload["activity_state"] == "thinking"
+
+
+# ---------------------------------------------------------------------------
+# Coord adapter — passes rich payload to collector
+# ---------------------------------------------------------------------------
+
+
+class _FakeCollectorRecorder:
+    """Captures emit_console_ws_state calls so we can assert on the
+    rich kwargs the lifted coord_adapter.emit_state passes through."""
+
+    def __init__(self) -> None:
+        self.state_calls: list[dict[str, Any]] = []
+        self.activity_calls: list[dict[str, Any]] = []
+
+    def emit_console_ws_state(
+        self,
+        ws_id: str,
+        state: str,
+        *,
+        tokens: int = 0,
+        context_ratio: float = 0.0,
+        activity: str = "",
+        activity_state: str = "",
+        content: str = "",
+    ) -> None:
+        self.state_calls.append(
+            {
+                "ws_id": ws_id,
+                "state": state,
+                "tokens": tokens,
+                "context_ratio": context_ratio,
+                "activity": activity,
+                "activity_state": activity_state,
+                "content": content,
+            }
+        )
+
+    def update_console_ws_activity(self, ws_id: str, *, activity: str, activity_state: str) -> None:
+        self.activity_calls.append(
+            {"ws_id": ws_id, "activity": activity, "activity_state": activity_state}
+        )
+
+    def emit_console_ws_created(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    def emit_console_ws_closed(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    def emit_console_ws_rename(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    def ensure_console_pseudo_node(self) -> None:
+        pass
+
+
+def _build_adapter_and_ws(ws_id: str = "coord-ws-1") -> tuple[Any, Any, _FakeCollectorRecorder]:
+    """Construct a minimal adapter + Workstream + UI for emit_state tests.
+
+    Skips the full SessionManager wire-up — the adapter's ``emit_state``
+    only reads ``ws.id`` and ``ws.ui``, so a real ``Workstream`` with
+    a populated ``ConsoleCoordinatorUI`` is enough.
+    """
+    from turnstone.console.coordinator_adapter import CoordinatorAdapter
+    from turnstone.core.workstream import Workstream
+
+    recorder = _FakeCollectorRecorder()
+    adapter = CoordinatorAdapter(
+        collector=recorder,  # type: ignore[arg-type]
+        ui_factory=lambda ws: ConsoleCoordinatorUI(ws_id=ws.id, user_id=ws.user_id),
+        session_factory=lambda ws: MagicMock(),
+    )
+    ws = Workstream(id=ws_id, user_id="u1", name="my-coord")
+    ws.ui = ConsoleCoordinatorUI(ws_id=ws_id, user_id="u1")
+    return adapter, ws, recorder
+
+
+def test_coord_adapter_emit_state_passes_rich_payload_to_collector() -> None:
+    """Pre-lift coord_adapter.emit_state called collector with state-only;
+    post-lift it reads the UI's per-ws snapshot under lock and passes
+    tokens / context_ratio / activity / content kwargs through."""
+    adapter, ws, recorder = _build_adapter_and_ws()
+    with _patch_get_storage(MagicMock()):
+        ws.ui.on_status(
+            {"prompt_tokens": 60, "completion_tokens": 40},
+            context_window=400,
+            effort="medium",
+        )
+    ws.ui.on_content_token("partial answer")
+    ws.ui.on_thinking_start()
+    adapter.emit_state(ws, WorkstreamState.RUNNING)
+    assert len(recorder.state_calls) == 1
+    call = recorder.state_calls[0]
+    assert call["ws_id"] == ws.id
+    assert call["state"] == "running"
+    assert call["tokens"] == 100
+    assert call["context_ratio"] == pytest.approx(0.25)
+    assert call["activity"] == "Thinking…"
+    assert call["activity_state"] == "thinking"
+    # Mid-turn (RUNNING) — content stays accumulated for the eventual IDLE drain.
+    assert call["content"] == ""
+
+
+def test_coord_adapter_emit_state_idle_drains_content() -> None:
+    """IDLE state-change drains the turn-content accumulator and
+    piggybacks the joined content on the broadcast — same shape WebUI
+    uses on global_queue. Subsequent emit_state must see the
+    accumulator cleared."""
+    adapter, ws, recorder = _build_adapter_and_ws()
+    ws.ui.on_content_token("Here's ")
+    ws.ui.on_content_token("the result.")
+    adapter.emit_state(ws, WorkstreamState.IDLE)
+    assert len(recorder.state_calls) == 1
+    assert recorder.state_calls[0]["content"] == "Here's the result."
+    # Accumulator drained — next emit_state sees nothing carried over.
+    adapter.emit_state(ws, WorkstreamState.IDLE)
+    assert recorder.state_calls[1]["content"] == ""
+
+
+def test_coord_adapter_emit_state_handles_missing_ui_defensively() -> None:
+    """``ws.ui`` can be ``None`` mid-eviction; emit_state still
+    broadcasts the state-change with empty rich fields so the
+    dashboard's coord row still flips state instead of going stale."""
+    adapter, ws, recorder = _build_adapter_and_ws()
+    ws.ui = None  # simulate teardown race
+    adapter.emit_state(ws, WorkstreamState.RUNNING)
+    assert len(recorder.state_calls) == 1
+    call = recorder.state_calls[0]
+    assert call["state"] == "running"
+    assert call["tokens"] == 0
+    assert call["content"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Coord activity broadcast — UI fans out directly to the collector
+# ---------------------------------------------------------------------------
+
+
+def test_coord_ui_broadcast_activity_calls_collector() -> None:
+    """Live activity transitions on coord (between state changes) reach
+    the cluster collector via the new ``update_console_ws_activity``
+    method. WebUI's analog goes via the global SSE queue; coord's
+    UI calls the collector directly since the console isn't a node."""
+    recorder = _FakeCollectorRecorder()
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ConsoleCoordinatorUI._collector = recorder  # type: ignore[assignment]
+    try:
+        ui.on_thinking_start()  # base impl calls _broadcast_activity
+        assert len(recorder.activity_calls) == 1
+        call = recorder.activity_calls[0]
+        assert call["ws_id"] == "coord-ws"
+        assert call["activity"] == "Thinking…"
+        assert call["activity_state"] == "thinking"
+    finally:
+        ConsoleCoordinatorUI._collector = None
+
+
+def test_coord_ui_broadcast_activity_swallows_collector_failure() -> None:
+    """A flaky collector must NOT block the worker thread — activity
+    fan-out is observational, the worker keeps running on collector
+    failure."""
+    recorder = MagicMock()
+    recorder.update_console_ws_activity.side_effect = RuntimeError("collector dead")
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ConsoleCoordinatorUI._collector = recorder
+    try:
+        ui.on_thinking_start()  # must not raise
+        recorder.update_console_ws_activity.assert_called_once()
+    finally:
+        ConsoleCoordinatorUI._collector = None
+
+
+def test_coord_ui_broadcast_activity_no_op_when_collector_unset() -> None:
+    """Tests / tooling that don't wire a collector shouldn't crash."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ConsoleCoordinatorUI._collector = None
+    ui.on_thinking_start()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Spawn metrics — coord wires its own hook
+# ---------------------------------------------------------------------------
+
+
+def test_coord_spawn_metrics_increments_messages_and_resets_tool_count() -> None:
+    """Coord's ``_coord_spawn_metrics`` mirrors interactive's per-spawn
+    counter writes (sans the Prometheus call) so the rich ``ws_state``
+    broadcast renders the same per-turn shape."""
+    from turnstone.console.server import _coord_spawn_metrics
+
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui._ws_messages = 5
+    ui._ws_turn_tool_calls = 3
+    _coord_spawn_metrics(MagicMock(), ui)
+    assert ui._ws_messages == 6
+    assert ui._ws_turn_tool_calls == 0
+
+
+def test_coord_spawn_metrics_tolerates_ui_without_counters() -> None:
+    """A SessionUI subclass without the per-ws counters shouldn't trip
+    the hook — defensive guard mirrors the interactive analog."""
+    from turnstone.console.server import _coord_spawn_metrics
+
+    class _StubUI:
+        pass
+
+    _coord_spawn_metrics(MagicMock(), _StubUI())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Snapshot lock — single-acquisition guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_acquires_ws_lock_exactly_once() -> None:
+    """Snapshot must read all four fields under a single lock acquisition
+    so concurrent on_status / on_thinking_start writes can't tear the
+    payload."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    acquire_count = 0
+    inner = ui._ws_lock
+
+    class _CountingLock:
+        def __enter__(self) -> None:
+            nonlocal acquire_count
+            acquire_count += 1
+            inner.acquire()
+
+        def __exit__(self, *a: Any) -> None:
+            inner.release()
+
+        def acquire(self, *a: Any, **kw: Any) -> bool:
+            return inner.acquire(*a, **kw)
+
+        def release(self) -> None:
+            inner.release()
+
+    ui._ws_lock = _CountingLock()  # type: ignore[assignment]
+    ui.snapshot_and_consume_state_payload("idle")
+    assert acquire_count == 1, (
+        f"snapshot acquired _ws_lock {acquire_count} times; concurrent "
+        "writes could tear the rich payload"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — snapshot under load
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_under_concurrent_writes_does_not_crash() -> None:
+    """Sanity stress: snapshot reads while on_status / on_thinking_start /
+    on_content_token write concurrently. Reader cycles through
+    ``("running", "idle", "error")`` so the IDLE/ERROR drain branches
+    that mutate ``_ws_turn_content`` actually get exercised against
+    concurrent appends — running-only would only hit the read-only
+    snapshot path. Each thread's exception (if any) is captured + raised
+    on join so a silent worker crash can't slip through as a bare
+    deadlock-check pass."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    writer_exc: list[BaseException] = []
+    reader_exc: list[BaseException] = []
+
+    def _writer() -> None:
+        try:
+            with _patch_get_storage(MagicMock()):
+                for i in range(50):
+                    ui.on_status(
+                        {"prompt_tokens": i, "completion_tokens": i},
+                        context_window=1000,
+                        effort="low",
+                    )
+                    ui.on_content_token(f"chunk-{i}")
+                    ui.on_thinking_start()
+        except BaseException as exc:  # noqa: BLE001 — surface to main thread
+            writer_exc.append(exc)
+
+    def _reader() -> None:
+        try:
+            states = ("running", "idle", "error")
+            for i in range(50):
+                ui.snapshot_and_consume_state_payload(states[i % len(states)])
+        except BaseException as exc:  # noqa: BLE001 — surface to main thread
+            reader_exc.append(exc)
+
+    writer = threading.Thread(target=_writer)
+    reader = threading.Thread(target=_reader)
+    writer.start()
+    reader.start()
+    writer.join(timeout=5)
+    reader.join(timeout=5)
+    assert not writer.is_alive(), "writer thread deadlocked"
+    assert not reader.is_alive(), "reader thread deadlocked"
+    assert not writer_exc, f"writer raised: {writer_exc[0]!r}"
+    assert not reader_exc, f"reader raised: {reader_exc[0]!r}"
+
+
+def test_coord_on_stream_end_clears_activity() -> None:
+    """Lifted ``on_stream_end`` body clears ``_ws_current_activity``
+    and ``_ws_activity_state`` so the dashboard's coord row stops
+    showing the stale 'Thinking…' indicator after the stream
+    finishes. Pre-lift coord just enqueued ``stream_end`` without
+    touching activity — this test pins the new clear path so a
+    future re-stub doesn't silently re-introduce a stuck activity
+    indicator."""
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ui._ws_current_activity = "Thinking…"
+    ui._ws_activity_state = "thinking"
+    ui.on_stream_end()
+    assert ui._ws_current_activity == ""
+    assert ui._ws_activity_state == ""
+
+
+# ---------------------------------------------------------------------------
+# WebUI override semantics still preserved
+# ---------------------------------------------------------------------------
+
+
+def test_webui_on_status_still_records_prometheus_metrics() -> None:
+    """The lift moves the per-ws writes to SessionUIBase but WebUI's
+    override must still fire ``_metrics.record_*`` (Prometheus on the
+    node /metrics endpoint). Regression guard against a future refactor
+    accidentally dropping the override."""
+    import queue
+
+    from turnstone.server import WebUI
+
+    WebUI._global_queue = queue.Queue()
+    try:
+        ui = WebUI(ws_id="ws-int", user_id="u1")
+        with patch("turnstone.server._metrics") as mock_metrics, _patch_get_storage(MagicMock()):
+            ui.on_status(
+                {"prompt_tokens": 10, "completion_tokens": 5},
+                context_window=200,
+                effort="low",
+            )
+        mock_metrics.record_tokens.assert_called_once_with(10, 5)
+        mock_metrics.record_cache_tokens.assert_called_once()
+        mock_metrics.record_context_ratio.assert_called_once()
+    finally:
+        WebUI._global_queue = None
+
+
+def test_webui_on_tool_result_still_records_prometheus_tool_call() -> None:
+    """Same as above for ``on_tool_result``."""
+    import queue
+
+    from turnstone.server import WebUI
+
+    WebUI._global_queue = queue.Queue()
+    try:
+        ui = WebUI(ws_id="ws-int", user_id="u1")
+        with patch("turnstone.server._metrics") as mock_metrics:
+            ui.on_tool_result("call-1", "bash", "output")
+        mock_metrics.record_tool_call.assert_called_once_with("bash")
+        # Per-ws counter writes happened too (inherited from base).
+        assert ui._ws_tool_calls == {"bash": 1}
+        assert ui._ws_turn_tool_calls == 1
+    finally:
+        WebUI._global_queue = None

--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -359,6 +359,63 @@ def test_coord_ui_broadcast_activity_no_op_when_collector_unset() -> None:
     ui.on_thinking_start()  # must not raise
 
 
+def test_coord_ui_broadcast_activity_failure_does_not_strand_dedup() -> None:
+    """Regression for the Copilot finding on PR #420: post-fix the
+    dedup state ``_last_broadcast_activity`` is updated **only after**
+    a successful collector call. If the collector raises mid-broadcast
+    on tick #1, tick #2 with the same activity tuple must still
+    attempt the broadcast (otherwise a transient collector failure
+    would strand the dashboard's coord row at the pre-failure
+    activity until the activity actually changes). Pre-fix the
+    dedup state was assigned inside the lock before the collector
+    call, so the failed broadcast still updated it and tick #2
+    silently no-op'd."""
+    recorder = MagicMock()
+    # First call fails (transient collector outage); second call succeeds.
+    recorder.update_console_ws_activity.side_effect = [
+        RuntimeError("collector dead"),
+        None,
+    ]
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ConsoleCoordinatorUI._collector = recorder
+    try:
+        # Tick #1 — collector raises; dedup state must NOT update.
+        ui.on_thinking_start()
+        assert ui._last_broadcast_activity is None, (
+            "dedup state was updated despite a failed collector call — "
+            "next identical tick would be silently suppressed"
+        )
+        # Tick #2 — same activity tuple. Pre-fix this would no-op
+        # (because dedup state was already (Thinking…, thinking)).
+        # Post-fix it retries; collector succeeds; dedup state lands.
+        ui.on_thinking_start()
+        assert recorder.update_console_ws_activity.call_count == 2, (
+            "second tick was deduped despite the first call failing"
+        )
+        assert ui._last_broadcast_activity == ("Thinking…", "thinking")
+    finally:
+        ConsoleCoordinatorUI._collector = None
+
+
+def test_coord_ui_broadcast_activity_dedup_skips_identical_after_success() -> None:
+    """Happy-path dedup: after a successful broadcast, the next identical
+    tick is deduped — the cluster collector lock is not re-acquired
+    for a no-op write. This is the perf optimization the dedup is
+    there for; the regression test above checks the failure-recovery
+    invariant doesn't break it."""
+    recorder = MagicMock()
+    ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
+    ConsoleCoordinatorUI._collector = recorder
+    try:
+        ui.on_thinking_start()  # tick 1 — fires
+        ui.on_thinking_start()  # tick 2 — same tuple, deduped
+        ui.on_thinking_start()  # tick 3 — same tuple, deduped
+        assert recorder.update_console_ws_activity.call_count == 1
+        assert ui._last_broadcast_activity == ("Thinking…", "thinking")
+    finally:
+        ConsoleCoordinatorUI._collector = None
+
+
 # ---------------------------------------------------------------------------
 # Spawn metrics — coord wires its own hook
 # ---------------------------------------------------------------------------
@@ -440,8 +497,8 @@ def test_snapshot_under_concurrent_writes_does_not_crash() -> None:
     on join so a silent worker crash can't slip through as a bare
     deadlock-check pass."""
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
-    writer_exc: list[BaseException] = []
-    reader_exc: list[BaseException] = []
+    writer_exc: list[Exception] = []
+    reader_exc: list[Exception] = []
 
     def _writer() -> None:
         try:
@@ -454,7 +511,7 @@ def test_snapshot_under_concurrent_writes_does_not_crash() -> None:
                     )
                     ui.on_content_token(f"chunk-{i}")
                     ui.on_thinking_start()
-        except BaseException as exc:  # noqa: BLE001 — surface to main thread
+        except Exception as exc:  # noqa: BLE001 — surface to main thread
             writer_exc.append(exc)
 
     def _reader() -> None:
@@ -462,7 +519,7 @@ def test_snapshot_under_concurrent_writes_does_not_crash() -> None:
             states = ("running", "idle", "error")
             for i in range(50):
                 ui.snapshot_and_consume_state_payload(states[i % len(states)])
-        except BaseException as exc:  # noqa: BLE001 — surface to main thread
+        except Exception as exc:  # noqa: BLE001 — surface to main thread
             reader_exc.append(exc)
 
     writer = threading.Thread(target=_writer)

--- a/tests/test_coordinator_adapter.py
+++ b/tests/test_coordinator_adapter.py
@@ -88,11 +88,21 @@ def test_emit_created_calls_collector_with_coord_fields() -> None:
 
 
 def test_emit_state_calls_collector_state() -> None:
+    """Post-rich-payload, emit_state passes tokens / context_ratio /
+    activity / activity_state / content kwargs read from ws.ui's
+    snapshot. Default values (zeros / empty strings) when the UI
+    hasn't recorded any per-ws metrics yet."""
     adapter, collector = _make_adapter()
     ws = _make_ws()
     adapter.emit_state(ws, WorkstreamState.RUNNING)
     collector.emit_console_ws_state.assert_called_once_with(
-        "coord-1", WorkstreamState.RUNNING.value
+        "coord-1",
+        WorkstreamState.RUNNING.value,
+        tokens=0,
+        context_ratio=0.0,
+        activity="",
+        activity_state="",
+        content="",
     )
 
 

--- a/tests/test_webui_content.py
+++ b/tests/test_webui_content.py
@@ -137,7 +137,9 @@ class TestContentAccumulation:
 
     def test_content_cap_prevents_unbounded_growth(self):
         """Content exceeding the cap should stop accumulating."""
-        from turnstone.server import _MAX_TURN_CONTENT_CHARS
+        # Constant lifted from turnstone.server to turnstone.core.session_ui_base
+        # in the rich ws_state payload work so coord enforces the same ceiling.
+        from turnstone.core.session_ui_base import _MAX_TURN_CONTENT_CHARS
 
         ui = _make_ui()
         # Fill to capacity

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -1094,14 +1094,35 @@ class ClusterCollector:
             node.workstreams.pop(ws_id, None)
         self._fanout({"type": "ws_closed", "ws_id": ws_id})
 
-    def emit_console_ws_state(self, ws_id: str, state: str) -> None:
+    def emit_console_ws_state(
+        self,
+        ws_id: str,
+        state: str,
+        *,
+        tokens: int = 0,
+        context_ratio: float = 0.0,
+        activity: str = "",
+        activity_state: str = "",
+        content: str = "",
+    ) -> None:
         """Update the coordinator row's state on the console pseudo-node + fan out.
 
-        Coordinators don't surface live-token counts the way real-node
-        workstreams do (the collector reads aggregate tokens from the
-        node's ``/v1/api/dashboard`` feed, which the console doesn't
-        expose).  Emit state transitions only — downstream rendering
-        gracefully handles the absent ``tokens`` field.
+        The keyword args carry the rich-payload snapshot the cluster
+        dashboard renders for both kinds (matches the interactive
+        ``ws_state`` event shape the SSE relay produces in
+        :meth:`_apply_delta`). Pre-rich-payload coord broadcast was
+        state-only with ``tokens=0`` / ``content=""`` hardcoded —
+        the dashboard's coord row showed the state column updating
+        but no token count, no activity, no per-turn content. With
+        the lift, all four populate (per the per-ws metric writes
+        :class:`ConsoleCoordinatorUI` inherits from
+        :class:`SessionUIBase`), so coord rows match interactive in
+        the cluster overview.
+
+        Defaults are kept so :class:`turnstone.console.coordinator_adapter.CoordinatorAdapter`
+        is the only production caller wiring the rich kwargs; tests
+        and any future call site can stay state-only without
+        breaking.
         """
         with self._lock:
             node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
@@ -1111,18 +1132,60 @@ class ClusterCollector:
             if entry is None:
                 return
             entry["state"] = state
+            entry["tokens"] = tokens
+            entry["context_ratio"] = context_ratio
+            entry["activity"] = activity
+            entry["activity_state"] = activity_state
         self._fanout(
             {
                 "type": "cluster_state",
                 "ws_id": ws_id,
                 "state": state,
                 "node_id": self.CONSOLE_PSEUDO_NODE_ID,
-                "tokens": 0,
-                "content": "",
+                "tokens": tokens,
+                "content": content,
                 "kind": WorkstreamKind.COORDINATOR.value,
                 "parent_ws_id": None,
             }
         )
+
+    def update_console_ws_activity(
+        self,
+        ws_id: str,
+        *,
+        activity: str,
+        activity_state: str,
+    ) -> None:
+        """Update a coord row's live activity transition (no fan-out).
+
+        Mirrors :meth:`_apply_delta`'s ``ws_activity`` handler for
+        real-node workstreams: writes the in-memory pseudo-node
+        entry but does NOT fan out a separate event over the cluster
+        SSE stream (interactive doesn't either — activity is
+        snapshot data piggybacked on subsequent state-change
+        broadcasts). The dashboard's per-ws polling reads the
+        in-memory row, so live activity ticks land on the next
+        snapshot fetch even without a dedicated SSE event.
+
+        Named ``update_*`` rather than ``emit_*`` to flag the
+        no-fan-out asymmetry vs. the rest of the
+        ``emit_console_ws_*`` family (``_created`` / ``_closed`` /
+        ``_state`` / ``_rename`` all call ``self._fanout`` — this
+        one doesn't).
+
+        Best-effort: drop silently if the pseudo-node or the row
+        isn't present (e.g. activity tick arrives between row pop
+        and listener re-registration during evict).
+        """
+        with self._lock:
+            node = self._nodes.get(self.CONSOLE_PSEUDO_NODE_ID)
+            if node is None:
+                return
+            entry = node.workstreams.get(ws_id)
+            if entry is None:
+                return
+            entry["activity"] = activity
+            entry["activity_state"] = activity_state
 
     def emit_console_ws_rename(self, ws_id: str, name: str) -> None:
         """Rename the coordinator row + fan out ``ws_rename``."""

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -146,8 +146,41 @@ class CoordinatorAdapter:
             log.debug("coord_adapter.created_fanout_failed ws=%s", ws.id[:8], exc_info=True)
 
     def emit_state(self, ws: Workstream, state: WorkstreamState) -> None:
+        """Fan a state-change with the rich payload snapshot to the collector.
+
+        Reads tokens / context_ratio / activity / content from
+        ``ws.ui`` via the lifted :meth:`SessionUIBase.snapshot_and_consume_state_payload`
+        helper (which handles the IDLE/ERROR ``_ws_turn_content``
+        consume + clear under ``_ws_lock``). Pre-rich-payload this
+        broadcast was state-only; the dashboard's coord row now
+        renders the same tokens / activity / content fields
+        interactive rows do.
+
+        Defensive: ``ws.ui`` can be ``None`` mid-eviction; in that
+        case we still broadcast the state-change with empty rich
+        fields so the dashboard's coord row still flips state.
+        """
+        ui = ws.ui
+        if ui is not None and hasattr(ui, "snapshot_and_consume_state_payload"):
+            payload = ui.snapshot_and_consume_state_payload(state.value)
+        else:
+            payload = {
+                "tokens": 0,
+                "context_ratio": 0.0,
+                "activity": "",
+                "activity_state": "",
+                "content": "",
+            }
         try:
-            self._collector.emit_console_ws_state(ws.id, state.value)
+            self._collector.emit_console_ws_state(
+                ws.id,
+                state.value,
+                tokens=payload["tokens"],
+                context_ratio=payload["context_ratio"],
+                activity=payload["activity"],
+                activity_state=payload["activity_state"],
+                content=payload["content"],
+            )
         except Exception:
             log.debug("coord_adapter.state_fanout_failed ws=%s", ws.id[:8], exc_info=True)
 

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -2,14 +2,26 @@
 
 Mirrors ``turnstone.server.WebUI`` but scoped to the console's needs:
 
-- Per-session SSE listener fan-out (same ``threading.Lock`` + queue list
-  pattern as WebUI).
+- Per-session SSE listener fan-out (inherited from
+  :class:`SessionUIBase` — same ``threading.Lock`` + queue list
+  pattern WebUI uses).
 - ``threading.Event`` + ``_approval_result`` / ``_plan_result`` for
   blocking the worker thread until a console endpoint delivers the
-  decision.
-- No global broadcast channel and no per-node metrics — the console is
-  not a node.  Dashboard aggregation for coordinator sessions lands in
-  Phase D; here we only emit events the one-pane UI consumes.
+  decision (inherited).
+- Per-ws metric tracking + turn-content accumulator + activity
+  bookkeeping (inherited from :class:`SessionUIBase` post the rich
+  ``ws_state`` payload lift). Coord populates the same
+  ``_ws_prompt_tokens`` / ``_ws_context_ratio`` /
+  ``_ws_current_activity`` fields interactive does, and
+  ``coord_adapter.emit_state`` reads them under lock to broadcast
+  the rich payload to the cluster collector.
+- No global SSE broadcast channel — the console isn't a node and
+  has no ``/v1/api/events/global`` analog. State + activity
+  broadcasts route through the cluster collector instead
+  (``coord_adapter.emit_state`` for state changes;
+  :meth:`_broadcast_activity` override for live activity ticks).
+- No per-node Prometheus metrics — the console has no /metrics
+  endpoint. WebUI's ``_metrics.record_*`` calls don't apply here.
 
 Contract: this class must conform to :class:`turnstone.core.session.SessionUI`.
 """
@@ -59,22 +71,19 @@ class ConsoleCoordinatorUI(SessionUIBase):
 
     # ------------------------------------------------------------------
     # SessionUI protocol — streaming
+    #
+    # ``on_thinking_start`` / ``on_thinking_stop`` / ``on_reasoning_token``
+    # / ``on_content_token`` / ``on_stream_end`` / ``on_tool_output_chunk``
+    # / ``on_tool_result`` / ``on_status`` / ``on_info`` / ``on_error``
+    # are inherited from :class:`SessionUIBase`. The lifted bodies do
+    # the per-ws metric writes the rich ``ws_state`` cluster broadcast
+    # reads (``_ws_prompt_tokens`` / ``_ws_context_ratio`` /
+    # ``_ws_current_activity`` / ``_ws_turn_content``); the cluster
+    # collector then renders coord rows on the dashboard with the same
+    # tokens / activity / content fields interactive rows have. Pre-lift
+    # coord populated none of these — the dashboard's coord row showed
+    # state-only.
     # ------------------------------------------------------------------
-
-    def on_thinking_start(self) -> None:
-        self._enqueue({"type": "thinking_start"})
-
-    def on_thinking_stop(self) -> None:
-        self._enqueue({"type": "thinking_stop"})
-
-    def on_reasoning_token(self, text: str) -> None:
-        self._enqueue({"type": "reasoning", "text": text})
-
-    def on_content_token(self, text: str) -> None:
-        self._enqueue({"type": "content", "text": text})
-
-    def on_stream_end(self) -> None:
-        self._enqueue({"type": "stream_end"})
 
     # ------------------------------------------------------------------
     # SessionUI protocol — approvals
@@ -161,52 +170,53 @@ class ConsoleCoordinatorUI(SessionUIBase):
     # ``resolve_plan`` inherited from :class:`SessionUIBase`.
 
     # ------------------------------------------------------------------
-    # SessionUI protocol — tool results + status + misc
+    # SessionUI protocol — broadcast hook + state change + rename
     # ------------------------------------------------------------------
 
-    def on_tool_result(
-        self,
-        call_id: str,
-        name: str,
-        output: str,
-        *,
-        is_error: bool = False,
-    ) -> None:
-        event: dict[str, Any] = {
-            "type": "tool_result",
-            "call_id": call_id,
-            "name": name,
-            "output": output,
-        }
-        if is_error:
-            event["is_error"] = True
-        self._enqueue(event)
+    def _broadcast_activity(self) -> None:
+        """Fan a current-activity snapshot out to the cluster collector.
 
-    def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
-        self._enqueue({"type": "tool_output_chunk", "call_id": call_id, "chunk": chunk})
+        Overrides the no-op base hook on :class:`SessionUIBase`. The
+        lifted streaming bodies (``on_thinking_start`` /
+        ``on_tool_result`` / ``on_stream_end``) call this whenever
+        ``_ws_current_activity`` flips, so the cluster dashboard's
+        coord rows show live activity transitions between state
+        changes the same way interactive rows do. Reads under
+        ``_ws_lock`` for snapshot consistency with the worker
+        thread's writes; collector failure is logged at debug —
+        activity broadcast is observational, never block the worker.
 
-    def on_status(self, usage: dict[str, Any], context_window: int, effort: str) -> None:
-        total = usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
-        pct = round(total / context_window * 100, 1) if context_window > 0 else 0
-        self._enqueue(
-            {
-                "type": "status",
-                "prompt_tokens": usage.get("prompt_tokens", 0),
-                "completion_tokens": usage.get("completion_tokens", 0),
-                "total_tokens": total,
-                "context_window": context_window,
-                "pct": pct,
-                "effort": effort,
-                "cache_creation_tokens": usage.get("cache_creation_tokens", 0),
-                "cache_read_tokens": usage.get("cache_read_tokens", 0),
-            }
-        )
-
-    def on_info(self, message: str) -> None:
-        self._enqueue({"type": "info", "message": message})
-
-    def on_error(self, message: str) -> None:
-        self._enqueue({"type": "error", "message": message})
+        Dedups back-to-back identical activity ticks against the
+        last-emitted ``(activity, activity_state)`` tuple. A
+        tool-heavy turn fires many ``on_tool_result`` calls in
+        succession that all clear the activity to ``("", "")``;
+        without this dedup each one acquires the cluster collector's
+        main lock for a no-op write. (Pre-lift coord didn't broadcast
+        activity at all, so this is genuinely new contention worth
+        gating.)
+        """
+        collector = ConsoleCoordinatorUI._collector
+        if collector is None:
+            return
+        with self._ws_lock:
+            activity = self._ws_current_activity
+            activity_state = self._ws_activity_state
+            current = (activity, activity_state)
+            if current == self._last_broadcast_activity:
+                return
+            self._last_broadcast_activity = current
+        try:
+            collector.update_console_ws_activity(
+                self.ws_id,
+                activity=activity,
+                activity_state=activity_state,
+            )
+        except Exception:
+            log.debug(
+                "coord_ui.activity_fanout_failed ws=%s",
+                self.ws_id,
+                exc_info=True,
+            )
 
     def on_state_change(self, state: str) -> None:
         # Flow state transitions through the unified SessionManager so

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -193,7 +193,12 @@ class ConsoleCoordinatorUI(SessionUIBase):
         without this dedup each one acquires the cluster collector's
         main lock for a no-op write. (Pre-lift coord didn't broadcast
         activity at all, so this is genuinely new contention worth
-        gating.)
+        gating.) The dedup state is updated **only after a successful
+        collector call** — if the collector raises mid-broadcast,
+        the next identical tick must retry instead of being silently
+        suppressed (otherwise a transient collector failure would
+        strand the dashboard's coord row at the pre-failure activity
+        until the activity actually changes).
         """
         collector = ConsoleCoordinatorUI._collector
         if collector is None:
@@ -204,7 +209,6 @@ class ConsoleCoordinatorUI(SessionUIBase):
             current = (activity, activity_state)
             if current == self._last_broadcast_activity:
                 return
-            self._last_broadcast_activity = current
         try:
             collector.update_console_ws_activity(
                 self.ws_id,
@@ -217,6 +221,18 @@ class ConsoleCoordinatorUI(SessionUIBase):
                 self.ws_id,
                 exc_info=True,
             )
+            return
+        # Update dedup state only on successful broadcast so a
+        # transient collector failure doesn't suppress the next
+        # identical tick's retry. Re-acquire the lock briefly —
+        # the worker thread is the only writer to
+        # ``_last_broadcast_activity``, so the only race is with
+        # another concurrent ``_broadcast_activity`` that just
+        # took the same snapshot; whichever lands the assignment
+        # last wins, and both correspond to the same broadcast
+        # tuple anyway.
+        with self._ws_lock:
+            self._last_broadcast_activity = current
 
     def on_state_change(self, state: str) -> None:
         # Flow state transitions through the unified SessionManager so

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2626,6 +2626,27 @@ def _audit_coordinator_create(
     )
 
 
+def _coord_spawn_metrics(_request: Request, ui: Any) -> None:
+    """Per-spawn counter writes for coord — mirrors interactive's pattern.
+
+    Wired onto :attr:`SessionEndpointConfig.spawn_metrics`. Increments
+    ``_ws_messages`` and resets ``_ws_turn_tool_calls`` so the rich
+    ``ws_state`` cluster broadcast renders the same per-turn shape
+    coord rows on the dashboard need. Coord doesn't have a Prometheus
+    endpoint to feed (the console isn't a node), so the
+    ``_metrics.record_message_sent()`` call interactive's analog
+    fires is omitted.
+    """
+    if (
+        hasattr(ui, "_ws_lock")
+        and hasattr(ui, "_ws_messages")
+        and hasattr(ui, "_ws_turn_tool_calls")
+    ):
+        with ui._ws_lock:
+            ui._ws_messages += 1
+            ui._ws_turn_tool_calls = 0
+
+
 async def _coord_saved_loaded_lookup(request: Request) -> set[str]:
     """Return ws_ids currently held in ``coord_mgr``'s warm pool.
 
@@ -9976,10 +9997,14 @@ def create_app(
         supports_attachments=True,
         attachment_owner_resolver=_coord_attachment_owner,
         attachment_helpers=coord_attachment_helpers,
-        # No per-conversation metrics on coord — the per-UI counters
-        # interactive maintains don't have an analog on the coord
-        # dashboard. Cluster-level metrics fan out via the collector.
-        spawn_metrics=None,
+        # Per-spawn counter writes — the rich ``ws_state`` payload
+        # cluster broadcast (PR #420) reads ``_ws_messages`` and
+        # resets ``_ws_turn_tool_calls`` per turn so coord rows render
+        # the same activity / per-turn counts interactive rows do.
+        # Coord doesn't fire Prometheus metrics (the console isn't a
+        # node and has no /metrics endpoint), but the per-UI counter
+        # writes match interactive's pattern.
+        spawn_metrics=_coord_spawn_metrics,
         emit_message_queued=True,
         events_replay=_coord_events_replay,
         create_supports_attachments=True,

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -8,16 +8,17 @@ thread on two pending-input gates (tool approval, plan review) that
 HTTP handlers resolve.
 
 That skeleton — plus per-workstream metrics tracking, intent-verdict
-bookkeeping, and output-warning persistence — lives here. Subclasses
-add only kind-specific broadcast (``_broadcast_state`` /
-``_broadcast_activity`` override hooks) and any node-level metrics
-adapters (``_metrics.record_*`` calls stay on ``WebUI`` since they
-feed the node's prometheus endpoint).
+bookkeeping, output-warning persistence, and the canonical
+``on_status`` / ``on_content_token`` / activity-tracking bodies —
+lives here. Subclasses add only kind-specific broadcast
+(``_broadcast_state`` / ``_broadcast_activity`` override hooks) and
+any node-level metrics adapters (``_metrics.record_*`` calls stay on
+``WebUI`` since they feed the node's prometheus endpoint).
 
 This module intentionally does not satisfy
-:class:`turnstone.core.session.SessionUI` by itself — some ``on_*``
-method bodies (``on_thinking_start``, ``on_state_change``, ``on_rename``)
-still require subclass implementation.
+:class:`turnstone.core.session.SessionUI` by itself — ``on_state_change``
+and ``on_rename`` still require subclass implementation, since their
+storage/transport routing is kind-specific.
 """
 
 from __future__ import annotations
@@ -37,6 +38,15 @@ log = get_logger(__name__)
 # UI's ``_LISTENER_QUEUE_MAX``. Per-queue cap keeps a slow SSE consumer
 # from bloating memory.
 _DEFAULT_LISTENER_QUEUE_MAX = 500
+
+# Cap on the per-turn assistant content accumulator. The accumulator
+# is piggybacked onto the ``ws_state:idle`` broadcast payload so the
+# cluster collector / dashboard can render the freshly-emitted assistant
+# turn without round-tripping storage; capping it keeps a runaway turn
+# from ballooning the broadcast event past the listener queues' size
+# budget. Lifted from WebUI in the rich ``ws_state`` payload work so
+# coord broadcasts hit the same ceiling.
+_MAX_TURN_CONTENT_CHARS = 256 * 1024
 
 
 class SessionUIBase:
@@ -95,6 +105,21 @@ class SessionUIBase:
         # Activity tracking for dashboard ("thinking" / "tool" / "").
         self._ws_current_activity: str = ""
         self._ws_activity_state: str = ""
+        # Turn-content accumulator: assistant tokens piggybacked onto
+        # the ``ws_state:idle`` broadcast so the dashboard renders the
+        # turn without an extra storage round-trip. Cleared on IDLE /
+        # ERROR transitions by :meth:`snapshot_and_consume_state_payload`.
+        self._ws_turn_content: list[str] = []
+        self._ws_turn_content_size: int = 0
+        # Last broadcast (activity, activity_state) tuple — used by
+        # :meth:`_broadcast_activity` overrides to dedup back-to-back
+        # identical activity ticks. Tool-heavy turns can fire many
+        # ``on_tool_result`` calls in succession that all clear the
+        # activity to ``("", "")``; without the dedup, each fan-out
+        # acquires the cluster collector's lock for a no-op write.
+        # ``None`` until the first broadcast so the first emit always
+        # fires.
+        self._last_broadcast_activity: tuple[str, str] | None = None
         # Verdicts from the LLM intent judge — tracked so
         # ``resolve_approval`` can stamp a ``user_decision`` onto every
         # verdict that fired during this approval round.
@@ -316,3 +341,244 @@ class SessionUIBase:
             )
         except Exception:
             log.debug("Failed to persist output assessment", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Streaming + status — lifted from WebUI in the rich ``ws_state``
+    # payload work so coord populates the same per-ws metric fields the
+    # cluster broadcast reads. Subclasses override ``_broadcast_state``
+    # and ``_broadcast_activity`` for kind-specific transport
+    # (interactive: per-node global SSE queue; coord: cluster collector).
+    # ``WebUI`` additionally overrides ``on_status`` / ``on_tool_result``
+    # to layer Prometheus ``_metrics.record_*`` calls (node-only) on top
+    # of the shared writes.
+    # ------------------------------------------------------------------
+
+    def on_thinking_start(self) -> None:
+        """Track that the model is thinking; broadcast activity + enqueue."""
+        with self._ws_lock:
+            self._ws_current_activity = "Thinking…"
+            self._ws_activity_state = "thinking"
+        self._broadcast_activity()
+        self._enqueue({"type": "thinking_start"})
+
+    def on_thinking_stop(self) -> None:
+        self._enqueue({"type": "thinking_stop"})
+
+    def on_reasoning_token(self, text: str) -> None:
+        self._enqueue({"type": "reasoning", "text": text})
+
+    def on_content_token(self, text: str) -> None:
+        """Append to the turn-content accumulator (capped) + enqueue.
+
+        The cap-check + append + size-update run under ``_ws_lock``
+        so a concurrent :meth:`snapshot_and_consume_state_payload`
+        IDLE/ERROR drain can't see a torn list mid-append. In
+        production this is single-writer-per-ws (the worker thread)
+        but the snapshot reader runs from coord's adapter via
+        ``mgr.set_state``; without the lock the writer's append
+        could land in an orphaned list reference the snapshot just
+        swapped out. Lock hold is microseconds.
+        """
+        with self._ws_lock:
+            if self._ws_turn_content_size < _MAX_TURN_CONTENT_CHARS:
+                self._ws_turn_content.append(text)
+                self._ws_turn_content_size += len(text)
+        self._enqueue({"type": "content", "text": text})
+
+    def on_stream_end(self) -> None:
+        with self._ws_lock:
+            self._ws_current_activity = ""
+            self._ws_activity_state = ""
+        self._broadcast_activity()
+        self._enqueue({"type": "stream_end"})
+
+    def on_tool_result(
+        self,
+        call_id: str,
+        name: str,
+        output: str,
+        *,
+        is_error: bool = False,
+    ) -> None:
+        """Track per-ws tool-call counts + clear activity + enqueue.
+
+        Subclasses can override to add kind-specific bookkeeping (e.g.
+        ``WebUI`` calls :func:`_metrics.record_tool_call` on top of the
+        shared writes); call ``super().on_tool_result(...)`` to keep
+        the per-ws counters consistent.
+        """
+        with self._ws_lock:
+            self._ws_tool_calls[name] = self._ws_tool_calls.get(name, 0) + 1
+            self._ws_turn_tool_calls += 1
+            self._ws_current_activity = ""
+            self._ws_activity_state = ""
+        self._broadcast_activity()
+        event: dict[str, Any] = {
+            "type": "tool_result",
+            "call_id": call_id,
+            "name": name,
+            "output": output,
+        }
+        if is_error:
+            event["is_error"] = True
+        self._enqueue(event)
+
+    def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
+        self._enqueue({"type": "tool_output_chunk", "call_id": call_id, "chunk": chunk})
+
+    def on_status(self, usage: dict[str, Any], context_window: int, effort: str) -> None:
+        """Record per-ws token / context counters + enqueue + persist usage.
+
+        Shared body: writes ``_ws_prompt_tokens`` / ``_ws_completion_tokens``
+        / ``_ws_context_ratio`` under ``_ws_lock``, fans the ``status``
+        event to listener queues, and persists a ``usage_event`` row to
+        storage for governance dashboards. Subclasses (currently
+        :class:`WebUI`) can override to layer node-only Prometheus
+        ``_metrics.record_*`` calls before / after; call
+        ``super().on_status(...)`` to keep the per-ws counters and
+        usage-event row consistent.
+
+        Behaviour change for coord: pre-lift coord's ``on_status`` was a
+        thin enqueue-only stub; the lift turns it into the same writes
+        WebUI does, so the cluster collector's rich ``ws_state``
+        broadcast reads non-zero ``tokens`` / ``context_ratio`` for
+        coord rows, AND coord ``usage_event`` rows now persist to
+        storage (governance gains visibility into coordinator token
+        consumption).
+
+        ``usage`` field access is defensive (``.get(..., 0)``) — pre-
+        lift coord's stub used the same defensive pattern, and a
+        provider-translation bug that produces a partial ``usage``
+        dict shouldn't be surfaced as a worker-thread KeyError.
+        """
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        total_tok = prompt_tokens + completion_tokens
+        pct = total_tok / context_window * 100 if context_window > 0 else 0
+        cache_creation = usage.get("cache_creation_tokens", 0)
+        cache_read = usage.get("cache_read_tokens", 0)
+        with self._ws_lock:
+            self._ws_prompt_tokens += prompt_tokens
+            self._ws_completion_tokens += completion_tokens
+            self._ws_context_ratio = total_tok / context_window if context_window > 0 else 0.0
+            tool_total = sum(self._ws_tool_calls.values())
+            tool_count = tool_total - self._ws_tool_calls_reported
+            self._ws_tool_calls_reported = tool_total
+            turn_tool_calls = self._ws_turn_tool_calls
+            turn_count = self._ws_messages
+        self._enqueue(
+            {
+                "type": "status",
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tok,
+                "context_window": context_window,
+                "pct": round(pct, 1),
+                "effort": effort,
+                "cache_creation_tokens": cache_creation,
+                "cache_read_tokens": cache_read,
+                "tool_calls_this_turn": turn_tool_calls,
+                "turn_count": turn_count,
+            }
+        )
+        try:
+            from turnstone.core.storage._registry import get_storage
+
+            storage = get_storage()
+            if storage is not None:
+                storage.record_usage_event(
+                    event_id=uuid.uuid4().hex,
+                    user_id=self._user_id,
+                    ws_id=self.ws_id,
+                    node_id="",
+                    model=usage.get("model", ""),
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    tool_calls_count=tool_count,
+                    cache_creation_tokens=cache_creation,
+                    cache_read_tokens=cache_read,
+                )
+        except Exception:
+            log.warning("Failed to record usage event", exc_info=True)
+
+    def on_info(self, message: str) -> None:
+        self._enqueue({"type": "info", "message": message})
+
+    def on_error(self, message: str) -> None:
+        self._enqueue({"type": "error", "message": message})
+
+    # ------------------------------------------------------------------
+    # Broadcast hooks — kind-specific transport.
+    #
+    # Default implementations are no-ops: subclasses override to fan
+    # the snapshot out to their kind's transport (interactive: per-node
+    # global SSE queue; coord: cluster collector). The shared on_* methods
+    # above call these unconditionally so adding broadcast on a future
+    # kind only requires the override.
+    # ------------------------------------------------------------------
+
+    def _broadcast_state(self, state: str) -> None:  # noqa: ARG002 — hook stub
+        """Fan a state-change snapshot out to the kind's transport.
+
+        Default: no-op. Subclasses override.
+        """
+
+    def _broadcast_activity(self) -> None:
+        """Fan a current-activity snapshot out to the kind's transport.
+
+        Default: no-op. Subclasses override.
+        """
+
+    # ------------------------------------------------------------------
+    # State-broadcast snapshot helper
+    # ------------------------------------------------------------------
+
+    def snapshot_and_consume_state_payload(self, state: str) -> dict[str, Any]:
+        """Return the rich-payload snapshot a state-change broadcast carries.
+
+        Reads under ``_ws_lock`` so the snapshot is internally consistent
+        with concurrent ``on_status`` / ``on_tool_result`` /
+        ``on_content_token`` writes (all of which take the same lock).
+        For terminal states (``"idle"`` / ``"error"``) the turn-content
+        accumulator is also swapped out — IDLE piggybacks the joined
+        content onto the broadcast so the dashboard renders the
+        assistant turn without an extra storage round-trip; ERROR
+        clears without emitting (the broadcast is just for the state
+        transition).
+
+        The IDLE branch swaps the accumulator OUT under the lock and
+        joins the captured list OUTSIDE the lock — keeps the lock
+        hold to microseconds even on a 256 KiB turn, and decouples
+        the join walk from any concurrent ``on_content_token`` racing
+        the swap.
+
+        Returns a dict with keys ``tokens`` / ``context_ratio`` /
+        ``activity`` / ``activity_state`` / ``content``. Callers fan
+        the dict out via their kind's transport
+        (:meth:`_broadcast_state` or, for coord,
+        :meth:`turnstone.console.coordinator_adapter.CoordinatorAdapter.emit_state`).
+        """
+        captured_content: list[str] = []
+        with self._ws_lock:
+            tokens = self._ws_prompt_tokens + self._ws_completion_tokens
+            ctx = self._ws_context_ratio
+            activity = self._ws_current_activity
+            activity_state = self._ws_activity_state
+            if state == "idle":
+                captured_content = self._ws_turn_content
+                self._ws_turn_content = []
+                self._ws_turn_content_size = 0
+            elif state == "error":
+                self._ws_turn_content = []
+                self._ws_turn_content_size = 0
+        # Join outside the lock — bounded at _MAX_TURN_CONTENT_CHARS but
+        # still O(n) over the captured fragments, so worth not blocking
+        # concurrent on_content_token writers for the duration.
+        content = "".join(captured_content) if captured_content else ""
+        return {
+            "tokens": tokens,
+            "context_ratio": ctx,
+            "activity": activity,
+            "activity_state": activity_state,
+            "content": content,
+        }

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -111,8 +111,6 @@ _VALID_WS_ID = re.compile(r"^[0-9a-f]{32}$")
 # WebUI — implements SessionUI for browser-based interaction
 # ---------------------------------------------------------------------------
 
-_MAX_TURN_CONTENT_CHARS = 256 * 1024  # cap piggybacked content on idle events
-
 # Orphan-attachment-reservation sweep cadence.  Threshold is measured
 # against the storage layer's `reserved_at` column (time the row last
 # transitioned into reserved state, NOT upload time), so a 1-hour cap
@@ -152,15 +150,11 @@ class WebUI(SessionUIBase):
         # holds in every ws_state/ws_activity event payload — mirrors
         # the storage-layer normalization at register_workstream.
         self._parent_ws_id = parent_ws_id if parent_ws_id else None
-        # Content accumulator — tokens appended in on_content_token(),
-        # joined and piggybacked onto the ws_state:idle global SSE
-        # event, then reset. WebUI-specific optimization; coord sessions
-        # don't broadcast rich ws_state payloads.
-        self._ws_turn_content: list[str] = []
-        self._ws_turn_content_size: int = 0
 
     # ``_enqueue`` / ``_register_listener`` / ``_unregister_listener``
-    # inherited from :class:`SessionUIBase`.
+    # inherited from :class:`SessionUIBase`. ``_ws_turn_content`` /
+    # ``_ws_turn_content_size`` accumulator fields lifted to
+    # :class:`SessionUIBase` so coord can populate them too.
 
     def _ws_kind_and_parent(self) -> tuple[WorkstreamKind, str | None]:
         """Return cached (kind, parent_ws_id) for broadcast event payloads.
@@ -173,32 +167,30 @@ class WebUI(SessionUIBase):
         return self._kind, self._parent_ws_id
 
     def _broadcast_state(self, state: str) -> None:
-        """Send a state-change event to the global SSE channel."""
+        """Send a state-change event to the global SSE channel.
+
+        Reads the rich-payload snapshot via the lifted
+        :meth:`SessionUIBase.snapshot_and_consume_state_payload`
+        helper, then puts the assembled ``ws_state`` event on the
+        global queue. The snapshot helper handles the IDLE/ERROR
+        ``_ws_turn_content`` consume + clear under ``_ws_lock``.
+        """
         if WebUI._global_queue is not None:
-            with self._ws_lock:
-                tokens = self._ws_prompt_tokens + self._ws_completion_tokens
-                ctx = self._ws_context_ratio
-                activity = self._ws_current_activity
-                activity_state = self._ws_activity_state
+            payload = self.snapshot_and_consume_state_payload(state)
             kind, parent_ws_id = self._ws_kind_and_parent()
             event: dict[str, Any] = {
                 "type": "ws_state",
                 "ws_id": self.ws_id,
                 "state": state,
-                "tokens": tokens,
-                "context_ratio": ctx,
-                "activity": activity,
-                "activity_state": activity_state,
+                "tokens": payload["tokens"],
+                "context_ratio": payload["context_ratio"],
+                "activity": payload["activity"],
+                "activity_state": payload["activity_state"],
                 "kind": kind,
                 "parent_ws_id": parent_ws_id,
             }
             if state == "idle":
-                event["content"] = "".join(self._ws_turn_content)
-                self._ws_turn_content = []
-                self._ws_turn_content_size = 0
-            elif state == "error":
-                self._ws_turn_content = []
-                self._ws_turn_content_size = 0
+                event["content"] = payload["content"]
             try:
                 WebUI._global_queue.put_nowait(event)
             except queue.Full:
@@ -224,32 +216,13 @@ class WebUI(SessionUIBase):
                 )
 
     # --- SessionUI protocol ---
-
-    def on_thinking_start(self) -> None:
-        with self._ws_lock:
-            self._ws_current_activity = "Thinking\u2026"
-            self._ws_activity_state = "thinking"
-        self._broadcast_activity()
-        self._enqueue({"type": "thinking_start"})
-
-    def on_thinking_stop(self) -> None:
-        self._enqueue({"type": "thinking_stop"})
-
-    def on_reasoning_token(self, text: str) -> None:
-        self._enqueue({"type": "reasoning", "text": text})
-
-    def on_content_token(self, text: str) -> None:
-        if self._ws_turn_content_size < _MAX_TURN_CONTENT_CHARS:
-            self._ws_turn_content.append(text)
-            self._ws_turn_content_size += len(text)
-        self._enqueue({"type": "content", "text": text})
-
-    def on_stream_end(self) -> None:
-        with self._ws_lock:
-            self._ws_current_activity = ""
-            self._ws_activity_state = ""
-        self._broadcast_activity()
-        self._enqueue({"type": "stream_end"})
+    #
+    # ``on_thinking_start`` / ``on_thinking_stop`` / ``on_reasoning_token``
+    # / ``on_content_token`` / ``on_stream_end`` / ``on_tool_output_chunk``
+    # / ``on_info`` / ``on_error`` are inherited from
+    # :class:`SessionUIBase`. ``on_status`` and ``on_tool_result`` are
+    # overridden below to layer Prometheus ``_metrics.record_*`` calls
+    # (node-only) on top of the shared per-ws metric writes.
 
     def approve_tools(self, items: list[dict[str, Any]]) -> tuple[bool, str | None]:
         self._reset_approval_cycle()
@@ -435,80 +408,28 @@ class WebUI(SessionUIBase):
         *,
         is_error: bool = False,
     ) -> None:
+        """Layer node-only Prometheus metrics on top of the shared body."""
         _metrics.record_tool_call(name)
-        with self._ws_lock:
-            self._ws_tool_calls[name] = self._ws_tool_calls.get(name, 0) + 1
-            self._ws_turn_tool_calls += 1
-            self._ws_current_activity = ""
-            self._ws_activity_state = ""
-        self._broadcast_activity()
-        event: dict[str, Any] = {
-            "type": "tool_result",
-            "call_id": call_id,
-            "name": name,
-            "output": output,
-        }
-        if is_error:
-            event["is_error"] = True
-        self._enqueue(event)
-
-    def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
-        self._enqueue({"type": "tool_output_chunk", "call_id": call_id, "chunk": chunk})
+        super().on_tool_result(call_id, name, output, is_error=is_error)
 
     def on_status(self, usage: dict[str, Any], context_window: int, effort: str) -> None:
-        total_tok = usage["prompt_tokens"] + usage["completion_tokens"]
-        pct = total_tok / context_window * 100 if context_window > 0 else 0
+        """Layer node-only Prometheus metrics on top of the shared body.
+
+        ``_metrics.record_*`` calls feed the node's prometheus
+        endpoint; the per-ws counter writes, the ``status`` event
+        enqueue, and the ``usage_event`` storage row are inherited
+        from :meth:`SessionUIBase.on_status`. ``usage`` field access
+        is defensive for parity with the lifted body.
+        """
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        total_tok = prompt_tokens + completion_tokens
         cache_creation = usage.get("cache_creation_tokens", 0)
         cache_read = usage.get("cache_read_tokens", 0)
-        _metrics.record_tokens(usage["prompt_tokens"], usage["completion_tokens"])
+        _metrics.record_tokens(prompt_tokens, completion_tokens)
         _metrics.record_cache_tokens(cache_creation, cache_read)
         _metrics.record_context_ratio(total_tok / context_window if context_window > 0 else 0.0)
-        with self._ws_lock:
-            self._ws_prompt_tokens += usage["prompt_tokens"]
-            self._ws_completion_tokens += usage["completion_tokens"]
-            self._ws_context_ratio = total_tok / context_window if context_window > 0 else 0.0
-            tool_total = sum(self._ws_tool_calls.values())
-            tool_count = tool_total - self._ws_tool_calls_reported
-            self._ws_tool_calls_reported = tool_total
-            turn_tool_calls = self._ws_turn_tool_calls
-            turn_count = self._ws_messages
-        self._enqueue(
-            {
-                "type": "status",
-                "prompt_tokens": usage["prompt_tokens"],
-                "completion_tokens": usage["completion_tokens"],
-                "total_tokens": total_tok,
-                "context_window": context_window,
-                "pct": round(pct, 1),
-                "effort": effort,
-                "cache_creation_tokens": cache_creation,
-                "cache_read_tokens": cache_read,
-                "tool_calls_this_turn": turn_tool_calls,
-                "turn_count": turn_count,
-            }
-        )
-        # Record usage event for governance dashboard
-        try:
-            from turnstone.core.storage._registry import get_storage
-
-            storage = get_storage()
-            if storage is not None:
-                import uuid
-
-                storage.record_usage_event(
-                    event_id=uuid.uuid4().hex,
-                    user_id=self._user_id,
-                    ws_id=self.ws_id,
-                    node_id="",
-                    model=usage.get("model", ""),
-                    prompt_tokens=usage["prompt_tokens"],
-                    completion_tokens=usage["completion_tokens"],
-                    tool_calls_count=tool_count,
-                    cache_creation_tokens=cache_creation,
-                    cache_read_tokens=cache_read,
-                )
-        except Exception:
-            log.warning("Failed to record usage event", exc_info=True)
+        super().on_status(usage, context_window, effort)
 
     def on_plan_review(self, content: str) -> str:
         self._plan_event.clear()
@@ -520,12 +441,10 @@ class WebUI(SessionUIBase):
         self._pending_plan_review = None
         return self._plan_result
 
-    def on_info(self, message: str) -> None:
-        self._enqueue({"type": "info", "message": message})
-
     def on_error(self, message: str) -> None:
+        """Layer node-only Prometheus error counter on top of the shared body."""
         _metrics.record_error()
-        self._enqueue({"type": "error", "message": message})
+        super().on_error(message)
 
     def on_state_change(self, state: str) -> None:
         # Update the Workstream object so dashboard/polling sees the new state
@@ -3516,11 +3435,17 @@ def create_app(
 
     def _interactive_spawn_metrics(_request: Request, ui: Any) -> None:
         """Per-conversation metrics fired once per send that spawns a
-        fresh worker. Coord wires ``None`` for this hook.
+        fresh worker. Coord wires its own
+        :func:`turnstone.console.server._coord_spawn_metrics` (the
+        Prometheus-free analog) post the rich ``ws_state`` payload
+        lift — both kinds need the per-UI counter writes so the
+        cluster broadcast renders the same per-turn shape.
 
-        The per-UI counters live on ``WebUI`` only — guard all three
-        attributes so a future ``SessionUI`` subclass without the
-        full counter set doesn't trip on the assignment.
+        The per-UI counters live on :class:`SessionUIBase`
+        (inherited by both :class:`WebUI` and
+        :class:`turnstone.console.coordinator_ui.ConsoleCoordinatorUI`),
+        so the ``hasattr`` guards survive only as defence against a
+        future ``SessionUI`` subclass that doesn't extend the base.
         """
         _metrics.record_message_sent()
         if (


### PR DESCRIPTION
Pre-lift coord's cluster broadcast was state-only — the dashboard's
coord rows showed the state column flipping but ``tokens`` /
``context_ratio`` / ``activity`` / ``content`` were all hardcoded
to zero / empty. The lift makes coord populate the same per-ws
metric fields interactive does and broadcasts them through the
cluster collector with the rich kwargs.

**Architecture changes:**

- Lift ``on_status`` / ``on_content_token`` / ``on_thinking_start`` /
  ``on_thinking_stop`` / ``on_stream_end`` / ``on_tool_result`` /
  ``on_reasoning_token`` / ``on_tool_output_chunk`` / ``on_info`` /
  ``on_error`` from ``WebUI`` to :class:`SessionUIBase` as base
  implementations. Coord inherits the bodies; the per-ws metric
  fields it had at the base but never populated now flow.
- ``WebUI`` keeps overrides for ``on_status`` / ``on_tool_result`` /
  ``on_error`` to layer Prometheus ``_metrics.record_*`` calls
  on top of ``super()`` (node-only — the console isn't a node).
  ``WebUI._broadcast_state`` now uses the new
  :meth:`SessionUIBase.snapshot_and_consume_state_payload` helper
  for the rich-payload snapshot read.
- ``ConsoleCoordinatorUI`` adds a ``_broadcast_activity`` override
  that calls the new
  :meth:`ClusterCollector.update_console_ws_activity` (in-memory
  pseudo-node row update; named ``update_*`` rather than ``emit_*``
  to flag the no-fanout asymmetry vs. the rest of the
  ``emit_console_ws_*`` family).
- ``coord_adapter.emit_state`` reads ``ws.ui``'s snapshot under
  ``_ws_lock`` and passes the rich kwargs to the extended
  :meth:`ClusterCollector.emit_console_ws_state`. Defensive when
  ``ws.ui is None`` mid-eviction (broadcasts state-only).
- ``coord_endpoint_config`` wires a new ``_coord_spawn_metrics``
  hook so per-spawn ``_ws_messages`` / ``_ws_turn_tool_calls``
  bookkeeping fires on coord too.
- ``_MAX_TURN_CONTENT_CHARS`` moved from ``turnstone.server`` to
  ``turnstone.core.session_ui_base`` so coord enforces the same
  per-turn content cap.

**Three observable behaviour changes** (CHANGELOG-callout-worthy):

- Coord persists ``usage_event`` storage rows on every status
  emission (governance dashboards / token-spend queries gain
  coord visibility).
- Coord broadcasts live activity transitions to the cluster
  collector (dashboard's coord rows show activity ticks between
  state changes the same way interactive does), with last-emitted
  dedup so a tool-heavy turn's repeated ``activity=""`` clears
  don't hammer the collector lock.
- Cluster ``cluster_state`` events for coord rows now carry
  non-zero ``tokens`` / ``content``. Frontend rendering that
  conditionally hid these on coord can drop the branch.

**Tests:** 23 new tests in ``tests/test_coord_rich_ws_state_payload.py``
(per-ws metric writes, snapshot helper drain semantics +
single-lock-acquisition, adapter rich-payload pass-through +
None-UI defensive handling, activity broadcast wire + dedup +
failure swallow + no-op-when-collector-unset, spawn_metrics
hook, concurrent-writes-during-snapshot stress with reader
cycling through running/idle/error so drain branches actually
run, on_stream_end activity-clear pin). Plus WebUI override
regression tests confirming ``_metrics.record_*`` still fires
on top of the lifted bodies. Existing
``tests/test_webui_content.py`` updated to import
``_MAX_TURN_CONTENT_CHARS`` from its new home;
``tests/test_coordinator_adapter.py`` updated to expect the
rich-payload kwargs (default zeros) on
``emit_console_ws_state``. Total: ``4491 → 4514``.
``ruff check`` clean, ``mypy`` clean on touched files.

**/review pipeline** (4 finders → verify → dedupe) caught 14
findings → 12 unique (3 collapsed as duplicates of the lockless
``on_content_token`` writer):

- bug-1 Minor: ``on_status`` regressed coord's defensive
  ``usage.get(...)`` indexing → restored ``.get(..., 0)`` for
  ``prompt_tokens`` / ``completion_tokens`` on both base + WebUI
  override.
- bug-2 Nit: concurrent-snapshot reader only used ``"running"`` →
  cycled through ``("running", "idle", "error")`` so drain
  branches run; also captures + re-raises thread exceptions
  instead of silently passing.
- bug-3 + sec-2 + perf-3 Nit (merged): ``on_content_token``
  mutated ``_ws_turn_content`` lockless while the snapshot drained
  under lock → wrapped the cap-check + append + size-update in
  ``_ws_lock``.
- perf-2 Minor: collector lock contention from per-event activity
  broadcasts → cached last-emitted ``(activity, activity_state)``
  on the UI; subsequent identical ticks return early without
  acquiring the collector lock.
- perf-4 Nit: join-under-lock in snapshot helper → swap-then-join
  pattern (capture list reference under lock, reassign to empty,
  join the captured list outside the lock). Halves the lock
  hold and decouples the join walk from concurrent appenders.
- q-1 Minor: ``emit_console_ws_activity`` was misleading (no
  ``_fanout`` call, unlike the rest of the ``emit_console_ws_*``
  family) → renamed to ``update_console_ws_activity`` + docstring
  call-out for the asymmetry.
- q-2 + q-3 Minor/Nit: stale docstrings on
  ``coordinator_ui.py`` (still claimed "no per-node metrics —
  Phase D") and ``_interactive_spawn_metrics`` (still claimed
  "counters live on WebUI only") → both updated to reflect the
  lifted base class + coord's new hook.
- q-4 Nit: broken Sphinx cross-ref
  ``:meth:\`_snapshot_and_consume_state_payload\``` → dropped
  the leading underscore.
- q-5 Nit: missing ``test_coord_on_stream_end_clears_activity``
  → added.

**Two findings explicitly deferred** (out-of-scope follow-ups,
documented in CHANGELOG):

- perf-1: synchronous ``record_usage_event`` INSERT on coord
  worker thread per status tick. Parity with WebUI is the lift's
  goal; if throughput becomes a concern, batch usage_event writes
  on a background flusher (would apply to both kinds).
- sec-1: coord assistant content now flows on the cluster SSE
  stream, which has no per-user filter today. Pre-existing
  exposure for interactive ``cluster_state`` events; the lift
  extends to coord rows. Proper fix needs SSE auth gating
  (``admin.cluster.inspect``) or per-listener user_id filtering
  — separate security project, doesn't gate this lift.