### PR TITLE
fix(coord): tree UI not updating when LLM deletes workstream

### DIFF
--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -696,7 +696,8 @@ def test_delete_emits_closed_with_reason_deleted() -> None:
     ws = mgr.create(user_id="u1", name="will-be-deleted")
     ws_id = ws.id
 
-    assert mgr.delete(ws_id) is True
+    deleted = mgr.delete(ws_id)
+    assert deleted is True
     # In-memory slot released — capacity restored just like close.
     assert mgr.get(ws_id) is None
     # Closed event fired with the deletion reason.

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -680,6 +680,104 @@ def test_close_unknown_returns_false() -> None:
 
 
 # ---------------------------------------------------------------------------
+# delete — hard-delete event broadcast (storage delete is the caller's job)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_emits_closed_with_reason_deleted() -> None:
+    """Hard-delete a still-loaded workstream: the in-memory slot
+    drops AND a ``ws_closed`` event fires with ``reason='deleted'``
+    so the cluster collector → coord adapter chain can re-emit as
+    ``child_ws_closed`` and the operator's child-tree drops the row.
+    Pre-fix the storage row vanished but no event fired, so a
+    long-lived dashboard tab would leave the deleted child visible
+    (with its last-known state) until a full reload."""
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", name="will-be-deleted")
+    ws_id = ws.id
+
+    assert mgr.delete(ws_id) is True
+    # In-memory slot released — capacity restored just like close.
+    assert mgr.get(ws_id) is None
+    # Closed event fired with the deletion reason.
+    closed_events = adapter.events_of("closed")
+    assert len(closed_events) == 1
+    ev = closed_events[0]
+    assert ev.ws_id == ws_id
+    assert ev.reason == "deleted"
+    assert ev.name == "will-be-deleted"
+    # UI cleanup ran (mirrors close ordering).
+    assert ws_id in adapter.cleaned_up
+
+
+def test_delete_unloaded_ws_still_fires_event() -> None:
+    """A row that was closed (and therefore unloaded from memory)
+    before delete still needs the broadcast — otherwise a closed
+    row that's then deleted leaves the closed-state child stuck on
+    the dashboard tree forever.  The in-memory return is False
+    (nothing to release) but the event MUST fire."""
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", name="closed-then-deleted")
+    ws_id = ws.id
+    mgr.close(ws_id)
+    # Drain the close event so we can assert the delete event in isolation.
+    pre_delete_closed = list(adapter.events_of("closed"))
+    assert len(pre_delete_closed) == 1
+    assert pre_delete_closed[0].reason == "closed"
+
+    # Deleting an already-unloaded ws — no in-memory slot to release.
+    result = mgr.delete(ws_id, name="closed-then-deleted")
+    assert result is False
+    # But the event MUST fire — the dashboard hasn't seen the row drop yet.
+    closed_events = adapter.events_of("closed")
+    assert len(closed_events) == 2
+    delete_event = closed_events[1]
+    assert delete_event.ws_id == ws_id
+    assert delete_event.reason == "deleted"
+    assert delete_event.name == "closed-then-deleted"
+
+
+def test_delete_falls_back_to_workstream_name_when_caller_omits() -> None:
+    """When the caller doesn't snapshot a name, the event payload
+    falls back to the live workstream's name so operator toasts on
+    the global queue still carry useful context."""
+    mgr, adapter, _ = _make_manager()
+    ws = mgr.create(user_id="u1", name="auto-name-from-ws")
+
+    mgr.delete(ws.id)  # no name kwarg
+    closed_events = adapter.events_of("closed")
+    assert closed_events[-1].name == "auto-name-from-ws"
+
+
+def test_delete_returns_false_for_unknown_ws_id() -> None:
+    """Idempotent on an absent + never-loaded ws_id — still fires
+    the event so a dashboard with a stale row can drop it, and
+    returns False so the caller knows nothing was tracked."""
+    mgr, adapter, _ = _make_manager()
+    result = mgr.delete("never-existed")
+    assert result is False
+    # Event still fires — a stale dashboard entry is exactly the
+    # case where this matters.
+    closed_events = adapter.events_of("closed")
+    assert len(closed_events) == 1
+    assert closed_events[0].ws_id == "never-existed"
+    assert closed_events[0].reason == "deleted"
+
+
+def test_delete_without_event_emitter_is_quiet() -> None:
+    """When the manager is constructed without an event emitter
+    (e.g. the no-op kind in tests), ``delete`` releases the slot
+    silently — the no-emitter branch must not raise."""
+    mgr, adapter, _ = _make_manager(event_emitter=None)
+    ws = mgr.create(user_id="u1")
+    result = mgr.delete(ws.id)
+    assert result is True
+    # Adapter still gets cleanup_ui — that's the kind-side surface,
+    # distinct from the lifecycle-event side channel.
+    assert ws.id in adapter.cleaned_up
+
+
+# ---------------------------------------------------------------------------
 # set_state
 # ---------------------------------------------------------------------------
 

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -73,6 +73,15 @@ def _inject_storage(storage):
 
 @pytest.fixture
 def delete_client(_inject_storage):
+    """Yield ``(TestClient, Starlette app)`` for the delete endpoint.
+
+    ``app.state.auth_storage`` is pre-attached so the endpoint's
+    pre-delete snapshot block runs (without it the snapshot is
+    skipped and the lifecycle event lands with ``name=""``).  Tests
+    that need a wired manager attach ``app.state.workstreams = mgr``
+    after the yield; tests that don't care just ignore the second
+    tuple member.
+    """
     app = Starlette(
         routes=[
             Mount(
@@ -88,7 +97,8 @@ def delete_client(_inject_storage):
         ],
         middleware=[Middleware(_InjectAuthMiddleware)],
     )
-    return TestClient(app)
+    app.state.auth_storage = _inject_storage
+    return TestClient(app), app
 
 
 @pytest.fixture
@@ -196,27 +206,63 @@ def settings_client(_inject_storage):
 
 class TestDeleteWorkstream:
     def test_delete_success(self, delete_client, storage):
+        client, _ = delete_client
         storage.register_workstream("ws-abc", "node-1", name="test")
-        r = delete_client.post("/v1/api/workstreams/ws-abc/delete")
+        r = client.post("/v1/api/workstreams/ws-abc/delete")
         assert r.status_code == 200
         assert r.json()["deleted"] == "ws-abc"
 
     def test_delete_not_found(self, delete_client):
-        r = delete_client.post("/v1/api/workstreams/nonexistent/delete")
+        client, _ = delete_client
+        r = client.post("/v1/api/workstreams/nonexistent/delete")
         assert r.status_code == 404
         assert "not found" in r.json()["error"].lower()
 
     def test_delete_error_redacted(self, delete_client, storage):
         """500 response should not leak exception internals."""
+        client, _ = delete_client
         storage.register_workstream("ws-abc", "node-1", name="test", user_id="test-user")
         with patch(
             "turnstone.core.memory.delete_workstream",
             side_effect=RuntimeError("secret internal detail"),
         ):
-            r = delete_client.post("/v1/api/workstreams/ws-abc/delete")
+            r = client.post("/v1/api/workstreams/ws-abc/delete")
         assert r.status_code == 500
         assert "Delete failed" in r.json()["error"]
         assert "secret" not in r.json()["error"]
+
+    def test_delete_fires_lifecycle_event_with_snapshotted_name(self, delete_client, storage):
+        """The endpoint must call ``mgr.delete(ws_id, name=...)`` after a
+        successful storage delete so the cluster collector → coord
+        adapter chain can re-emit ``child_ws_closed`` and the operator's
+        child-tree drops the row.  Without this the deleted child stays
+        visible (with its last-known state) until a full reload — a
+        coordinator that spawns→completes→deletes children leaves an
+        ever-growing tree on the dashboard."""
+        client, app = delete_client
+        storage.register_workstream("ws-event", "node-1", name="needs-event", user_id="test-user")
+        mgr = MagicMock()
+        app.state.workstreams = mgr
+        r = client.post("/v1/api/workstreams/ws-event/delete")
+        assert r.status_code == 200
+        # The event-emission call must use the name we snapshotted
+        # before the storage row was wiped.
+        mgr.delete.assert_called_once_with("ws-event", name="needs-event")
+
+    def test_delete_event_emit_failure_does_not_500(self, delete_client, storage):
+        """A best-effort event emit: if the manager's emitter chokes
+        (queue full, adapter mid-shutdown, etc.) the storage row is
+        already gone and the response must still be 200 — rolling
+        back the delete to satisfy a fan-out failure would corrupt
+        the operator's view of an already-vanished workstream."""
+        client, app = delete_client
+        storage.register_workstream("ws-flaky", "node-1", name="flaky", user_id="test-user")
+        mgr = MagicMock()
+        mgr.delete.side_effect = RuntimeError("queue full or whatever")
+        app.state.workstreams = mgr
+        r = client.post("/v1/api/workstreams/ws-flaky/delete")
+        assert r.status_code == 200
+        assert r.json()["deleted"] == "ws-flaky"
 
 
 # ===========================================================================

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -73,14 +73,14 @@ def _inject_storage(storage):
 
 @pytest.fixture
 def delete_client(_inject_storage):
-    """Yield ``(TestClient, Starlette app)`` for the delete endpoint.
+    """Return ``(TestClient, Starlette app)`` for the delete endpoint.
 
     ``app.state.auth_storage`` is pre-attached so the endpoint's
     pre-delete snapshot block runs (without it the snapshot is
     skipped and the lifecycle event lands with ``name=""``).  Tests
     that need a wired manager attach ``app.state.workstreams = mgr``
-    after the yield; tests that don't care just ignore the second
-    tuple member.
+    on the returned app; tests that don't care just ignore the
+    second tuple member.
     """
     app = Starlette(
         routes=[

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -633,6 +633,59 @@ class SessionManager:
                 self._open_locks[ws_id] = (lk, refs - 1)
 
     # ------------------------------------------------------------------
+    # delete — hard-delete event broadcast (storage row is caller's job)
+    # ------------------------------------------------------------------
+
+    def delete(self, ws_id: str, *, name: str = "") -> bool:
+        """Drop the in-memory slot if present + emit ``ws_closed`` with
+        ``reason="deleted"`` so subscribers (cluster collector → coord
+        adapter → child-tree UI) can drop the row.
+
+        Storage row removal is the **caller's** responsibility — the
+        delete HTTP endpoint already calls
+        :func:`turnstone.core.memory.delete_workstream` before invoking
+        this; the manager only handles the in-memory + event side so
+        the lifecycle event lands on the same global queue every other
+        terminal transition uses.
+
+        Distinct from :meth:`close` (which writes ``state='closed'`` so
+        the row is re-openable later) and :meth:`discard` (which fires
+        no event because it's the rollback partner of an unwound
+        ``defer_emit_created`` create).  Hard-delete advertises a
+        terminal transition with ``reason="deleted"`` regardless of
+        whether the workstream was loaded — a row that was closed
+        (and therefore unloaded from memory) before being deleted
+        still needs the broadcast so a long-lived dashboard tab
+        drops the entry from its tree.
+
+        Returns ``True`` when an in-memory slot was released, ``False``
+        when the id wasn't tracked.  The event fires either way; the
+        return value is informational for callers that care about
+        capacity accounting.
+        """
+        with self._lock:
+            ws = self._workstreams.pop(ws_id, None)
+            if ws is not None:
+                if ws_id in self._order:
+                    self._order.remove(ws_id)
+                if self._active_id == ws_id:
+                    self._active_id = self._order[0] if self._order else None
+        if ws is not None:
+            # cleanup_ui outside the manager lock — mirrors the close()
+            # ordering so any blocking UI teardown can't pin the
+            # slot-accounting mutex.
+            self._adapter.cleanup_ui(ws)
+        if self._event_emitter is not None:
+            # Fall back to the workstream's name when the caller didn't
+            # snapshot one (the event payload's ``name`` field surfaces
+            # in operator toasts on real-node closures; coord-side
+            # ``child_ws_closed`` ignores it but the global queue
+            # consumers don't all do so).
+            event_name = name or (ws.name if ws is not None else "")
+            self._event_emitter.emit_closed(ws_id, reason="deleted", name=event_name)
+        return ws is not None
+
+    # ------------------------------------------------------------------
     # close / set_state / close_idle
     # ------------------------------------------------------------------
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2179,15 +2179,18 @@ async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     name: str = ""
     _, ip = _audit_context(request)
     try:
-        # Snapshot kind/parent/name for the audit record + lifecycle
-        # event before the delete wipes the row.  Inside the try so a
-        # transient storage error surfaces through the endpoint's
-        # redacted 500 handler below rather than as an unhandled
-        # exception.  ``name`` is forwarded to ``mgr.delete`` so the
-        # ``ws_closed`` event payload carries the same field other
-        # terminal transitions emit (interactive operators see the
-        # name in close toasts; coord-side ``child_ws_closed`` ignores
-        # it but the global queue contract is uniform).
+        # Snapshot row fields before the delete wipes the row.  Inside
+        # the try so a transient storage error surfaces through the
+        # endpoint's redacted 500 handler below rather than as an
+        # unhandled exception.  ``kind`` / ``parent_ws_id`` go into the
+        # audit record; ``name`` is forwarded ONLY to ``mgr.delete`` so
+        # the ``ws_closed`` event payload carries the same field other
+        # terminal transitions emit (interactive operators see the name
+        # in close toasts; coord-side ``child_ws_closed`` ignores it
+        # but the global queue contract is uniform).  ``name`` is
+        # deliberately NOT in the audit detail — display names can be
+        # long / operator-noisy and aren't needed for forensic recall
+        # (ws_id + kind + parent are enough).
         if storage is not None:
             row = storage.get_workstream(ws_id) or {}
             kind = row.get("kind", "")

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2176,18 +2176,40 @@ async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     storage = getattr(request.app.state, "auth_storage", None)
     kind: str = ""
     parent_ws_id: str | None = None
+    name: str = ""
     _, ip = _audit_context(request)
     try:
-        # Snapshot kind/parent for the audit record before the delete
-        # wipes the row.  Inside the try so a transient storage error
-        # surfaces through the endpoint's redacted 500 handler below
-        # rather than as an unhandled exception.
+        # Snapshot kind/parent/name for the audit record + lifecycle
+        # event before the delete wipes the row.  Inside the try so a
+        # transient storage error surfaces through the endpoint's
+        # redacted 500 handler below rather than as an unhandled
+        # exception.  ``name`` is forwarded to ``mgr.delete`` so the
+        # ``ws_closed`` event payload carries the same field other
+        # terminal transitions emit (interactive operators see the
+        # name in close toasts; coord-side ``child_ws_closed`` ignores
+        # it but the global queue contract is uniform).
         if storage is not None:
             row = storage.get_workstream(ws_id) or {}
             kind = row.get("kind", "")
             parent_ws_id = row.get("parent_ws_id")
+            name = row.get("name", "") or ""
         if delete_workstream(ws_id):
             log.info("ws.deleted", ws_id=ws_id[:8])
+            # Fire ``ws_closed`` with ``reason='deleted'`` so the
+            # cluster collector → coord adapter chain re-emits as
+            # ``child_ws_closed`` and the operator's child-tree drops
+            # the row.  Without this the row stays visible (with its
+            # last-known state) until a full reload — a model that
+            # spawns→completes→deletes children leaves an
+            # ever-growing tree on the dashboard.  Best-effort: an
+            # emit failure must not roll back the storage delete or
+            # 500 the response.
+            mgr = getattr(request.app.state, "workstreams", None)
+            if mgr is not None:
+                try:
+                    mgr.delete(ws_id, name=name)
+                except Exception:
+                    log.warning("ws.delete.event_emit_failed", ws_id=ws_id[:8], exc_info=True)
             if storage is not None:
                 record_audit(
                     storage,


### PR DESCRIPTION
## Summary

- The coord LLM's `delete_workstream` tool wiped the storage row but fired no SSE event, so a long-lived dashboard tab kept the deleted child visible (with its last-known `idle`/`closed` state) until a full reload. A coordinator that spawns→completes→deletes children would leave an ever-growing tree.
- Adds `SessionManager.delete(ws_id, *, name="")` — drops the in-memory slot if present, emits `ws_closed` with `reason="deleted"` (mirrors `close()`'s shape but without the storage state-write since the row is already gone). Returns whether the slot was loaded; event fires either way so a closed-then-deleted ws still drops from the tree.
- Wires `delete_workstream_endpoint` to call `mgr.delete(ws_id, name=name)` after the storage delete succeeds, snapshotting `name` into the event payload before the row is wiped. Best-effort — a fan-out failure logs a warning but doesn't roll back the storage delete (the row is already gone).
- No JS changes needed: the cluster collector → coord adapter chain already listens for `ws_closed` and re-emits as `child_ws_closed`; the browser's `handleChildClosed` already keys on `reason === "deleted"` to mark the row.

## Test plan

- [x] 5 new unit tests in `tests/test_session_manager.py` covering: loaded-slot delete, unloaded (closed-then-deleted) still fires event, name fallback to `ws.name`, unknown ws_id, no-emitter quiet path.
- [x] 2 new endpoint tests in `tests/test_workstream_endpoints.py` covering: snapshotted name flows to `mgr.delete`, emit failure doesn't 500.
- [x] `delete_client` fixture refactored to yield `(client, app)` so the new tests reuse it instead of rebuilding the Starlette wiring (post-review polish).
- [x] `ruff check` + `mypy` clean on touched source files.
- [x] `pytest -m "not live"` across the affected suites — 91 pass on `tests/test_workstream_endpoints.py` + `tests/test_session_manager.py`; 422 across the broader coord/manager-adjacent suites.
- [ ] Manual: have the coord LLM spawn a child, close it, then delete it. Verify the row drops from the dashboard tree without a reload.