### PR TITLE
feat(coord): bundle child last-message inline in wait_for_workstream

### DIFF
--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -1390,6 +1390,295 @@ def test_wait_for_workstream_handles_non_string_mode(populated_storage):
 
 
 # ---------------------------------------------------------------------------
+# wait_for_workstream — last-message bundling
+# ---------------------------------------------------------------------------
+#
+# Each terminal child's last assistant turn (or a status sentinel) is
+# bundled inline so the coord LLM doesn't need a follow-up
+# inspect_workstream round-trip per ws.  The fields are additive
+# (``message`` / ``truncated``), so existing wait tests stay green.
+
+
+def test_wait_for_workstream_idle_returns_last_assistant_message(populated_storage):
+    """A child that finished normally surfaces its final assistant
+    turn inline so the coord doesn't have to inspect to read it."""
+    populated_storage.save_message("child-a", "user", "what's the answer?")
+    populated_storage.save_message("child-a", "assistant", "the answer is 42")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "idle"
+    assert snap["message"] == "the answer is 42"
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_idle_walks_past_trailing_tool_messages(populated_storage):
+    """The most recent assistant turn often sits behind a few tool
+    messages (assistant emits tool_calls → tool results land → final
+    assistant content follows).  The walk must skip non-assistant
+    rows when picking the last assistant content."""
+    populated_storage.save_message("child-a", "user", "do the thing")
+    populated_storage.save_message("child-a", "assistant", "calling tool")
+    populated_storage.save_message("child-a", "tool", "tool output", tool_call_id="t1")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    # The assistant message above is the most recent assistant turn —
+    # the trailing tool row must not block extraction.
+    assert result["results"]["child-a"]["message"] == "calling tool"
+
+
+def test_wait_for_workstream_idle_skips_empty_assistant_with_tool_calls(populated_storage):
+    """An assistant message with empty content + only tool_calls isn't
+    a final answer — walk further back for the last assistant message
+    that actually has text."""
+    populated_storage.save_message("child-a", "user", "first turn")
+    populated_storage.save_message("child-a", "assistant", "first assistant reply")
+    populated_storage.save_message("child-a", "user", "second turn")
+    populated_storage.save_message(
+        "child-a", "assistant", "", tool_calls='[{"id": "t1", "name": "x"}]'
+    )
+    populated_storage.save_message("child-a", "tool", "tool result", tool_call_id="t1")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    # Last assistant with non-empty content is the FIRST assistant message
+    # — the empty-content tool-calls assistant must be skipped.
+    assert result["results"]["child-a"]["message"] == "first assistant reply"
+
+
+def test_wait_for_workstream_idle_no_assistant_returns_sentinel(populated_storage):
+    """A workstream that reaches idle without an assistant turn in the
+    tail (rare but possible for a freshly registered ws closed before
+    generation, or a long-running ws whose final assistant message is
+    buried beyond the tail window) gets a hedged sentinel rather than
+    null — the model can distinguish 'no recent output' from 'still
+    running'."""
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "idle"
+    # No messages were saved for child-a in this test — sentinel kicks in.
+    # Wording is hedged ("recent") because the tail-only walk can't
+    # actually prove no assistant output exists in the full history.
+    assert snap["message"] == "(no recent assistant output)"
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_error_returns_last_assistant_message(populated_storage):
+    """An errored child still gets its last assistant turn surfaced —
+    that's usually the most useful diagnostic ('I was about to ...
+    when the error happened')."""
+    populated_storage.update_workstream_state("child-a", "error")
+    populated_storage.save_message("child-a", "user", "hi")
+    populated_storage.save_message("child-a", "assistant", "partial output before crash")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "error"
+    assert snap["message"] == "partial output before crash"
+
+
+def test_wait_for_workstream_error_with_no_output_returns_sentinel(populated_storage):
+    """When error fires with no assistant content in the tail (e.g. a
+    pre-flight provider auth failure that crashes before the model
+    speaks, or a >18-parallel-tool-call burst whose only assistant
+    row carries empty content), the same hedged sentinel applies.
+    The wording deliberately doesn't claim 'before producing output'
+    — the tail-only walk can't prove that.
+    """
+    populated_storage.update_workstream_state("child-a", "error")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "error"
+    assert snap["message"] == "(no recent assistant output)"
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_closed_returns_sentinel(populated_storage):
+    """Closed children get a status sentinel rather than a partial
+    last message — a half-finished thought from a workstream the
+    operator explicitly closed isn't useful (and could be misleading)."""
+    populated_storage.update_workstream_state("child-a", "closed")
+    populated_storage.save_message("child-a", "assistant", "mid-thought when closed")
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "closed"
+    assert snap["message"] == "(workstream closed)"
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_denied_returns_sentinel(populated_storage):
+    """Cross-tenant / nonexistent ws_ids surface as denied — the
+    sentinel lets the coord LLM recognise the rejection without
+    parsing state strings on its own."""
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["unrelated"], timeout=5, mode="any")
+    snap = result["results"]["unrelated"]
+    assert snap["state"] == "denied"
+    assert snap["message"].startswith("(workstream denied")
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_running_child_message_is_null(populated_storage):
+    """A still-running child after a timeout must report
+    ``message=None`` — anything else would be a partial last message
+    pretending to be a final answer.  The coord uses null to know
+    'still working, inspect later'."""
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a", "child-b"], timeout=1.0, mode="all")
+    # mode='all' on (idle, running) hits the timeout — child-b is still
+    # running and must come back with message=None.
+    assert result["complete"] is False
+    assert result["results"]["child-b"]["state"] == "running"
+    assert result["results"]["child-b"]["message"] is None
+    assert result["results"]["child-b"]["truncated"] is False
+
+
+def test_wait_for_workstream_truncates_oversize_message(populated_storage):
+    """A message past WAIT_MESSAGE_MAX_BYTES is truncated from the
+    END (preserve the lead) and ``truncated=True`` so the coord LLM
+    knows to inspect for the rest if it needs the full text."""
+    from turnstone.console.coordinator_client import WAIT_MESSAGE_MAX_BYTES
+
+    big = "A" * (WAIT_MESSAGE_MAX_BYTES * 2)
+    populated_storage.save_message("child-a", "user", "hi")
+    populated_storage.save_message("child-a", "assistant", big)
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    # Truncated — exactly the cap in bytes (single-byte chars), with the
+    # head preserved.
+    assert snap["truncated"] is True
+    assert len(snap["message"].encode("utf-8")) == WAIT_MESSAGE_MAX_BYTES
+    assert snap["message"].startswith("AAAA")
+
+
+def test_wait_for_workstream_storage_failure_leaves_message_null(populated_storage, monkeypatch):
+    """A transient storage error during the message read must not
+    fail the wait — the coord still gets state/tokens/updated, and
+    the per-ws ``message`` collapses to None so the model can fall
+    back to inspect."""
+    populated_storage.update_workstream_state("child-a", "idle")
+
+    def _broken_load(*_a, **_kw):
+        raise RuntimeError("simulated storage outage")
+
+    monkeypatch.setattr(populated_storage, "load_messages", _broken_load)
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+    snap = result["results"]["child-a"]
+    assert snap["state"] == "idle"
+    assert snap["message"] is None
+    assert snap["truncated"] is False
+
+
+def test_wait_for_workstream_does_not_pollute_progress_callback(populated_storage):
+    """The wait_progress SSE event shape is documented as separate
+    from the tool result — the per-tick snapshot dicts handed to the
+    progress callback must NOT carry the new ``message`` /
+    ``truncated`` fields, since enrichment happens after the loop
+    exits."""
+    populated_storage.save_message("child-a", "assistant", "ok")
+    client = _make_read_client(populated_storage)
+    captured: list[dict[str, dict[str, Any]]] = []
+
+    def _cb(snap: dict[str, dict[str, Any]], _elapsed: float) -> None:
+        # Deep-copy so a later mutation by enrichment can't fool the
+        # assertion (we want the shape AT CALLBACK TIME, not at end).
+        import copy
+
+        captured.append(copy.deepcopy(snap))
+
+    client.wait_for_workstream(["child-a"], timeout=5, mode="any", progress_callback=_cb)
+    assert captured  # at least one tick fired
+    for tick in captured:
+        for per_ws in tick.values():
+            assert "message" not in per_ws
+            assert "truncated" not in per_ws
+
+
+# ---------------------------------------------------------------------------
+# wait_for_workstream — helper-function unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_wait_message_below_cap_is_passthrough():
+    from turnstone.console.coordinator_client import _truncate_wait_message
+
+    text, trunc = _truncate_wait_message("hello", 100)
+    assert text == "hello"
+    assert trunc is False
+
+
+def test_truncate_wait_message_exact_cap_is_passthrough():
+    from turnstone.console.coordinator_client import _truncate_wait_message
+
+    text, trunc = _truncate_wait_message("a" * 5, 5)
+    assert text == "aaaaa"
+    assert trunc is False
+
+
+def test_truncate_wait_message_oversize_truncates_to_byte_cap():
+    from turnstone.console.coordinator_client import _truncate_wait_message
+
+    text, trunc = _truncate_wait_message("a" * 10, 5)
+    assert text == "aaaaa"
+    assert trunc is True
+
+
+def test_truncate_wait_message_handles_utf8_boundary():
+    """A multi-byte codepoint must never be split — back off to a valid
+    UTF-8 boundary even if it lands a couple bytes under the cap."""
+    from turnstone.console.coordinator_client import _truncate_wait_message
+
+    # "café" is 5 bytes (c=1, a=1, f=1, é=2).  Cap at 4 bytes lands
+    # mid-codepoint on the é; truncation must back off to 3 bytes.
+    text, trunc = _truncate_wait_message("café", 4)
+    assert trunc is True
+    assert text == "caf"
+    # And the result must be valid UTF-8 — re-encoding doesn't error.
+    text.encode("utf-8")
+
+
+def test_truncate_wait_message_zero_or_negative_cap_returns_empty():
+    from turnstone.console.coordinator_client import _truncate_wait_message
+
+    text, trunc = _truncate_wait_message("anything", 0)
+    assert text == ""
+    assert trunc is True
+
+
+def test_last_assistant_text_returns_content_when_present(populated_storage):
+    """Pins the third leg of the tri-state contract: a populated tail
+    returns the actual assistant content string (not ``""``, not
+    ``None``).  Integration tests cover this through enrichment, but a
+    direct unit test makes the contract harder to break in a refactor."""
+    from turnstone.console.coordinator_client import _last_assistant_text
+
+    populated_storage.save_message("child-a", "user", "hello")
+    populated_storage.save_message("child-a", "assistant", "hi back")
+    assert _last_assistant_text(populated_storage, "child-a") == "hi back"
+
+
+def test_last_assistant_text_returns_empty_when_no_messages(populated_storage):
+    from turnstone.console.coordinator_client import _last_assistant_text
+
+    # child-a has no messages saved.
+    assert _last_assistant_text(populated_storage, "child-a") == ""
+
+
+def test_last_assistant_text_returns_none_on_storage_failure(populated_storage, monkeypatch):
+    from turnstone.console.coordinator_client import _last_assistant_text
+
+    def _broken(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(populated_storage, "load_messages", _broken)
+    assert _last_assistant_text(populated_storage, "child-a") is None
+
+
+# ---------------------------------------------------------------------------
 # task_list
 # ---------------------------------------------------------------------------
 

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -582,8 +582,11 @@ class CoordinatorClient:
 
         ``message`` carries the child's last assistant message text for
         ``idle`` / ``error`` states, or a short status sentinel for
-        ``closed`` / ``deleted`` / ``denied``; non-terminal entries
-        (e.g. ``running`` after a timeout) carry ``None``.  Capped at
+        ``closed`` / ``denied``.  Non-terminal entries (e.g. ``running``
+        after a timeout) and ``deleted`` rows carry ``None`` — hard
+        deletes cascade rows out of storage so a real ``deleted`` state
+        is never observed; the legacy/synthetic-row path falls into the
+        same null-message shape as a still-running ws.  Capped at
         ``WAIT_MESSAGE_MAX_BYTES`` UTF-8 bytes per ws — when the cap
         triggers, ``truncated`` is ``True`` so the model can opt into a
         follow-up ``inspect_workstream`` for the rest.  Bundled inline

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -23,6 +23,7 @@ JWTs carrying the real user's identity + scopes.
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import secrets
 import threading
@@ -77,6 +78,35 @@ WAIT_MAX_TIMEOUT: float = 600.0
 # reads — still cheaper than the 20+ inspect_workstream model turns the
 # tool replaces.
 WAIT_POLL_INTERVAL: float = 0.5
+
+# Per-ws cap on the inline ``message`` field bundled into wait_for_workstream
+# results.  Sized so a fan-out of 32 children at the cap is ~192 KiB of
+# tool output — large but not catastrophic on commercial models, and
+# typical waits run with a handful of children.  Truncation is from the
+# END (the lead is usually more informative than the tail) and sets a
+# ``truncated=True`` flag so the model can opt into a follow-up read if
+# the trailing bytes matter.
+WAIT_MESSAGE_MAX_BYTES: int = 6 * 1024
+
+# How many tail messages ``wait_for_workstream`` reads when extracting a
+# child's last assistant turn.  The conversation tail almost always
+# contains the final assistant message within the last few rows
+# (assistant + a handful of tool results); 20 is generous head-room
+# without scanning the full history of a long-lived workstream.
+_WAIT_MESSAGE_TAIL_LIMIT: int = 20
+
+# Sentinel strings used when a terminal state has no usable assistant
+# content to return.  Pinned as constants so callers (and tests) can
+# rely on the exact text rather than a fuzzed message.  The
+# ``NO_RECENT_ASSISTANT`` sentinel is intentionally hedged ("recent")
+# rather than absolute — the message walk only looks at the
+# ``_WAIT_MESSAGE_TAIL_LIMIT`` row tail, so an assistant turn buried
+# beyond that window (e.g. a single burst of >18 parallel tool calls
+# followed by an error) would otherwise produce a sentinel that
+# falsely claims no output exists at all.
+_WAIT_SENTINEL_CLOSED = "(workstream closed)"
+_WAIT_SENTINEL_DENIED = "(workstream denied: not in coordinator subtree or does not exist)"
+_WAIT_SENTINEL_NO_RECENT_ASSISTANT = "(no recent assistant output)"
 
 _TASK_STATUSES = frozenset({"pending", "in_progress", "done", "blocked"})
 # Hard cap on tasks per coordinator — the full list is read and re-serialized
@@ -544,11 +574,21 @@ class CoordinatorClient:
         stays in the set so a legacy / synthetic-test row carrying
         that state still counts).  ``mode='all'`` returns once every
         ws_id has settled (real terminal OR ``denied``).  Returns
-        ``{"results": {ws_id: {state, tokens, updated}},
+        ``{"results": {ws_id: {state, tokens, updated, message, truncated}},
         "elapsed": float, "complete": bool, "mode": mode}``.  ``complete``
         is True when the wait condition was met before the deadline,
         False when the timeout fired (results carry whatever last state
         was observed).
+
+        ``message`` carries the child's last assistant message text for
+        ``idle`` / ``error`` states, or a short status sentinel for
+        ``closed`` / ``deleted`` / ``denied``; non-terminal entries
+        (e.g. ``running`` after a timeout) carry ``None``.  Capped at
+        ``WAIT_MESSAGE_MAX_BYTES`` UTF-8 bytes per ws — when the cap
+        triggers, ``truncated`` is ``True`` so the model can opt into a
+        follow-up ``inspect_workstream`` for the rest.  Bundled inline
+        so the coordinator LLM doesn't need an extra round-trip per
+        child to see what came back.
 
         ``since`` — optional prior snapshot (typically the ``results``
         dict from an earlier ``wait_for_workstream`` call).  When
@@ -757,8 +797,56 @@ class CoordinatorClient:
             if remaining <= 0:
                 break
             time.sleep(min(self._WAIT_POLL_INTERVAL, remaining))
+        # Bundle each terminal child's last assistant message inline so the
+        # coordinator LLM doesn't have to follow up with one
+        # ``inspect_workstream`` per ws.  Only ``idle`` / ``error`` ws_ids
+        # actually hit storage (``closed`` / ``denied`` return a sentinel
+        # without I/O), so split them and parallelize the storage-bound
+        # subset across a small thread pool — at the WAIT_MAX_WS_IDS=32
+        # cap, 8 workers cuts a worst-case all-idle fan-out from 32
+        # sequential storage round-trips down to 4 batches, which lands
+        # inside the WAIT_POLL_INTERVAL the model already tolerates
+        # between ticks.  Storage backends use SQLAlchemy with
+        # ``check_same_thread=False`` (SQLite) / a connection pool
+        # (Postgres), so concurrent reads from the worker pool are safe.
+        io_wids = [
+            wid
+            for wid, snap in last_results.items()
+            if str(snap.get("state") or "") in ("idle", "error")
+        ]
+        io_pairs: dict[str, tuple[str | None, bool]] = {}
+        if io_wids:
+
+            def _enrich(wid: str) -> tuple[str, str | None, bool]:
+                state = str(last_results[wid].get("state") or "")
+                msg, trunc = _wait_message_for(self._storage, wid, state)
+                return wid, msg, trunc
+
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(8, len(io_wids)),
+                thread_name_prefix="coord-wait-enrich",
+            ) as ex:
+                for wid, msg, trunc in ex.map(_enrich, io_wids):
+                    io_pairs[wid] = (msg, trunc)
+
+        # Build the final dict.  Fresh per-ws dicts (not in-place
+        # mutation) so any in-flight ``wait_progress`` SSE event still
+        # holds a reference to the tick's pre-enrichment snapshot — its
+        # shape is documented as separate from the returned tool result
+        # and must not silently grow new fields just because the wait
+        # completed.
+        enriched_results: dict[str, dict[str, Any]] = {}
+        for wid, snap in last_results.items():
+            state = str(snap.get("state") or "")
+            if wid in io_pairs:
+                msg, trunc = io_pairs[wid]
+            elif state in WAIT_TERMINAL_STATES:
+                msg, trunc = _wait_message_for(self._storage, wid, state)
+            else:
+                msg, trunc = None, False
+            enriched_results[wid] = {**snap, "message": msg, "truncated": trunc}
         return {
-            "results": last_results,
+            "results": enriched_results,
             "complete": complete,
             "elapsed": round(time.monotonic() - start, 3),
             "mode": mode,
@@ -1531,3 +1619,110 @@ def _serialize_verdicts(rows: list[Any]) -> list[dict[str, Any]]:
             except Exception:
                 out.append({"raw": str(r)})
     return out
+
+
+# ---------------------------------------------------------------------------
+# wait_for_workstream — last-message extraction
+# ---------------------------------------------------------------------------
+
+
+def _truncate_wait_message(text: str, max_bytes: int) -> tuple[str, bool]:
+    """Cap ``text`` to ``max_bytes`` UTF-8 bytes, truncating from the END.
+
+    Returns ``(text, truncated)``.  Encodes to UTF-8 first so the cap is a
+    real wire-size cap rather than a character-count proxy.  ``errors='ignore'``
+    on the decode silently drops a trailing partial codepoint when the byte
+    cut lands mid-multi-byte-sequence — keeps the truncated string valid
+    UTF-8 (so JSON serialization can't fail) without an explicit boundary
+    walk.
+    """
+    if max_bytes <= 0:
+        return "", bool(text)
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False
+    return encoded[:max_bytes].decode("utf-8", errors="ignore"), True
+
+
+def _last_assistant_text(storage: Any, ws_id: str) -> str | None:
+    """Walk the conversation tail backward and return the most recent
+    assistant message's text content.
+
+    Returns:
+    - The content string when the tail contains an assistant message
+      with a non-empty ``content`` field.
+    - Empty string when no qualifying assistant message exists in the
+      fetched tail (e.g. a workstream that errored before emitting any
+      assistant output, or one whose final assistant turn is buried
+      beyond the tail window).
+    - ``None`` when the storage read itself failed — distinct from the
+      empty-string case so callers can leave ``message: null`` instead
+      of substituting a sentinel.
+
+    The tail load is bounded by ``_WAIT_MESSAGE_TAIL_LIMIT`` so a
+    long-running workstream's full message log never has to be paged
+    in just to surface its final turn.
+    """
+    try:
+        rows = storage.load_messages(ws_id, limit=_WAIT_MESSAGE_TAIL_LIMIT)
+    except Exception:
+        log.debug("coord_client.wait.load_messages_failed ws=%s", ws_id, exc_info=True)
+        return None
+    for msg in reversed(rows):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+    return ""
+
+
+def _wait_message_for(
+    storage: Any,
+    ws_id: str,
+    state: str,
+    *,
+    max_bytes: int = WAIT_MESSAGE_MAX_BYTES,
+) -> tuple[str | None, bool]:
+    """Return ``(message, truncated)`` for a wait_for_workstream result entry.
+
+    The returned tuple is appended to each per-ws snapshot as
+    ``message`` / ``truncated`` so the coordinator LLM doesn't need a
+    follow-up ``inspect_workstream`` round-trip to read what each child
+    actually produced.
+
+    Branching by ``state``:
+
+    - ``idle`` / ``error`` — last assistant message text from the
+      conversation tail, or a hedged sentinel when the tail has no
+      assistant content (covers both 'never emitted a turn' and 'last
+      turn is buried beyond the tail window' — the sentinel doesn't
+      claim either way).
+    - ``closed`` / ``denied`` — short status sentinel.  No
+      message-history read because there's nothing meaningful to
+      return — a partial last message could be misleading mid-thought.
+    - any other state (e.g. ``running``, or a ``deleted`` synthetic /
+      legacy row) — ``(None, False)`` so the coordinator sees null
+      inline and knows to keep waiting / inspect explicitly.  Hard
+      deletes cascade rows out of storage, so the wait poll never
+      observes a real ``deleted`` state in normal operation.
+
+    Storage failures during the message read collapse to ``(None, False)``
+    so a transient read error degrades gracefully (the wait itself
+    already completed; the model just gets ``message: null`` for the
+    affected ws and can fall back to inspect).
+    """
+    if state == "denied":
+        return _WAIT_SENTINEL_DENIED, False
+    if state == "closed":
+        return _WAIT_SENTINEL_CLOSED, False
+    if state in ("idle", "error"):
+        text = _last_assistant_text(storage, ws_id)
+        if text is None:
+            return None, False
+        if not text:
+            return _WAIT_SENTINEL_NO_RECENT_ASSISTANT, False
+        return _truncate_wait_message(text, max_bytes)
+    return None, False


### PR DESCRIPTION
## Summary

- Each per-ws snapshot returned by `wait_for_workstream` now carries `message` + `truncated` so the coordinator LLM doesn't need a follow-up `inspect_workstream` round-trip per child to see what came back.
- `idle` / `error` → last assistant turn (capped at 6 KiB UTF-8 bytes, truncated from the end with `truncated=True`); `closed` / `denied` → status sentinel; `running` children → `null`. Hedged sentinel `"(no recent assistant output)"` for terminal states whose tail walk finds no assistant content (covers both 'never emitted a turn' and 'last turn buried beyond the 20-row tail window').
- Storage reads for `idle`/`error` parallelize across an 8-worker thread pool so a worst-case 32-child fan-out lands in 4 batches instead of 32 sequential round-trips. Sentinel-only states bypass the pool. Storage backends (SQLAlchemy `check_same_thread=False` / connection pool) are thread-safe under concurrent reads.
- The wait_progress SSE event shape is preserved — enrichment builds fresh per-ws dicts rather than mutating the in-loop snapshot references.

## Test plan

- [x] 16 new unit + integration tests in `tests/test_coordinator_client.py` (idle / error / closed / denied / running / truncation / UTF-8 boundary / oversize / storage failure / progress-callback shape isolation).
- [x] `pytest -m "not live"` across the full coordinator suite — 393 pass.
- [x] `ruff check` + `mypy` clean on touched files.
- [ ] Manual: spawn a child via the coord, have it produce a non-trivial response, call wait_for_workstream from the coord LLM, and verify the message lands in the tool output without a follow-up inspect.