### PR TITLE
refactor(ui): drop legacy .ts-msg* dual-classing in chat surfaces

### DIFF
--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -9,219 +9,12 @@
    ========================================================================== */
 
 /* ==========================================================================
-   Messages — single-column left-aligned blocks
-   Differentiation is by left-border colour only (no role labels).
-   ========================================================================== */
-.ts-msg {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  padding: 8px 12px;
-  margin-bottom: 4px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-left-width: 3px;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.55;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-}
-
-.ts-msg--user {
-  border-left-color: var(--accent);
-}
-.ts-msg--assistant {
-  border-left-color: var(--border-strong);
-}
-.ts-msg--reasoning {
-  /* Dashed on the left-accent only — the other three sides keep the
-     solid 1px outline so the block stays a crisp card rather than
-     turning into a fully dotted box. */
-  border-left-style: dashed;
-  border-left-color: var(--fg-dim);
-  color: var(--fg-dim);
-  font-style: italic;
-}
-.ts-msg--tool {
-  font-family: var(--font-mono);
-  background: var(--code-bg);
-  border-left-color: var(--cyan);
-}
-.ts-msg--error {
-  border-left-color: var(--red);
-  color: var(--red);
-}
-.ts-msg--info {
-  border-left-color: var(--cyan);
-  color: var(--cyan);
-  font-size: 12px;
-}
-
-/* Content container.  Markdown renders here (streamingRender writes
-   innerHTML; renderer.js is the trust boundary for that sink).
-   ``white-space: normal`` is intentional: the markdown converter leaves
-   ``\n`` text nodes between block siblings (headings → paragraphs →
-   katex-display → ...).  ``pre-wrap`` rendered every one of those as
-   visible vertical space, stacking 20-30px gaps between every section.
-   ``<pre>`` blocks have ``white-space: pre`` built in, so fenced code
-   still preserves its formatting; mid-stream partial fences before the
-   closing ``\`\`\`` arrives render as collapsed text for a frame and
-   then snap back when the next render tick wraps them in ``<pre>``.
-   User-typed messages render through ``.msg-user-text`` (a separate
-   path that preserves its own newlines), so this change only affects
-   assistant markdown output. */
-.ts-msg-body {
-  min-width: 0;
-  white-space: normal;
-}
-.ts-msg-body > *:first-child {
-  margin-top: 0;
-}
-.ts-msg-body > *:last-child {
-  margin-bottom: 0;
-}
-/* Tighten paragraph rhythm to match the heading/list margins above —
-   without this, browser-default 1em top + 1em bottom (~28px stacked)
-   makes paragraphs read as if they're in a different document from
-   the surrounding headings. */
-.ts-msg-body p {
-  margin: 6px 0;
-}
-.ts-msg-body pre {
-  margin: 6px 0;
-  padding: 8px 10px;
-  background: var(--code-bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  overflow-x: auto;
-  font-size: 12px;
-}
-.ts-msg-body code {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  background: var(--bg-highlight);
-  padding: 1px 4px;
-  border-radius: 2px;
-  /* Preserve internal whitespace + allow wrapping.  The body sets
-     ``white-space: normal`` to collapse phantom inter-block ``\n`` text
-     nodes; inline ``<code>`` would inherit that and silently collapse
-     multiple spaces inside backtick spans.  ``<pre>`` blocks rely on
-     the user-agent ``pre { white-space: pre }`` rule and don't need
-     this override. */
-  white-space: pre-wrap;
-}
-.ts-msg-body pre code {
-  background: none;
-  padding: 0;
-  border-radius: 0;
-}
-.ts-msg-body a {
-  color: var(--accent);
-  text-decoration: underline;
-}
-.ts-msg-body h1,
-.ts-msg-body h2,
-.ts-msg-body h3,
-.ts-msg-body h4,
-.ts-msg-body h5,
-.ts-msg-body h6 {
-  font-family: var(--font-ui);
-  font-weight: 600;
-  margin: 8px 0 4px;
-  color: var(--fg-bright);
-}
-.ts-msg-body h1 {
-  font-size: 16px;
-}
-.ts-msg-body h2 {
-  font-size: 14px;
-}
-.ts-msg-body h3 {
-  font-size: 13px;
-}
-.ts-msg-body h4,
-.ts-msg-body h5,
-.ts-msg-body h6 {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.ts-msg-body ul,
-.ts-msg-body ol {
-  margin: 4px 0 4px 20px;
-}
-.ts-msg-body li {
-  margin: 2px 0;
-}
-.ts-msg-body strong {
-  color: var(--fg-bright);
-}
-.ts-msg-body em {
-  font-style: italic;
-}
-.ts-msg-body blockquote {
-  border-left: 2px solid var(--border-strong);
-  padding-left: 10px;
-  margin: 6px 0;
-  color: var(--fg-dim);
-}
-
-/* Floating action toolbar — edit / rewind / retry / copy slots.
-   Absolute top-right so the message body stays full-width. */
-.ts-msg-actions {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  display: flex;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-.ts-msg:hover .ts-msg-actions,
-.ts-msg:focus-within .ts-msg-actions {
-  opacity: 1;
-}
-.ts-msg-action-btn {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--fg-dim);
-  border-radius: var(--radius-sm);
-  padding: 2px 6px;
-  font: inherit;
-  font-size: 11px;
-  cursor: pointer;
-  transition:
-    background 0.1s,
-    border-color 0.1s,
-    color 0.1s;
-}
-.ts-msg-action-btn:hover {
-  background: var(--bg-highlight);
-  color: var(--fg-bright);
-  border-color: var(--accent-dim);
-}
-.ts-msg-action-btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-
-/* On coarse-pointer / hover-none devices, keep the toolbar visible — no hover. */
-@media (hover: none) and (pointer: coarse) {
-  .ts-msg-actions {
-    opacity: 1;
-  }
-  .ts-msg-action-btn {
-    padding: 4px 8px;
-    font-size: 12px;
-  }
-}
-
-/* ==========================================================================
    Approval shell — shared by inline (per-tool, interactive UI) and
    batch (pinned bottom bar, coordinator).  Same visual vocabulary,
    different layout hook.
+
+   The message primitive (.msg / .msg-body / .msg-actions / .msg-action-btn)
+   used by inline approval blocks is defined further down in this file.
    ========================================================================== */
 .ts-approval {
   display: flex;
@@ -229,13 +22,15 @@
   gap: 6px;
 }
 
-/* Inline variant: an approval block living as a .ts-msg in the
-   message stream, one per tool call awaiting approval.  Cyan to match
-   the .ts-msg--tool execution-result colour — both are tool-role
-   surfaces, distinct from user (amber) and assistant (neutral). */
-.ts-msg.ts-approval--inline {
+/* Inline variant: an approval block living as a .msg in the message
+   stream, one per tool call awaiting approval.  Cyan to match the
+   .msg.tool execution-result colour — both are tool-role surfaces,
+   distinct from user (amber) and assistant (neutral).  Selector qualifier
+   choice (.msg.ts-approval--inline vs bare) is explained at the matching
+   rule in ui/static/style.css. */
+.msg.ts-approval--inline {
   border-left-color: var(--cyan);
-  background: var(--bg-elevated);
+  background: var(--panel-2);
 }
 
 /* Batch variant: pinned to the bottom of the chat pane, batches all
@@ -957,10 +752,10 @@
    Mobile (<700px) — chat.css components stack vertically.
    ========================================================================== */
 @media (max-width: 700px) {
-  .ts-msg {
+  .msg {
     padding: 6px 10px;
   }
-  .ts-msg-body pre {
+  .msg-body pre {
     margin: 4px -6px;
     border-radius: 0;
   }
@@ -990,8 +785,8 @@
    Reduced motion — disable chat.css transitions.
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {
-  .ts-msg-actions,
-  .ts-msg-action-btn,
+  .msg-actions,
+  .msg-action-btn,
   .ts-approval-btn,
   .ts-composer-attach,
   .ts-composer-input,
@@ -1003,9 +798,8 @@
 /* ==========================================================================
    Message primitive — chat-style single-column message block.  Semantic
    variant carries via 3px left-border colour (and text colour for
-   error/info).  Used by the coordinator chat view directly (pure .msg
-   classes) and by the per-node server chat UI dual-classed alongside
-   the .ts-msg family above (so the two rule families compose).
+   error/info).  Shared by the coordinator chat view and the per-node
+   server chat UI; both render pure .msg classes.
 
    Variants:
      .msg                 base (assistant / generic)
@@ -1059,9 +853,8 @@
 }
 .msg.tool {
   background: var(--panel);
-  /* Cyan to match the per-node UI's .ts-msg--tool and .ts-approval
-     borders — tool-role surfaces share one colour, distinct from
-     user (amber) and assistant (neutral). */
+  /* Cyan for tool-role surfaces — shared with .ts-approval borders so
+     user (amber) / assistant (neutral) / tool (cyan) read distinctly. */
   border-left-color: var(--cyan);
   font-family: var(--font-mono);
   font-size: 12px;
@@ -1095,10 +888,24 @@
 
 /* Markdown body — renderer.js writes innerHTML here; trust boundary
    lives there, not in CSS. Keep styles tight so streamed content
-   doesn't jitter layout as tokens arrive. */
+   doesn't jitter layout as tokens arrive.
+
+   ``white-space: normal`` is intentional (and explicit so a future edit
+   doesn't "simplify" by reaching for ``pre-wrap``).  The markdown
+   converter leaves ``\n`` text nodes between block siblings (headings →
+   paragraphs → katex-display → ...).  ``pre-wrap`` rendered every one
+   of those as visible vertical space, stacking 20-30px gaps between
+   every section.  ``<pre>`` blocks have ``white-space: pre`` built in
+   so fenced code still preserves formatting; mid-stream partial fences
+   before the closing ``\`\`\`` arrives render as collapsed text for a
+   frame and then snap back when the next render tick wraps them in
+   ``<pre>``.  User-typed messages render through ``.msg-user-text`` (a
+   separate path that preserves its own newlines), so this default only
+   affects assistant markdown output. */
 .msg-body {
   min-width: 0;
   max-width: 100%;
+  white-space: normal;
 }
 
 /* Streaming caret — append to the end of .msg-body when the message is
@@ -1148,9 +955,10 @@
   background: var(--panel);
   border: 1px solid var(--hair-2);
   border-radius: 3px;
-  /* Preserve internal whitespace + allow wrapping; see the matching
-     rule above for the rationale (the body's ``white-space: normal``
-     would otherwise collapse spaces inside backtick spans). */
+  /* Preserve internal whitespace + allow wrapping.  The body's
+     ``white-space: normal`` (above) would otherwise collapse multiple
+     spaces inside backtick spans; ``<pre>`` blocks rely on the
+     user-agent ``pre { white-space: pre }`` rule and don't need this. */
   white-space: pre-wrap;
 }
 

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -611,8 +611,7 @@ Pane.prototype.handleEvent = function (evt) {
       this.removeThinkingIndicator();
       if (!this.currentReasoningEl) {
         this.currentReasoningEl = document.createElement("div");
-        this.currentReasoningEl.className =
-          "ts-msg ts-msg--reasoning msg reasoning";
+        this.currentReasoningEl.className = "msg reasoning";
         this.messagesEl.appendChild(this.currentReasoningEl);
       }
       this.currentReasoningEl.textContent += evt.text;
@@ -626,15 +625,9 @@ Pane.prototype.handleEvent = function (evt) {
       }
       if (!this.currentAssistantEl) {
         this.currentAssistantEl = document.createElement("div");
-        this.currentAssistantEl.className =
-          "ts-msg ts-msg--assistant msg assistant";
-        // streamingRender targets a .ts-msg-body inner wrapper so the
-        // shared markdown rules in chat.css (h1/h2/h3/code/blockquote
-        // scoped to .ts-msg-body *) actually match on this page — the
-        // coordinator page uses the same .ts-msg-body wrapper so the
-        // two chat views stay visually aligned.
+        this.currentAssistantEl.className = "msg assistant";
         this.currentAssistantBodyEl = document.createElement("div");
-        this.currentAssistantBodyEl.className = "ts-msg-body msg-body";
+        this.currentAssistantBodyEl.className = "msg-body";
         this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
         this.messagesEl.appendChild(this.currentAssistantEl);
       }
@@ -860,7 +853,7 @@ Pane.prototype.removeThinkingIndicator = function () {
 Pane.prototype.addUserMessage = function (text, attachments) {
   this.removeEmptyState();
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--user msg user";
+  el.className = "msg user";
   var textEl = document.createElement("div");
   textEl.className = "msg-user-text";
   textEl.textContent = text;
@@ -895,7 +888,7 @@ Pane.prototype.addQueuedMessage = function (text, priority) {
   this.removeEmptyState();
   var self = this;
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--user msg user msg-queued";
+  el.className = "msg user msg-queued";
   el.setAttribute("role", "status");
   if (priority === "important") {
     el.classList.add("msg-queued-important");
@@ -962,12 +955,12 @@ Pane.prototype._dequeueMessage = function (el) {
 Pane.prototype._addUserMsgActions = function (el, text) {
   var self = this;
   var bar = document.createElement("div");
-  bar.className = "msg-actions ts-msg-actions";
+  bar.className = "msg-actions";
   bar.setAttribute("role", "toolbar");
   bar.setAttribute("aria-label", "Message actions");
   // Edit button
   var editBtn = document.createElement("button");
-  editBtn.className = "msg-action-btn ts-msg-action-btn";
+  editBtn.className = "msg-action-btn";
   editBtn.title = "Edit & resend";
   editBtn.setAttribute("aria-label", "Edit and resend this message");
   var editIcon = document.createElement("span");
@@ -981,7 +974,7 @@ Pane.prototype._addUserMsgActions = function (el, text) {
   bar.appendChild(editBtn);
   // Rewind-to-here button
   var rewindBtn = document.createElement("button");
-  rewindBtn.className = "msg-action-btn ts-msg-action-btn";
+  rewindBtn.className = "msg-action-btn";
   rewindBtn.title = "Rewind to before this message";
   rewindBtn.setAttribute(
     "aria-label",
@@ -1004,13 +997,13 @@ Pane.prototype._addRetryAction = function (el) {
   var bar = el.querySelector(".msg-actions");
   if (!bar) {
     bar = document.createElement("div");
-    bar.className = "msg-actions ts-msg-actions";
+    bar.className = "msg-actions";
     bar.setAttribute("role", "toolbar");
     bar.setAttribute("aria-label", "Message actions");
     el.appendChild(bar);
   }
   var btn = document.createElement("button");
-  btn.className = "msg-action-btn ts-msg-action-btn";
+  btn.className = "msg-action-btn";
   btn.title = "Retry (regenerate response)";
   btn.setAttribute("aria-label", "Retry last response");
   var icon = document.createElement("span");
@@ -1040,7 +1033,7 @@ Pane.prototype._rewindToMessage = function (msgEl) {
   if (this.busy) return;
   var self = this;
   // Count how many user messages come at or after this one
-  var userMsgs = this.messagesEl.querySelectorAll(".ts-msg--user");
+  var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
   var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
   if (idx < 0) return;
   var turnsToRewind = userMsgs.length - idx;
@@ -1124,7 +1117,7 @@ Pane.prototype._editAndResend = function (msgEl, newText) {
   if (this.busy) return;
   var self = this;
   // Count turns to rewind (from this message onward)
-  var userMsgs = this.messagesEl.querySelectorAll(".ts-msg--user");
+  var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
   var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
   if (idx < 0) return;
   var turnsToRewind = userMsgs.length - idx;
@@ -1177,7 +1170,7 @@ Pane.prototype.replayHistory = function (messages) {
           var wasDenied = !!msg.denied;
           var block = document.createElement("div");
           block.className =
-            "ts-msg ts-approval ts-approval--inline " +
+            "msg ts-approval ts-approval--inline " +
             (wasDenied ? "denied" : "approved");
           msg.tool_calls.forEach(function (tc) {
             var div = document.createElement("div");
@@ -1232,9 +1225,9 @@ Pane.prototype.replayHistory = function (messages) {
       }
       if (msg.content) {
         var el = document.createElement("div");
-        el.className = "ts-msg ts-msg--assistant msg assistant";
+        el.className = "msg assistant";
         var bodyEl = document.createElement("div");
-        bodyEl.className = "ts-msg-body msg-body";
+        bodyEl.className = "msg-body";
         var rendered = renderMarkdown(msg.content);
         bodyEl.innerHTML = rendered;
         el.appendChild(bodyEl);
@@ -1280,13 +1273,12 @@ Pane.prototype.replayHistory = function (messages) {
 
 Pane.prototype._attachRetryToLastAssistant = function () {
   // Remove any previous retry buttons
-  var old = this.messagesEl.querySelectorAll(".ts-msg--assistant .msg-actions");
+  var old = this.messagesEl.querySelectorAll(".msg.assistant .msg-actions");
   for (var i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
   // Find the last assistant message with content and add retry.
-  // Reasoning blocks emit as .ts-msg--reasoning (distinct modifier)
-  // so the .ts-msg--assistant selector already excludes them — no
-  // extra guard needed.
-  var assistants = this.messagesEl.querySelectorAll(".ts-msg--assistant");
+  // Reasoning blocks emit as .msg.reasoning (distinct modifier) so the
+  // .msg.assistant selector already excludes them — no extra guard needed.
+  var assistants = this.messagesEl.querySelectorAll(".msg.assistant");
   if (assistants.length) {
     this._addRetryAction(assistants[assistants.length - 1]);
   }
@@ -1300,8 +1292,7 @@ Pane.prototype.showInlineToolBlock = function (
   var self = this;
   var block = document.createElement("div");
   block.className =
-    "ts-msg ts-approval ts-approval--inline" +
-    (autoApproved ? " approved" : "");
+    "msg ts-approval ts-approval--inline" + (autoApproved ? " approved" : "");
   if (!autoApproved) {
     block.setAttribute("role", "alertdialog");
     block.setAttribute("aria-label", "Tool approval required");
@@ -1735,7 +1726,7 @@ Pane.prototype.updateVerdictGlow = function (recommendation) {
 
 Pane.prototype.addInfoMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--info msg info";
+  el.className = "msg info";
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);
   this.scrollToBottom();
@@ -1743,7 +1734,7 @@ Pane.prototype.addInfoMessage = function (text) {
 
 Pane.prototype.addErrorMessage = function (text) {
   var el = document.createElement("div");
-  el.className = "ts-msg ts-msg--error msg error";
+  el.className = "msg error";
   el.setAttribute("role", "alert");
   el.textContent = stripAnsi(text);
   this.messagesEl.appendChild(el);

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -706,7 +706,8 @@
 }
 
 /* Streaming content — .msg.reasoning (chat.css) styles reasoning
-   bubbles; .reasoning as a bare role class is no longer emitted. */
+   bubbles; .reasoning is never emitted on its own, only paired with
+   the .msg base class. */
 .thinking-indicator {
   color: var(--fg-dim);
   font-size: 12px;

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -631,15 +631,15 @@
   padding: 16px 12px;
   display: flex;
   flex-direction: column;
-  /* No flexbox gap — .ts-msg / .msg supply their own margin-bottom for
-     inter-card spacing.  A 14px gap here was stacking with the 4px
-     card margin-bottom and pushing the per-card spacing to ~18px. */
+  /* No flexbox gap — .msg supplies its own margin-bottom for inter-card
+     spacing.  A 14px gap here was stacking with the 4px card
+     margin-bottom and pushing the per-card spacing to ~18px. */
 }
-/* .ts-msg (shared_static/chat.css) provides padding / border / radius /
+/* .msg (shared_static/chat.css) provides padding / border / radius /
    line-height / word-wrap / margin / background.  The interactive UI
    adds a brighter text colour on user messages so "the thing I said"
    reads distinctly against the lower-chroma assistant colour. */
-.ts-msg--user {
+.msg.user {
   color: var(--fg-bright);
 }
 .msg-queued {
@@ -674,15 +674,14 @@
 .queued-dismiss:hover {
   color: var(--red);
 }
-/* .ts-msg--assistant / .ts-msg--info / .ts-msg--error alignment +
-   baseline visuals come from shared_static/chat.css.  Interactive UI
-   adds a pre-wrap override for info messages and a tightened
-   tool-message shape with the yellow accent bar the instrument-panel
-   look established. */
-.ts-msg--info {
+/* .msg.assistant / .msg.info / .msg.error alignment + baseline visuals
+   come from shared_static/chat.css.  Interactive UI adds a pre-wrap
+   override for info messages and a tightened tool-message shape with
+   the cyan accent bar the instrument-panel look established. */
+.msg.info {
   white-space: pre-wrap;
 }
-.ts-msg--tool {
+.msg.tool {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   /* Tool cards use --cyan to read distinctly from user (amber) and
@@ -692,13 +691,13 @@
   font-size: 12px;
   padding: 8px 12px;
 }
-.ts-msg--tool .tool-header {
+.msg.tool .tool-header {
   color: var(--cyan);
   font-weight: 600;
   margin-bottom: 4px;
   font-size: 11px;
 }
-.ts-msg--tool .tool-preview {
+.msg.tool .tool-preview {
   color: var(--fg-dim);
   white-space: pre-wrap;
   font-size: 12px;
@@ -706,9 +705,8 @@
   overflow-y: auto;
 }
 
-/* Streaming content — .ts-msg--reasoning (chat.css) styles reasoning
-   bubbles; .reasoning was the legacy role class and is no longer
-   emitted. */
+/* Streaming content — .msg.reasoning (chat.css) styles reasoning
+   bubbles; .reasoning as a bare role class is no longer emitted. */
 .thinking-indicator {
   color: var(--fg-dim);
   font-size: 12px;
@@ -737,58 +735,58 @@
 body {
   position: static;
 }
-.ts-msg--assistant h1,
-.ts-msg--assistant h2,
-.ts-msg--assistant h3,
-.ts-msg--assistant h4,
-.ts-msg--assistant h5,
-.ts-msg--assistant h6 {
+.msg.assistant h1,
+.msg.assistant h2,
+.msg.assistant h3,
+.msg.assistant h4,
+.msg.assistant h5,
+.msg.assistant h6 {
   color: var(--accent);
   margin: 8px 0 4px;
   font-family: var(--font-ui);
 }
-.ts-msg--assistant h1 {
+.msg.assistant h1 {
   font-size: 18px;
 }
-.ts-msg--assistant h2 {
+.msg.assistant h2 {
   font-size: 16px;
 }
-.ts-msg--assistant h3 {
+.msg.assistant h3 {
   font-size: 14px;
 }
-.ts-msg--assistant h4 {
+.msg.assistant h4 {
   font-size: 13px;
   font-weight: 600;
 }
-.ts-msg--assistant h5 {
+.msg.assistant h5 {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.ts-msg--assistant h6 {
+.msg.assistant h6 {
   font-size: 12px;
   font-weight: 500;
   color: var(--fg-dim);
 }
-.ts-msg--assistant strong {
+.msg.assistant strong {
   color: var(--fg-bright);
 }
-.ts-msg--assistant em {
+.msg.assistant em {
   color: var(--magenta);
 }
-.ts-msg--assistant del {
+.msg.assistant del {
   color: var(--fg-dim);
   text-decoration: line-through;
 }
-.ts-msg--assistant code {
+.msg.assistant code {
   background: var(--code-bg);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   font-size: 12px;
   border: 1px solid var(--border);
 }
-.ts-msg--assistant pre {
+.msg.assistant pre {
   background: var(--code-bg);
   padding: 12px 14px;
   border-radius: var(--radius);
@@ -796,90 +794,90 @@ body {
   margin: 8px 0;
   border: 1px solid var(--border);
 }
-.ts-msg--assistant pre code {
+.msg.assistant pre code {
   background: none;
   padding: 0;
   border: none;
 }
-.ts-msg--assistant ul,
-.ts-msg--assistant ol {
+.msg.assistant ul,
+.msg.assistant ol {
   margin: 4px 0 4px 20px;
 }
-.ts-msg--assistant li {
+.msg.assistant li {
   margin: 2px 0;
 }
-.ts-msg--assistant a {
+.msg.assistant a {
   color: var(--accent);
   text-decoration: underline;
 }
-.ts-msg--assistant blockquote {
+.msg.assistant blockquote {
   border-left: 3px solid var(--accent-dim);
   padding-left: 12px;
   color: var(--fg-dim);
   margin: 6px 0;
 }
-.ts-msg--assistant hr {
+.msg.assistant hr {
   border: none;
   border-top: 1px solid var(--border);
   margin: 8px 0;
 }
-.ts-msg--assistant p {
+.msg.assistant p {
   margin: 4px 0;
 }
-.ts-msg--assistant .table-wrap {
+.msg.assistant .table-wrap {
   overflow-x: auto;
   margin: 8px 0;
   -webkit-overflow-scrolling: touch;
 }
-.ts-msg--assistant .table-wrap:focus-visible {
+.msg.assistant .table-wrap:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.ts-msg--assistant table {
+.msg.assistant table {
   border-collapse: collapse;
   width: auto;
   min-width: 50%;
   font-size: 13px;
 }
-.ts-msg--assistant thead {
+.msg.assistant thead {
   border-bottom: 2px solid var(--border-strong);
 }
-.ts-msg--assistant th {
+.msg.assistant th {
   background: var(--code-bg);
   font-weight: 600;
   color: var(--fg-bright);
 }
-.ts-msg--assistant th,
-.ts-msg--assistant td {
+.msg.assistant th,
+.msg.assistant td {
   padding: 6px 12px;
   border: 1px solid var(--border-strong);
 }
-.ts-msg--assistant tbody tr {
+.msg.assistant tbody tr {
   transition: background 0.12s ease;
 }
-.ts-msg--assistant tbody tr:nth-child(even) {
+.msg.assistant tbody tr:nth-child(even) {
   background: var(--row-alt);
 }
-.ts-msg--assistant tbody tr:hover {
+.msg.assistant tbody tr:hover {
   background: var(--bg-highlight);
 }
-.ts-msg--assistant .align-left {
+.msg.assistant .align-left {
   text-align: left;
 }
-.ts-msg--assistant .align-center {
+.msg.assistant .align-center {
   text-align: center;
 }
-.ts-msg--assistant .align-right {
+.msg.assistant .align-right {
   text-align: right;
 }
-.ts-msg--assistant img {
+.msg.assistant img {
   display: block;
   max-width: 100%;
   height: auto;
   border-radius: var(--radius);
   margin: 4px 0;
 }
-.ts-msg--assistant .img-placeholder {
+.msg.assistant .img-placeholder {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -891,49 +889,49 @@ body {
   cursor: pointer;
   transition: border-color 0.12s ease;
 }
-.ts-msg--assistant .img-placeholder:hover {
+.msg.assistant .img-placeholder:hover {
   border-color: var(--accent);
 }
-.ts-msg--assistant .img-placeholder:focus-visible {
+.msg.assistant .img-placeholder:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.ts-msg--assistant .img-placeholder-icon {
+.msg.assistant .img-placeholder-icon {
   font-size: 16px;
 }
-.ts-msg--assistant .img-placeholder-label {
+.msg.assistant .img-placeholder-label {
   color: var(--fg-bright);
   font-size: 13px;
 }
-.ts-msg--assistant .img-placeholder-domain {
+.msg.assistant .img-placeholder-domain {
   color: var(--fg-dim);
   font-size: 11px;
 }
-.ts-msg--assistant li > input[type="checkbox"] {
+.msg.assistant li > input[type="checkbox"] {
   margin-right: 6px;
   vertical-align: middle;
   accent-color: var(--accent);
 }
-.ts-msg--assistant blockquote blockquote {
+.msg.assistant blockquote blockquote {
   margin: 4px 0;
   border-left-color: var(--border-strong);
 }
-.ts-msg--assistant blockquote blockquote blockquote {
+.msg.assistant blockquote blockquote blockquote {
   border-left-color: var(--border);
 }
-.ts-msg--assistant .katex-display {
+.msg.assistant .katex-display {
   margin: 8px 0;
   padding: 8px 0;
   overflow-x: auto;
   overflow-y: hidden;
 }
-.ts-msg--assistant .katex-error {
+.msg.assistant .katex-error {
   color: var(--red) !important;
   font-size: 12px;
 }
 
 /* Syntax highlighting — highlight.js theme (instrument panel) */
-.ts-msg--assistant pre code.hljs {
+.msg.assistant pre code.hljs {
   background: var(--code-bg);
   color: var(--fg);
   padding: 0;
@@ -1020,7 +1018,7 @@ body {
   display: inline-block;
   width: 100%;
 }
-.ts-msg--assistant pre.code-terminal {
+.msg.assistant pre.code-terminal {
   border-left: 2px solid var(--green);
 }
 [data-theme="light"] .hljs-addition {
@@ -1031,28 +1029,28 @@ body {
 }
 
 /* Mermaid diagrams */
-.ts-msg--assistant .mermaid-container {
+.msg.assistant .mermaid-container {
   margin: 8px 0;
   text-align: center;
   border-radius: var(--radius);
   overflow-x: auto;
   min-height: 40px;
 }
-.ts-msg--assistant .mermaid-container svg {
+.msg.assistant .mermaid-container svg {
   max-width: 100%;
   height: auto;
 }
-.ts-msg--assistant .mermaid-loading {
+.msg.assistant .mermaid-loading {
   padding: 16px;
   color: var(--fg-dim);
   font-size: 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
 }
-.ts-msg--assistant .mermaid-error {
+.msg.assistant .mermaid-error {
   text-align: left;
 }
-.ts-msg--assistant .mermaid-error-msg {
+.msg.assistant .mermaid-error-msg {
   padding: 8px 12px;
   color: var(--red);
   font-size: 12px;
@@ -1060,36 +1058,36 @@ body {
   border-bottom: 1px solid var(--border);
 }
 @media (prefers-reduced-motion: reduce) {
-  .ts-msg--assistant .mermaid-container svg * {
+  .msg.assistant .mermaid-container svg * {
     animation: none !important;
   }
 }
 
 /* Safe HTML elements */
-.ts-msg--assistant details {
+.msg.assistant details {
   margin: 8px 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-surface);
   overflow: hidden;
 }
-.ts-msg--assistant details summary {
+.msg.assistant details summary {
   padding: 8px 12px;
   cursor: pointer;
   font-weight: 600;
   color: var(--fg-bright);
   user-select: none;
 }
-.ts-msg--assistant details summary:hover {
+.msg.assistant details summary:hover {
   color: var(--accent);
 }
-.ts-msg--assistant details[open] > summary {
+.msg.assistant details[open] > summary {
   border-bottom: 1px solid var(--border);
 }
-.ts-msg--assistant details > :not(summary) {
+.msg.assistant details > :not(summary) {
   padding: 0 12px;
 }
-.ts-msg--assistant kbd {
+.msg.assistant kbd {
   background: var(--bg-highlight);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -1098,7 +1096,7 @@ body {
   font-family: var(--font-mono);
   box-shadow: 0 1px 0 var(--border-strong);
 }
-.ts-msg--assistant mark {
+.msg.assistant mark {
   background: var(--yellow-glow);
   color: var(--fg-bright);
   border-radius: 2px;
@@ -1106,14 +1104,14 @@ body {
 }
 
 /* GFM Callouts / Alerts */
-.ts-msg--assistant .callout {
+.msg.assistant .callout {
   border-left: 3px solid var(--border-strong);
   border-radius: var(--radius);
   background: var(--bg-surface);
   margin: 8px 0;
   overflow: hidden;
 }
-.ts-msg--assistant .callout-title {
+.msg.assistant .callout-title {
   padding: 8px 12px 4px;
   font-weight: 600;
   font-size: 13px;
@@ -1121,107 +1119,107 @@ body {
   align-items: center;
   gap: 6px;
 }
-.ts-msg--assistant .callout-icon {
+.msg.assistant .callout-icon {
   font-size: 14px;
 }
-.ts-msg--assistant .callout-body {
+.msg.assistant .callout-body {
   padding: 0 12px 8px;
   color: var(--fg);
 }
-.ts-msg--assistant .callout-body p:first-child {
+.msg.assistant .callout-body p:first-child {
   margin-top: 0;
 }
-.ts-msg--assistant .callout-body p:last-child {
+.msg.assistant .callout-body p:last-child {
   margin-bottom: 0;
 }
-.ts-msg--assistant .callout-note {
+.msg.assistant .callout-note {
   border-left-color: var(--cyan);
 }
-.ts-msg--assistant .callout-note .callout-title {
+.msg.assistant .callout-note .callout-title {
   color: var(--cyan);
 }
-.ts-msg--assistant .callout-tip {
+.msg.assistant .callout-tip {
   border-left-color: var(--green);
 }
-.ts-msg--assistant .callout-tip .callout-title {
+.msg.assistant .callout-tip .callout-title {
   color: var(--green);
 }
-.ts-msg--assistant .callout-important {
+.msg.assistant .callout-important {
   border-left-color: var(--magenta);
 }
-.ts-msg--assistant .callout-important .callout-title {
+.msg.assistant .callout-important .callout-title {
   color: var(--magenta);
 }
-.ts-msg--assistant .callout-warning {
+.msg.assistant .callout-warning {
   border-left-color: var(--yellow);
 }
-.ts-msg--assistant .callout-warning .callout-title {
+.msg.assistant .callout-warning .callout-title {
   color: var(--yellow);
 }
-.ts-msg--assistant .callout-caution {
+.msg.assistant .callout-caution {
   border-left-color: var(--red);
 }
-.ts-msg--assistant .callout-caution .callout-title {
+.msg.assistant .callout-caution .callout-title {
   color: var(--red);
 }
 
 /* Definition lists */
-.ts-msg--assistant dl {
+.msg.assistant dl {
   margin: 8px 0;
 }
-.ts-msg--assistant dt {
+.msg.assistant dt {
   font-weight: 600;
   color: var(--fg-bright);
   margin-top: 8px;
 }
-.ts-msg--assistant dt:first-child {
+.msg.assistant dt:first-child {
   margin-top: 0;
 }
-.ts-msg--assistant dd {
+.msg.assistant dd {
   margin: 2px 0 0 20px;
   padding-left: 12px;
   border-left: 2px solid var(--border-strong);
 }
 
 /* Footnotes */
-.ts-msg--assistant .footnotes {
+.msg.assistant .footnotes {
   margin-top: 16px;
   font-size: 12px;
   color: var(--fg-dim);
 }
-.ts-msg--assistant .footnotes-sep {
+.msg.assistant .footnotes-sep {
   border: none;
   border-top: 1px solid var(--border);
   margin-bottom: 8px;
 }
-.ts-msg--assistant .footnotes-list {
+.msg.assistant .footnotes-list {
   margin: 0 0 0 20px;
   padding: 0;
 }
-.ts-msg--assistant .footnote-item {
+.msg.assistant .footnote-item {
   margin: 4px 0;
   line-height: 1.5;
 }
-.ts-msg--assistant .fn-ref a {
+.msg.assistant .fn-ref a {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   font-weight: 600;
 }
-.ts-msg--assistant .fn-ref a:hover {
+.msg.assistant .fn-ref a:hover {
   text-decoration: underline;
 }
-.ts-msg--assistant .fn-backref {
+.msg.assistant .fn-backref {
   color: var(--accent);
   text-decoration: none;
   font-size: 11px;
   margin-left: 4px;
 }
-.ts-msg--assistant .fn-backref:hover {
+.msg.assistant .fn-backref:hover {
   text-decoration: underline;
 }
-.ts-msg--assistant .fn-ref a:focus-visible,
-.ts-msg--assistant .fn-backref:focus-visible {
+.msg.assistant .fn-ref a:focus-visible,
+.msg.assistant .fn-backref:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
   border-radius: 2px;
@@ -1682,7 +1680,7 @@ body {
 .ts-approval {
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  /* Cyan matches .ts-msg--tool — both are tool-role surfaces. */
+  /* Cyan matches .msg.tool — both are tool-role surfaces. */
   border-left: 3px solid var(--cyan);
   border-radius: var(--radius);
   padding: 0;
@@ -3133,8 +3131,8 @@ audio.media-player {
   #health-indicator,
   #theme-toggle,
   #mcp-status,
-  .ts-msg--assistant tbody tr,
-  .ts-msg--assistant .img-placeholder,
+  .msg.assistant tbody tr,
+  .msg.assistant .img-placeholder,
   .media-play-btn,
   #new-ws-cancel,
   #new-ws-submit,
@@ -3158,7 +3156,7 @@ audio.media-player {
    per-node UI surface; coord uses the .approval-dock pattern instead.
 
    DOM shape rendered by buildToolDiv() + renderVerdictBadge():
-     .ts-msg.ts-approval.ts-approval--inline[.approved]  ← outer card
+     .msg.ts-approval.ts-approval--inline[.approved]  ← outer card
        .ts-approval-tool
          .tool-name                   ← tool function name
          .tool-cmd                    ← header / command
@@ -3172,14 +3170,15 @@ audio.media-player {
 
    The block uses the unified token palette (--cyan / --ink / --panel /
    --ok / --err / --warn) rather than the older --yellow / --green /
-   --red literals; .ts-msg.msg:not(.tool) below also flips the body font
-   from --font-mono (legacy .ts-msg default) to --font-ui for prose
-   message variants, with .msg.tool retaining mono via chat.css.
+   --red literals.
    ========================================================================== */
 
-.ts-msg.ts-approval--inline {
-  /* Cyan for tool-role surfaces — matches .ts-msg--tool border + the
-     .ts-approval container in the chat-css approval theme.
+.msg.ts-approval--inline {
+  /* Cyan for tool-role surfaces — matches .msg.tool border + the
+     .ts-approval container in the chat-css approval theme.  Selector
+     keeps the .msg qualifier so its (0,2,0) specificity ties with
+     .ts-approval.approved/.denied/.error and the later-cascade rule
+     here wins, holding the inline card cyan regardless of state.
      width: 100% forces consistent card width across tool calls; without
      it, cards shrink to content width (short-output cards read narrow,
      long-output cards read full-width → jagged column). */
@@ -3188,17 +3187,6 @@ audio.media-player {
   width: 100%;
   box-sizing: border-box;
   align-self: stretch;
-}
-
-/* Legacy .ts-msg rule forces font-family: var(--font-mono) on every
-   chat turn.  Override for user/assistant/reasoning/info/error where
-   body prose is meant to be UI font.  .msg.tool keeps mono via the
-   .msg.tool { font-family: var(--font-mono); } rule in chat.css. */
-.ts-msg.msg:not(.tool) {
-  font-family: var(--font-ui);
-}
-.ts-msg-body.msg-body {
-  font-family: inherit;
 }
 
 .ts-approval-tool {


### PR DESCRIPTION
## Summary

Third and final follow-up after #431 stripped the `data-design="v1"` gate. This drops the parallel `.ts-msg*` legacy class family that had been kept as a transitional bridge during the gated rollout — both chat surfaces now render with the unified `.msg / .msg-body / .msg-actions / .msg-action-btn` primitive.

- `turnstone/shared_static/chat.css` — deleted the ~210-line legacy `.ts-msg*` rule block (Messages + floating action toolbar + mobile + reduced-motion sections); renamed `.ts-msg.ts-approval--inline` → `.msg.ts-approval--inline`; restored the streaming-markdown rationale (`white-space: normal` intent + partial-fence behavior + `.msg-user-text` path) on `.msg-body`, with `white-space: normal` now declared explicitly so a future "simplification" can't silently break streaming.
- `turnstone/ui/static/app.js` — dropped the `ts-msg*` half of every dual-class string and updated `querySelector` callsites (`.ts-msg--user` → `.msg.user`, `.ts-msg--assistant` → `.msg.assistant`).
- `turnstone/ui/static/style.css` — renamed all `.ts-msg--*` selectors to `.msg.*`; removed two now-dead override rules (`.ts-msg.msg:not(.tool)` and `.ts-msg-body.msg-body` font-family overrides) that existed solely to unwind the legacy `.ts-msg` font-mono default that's now gone.

Net **−213 lines**.

The coordinator chat view (`console/static/coordinator/`) was already pure `.msg*` and is unchanged.

## Decisions worth knowing

- **`.msg.ts-approval--inline` keeps the `.msg` qualifier** (rather than going bare). The qualifier preserves `(0,2,0)` specificity so the inline-approval rule ties with `.ts-approval.approved/.denied/.error` and the later-cascade rule wins, holding the inline card cyan regardless of state. Bare `.ts-approval--inline` would suddenly let the state classes flip the card colour. Comments at `chat.css:25-32` and `style.css:3176-3190` document this.
- **Composer rename deferred**. `.ts-composer-*` → `.composer-*` would touch ~80 call sites across `composer.js` and `chat.css`; bundling it would have obscured the message-class verification. Worth a follow-up PR.

## Verification

- `bug 0 / security 0 / performance 0 / quality 3 (3 confirmed)` from the multi-stage review pipeline; all three quality findings (lost streaming-markdown rationale + dangling cross-reference + duplicated cascade-tie comment) addressed in the committed version.
- `scripts/css_specificity_audit.py` (newly landed in #433): **26 findings on origin/main, 26 on this branch** — the refactor doesn't introduce or remove any cascade flips.
- 538 backend tests pass (`test_app_js`, `test_webui_content`, `test_webui_auto_approve_visibility`, `test_web_helpers`, `test_html`, `test_auth`, `test_console`, `test_api_versioning`, `test_coordinator_*`).
- No headless frontend test suite exists; **manual visual verification still required** before merge.

## Test plan

- [ ] Per-node UI: load a workstream, send a message, watch a tool call get approved / denied / errored. Verify message cards, hover-revealed action toolbar, `.msg-body` markdown, tool-call card, approval card with verdict badge, auto-approved badge, and tool-output rendering all unchanged.
- [ ] Coordinator chat view: identical to pre-merge (it already used pure `.msg*` classes; the only chat.css delta affecting it is the legacy block removal).
- [ ] Both light and dark themes.