### PR TITLE
refactor(server): converge dashboard row shape on ws_id + post-Stage-2 doc sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Three release tracks are maintained:
 
 ### Changed
 
+- **Dashboard row shape: ``id`` → ``ws_id``.** The
+  ``GET /v1/api/dashboard`` row dict now keys the workstream
+  identifier as ``ws_id`` (matching the rest of the v1 workstream
+  surface — active list, saved list, history, detail). The Stage 2
+  list-verb lift converged ``/v1/api/workstreams`` and
+  ``/v1/api/workstreams/saved`` on ``ws_id`` but left dashboard
+  alone to keep that PR's diff focused; this lands the same rename
+  on the remaining endpoint so the v1 row shape is consistent
+  across the family. Pydantic ``DashboardWorkstream`` and the
+  TypeScript SDK ``DashboardWorkstream`` interface both rename the
+  field accordingly. The bundled web UI is the only consumer that
+  reads ``dashboard.workstreams[].id`` and is updated atomically;
+  no external SDK on a stable line reads the field, so the swap is
+  bounded by normal static-asset reload. Console
+  ``_fetch_live_block`` (cluster-inspect's projection over a
+  remote node's dashboard payload) is updated to match.
+
 - **Coordinator gains rich `ws_state` payload + live activity broadcast**
   ([§ Post-P3 reckoning item #2 follow-up]). Pre-lift coord's
   cluster broadcast was state-only — the dashboard's coord rows

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -571,8 +571,8 @@ Returns a list of all active workstreams.
 ```json
 {
   "workstreams": [
-    {"id": "abc123", "name": "default", "state": "idle"},
-    {"id": "def456", "name": "hacker-news", "state": "thinking"}
+    {"ws_id": "abc123", "name": "default", "state": "idle"},
+    {"ws_id": "def456", "name": "hacker-news", "state": "thinking"}
   ]
 }
 ```
@@ -581,7 +581,7 @@ Each workstream object:
 
 | Field        | Type        | Description                                            |
 |--------------|-------------|--------------------------------------------------------|
-| `id`         | string      | Unique workstream routing identifier                   |
+| `ws_id`      | string      | Unique workstream routing identifier                   |
 | `name`       | string      | Display name (alias if set, otherwise `ws-xxxx`)       |
 | `state`      | string      | Current state (see state values above)                 |
 

--- a/docs/bulk-endpoints.md
+++ b/docs/bulk-endpoints.md
@@ -12,8 +12,8 @@ Existing bulk endpoints at time of writing:
 |---------------------------------------------------------|--------------------------|------------------------------------------|
 | `GET  /v1/api/cluster/ws/live?ids=a,b,c`                | bulk read                | `{results, denied, truncated}`           |
 | model tool `spawn_batch`                                 | bulk create (per-item)   | `{results, denied}`                      |
-| `POST /v1/api/coordinator/{ws_id}/stop_cascade`          | cascade mutation         | `{cancelled, failed, skipped}`           |
-| `POST /v1/api/coordinator/{ws_id}/close_all_children`    | cascade mutation         | `{closed, failed, skipped}`              |
+| `POST /v1/api/workstreams/{ws_id}/stop_cascade`          | cascade mutation         | `{cancelled, failed, skipped}`           |
+| `POST /v1/api/workstreams/{ws_id}/close_all_children`    | cascade mutation         | `{closed, failed, skipped}`              |
 
 ---
 

--- a/docs/coordinator-api-tour.md
+++ b/docs/coordinator-api-tour.md
@@ -26,28 +26,43 @@ schema changes.
 
 ## The 9 steps
 
-| # | Action                       | Operation                                                   | Operation id                                                |
-|---|------------------------------|-------------------------------------------------------------|-------------------------------------------------------------|
-| 1 | Create                       | `POST /v1/api/coordinator/new`                              | `v1_api_coordinator_new_post`                               |
-| 2 | Subscribe to events          | `GET /v1/api/coordinator/{ws_id}/events` (SSE)              | `v1_api_coordinator_{ws_id}_events_get`                     |
-| 3 | Send a user message          | `POST /v1/api/coordinator/{ws_id}/send`                     | `v1_api_coordinator_{ws_id}_send_post`                      |
-| 4 | Inspect children             | `GET /v1/api/coordinator/{ws_id}/children`                  | `v1_api_coordinator_{ws_id}_children_get`                   |
-| 5 | Inspect one workstream       | `GET /v1/api/cluster/ws/{ws_id}/detail`                     | `v1_api_cluster_ws_{ws_id}_detail_get`                      |
-| 6 | Wait for fan-out             | model-side tool `wait_for_workstream`                       | — (tool call, not HTTP)                                     |
-| 7 | Govern                       | `POST /v1/api/coordinator/{ws_id}/trust`                    | `v1_api_coordinator_{ws_id}_trust_post`                     |
-|   |                              | `POST /v1/api/coordinator/{ws_id}/restrict`                 | `v1_api_coordinator_{ws_id}_restrict_post`                  |
-|   |                              | `POST /v1/api/coordinator/{ws_id}/stop_cascade`             | `v1_api_coordinator_{ws_id}_stop_cascade_post`              |
-|   |                              | `POST /v1/api/coordinator/{ws_id}/close_all_children`       | `v1_api_coordinator_{ws_id}_close_all_children_post`        |
-| 8 | Approve / cancel             | `POST /v1/api/coordinator/{ws_id}/approve`                  | `v1_api_coordinator_{ws_id}_approve_post`                   |
-|   |                              | `POST /v1/api/coordinator/{ws_id}/cancel`                   | `v1_api_coordinator_{ws_id}_cancel_post`                    |
-| 9 | Close                        | `POST /v1/api/coordinator/{ws_id}/close`                    | `v1_api_coordinator_{ws_id}_close_post`                     |
+> **URL convergence (1.5.0).** Pre-1.5 coord-only endpoints lived
+> under `/v1/api/coordinator/...`. The Stage 2 verb-shape lift
+> consolidated coord and interactive onto the unified
+> `/v1/api/workstreams/{ws_id}/<verb>` tree; coord still distinguishes
+> itself via the `kind=coordinator` row classifier rather than a
+> separate URL space. The endpoints below reflect the post-lift
+> surface served by `turnstone-console`.
+
+| # | Action                       | Operation                                                   |
+|---|------------------------------|-------------------------------------------------------------|
+| 1 | Create                       | `POST /v1/api/workstreams/new`                              |
+| 2 | Subscribe to events          | `GET /v1/api/workstreams/{ws_id}/events` (SSE)              |
+| 3 | Send a user message          | `POST /v1/api/workstreams/{ws_id}/send`                     |
+| 4 | Inspect children             | `GET /v1/api/workstreams/{ws_id}/children`                  |
+| 5 | Inspect one workstream       | `GET /v1/api/cluster/ws/{ws_id}/detail`                     |
+| 6 | Wait for fan-out             | model-side tool `wait_for_workstream`                       |
+| 7 | Govern                       | `POST /v1/api/workstreams/{ws_id}/trust`                    |
+|   |                              | `POST /v1/api/workstreams/{ws_id}/restrict`                 |
+|   |                              | `POST /v1/api/workstreams/{ws_id}/stop_cascade`             |
+|   |                              | `POST /v1/api/workstreams/{ws_id}/close_all_children`       |
+| 8 | Approve / cancel             | `POST /v1/api/workstreams/{ws_id}/approve`                  |
+|   |                              | `POST /v1/api/workstreams/{ws_id}/cancel`                   |
+| 9 | Close                        | `POST /v1/api/workstreams/{ws_id}/close`                    |
+
+Refer to `/openapi.json` (Swagger UI at `/docs`) on any
+`turnstone-console` process for the authoritative operation ids and
+schemas. Coordinator-only verbs (`/children`, `/trust`, `/restrict`,
+`/stop_cascade`, `/close_all_children`) 404 against `kind=interactive`
+rows; the shared verbs (`/send`, `/approve`, `/cancel`, `/events`,
+`/history`, `/open`, `/close`, etc.) work on both kinds.
 
 ---
 
 ## 1. Create a coordinator
 
 ```http
-POST /v1/api/coordinator/new
+POST /v1/api/workstreams/new
 Content-Type: application/json
 Authorization: Bearer <token>
 
@@ -80,7 +95,7 @@ subscribers (step 2) see the session warm up as token traffic starts.
 ## 2. Subscribe to the per-coordinator event stream
 
 ```http
-GET /v1/api/coordinator/{ws_id}/events HTTP/1.1
+GET /v1/api/workstreams/{ws_id}/events HTTP/1.1
 Accept: text/event-stream
 Authorization: Bearer <token>
 ```
@@ -124,7 +139,7 @@ operator.
 ## 3. Send the first user message
 
 ```http
-POST /v1/api/coordinator/{ws_id}/send
+POST /v1/api/workstreams/{ws_id}/send
 Content-Type: application/json
 
 {"message": "audit /auth for CSRF handling across all active routes"}
@@ -147,7 +162,7 @@ events, finishing with `state_change → idle` or an
 ## 4. Inspect direct children
 
 ```http
-GET /v1/api/coordinator/{ws_id}/children HTTP/1.1
+GET /v1/api/workstreams/{ws_id}/children HTTP/1.1
 ```
 
 ```json
@@ -244,7 +259,7 @@ burst can't starve audit writes.
 ### `POST /trust` — auto-approve own-subtree sends
 
 ```json
-POST /v1/api/coordinator/{ws_id}/trust
+POST /v1/api/workstreams/{ws_id}/trust
 {"send": true}
 ```
 
@@ -258,7 +273,7 @@ second grants a service token the opt-in it otherwise wouldn't get).
 ### `POST /restrict` — revoke tool access mid-session
 
 ```json
-POST /v1/api/coordinator/{ws_id}/restrict
+POST /v1/api/workstreams/{ws_id}/restrict
 {"revoke": ["spawn_workstream", "delete_workstream"]}
 ```
 
@@ -270,7 +285,7 @@ opt in per session.  Cap 256 tool names per request, 128 chars each.
 ### `POST /stop_cascade` — cancel the subtree
 
 ```json
-POST /v1/api/coordinator/{ws_id}/stop_cascade
+POST /v1/api/workstreams/{ws_id}/stop_cascade
 {}
 ```
 
@@ -292,7 +307,7 @@ propagate via the child's SSE stream.
 ### `POST /close_all_children` — soft-close the direct fan-out
 
 ```json
-POST /v1/api/coordinator/{ws_id}/close_all_children
+POST /v1/api/workstreams/{ws_id}/close_all_children
 {"reason": "audit round complete"}
 ```
 
@@ -323,7 +338,7 @@ event.  The coordinator's worker thread is blocked inside
 `ui.approve_tools` waiting for this POST.
 
 ```json
-POST /v1/api/coordinator/{ws_id}/approve
+POST /v1/api/workstreams/{ws_id}/approve
 {"approved": true, "feedback": null, "always": false}
 {"approved": false, "feedback": "spawn count looks too high — try 3 not 10"}
 {"approved": true, "feedback": null, "always": true}    // always-approve this tool name
@@ -333,7 +348,7 @@ POST /v1/api/coordinator/{ws_id}/approve
 idle and open for a fresh `send`:
 
 ```json
-POST /v1/api/coordinator/{ws_id}/cancel
+POST /v1/api/workstreams/{ws_id}/cancel
 {}
 ```
 
@@ -342,7 +357,7 @@ POST /v1/api/coordinator/{ws_id}/cancel
 ## 9. Close
 
 ```json
-POST /v1/api/coordinator/{ws_id}/close
+POST /v1/api/workstreams/{ws_id}/close
 {}
 ```
 
@@ -350,7 +365,7 @@ Soft-closes the session — state persists, children keep running (use
 `close_all_children` or `stop_cascade` first to wind them down), the
 worker thread exits, SSE streams send a final `stream_end` and
 disconnect.  The row is reopenable via
-`POST /v1/api/coordinator/{ws_id}/open` so long as it hasn't been
+`POST /v1/api/workstreams/{ws_id}/open` so long as it hasn't been
 deleted.
 
 ---

--- a/docs/coordinator-api-tour.md
+++ b/docs/coordinator-api-tour.md
@@ -258,7 +258,7 @@ burst can't starve audit writes.
 
 ### `POST /trust` — auto-approve own-subtree sends
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/trust
 {"send": true}
 ```
@@ -272,7 +272,7 @@ second grants a service token the opt-in it otherwise wouldn't get).
 
 ### `POST /restrict` — revoke tool access mid-session
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/restrict
 {"revoke": ["spawn_workstream", "delete_workstream"]}
 ```
@@ -284,7 +284,7 @@ opt in per session.  Cap 256 tool names per request, 128 chars each.
 
 ### `POST /stop_cascade` — cancel the subtree
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/stop_cascade
 {}
 ```
@@ -306,7 +306,7 @@ propagate via the child's SSE stream.
 
 ### `POST /close_all_children` — soft-close the direct fan-out
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/close_all_children
 {"reason": "audit round complete"}
 ```
@@ -337,7 +337,7 @@ The `approve` endpoint is what resolves an `approve_request` SSE
 event.  The coordinator's worker thread is blocked inside
 `ui.approve_tools` waiting for this POST.
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/approve
 {"approved": true, "feedback": null, "always": false}
 {"approved": false, "feedback": "spawn count looks too high — try 3 not 10"}
@@ -347,7 +347,7 @@ POST /v1/api/workstreams/{ws_id}/approve
 `cancel` drops the in-flight generation but leaves the coordinator
 idle and open for a fresh `send`:
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/cancel
 {}
 ```
@@ -356,7 +356,7 @@ POST /v1/api/workstreams/{ws_id}/cancel
 
 ## 9. Close
 
-```json
+```http
 POST /v1/api/workstreams/{ws_id}/close
 {}
 ```

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2342,9 +2342,10 @@
         "type": "object"
       },
       "DashboardWorkstream": {
+        "description": "Dashboard row shape for ``GET /v1/api/dashboard``.\n\nRenamed ``id`` \u2192 ``ws_id`` for v1 row-shape consistency with\nthe rest of the workstream surface (active list, saved list,\nhistory, detail, etc.). Frontend consumers reading\n``dashboard.workstreams[].id`` swap to ``.ws_id``.",
         "properties": {
-          "id": {
-            "title": "Id",
+          "ws_id": {
+            "title": "Ws Id",
             "type": "string"
           },
           "name": {
@@ -2423,7 +2424,7 @@
           }
         },
         "required": [
-          "id",
+          "ws_id",
           "name",
           "state"
         ],

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -201,7 +201,7 @@ export interface WorkstreamHistoryResponse {
 }
 
 export interface DashboardWorkstream {
-  id: string;
+  ws_id: string;
   name: string;
   state: string;
   title?: string;

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -1565,7 +1565,7 @@ def test_cluster_inspect_node_backed_success(storage):
     payload = {
         "workstreams": [
             {
-                "id": ws_id,
+                "ws_id": ws_id,
                 "state": "running",
                 "tokens": 512,
                 "context_ratio": 0.25,
@@ -1608,7 +1608,7 @@ def test_cluster_inspect_node_backed_pending_approval_synthesized(storage):
     payload = {
         "workstreams": [
             {
-                "id": ws_id,
+                "ws_id": ws_id,
                 "state": "attention",
                 "activity_state": "approval",
                 "activity": "awaiting approval",
@@ -1661,7 +1661,7 @@ def test_cluster_inspect_node_missing_entry_live_null(storage):
     _seed_node_workstream(storage, ws_id=ws_id, node_id="node-a")
     payload = {
         "workstreams": [
-            {"id": "different-" + "x" * 24, "state": "idle"},
+            {"ws_id": "different-" + "x" * 24, "state": "idle"},
         ]
     }
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())

--- a/tests/test_sdk_server.py
+++ b/tests/test_sdk_server.py
@@ -60,7 +60,7 @@ async def test_dashboard():
                 {
                     "workstreams": [
                         {
-                            "id": "ws1",
+                            "ws_id": "ws1",
                             "name": "demo",
                             "state": "idle",
                             "tokens": 100,

--- a/tests/test_service_auth_boundary.py
+++ b/tests/test_service_auth_boundary.py
@@ -318,13 +318,13 @@ class TestDashboardCache4xxLogLevel:
             calls["n"] += 1
             if calls["n"] == 1:
                 return httpx.Response(403, text="forbidden")
-            return httpx.Response(200, json={"workstreams": [{"id": "ws-1"}]})
+            return httpx.Response(200, json={"workstreams": [{"ws_id": "ws-1"}]})
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         first = await cache.get("node-1", "http://node-1:8001", client, {})
         second = await cache.get("node-1", "http://node-1:8001", client, {})
         assert first is None
-        assert second == {"workstreams": [{"id": "ws-1"}]}
+        assert second == {"workstreams": [{"ws_id": "ws-1"}]}
         assert calls["n"] == 2, "4xx must bypass the cache so the retry reaches upstream"
 
 

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -220,7 +220,15 @@ class ListWorkstreamsResponse(BaseModel):
 
 
 class DashboardWorkstream(BaseModel):
-    id: str
+    """Dashboard row shape for ``GET /v1/api/dashboard``.
+
+    Renamed ``id`` → ``ws_id`` for v1 row-shape consistency with
+    the rest of the workstream surface (active list, saved list,
+    history, detail, etc.). Frontend consumers reading
+    ``dashboard.workstreams[].id`` swap to ``.ws_id``.
+    """
+
+    ws_id: str
     name: str
     state: str
     title: str = ""

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -809,7 +809,7 @@ async def _fetch_live_block(
     if payload is None:
         return None
     for entry in payload.get("workstreams", []) or []:
-        if isinstance(entry, dict) and entry.get("id") == ws_id:
+        if isinstance(entry, dict) and entry.get("ws_id") == ws_id:
             live = {k: entry.get(k) for k in _CLUSTER_WS_LIVE_KEYS if k in entry}
             # Derived field — kept in lockstep with
             # _coordinator_live_snapshot so both origins produce the

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1135,14 +1135,7 @@ async def global_events_sse(request: Request) -> Response:
 
 
 async def dashboard(request: Request) -> JSONResponse:
-    """GET /v1/api/dashboard — enriched workstream data + aggregate stats.
-
-    NOTE: row shape still uses ``"id"`` (not ``"ws_id"``) — Stage 2's
-    list-verb lift converged ``/v1/api/workstreams`` and
-    ``/saved`` on ``ws_id`` but left dashboard alone to keep that
-    PR's diff focused. The same rename should land here as a separate
-    cleanup so the v1 row shape is consistent across the family.
-    """
+    """GET /v1/api/dashboard — enriched workstream data + aggregate stats."""
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: SessionManager = request.app.state.workstreams
@@ -1170,7 +1163,7 @@ async def dashboard(request: Request) -> JSONResponse:
             title = get_workstream_display_name(ws.session.ws_id) or ""
         ws_list.append(
             {
-                "id": ws.id,
+                "ws_id": ws.id,
                 "name": title or ws.name,
                 "state": ws.state.value,
                 "title": title,

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -3644,7 +3644,7 @@ function loadDashboard() {
       renderDashboardTable(wsList, agg);
       var activeWsIds = {};
       wsList.forEach(function (ws) {
-        activeWsIds[ws.id] = true;
+        activeWsIds[ws.ws_id] = true;
       });
       var savedList = (res[1].workstreams || []).filter(function (s) {
         return !activeWsIds[s.ws_id];
@@ -3674,14 +3674,18 @@ function renderDashboardTable(wsList, agg) {
   }
   wsList.forEach(function (ws) {
     var liveState =
-      (workstreams[ws.id] && workstreams[ws.id].state) || ws.state || "idle";
+      (workstreams[ws.ws_id] && workstreams[ws.ws_id].state) ||
+      ws.state ||
+      "idle";
     var liveName =
-      (workstreams[ws.id] && workstreams[ws.id].name) || ws.name || ws.id;
+      (workstreams[ws.ws_id] && workstreams[ws.ws_id].name) ||
+      ws.name ||
+      ws.ws_id;
     var sd = STATE_DISPLAY[liveState] || STATE_DISPLAY.idle;
 
     var row = document.createElement("div");
     row.className = "dash-row";
-    row.dataset.wsId = ws.id;
+    row.dataset.wsId = ws.ws_id;
     row.dataset.state = liveState;
     row.setAttribute("role", "button");
     row.setAttribute("tabindex", "0");
@@ -3754,12 +3758,12 @@ function renderDashboardTable(wsList, agg) {
     row.appendChild(sub);
 
     row.onclick = function () {
-      dashboardSwitchWorkstream(ws.id);
+      dashboardSwitchWorkstream(ws.ws_id);
     };
     row.onkeydown = function (e) {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        dashboardSwitchWorkstream(ws.id);
+        dashboardSwitchWorkstream(ws.ws_id);
       }
     };
 


### PR DESCRIPTION
## Summary

Two small follow-ups from the Stage 2 SessionManager unification cycle, ahead of the v1.5.0 stable tag.

**1. Dashboard row shape: `id` → `ws_id`** (`417889f`)

The `/v1/api/dashboard` row dict was the last workstream-listing surface keyed on `id` rather than `ws_id`. The Stage 2 list-verb lift (#418) converged `/v1/api/workstreams` and `/v1/api/workstreams/saved` on `ws_id` but explicitly left dashboard alone to keep that PR's diff focused; this lands the same rename on the remaining endpoint so the v1 row shape is consistent across the family.

- Pydantic ``DashboardWorkstream`` and TS SDK ``DashboardWorkstream`` interface both rename ``id`` → ``ws_id``.
- Bundled web UI (`turnstone/ui/static/app.js`) is the only frontend reader of `dashboard.workstreams[].id` and is updated atomically.
- Console `_fetch_live_block` (cluster-inspect's projection over a remote node's `/dashboard` payload) flips its `entry.get(\"id\")` lookup to `entry.get(\"ws_id\")`.
- `_build_node_snapshot` (the global-events SSE `node_snapshot` payload consumed by the cluster collector) deliberately stays on `id` — it's part of a separate cluster-row family that's internally consistent and would need its own coordinated sweep.
- Drive-by: stale `id` example in `docs/api-reference.md` for the earlier `/v1/api/workstreams` rename.

**2. Coordinator URL tree doc sweep** (`4ab706a`)

`docs/coordinator-api-tour.md` and `docs/bulk-endpoints.md` still documented the pre-Stage-2 `/v1/api/coordinator/*` URL tree (removed in P0 of the verb-lift cycle). Rewrites all 9 step URLs in the lifecycle tour to the unified `/v1/api/workstreams/{ws_id}/<verb>` shape, adds a one-block convergence callout noting the historical surface, and drops the operation-id column (now best looked up live via `/openapi.json` since op ids shifted with the URL move).

## Test plan

- [x] `ruff check turnstone/ tests/` — clean
- [x] `mypy` on changed files — clean
- [x] Full pytest (`-m \"not live\"`) — 4554 passed
- [x] `/review` run before commit — surfaced one stale doc reference (`docs/api-reference.md`) which is included in the commit
- [ ] Manual smoke: dashboard table renders rows after deploy (interactive shipped frontend reads `ws.ws_id`)

## Out of scope

A follow-up branch will remove the legacy URL adapters (`/v1/api/send`, `/v1/api/approve`, `/v1/api/cancel`, `/v1/api/events?ws_id=`, `/v1/api/workstreams/close`) post-merge, since 1.5.0 is the right window for a breaking URL-shape consolidation but it deserves its own focused PR.