### PR TITLE
fix(ui): bootstrap pane in switchTab when none exists

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1,0 +1,38 @@
+"""Static smoke guards for ``turnstone/ui/static/app.js``.
+
+The interactive WebUI's app.js has no JS test framework on the
+project side. This file holds Python-side string-presence assertions
+that catch regressions on critical paths — the kind of one-line
+deletion or rename that breaks the UI silently and only surfaces in
+manual testing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
+
+
+def test_switch_tab_bootstraps_pane_when_none_exists() -> None:
+    """``switchTab`` must create a pane when none exists. A fresh-
+    loaded interactive UI with no workstreams shows the dashboard
+    and creates no panes (per ``initWorkstreams``); the user's first
+    ``create`` or ``open`` then calls ``switchTab(newWsId)``. Pre-fix,
+    the early ``if (!pane) return;`` left switchTab with nowhere to
+    attach — the chat UI never connected SSE for the freshly-created
+    workstream, and only a page refresh fixed it. This test guards
+    against accidentally re-introducing the early-return."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    start = body.index("function switchTab(wsId) {")
+    # Bound the search to the function body — switchTab is short.
+    fn = body[start : start + 2000]
+    assert "if (!pane) return;" not in fn, (
+        "switchTab must not early-return when no pane exists — that's "
+        "the no-chat-after-first-create bug. Bootstrap a pane instead."
+    )
+    # Affirmatively check the bootstrap path exists.
+    assert "createPane(wsId)" in fn, (
+        "switchTab must call createPane(wsId) to bootstrap the first "
+        "pane when getFocusedPane returns null"
+    )

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -2994,7 +2994,21 @@ function updateTabIndicator(wsId, state, extra) {
 function switchTab(wsId) {
   closeTabDropdown();
   var pane = getFocusedPane();
-  if (!pane) return;
+  if (!pane) {
+    // Bootstrap the first pane on a fresh-loaded page that had no
+    // workstreams to render at init time. Without this, creating
+    // or opening a workstream from the dashboard left switchTab
+    // with nowhere to attach: it early-returned, no SSE connected,
+    // the chat UI showed nothing, and only a refresh fixed it
+    // (initWorkstreams creates the pane on a now-populated
+    // workstreams list). Mirrors the bootstrap block in
+    // initWorkstreams; renderLayout fires once so the pane DOM is
+    // attached before the rest of switchTab connects SSE.
+    pane = createPane(wsId);
+    splitRoot = { type: "leaf", pane: pane };
+    setFocusedPane(pane.id);
+    renderLayout();
+  }
   if (wsId === pane.wsId && !dashboardVisible) return;
 
   // Track last active for close_tab_action


### PR DESCRIPTION
## Summary

Creating or opening a workstream from the dashboard left the chat UI blank until the operator refreshed the page. Subsequent creations on the same node worked correctly.

## Root cause

`initWorkstreams` only bootstraps a pane if there's already at least one workstream:

```js
if (!wsIds.length) {
  renderTabBar();
  showDashboard();
  return;  // no pane created
}
```

So a fresh-loaded page with zero workstreams had `panes = {}` and `focusedPaneId = null`. The user then creates / opens their first workstream → the create handler calls `switchTab(newWsId)` → `switchTab` does:

```js
var pane = getFocusedPane();
if (!pane) return;  // bails — no pane to attach to
```

The new ws was added to `workstreams` dict, the dashboard was hidden, but no pane was bootstrapped, no SSE connected, and the chat area sat empty. Refresh fixed it because `initWorkstreams` then saw the populated list and took the bootstrap branch.

After the refresh, `panes` was non-empty, so subsequent creations had a focused pane for `switchTab` to operate on — explaining the "subsequent creations work correctly" symptom.

## Fix

`switchTab` now mirrors `initWorkstreams`'s bootstrap when `getFocusedPane()` returns null: `createPane(wsId)` + `splitRoot` leaf + `setFocusedPane` + `renderLayout`. The rest of `switchTab` (disconnectSSE / reset / connectSSE) runs as before — no-ops on the just-constructed pane up to the `connectSSE` call which is exactly what we want.

## Test plan

- [ ] Fresh-loaded interactive WebUI with no existing workstreams → dashboard view → create a workstream → chat UI should render and SSE should connect, no refresh needed.
- [ ] Same scenario but via "open saved workstream" → same outcome.
- [ ] Subsequent creations on the same node → still work (regression check).
- [ ] Existing flow (page loads with a non-empty workstream list, switchTab between existing tabs) → no behavior change.

Static smoke guard added in `tests/test_app_js.py` to catch the early-return regressing.