### PR TITLE
fix(ui): preserve approval pill when tool errors

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -50,37 +50,45 @@ def test_tool_error_does_not_overwrite_approval_badge() -> None:
     state, so the user lost the record that they had approved the
     call. This test pins the new append-sibling behaviour."""
     body = _APP_JS.read_text(encoding="utf-8")
-    # Affirmatively check that both sites construct a fresh error badge
-    # under an idempotency guard keyed off the ``--error`` modifier.
-    # The presence of these guards is the structural marker of the fix
-    # — pre-fix the code mutated the existing approval badge, so neither
-    # selector appeared anywhere in the file.
-    assert '!parentBlock.querySelector(".ts-approval-badge--error")' in body, (
-        "appendToolOutput must guard error-badge creation with an "
-        "existence check on .ts-approval-badge--error so duplicate fires "
-        "do not stack badges."
+    # Affirmatively check that an idempotency guard exists somewhere:
+    # a ``querySelector(".ts-approval-badge--error")`` lookup is the
+    # structural marker of the fix. Pre-fix the modifier never appeared
+    # in app.js at all. Loose on quote style and surrounding form (the
+    # guard might be a negated ``if (!q) {build...}`` block at a call
+    # site, or a positive ``if (q) return;`` early-exit inside an
+    # extracted helper) so a later refactor doesn't trip CI on
+    # cosmetics.
+    error_guard_re = re.compile(
+        r"""querySelector\(\s*['"]\.ts-approval-badge--error['"]\s*\)""",
     )
-    assert '!lastToolBlock.querySelector(".ts-approval-badge--error")' in body, (
-        "replayHistory must guard error-badge creation with an "
-        "existence check on .ts-approval-badge--error so re-renders do "
-        "not stack badges."
+    assert error_guard_re.search(body), (
+        "The error-badge code path must guard creation with a "
+        "querySelector for .ts-approval-badge--error so duplicate fires "
+        "(live + history re-render) do not stack badges."
     )
-    # Forbid the specific mutate-existing-badge sequence: a generic
+    # Forbid the mutate-existing-badge sequence: a generic
     # ``.ts-approval-badge`` lookup followed within a handful of lines
-    # by an assignment of the ``--error`` modifier to the same handle.
-    # Two unrelated call sites (history rendering + live tool-output
+    # by mutating that same handle into the ``--error`` state. Two
+    # unrelated call sites (history rendering + live tool-output
     # insertion) legitimately query ``.ts-approval-badge`` to position
     # output above it, so the bare query alone is not the anti-pattern;
-    # the close pairing with an ``--error`` className overwrite is.
-    pattern = re.compile(
-        r'(\w+)\s*=\s*\w+\.querySelector\("\.ts-approval-badge"\)\s*;'
-        r".{0,200}?"
-        r'\1\.className\s*=\s*"ts-approval-badge ts-approval-badge--error"',
+    # the close pairing with an ``--error`` class mutation is. Accept
+    # either quote style and catch both ``className = "..."`` and
+    # ``classList.add("ts-approval-badge--error")`` forms.
+    overwrite_re = re.compile(
+        r"""(\w+)\s*=\s*\w+\.querySelector\(\s*(["'])\.ts-approval-badge\2\s*\)\s*;"""
+        r""".{0,200}?"""
+        r"""(?:"""
+        r"""\1\.className\s*=\s*(["'])[^"']*\bts-approval-badge--error\b[^"']*\3"""
+        r"""|"""
+        r"""\1\.classList\.add\([^)]*(["'])ts-approval-badge--error\4[^)]*\)"""
+        r""")""",
         re.DOTALL,
     )
-    assert not pattern.search(body), (
+    assert not overwrite_re.search(body), (
         "Found the badge-overwrite anti-pattern: a queried "
-        ".ts-approval-badge handle whose className is reassigned to "
-        "the --error variant. Append a sibling badge instead so the "
-        "approval verdict stays visible alongside the error."
+        ".ts-approval-badge handle is mutated into the --error variant "
+        "(via className overwrite or classList.add). Append a sibling "
+        "badge instead so the approval verdict stays visible alongside "
+        "the error."
     )

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -9,6 +9,7 @@ manual testing.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
@@ -35,4 +36,51 @@ def test_switch_tab_bootstraps_pane_when_none_exists() -> None:
     assert "createPane(wsId)" in fn, (
         "switchTab must call createPane(wsId) to bootstrap the first "
         "pane when getFocusedPane returns null"
+    )
+
+
+def test_tool_error_does_not_overwrite_approval_badge() -> None:
+    """When an approved tool subsequently errors, the existing
+    ``✓ approved`` (or ``✓ auto-approved``) pill must remain visible —
+    the error indicator is appended as a sibling pill, not by mutating
+    the approval pill in place. Pre-fix, both ``appendToolOutput``
+    (live) and ``replayHistory`` (history reconstruction) located the
+    existing approval badge via ``querySelector(".ts-approval-badge")``
+    and overwrote its className + textContent with the ``--error``
+    state, so the user lost the record that they had approved the
+    call. This test pins the new append-sibling behaviour."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    # Affirmatively check that both sites construct a fresh error badge
+    # under an idempotency guard keyed off the ``--error`` modifier.
+    # The presence of these guards is the structural marker of the fix
+    # — pre-fix the code mutated the existing approval badge, so neither
+    # selector appeared anywhere in the file.
+    assert '!parentBlock.querySelector(".ts-approval-badge--error")' in body, (
+        "appendToolOutput must guard error-badge creation with an "
+        "existence check on .ts-approval-badge--error so duplicate fires "
+        "do not stack badges."
+    )
+    assert '!lastToolBlock.querySelector(".ts-approval-badge--error")' in body, (
+        "replayHistory must guard error-badge creation with an "
+        "existence check on .ts-approval-badge--error so re-renders do "
+        "not stack badges."
+    )
+    # Forbid the specific mutate-existing-badge sequence: a generic
+    # ``.ts-approval-badge`` lookup followed within a handful of lines
+    # by an assignment of the ``--error`` modifier to the same handle.
+    # Two unrelated call sites (history rendering + live tool-output
+    # insertion) legitimately query ``.ts-approval-badge`` to position
+    # output above it, so the bare query alone is not the anti-pattern;
+    # the close pairing with an ``--error`` className overwrite is.
+    pattern = re.compile(
+        r'(\w+)\s*=\s*\w+\.querySelector\("\.ts-approval-badge"\)\s*;'
+        r".{0,200}?"
+        r'\1\.className\s*=\s*"ts-approval-badge ts-approval-badge--error"',
+        re.DOTALL,
+    )
+    assert not pattern.search(body), (
+        "Found the badge-overwrite anti-pattern: a queried "
+        ".ts-approval-badge handle whose className is reassigned to "
+        "the --error variant. Append a sibling badge instead so the "
+        "approval verdict stays visible alongside the error."
     )

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1269,16 +1269,7 @@ Pane.prototype.replayHistory = function (messages) {
         }
         if (isToolError && !lastToolBlock.classList.contains("denied")) {
           lastToolBlock.classList.add("error");
-          // Append the error badge as a sibling of the existing approved
-          // / denied pill so the approval verdict stays visible alongside
-          // the execution outcome.
-          if (!lastToolBlock.querySelector(".ts-approval-badge--error")) {
-            var errBadge = document.createElement("div");
-            errBadge.setAttribute("role", "status");
-            errBadge.className = "ts-approval-badge ts-approval-badge--error";
-            errBadge.textContent = "\u2717 error";
-            lastToolBlock.appendChild(errBadge);
-          }
+          appendToolErrorBadge(lastToolBlock);
         }
       }
     }
@@ -1603,16 +1594,7 @@ Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
     var parentBlock = target.closest(".ts-approval");
     if (parentBlock && !parentBlock.classList.contains("denied")) {
       parentBlock.classList.add("error");
-      // Append the error badge as a sibling of the existing approved
-      // pill so the approval verdict stays visible alongside the
-      // execution outcome.
-      if (!parentBlock.querySelector(".ts-approval-badge--error")) {
-        var errBadge = document.createElement("div");
-        errBadge.setAttribute("role", "status");
-        errBadge.className = "ts-approval-badge ts-approval-badge--error";
-        errBadge.textContent = "\u2717 error";
-        parentBlock.appendChild(errBadge);
-      }
+      appendToolErrorBadge(parentBlock);
     }
   }
 
@@ -4947,6 +4929,20 @@ function toggleVerdictDetail(btn) {
     detail.style.display = isHidden ? "block" : "none";
     btn.textContent = isHidden ? "hide" : "details";
   }
+}
+
+// Append an "✗ error" pill to an approval block as a sibling of the
+// existing approved/denied/auto-approved pill, so the approval verdict
+// stays visible alongside the execution outcome. Idempotent — re-fires
+// (live + history rerender) do not stack badges.
+function appendToolErrorBadge(blockEl) {
+  if (!blockEl) return;
+  if (blockEl.querySelector(".ts-approval-badge--error")) return;
+  var errBadge = document.createElement("div");
+  errBadge.setAttribute("role", "status");
+  errBadge.className = "ts-approval-badge ts-approval-badge--error";
+  errBadge.textContent = "✗ error";
+  blockEl.appendChild(errBadge);
 }
 
 function makeCollapsible(el) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1269,10 +1269,15 @@ Pane.prototype.replayHistory = function (messages) {
         }
         if (isToolError && !lastToolBlock.classList.contains("denied")) {
           lastToolBlock.classList.add("error");
-          var errorBdg = lastToolBlock.querySelector(".ts-approval-badge");
-          if (errorBdg) {
-            errorBdg.className = "ts-approval-badge ts-approval-badge--error";
-            errorBdg.textContent = "\u2717 error";
+          // Append the error badge as a sibling of the existing approved
+          // / denied pill so the approval verdict stays visible alongside
+          // the execution outcome.
+          if (!lastToolBlock.querySelector(".ts-approval-badge--error")) {
+            var errBadge = document.createElement("div");
+            errBadge.setAttribute("role", "status");
+            errBadge.className = "ts-approval-badge ts-approval-badge--error";
+            errBadge.textContent = "\u2717 error";
+            lastToolBlock.appendChild(errBadge);
           }
         }
       }
@@ -1598,10 +1603,15 @@ Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
     var parentBlock = target.closest(".ts-approval");
     if (parentBlock && !parentBlock.classList.contains("denied")) {
       parentBlock.classList.add("error");
-      var badge = parentBlock.querySelector(".ts-approval-badge");
-      if (badge) {
-        badge.className = "ts-approval-badge ts-approval-badge--error";
-        badge.textContent = "\u2717 error";
+      // Append the error badge as a sibling of the existing approved
+      // pill so the approval verdict stays visible alongside the
+      // execution outcome.
+      if (!parentBlock.querySelector(".ts-approval-badge--error")) {
+        var errBadge = document.createElement("div");
+        errBadge.setAttribute("role", "status");
+        errBadge.className = "ts-approval-badge ts-approval-badge--error";
+        errBadge.textContent = "\u2717 error";
+        parentBlock.appendChild(errBadge);
       }
     }
   }


### PR DESCRIPTION
## Summary

- When an approved (or auto-approved) tool subsequently failed, both `replayHistory` and `appendToolOutput` overwrote the existing `.ts-approval-badge` with the `--error` variant — losing the record that the user had approved the call.
- Fix: append a separate `--error` pill as a sibling of the existing approval pill. The `.ts-approval` parent is `flex-direction: column; gap: 6px`, so the two pills stack vertically and read as a small status timeline ("approved, then errored"). Idempotency guard via `querySelector(".ts-approval-badge--error")` so duplicate fires don't stack badges.
- CSS unchanged — the `--error` modifier already exists in both per-node and shared chat stylesheets.

Adds a static-string guard in `tests/test_app_js.py` that pins both call sites and forbids the mutate-in-place anti-pattern via a regex pairing a queried `.ts-approval-badge` handle with an `--error` className overwrite.

Deferred from #431.

## Test plan

- [x] `pytest -m "not live"` — 4654 pass
- [x] `ruff check` + `ruff format --check` + `mypy` on `tests/test_app_js.py` — clean
- [x] `node --check turnstone/ui/static/app.js` — parses
- [x] `/review` short pipeline (bug + quality → verify → dedupe) — 0 bugs; 4 quality nits applied
- [ ] Manual repro in browser: send a message that triggers an approved tool call, then have the tool fail (invalid command, 404 fetch, etc.). Confirm the `✓ APPROVED` pill stays visible with `✗ ERROR` rendered below it, both for live (live SSE) and history (page reload) paths.