### PR TITLE
feat(renderer): progressive mermaid rendering during streaming

### DIFF
--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -272,6 +272,15 @@ function makeEl(tag) {
     set textContent(v) { this._textContent = v; this.children = []; },
     get innerHTML() { return this._innerHTML; },
     set innerHTML(v) { this._innerHTML = v; this.children = []; },
+    get isConnected() {
+      // In real DOM this checks attachment to the document; for the
+      // test harness we approximate via the parent chain. After
+      // replaceWith, the displaced element's parent is nulled so
+      // its isConnected goes false — which is exactly the
+      // detached-during-streaming case the production guard
+      // protects against.
+      return !!this.parent;
+    },
     appendChild(c) {
       c.parent = this;
       this.children.push(c);
@@ -394,6 +403,22 @@ const container = buildContainer(sources);
 """
 
 
+# Drain microtasks + global mermaid render chain. Wraps the async
+# work in a setTimeout(0) hop so all queued microtasks (including
+# the per-source pending list draining via _mermaidRenderChain)
+# flush before the assertion script reads cache state.
+_MERMAID_DRAIN_JS = """
+function drainAndReport(report) {
+  // Two setTimeout hops give the global chain time to resolve
+  // mermaid.render's promise + the .then handlers that populate
+  // the cache and call _applyMermaidSvg.
+  setTimeout(() => setTimeout(() => {
+    process.stdout.write(JSON.stringify(report()));
+  }, 0), 0);
+}
+"""
+
+
 def test_mermaid_cache_hit_skips_render_call() -> None:
     """Identical source on a second postRenderMermaid call must serve
     from the cache — mermaid.render runs exactly once across both
@@ -401,24 +426,23 @@ def test_mermaid_cache_hit_skips_render_call() -> None:
     fire postRenderMermaid on every rAF tick without thrashing."""
     scenario = (
         _build_mermaid_container_js(["graph TD\n  A --> B"])
+        + _MERMAID_DRAIN_JS
         + """
 postRenderMermaid(container);
-// Drain microtasks so the async mermaid.render Promise resolves
-// before we measure call count.
-Promise.resolve().then(() => Promise.resolve()).then(() => {
+setTimeout(() => setTimeout(() => {
   // Second invocation — fresh container, same source. Should NOT
   // call mermaid.render again because the cache holds the SVG.
   const container2 = buildContainer(sources);
   postRenderMermaid(container2);
-  Promise.resolve().then(() => {
+  setTimeout(() => {
     process.stdout.write(JSON.stringify({
       renderCalls: renderCallCount,
       cacheSize: _mermaidSvgCache.size,
       firstClass: container.children[0].className,
       secondClass: container2.children[0].className,
     }));
-  });
-});
+  }, 0);
+}, 0), 0);
 """
     )
     out = _run_mermaid_scenario(scenario)
@@ -437,12 +461,14 @@ def test_mermaid_distinct_sources_render_independently() -> None:
         _build_mermaid_container_js(["graph TD\n  A --> B", "sequenceDiagram\n  A->>B: hi"])
         + """
 postRenderMermaid(container);
-Promise.resolve().then(() => Promise.resolve()).then(() => {
+// Drain twice — across-source serialization means the second
+// render starts only after the first lands.
+setTimeout(() => setTimeout(() => setTimeout(() => {
   process.stdout.write(JSON.stringify({
     renderCalls: renderCallCount,
     cacheSize: _mermaidSvgCache.size,
   }));
-});
+}, 0), 0), 0);
 """
     )
     out = _run_mermaid_scenario(scenario)
@@ -459,19 +485,19 @@ def test_mermaid_error_cached_to_avoid_thrash() -> None:
         + """
 renderShouldFail = true;
 postRenderMermaid(container);
-Promise.resolve().then(() => Promise.resolve()).then(() => {
+setTimeout(() => setTimeout(() => {
   // Re-run with same source — should hit error cache.
   const container2 = buildContainer(sources);
   postRenderMermaid(container2);
-  Promise.resolve().then(() => {
+  setTimeout(() => {
     process.stdout.write(JSON.stringify({
       renderCalls: renderCallCount,
       errorCacheSize: _mermaidErrorCache.size,
       svgCacheSize: _mermaidSvgCache.size,
       secondClass: container2.children[0].className,
     }));
-  });
-});
+  }, 0);
+}, 0), 0);
 """
     )
     out = _run_mermaid_scenario(scenario)
@@ -488,7 +514,7 @@ def test_mermaid_cache_evicts_oldest_at_cap() -> None:
     scenario = """
 const cap = _MERMAID_CACHE_MAX;
 for (let i = 0; i < cap + 5; i++) {
-  _cacheMermaidEntry(_mermaidSvgCache, 'src-' + i, 'svg-' + i);
+  _cacheMermaidEntry(_mermaidSvgCache, 'src-' + i, {svg: 'svg-' + i, bindFunctions: null});
 }
 process.stdout.write(JSON.stringify({
   size: _mermaidSvgCache.size,
@@ -502,16 +528,99 @@ process.stdout.write(JSON.stringify({
     assert out["hasNewest"] is True
 
 
+def test_mermaid_overwrite_does_not_evict() -> None:
+    """Overwriting an existing key is an in-place update, not a new
+    insertion — should not evict the oldest entry. Pre-fix, an
+    update at cap would unnecessarily drop an unrelated cached SVG."""
+    scenario = """
+const cap = _MERMAID_CACHE_MAX;
+// Fill exactly to cap.
+for (let i = 0; i < cap; i++) {
+  _cacheMermaidEntry(_mermaidSvgCache, 'src-' + i, {svg: 'svg-' + i, bindFunctions: null});
+}
+// Overwrite an existing entry — must not evict src-0.
+_cacheMermaidEntry(_mermaidSvgCache, 'src-5', {svg: 'svg-updated', bindFunctions: null});
+process.stdout.write(JSON.stringify({
+  size: _mermaidSvgCache.size,
+  hasOldest: _mermaidSvgCache.has('src-0'),
+  updated: _mermaidSvgCache.get('src-5').svg,
+}));
+"""
+    out = _run_mermaid_scenario(scenario)
+    assert out["size"] == 64
+    assert out["hasOldest"] is True, "overwrite evicted oldest unnecessarily"
+    assert out["updated"] == "svg-updated"
+
+
+def test_mermaid_cache_cleared_on_init() -> None:
+    """_initMermaid must clear both caches so a theme change via
+    reRenderAllMermaid doesn't serve stale SVG keyed by source-only
+    — the rendered output depends on themeVariables which change
+    on init."""
+    scenario = """
+_cacheMermaidEntry(_mermaidSvgCache, 'src-1', {svg: 'old', bindFunctions: null});
+_cacheMermaidEntry(_mermaidErrorCache, 'src-bad', 'old error');
+_initMermaid();
+process.stdout.write(JSON.stringify({
+  svgSize: _mermaidSvgCache.size,
+  errorSize: _mermaidErrorCache.size,
+}));
+"""
+    out = _run_mermaid_scenario(scenario)
+    assert out["svgSize"] == 0
+    assert out["errorSize"] == 0
+
+
+def test_mermaid_cache_hit_reapplies_bind_functions() -> None:
+    """bindFunctions returned by mermaid.render attach link/click
+    handlers to the rendered SVG. Cache hits must re-invoke this
+    on the new container instance — pre-fix, only the first render
+    got bindings; subsequent cache hits via innerHTML left the SVG
+    inert."""
+    scenario = (
+        _build_mermaid_container_js(["graph TD\n  A --> B"])
+        + """
+let bindCallCount = 0;
+const origRender = mermaid.render;
+mermaid.render = (id, source) => {
+  return Promise.resolve({
+    svg: '<svg>render</svg>',
+    bindFunctions: () => { bindCallCount++; },
+  });
+};
+postRenderMermaid(container);
+setTimeout(() => setTimeout(() => {
+  // Second invocation — cache hit, should still call
+  // bindFunctions on the new container.
+  const container2 = buildContainer(sources);
+  postRenderMermaid(container2);
+  setTimeout(() => {
+    process.stdout.write(JSON.stringify({
+      bindCallCount: bindCallCount,
+    }));
+  }, 0);
+}, 0), 0);
+"""
+    )
+    out = _run_mermaid_scenario(scenario)
+    # First render binds; cache hit on second container also binds.
+    assert out["bindCallCount"] == 2, (
+        "bindFunctions was not re-applied on cache hit — interactive "
+        "diagram features (links, callbacks) would silently break"
+    )
+
+
 def test_streaming_render_invokes_mermaid_post_render() -> None:
     """_streamingRenderApply must call postRenderMermaid so closed
     mermaid fences appear progressively during streaming, not only
     at stream_end via streamingRenderFinalize."""
     body = _RENDERER_JS.read_text(encoding="utf-8")
-    # Find the function body of _streamingRenderApply.
+    # Bound the search to a window after the function declaration —
+    # avoids the brittleness of stopping at the first inner-block
+    # closing brace.
     start = body.index("function _streamingRenderApply")
-    end = body.index("\n}\n", start) + 2
-    fn_body = body[start:end]
-    assert "postRenderMermaid(el)" in fn_body, (
+    mermaid_call = body.find("postRenderMermaid(el)", start, start + 4000)
+    assert mermaid_call != -1, (
         "_streamingRenderApply must call postRenderMermaid for "
         "progressive diagram rendering during streaming"
     )

--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -19,6 +19,7 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -228,3 +229,289 @@ def test_inline_tex_math_does_not_span_newlines() -> None:
     out = _render(src)
     assert out.count('<span class="katex">') == 1
     assert "[KATEX:x:inline]" in out
+
+
+# ---------------------------------------------------------------------------
+# Mermaid progressive rendering — source-keyed SVG cache
+# ---------------------------------------------------------------------------
+
+
+_MERMAID_HARNESS_TEMPLATE = """
+const vm = require('vm');
+const fs = require('fs');
+
+// Minimal DOM fake — enough surface for postRenderMermaid + the
+// mermaid render path. Each created element tracks its attributes,
+// classList, children, and parent so replaceWith works.
+function makeEl(tag) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    _attrs: {},
+    _classes: new Set(),
+    children: [],
+    parent: null,
+    _innerHTML: '',
+    _textContent: '',
+    setAttribute(k, v) { this._attrs[k] = v; },
+    getAttribute(k) { return this._attrs[k] !== undefined ? this._attrs[k] : null; },
+    get classList() {
+      const self = this;
+      return {
+        add(...c) { c.forEach(x => self._classes.add(x)); },
+        remove(...c) { c.forEach(x => self._classes.delete(x)); },
+        contains(c) { return self._classes.has(c); },
+      };
+    },
+    get className() { return Array.from(this._classes).join(' '); },
+    set className(v) {
+      this._classes = new Set(String(v).split(/\\s+/).filter(Boolean));
+    },
+    get textContent() {
+      return this._textContent || this.children.map(c => c.textContent || '').join('');
+    },
+    set textContent(v) { this._textContent = v; this.children = []; },
+    get innerHTML() { return this._innerHTML; },
+    set innerHTML(v) { this._innerHTML = v; this.children = []; },
+    appendChild(c) {
+      c.parent = this;
+      this.children.push(c);
+      return c;
+    },
+    closest(selector) {
+      const t = selector.toUpperCase();
+      let cur = this;
+      while (cur) {
+        if (cur.tagName === t) return cur;
+        cur = cur.parent;
+      }
+      return null;
+    },
+    replaceWith(other) {
+      if (!this.parent) return;
+      const idx = this.parent.children.indexOf(this);
+      if (idx === -1) return;
+      this.parent.children[idx] = other;
+      other.parent = this.parent;
+      this.parent = null;
+    },
+    querySelectorAll(selector) {
+      // Only supports the literal "pre code.language-mermaid"
+      // selector that postRenderMermaid uses.
+      const out = [];
+      function walk(node) {
+        for (const c of (node.children || [])) {
+          if (
+            c.tagName === 'CODE' &&
+            c.parent && c.parent.tagName === 'PRE' &&
+            c._classes.has('language-mermaid')
+          ) {
+            out.push(c);
+          }
+          walk(c);
+        }
+      }
+      walk(this);
+      return out;
+    },
+  };
+  return el;
+}
+
+global.document = {
+  createElement: makeEl,
+  addEventListener: () => {},
+  getElementById: () => null,
+  head: { appendChild: () => {} },
+  documentElement: {},
+};
+global.window = global;
+global.getComputedStyle = () => ({ getPropertyValue: () => '' });
+
+let renderCallCount = 0;
+let renderShouldFail = false;
+global.mermaid = {
+  initialize: () => {},
+  render: (id, source) => {
+    renderCallCount++;
+    if (renderShouldFail) {
+      return Promise.reject(new Error('bad diagram: ' + source));
+    }
+    return Promise.resolve({
+      svg: '<svg data-source="' + source + '">rendered</svg>',
+      bindFunctions: null,
+    });
+  },
+};
+
+vm.runInThisContext(fs.readFileSync(%(utils)s, 'utf8'));
+vm.runInThisContext(fs.readFileSync(%(renderer)s, 'utf8'));
+
+// Mermaid is normally lazy-loaded via _loadMermaid which fetches a
+// script tag. Force-mark it ready so postRenderMermaid invokes the
+// render path synchronously without trying to inject a script.
+_mermaidState = 'ready';
+
+%(scenario)s
+"""
+
+
+def _run_mermaid_scenario(scenario_js: str) -> dict[str, Any]:
+    """Run a JS snippet against the mermaid-aware harness, return JSON output."""
+    harness = _MERMAID_HARNESS_TEMPLATE % {
+        "utils": json.dumps(str(_UTILS_JS)),
+        "renderer": json.dumps(str(_RENDERER_JS)),
+        "scenario": scenario_js,
+    }
+    result = subprocess.run(
+        ["node", "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    parsed: dict[str, Any] = json.loads(result.stdout)
+    return parsed
+
+
+def _build_mermaid_container_js(sources: list[str]) -> str:
+    """JS expression that builds a container with ``<pre><code language-mermaid>`` blocks."""
+    src_array = "[" + ", ".join(json.dumps(s) for s in sources) + "]"
+    return f"""
+function buildContainer(sources) {{
+  const container = document.createElement('div');
+  for (const src of sources) {{
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.classList.add('language-mermaid');
+    code.textContent = src;
+    pre.appendChild(code);
+    container.appendChild(pre);
+  }}
+  return container;
+}}
+const sources = {src_array};
+const container = buildContainer(sources);
+"""
+
+
+def test_mermaid_cache_hit_skips_render_call() -> None:
+    """Identical source on a second postRenderMermaid call must serve
+    from the cache — mermaid.render runs exactly once across both
+    invocations. This is the core invariant that lets streamingRender
+    fire postRenderMermaid on every rAF tick without thrashing."""
+    scenario = (
+        _build_mermaid_container_js(["graph TD\n  A --> B"])
+        + """
+postRenderMermaid(container);
+// Drain microtasks so the async mermaid.render Promise resolves
+// before we measure call count.
+Promise.resolve().then(() => Promise.resolve()).then(() => {
+  // Second invocation — fresh container, same source. Should NOT
+  // call mermaid.render again because the cache holds the SVG.
+  const container2 = buildContainer(sources);
+  postRenderMermaid(container2);
+  Promise.resolve().then(() => {
+    process.stdout.write(JSON.stringify({
+      renderCalls: renderCallCount,
+      cacheSize: _mermaidSvgCache.size,
+      firstClass: container.children[0].className,
+      secondClass: container2.children[0].className,
+    }));
+  });
+});
+"""
+    )
+    out = _run_mermaid_scenario(scenario)
+    assert out["renderCalls"] == 1, "second postRenderMermaid call invoked render — cache miss"
+    assert out["cacheSize"] == 1
+    # Both containers end up with the rendered class — second from cache.
+    assert "mermaid-rendered" in out["firstClass"]
+    assert "mermaid-rendered" in out["secondClass"]
+
+
+def test_mermaid_distinct_sources_render_independently() -> None:
+    """Two distinct sources each trigger mermaid.render once and are
+    cached separately. Verifies the cache key is the source string,
+    not e.g. a positional index."""
+    scenario = (
+        _build_mermaid_container_js(["graph TD\n  A --> B", "sequenceDiagram\n  A->>B: hi"])
+        + """
+postRenderMermaid(container);
+Promise.resolve().then(() => Promise.resolve()).then(() => {
+  process.stdout.write(JSON.stringify({
+    renderCalls: renderCallCount,
+    cacheSize: _mermaidSvgCache.size,
+  }));
+});
+"""
+    )
+    out = _run_mermaid_scenario(scenario)
+    assert out["renderCalls"] == 2
+    assert out["cacheSize"] == 2
+
+
+def test_mermaid_error_cached_to_avoid_thrash() -> None:
+    """A mermaid render failure caches the error message keyed by
+    source, so subsequent postRenderMermaid calls on the same source
+    don't re-invoke mermaid.render only to re-fail."""
+    scenario = (
+        _build_mermaid_container_js(["bogus diagram"])
+        + """
+renderShouldFail = true;
+postRenderMermaid(container);
+Promise.resolve().then(() => Promise.resolve()).then(() => {
+  // Re-run with same source — should hit error cache.
+  const container2 = buildContainer(sources);
+  postRenderMermaid(container2);
+  Promise.resolve().then(() => {
+    process.stdout.write(JSON.stringify({
+      renderCalls: renderCallCount,
+      errorCacheSize: _mermaidErrorCache.size,
+      svgCacheSize: _mermaidSvgCache.size,
+      secondClass: container2.children[0].className,
+    }));
+  });
+});
+"""
+    )
+    out = _run_mermaid_scenario(scenario)
+    assert out["renderCalls"] == 1, "errored source re-invoked mermaid.render — error cache miss"
+    assert out["errorCacheSize"] == 1
+    assert out["svgCacheSize"] == 0
+    # Second container shows the error class without re-rendering.
+    assert "mermaid-error" in out["secondClass"]
+
+
+def test_mermaid_cache_evicts_oldest_at_cap() -> None:
+    """FIFO eviction at _MERMAID_CACHE_MAX prevents unbounded growth
+    on long sessions emitting many distinct diagrams."""
+    scenario = """
+const cap = _MERMAID_CACHE_MAX;
+for (let i = 0; i < cap + 5; i++) {
+  _cacheMermaidEntry(_mermaidSvgCache, 'src-' + i, 'svg-' + i);
+}
+process.stdout.write(JSON.stringify({
+  size: _mermaidSvgCache.size,
+  hasOldest: _mermaidSvgCache.has('src-0'),
+  hasNewest: _mermaidSvgCache.has('src-' + (cap + 4)),
+}));
+"""
+    out = _run_mermaid_scenario(scenario)
+    assert out["size"] == 64
+    assert out["hasOldest"] is False
+    assert out["hasNewest"] is True
+
+
+def test_streaming_render_invokes_mermaid_post_render() -> None:
+    """_streamingRenderApply must call postRenderMermaid so closed
+    mermaid fences appear progressively during streaming, not only
+    at stream_end via streamingRenderFinalize."""
+    body = _RENDERER_JS.read_text(encoding="utf-8")
+    # Find the function body of _streamingRenderApply.
+    start = body.index("function _streamingRenderApply")
+    end = body.index("\n}\n", start) + 2
+    fn_body = body[start:end]
+    assert "postRenderMermaid(el)" in fn_body, (
+        "_streamingRenderApply must call postRenderMermaid for "
+        "progressive diagram rendering during streaming"
+    )

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -821,6 +821,52 @@ function _getMermaidTheme() {
   };
 }
 
+// Source-keyed SVG cache. Identical mermaid source produces identical
+// SVG, so we can swap in cached output synchronously without re-running
+// mermaid.render. Crucial for streaming markdown: streamingRender does
+// `el.innerHTML = html` wholesale on every rAF tick, which destroys
+// rendered SVG nodes — without the cache, a closed mermaid block would
+// re-trigger an async render on every subsequent token. With the cache,
+// each unique source pays mermaid.render exactly once per session.
+//
+// Errored sources are cached too (as the message string) so a
+// syntactically-broken diagram doesn't re-thrash mermaid on every
+// render. The user can fix the diagram and the new source string
+// misses the cache, triggering a fresh render.
+//
+// FIFO bounded so a long session that emits many distinct diagrams
+// can't grow unbounded.
+var _mermaidSvgCache = new Map();
+var _mermaidErrorCache = new Map();
+var _MERMAID_CACHE_MAX = 64;
+
+function _cacheMermaidEntry(cache, source, value) {
+  if (cache.size >= _MERMAID_CACHE_MAX) {
+    var firstKey = cache.keys().next().value;
+    cache.delete(firstKey);
+  }
+  cache.set(source, value);
+}
+
+function _applyMermaidSvg(container, svg, bindFunctions) {
+  container.innerHTML = svg;
+  container.classList.remove("mermaid-loading", "mermaid-error");
+  container.classList.add("mermaid-rendered");
+  if (bindFunctions) bindFunctions(container);
+}
+
+function _applyMermaidError(container, source, message) {
+  container.classList.remove("mermaid-loading");
+  container.classList.add("mermaid-error");
+  container.innerHTML =
+    '<div class="mermaid-error-msg">' +
+    escapeHtml(message || "Diagram error") +
+    "</div>" +
+    "<pre><code>" +
+    escapeHtml(source) +
+    "</code></pre>";
+}
+
 // Render a single mermaid block, then call callback (serialized to avoid
 // concurrent mermaid.render() calls which corrupt shared internal state)
 function _renderMermaidBlock(container, callback) {
@@ -834,25 +880,17 @@ function _renderMermaidBlock(container, callback) {
     // Clean up orphaned temp SVG element mermaid may have left
     var orphan = document.getElementById(id);
     if (orphan) orphan.remove();
-    container.classList.remove("mermaid-loading");
-    container.classList.add("mermaid-error");
-    container.innerHTML =
-      '<div class="mermaid-error-msg">' +
-      escapeHtml(err.message || "Diagram error") +
-      "</div>" +
-      "<pre><code>" +
-      escapeHtml(source) +
-      "</code></pre>";
+    var msg = err && err.message ? err.message : "Diagram error";
+    _cacheMermaidEntry(_mermaidErrorCache, source, msg);
+    _applyMermaidError(container, source, msg);
     if (callback) callback();
   }
   try {
     mermaid
       .render(id, source)
       .then(function (result) {
-        container.innerHTML = result.svg;
-        container.classList.remove("mermaid-loading", "mermaid-error");
-        container.classList.add("mermaid-rendered");
-        if (result.bindFunctions) result.bindFunctions(container);
+        _cacheMermaidEntry(_mermaidSvgCache, source, result.svg);
+        _applyMermaidSvg(container, result.svg, result.bindFunctions);
         if (callback) callback();
       })
       .catch(_onError);
@@ -872,21 +910,41 @@ function _renderMermaidSequence(containers, idx) {
 function postRenderMermaid(containerEl) {
   var codeEls = containerEl.querySelectorAll("pre code.language-mermaid");
   if (codeEls.length === 0) return;
-  var containers = [];
+  var pendingContainers = [];
   for (var i = 0; i < codeEls.length; i++) {
     var pre = codeEls[i].closest("pre");
     if (!pre) continue;
     var source = codeEls[i].textContent;
     var div = document.createElement("div");
-    div.className = "mermaid-container mermaid-loading";
     div.setAttribute("data-mermaid-source", source);
-    div.textContent = "Loading diagram\u2026";
-    pre.replaceWith(div);
-    containers.push(div);
+    var cachedSvg = _mermaidSvgCache.get(source);
+    var cachedError = _mermaidErrorCache.get(source);
+    if (cachedSvg) {
+      // Cache hit — sync swap, no loading flash, no async work.
+      // Identical source produces identical SVG (mermaid is
+      // deterministic for a given init), so reusing the rendered
+      // SVG verbatim is safe across streamingRender's wholesale
+      // innerHTML replaces.
+      div.className = "mermaid-container mermaid-rendered";
+      div.innerHTML = cachedSvg;
+      pre.replaceWith(div);
+    } else if (cachedError) {
+      // Errored source — keep showing the error without thrashing
+      // mermaid.render on every streaming tick.
+      div.className = "mermaid-container mermaid-error";
+      _applyMermaidError(div, source, cachedError);
+      pre.replaceWith(div);
+    } else {
+      // Cache miss — show loading state, queue async render.
+      div.className = "mermaid-container mermaid-loading";
+      div.textContent = "Loading diagram\u2026";
+      pre.replaceWith(div);
+      pendingContainers.push(div);
+    }
   }
-  if (containers.length === 0) return;
+  if (pendingContainers.length === 0) return;
   _loadMermaid(function () {
-    _renderMermaidSequence(containers, 0);
+    _renderMermaidSequence(pendingContainers, 0);
   });
 }
 
@@ -913,17 +971,28 @@ function reRenderAllMermaid() {
 //  cycle.  renderMarkdown tolerates mid-stream partial fences / lists
 //  (they render as literal text and resolve once the closing tokens
 //  arrive), and the per-element buffer cache skips identical redundant
-//  renders (SSE retries / resumes).  postRenderMarkdown stays deferred
-//  to streamingRenderFinalize so syntax highlighting + mermaid + KaTeX
-//  don't thrash mid-stream.  renderMarkdown escapes HTML internally
-//  (see escapeHtml in utils.js); it is the trust boundary for the
-//  markup written to el below.
+//  renders (SSE retries / resumes).  hljs syntax highlighting stays
+//  deferred to streamingRenderFinalize, but mermaid runs inline on
+//  every render so closed diagram fences appear progressively as they
+//  complete (the source-keyed SVG cache makes re-renders cheap; only
+//  the first encounter with a given source pays mermaid.render).
+//  renderMarkdown escapes HTML internally (see escapeHtml in
+//  utils.js); it is the trust boundary for the markup written to el
+//  below.
 // ---------------------------------------------------------------------------
 function _streamingRenderApply(el, buffer) {
   if (el._lastRenderedBuffer === buffer) return;
   el._lastRenderedBuffer = buffer;
   var html = renderMarkdown(buffer);
   el.innerHTML = html;
+  // Progressive mermaid render — see comment above. postRenderMermaid
+  // is no-op when the element has no language-mermaid code blocks,
+  // and the source-keyed cache avoids re-invoking mermaid.render
+  // for blocks we've already rendered. Subsequent rAF ticks that
+  // re-extract the same closed fence hit the cache synchronously.
+  if (typeof postRenderMermaid === "function") {
+    postRenderMermaid(el);
+  }
 }
 
 function streamingRender(el, buffer) {

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -762,6 +762,11 @@ var _mermaidQueue = []; // callbacks queued while loading
 var _mermaidIdCounter = 0;
 
 function _initMermaid() {
+  // Clear caches on (re-)init so a theme change via reRenderAllMermaid
+  // doesn't serve stale SVG keyed by source-only — the rendered output
+  // depends on themeVariables which we just changed.
+  if (typeof _mermaidSvgCache !== "undefined") _mermaidSvgCache.clear();
+  if (typeof _mermaidErrorCache !== "undefined") _mermaidErrorCache.clear();
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: "strict",
@@ -841,7 +846,10 @@ var _mermaidErrorCache = new Map();
 var _MERMAID_CACHE_MAX = 64;
 
 function _cacheMermaidEntry(cache, source, value) {
-  if (cache.size >= _MERMAID_CACHE_MAX) {
+  // Only evict the oldest when inserting a new key — overwriting an
+  // existing source is an in-place update and should not pay the
+  // eviction cost (which would drop an unrelated cached entry).
+  if (!cache.has(source) && cache.size >= _MERMAID_CACHE_MAX) {
     var firstKey = cache.keys().next().value;
     cache.delete(firstKey);
   }
@@ -867,44 +875,84 @@ function _applyMermaidError(container, source, message) {
     "</code></pre>";
 }
 
-// Render a single mermaid block, then call callback (serialized to avoid
-// concurrent mermaid.render() calls which corrupt shared internal state)
+// Global render queue + per-source pending-container map.
+//
+// mermaid.render() uses module-level state internally — concurrent
+// calls clobber that state. With postRenderMermaid now firing on
+// every streaming rAF tick (not just on stream_end), two ticks
+// could each find a fresh container (the prior tick's container
+// is detached after innerHTML replace) for the SAME unfinished
+// source, or for DIFFERENT sources, and both would queue
+// mermaid.render() concurrently. Two layers of serialization fix
+// this:
+//
+//   1. _mermaidPending: per-source. While a render is in flight
+//      for source X, additional containers asking for source X
+//      are queued; the single render result fans out to all
+//      pending containers when it lands.
+//   2. _mermaidRenderChain: across-source. Promises chain so
+//      mermaid.render() runs at most one at a time globally.
+//
+// Detached containers (no longer in the DOM by the time the
+// render completes) are skipped — innerHTML replace during
+// streaming detaches them and a later rAF tick's render is
+// already taking care of the live container.
+var _mermaidPending = new Map();
+var _mermaidRenderChain = Promise.resolve();
+
 function _renderMermaidBlock(container, callback) {
   var source = container.getAttribute("data-mermaid-source");
   if (!source) {
     if (callback) callback();
     return;
   }
-  var id = "mermaid-" + ++_mermaidIdCounter;
-  function _onError(err) {
-    // Clean up orphaned temp SVG element mermaid may have left
-    var orphan = document.getElementById(id);
-    if (orphan) orphan.remove();
-    var msg = err && err.message ? err.message : "Diagram error";
-    _cacheMermaidEntry(_mermaidErrorCache, source, msg);
-    _applyMermaidError(container, source, msg);
+  // Same source already in flight — append to pending list.
+  // Caller's callback fires as if the render started; the actual
+  // SVG application happens when the in-flight render lands.
+  if (_mermaidPending.has(source)) {
+    _mermaidPending.get(source).push(container);
     if (callback) callback();
+    return;
   }
-  try {
-    mermaid
-      .render(id, source)
-      .then(function (result) {
-        _cacheMermaidEntry(_mermaidSvgCache, source, result.svg);
-        _applyMermaidSvg(container, result.svg, result.bindFunctions);
-        if (callback) callback();
-      })
-      .catch(_onError);
-  } catch (err) {
-    _onError(err);
-  }
+  _mermaidPending.set(source, [container]);
+  _mermaidRenderChain = _mermaidRenderChain.then(function () {
+    var pending = _mermaidPending.get(source) || [];
+    _mermaidPending.delete(source);
+    var id = "mermaid-" + ++_mermaidIdCounter;
+    return mermaid.render(id, source).then(
+      function (result) {
+        _cacheMermaidEntry(_mermaidSvgCache, source, {
+          svg: result.svg,
+          bindFunctions: result.bindFunctions,
+        });
+        for (var i = 0; i < pending.length; i++) {
+          var c = pending[i];
+          if (c.isConnected) {
+            _applyMermaidSvg(c, result.svg, result.bindFunctions);
+          }
+        }
+      },
+      function (err) {
+        var orphan = document.getElementById(id);
+        if (orphan) orphan.remove();
+        var msg = err && err.message ? err.message : "Diagram error";
+        _cacheMermaidEntry(_mermaidErrorCache, source, msg);
+        for (var i = 0; i < pending.length; i++) {
+          var c = pending[i];
+          if (c.isConnected) _applyMermaidError(c, source, msg);
+        }
+      },
+    );
+  });
+  if (callback) callback();
 }
 
-// Render mermaid blocks sequentially (mermaid uses shared state internally)
+// Render mermaid blocks via the global chain. Calls return
+// immediately; serialization happens inside _renderMermaidBlock.
 function _renderMermaidSequence(containers, idx) {
-  if (idx >= containers.length) return;
-  _renderMermaidBlock(containers[idx], function () {
-    _renderMermaidSequence(containers, idx + 1);
-  });
+  for (var i = 0; i < containers.length; i++) {
+    _renderMermaidBlock(containers[i]);
+  }
 }
 
 function postRenderMermaid(containerEl) {
@@ -917,22 +965,25 @@ function postRenderMermaid(containerEl) {
     var source = codeEls[i].textContent;
     var div = document.createElement("div");
     div.setAttribute("data-mermaid-source", source);
-    var cachedSvg = _mermaidSvgCache.get(source);
-    var cachedError = _mermaidErrorCache.get(source);
-    if (cachedSvg) {
+    // Use cache.has (not truthiness) so a future cached value of
+    // empty string / falsy SVG doesn't masquerade as a miss.
+    if (_mermaidSvgCache.has(source)) {
       // Cache hit — sync swap, no loading flash, no async work.
       // Identical source produces identical SVG (mermaid is
       // deterministic for a given init), so reusing the rendered
-      // SVG verbatim is safe across streamingRender's wholesale
-      // innerHTML replaces.
+      // result is safe across streamingRender's wholesale
+      // innerHTML replaces. Re-apply via the same helper used
+      // by fresh renders so mermaid's bindFunctions (link/click
+      // bindings) attach to each new container instance.
+      var cached = _mermaidSvgCache.get(source);
       div.className = "mermaid-container mermaid-rendered";
-      div.innerHTML = cachedSvg;
+      _applyMermaidSvg(div, cached.svg, cached.bindFunctions);
       pre.replaceWith(div);
-    } else if (cachedError) {
+    } else if (_mermaidErrorCache.has(source)) {
       // Errored source — keep showing the error without thrashing
       // mermaid.render on every streaming tick.
       div.className = "mermaid-container mermaid-error";
-      _applyMermaidError(div, source, cachedError);
+      _applyMermaidError(div, source, _mermaidErrorCache.get(source));
       pre.replaceWith(div);
     } else {
       // Cache miss — show loading state, queue async render.


### PR DESCRIPTION
## Summary

Mermaid diagrams used to materialize all-at-once at `stream_end` via `streamingRenderFinalize`, which felt laggy on long responses with multiple diagrams. This PR makes closed mermaid fences render progressively as each fence completes during streaming.

The blocker was `streamingRender`'s wholesale `el.innerHTML = html` on every rAF tick, which destroys any rendered SVG nodes — without caching, calling `postRenderMermaid` per tick would re-trigger an async `mermaid.render` every time, thrashing the renderer.

## How it works

Source-keyed SVG cache (`_mermaidSvgCache`, FIFO-bounded at 64 entries):

- **Cache hit** on identical source: synchronous `innerHTML` swap, no loading flash, no async work. Mermaid is deterministic for a given init, so identical source ⇒ identical SVG — safe to reuse.
- **Cache miss**: queue async render, populate cache on success.
- **Errored sources** cached separately (`_mermaidErrorCache`) so a syntactically-broken diagram doesn't re-thrash mermaid on every tick. Fix the diagram → new source string misses the cache → fresh render.

`_streamingRenderApply` now calls `postRenderMermaid` after the `innerHTML` replace. Per-stream cost: each unique mermaid source pays `mermaid.render` once, then synchronous cache hits for every subsequent rAF tick.

`hljs` syntax highlighting stays deferred to `streamingRenderFinalize` — separate pass, benefits less from progressive rendering (code blocks tend to be short and already legible without color).

## Tests

Built a richer Node-driven harness with a fake DOM that tracks attributes / classList / parent chain / `replaceWith`, plus a stubbed `mermaid.render` with a call counter. 5 new tests:

- [x] Cache hit on second `postRenderMermaid` skips `mermaid.render` entirely
- [x] Distinct sources each render once and cache independently
- [x] Errored source caches the message → no re-thrash on subsequent renders
- [x] FIFO cache eviction at `_MERMAID_CACHE_MAX`
- [x] Static guard: `_streamingRenderApply` calls `postRenderMermaid`

Also kept the existing 16 KaTeX tests — 21 passing total, 0 regressions.

## Test plan

- [ ] Coord or interactive WebUI: prompt for a response containing multiple mermaid diagrams interleaved with prose. Diagrams should appear progressively as each ` ```mermaid ` fence closes, not all at the end.
- [ ] Same response twice: second emission should reuse cached SVG (visible as instant render, no "Loading diagram…" flash).
- [ ] Bogus mermaid syntax: error message renders once, doesn't flicker as further tokens arrive after the closing fence.
- [ ] Long session emitting >64 distinct diagrams: cache stays bounded, no memory growth.