### PR TITLE
refactor(ui): drop legacy ts-composer prefix on shared composer

### DIFF
--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -272,7 +272,7 @@
    send button.  Coordinator omits chips + paperclip; interactive
    includes both.  Same wrapper, same textarea + send styling.
    ========================================================================== */
-.ts-composer {
+.composer {
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -285,16 +285,16 @@
   border-top: 1px solid var(--border-strong);
 }
 
-.ts-composer-chips {
+.composer-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
 }
-.ts-composer-chips:empty {
+.composer-chips:empty {
   display: none;
 }
 
-.ts-composer-chip {
+.composer-chip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -306,11 +306,11 @@
   border-radius: var(--radius-sm);
   color: var(--fg);
 }
-.ts-composer-chip-size {
+.composer-chip-size {
   color: var(--fg-dim);
   font-variant-numeric: tabular-nums;
 }
-.ts-composer-chip-remove {
+.composer-chip-remove {
   background: none;
   border: none;
   color: var(--fg-dim);
@@ -320,17 +320,17 @@
   font-size: 13px;
   line-height: 1;
 }
-.ts-composer-chip-remove:hover {
+.composer-chip-remove:hover {
   color: var(--red);
 }
 
-.ts-composer-row {
+.composer-row {
   display: flex;
   align-items: flex-end;
   gap: 6px;
 }
 
-.ts-composer-attach {
+.composer-attach {
   background: transparent;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -345,17 +345,17 @@
     color 0.12s,
     border-color 0.12s;
 }
-.ts-composer-attach:hover {
+.composer-attach:hover {
   background: var(--bg-highlight);
   color: var(--accent);
   border-color: var(--accent-dim);
 }
-.ts-composer-attach:focus-visible {
+.composer-attach:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
-.ts-composer-input {
+.composer-input {
   flex: 1;
   min-height: 32px;
   max-height: 160px;
@@ -374,21 +374,21 @@
     border-color 0.15s,
     box-shadow 0.15s;
 }
-.ts-composer-input:focus-visible {
+.composer-input:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
-.ts-composer-input:disabled {
+.composer-input:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
-.ts-composer-input::placeholder {
+.composer-input::placeholder {
   color: var(--fg-dim);
   opacity: 0.7;
 }
 
-.ts-composer-send {
+.composer-send {
   font: inherit;
   font-family: var(--font-mono);
   font-size: 12px;
@@ -403,24 +403,24 @@
   transition: filter 0.12s;
   letter-spacing: 0.02em;
 }
-.ts-composer-send:hover {
+.composer-send:hover {
   filter: brightness(1.08);
 }
-.ts-composer-send:focus-visible {
+.composer-send:focus-visible {
   outline: 2px solid var(--fg);
   outline-offset: 2px;
 }
-.ts-composer-send:disabled {
+.composer-send:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   filter: none;
 }
-.ts-composer-send--queue {
+.composer-send--queue {
   background: transparent;
   color: var(--accent);
   border-color: var(--accent);
 }
-.ts-composer-send--queue:hover {
+.composer-send--queue:hover {
   background: var(--accent-dim);
   filter: none;
 }
@@ -428,7 +428,7 @@
 /* Stop button — only rendered when the composer was constructed with
    stopBtn=true.  Distinct red colour signals "interrupt the in-flight
    generation" rather than "send another message". */
-.ts-composer-stop {
+.composer-stop {
   background: var(--red, #c94040);
   min-width: 120px;
   text-align: center;
@@ -443,11 +443,11 @@
   cursor: pointer;
   height: 32px;
 }
-.ts-composer-stop:focus-visible {
+.composer-stop:focus-visible {
   outline: 2px solid var(--fg-bright, #e8ecf4);
   outline-offset: 2px;
 }
-[data-theme="light"] .ts-composer-stop {
+[data-theme="light"] .composer-stop {
   color: #fff;
 }
 
@@ -458,15 +458,15 @@
    row pairs an attach / options cluster on the left with a
    primary "Create" / "Start" button on the right.
    ============================================================ */
-.ts-composer--stacked {
+.composer--stacked {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.ts-composer--stacked .ts-composer-text {
+.composer--stacked .composer-text {
   display: flex;
 }
-.ts-composer--stacked .ts-composer-input {
+.composer--stacked .composer-input {
   flex: 1;
   min-height: 72px;
   /* Blend the textarea into its enclosing panel in stacked layout —
@@ -480,18 +480,18 @@
   padding: 6px 8px;
   resize: vertical;
 }
-.ts-composer--stacked .ts-composer-input:focus-visible {
+.composer--stacked .composer-input:focus-visible {
   box-shadow: none;
   border-bottom-color: var(--accent);
 }
-.ts-composer--stacked .ts-composer-row {
+.composer--stacked .composer-row {
   align-items: center;
 }
 /* Space the primary action button away from the left-clustered
    attach + options buttons in the stacked layout.  The send
    button is always the LAST element in the action row; push it
    to the right edge via margin-left:auto. */
-.ts-composer--stacked .ts-composer-send {
+.composer--stacked .composer-send {
   margin-left: auto;
 }
 
@@ -499,7 +499,7 @@
    Options disclosure — toggle button + collapsible panel.
    Rendered when the composer is constructed with opts.options.
    ============================================================ */
-.ts-composer-options-btn {
+.composer-options-btn {
   background: transparent;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -516,26 +516,26 @@
     background 0.12s,
     border-color 0.12s;
 }
-.ts-composer-options-btn:hover {
+.composer-options-btn:hover {
   background: var(--bg-highlight);
   border-color: var(--accent-dim);
 }
-.ts-composer-options-btn:focus-visible {
+.composer-options-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
-.ts-composer-options-btn[aria-expanded="true"] .ts-composer-options-caret {
+.composer-options-btn[aria-expanded="true"] .composer-options-caret {
   /* Flip ▾ to ▴ via transform so the glyph file stays single-char. */
   display: inline-block;
   transform: rotate(180deg);
 }
-.ts-composer-options-summary {
+.composer-options-summary {
   color: var(--fg-dim);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.02em;
 }
-.ts-composer-options-panel {
+.composer-options-panel {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 6px 12px;
@@ -555,19 +555,19 @@
    and comes later in the cascade, so a bare [hidden] attribute
    alone doesn't hide the panel.  Override here so toggleOptions()
    works via the standard hidden attribute. */
-.ts-composer-options-panel[hidden] {
+.composer-options-panel[hidden] {
   display: none;
 }
-.ts-composer-options-field {
+.composer-options-field {
   display: contents;
 }
-.ts-composer-options-field > label {
+.composer-options-field > label {
   color: var(--fg-dim);
   text-transform: uppercase;
   font-size: 10px;
   letter-spacing: 0.05em;
 }
-.ts-composer-options-control {
+.composer-options-control {
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--fg);
@@ -577,14 +577,14 @@
   padding: 4px 6px;
   width: 100%;
 }
-.ts-composer-options-control:focus-visible {
+.composer-options-control:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
 /* Active-state flip on the toggle button itself (mirrors the
    dashboard composer's affordance). */
-.ts-composer-options-btn[aria-expanded="true"] {
+.composer-options-btn[aria-expanded="true"] {
   color: var(--fg);
   background: var(--bg);
 }
@@ -759,15 +759,15 @@
     margin: 4px -6px;
     border-radius: 0;
   }
-  .ts-composer {
+  .composer {
     padding: 6px 10px;
   }
-  .ts-composer-input {
+  .composer-input {
     min-height: 40px;
     max-height: 120px;
     resize: none;
   }
-  .ts-composer-send {
+  .composer-send {
     height: 40px;
     padding: 6px 14px;
   }
@@ -788,9 +788,9 @@
   .msg-actions,
   .msg-action-btn,
   .ts-approval-btn,
-  .ts-composer-attach,
-  .ts-composer-input,
-  .ts-composer-send {
+  .composer-attach,
+  .composer-input,
+  .composer-send {
     transition: none;
   }
 }

--- a/turnstone/shared_static/composer.js
+++ b/turnstone/shared_static/composer.js
@@ -141,9 +141,9 @@
     var opts = this._opts;
 
     var root = document.createElement("div");
-    root.className = "ts-composer";
+    root.className = "composer";
     var layout = opts.layout === "stacked" ? "stacked" : "inline";
-    if (layout === "stacked") root.classList.add("ts-composer--stacked");
+    if (layout === "stacked") root.classList.add("composer--stacked");
     this.el = root;
 
     // Attachment chips row — always present in the DOM when attachments
@@ -151,7 +151,7 @@
     // by CSS until populated.
     if (opts.attachments) {
       this.chipsEl = document.createElement("div");
-      this.chipsEl.className = "ts-composer-chips";
+      this.chipsEl.className = "composer-chips";
       this.chipsEl.setAttribute("role", "list");
       this.chipsEl.setAttribute("aria-label", "Pending attachments");
       root.appendChild(this.chipsEl);
@@ -165,14 +165,14 @@
     var actionRow;
     if (layout === "stacked") {
       textRow = document.createElement("div");
-      textRow.className = "ts-composer-text";
+      textRow.className = "composer-text";
       root.appendChild(textRow);
       actionRow = document.createElement("div");
-      actionRow.className = "ts-composer-row";
+      actionRow.className = "composer-row";
       root.appendChild(actionRow);
     } else {
       actionRow = document.createElement("div");
-      actionRow.className = "ts-composer-row";
+      actionRow.className = "composer-row";
       root.appendChild(actionRow);
       textRow = actionRow;
     }
@@ -194,7 +194,7 @@
       return;
     }
     this.attachBtn = makeButton({
-      className: "ts-composer-attach",
+      className: "composer-attach",
       text: "\ud83d\udcce",
       ariaLabel: "Attach files",
       title: "Attach files",
@@ -211,7 +211,7 @@
 
   Composer.prototype._buildInput = function (row, opts) {
     this.inputEl = document.createElement("textarea");
-    this.inputEl.className = "ts-composer-input";
+    this.inputEl.className = "composer-input";
     this.inputEl.rows = opts.rows && opts.rows > 0 ? opts.rows : 1;
     var defaultPlaceholder = this._isTouch
       ? "Type a message\u2026"
@@ -239,7 +239,7 @@
           ? "Queue"
           : this._sendLabel;
     this.sendBtn = makeButton({
-      className: "ts-composer-send",
+      className: "composer-send",
       text: this._sendLabel,
       ariaLabel: this._sendLabel + " message",
     });
@@ -253,7 +253,7 @@
     }
     this._stopLabel = opts.stopLabel || "\u25a0 Stop";
     this.stopBtn = makeButton({
-      className: "ts-composer-stop",
+      className: "composer-stop",
       text: this._stopLabel,
       ariaLabel: "Stop generation",
     });
@@ -270,23 +270,23 @@
     }
     this.optionsBtn = document.createElement("button");
     this.optionsBtn.type = "button";
-    this.optionsBtn.className = "ts-composer-options-btn";
+    this.optionsBtn.className = "composer-options-btn";
     this.optionsBtn.setAttribute("aria-label", "Toggle options");
     this.optionsBtn.setAttribute("title", "Options");
     this.optionsBtn.setAttribute("aria-expanded", "false");
     var labelSpan = document.createElement("span");
-    labelSpan.className = "ts-composer-options-btn-label";
+    labelSpan.className = "composer-options-btn-label";
     labelSpan.textContent = opts.options.toggleLabel || "Options";
     this.optionsBtn.appendChild(labelSpan);
     var caret = document.createElement("span");
-    caret.className = "ts-composer-options-caret";
+    caret.className = "composer-options-caret";
     caret.setAttribute("aria-hidden", "true");
     caret.textContent = "\u25be"; // ▾
     this.optionsBtn.appendChild(caret);
     row.appendChild(this.optionsBtn);
 
     this.optionsSummaryEl = document.createElement("span");
-    this.optionsSummaryEl.className = "ts-composer-options-summary";
+    this.optionsSummaryEl.className = "composer-options-summary";
     this.optionsSummaryEl.setAttribute("aria-live", "polite");
     this.optionsSummaryEl.hidden = true;
     row.appendChild(this.optionsSummaryEl);
@@ -299,10 +299,9 @@
       return;
     }
     this.optionsPanel = document.createElement("div");
-    this.optionsPanel.className = "ts-composer-options-panel";
+    this.optionsPanel.className = "composer-options-panel";
     this.optionsPanel.hidden = true;
-    var panelId =
-      "ts-composer-options-" + Math.random().toString(36).slice(2, 10);
+    var panelId = "composer-options-" + Math.random().toString(36).slice(2, 10);
     this.optionsPanel.id = panelId;
     this.optionsBtn.setAttribute("aria-controls", panelId);
 
@@ -316,7 +315,7 @@
 
   Composer.prototype._buildOptionField = function (field, idx, panelId) {
     var rowEl = document.createElement("div");
-    rowEl.className = "ts-composer-options-field";
+    rowEl.className = "composer-options-field";
 
     var lbl = document.createElement("label");
     lbl.textContent = field.label || field.id || "";
@@ -341,7 +340,7 @@
       if (field.autocomplete) ctrl.autocomplete = field.autocomplete;
     }
     ctrl.id = ctrlId;
-    ctrl.className = "ts-composer-options-control";
+    ctrl.className = "composer-options-control";
     if (field.initial != null) ctrl.value = String(field.initial);
     rowEl.appendChild(ctrl);
 
@@ -562,7 +561,7 @@
     // --queue class is queue-specific (the colour flip signals "this
     // button now queues rather than sends").
     this.sendBtn.classList.toggle(
-      "ts-composer-send--queue",
+      "composer-send--queue",
       !!(b && opts.queueWhileBusy),
     );
     // Placeholder swap applies whenever busy, not only in queue mode —

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -225,31 +225,30 @@ function _formatAttachSize(n) {
 Pane.prototype._renderAttachmentChip = function (info) {
   var self = this;
   var chip = document.createElement("span");
-  chip.className =
-    "ts-composer-chip ts-composer-chip-" + (info.kind || "other");
+  chip.className = "composer-chip composer-chip-" + (info.kind || "other");
   chip.setAttribute("role", "listitem");
   chip.dataset.attachmentId = info.attachment_id;
 
   var icon = document.createElement("span");
-  icon.className = "ts-composer-chip-icon";
+  icon.className = "composer-chip-icon";
   icon.setAttribute("aria-hidden", "true");
   icon.textContent = info.kind === "image" ? "\ud83d\uddbc" : "\ud83d\udcc4";
   chip.appendChild(icon);
 
   var label = document.createElement("span");
-  label.className = "ts-composer-chip-name";
+  label.className = "composer-chip-name";
   label.textContent = info.filename || "(unnamed)";
   label.title = info.filename || "";
   chip.appendChild(label);
 
   var size = document.createElement("span");
-  size.className = "ts-composer-chip-size";
+  size.className = "composer-chip-size";
   size.textContent = _formatAttachSize(info.size_bytes || 0);
   chip.appendChild(size);
 
   var remove = document.createElement("button");
   remove.type = "button";
-  remove.className = "ts-composer-chip-remove";
+  remove.className = "composer-chip-remove";
   remove.setAttribute(
     "aria-label",
     "Remove attachment " + (info.filename || ""),
@@ -342,12 +341,12 @@ Pane.prototype._swapPlaceholderChip = function (placeholderId, info) {
   );
   if (chip) {
     chip.dataset.attachmentId = info.attachment_id;
-    var name = chip.querySelector(".ts-composer-chip-name");
+    var name = chip.querySelector(".composer-chip-name");
     if (name) {
       name.textContent = info.filename || "(unnamed)";
       name.title = info.filename || "";
     }
-    var size = chip.querySelector(".ts-composer-chip-size");
+    var size = chip.querySelector(".composer-chip-size");
     if (size) size.textContent = _formatAttachSize(info.size_bytes || 0);
   } else {
     // Chip missing (user removed it mid-upload?); render fresh.

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -1398,15 +1398,15 @@ body {
    ========================================================================== */
 
 /* Attachment chips — pill cluster above the textarea */
-.ts-composer-chips {
+.composer-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
-.ts-composer-chips:empty {
+.composer-chips:empty {
   display: none;
 }
-.ts-composer-chip {
+.composer-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1419,22 +1419,22 @@ body {
   font-size: 11px;
   max-width: 280px;
 }
-.ts-composer-chip-icon {
+.composer-chip-icon {
   font-size: 12px;
   opacity: 0.7;
 }
-.ts-composer-chip-name {
+.composer-chip-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 180px;
 }
-.ts-composer-chip-size {
+.composer-chip-size {
   color: var(--fg-dim, var(--fg));
   opacity: 0.65;
   font-size: 10px;
 }
-.ts-composer-chip-remove {
+.composer-chip-remove {
   background: transparent;
   color: var(--fg-dim, var(--fg));
   border: none;
@@ -1444,11 +1444,11 @@ body {
   cursor: pointer;
   border-radius: 50%;
 }
-.ts-composer-chip-remove:hover {
+.composer-chip-remove:hover {
   color: var(--red, #c94040);
   background: var(--bg-surface);
 }
-.ts-composer-chip-remove:focus-visible {
+.composer-chip-remove:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
@@ -2197,7 +2197,7 @@ audio.media-player {
 /* Slightly thicker ring than chat.css (2px → 3px) — the interactive
    pane sits over denser pane-bottom chrome, so the ring needs more
    visual weight to pop. */
-.ts-composer-input:focus-visible {
+.composer-input:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
@@ -3126,7 +3126,7 @@ audio.media-player {
   .ts-approval-btn,
   .ts-approval-feedback,
   #plan-buttons button,
-  .ts-composer button,
+  .composer button,
   .dashboard-new-btn,
   .dashboard-input,
   #health-indicator,


### PR DESCRIPTION
## Summary

Follow-up to #434, which unified the chat-message primitive on `.msg` and explicitly noted that the parallel `.ts-composer-*` prefix on the shared composer widget was still in place. This PR drops it so the widget sits in the shared/* vocabulary the same way `.msg` does.

Mechanical 1:1 rename (`ts-composer` → `composer`) across:

| File | Renames |
|---|---|
| `shared_static/chat.css` | 48 selectors |
| `shared_static/composer.js` | 19 className strings |
| `ui/static/style.css` | 11 per-node UI overrides |
| `ui/static/app.js` | 7 chip queries / className strings |

Net **−2 lines** (rename is byte-shrink, formatter touches account for the rest).

## Pre-rename collision check

All `composer`-substring matches in the codebase that aren't part of `.ts-composer-*`:
- IDs `#coord-composer-mount`, `#coord-composer-panel`, `#coord-composer-503`, `#home-coord-composer-mount` — IDs are a different namespace from classes, no collision.
- `.home-composer-banner` / `.home-composer-error` (console/static/style.css) — different prefix (`home-composer-*`), unrelated to the chip-system classes.
- No bare `.composer { ... }` rule existed before.

## Verification

- Multi-stage code review pipeline: `bug 0 / security 0 / performance 0 / quality 0` — all four finders returned empty (clean mechanical rename).
- `scripts/css_specificity_audit.py`: **26 findings on origin/main, 26 on this branch** — no new cascade flips.
- 189 backend tests pass (`test_app_js`, `test_webui_content`, `test_webui_auto_approve_visibility`, `test_html`, `test_web_helpers`, `test_coordinator_adapter`, `test_coordinator_client`).
- No headless frontend test exists; **manual visual verification still required**.

## Test plan

- [ ] Per-node UI: textarea types + send works; Enter and Shift-Enter behave correctly; stop button appears during generation and cancels.
- [ ] Attachments: paperclip opens file picker; paste image into textarea attaches; drag/drop file onto pane attaches; chip pills render with name + size; chip remove (×) button strips; chip strip refreshes after dispatch.
- [ ] Options panel: toggle button expands/collapses; controls inside (model selectors, etc.) functional.
- [ ] Coordinator: same composer surface (it shares `composer.js` + `chat.css`); send works.
- [ ] Stacked layout (workstream creation forms): textarea is dominant, action row pairs left-cluster + right-side primary button, "Create" / "Start" pushed to right edge.
- [ ] Mobile (<700px): composer collapses to mobile sizing; textarea grows up to 120px; send button grows to 40px height.
- [ ] Both light and dark themes.