### PR TITLE
fix(renderer): handle LaTeX-style \(...\) and \[...\] math delimiters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
+      # Node is required by tests/test_renderer_js.py — without
+      # explicit setup, that suite silently skips if the runner
+      # image happens not to ship Node, masking regressions in
+      # the browser-side renderer.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "20"
       - run: pip install -e ".[test]"
       - run: pytest tests/ -m "not live" --cov=turnstone --cov-report=term-missing --cov-report=xml -q
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -72,6 +79,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "20"
       - run: pip install -e ".[test,postgres]"
       - run: pytest tests/ -m "not live" --storage-backend=postgresql -q
         env:

--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -1,0 +1,179 @@
+"""Smoke tests for ``turnstone/shared_static/renderer.js``.
+
+The renderer is browser-only JS with no test framework on the project
+side. These tests drive it through ``node`` against a minimal browser-
+shim harness so a regression on the markdown / KaTeX wiring surfaces
+in CI rather than at runtime in the operator's browser.
+
+Each test invokes ``node -e`` with a small wrapper that loads
+``utils.js`` + ``renderer.js`` via ``vm.runInThisContext``, stubs
+``document`` / ``katex`` enough for the renderer to run, then prints
+the rendered HTML for a sample input. The assertions check the
+resulting markup contains the expected ``<span class="katex">…</span>``
+placeholder and not the raw delimiter.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_UTILS_JS = _REPO_ROOT / "turnstone/shared_static/utils.js"
+_RENDERER_JS = _REPO_ROOT / "turnstone/shared_static/renderer.js"
+
+
+def _has_node() -> bool:
+    return shutil.which("node") is not None
+
+
+pytestmark = pytest.mark.skipif(not _has_node(), reason="node not available")
+
+
+_HARNESS_TEMPLATE = """
+const vm = require('vm');
+const fs = require('fs');
+global.document = {
+  createElement: () => {
+    let t = '';
+    return {
+      get textContent() { return t; },
+      set textContent(v) { t = v; },
+      get innerHTML() {
+        return t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      },
+    };
+  },
+  addEventListener: () => {},
+};
+global.katex = {
+  renderToString: (tex, opts) =>
+    '<span class="katex">[KATEX:' +
+    tex.replace(/\\n/g, '\\\\n') +
+    (opts.displayMode ? ':display' : ':inline') +
+    ']</span>',
+};
+global.window = global;
+vm.runInThisContext(fs.readFileSync(%(utils)s, 'utf8'));
+vm.runInThisContext(fs.readFileSync(%(renderer)s, 'utf8'));
+const input = %(input)s;
+process.stdout.write(renderMarkdown(input));
+"""
+
+
+def _render(markdown: str) -> str:
+    """Render ``markdown`` through renderer.js + return the HTML."""
+    harness = _HARNESS_TEMPLATE % {
+        "utils": json.dumps(str(_UTILS_JS)),
+        "renderer": json.dumps(str(_RENDERER_JS)),
+        "input": json.dumps(markdown),
+    }
+    result = subprocess.run(
+        ["node", "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# KaTeX delimiter handling — both TeX and LaTeX styles
+# ---------------------------------------------------------------------------
+
+
+def test_tex_inline_math_renders() -> None:
+    out = _render("The formula $E = mc^2$ is famous.")
+    assert '<span class="katex">' in out
+    assert "[KATEX:E = mc^2:inline]" in out
+    assert "$E = mc^2$" not in out  # raw delimiters consumed
+
+
+def test_tex_display_math_renders() -> None:
+    out = _render("$$\nE = mc^2\n$$")
+    assert '<span class="katex">' in out
+    assert ":display]" in out
+
+
+def test_latex_inline_math_renders() -> None:
+    r"""LaTeX-style \(...\) inline math. GPT-5 / o-series / Claude
+    with reasoning effort emit this style by default; without
+    explicit support the model output passed through as raw \(x\)
+    text in coord + interactive UIs."""
+    out = _render(r"The formula \(E = mc^2\) is famous.")
+    assert '<span class="katex">' in out
+    assert "[KATEX:E = mc^2:inline]" in out
+    assert r"\(E = mc^2\)" not in out
+
+
+def test_latex_display_math_renders() -> None:
+    r"""LaTeX-style \[...\] display math."""
+    out = _render("Intro\n\n\\[\nE = mc^2\n\\]\n\nMore")
+    assert '<span class="katex">' in out
+    assert ":display]" in out
+    assert "\\[" not in out
+    assert "\\]" not in out
+
+
+def test_latex_math_in_list_item_renders() -> None:
+    """Nested-in-markdown-block — the original bug report. The list
+    item is processed via line-by-line + inlineMarkdown; the math
+    placeholder must survive that path."""
+    out = _render(r"- Item with \(E = mc^2\) math")
+    assert "<li>" in out
+    assert '<span class="katex">' in out
+    assert "[KATEX:E = mc^2:inline]" in out
+
+
+def test_latex_math_in_blockquote_renders() -> None:
+    out = _render(r"> Note: \(x^2\) is squared.")
+    assert "<blockquote>" in out
+    assert '<span class="katex">' in out
+
+
+def test_latex_math_in_bold_renders() -> None:
+    out = _render(r"Then **\(x^2\)** end.")
+    assert "<strong>" in out
+    assert '<span class="katex">' in out
+
+
+def test_mixed_tex_and_latex_styles() -> None:
+    out = _render(r"Here $x$ then \(y\) end.")
+    assert out.count('<span class="katex">') == 2
+    assert "[KATEX:x:inline]" in out
+    assert "[KATEX:y:inline]" in out
+
+
+def test_latex_math_inside_inline_code_preserved() -> None:
+    r"""\(...\) inside inline code must NOT render as math —
+    code is escaped + left literal."""
+    out = _render(r"Code: `\(x\)` raw.")
+    assert r"<code>\(x\)</code>" in out
+    assert '<span class="katex">' not in out
+
+
+def test_latex_math_inside_fenced_code_preserved() -> None:
+    r"""\(...\) inside a fenced block must stay literal."""
+    out = _render("```\nA \\(x\\) sample\n```")
+    assert "<pre><code>" in out
+    assert '<span class="katex">' not in out
+
+
+def test_solo_escaped_bracket_does_not_render_as_math() -> None:
+    r"""A lone \[ with no matching \] is not math — it's a markdown
+    bracket escape. Don't hijack it."""
+    out = _render(r"No math: \[ alone.")
+    assert '<span class="katex">' not in out
+
+
+def test_markdown_link_unaffected_by_math_protection() -> None:
+    r"""Math regex uses \[ / \] (escaped brackets), not bare [...].
+    Markdown links must still render."""
+    out = _render("See [docs](https://example.com).")
+    assert '<a href="https://example.com"' in out
+    assert ">docs</a>" in out

--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -177,3 +177,54 @@ def test_markdown_link_unaffected_by_math_protection() -> None:
     out = _render("See [docs](https://example.com).")
     assert '<a href="https://example.com"' in out
     assert ">docs</a>" in out
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — Copilot review on PR #425
+# ---------------------------------------------------------------------------
+
+
+def test_display_math_inside_inline_code_stays_literal() -> None:
+    r"""``$$...$$`` inside backticks must NOT trigger display-math
+    extraction — otherwise the math sentinel ends up wrapped inside
+    the <code> placeholder and leaks into rendered HTML as a raw
+    null-byte sentinel string.
+
+    Pre-#425 ordering ran display-math before inline code, which
+    caused this leak. The reordering makes inline code seal first.
+    """
+    out = _render(r"Use `$$x$$` for display math.")
+    assert "<code>$$x$$</code>" in out
+    assert '<span class="katex">' not in out
+    assert "\x00" not in out  # no leaked sentinel
+
+
+def test_latex_display_math_inside_inline_code_stays_literal() -> None:
+    r"""Same as above, but for the LaTeX-style \[...\] delimiter."""
+    out = _render(r"Use `\[x\]` for display math.")
+    assert r"<code>\[x\]</code>" in out
+    assert '<span class="katex">' not in out
+    assert "\x00" not in out
+
+
+def test_inline_latex_math_does_not_span_paragraphs() -> None:
+    r"""An unterminated \(...\) on one line must not eat the
+    following paragraph until it finds a closing \) — that would
+    consume large chunks of text under streaming markdown where
+    the closer hasn't arrived yet. Mirrors the $...$ behavior."""
+    src = "Open \\(unterminated\n\nNext paragraph with \\(x\\) here."
+    out = _render(src)
+    # The bare \( on line 1 should NOT match; the well-formed \(x\)
+    # on the second paragraph should render normally.
+    assert out.count('<span class="katex">') == 1
+    assert "[KATEX:x:inline]" in out
+    # The "unterminated" stays as raw text.
+    assert "unterminated" in out
+
+
+def test_inline_tex_math_does_not_span_newlines() -> None:
+    """Existing $...$ behavior — regression guard."""
+    src = "Open $unterminated\n\nNext paragraph $x$ here."
+    out = _render(src)
+    assert out.count('<span class="katex">') == 1
+    assert "[KATEX:x:inline]" in out

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -357,9 +357,18 @@ function renderMarkdown(text) {
     },
   );
 
-  // Protect display math ($$...$$) — must come before inline code/math
+  // Protect display math — must come before inline code/math.
+  // Two delimiter styles: TeX ($$...$$) and LaTeX (\[...\]). Most
+  // models emit one or the other depending on system-prompt style;
+  // GPT-5 / o-series and Claude with reasoning effort tend to emit
+  // the LaTeX form. Without both, math nested in a markdown
+  // paragraph silently passes through as raw \[...\] text.
   var mathBlocks = [];
   text = text.replace(/\$\$([\s\S]+?)\$\$/g, function (m, tex) {
+    mathBlocks.push(renderLatex(tex.trim(), true));
+    return "\x00MB" + (mathBlocks.length - 1) + "\x00";
+  });
+  text = text.replace(/\\\[([\s\S]+?)\\\]/g, function (m, tex) {
     mathBlocks.push(renderLatex(tex.trim(), true));
     return "\x00MB" + (mathBlocks.length - 1) + "\x00";
   });
@@ -371,10 +380,15 @@ function renderMarkdown(text) {
     return "\x00IC" + (inlineCodes.length - 1) + "\x00";
   });
 
-  // Protect inline math ($...$) — after inline code so `$x$` in code is safe
+  // Protect inline math — both delimiter styles ($...$ and \(...\)).
+  // After inline code so `$x$` / `\(x\)` inside code stays literal.
   var inlineMaths = [];
   text = text.replace(/\$([^\$\n]+?)\$/g, function (m, tex) {
     inlineMaths.push(renderLatex(tex, false));
+    return "\x00IM" + (inlineMaths.length - 1) + "\x00";
+  });
+  text = text.replace(/\\\(([\s\S]+?)\\\)/g, function (m, tex) {
+    inlineMaths.push(renderLatex(tex.trim(), false));
     return "\x00IM" + (inlineMaths.length - 1) + "\x00";
   });
 

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -357,12 +357,29 @@ function renderMarkdown(text) {
     },
   );
 
-  // Protect display math — must come before inline code/math.
-  // Two delimiter styles: TeX ($$...$$) and LaTeX (\[...\]). Most
-  // models emit one or the other depending on system-prompt style;
-  // GPT-5 / o-series and Claude with reasoning effort tend to emit
-  // the LaTeX form. Without both, math nested in a markdown
-  // paragraph silently passes through as raw \[...\] text.
+  // Protect inline code FIRST so backtick spans containing math
+  // delimiters (e.g. `` `$$x$$` `` or `` `\[x\]` ``) stay literal.
+  // Display math used to run first, but that lets the math regex
+  // consume delimiters inside backticks and replace them with
+  // \x00MB…\x00 sentinels — sentinels then captured by the inline
+  // code grab end up restored INSIDE the <code>, leaking the
+  // null-byte placeholder into rendered output. Code first means
+  // backticks seal their content before any math regex sees it.
+  // The reverse edge case (math containing backticks, e.g.
+  // ``$$ \verb|`x`| $$``) is much rarer and KaTeX would reject
+  // the verbatim syntax anyway.
+  var inlineCodes = [];
+  text = text.replace(/`([^`\n]+)`/g, function (m, code) {
+    inlineCodes.push("<code>" + escapeHtml(code) + "</code>");
+    return "\x00IC" + (inlineCodes.length - 1) + "\x00";
+  });
+
+  // Protect display math — both TeX ($$...$$) and LaTeX (\[...\])
+  // delimiter styles. Most models emit one or the other depending
+  // on system-prompt style; GPT-5 / o-series and Claude with
+  // reasoning effort tend to emit the LaTeX form. Without both,
+  // math nested in a markdown paragraph silently passes through
+  // as raw \[...\] text.
   var mathBlocks = [];
   text = text.replace(/\$\$([\s\S]+?)\$\$/g, function (m, tex) {
     mathBlocks.push(renderLatex(tex.trim(), true));
@@ -373,21 +390,19 @@ function renderMarkdown(text) {
     return "\x00MB" + (mathBlocks.length - 1) + "\x00";
   });
 
-  // Protect inline code
-  var inlineCodes = [];
-  text = text.replace(/`([^`\n]+)`/g, function (m, code) {
-    inlineCodes.push("<code>" + escapeHtml(code) + "</code>");
-    return "\x00IC" + (inlineCodes.length - 1) + "\x00";
-  });
-
   // Protect inline math — both delimiter styles ($...$ and \(...\)).
-  // After inline code so `$x$` / `\(x\)` inside code stays literal.
+  // Both regexes explicitly forbid newlines inside the captured
+  // group: an unterminated \(...\) (or $...$) on one line would
+  // otherwise eat the next paragraph until it found a closing
+  // delimiter, which is jarring on streaming markdown where the
+  // closer hasn't arrived yet. Display math (\[...\] / $$...$$)
+  // is the multi-line form by design.
   var inlineMaths = [];
   text = text.replace(/\$([^\$\n]+?)\$/g, function (m, tex) {
     inlineMaths.push(renderLatex(tex, false));
     return "\x00IM" + (inlineMaths.length - 1) + "\x00";
   });
-  text = text.replace(/\\\(([\s\S]+?)\\\)/g, function (m, tex) {
+  text = text.replace(/\\\(([^\n]+?)\\\)/g, function (m, tex) {
     inlineMaths.push(renderLatex(tex.trim(), false));
     return "\x00IM" + (inlineMaths.length - 1) + "\x00";
   });


### PR DESCRIPTION
## Summary

KaTeX rendering looked broken for math nested inside markdown — the actual cause: the browser renderer at `turnstone/shared_static/renderer.js` only recognized **TeX-style** delimiters (`$...$` / `$$...$$`), but most modern LLMs (GPT-5 / o-series, Claude with reasoning effort) emit **LaTeX-style** delimiters by default:

- `\(...\)` for inline math
- `\[...\]` for display math

Those flowed through unchanged as raw text. Math at the top of a message also failed; the "nested in markdown" framing was just the most visible symptom because the surrounding rendered markdown made the unrendered raw `\(x^2\)` stand out.

Added a second regex pass for each style alongside the existing TeX patterns. Both styles now feed the same `mathBlocks` / `inlineMaths` placeholder pipeline, so all the existing nested-block handling (lists, blockquotes, tables, bold, headings, `<details>`, post-render KaTeX markup) Just Works.

## Edge cases verified

The new `tests/test_renderer_js.py` harness drives `renderer.js` through Node (`vm.runInThisContext`) with stubbed `document` / `katex` globals — first JS-side regression guard the renderer has had:

- [x] `\(...\)` inside inline code stays literal
- [x] `\(...\)` inside fenced code blocks stays literal
- [x] Solo `\[` with no closing `\]` doesn't trigger spurious math
- [x] Markdown links `[text](url)` untouched (math regex uses `\[` `\]`, not `[` `]`)
- [x] Mixed TeX + LaTeX delimiters in one message both render
- [x] LaTeX math inside list items / blockquotes / bold all render

12 new tests, all green. Skips cleanly when `node` isn't on `PATH`.

## Test plan

- [ ] Open coord or interactive WebUI, send a prompt that elicits math (e.g., "explain Einstein's mass-energy equivalence with the formula"). Verify the model's `\(E = mc^2\)` / `\[...\]` output renders as styled KaTeX in the chat bubble, not as raw `\(...\)` text.
- [ ] Nested cases: same prompt with "in a bulleted list" / "as a blockquote" / "inside a table cell". Each should render the math inline.
- [ ] Backwards compat: `$E = mc^2$` and `$$E = mc^2$$` still render.