### PR TITLE
fix(coord): None-safe slice in _evaluate_intent projection

### DIFF
--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -1246,6 +1246,60 @@ def test_spawn_batch_evaluate_intent_handles_empty_children_defensively(coord_se
 
 
 # ---------------------------------------------------------------------------
+# Regression: tasks(update) without title — _prepare_tasks stores
+# ``item["title"] = None`` (title is optional on update), then
+# _evaluate_intent's projection sliced ``it.get("title", "")[:100]``.
+# dict.get returns the stored ``None`` (the default applies only when
+# the key is absent), so the slice raised TypeError and aborted the
+# whole batch.  Sibling tool calls in the same parallel batch then
+# surfaced as "Tool execution was cancelled" because the assistant
+# message had recorded the tool calls but the evaluator never wrote
+# tool-result entries.
+# ---------------------------------------------------------------------------
+
+
+def test_tasks_update_without_title_evaluates_intent_cleanly(coord_session, monkeypatch):
+    """tasks(update) with status only (no title) must not crash the
+    intent projection — the missing-but-optional title field stored as
+    None used to TypeError on the [:100] slice."""
+    sess, _coord, _ui = coord_session
+    _stub_judge_for_evaluate_intent(monkeypatch, sess)
+    item = sess._prepare_tool(
+        _tc("tasks", {"action": "update", "task_id": "tsk_1", "status": "in_progress"})
+    )
+    assert "error" not in item
+    # The crash trigger: item["title"] is None after _prepare_tasks.
+    assert item["title"] is None
+    sess._evaluate_intent([item])
+    assert item["func_args"] == {
+        "action": "update",
+        "task_id": "tsk_1",
+        "title": "",
+    }
+
+
+def test_tasks_update_without_title_in_parallel_batch_does_not_cancel_siblings(
+    coord_session, monkeypatch
+):
+    """Reproduce the parallel-batch failure mode: tasks(update) without
+    title alongside other tools.  Pre-fix, the evaluator raised before
+    any sibling executed, leaving every sibling reported as cancelled.
+    Post-fix, all items get func_args populated and the batch proceeds
+    to the judge."""
+    sess, _coord, _ui = coord_session
+    _stub_judge_for_evaluate_intent(monkeypatch, sess)
+    update_item = sess._prepare_tool(
+        _tc("tasks", {"action": "update", "task_id": "tsk_1", "status": "in_progress"})
+    )
+    # tasks(add) — sibling that previously got orphaned/cancelled.
+    add_item = sess._prepare_tool(_tc("tasks", {"action": "add", "title": "next step"}))
+    sess._evaluate_intent([update_item, add_item])
+    # Both items projected; neither carried over the None crash.
+    assert update_item["func_args"]["title"] == ""
+    assert add_item["func_args"]["title"] == "next step"
+
+
+# ---------------------------------------------------------------------------
 # close_all_children
 # ---------------------------------------------------------------------------
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3348,11 +3348,11 @@ class ChatSession:
                     "name": it.get("watch_name", ""),
                 }
             elif name == "notify":
-                it["func_args"] = {"message": it.get("message", "")[:200]}
+                it["func_args"] = {"message": (it.get("message") or "")[:200]}
             elif name == "task_agent":
-                it["func_args"] = {"prompt": it.get("prompt", "")[:200]}
+                it["func_args"] = {"prompt": (it.get("prompt") or "")[:200]}
             elif name == "plan_agent":
-                it["func_args"] = {"goal": it.get("prompt", "")[:200]}
+                it["func_args"] = {"goal": (it.get("prompt") or "")[:200]}
             # Coordinator tool args — only the ``needs_approval=True`` set
             # reaches this point (read-only inspect / list_* / wait
             # tools are filtered above), so this matches the auditable
@@ -3361,7 +3361,7 @@ class ChatSession:
             elif name == "spawn_workstream":
                 it["func_args"] = {
                     "skill": it.get("skill", ""),
-                    "initial_message": it.get("initial_message", "")[:200],
+                    "initial_message": (it.get("initial_message") or "")[:200],
                     "target_node": it.get("target_node", ""),
                     "name": it.get("name", ""),
                     "model": it.get("model", ""),
@@ -3383,7 +3383,9 @@ class ChatSession:
                         {
                             "skill": c.get("skill", "") if isinstance(c, dict) else "",
                             "initial_message": (
-                                c.get("initial_message", "")[:200] if isinstance(c, dict) else ""
+                                (c.get("initial_message") or "")[:200]
+                                if isinstance(c, dict)
+                                else ""
                             ),
                             "target_node": (
                                 c.get("target_node", "") if isinstance(c, dict) else ""
@@ -3395,22 +3397,31 @@ class ChatSession:
             elif name == "send_to_workstream":
                 it["func_args"] = {
                     "ws_id": it.get("ws_id", ""),
-                    "message": it.get("message", "")[:200],
+                    "message": (it.get("message") or "")[:200],
                 }
             elif name == "close_workstream":
                 it["func_args"] = {
                     "ws_id": it.get("ws_id", ""),
-                    "reason": it.get("reason", "")[:200],
+                    "reason": (it.get("reason") or "")[:200],
                 }
             elif name == "close_all_children":
-                it["func_args"] = {"reason": it.get("reason", "")[:200]}
+                it["func_args"] = {"reason": (it.get("reason") or "")[:200]}
             elif name in ("cancel_workstream", "delete_workstream"):
                 it["func_args"] = {"ws_id": it.get("ws_id", "")}
             elif name == "tasks":
+                # ``title`` is optional on update — _prepare_tasks stores
+                # ``None`` when omitted, so dict.get(x, "") returns None
+                # (not the default) and slicing crashes.  Collapse via
+                # ``or ""`` so absent and explicit-None both fall back to
+                # empty string.  The other projections above use the same
+                # pattern defensively — a future preparer that stores
+                # None for any of these fields shouldn't take down the
+                # whole batch (every sibling tool call gets reported as
+                # cancelled) on a single missing optional field.
                 it["func_args"] = {
                     "action": it.get("action", ""),
                     "task_id": it.get("task_id", ""),
-                    "title": it.get("title", "")[:100],
+                    "title": (it.get("title") or "")[:100],
                 }
             elif it.get("mcp_args"):
                 it["func_args"] = it["mcp_args"]


### PR DESCRIPTION
## Summary
Fix a bug a coordinator hit during execution: a parallel batch containing \`tasks(update)\` without a \`title\` crashed with \`TypeError: 'NoneType' object is not subscriptable\` at \`turnstone/core/session.py:3413\`, then surfaced as \"Tool execution was cancelled\" for every sibling tool in the batch.

### Root cause
- \`tasks(update)\` makes \`title\` optional — the schema lets you update just \`status\` or \`child_ws_id\`. \`_prepare_tasks\` (session.py:5874) stores \`item[\"title\"] = None\` in that case.
- \`_evaluate_intent\`'s projection at session.py:3413 sliced via \`it.get(\"title\", \"\")[:100]\`. \`dict.get\` returns the stored \`None\` (the default kicks in only when the key is absent), and \`None[:100]\` raises \`TypeError\`.
- The exception fired BEFORE any tool in the batch executed, but after the assistant's tool-call message was on the wire. With no matching tool-result entries, later reconstruction (\`_openai_common\`/\`_anthropic\`/storage utils) synthesised \"Tool execution was cancelled\" for every sibling — the misleading visible symptom.

### Fix
- Swap \`it.get(x, \"\")[:N]\` → \`(it.get(x) or \"\")[:N]\` for every slice projection in \`_evaluate_intent\` (notify / task_agent / plan_agent / spawn_workstream / spawn_batch / send_to_workstream / close_workstream / close_all_children / tasks). The other tools weren't observed crashing, but the bug shape is identical and the cost is trivial — hardens the projection layer once instead of relying on every \`_prepare_*\` method to never store \`None\`.
- Regression tests reproduce the exact \`TypeError\` standalone and in a parallel batch alongside \`tasks(add)\`. Both fail on \`main\` and pass with the fix.

## Test plan
- [x] \`uv run pytest tests/test_coordinator_tools.py\` — 89 passed
- [x] \`uv run pytest tests/ -k \"tasks or coordinator or session\"\` — 785 passed
- [x] \`uv run ruff check turnstone/core/session.py tests/test_coordinator_tools.py\` — clean
- [x] \`uv run mypy turnstone/core/session.py\` — clean
- [x] Verified the new tests fail on \`main\` with the reported \`TypeError: 'NoneType' object is not subscriptable\` at session.py:3413