### PR TITLE
fix(coord): tasks parallel-batch + list_nodes flat-arg filters

### DIFF
--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -1006,16 +1006,33 @@ def test_tasks_mixed_read_and_write_in_batch_rejected(coord_session):
 
 
 def test_tasks_all_writes_in_batch_permitted(coord_session):
-    """All-write batches are SAFE: writes serialise under
-    ``CoordinatorClient``'s per-ws lock and the result is
-    deterministic against the input set even if the dispatch order
-    isn't.  Four parallel ``tasks(add=...)`` is the canonical
-    "decompose plan into N tasks" shape."""
+    """All-write batches are SAFE: the dispatcher runs them serially
+    in input order (see ``test_tasks_writes_run_in_input_order``) so
+    the final task list ordering matches the model's emit order, and
+    each per-call lock acquisition under ``CoordinatorClient`` keeps
+    the storage row consistent.  Four parallel ``tasks(add=...)`` is
+    the canonical "decompose plan into N tasks" shape."""
     sess, coord, _ui = coord_session
-    coord.tasks_add.side_effect = lambda *a, **kw: {
-        "ok": True,
-        "task": {"id": "t1", "title": kw.get("title", ""), "status": "pending"},
-    }
+    # Real ``CoordinatorClient.tasks_add`` returns the task dict
+    # directly with top-level ``id`` / ``title`` / ``status`` /
+    # ``child_ws_id`` / ``created`` / ``updated``.  Stubbing with
+    # the matching shape so a future refactor that depends on the
+    # actual contract (``result.get("id")`` etc.) doesn't pass
+    # vacuously here.
+    next_task_num = [0]
+
+    def _tasks_add(*_a, **kw):
+        next_task_num[0] += 1
+        return {
+            "id": f"t{next_task_num[0]}",
+            "title": kw.get("title", ""),
+            "status": "pending",
+            "child_ws_id": kw.get("child_ws_id", ""),
+            "created": "2026-04-28T00:00:00",
+            "updated": "2026-04-28T00:00:00",
+        }
+
+    coord.tasks_add.side_effect = _tasks_add
     tool_calls = [
         _tc("tasks", {"action": "add", "title": f"task {i}"}, call_id=f"call-{i}") for i in range(4)
     ]
@@ -1023,6 +1040,73 @@ def test_tasks_all_writes_in_batch_permitted(coord_session):
     for _cid, output in results:
         assert "read-after-write" not in output.lower(), output
         assert "cannot run" not in output.lower(), output
+
+
+def test_tasks_writes_run_in_input_order(coord_session):
+    """Regression guard: ``tasks_add`` calls must reach the
+    coordinator client in the SAME order the model emitted them.
+    Pre-fix, ``ThreadPoolExecutor.map`` dispatched in
+    scheduler-dependent order — the SET of tasks ended up consistent
+    but the final list ordering (and timestamps/IDs) varied
+    run-to-run.  The fix runs any batch containing a tasks-write
+    serially in input order; this test pins the property by capturing
+    the title sequence as ``tasks_add`` sees it."""
+    sess, coord, _ui = coord_session
+    seen_titles: list[str] = []
+
+    def _tasks_add(*_a, **kw):
+        seen_titles.append(kw.get("title", ""))
+        return {
+            "id": f"t{len(seen_titles)}",
+            "title": kw.get("title", ""),
+            "status": "pending",
+            "child_ws_id": "",
+            "created": "2026-04-28T00:00:00",
+            "updated": "2026-04-28T00:00:00",
+        }
+
+    coord.tasks_add.side_effect = _tasks_add
+    titles = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]
+    tool_calls = [
+        _tc("tasks", {"action": "add", "title": t}, call_id=f"call-{i}")
+        for i, t in enumerate(titles)
+    ]
+    sess._execute_tools(tool_calls)
+    # Exact input-order preservation — no scheduler-dependent
+    # interleaving.
+    assert seen_titles == titles
+
+
+def test_tasks_writes_serial_when_mixed_with_non_tasks_siblings(coord_session):
+    """Even when the batch mixes a tasks-write with non-tasks
+    siblings, the tasks-write path must still preserve input order
+    (the dispatcher runs the WHOLE batch serially in this case to
+    keep the implementation simple).  A coord adding 2 tasks +
+    listing nodes in one turn shouldn't see scheduler-shuffled task
+    titles."""
+    sess, coord, _ui = coord_session
+    seen_titles: list[str] = []
+
+    def _tasks_add(*_a, **kw):
+        seen_titles.append(kw.get("title", ""))
+        return {
+            "id": f"t{len(seen_titles)}",
+            "title": kw.get("title", ""),
+            "status": "pending",
+            "child_ws_id": "",
+            "created": "2026-04-28T00:00:00",
+            "updated": "2026-04-28T00:00:00",
+        }
+
+    coord.tasks_add.side_effect = _tasks_add
+    coord.list_nodes.return_value = {"nodes": [], "truncated": False}
+    tool_calls = [
+        _tc("tasks", {"action": "add", "title": "first"}, call_id="call-1"),
+        _tc("list_nodes", {}, call_id="call-2"),
+        _tc("tasks", {"action": "add", "title": "second"}, call_id="call-3"),
+    ]
+    sess._execute_tools(tool_calls)
+    assert seen_titles == ["first", "second"]
 
 
 def test_tasks_all_reads_in_batch_permitted(coord_session):
@@ -1053,9 +1137,15 @@ def test_tasks_write_with_non_tasks_sibling_permitted(coord_session):
     race regardless of dispatch order.  This is the natural batch
     shape for "add a task AND look up something else"."""
     sess, coord, _ui = coord_session
+    # Match real ``CoordinatorClient.tasks_add`` shape — dict
+    # returned directly, not wrapped in ``{"ok": True, "task": ...}``.
     coord.tasks_add.return_value = {
-        "ok": True,
-        "task": {"id": "t1", "title": "a", "status": "pending"},
+        "id": "t1",
+        "title": "a",
+        "status": "pending",
+        "child_ws_id": "",
+        "created": "2026-04-28T00:00:00",
+        "updated": "2026-04-28T00:00:00",
     }
     tool_calls = [
         _tc("tasks", {"action": "add", "title": "a"}, call_id="call-1"),

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -899,43 +899,104 @@ def test_tasks_reorder_requires_list_of_strings(coord_session):
     assert "error" in item
 
 
-def test_tasks_rejected_when_called_in_parallel_batch(coord_session):
-    """``tasks(...)`` mutates an ordered list and supports a ``list``
-    action that reads it back — a parallel batch like
-    ``[tasks(add=...), tasks(list)]`` has unspecified ordering inside
-    ``run_one``'s ThreadPoolExecutor.  Rather than warn the model in
-    the tool description (cognitive overhead on every call), we
-    reject the call site explicitly when the violation actually
-    happens.  The error tells the model to retry serially."""
+def test_tasks_mixed_read_and_write_in_batch_rejected(coord_session):
+    """The only shape the guard now rejects: ``tasks(list)`` paralleled
+    with a ``tasks`` mutating action.  Read-after-write ordering inside
+    ``run_one``'s ThreadPoolExecutor is unspecified, so the read can
+    land before or after the write and produce inconsistent state.
+    Both ``tasks(...)`` calls in the batch get the rejection error."""
     sess, _coord, _ui = coord_session
     tool_calls = [
-        _tc("tasks", {"action": "list"}, call_id="call-1"),
-        _tc("inspect_workstream", {"ws_id": "child-x"}, call_id="call-2"),
+        _tc("tasks", {"action": "add", "title": "a thing"}, call_id="call-1"),
+        _tc("tasks", {"action": "list"}, call_id="call-2"),
     ]
     results, _fb = sess._execute_tools(tool_calls)
-    # The tasks(...) call comes back as an error; the sibling
-    # inspect_workstream is unaffected.
     by_id = dict(results)
-    assert "parallel tool batch" in by_id["call-1"].lower()
-    # The inspect call was permitted to dispatch — its result is
-    # NOT the parallel-batch error.
-    assert "parallel tool batch" not in by_id["call-2"].lower()
+    assert "read" in by_id["call-1"].lower() and "write" in by_id["call-1"].lower()
+    assert "read" in by_id["call-2"].lower() and "write" in by_id["call-2"].lower()
+
+
+def test_tasks_all_writes_in_batch_permitted(coord_session):
+    """All-write batches are SAFE: writes serialise under
+    ``CoordinatorClient``'s per-ws lock and the result is
+    deterministic against the input set even if the dispatch order
+    isn't.  Four parallel ``tasks(add=...)`` is the canonical
+    "decompose plan into N tasks" shape."""
+    sess, coord, _ui = coord_session
+    coord.tasks_add.side_effect = lambda *a, **kw: {
+        "ok": True,
+        "task": {"id": "t1", "title": kw.get("title", ""), "status": "pending"},
+    }
+    tool_calls = [
+        _tc("tasks", {"action": "add", "title": f"task {i}"}, call_id=f"call-{i}") for i in range(4)
+    ]
+    results, _fb = sess._execute_tools(tool_calls)
+    for _cid, output in results:
+        assert "read-after-write" not in output.lower(), output
+        assert "cannot run" not in output.lower(), output
+
+
+def test_tasks_all_reads_in_batch_permitted(coord_session):
+    """All-read batches are SAFE: nothing to race against."""
+    sess, coord, _ui = coord_session
+    coord.tasks_get.return_value = {"tasks": []}
+    tool_calls = [
+        _tc("tasks", {"action": "list"}, call_id="call-1"),
+        _tc("tasks", {"action": "list"}, call_id="call-2"),
+    ]
+    results, _fb = sess._execute_tools(tool_calls)
+    for _cid, output in results:
+        assert "read-after-write" not in output.lower(), output
 
 
 def test_tasks_runs_normally_when_alone_in_batch(coord_session):
-    """A single ``tasks(...)`` call is unaffected by the
-    parallel-incompatible guard — only multi-call batches trip it."""
+    """A single ``tasks(...)`` call is unaffected by the read-after-
+    write guard — only multi-call batches with a mix can trip it."""
     sess, _coord, _ui = coord_session
     results, _fb = sess._execute_tools([_tc("tasks", {"action": "list"})])
     _call_id, output = results[0]
-    # Empty task list returns a clean payload, not the parallel-batch error.
-    assert "parallel tool batch" not in output.lower()
+    assert "read-after-write" not in output.lower()
 
 
-def test_other_tools_unaffected_by_parallel_batch_guard(coord_session):
-    """Tools NOT in ``_PARALLEL_INCOMPATIBLE_TOOLS`` (e.g. inspect /
-    list) keep working in parallel batches — the guard is narrowly
-    scoped to tools whose semantics actually require serialisation."""
+def test_tasks_write_with_non_tasks_sibling_permitted(coord_session):
+    """A ``tasks`` write paralleled with a non-``tasks`` sibling is
+    fine — the sibling doesn't touch tasks state, so there's no
+    race regardless of dispatch order.  This is the natural batch
+    shape for "add a task AND look up something else"."""
+    sess, coord, _ui = coord_session
+    coord.tasks_add.return_value = {
+        "ok": True,
+        "task": {"id": "t1", "title": "a", "status": "pending"},
+    }
+    tool_calls = [
+        _tc("tasks", {"action": "add", "title": "a"}, call_id="call-1"),
+        _tc("inspect_workstream", {"ws_id": "child-x"}, call_id="call-2"),
+    ]
+    results, _fb = sess._execute_tools(tool_calls)
+    for _cid, output in results:
+        assert "read-after-write" not in output.lower(), output
+
+
+def test_tasks_read_with_non_tasks_sibling_permitted(coord_session):
+    """Mirror of the write-with-sibling test for the read direction.
+    Common shape: ``tasks(list)`` paralleled with ``list_workstreams``
+    / ``list_nodes`` for a planning snapshot."""
+    sess, coord, _ui = coord_session
+    coord.tasks_get.return_value = {"tasks": []}
+    tool_calls = [
+        _tc("tasks", {"action": "list"}, call_id="call-1"),
+        _tc("list_workstreams", {}, call_id="call-2"),
+        _tc("list_nodes", {}, call_id="call-3"),
+    ]
+    results, _fb = sess._execute_tools(tool_calls)
+    for _cid, output in results:
+        assert "read-after-write" not in output.lower(), output
+
+
+def test_non_tasks_parallel_batch_unaffected(coord_session):
+    """Tools other than ``tasks`` keep working in parallel batches
+    regardless of read/write semantics — the guard is scoped only
+    to ``tasks``'s read-after-write hazard."""
     sess, _coord, _ui = coord_session
     tool_calls = [
         _tc("inspect_workstream", {"ws_id": "child-a"}, call_id="call-1"),
@@ -943,7 +1004,7 @@ def test_other_tools_unaffected_by_parallel_batch_guard(coord_session):
     ]
     results, _fb = sess._execute_tools(tool_calls)
     for _cid, output in results:
-        assert "parallel tool batch" not in output.lower()
+        assert "read-after-write" not in output.lower()
 
 
 def test_tasks_exec_list_returns_tasks(coord_session):

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -649,6 +649,95 @@ def test_list_nodes_prepare_drops_invalid_filter_types(coord_session):
     assert item["filters"] == {"arch": "x86_64"}
 
 
+def test_list_nodes_prepare_accepts_flat_args_as_filters(coord_session):
+    """The model frequently drops the ``filters`` nesting and passes
+    each filter as a top-level kwarg (``list_nodes(os="Linux",
+    has_gpu=true)``).  Operators saw this surface during shakedown:
+    flat-arg calls returned the full cluster because the strict-
+    nested prepare silently dropped the filter.  The relaxed prepare
+    treats every top-level non-reserved kwarg as a flat filter."""
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(
+        _tc("list_nodes", {"os": "Linux", "gpu_has_nvidia": True, "memory_gb": 64})
+    )
+    assert item["filters"] == {"os": "Linux", "gpu_has_nvidia": True, "memory_gb": 64}
+
+
+def test_list_nodes_prepare_reserves_paging_and_visibility_kwargs(coord_session):
+    """Top-level reserved kwargs (``limit``, ``include_network_detail``,
+    ``include_inactive``, ``filters``) are control parameters, NOT
+    filters.  A flat call like ``list_nodes(limit=10, os="Linux")``
+    must put ``limit`` on the paging path and ``os`` in the
+    filter dict — not vice-versa."""
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(
+        _tc(
+            "list_nodes",
+            {
+                "limit": 10,
+                "include_network_detail": True,
+                "include_inactive": True,
+                "os": "Linux",
+            },
+        )
+    )
+    assert item["limit"] == 10
+    assert item["include_network_detail"] is True
+    assert item["include_inactive"] is True
+    assert item["filters"] == {"os": "Linux"}
+
+
+def test_list_nodes_prepare_nested_wins_on_key_collision(coord_session):
+    """When the model accidentally passes the same filter key both
+    nested AND flat (rare but possible mid-refactor), the canonical
+    nested form wins so the call is deterministic."""
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(
+        _tc(
+            "list_nodes",
+            {
+                "filters": {"os": "Linux"},  # canonical
+                "os": "DifferentOS",  # flat — should NOT override
+            },
+        )
+    )
+    assert item["filters"] == {"os": "Linux"}
+
+
+def test_list_nodes_prepare_mixes_nested_and_flat(coord_session):
+    """A model can split filters across both shapes.  Both contribute
+    to the final filter set; nested wins only on direct collisions."""
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(
+        _tc(
+            "list_nodes",
+            {
+                "filters": {"os": "Linux"},
+                "gpu_has_nvidia": True,
+                "memory_gb": 64,
+            },
+        )
+    )
+    assert item["filters"] == {
+        "os": "Linux",
+        "gpu_has_nvidia": True,
+        "memory_gb": 64,
+    }
+
+
+def test_list_nodes_exec_dispatches_flat_arg_filters(coord_session):
+    """End-to-end: flat-arg filters must actually flow through to the
+    coordinator client's ``list_nodes(filters=...)`` call.  The bug
+    operators reported was the filters being silently dropped on the
+    way to storage; this test pins the prepare→exec wiring."""
+    sess, coord, _ui = coord_session
+    coord.list_nodes.return_value = {"nodes": [], "truncated": False}
+    item = sess._prepare_tool(_tc("list_nodes", {"os": "Linux"}))
+    sess._exec_list_nodes(item)
+    kwargs = coord.list_nodes.call_args.kwargs
+    assert kwargs["filters"] == {"os": "Linux"}
+
+
 def test_list_nodes_prepare_clamps_limit(coord_session):
     sess, _coord, _ui = coord_session
     over = sess._prepare_tool(_tc("list_nodes", {"limit": 9999}))

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3847,9 +3847,11 @@ class ChatSession:
         #
         # All-write and all-read batches are SAFE:
         #   - Writes serialise under the per-ws lock in
-        #     ``CoordinatorClient.tasks_*``; the result is
-        #     deterministic against the input set even if the
-        #     dispatch order isn't.
+        #     ``CoordinatorClient.tasks_*``, AND a batch containing
+        #     any ``tasks`` write runs serially in input order (see
+        #     the run-loop branch below) so the final task list
+        #     ordering matches what the model emitted, not the
+        #     scheduler's acquisition order.
         #   - Reads can't race against anything.
         #
         # The rule below only fires on the MIX, so the natural
@@ -3968,8 +3970,26 @@ class ChatSession:
         if len(items) == 1:
             results = [run_one(items[0])]
         else:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                results = list(pool.map(run_one, items))
+            # When the batch contains any ``tasks`` write, run every
+            # item serially in input order.  ``tasks_add`` appends
+            # under a per-ws lock; a parallel ThreadPoolExecutor's
+            # scheduler-dependent acquisition order would otherwise
+            # produce a final task list whose ordering varies
+            # run-to-run, even though the SET of tasks is consistent.
+            # The model emitted the writes in a particular order;
+            # respecting that is the deterministic shape both
+            # operators and the model expect.  Other batches stay
+            # parallel — the perf payoff is real and there's no
+            # ordering hazard against state outside ``tasks``.
+            has_tasks_write = any(
+                it.get("func_name") == "tasks" and it.get("action") in _TASKS_WRITE_ACTIONS
+                for it in items
+            )
+            if has_tasks_write:
+                results = [run_one(it) for it in items]
+            else:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+                    results = list(pool.map(run_one, items))
 
         # Post-plan gate: iterative review loop.  When the user gives
         # feedback the plan agent re-runs and the revised plan is shown

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -203,15 +203,14 @@ _VALID_MEMORY_SCOPES: tuple[str, ...] = ("global", "workstream", "user", "coordi
 # :meth:`ChatSession._implicit_scope_walk`.
 _IMPLICIT_SCOPE_WALK: tuple[str, ...] = ("workstream", "user", "global")
 
-# Tools that MUST run alone in their assistant batch.  ``tasks`` mutates
-# its own ordered list and supports a ``list`` action that reads it
-# back; a parallel batch like ``[tasks(add=...), tasks(list)]`` has
-# unspecified ordering inside ``_execute_tools.run_one``'s
-# ThreadPoolExecutor and the read can land before or after the write.
-# Rather than warn the model in the tool description (extra cognitive
-# overhead on every call), we reject the call site explicitly when
-# the violation actually happens — see ``_execute_tools``.
-_PARALLEL_INCOMPATIBLE_TOOLS: frozenset[str] = frozenset({"tasks"})
+# ``tasks`` action classifier — partitions actions into read vs write
+# so the parallel-batch guard can permit homogeneous batches (all
+# writes serialise under the per-ws lock and converge to a consistent
+# result; all reads can't race) and reject only the mixed read+write
+# shape where ``tasks(list)`` paralleled with ``tasks(add=...)`` has
+# unspecified ordering inside ``_execute_tools``'s ThreadPoolExecutor.
+_TASKS_READ_ACTIONS: frozenset[str] = frozenset({"list"})
+_TASKS_WRITE_ACTIONS: frozenset[str] = frozenset({"add", "update", "remove", "reorder"})
 
 # Matches resource paths referenced in skill content (scripts/foo.py, etc.)
 _RESOURCE_PATH_RE = re.compile(
@@ -3829,31 +3828,47 @@ class ChatSession:
         # results).  See the docstring on this method.
         items = [self._safe_prepare_tool(tc) for tc in tool_calls]
 
-        # Reject parallel-incompatible tools when the batch has more
-        # than one call.  Some tools have read-after-write semantics
-        # against their own state (``tasks`` is the canonical
-        # example: a parallel ``add`` + ``list`` has unspecified
-        # ordering), and the prior shape relied on the model to
-        # discipline itself via a docstring warning.  Turning the
-        # silent footgun into an explicit error means the model only
-        # has to think about it the moment it actually violates the
-        # rule, not on every single tool call.  Re-emit serially in
-        # a follow-up turn.
+        # Reject the read+write mix on ``tasks`` within a single
+        # parallel batch.  ``tasks`` mutates an ordered planning
+        # list and supports a ``list`` read; a batch like
+        # ``[tasks(add=...), tasks(list)]`` has unspecified
+        # ordering inside ``_execute_tools.run_one``'s
+        # ThreadPoolExecutor — the read can land before or after
+        # the write and produce inconsistent state to the model.
+        #
+        # All-write and all-read batches are SAFE:
+        #   - Writes serialise under the per-ws lock in
+        #     ``CoordinatorClient.tasks_*``; the result is
+        #     deterministic against the input set even if the
+        #     dispatch order isn't.
+        #   - Reads can't race against anything.
+        #
+        # The rule below only fires on the MIX, so the natural
+        # batch shapes ("add four tasks at once", "list nodes +
+        # list skills + tasks(list) for a planning snapshot") are
+        # both permitted; only the genuinely-broken shape gets
+        # rejected.  Non-tasks siblings paralleled with tasks()
+        # are unaffected — they don't touch the tasks state.
         if len(items) > 1:
-            for item in items:
-                if (
-                    item.get("func_name") in _PARALLEL_INCOMPATIBLE_TOOLS
-                    and not item.get("error")
-                    and not item.get("denied")
-                ):
-                    item["error"] = (
-                        f"Error: {item['func_name']}(...) cannot be called in a "
-                        "parallel tool batch — its read-after-write ordering "
-                        "against sibling tool calls is not guaranteed. Re-emit "
-                        f"this {item['func_name']} call on its own in the next "
-                        "assistant turn."
-                    )
-                    item["needs_approval"] = False
+            tasks_items = [
+                it
+                for it in items
+                if it.get("func_name") == "tasks" and not it.get("error") and not it.get("denied")
+            ]
+            if tasks_items:
+                has_read = any(it.get("action") in _TASKS_READ_ACTIONS for it in tasks_items)
+                has_write = any(it.get("action") in _TASKS_WRITE_ACTIONS for it in tasks_items)
+                if has_read and has_write:
+                    for it in tasks_items:
+                        it["error"] = (
+                            "Error: tasks(...) read (`list`) and write "
+                            "(`add` / `update` / `remove` / `reorder`) actions "
+                            "cannot run in the same parallel tool batch — the "
+                            "read-after-write ordering is not guaranteed. "
+                            "All-reads or all-writes are fine; mix only by "
+                            "splitting them across separate assistant turns."
+                        )
+                        it["needs_approval"] = False
 
         # Intent validation (advisory, non-blocking).
         # Cancel any prior judge thread before spawning a new one.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -203,6 +203,15 @@ _VALID_MEMORY_SCOPES: tuple[str, ...] = ("global", "workstream", "user", "coordi
 # :meth:`ChatSession._implicit_scope_walk`.
 _IMPLICIT_SCOPE_WALK: tuple[str, ...] = ("workstream", "user", "global")
 
+# ``list_nodes`` reserves four top-level kwargs for control parameters
+# (filters / paging / output verbosity / liveness toggle).  Anything
+# else the model passes at the top level is treated as a flat filter
+# entry — see :meth:`ChatSession._prepare_list_nodes`.
+_LIST_NODES_RESERVED_ARGS: frozenset[str] = frozenset(
+    {"filters", "limit", "include_network_detail", "include_inactive"}
+)
+
+
 # ``tasks`` action classifier — partitions actions into read vs write
 # so the parallel-batch guard can permit homogeneous batches (all
 # writes serialise under the per-ws lock and converge to a consistent
@@ -6059,15 +6068,35 @@ class ChatSession:
     def _prepare_list_nodes(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._coord_client is None:
             return self._coord_tool_error(call_id, "list_nodes", "coordinator client unavailable")
+        # Metadata values are JSON-encoded at rest; the client handles
+        # the encode/decode so preserve the model's natural types (``4``
+        # stays an int, ``"gpu"`` stays a string) rather than
+        # stringifying here.
+        #
+        # Two accepted shapes:
+        #
+        #   list_nodes(filters={"os": "Linux"})   ← canonical, nested
+        #   list_nodes(os="Linux")                ← flat top-level args
+        #
+        # Several models drop the ``filters`` nesting and emit each
+        # filter as a top-level kwarg; the strict-nested-only shape
+        # silently degraded those calls to "no filter" and returned
+        # the full cluster, which an operator hit during shakedown
+        # ("``os="DefinitelyNotAnOS"`` returned all 10 nodes").
+        # Treating top-level non-reserved args as filters fixes the
+        # natural mistake without changing the canonical shape;
+        # nested entries still win on key collision.
         raw_filters = args.get("filters")
-        # Metadata values are JSON-encoded at rest; the client handles the
-        # encode/decode so preserve the model's natural types (``4`` stays
-        # an int, ``"gpu"`` stays a string) rather than stringifying here.
         filters: dict[str, Any] = {}
         if isinstance(raw_filters, dict):
             for k, v in raw_filters.items():
                 if isinstance(k, str) and k and isinstance(v, (str, int, float, bool)):
                     filters[k] = v
+        for k, v in args.items():
+            if k in _LIST_NODES_RESERVED_ARGS:
+                continue
+            if isinstance(k, str) and k and isinstance(v, (str, int, float, bool)):
+                filters.setdefault(k, v)
         try:
             limit = int(args.get("limit") or 100)
         except (TypeError, ValueError):


### PR DESCRIPTION
## Summary

Two coordinator-harness ergonomic fixes from an operator's shakedown session:

### 1. `tasks` parallel-batch rule scoped to read+write mix only (`13cb6a3`)

The prior rule rejected ANY `tasks(...)` call paralleled with anything. Operator hit it on the natural decompose-the-plan turn:

```
[tasks(add×4), list_nodes, list_skills, list_workstreams]
```

All-write batches serialise under the per-ws lock; all-read batches can't race. The only genuinely-broken shape is `tasks(list)` paralleled with a `tasks` mutating action — that's the only one we still reject.

### 2. `list_nodes` accepts flat-arg filters (`c5fe3e7`)

Operator reported `list_nodes(os="Linux")` returning all 10 nodes regardless of filter. Storage filter pipeline was fine (existing test pins it); bug was upstream — `_prepare_list_nodes` only honoured the canonical nested `filters={...}` shape and silently dropped flat top-level kwargs. Several models drop the nesting in practice; we now accept either shape, with nested winning on key collision.

## Behaviour matrix

| Shape | `tasks` rule | `list_nodes` filter |
|---|---|---|
| `tasks(add) × 4` | ✓ permitted | n/a |
| `tasks(list) × 2` | ✓ permitted | n/a |
| `tasks(add) + non-tasks` | ✓ permitted | n/a |
| `tasks(list) + non-tasks` | ✓ permitted | n/a |
| `tasks(add) + tasks(list)` | ✗ rejected (the actual race) | n/a |
| `list_nodes(filters={"os":"Linux"})` | n/a | ✓ filtered (canonical) |
| `list_nodes(os="Linux")` | n/a | ✓ filtered (flat — was being ignored) |
| `list_nodes(filters={"os":"Linux"}, os="X")` | n/a | nested wins → filters by `os=Linux` |

## Test plan
- [x] `pytest -m "not live"` — 4818 pass (+9 net across both fixes)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] 6 tests cover the relaxed `tasks` rule (all-write OK, all-read OK, write+sibling OK, read+sibling OK, non-tasks-only, mixed read+write rejected)
- [x] 5 tests cover `list_nodes` filter shapes (flat-only, reserved-args partition, nested-wins-collision, mix, prepare→exec wiring)
- [ ] Manual: re-run operator's `list_nodes(os="DefinitelyNotAnOS")` and confirm zero matches
- [ ] Manual: re-run `[tasks(add×4), list_nodes, list_skills, list_workstreams]` and confirm all 7 calls dispatch