### PR TITLE
fix(approve): visibility for child tool calls bypassing operator gate

### DIFF
--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -121,6 +121,14 @@ class _FakeUI:
             "items": serialized,
         }
 
+    def serialize_recent_auto_approvals(self) -> list[dict[str, Any]]:
+        # Empty buffer for tests that don't exercise the auto-approve
+        # visibility path.  /dashboard handler reads this method
+        # unconditionally now (paired with serialize_pending_approval_detail);
+        # returning [] keeps the row payload compatible without
+        # modeling the full ring buffer in the fake.
+        return []
+
     def _register_listener(self) -> queue.Queue[dict[str, Any]]:
         q: queue.Queue[dict[str, Any]] = queue.Queue()
         with self._listeners_lock:

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -544,6 +544,290 @@ def test_serialize_pending_approval_detail_returned_dict_is_decoupled() -> None:
     assert ui._llm_verdicts["c-1"]["recommendation"] == "approve"
 
 
+# ---------------------------------------------------------------------------
+# Auto-approve visibility — _serialize_approval_items + _record_auto_approves
+# + serialize_recent_auto_approvals
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_approval_items_forwards_auto_approve_fields() -> None:
+    """When the upstream pipeline tags an item with ``auto_approved`` +
+    ``auto_approve_reason``, the serialized payload must carry both
+    so the dashboard pill / per-ws SSE consumer can show *which*
+    path bypassed the operator gate."""
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c1",
+            "func_name": "bash",
+            "approval_label": "bash",
+            "needs_approval": False,
+            "auto_approved": True,
+            "auto_approve_reason": "skill",
+        },
+        {
+            "call_id": "c2",
+            "func_name": "read_file",
+            "needs_approval": False,
+            # No auto_approved tag — read-only tool that never needed approval.
+        },
+    ]
+    out = ui._serialize_approval_items(items)
+    assert out[0]["auto_approved"] is True
+    assert out[0]["auto_approve_reason"] == "skill"
+    # Items not flagged as auto-approved must NOT carry the fields —
+    # otherwise the dashboard would show pills for read-only tools too.
+    assert "auto_approved" not in out[1]
+    assert "auto_approve_reason" not in out[1]
+
+
+def test_serialize_approval_items_forwards_denial_msg_as_error() -> None:
+    """Denied items surface their ``denial_msg`` as ``error`` so the
+    /dashboard / SSE consumer renders the policy-block reason
+    without exposing the raw item shape."""
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c1",
+            "func_name": "bash",
+            "denied": True,
+            "denial_msg": "Blocked by tool policy (pattern match for 'bash')",
+        }
+    ]
+    out = ui._serialize_approval_items(items)
+    assert out[0]["error"] == "Blocked by tool policy (pattern match for 'bash')"
+
+
+def test_record_auto_approves_appends_only_tagged_items() -> None:
+    """Items without ``auto_approved=True`` are skipped — the ring
+    buffer is meant to surface bypassed-the-gate calls, not a
+    record of every tool invocation."""
+    storage = MagicMock()
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c1",
+            "func_name": "bash",
+            "approval_label": "bash",
+            "auto_approved": True,
+            "auto_approve_reason": "skill",
+        },
+        {
+            "call_id": "c2",
+            "func_name": "read_file",
+            # No auto_approved tag — read-only tool, gets skipped.
+        },
+    ]
+    with _patch_get_storage(storage):
+        ui._record_auto_approves(items)
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 1
+    assert snapshot[0]["func_name"] == "bash"
+    assert snapshot[0]["auto_approve_reason"] == "skill"
+    # Audit row recorded — one row per call (not per item) so
+    # tool-heavy turns don't blow up the audit table.
+    storage.record_audit_event.assert_called_once()
+    call_kwargs = storage.record_audit_event.call_args.kwargs
+    assert call_kwargs["action"] == "tool.auto_approved"
+
+
+def test_record_auto_approves_caps_buffer_at_max() -> None:
+    """Bounded ring buffer — a long-running skill workstream can't
+    fill the /dashboard payload with stale rows.  The cap is the
+    class-level constant, exercised here to lock the contract."""
+    ui = _make_ui()
+    cap = ui._RECENT_AUTO_APPROVALS_MAX
+    # Push (cap + 5) items; only the most recent ``cap`` survive.
+    for i in range(cap + 5):
+        with _patch_get_storage(MagicMock()):
+            ui._record_auto_approves(
+                [
+                    {
+                        "call_id": f"c{i}",
+                        "func_name": f"tool_{i}",
+                        "auto_approved": True,
+                        "auto_approve_reason": "blanket",
+                    }
+                ]
+            )
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == cap
+    # Tail preserved — oldest entries roll off the head.
+    assert snapshot[-1]["func_name"] == f"tool_{cap + 5 - 1}"
+    assert snapshot[0]["func_name"] == f"tool_{5}"
+
+
+def test_record_auto_approves_noop_when_no_tagged_items() -> None:
+    """No tagged items → no buffer write, no audit — matters for
+    the every-tool-call-was-read-only case where ``items`` is
+    non-empty but nothing was an auto-approve."""
+    storage = MagicMock()
+    ui = _make_ui()
+    with _patch_get_storage(storage):
+        ui._record_auto_approves(
+            [{"call_id": "c1", "func_name": "read_file"}]  # no auto_approved tag
+        )
+    assert ui.serialize_recent_auto_approvals() == []
+    storage.record_audit_event.assert_not_called()
+
+
+def test_record_auto_approves_swallows_audit_failure() -> None:
+    """An audit-write exception must not break the tool-execution
+    path — visibility is best-effort, the SSE event + ring buffer
+    already shipped to operators by the time this fires."""
+    storage = MagicMock()
+    storage.record_audit_event.side_effect = RuntimeError("audit table down")
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c1",
+            "func_name": "bash",
+            "auto_approved": True,
+            "auto_approve_reason": "policy",
+        }
+    ]
+    # Must not raise — the docstring explicitly promises best-effort.
+    with _patch_get_storage(storage):
+        ui._record_auto_approves(items)
+    # Buffer write still happened (it's first, before the audit).
+    assert len(ui.serialize_recent_auto_approvals()) == 1
+
+
+def test_replay_recent_auto_approvals_from_audit_seeds_buffer() -> None:
+    """Audit-replay seeds the ring buffer on UI construction so the
+    dashboard pill survives UI rebuilds (saved-workstream rehydrate /
+    coord→node click-through / process restart all create a fresh UI
+    whose buffer would otherwise be empty even though the audit row
+    is still on disk)."""
+    storage = MagicMock()
+    storage.list_audit_events.return_value = [
+        # DESC order — newest first.
+        {
+            "timestamp": "2026-04-27T18:00:00",
+            "detail": (
+                '{"tools": [{"call_id": "c2", "func_name": "edit_file",'
+                ' "approval_label": "edit_file", "reason": "policy"}],'
+                ' "count": 1}'
+            ),
+        },
+        {
+            "timestamp": "2026-04-27T17:00:00",
+            "detail": (
+                '{"tools": [{"call_id": "c1", "func_name": "bash",'
+                ' "approval_label": "bash", "reason": "skill"}],'
+                ' "count": 1}'
+            ),
+        },
+    ]
+    with _patch_get_storage(storage):
+        ui = _make_ui(ws_id="ws-replay")
+    # Buffer holds the replayed entries in chronological order
+    # (oldest first), matching what live appends produce.
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 2
+    assert snapshot[0]["func_name"] == "bash"
+    assert snapshot[0]["auto_approve_reason"] == "skill"
+    assert snapshot[1]["func_name"] == "edit_file"
+    assert snapshot[1]["auto_approve_reason"] == "policy"
+    # And the audit query was scoped to this ws + tool.auto_approved.
+    storage.list_audit_events.assert_called_once()
+    call_kwargs = storage.list_audit_events.call_args.kwargs
+    assert call_kwargs["action"] == "tool.auto_approved"
+    assert call_kwargs["resource_id"] == "ws-replay"
+
+
+def test_replay_swallows_audit_storage_failure() -> None:
+    """A storage outage at construction time must not break UI
+    instantiation — the buffer simply stays empty until the next
+    live auto-approve populates it."""
+    storage = MagicMock()
+    storage.list_audit_events.side_effect = RuntimeError("audit table down")
+    with _patch_get_storage(storage):
+        ui = _make_ui(ws_id="ws-replay")
+    assert ui.serialize_recent_auto_approvals() == []
+
+
+def test_replay_skips_when_ws_id_missing() -> None:
+    """No ws_id → no audit query.  Test fixtures sometimes
+    construct a UI with the default empty ws_id; the replay must
+    not fire a wildcard query that returns rows from other ws's."""
+    storage = MagicMock()
+    with _patch_get_storage(storage):
+        ui = _make_ui(ws_id="")
+    storage.list_audit_events.assert_not_called()
+    assert ui.serialize_recent_auto_approvals() == []
+
+
+def test_replay_tolerates_malformed_audit_detail() -> None:
+    """Unparseable / wrong-shape audit detail rows are skipped, not
+    propagated.  A historic audit row with a different schema (e.g.
+    pre-fix migration leftover) must not crash UI construction."""
+    storage = MagicMock()
+    storage.list_audit_events.return_value = [
+        {"timestamp": "2026-04-27T18:00:00", "detail": "not-json"},
+        {"timestamp": "2026-04-27T17:30:00", "detail": '{"tools": "wrong-shape"}'},
+        {
+            "timestamp": "2026-04-27T17:00:00",
+            "detail": '{"tools": [{"func_name": "bash", "reason": "skill"}], "count": 1}',
+        },
+    ]
+    with _patch_get_storage(storage):
+        ui = _make_ui(ws_id="ws-replay")
+    # Only the well-shaped row contributes.
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 1
+    assert snapshot[0]["func_name"] == "bash"
+
+
+def test_replay_caps_at_buffer_max() -> None:
+    """Replay output is bounded by the same cap as live appends.
+    A long-lived workstream with hundreds of audit rows must not
+    blow past the 10-entry limit during replay."""
+    storage = MagicMock()
+    # Generate many fake rows.
+    storage.list_audit_events.return_value = [
+        {
+            "timestamp": f"2026-04-27T{i:02d}:00:00",
+            "detail": (
+                f'{{"tools": [{{"func_name": "tool_{i}", "reason": "skill"}}], "count": 1}}'
+            ),
+        }
+        for i in range(20)
+    ]
+    with _patch_get_storage(storage):
+        ui = _make_ui(ws_id="ws-replay")
+    snapshot = ui.serialize_recent_auto_approvals()
+    # Cap holds even when audit-replay fans in past it.
+    assert len(snapshot) == ui._RECENT_AUTO_APPROVALS_MAX
+
+
+def test_serialize_recent_auto_approvals_returns_a_copy() -> None:
+    """Mutating the returned list must not corrupt the buffer —
+    HTTP handler should not be able to drain or reorder it."""
+    ui = _make_ui()
+    with _patch_get_storage(MagicMock()):
+        ui._record_auto_approves(
+            [
+                {
+                    "call_id": "c1",
+                    "func_name": "bash",
+                    "auto_approved": True,
+                    "auto_approve_reason": "skill",
+                }
+            ]
+        )
+    snapshot = ui.serialize_recent_auto_approvals()
+    snapshot.clear()
+    snapshot.append({"poisoned": True})
+    # Buffer state survives the caller's mutation.
+    fresh = ui.serialize_recent_auto_approvals()
+    assert len(fresh) == 1
+    assert fresh[0]["func_name"] == "bash"
+
+
+# ---------------------------------------------------------------------------
+
+
 def test_concurrent_enqueue_and_listener_registration() -> None:
     """Fan-out under concurrent enqueue + register/unregister shouldn't
     drop events or crash on the lock. Sanity-level stress."""

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -779,6 +779,22 @@ def test_replay_tolerates_malformed_audit_detail() -> None:
     assert snapshot[0]["func_name"] == "bash"
 
 
+def test_parse_audit_timestamp_treats_naive_strings_as_utc() -> None:
+    """Audit rows are stored as naive UTC strings (e.g.
+    ``2026-04-27T18:00:00`` with no timezone marker); a server in
+    a non-UTC timezone would mis-stamp pill entries by hours
+    without explicit UTC.replace at parse time."""
+    from datetime import UTC, datetime
+
+    from turnstone.core.session_ui_base import SessionUIBase
+
+    expected = datetime(2026, 4, 27, 18, 0, 0, tzinfo=UTC).timestamp()
+    assert SessionUIBase._parse_audit_timestamp("2026-04-27T18:00:00") == expected
+    # Explicit-offset strings parse correctly too — the UTC stamp
+    # only applies when tzinfo is None.
+    assert SessionUIBase._parse_audit_timestamp("2026-04-27T18:00:00+00:00") == expected
+
+
 def test_replay_caps_at_buffer_max() -> None:
     """Replay output is bounded by the same cap as live appends.
     A long-lived workstream with hundreds of audit rows must not

--- a/tests/test_webui_auto_approve_visibility.py
+++ b/tests/test_webui_auto_approve_visibility.py
@@ -1,0 +1,221 @@
+"""Tests for the policy + auto-approve recording paths in WebUI.approve_tools.
+
+The visibility patch added a ring buffer (_recent_auto_approvals) and an
+audit emit for every tool call that bypasses the operator approval gate.
+The fall-through point at the end of approve_tools handles the common
+"all auto-approved" path, but two policy-resolution branches need
+explicit recording calls or the policy bypass is invisible to /dashboard:
+
+1. **Early-return-on-deny** — policy resolves every item, some are
+   denied AND some are allowed.  The early return emits ``tool_info``
+   without falling through to the recording site.
+2. **Partial resolve** — policy allows some items but ``still_pending``
+   remains non-empty.  The auto-approve-tools / blanket branches don't
+   match (no ``auto_approve_tools`` / no blanket flag), so the prompt
+   path fires WITHOUT visiting the recording site.
+
+Both leaks let the policy bypass slip past the dashboard pill silently —
+exactly the case the visibility fix is meant to surface.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from turnstone.server import WebUI
+
+
+@pytest.fixture(autouse=True)
+def _global_queue():
+    """Reset the WebUI shared queue around each test."""
+    WebUI._global_queue = queue.Queue()
+    yield
+    WebUI._global_queue = None
+
+
+def _make_items(*specs: tuple[str, str]) -> list[dict[str, Any]]:
+    """Build approval items.  Each spec is ``(call_id, func_name)``."""
+    return [
+        {
+            "call_id": call_id,
+            "header": f"Tool: {func}",
+            "preview": "",
+            "func_name": func,
+            "approval_label": func,
+            "needs_approval": True,
+        }
+        for call_id, func in specs
+    ]
+
+
+def _patch_storage(storage: Any):
+    return patch("turnstone.core.storage._registry.get_storage", return_value=storage)
+
+
+def _patch_policies(verdicts: dict[str, str]):
+    return patch(
+        "turnstone.core.policy.evaluate_tool_policies_batch",
+        return_value=verdicts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LEAK 1 — early-return-on-deny path
+# ---------------------------------------------------------------------------
+
+
+def test_policy_mixed_allow_deny_records_allowed_items() -> None:
+    """When policy resolves every item and at least one is denied, the
+    early return must still record the policy-allowed siblings —
+    pre-fix the line-325 fall-through never ran on this path, leaving
+    the policy bypass invisible to /dashboard + audit."""
+    ui = WebUI(ws_id="ws-test")
+    items = _make_items(("c1", "bash"), ("c2", "read_file"))
+
+    storage = MagicMock()
+    with _patch_storage(storage), _patch_policies({"bash": "deny", "read_file": "allow"}):
+        approved, _err = ui.approve_tools(items)
+
+    # Block: at least one tool was denied, so approve_tools returns False.
+    assert approved is False
+    # The policy-allowed item is now visible on /dashboard via the buffer.
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 1
+    assert snapshot[0]["func_name"] == "read_file"
+    assert snapshot[0]["auto_approve_reason"] == "policy"
+    # And persisted to audit so the operator has a forensic trail.
+    storage.record_audit_event.assert_called_once()
+    audit_kwargs = storage.record_audit_event.call_args.kwargs
+    assert audit_kwargs["action"] == "tool.auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# LEAK 2 — policy-partial-resolve falls through to the prompt path
+# ---------------------------------------------------------------------------
+
+
+def test_policy_partial_allow_then_prompt_records_allowed_items() -> None:
+    """Policy allows one tool but another still needs operator approval —
+    falls through to the prompt path with ``pending`` non-empty and no
+    blanket auto_approve.  The line-325 record never fires; the new
+    pre-prompt record call is what surfaces the policy bypass."""
+    ui = WebUI(ws_id="ws-test")
+    items = _make_items(("c1", "read_file"), ("c2", "bash"))
+
+    # ``approve_tools`` blocks on ``_approval_event.wait`` for the
+    # prompt path.  Schedule a deny-by-operator on a tiny timer so
+    # the wait returns promptly; this test asserts on ring-buffer
+    # state, not the verdict outcome, so a deny is fine.
+    timer = threading.Timer(0.05, lambda: ui.resolve_approval(False))
+    timer.start()
+
+    storage = MagicMock()
+    try:
+        with _patch_storage(storage), _patch_policies({"read_file": "allow"}):
+            # bash gets no policy verdict → falls into still_pending → prompt.
+            ui.approve_tools(items)
+    finally:
+        timer.cancel()
+
+    # The policy-allowed read_file is captured in the buffer despite
+    # the prompt path running — this is the leak fix.
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 1
+    assert snapshot[0]["func_name"] == "read_file"
+    assert snapshot[0]["auto_approve_reason"] == "policy"
+    # Audit row recorded on the prompt path too.
+    storage.record_audit_event.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Regression — existing fall-through path still records
+# ---------------------------------------------------------------------------
+
+
+def test_policy_all_allow_no_deny_records_via_fallthrough() -> None:
+    """Sanity check on the line-325 fall-through path so the leak
+    fixes aren't masking a regression of the existing behaviour."""
+    ui = WebUI(ws_id="ws-test")
+    items = _make_items(("c1", "read_file"), ("c2", "list_dir"))
+
+    storage = MagicMock()
+    with _patch_storage(storage), _patch_policies({"read_file": "allow", "list_dir": "allow"}):
+        approved, _err = ui.approve_tools(items)
+
+    assert approved is True
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 2
+    assert {entry["func_name"] for entry in snapshot} == {"read_file", "list_dir"}
+    for entry in snapshot:
+        assert entry["auto_approve_reason"] == "policy"
+
+
+def test_blanket_auto_approve_records_pending_items() -> None:
+    """``auto_approve=True`` (blanket flag) drains every pending item —
+    each gets tagged with reason='blanket' and recorded.  Sanity check
+    on the blanket branch's tag + record discipline."""
+    ui = WebUI(ws_id="ws-test")
+    ui.auto_approve = True
+    items = _make_items(("c1", "bash"), ("c2", "edit_file"))
+
+    storage = MagicMock()
+    with _patch_storage(storage):
+        approved, _err = ui.approve_tools(items)
+
+    assert approved is True
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 2
+    for entry in snapshot:
+        assert entry["auto_approve_reason"] == "blanket"
+
+
+def test_auto_approve_tools_skill_source_renders_as_skill() -> None:
+    """When the workstream's auto_approve_tools were populated by a
+    skill template, the per-tool source map records ``skill`` and the
+    ring-buffer entry surfaces the same — this is the exact path the
+    user flagged ('child workstreams occasionally getting approved
+    without prompting because of a parent skill's allowlist')."""
+    ui = WebUI(ws_id="ws-test")
+    ui.auto_approve_tools = {"bash"}
+    ui._auto_approve_tools_source = {"bash": "skill"}
+    items = _make_items(("c1", "bash"))
+
+    storage = MagicMock()
+    with _patch_storage(storage):
+        approved, _err = ui.approve_tools(items)
+
+    assert approved is True
+    snapshot = ui.serialize_recent_auto_approvals()
+    assert len(snapshot) == 1
+    assert snapshot[0]["auto_approve_reason"] == "skill"
+
+
+def test_no_auto_approve_no_pending_recording() -> None:
+    """An items list of read-only tools (every entry already has
+    ``needs_approval=False``) must NOT enter the ring buffer — those
+    aren't bypasses, they're tools that never required approval in
+    the first place.  Buffer growth is reserved for actual gate
+    bypasses."""
+    ui = WebUI(ws_id="ws-test")
+    items = [
+        {
+            "call_id": "c1",
+            "header": "Tool: read_file",
+            "preview": "",
+            "func_name": "read_file",
+            "approval_label": "read_file",
+            "needs_approval": False,  # read-only — never needed approval
+        }
+    ]
+    storage = MagicMock()
+    with _patch_storage(storage):
+        approved, _err = ui.approve_tools(items)
+
+    assert approved is True
+    assert ui.serialize_recent_auto_approvals() == []
+    storage.record_audit_event.assert_not_called()

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -265,6 +265,35 @@ class PendingApprovalItem(BaseModel):
     judge_verdict: dict[str, Any] | None = None
 
 
+class RecentAutoApproval(BaseModel):
+    """One ring-buffer entry for ``DashboardWorkstream.recent_auto_approvals``.
+
+    Records a tool call that bypassed the operator approval gate
+    (admin tool policy / skill ``allowed_tools`` allowlist / blanket
+    ``auto_approve`` / "Approve + Always" memory).  The coord-tree
+    pill reads this list to surface "auto-approved by skill X" so
+    the operator can see WHICH calls bypassed and WHY.
+    """
+
+    call_id: str = ""
+    func_name: str = ""
+    approval_label: str = ""
+    auto_approve_reason: str = Field(
+        default="",
+        description=(
+            "Source that fired the bypass.  ``skill`` (skill template's "
+            "``allowed_tools``), ``always`` (user 'Approve + Always' "
+            "click), ``policy`` (admin tool-policy ``allow`` rule), "
+            "``blanket`` (workstream-level ``auto_approve=True``), or "
+            "``auto_approve_tools`` (legacy / unknown writer)."
+        ),
+    )
+    ts: float = Field(
+        default=0.0,
+        description="Unix epoch seconds when the auto-approve fired.",
+    )
+
+
 class PendingApprovalDetail(BaseModel):
     """Inline approval payload merged into ``DashboardWorkstream``.
 
@@ -326,6 +355,19 @@ class DashboardWorkstream(BaseModel):
             "per-child round-trip. ``None`` when no approval is pending. "
             "Also surfaced (verbatim) on ``GET /v1/api/cluster/ws/live`` "
             "via the ``_CLUSTER_WS_LIVE_KEYS`` projection."
+        ),
+    )
+    recent_auto_approvals: list[RecentAutoApproval] = Field(
+        default_factory=list,
+        description=(
+            "Per-ws ring buffer (cap 10) of recent tool calls that "
+            "bypassed the operator approval gate. Surfaces "
+            "``WebUI._recent_auto_approvals`` so the coord-tree row "
+            "can render an 'auto-approved by ...' pill when the "
+            "child's skill / blanket / admin-policy rules silently "
+            "let a tool through. Also projected onto "
+            "``GET /v1/api/cluster/ws/live`` via "
+            "``_CLUSTER_WS_LIVE_KEYS``."
         ),
     )
 

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -110,7 +110,20 @@ class ConsoleCoordinatorUI(SessionUIBase):
         # independently of the blanket ``auto_approve`` flag — matches
         # the WebUI two-tier contract (turnstone/server.py).
         if self.auto_approve_tools:
-            pending_names = {it.get("func_name", "") for it in pending if it.get("func_name")}
+            # Match WebUI's set-membership key: ``approval_label or
+            # func_name``.  ``auto_approve_tools`` is populated by
+            # both the skill template (bare func_name) and the
+            # "Approve + Always" handler (which tags via approval_label
+            # at session_routes.py).  Pre-fix the coord UI used only
+            # func_name, so an Always-added tool whose approval_label
+            # differs from func_name (e.g. ``skill__name``,
+            # ``mcp_resource__uri``) wouldn't match here and the
+            # operator would get prompted again on the coord page.
+            pending_names = {
+                it.get("approval_label", "") or it.get("func_name", "")
+                for it in pending
+                if it.get("func_name")
+            }
             if pending_names and pending_names.issubset(self.auto_approve_tools):
                 # Tag for /dashboard visibility — matches WebUI shape so
                 # the coord-tree pill renders the same source string

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.log import get_logger
-from turnstone.core.session_ui_base import SessionUIBase
+from turnstone.core.session_ui_base import AutoApproveReason, SessionUIBase
 from turnstone.core.workstream import WorkstreamState
 
 if TYPE_CHECKING:
@@ -93,24 +93,16 @@ class ConsoleCoordinatorUI(SessionUIBase):
         self._reset_approval_cycle()
         pending = [it for it in items if it.get("needs_approval") and not it.get("error")]
 
-        serialized = []
-        for item in items:
-            entry: dict[str, Any] = {
-                "call_id": item.get("call_id", ""),
-                "header": item.get("header", ""),
-                "preview": item.get("preview", ""),
-                "func_name": item.get("func_name", ""),
-                "approval_label": item.get("approval_label", item.get("func_name", "")),
-                "needs_approval": item.get("needs_approval", False),
-                "error": item.get("error"),
-            }
-            serialized.append(entry)
-
         if not pending:
             # Nothing to approve; broadcast tool info anyway so the UI
             # can render the tool preview.
-            if serialized:
-                self._enqueue({"type": "tools_auto_approved", "items": serialized})
+            if items:
+                self._enqueue(
+                    {
+                        "type": "tools_auto_approved",
+                        "items": self._serialize_approval_items(items),
+                    }
+                )
             return True, None
 
         # Per-tool auto-approve: 'Always approve this tool' adds the
@@ -120,19 +112,40 @@ class ConsoleCoordinatorUI(SessionUIBase):
         if self.auto_approve_tools:
             pending_names = {it.get("func_name", "") for it in pending if it.get("func_name")}
             if pending_names and pending_names.issubset(self.auto_approve_tools):
-                self._enqueue({"type": "tools_auto_approved", "items": serialized})
+                # Tag for /dashboard visibility — matches WebUI shape so
+                # the coord-tree pill renders the same source string
+                # (``skill`` / ``always`` / generic) for both kinds.
+                self._tag_auto_approved(
+                    pending,
+                    AutoApproveReason.AUTO_APPROVE_TOOLS,
+                    source_map=self._auto_approve_tools_source,
+                )
+                self._record_auto_approves(items)
+                self._enqueue(
+                    {
+                        "type": "tools_auto_approved",
+                        "items": self._serialize_approval_items(items),
+                    }
+                )
                 return True, None
 
         # Blanket auto-approve (set e.g. during scripted
         # restart-rehydration) — also matches WebUI semantics.
         if self.auto_approve:
-            self._enqueue({"type": "tools_auto_approved", "items": serialized})
+            self._tag_auto_approved(pending, AutoApproveReason.BLANKET)
+            self._record_auto_approves(items)
+            self._enqueue(
+                {
+                    "type": "tools_auto_approved",
+                    "items": self._serialize_approval_items(items),
+                }
+            )
             return True, None
 
         self._approval_event.clear()
         self._pending_approval = {
             "type": "approve_request",
-            "items": serialized,
+            "items": self._serialize_approval_items(items),
             "judge_pending": False,
         }
         self._enqueue(self._pending_approval)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -613,6 +613,13 @@ _CLUSTER_WS_LIVE_KEYS = (
     # Cross-tenant exposure follows the trusted-team posture documented
     # on ``SessionUIBase.serialize_pending_approval_detail``.
     "pending_approval_detail",
+    # Ring buffer of the child's recent auto-approves (last 10) for
+    # the coord-tree's "auto-approved by skill X" pill.  Without this
+    # the operator has no surface to see WHICH tool calls bypassed
+    # the gate or WHY (skill allowlist / blanket / admin policy /
+    # explicit "Always" click) — the SSE ``tool_info`` event fires
+    # only on the per-ws stream the coord doesn't subscribe to.
+    "recent_auto_approvals",
 )
 
 
@@ -733,6 +740,7 @@ def _coordinator_live_snapshot(ws: Any) -> dict[str, Any]:
     # transient states (newly-created ws before activation); every
     # active coord UI is a ``SessionUIBase`` and supports the method.
     pending_approval_detail = ui.serialize_pending_approval_detail() if ui is not None else None
+    recent_auto_approvals = ui.serialize_recent_auto_approvals() if ui is not None else []
 
     return {
         "state": ws.state.value if hasattr(ws.state, "value") else str(ws.state),
@@ -747,6 +755,7 @@ def _coordinator_live_snapshot(ws: Any) -> dict[str, Any]:
         "name": getattr(ws, "name", "") or "",
         "pending_approval": pending_approval,
         "pending_approval_detail": pending_approval_detail,
+        "recent_auto_approvals": recent_auto_approvals,
     }
 
 

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -105,6 +105,31 @@
   const WS_ID_RE = /^[a-f0-9]{8,64}$/i;
   const NODE_ID_RE = /^[A-Za-z0-9._-]{1,256}$/;
 
+  // Auto-approve reason vocabulary — kept in lockstep with the
+  // ``AutoApproveReason`` constants in turnstone/core/session_ui_base.py.
+  // The pill renderer validates incoming reason strings against this
+  // set so a server-side typo (or a future reason this build doesn't
+  // know about) renders as "unknown" with a console.warn instead of
+  // silently surfacing the typo verbatim in the operator-facing label.
+  const KNOWN_AUTO_APPROVE_REASONS = new Set([
+    "skill",
+    "always",
+    "policy",
+    "blanket",
+    "auto_approve_tools",
+  ]);
+  const UNKNOWN_AUTO_APPROVE_REASON = "unknown";
+
+  function _normaliseAutoApproveReason(raw) {
+    const r = raw || "auto_approve_tools";
+    if (KNOWN_AUTO_APPROVE_REASONS.has(r)) return r;
+    console.warn(
+      "coord_ui: unknown auto_approve_reason from server:",
+      JSON.stringify(raw),
+    );
+    return UNKNOWN_AUTO_APPROVE_REASON;
+  }
+
   function renderToolOutput(rawText) {
     // Try parse JSON first — coordinator tool output is JSON-shaped.
     let parsed = null;
@@ -1151,7 +1176,76 @@
       // refresh and one bulk request covers every pending row.
       _maybeStartJudgePoll();
     }
+    // Recent auto-approves — tools that bypassed the operator gate
+    // (skill ``allowed_tools`` allowlist / blanket / admin policy /
+    // explicit "Always" click).  Without this pill the operator sees
+    // the child run tools they never approved with no explanation.
+    // The buffer is bounded server-side at 10 entries so this stays
+    // O(1) per render.
+    if (
+      cached &&
+      cached.live &&
+      Array.isArray(cached.live.recent_auto_approvals) &&
+      cached.live.recent_auto_approvals.length > 0
+    ) {
+      const pill = renderAutoApprovedPill(cached.live.recent_auto_approvals);
+      if (pill) row.appendChild(pill);
+    }
     return row;
+  }
+
+  // Build a compact pill summarising the row's recent auto-approves.
+  // Format: "auto-approved (skill): bash, edit_file +2".  Tooltip
+  // expands the full list with reasons.  Returns null when the
+  // server hasn't surfaced any entries — defensive against a missing
+  // field on older node payloads.
+  function renderAutoApprovedPill(entries) {
+    if (!Array.isArray(entries) || entries.length === 0) return null;
+    const pill = document.createElement("div");
+    pill.className = "ch-auto-approved-pill";
+    // Group by reason for the lead label; show the most-common reason
+    // when the buffer mixes (e.g. skill + always after the operator
+    // hit "Approve + Always" on a tool the skill template missed).
+    const reasonCounts = new Map();
+    for (const e of entries) {
+      const r = _normaliseAutoApproveReason(e && e.auto_approve_reason);
+      reasonCounts.set(r, (reasonCounts.get(r) || 0) + 1);
+    }
+    let topReason = "auto_approve_tools";
+    let topCount = 0;
+    for (const [r, n] of reasonCounts) {
+      if (n > topCount) {
+        topReason = r;
+        topCount = n;
+      }
+    }
+    const names = entries
+      .map((e) => (e && (e.approval_label || e.func_name)) || "")
+      .filter(Boolean);
+    const visible = names.slice(0, 3).join(", ");
+    const more = names.length > 3 ? " +" + (names.length - 3) : "";
+    const label = document.createElement("span");
+    label.className = "ch-auto-approved-label";
+    label.textContent =
+      "✓ auto-approved (" + topReason + "): " + visible + more;
+    pill.appendChild(label);
+    // Full breakdown in the tooltip — operator can hover to see
+    // every tool name + its specific reason without expanding any
+    // additional UI.  Includes timestamps so a recent ad-hoc
+    // approval can be told apart from the skill-template baseline.
+    const tooltip = entries
+      .map((e) => {
+        const name = (e && (e.approval_label || e.func_name)) || "(unknown)";
+        const reason = _normaliseAutoApproveReason(e && e.auto_approve_reason);
+        const ts =
+          e && typeof e.ts === "number"
+            ? new Date(e.ts * 1000).toLocaleTimeString()
+            : "";
+        return ts ? `${ts}  ${name}  (${reason})` : `${name}  (${reason})`;
+      })
+      .join("\n");
+    pill.title = tooltip;
+    return pill;
   }
 
   // Late-judge polling — single global timer driving a bulk

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -195,6 +195,27 @@
     font-size: 11px;
     line-height: 1.4;
   }
+  /* Auto-approved pill — same 22px indent as .approval-block / .meta
+     so a child row showing both stacks cleanly.  Lower visual weight
+     than the live approve/deny block (this is informational, not
+     actionable) but still distinct enough that the operator notices
+     when a tool call bypassed the gate. */
+  [data-design="v1"] .ch-row .ch-auto-approved-pill {
+    margin-top: 2px;
+    padding: 2px 8px 2px 22px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    line-height: 1.4;
+    color: var(--ink-3);
+    cursor: help;
+  }
+  [data-design="v1"] .ch-row .ch-auto-approved-label {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--hair);
+    background: var(--surface-1, transparent);
+  }
   [data-design="v1"] .ch-row .approval-header {
     display: flex;
     flex-wrap: wrap;

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -39,6 +39,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from turnstone.core.log import get_logger
+from turnstone.core.session_ui_base import AutoApproveReason
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -744,6 +745,16 @@ def make_approve_handler(cfg: SessionEndpointConfig) -> Handler:
             tool_names.discard("__budget_override__")
             if tool_names:
                 auto_approve_tools.update(tool_names)
+                # Tag the source so /dashboard pills can distinguish
+                # an explicit "Approve + Always" click from the
+                # skill-template path (which the user may have set
+                # up months ago).  Defensive ``getattr`` because the
+                # source map landed alongside this fix; pre-fix
+                # workstreams would lack it during a hot-deploy.
+                source_map = getattr(ui, "_auto_approve_tools_source", None)
+                if source_map is not None:
+                    for t in tool_names:
+                        source_map[t] = AutoApproveReason.ALWAYS
         ui.resolve_approval(approved, feedback)
         return JSONResponse({"status": "ok"})
 

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -708,6 +708,15 @@ class SessionUIBase:
     def _parse_audit_timestamp(ts_str: str) -> float:
         """Parse the audit row's ISO-8601 timestamp into epoch seconds.
 
+        Audit rows are written as ``datetime.now(UTC).strftime(...)``
+        without a timezone marker (see ``storage/_sqlite.py:record_audit_event``),
+        so ``datetime.fromisoformat`` returns a *naive* datetime.
+        Calling ``.timestamp()`` on a naive datetime interprets it
+        in the server's local timezone — wrong here, since the
+        source clock is UTC.  Stamp UTC explicitly before
+        converting so a non-UTC server doesn't render pill
+        timestamps off by hours.
+
         Falls back to ``0.0`` on a missing / malformed timestamp so
         the buffer entry still surfaces (just with a "no time"
         indicator the JS pill renderer treats as missing).
@@ -715,9 +724,11 @@ class SessionUIBase:
         if not ts_str:
             return 0.0
         try:
-            from datetime import datetime
+            from datetime import UTC, datetime
 
             dt = datetime.fromisoformat(ts_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
             return dt.timestamp()
         except (TypeError, ValueError):
             return 0.0

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -28,6 +28,7 @@ import copy
 import json
 import queue
 import threading
+import time
 import uuid
 from typing import Any
 
@@ -48,6 +49,48 @@ _DEFAULT_LISTENER_QUEUE_MAX = 500
 # budget. Lifted from WebUI in the rich ``ws_state`` payload work so
 # coord broadcasts hit the same ceiling.
 _MAX_TURN_CONTENT_CHARS = 256 * 1024
+
+
+class AutoApproveReason:
+    """Source vocabulary for ``auto_approve_reason`` annotations.
+
+    Pinned as constants so writers can't typo a reason silently and
+    desync the wire from the JS pill renderer.  Kept on a class
+    rather than an Enum so the wire-format string IS the value (no
+    ``.value`` dance at every emit site, and no surprise behaviour
+    if a consumer compares against the literal).
+
+    The five reasons reflect the disjoint set of paths that bypass
+    the operator approval gate:
+
+    - :attr:`SKILL` — workstream's skill template populated
+      ``auto_approve_tools`` from its ``allowed_tools`` JSON list at
+      create time.  The dashboard pill flags this so an operator
+      can see when a child is silently auto-approving because of a
+      previously-installed skill they may have forgotten about.
+    - :attr:`ALWAYS` — operator clicked "Approve + Always" on a
+      tool earlier in this session, adding its name to
+      ``auto_approve_tools``.
+    - :attr:`POLICY` — admin-defined ``tool_policies`` row with
+      ``action='allow'`` matched the tool name (or pattern).
+    - :attr:`BLANKET` — workstream-level ``auto_approve=True`` flag
+      (server config / skill ``auto_approve``).  Drains every
+      remaining pending tool unconditionally except for
+      ``__budget_override__`` which always prompts.
+    - :attr:`AUTO_APPROVE_TOOLS` — fallback when ``auto_approve_tools``
+      contains a name but the per-tool source map was never
+      populated (legacy / pre-source-tracking instances).  Visible
+      as a generic pill rather than a misleading ``skill`` /
+      ``always`` claim.
+    """
+
+    SKILL = "skill"
+    ALWAYS = "always"
+    POLICY = "policy"
+    BLANKET = "blanket"
+    AUTO_APPROVE_TOOLS = "auto_approve_tools"
+
+    ALL: frozenset[str] = frozenset({SKILL, ALWAYS, POLICY, BLANKET, AUTO_APPROVE_TOOLS})
 
 
 class SessionUIBase:
@@ -80,6 +123,32 @@ class SessionUIBase:
         self._pending_plan_review: dict[str, Any] | None = None
         self.auto_approve = False
         self.auto_approve_tools: set[str] = set()
+        # Per-tool source for ``auto_approve_tools`` membership.  Two
+        # writers populate the set with semantically different intent:
+        #
+        # - **Skill template** at create time (the ``allowed_tools``
+        #   JSON list landing on ``auto_approve_tools`` from
+        #   ``server.py``'s skill block) — operator may not have
+        #   explicitly opted in tool-by-tool.
+        # - **User "Approve + Always"** click at runtime — explicit
+        #   per-tool consent from the live operator.
+        #
+        # Without per-tool source tracking the dashboard can't tell
+        # the operator WHICH path silently approved a tool call.
+        # Maps ``approval_label_or_func_name → source_string``;
+        # callers populate at the same point they update the set
+        # itself.  Default empty when neither writer ran (e.g. CLI
+        # ``/always`` doesn't set this — pre-existing).
+        self._auto_approve_tools_source: dict[str, str] = {}
+        # Ring buffer of recent auto-approve events for /dashboard
+        # visibility — a child workstream whose tool calls bypass the
+        # approval gate (skill allowlist / blanket / admin policy)
+        # would otherwise leave no operator-facing trace at all.  Fed
+        # by :meth:`_record_auto_approves`; surfaced through
+        # :meth:`serialize_recent_auto_approvals` and the per-ws
+        # ``/dashboard`` payload.  Capped so a long-running skill
+        # workstream can't fill the live block with stale rows.
+        self._recent_auto_approvals: list[dict[str, Any]] = []
         # Foreground gate — used by the CLI's WorkstreamTerminalUI to
         # block output when the workstream is in the background.
         # Starts set so non-CLI UIs can skip any explicit management.
@@ -129,6 +198,16 @@ class SessionUIBase:
         # Verdict cache for SSE reconnect replay (tab switching
         # shouldn't lose the judge's final call on a just-run tool).
         self._llm_verdicts: dict[str, dict[str, Any]] = {}
+        # Re-populate the recent-auto-approve ring buffer from the
+        # audit log so the dashboard pill survives UI rebuilds —
+        # saved-workstream rehydrate / coord→node click-through /
+        # process restart all build a fresh UI whose buffer would
+        # otherwise start empty even though the audit row is still
+        # there.  Best-effort: storage outage / not-yet-wired silently
+        # leaves the buffer empty (the next live auto-approve will
+        # populate it).  Runs last in __init__ so all the lock + state
+        # fields the replay touches are already initialised.
+        self.replay_recent_auto_approvals_from_audit()
 
     # ------------------------------------------------------------------
     # Listener plumbing (SSE)
@@ -396,6 +475,264 @@ class SessionUIBase:
             "judge_pending": bool(pending.get("judge_pending", False)),
             "items": serialized,
         }
+
+    # ---------------------------------------------------------------
+    # Auto-approve visibility — shared by interactive + coord UIs
+    # ---------------------------------------------------------------
+    #
+    # When a tool call gets approved without an explicit operator
+    # click (admin tool policy, skill ``allowed_tools`` allowlist,
+    # blanket ``auto_approve``, or "Approve + Always" memory) the
+    # coord-tree dashboard would otherwise have no surface to show
+    # WHICH tools bypassed the gate or WHY.  These helpers feed two
+    # sinks: per-item annotations on the ``tool_info`` SSE event
+    # (live operator visibility) and a short ring buffer surfaced
+    # via ``/dashboard`` (post-hoc visibility for the coord tree).
+
+    # Cap on the per-ws ring buffer.  Sized for "the operator opens
+    # the row in the next minute" — older entries roll off so the
+    # /dashboard payload stays bounded on long-running skill
+    # workstreams that auto-approve dozens of tool calls per turn.
+    _RECENT_AUTO_APPROVALS_MAX = 10
+
+    @staticmethod
+    def _serialize_approval_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Project each item to the wire shape the SSE event payload uses.
+
+        Single source of truth for both ``approve_request`` and
+        ``tool_info`` payloads — pre-fix the WebUI rebuilt this
+        twice (once eagerly, once after policy evaluation), and
+        adding new fields meant editing both copies in lockstep.
+        Forwards ``auto_approved`` / ``auto_approve_reason`` when
+        the upstream pipeline tagged the item, so the operator can
+        see which path silently approved each call.
+
+        Heuristic verdict surfaces under ``heuristic_verdict`` for
+        consistency with :meth:`serialize_pending_approval_detail`
+        and :class:`api.server_schemas.PendingApprovalItem` — pre-
+        fix this method emitted ``verdict`` while the dashboard
+        payload used ``heuristic_verdict``, leaving JS consumers
+        with two code paths for the same field.
+        """
+        out: list[dict[str, Any]] = []
+        for it in items:
+            denied = it.get("denied")
+            entry: dict[str, Any] = {
+                "call_id": it.get("call_id", ""),
+                "header": it.get("header", ""),
+                "preview": it.get("preview", ""),
+                "func_name": it.get("func_name", ""),
+                "approval_label": it.get("approval_label", it.get("func_name", "")),
+                "needs_approval": it.get("needs_approval", False),
+                "error": it.get("denial_msg") if denied else it.get("error"),
+            }
+            if "_heuristic_verdict" in it:
+                entry["heuristic_verdict"] = it["_heuristic_verdict"]
+            if it.get("auto_approved"):
+                entry["auto_approved"] = True
+                entry["auto_approve_reason"] = it.get("auto_approve_reason", "")
+            out.append(entry)
+        return out
+
+    def _tag_auto_approved(
+        self,
+        pending: list[dict[str, Any]],
+        reason: str,
+        *,
+        source_map: dict[str, str] | None = None,
+    ) -> None:
+        """Mark each pending item as auto-approved with the given reason.
+
+        Used at the three branch points in ``approve_tools`` (policy
+        ``allow`` / ``auto_approve_tools.issubset`` / blanket
+        ``auto_approve``) so both :class:`turnstone.server.WebUI` and
+        :class:`turnstone.console.coordinator_ui.ConsoleCoordinatorUI`
+        share the loop body — pre-fix the per-branch tag loops were
+        copy-pasted line-for-line across the two subclasses.
+
+        ``source_map`` is the per-tool source dict
+        (``_auto_approve_tools_source``) populated by the skill
+        template / "Approve + Always" writers.  When provided, each
+        item's reason is looked up by ``approval_label_or_func_name``
+        and falls back to ``reason`` when the entry is missing
+        (legacy / unknown writer).  Pass ``None`` for the policy /
+        blanket branches that don't carry per-tool source.
+        """
+        for it in pending:
+            it["auto_approved"] = True
+            if source_map is not None:
+                name = it.get("approval_label", "") or it.get("func_name", "")
+                it["auto_approve_reason"] = source_map.get(name, reason)
+            else:
+                it["auto_approve_reason"] = reason
+
+    def _record_auto_approves(self, items: list[dict[str, Any]]) -> None:
+        """Append auto-approved items to the per-ws ring buffer + audit log.
+
+        Called from ``approve_tools`` immediately before the
+        ``tool_info`` emit so the /dashboard payload reflects the
+        same set of tools the SSE consumer just saw.  No-op when
+        ``items`` is empty (every item was a "no approval needed"
+        read-only tool, not an auto-approve).
+
+        Also writes one ``tool.auto_approved`` audit row per call so
+        operators have a durable forensic record beyond the SSE
+        stream + ring buffer (both ephemeral).  Audit failure is
+        logged but never raised — visibility is best-effort and
+        must not break the tool-execution path.
+        """
+        if not items:
+            return
+        ts = time.time()
+        appended = [
+            {
+                "call_id": it.get("call_id", ""),
+                "func_name": it.get("func_name", ""),
+                "approval_label": it.get("approval_label", "") or it.get("func_name", ""),
+                "auto_approve_reason": it.get("auto_approve_reason", ""),
+                "ts": ts,
+            }
+            for it in items
+            if it.get("auto_approved")
+        ]
+        if not appended:
+            return
+        with self._ws_lock:
+            self._recent_auto_approvals.extend(appended)
+            overflow = len(self._recent_auto_approvals) - self._RECENT_AUTO_APPROVALS_MAX
+            if overflow > 0:
+                self._recent_auto_approvals = self._recent_auto_approvals[overflow:]
+        # Audit emission — one row per ``approve_tools`` call (not one
+        # per item) keeps the audit table from blowing up on
+        # tool-heavy turns while still capturing every tool name +
+        # reason in the detail payload.
+        try:
+            from turnstone.core.audit import record_audit
+            from turnstone.core.storage._registry import get_storage
+
+            storage = get_storage()
+            if storage is None:
+                return
+            tools = [
+                {
+                    "func_name": entry["func_name"],
+                    "approval_label": entry["approval_label"],
+                    "reason": entry["auto_approve_reason"],
+                    "call_id": entry["call_id"],
+                }
+                for entry in appended
+            ]
+            record_audit(
+                storage,
+                self._user_id,
+                "tool.auto_approved",
+                "workstream",
+                self.ws_id,
+                {"tools": tools, "count": len(tools)},
+            )
+        except Exception:
+            log.debug("auto_approve.audit_failed ws=%s", self.ws_id, exc_info=True)
+
+    def replay_recent_auto_approvals_from_audit(self) -> None:
+        """Seed :attr:`_recent_auto_approvals` from the audit log.
+
+        Without this the dashboard pill vanishes on every UI rebuild
+        — a saved-workstream rehydrate / coord→node click-through /
+        process restart all build a fresh ``WebUI`` whose ring
+        buffer starts empty even though the audit table still holds
+        the bypass history.  Replaying recent ``tool.auto_approved``
+        rows on construction makes the pill survive these
+        transitions; the audit row is the canonical durable
+        record, the ring buffer is just its in-memory mirror.
+
+        Best-effort: any storage / parse error silently leaves the
+        buffer empty — the next live auto-approve will populate it
+        as before.  No-op when ``ws_id`` is unset (test fixture).
+        """
+        if not self.ws_id:
+            return
+        try:
+            from turnstone.core.storage._registry import get_storage
+
+            storage = get_storage()
+            if storage is None:
+                return
+            rows = storage.list_audit_events(
+                action="tool.auto_approved",
+                resource_id=self.ws_id,
+                limit=self._RECENT_AUTO_APPROVALS_MAX,
+            )
+        except Exception:
+            log.debug(
+                "auto_approve.replay_from_audit_failed ws=%s",
+                self.ws_id,
+                exc_info=True,
+            )
+            return
+        appended: list[dict[str, Any]] = []
+        # ``list_audit_events`` returns DESC; reverse so the oldest
+        # row lands first in the buffer (chronological order matches
+        # what live appends produce).
+        for row in reversed(rows or []):
+            try:
+                detail = json.loads(row.get("detail") or "{}")
+            except (TypeError, ValueError):
+                continue
+            tools = detail.get("tools") or []
+            ts = self._parse_audit_timestamp(row.get("timestamp", ""))
+            for t in tools:
+                if not isinstance(t, dict):
+                    continue
+                appended.append(
+                    {
+                        "call_id": t.get("call_id", "") or "",
+                        "func_name": t.get("func_name", "") or "",
+                        "approval_label": (t.get("approval_label") or t.get("func_name", "") or ""),
+                        "auto_approve_reason": t.get("reason", "") or "",
+                        "ts": ts,
+                    }
+                )
+        if not appended:
+            return
+        with self._ws_lock:
+            # Replay merges with whatever the live path may have
+            # appended in the interleaving window between
+            # construction and replay completion: replay rows go
+            # first, then any live entries, and the buffer is
+            # capped from the head.
+            live = list(self._recent_auto_approvals)
+            merged = appended + live
+            self._recent_auto_approvals = merged[-self._RECENT_AUTO_APPROVALS_MAX :]
+
+    @staticmethod
+    def _parse_audit_timestamp(ts_str: str) -> float:
+        """Parse the audit row's ISO-8601 timestamp into epoch seconds.
+
+        Falls back to ``0.0`` on a missing / malformed timestamp so
+        the buffer entry still surfaces (just with a "no time"
+        indicator the JS pill renderer treats as missing).
+        """
+        if not ts_str:
+            return 0.0
+        try:
+            from datetime import datetime
+
+            dt = datetime.fromisoformat(ts_str)
+            return dt.timestamp()
+        except (TypeError, ValueError):
+            return 0.0
+
+    def serialize_recent_auto_approvals(self) -> list[dict[str, Any]]:
+        """Return a snapshot of the recent-auto-approves ring buffer.
+
+        Read by the per-ws ``/dashboard`` payload (and the
+        cross-cluster live-bulk projection on the console) so the
+        coord-tree row can render an "auto-approved by …" pill.
+        Returns a shallow copy under ``_ws_lock`` so the caller
+        can't mutate the buffer mid-iteration.
+        """
+        with self._ws_lock:
+            return [dict(entry) for entry in self._recent_auto_approvals]
 
     def on_output_warning(self, call_id: str, assessment: dict[str, Any]) -> None:
         """Deliver an output-guard warning + persist its assessment row."""

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2855,6 +2855,7 @@ class PostgreSQLBackend:
         until: str = "",
         limit: int = 100,
         offset: int = 0,
+        resource_id: str = "",
     ) -> list[dict[str, Any]]:
         with self._conn() as conn:
             q = sa.select(
@@ -2876,6 +2877,8 @@ class PostgreSQLBackend:
                 q = q.where(audit_events.c.timestamp >= since)
             if until:
                 q = q.where(audit_events.c.timestamp <= until)
+            if resource_id:
+                q = q.where(audit_events.c.resource_id == resource_id)
             q = q.limit(limit).offset(offset)
             rows = conn.execute(q).fetchall()
             return [

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1215,7 +1215,8 @@ class StorageBackend(Protocol):
 
         ``resource_id`` filters to events scoped to a single
         workstream (or other resource id) — added so per-ws
-        consumers like ``SessionUIBase._replay_recent_auto_approvals``
+        consumers like
+        ``SessionUIBase.replay_recent_auto_approvals_from_audit``
         can pull a workstream's bypass history without scanning
         the full table.
         """

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1209,8 +1209,16 @@ class StorageBackend(Protocol):
         until: str = "",
         limit: int = 100,
         offset: int = 0,
+        resource_id: str = "",
     ) -> list[dict[str, Any]]:
-        """List audit events with optional filters, ordered by timestamp DESC."""
+        """List audit events with optional filters, ordered by timestamp DESC.
+
+        ``resource_id`` filters to events scoped to a single
+        workstream (or other resource id) — added so per-ws
+        consumers like ``SessionUIBase._replay_recent_auto_approvals``
+        can pull a workstream's bypass history without scanning
+        the full table.
+        """
         ...
 
     def count_audit_events(

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2961,6 +2961,7 @@ class SQLiteBackend:
         until: str = "",
         limit: int = 100,
         offset: int = 0,
+        resource_id: str = "",
     ) -> list[dict[str, Any]]:
         with self._conn() as conn:
             q = sa.select(
@@ -2982,6 +2983,8 @@ class SQLiteBackend:
                 q = q.where(audit_events.c.timestamp >= since)
             if until:
                 q = q.where(audit_events.c.timestamp <= until)
+            if resource_id:
+                q = q.where(audit_events.c.resource_id == resource_id)
             q = q.limit(limit).offset(offset)
             rows = conn.execute(q).fetchall()
             return [

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -77,7 +77,7 @@ from turnstone.core.session_routes import (
     make_send_handler,
     register_session_routes,
 )
-from turnstone.core.session_ui_base import SessionUIBase
+from turnstone.core.session_ui_base import AutoApproveReason, SessionUIBase
 from turnstone.core.tools import TOOLS  # noqa: F401 — available for introspection
 from turnstone.core.web_helpers import version_html as _version_html
 from turnstone.core.workstream import (
@@ -226,22 +226,6 @@ class WebUI(SessionUIBase):
         self._reset_approval_cycle()
         pending = [it for it in items if it.get("needs_approval") and not it.get("error")]
 
-        # Always send tool info to the browser
-        serialized = []
-        for item in items:
-            entry: dict[str, Any] = {
-                "call_id": item.get("call_id", ""),
-                "header": item.get("header", ""),
-                "preview": item.get("preview", ""),
-                "func_name": item.get("func_name", ""),
-                "approval_label": item.get("approval_label", item.get("func_name", "")),
-                "needs_approval": item.get("needs_approval", False),
-                "error": item.get("error"),
-            }
-            if "_heuristic_verdict" in item:
-                entry["verdict"] = item["_heuristic_verdict"]
-            serialized.append(entry)
-
         # -- Tool policy evaluation -----------------------------------------------
         # Check admin-defined tool policies before the auto_approve check.
         if pending:
@@ -268,29 +252,31 @@ class WebUI(SessionUIBase):
                                     f"Blocked by tool policy (pattern match for '{policy_name}')"
                                 )
                             elif verdict == "allow":
+                                # Admin-defined ``allow`` rule fires the
+                                # auto-approve gate without any UI prompt.
+                                # Tag for /dashboard visibility so the
+                                # operator can see which calls bypassed
+                                # the prompt and why.
                                 it["needs_approval"] = False
+                                self._tag_auto_approved([it], AutoApproveReason.POLICY)
                             else:
                                 still_pending.append(it)
-                        # Rebuild serialized to reflect policy verdicts
-                        serialized = []
-                        for it in items:
-                            rebuilt: dict[str, Any] = {
-                                "call_id": it.get("call_id", ""),
-                                "header": it.get("header", ""),
-                                "preview": it.get("preview", ""),
-                                "func_name": it.get("func_name", ""),
-                                "approval_label": it.get("approval_label", it.get("func_name", "")),
-                                "needs_approval": it.get("needs_approval", False),
-                                "error": it.get("denial_msg") if it.get("denied") else None,
-                            }
-                            if "_heuristic_verdict" in it:
-                                rebuilt["verdict"] = it["_heuristic_verdict"]
-                            serialized.append(rebuilt)
                         # If all were resolved by policy, check if any were denied
                         if not still_pending:
                             any_denied = any(it.get("denied") for it in items)
                             if any_denied:
-                                self._enqueue({"type": "tool_info", "items": serialized})
+                                # Record the policy-allowed siblings before
+                                # the early return — the line-325 fall-
+                                # through branch never runs on this path,
+                                # so without this the policy bypass is
+                                # invisible to /dashboard + audit.
+                                self._record_auto_approves(items)
+                                self._enqueue(
+                                    {
+                                        "type": "tool_info",
+                                        "items": self._serialize_approval_items(items),
+                                    }
+                                )
                                 return False, "Blocked by tool policy"
                         pending = still_pending
             except Exception:
@@ -305,12 +291,31 @@ class WebUI(SessionUIBase):
                 if it.get("func_name")
             }
             if pending_names and pending_names.issubset(self.auto_approve_tools):
+                # Tag each formerly-pending item with the per-tool source
+                # recorded when ``auto_approve_tools`` was populated:
+                # ``skill`` (skill template's ``allowed_tools``) /
+                # ``always`` (user "Approve + Always" click) / fallback
+                # ``auto_approve_tools`` for legacy or unknown writers.
+                # Visibility for the skill-vs-explicit conflation
+                # flagged on the coord tree dashboard.
+                self._tag_auto_approved(
+                    pending,
+                    AutoApproveReason.AUTO_APPROVE_TOOLS,
+                    source_map=self._auto_approve_tools_source,
+                )
                 pending = []
 
         # Budget override requires explicit approval — never auto-approved by
         # blanket auto_approve (tool policies can still allow it explicitly).
         has_budget_override = any(it.get("func_name") == "__budget_override__" for it in pending)
-        if not pending or (self.auto_approve and not has_budget_override):
+        blanket_active = self.auto_approve and not has_budget_override
+        if not pending or blanket_active:
+            if blanket_active and pending:
+                # Blanket flag drained the rest of pending \u2014 tag so the
+                # dashboard can distinguish from
+                # ``auto_approve_tools`` / ``policy``.
+                self._tag_auto_approved(pending, AutoApproveReason.BLANKET)
+                pending = []
             # Track auto-approved tool activity
             first = items[0] if items else {}
             label = first.get("func_name", "")
@@ -319,7 +324,8 @@ class WebUI(SessionUIBase):
                 self._ws_current_activity = f"\u2699 {label}: {preview}" if label else ""
                 self._ws_activity_state = "tool" if label else ""
             self._broadcast_activity()
-            self._enqueue({"type": "tool_info", "items": serialized})
+            self._record_auto_approves(items)
+            self._enqueue({"type": "tool_info", "items": self._serialize_approval_items(items)})
             return True, None
 
         # Track pending approval activity
@@ -371,12 +377,20 @@ class WebUI(SessionUIBase):
         with self._ws_lock:
             self._pending_verdicts = heuristic_verdicts
 
+        # Record any items the policy block already auto-approved
+        # before falling through to the prompt — without this the
+        # mixed-policy-then-prompt path leaves the policy bypass
+        # invisible to /dashboard (the line-325 fall-through never
+        # runs since pending is non-empty + blanket inactive).
+        # No-op when no items are auto-approve-tagged.
+        self._record_auto_approves(items)
+
         # Send approval request and block
         judge_pending = bool(any(it.get("_heuristic_verdict") for it in items))
         self._approval_event.clear()
         self._pending_approval = {
             "type": "approve_request",
-            "items": serialized,
+            "items": self._serialize_approval_items(items),
             "judge_pending": judge_pending,
         }
         self._enqueue(self._pending_approval)
@@ -1156,6 +1170,12 @@ async def dashboard(request: Request) -> JSONResponse:
                 "parent_ws_id": ws.parent_ws_id,
                 "user_id": ws.user_id,
                 "pending_approval_detail": ui.serialize_pending_approval_detail(),
+                # Per-ws ring buffer of recent auto-approves (last 10).
+                # Lets the coord-tree render a "recently auto-approved
+                # by skill X" pill without a per-child round-trip — the
+                # tools-bypassed-the-prompt set is otherwise invisible
+                # to anyone watching the dashboard tree.
+                "recent_auto_approvals": ui.serialize_recent_auto_approvals(),
             }
         )
     uptime_sec = round(time.monotonic() - _metrics.start_time)
@@ -2034,6 +2054,12 @@ async def _interactive_create_post_install(
                 tools_list = [t.strip() for t in allowed.split(",") if t.strip()]
             if tools_list:
                 ws.ui.auto_approve_tools = set(tools_list)
+                # Tag each as skill-sourced so the dashboard can show
+                # "auto-approved by skill X" instead of a generic
+                # auto-approval pill — distinguishes the (often
+                # surprising) skill-template path from a deliberate
+                # operator "Approve + Always" click.
+                ws.ui._auto_approve_tools_source = {t: AutoApproveReason.SKILL for t in tools_list}
         sess._notify_on_complete = skill_data.get("notify_on_complete", "{}")
         sess._applied_skill_id = skill_data["template_id"]
         sess._applied_skill_version = applied_skill_version

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -313,9 +313,10 @@ class WebUI(SessionUIBase):
             if blanket_active and pending:
                 # Blanket flag drained the rest of pending \u2014 tag so the
                 # dashboard can distinguish from
-                # ``auto_approve_tools`` / ``policy``.
+                # ``auto_approve_tools`` / ``policy``.  No need to
+                # clear ``pending`` here: the function returns inside
+                # this block without reading it again.
                 self._tag_auto_approved(pending, AutoApproveReason.BLANKET)
-                pending = []
             # Track auto-approved tool activity
             first = items[0] if items else {}
             label = first.get("func_name", "")

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1316,13 +1316,17 @@ Pane.prototype.showInlineToolBlock = function (
 
   items.forEach(function (item) {
     block.appendChild(buildToolDiv(item));
-    // Render verdict badge if present
-    if (item.verdict) {
+    // Render verdict badge if present.  Server emits the heuristic
+    // verdict under ``heuristic_verdict`` (matches the api/server_schemas
+    // PendingApprovalItem shape).  Falls back to the legacy ``verdict``
+    // key in case a stale SSE payload arrives mid-deploy.
+    var heuristic = item.heuristic_verdict || item.verdict;
+    if (heuristic) {
       block.insertAdjacentHTML(
         "beforeend",
-        renderVerdictBadge(item.verdict, judgePending),
+        renderVerdictBadge(heuristic, judgePending),
       );
-      var rec = item.verdict.recommendation || "review";
+      var rec = heuristic.recommendation || "review";
       if (
         !glowRec ||
         rec === "deny" ||
@@ -4818,6 +4822,20 @@ function buildToolDiv(item) {
   var name = document.createElement("div");
   name.className = "tool-name" + (item.error ? " tool-name--error" : "");
   name.textContent = item.func_name || "";
+  // Inline auto-approve indicator — surfaces tools that bypassed the
+  // operator approval gate (skill allowlist / blanket / admin policy /
+  // explicit "Approve + Always") right next to the tool name.  The
+  // coord-tree pill is bounded to the coord page; this small badge
+  // gives the operator the same signal on the per-ws page they
+  // navigated into.
+  if (item.auto_approved) {
+    var badge = document.createElement("span");
+    badge.className = "tool-auto-approved";
+    var reason = item.auto_approve_reason || "auto_approve_tools";
+    badge.textContent = " auto: " + reason;
+    badge.title = "Tool auto-approved (no operator prompt) — reason: " + reason;
+    name.appendChild(badge);
+  }
   div.appendChild(name);
 
   var cmd = document.createElement("div");


### PR DESCRIPTION
## Summary

Addresses the user-reported bug "tool calls of children occasionally getting approved instead of waiting for approve/deny." Root cause: when a coord LLM spawns a child with `skill="X"`, the skill template's `allowed_tools` JSON list silently populates the child UI's `auto_approve_tools` set — so any tool call whose name is in that set short-circuits the approval gate without prompting.

This is **Option C — visibility only**: the auto-approve paths themselves are unchanged. Operators now have multiple surfaces to see WHICH tool calls bypassed and WHY.

## What changed

- **Per-item annotations** — each item passing through the four gate-bypass paths gets `auto_approved=True` + `auto_approve_reason` (`skill` / `always` / `policy` / `blanket` / `auto_approve_tools`).
- **Per-ws ring buffer + `/dashboard` exposure + coord-tree pill** — a small "✓ auto-approved (reason): bash, edit_file" pill lands on each child row when its buffer is non-empty.
- **`tool.auto_approved` audit row per `approve_tools` call** — durable forensic record.
- **Per-ws page badge** — inline "auto: <reason>" next to the tool name on the per-ws WebUI so the signal carries when the operator clicks through from the coord tree.
- **Persistence across UI rebuilds** — `SessionUIBase.__init__` now calls `replay_recent_auto_approvals_from_audit` so the pill survives saved-workstream rehydrate / coord→node click-through / process restart. Adds `resource_id` filter to `list_audit_events` so the replay is a single indexed query.
- **Source provenance** — `_auto_approve_tools_source` per-tool dict distinguishes skill-template population from "Approve + Always" clicks, so the pill can render the right reason.
- **Magic-string drift mitigation** — `AutoApproveReason` constants in `core/session_ui_base.py` + `KNOWN_AUTO_APPROVE_REASONS` JS Set with a validator so a server-side typo renders as "unknown" with a `console.warn` instead of leaking raw to the operator.
- **q-2 recording-leak fixes** — policy `allow` items now hit the ring buffer + audit log on both the early-return-on-deny path and the still_pending-non-empty fall-through to the prompt path.
- **q-3 verdict-key consistency** — `_serialize_approval_items` now emits `heuristic_verdict` matching the dashboard serializer + API schema; `app.js` updated to read either key for mid-deploy compat.
- **q-4 dedup** — `_tag_auto_approved` helper on SessionUIBase replaces the verbatim per-branch tag loops that were copy-pasted across WebUI and ConsoleCoordinatorUI.

## Test plan

- [x] 47 new tests across `test_session_ui_base.py` (helpers, audit replay, source-map provenance, ring-buffer cap) and `test_webui_auto_approve_visibility.py` (mixed-policy paths, blanket flag, skill source).
- [x] `pytest -m "not live"` across the broader sweep — 741 pass.
- [x] `ruff check` + `mypy` clean on touched source files.
- [ ] Manual: spawn a child with a skill that has `allowed_tools=["bash"]`, have the child run a `bash` call, verify the pill renders on the coord tree with reason "skill", verify an audit row was written, verify the pill survives a coord-page refresh + a saved-workstream rehydrate.