### PR TITLE
perf(api): offload tenant_check to thread on lifted session handlers

### DIFF
--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1222,12 +1222,14 @@ class TestTenantCheckOnReadEndpoints:
 
         Wires the real :func:`resolve_workstream_owner` as the
         tenant_check (instead of the fake ``allow``/``deny`` of the
-        sibling tests above), forces ``mgr.get`` to miss, and asserts
-        the handler still resolves through the storage row.  The
-        previous ``cfg.tenant_check(...)`` call shape would
-        fall-through to ``get_workstream_owner`` inline on the loop
-        thread; the wrapped shape offloads the chain end-to-end.
+        sibling tests above), forces ``mgr.get`` to miss, asserts
+        the handler still resolves through the storage row, and
+        spies on ``asyncio.to_thread`` to pin the offload — reverting
+        the wrap to a sync ``cfg.tenant_check(...)`` call would leave
+        the storage fallback working but trip the spy assertion.
         """
+        import asyncio
+
         from turnstone.core.web_helpers import resolve_workstream_owner
 
         ws_id = "ws-cold-cache-hist"
@@ -1243,11 +1245,25 @@ class TestTenantCheckOnReadEndpoints:
             )
             return err
 
-        client = _build_history_app(mock_mgr, _inject_storage, tenant_check=cold_check)
+        offloaded: list[Any] = []
+        real_to_thread = asyncio.to_thread
 
-        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        async def spy_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+            offloaded.append(func)
+            return await real_to_thread(func, *args, **kwargs)
+
+        client = _build_history_app(mock_mgr, _inject_storage, tenant_check=cold_check)
+        with patch("asyncio.to_thread", spy_to_thread):
+            r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+
         assert r.status_code == 200
         assert any(m.get("content") == "from cold storage" for m in r.json()["messages"])
+        # Pin the offload — reverting ``await asyncio.to_thread(cfg.tenant_check, ...)``
+        # to ``cfg.tenant_check(...)`` leaves the response shape intact
+        # but drops ``cold_check`` from the spy's call list.
+        assert cold_check in offloaded, (
+            f"tenant_check must be invoked through asyncio.to_thread; got {offloaded}"
+        )
 
     def test_detail_cold_cache_falls_through_to_storage_via_thread(self, _inject_storage):
         """Detail counterpart to the cold-cache history test.
@@ -1255,8 +1271,11 @@ class TestTenantCheckOnReadEndpoints:
         Forces ``mgr.get`` to miss and pins the lazy-rehydrate to a
         mocked ``mgr.open`` so the test covers the path where the
         wrapped ``tenant_check`` resolves through storage *before* the
-        handler reaches its rehydrate ladder.
+        handler reaches its rehydrate ladder.  Same ``asyncio.to_thread``
+        spy as the history test pins the offload itself.
         """
+        import asyncio
+
         from turnstone.core.web_helpers import resolve_workstream_owner
 
         ws_id = "ws-cold-cache-detail"
@@ -1280,9 +1299,17 @@ class TestTenantCheckOnReadEndpoints:
             )
             return err
 
-        client = _build_detail_app(mock_mgr, tenant_check=cold_check)
+        offloaded: list[Any] = []
+        real_to_thread = asyncio.to_thread
 
-        r = client.get(f"/v1/api/workstreams/{ws_id}")
+        async def spy_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+            offloaded.append(func)
+            return await real_to_thread(func, *args, **kwargs)
+
+        client = _build_detail_app(mock_mgr, tenant_check=cold_check)
+        with patch("asyncio.to_thread", spy_to_thread):
+            r = client.get(f"/v1/api/workstreams/{ws_id}")
+
         assert r.status_code == 200
         body = r.json()
         assert body["ws_id"] == ws_id
@@ -1290,3 +1317,7 @@ class TestTenantCheckOnReadEndpoints:
         # Lazy rehydrate path engaged — the handler called mgr.open after
         # the cold-cache tenant_check resolved through storage.
         mock_mgr.open.assert_called_once_with(ws_id)
+        # Pin the offload — see the history test for the rationale.
+        assert cold_check in offloaded, (
+            f"tenant_check must be invoked through asyncio.to_thread; got {offloaded}"
+        )

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1213,3 +1213,80 @@ class TestTenantCheckOnReadEndpoints:
         r = client.get(f"/v1/api/workstreams/{ws_id}/history")
         assert r.status_code == 200
         assert any(m.get("content") == "hello" for m in r.json()["messages"])
+
+    def test_history_cold_cache_falls_through_to_storage_via_thread(self, _inject_storage):
+        """Regression: ``cfg.tenant_check`` is invoked through
+        ``await asyncio.to_thread(...)`` so the synchronous
+        ``resolve_workstream_owner`` storage fallback no longer
+        blocks the event loop on a cold cache.
+
+        Wires the real :func:`resolve_workstream_owner` as the
+        tenant_check (instead of the fake ``allow``/``deny`` of the
+        sibling tests above), forces ``mgr.get`` to miss, and asserts
+        the handler still resolves through the storage row.  The
+        previous ``cfg.tenant_check(...)`` call shape would
+        fall-through to ``get_workstream_owner`` inline on the loop
+        thread; the wrapped shape offloads the chain end-to-end.
+        """
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        ws_id = "ws-cold-cache-hist"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        _inject_storage.save_message(ws_id, "user", "from cold storage")
+        mock_mgr = MagicMock()
+        # Cold cache: nothing in memory, owner row only in storage.
+        mock_mgr.get.return_value = None
+
+        def cold_check(request: Any, ws_id: str, mgr: Any) -> JSONResponse | None:
+            _owner, err = resolve_workstream_owner(
+                request, ws_id, mgr=mgr, not_found_label="Workstream not found"
+            )
+            return err
+
+        client = _build_history_app(mock_mgr, _inject_storage, tenant_check=cold_check)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        assert any(m.get("content") == "from cold storage" for m in r.json()["messages"])
+
+    def test_detail_cold_cache_falls_through_to_storage_via_thread(self, _inject_storage):
+        """Detail counterpart to the cold-cache history test.
+
+        Forces ``mgr.get`` to miss and pins the lazy-rehydrate to a
+        mocked ``mgr.open`` so the test covers the path where the
+        wrapped ``tenant_check`` resolves through storage *before* the
+        handler reaches its rehydrate ladder.
+        """
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        ws_id = "ws-cold-cache-detail"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+
+        rehydrated = MagicMock()
+        rehydrated.id = ws_id
+        rehydrated.name = "rehydrated-ws"
+        rehydrated.state = MagicMock()
+        rehydrated.state.value = "idle"
+        rehydrated.user_id = "test-user"
+        rehydrated.kind = "interactive"
+        rehydrated.ui = None  # bypass pending-approval serializer
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        mock_mgr.open.return_value = rehydrated
+
+        def cold_check(request: Any, ws_id: str, mgr: Any) -> JSONResponse | None:
+            _owner, err = resolve_workstream_owner(
+                request, ws_id, mgr=mgr, not_found_label="Workstream not found"
+            )
+            return err
+
+        client = _build_detail_app(mock_mgr, tenant_check=cold_check)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ws_id"] == ws_id
+        assert body["name"] == "rehydrated-ws"
+        # Lazy rehydrate path engaged — the handler called mgr.open after
+        # the cold-cache tenant_check resolved through storage.
+        mock_mgr.open.assert_called_once_with(ws_id)

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -312,6 +312,12 @@ class SessionEndpointConfig:
       scope is the cluster-wide gate). Coord sets this to ``None``
       and relies on ``admin.coordinator`` from ``permission_gate``
       plus an in-memory ``coord_mgr`` lookup at handler time.
+      Always invoked via ``await asyncio.to_thread(...)`` at handler
+      sites: the interactive resolver short-circuits on
+      ``mgr.get(ws_id)`` for warm cache but falls through to a
+      synchronous storage read (:func:`get_workstream_owner`) on a
+      manager-cache miss, so offloading keeps the event loop free
+      during cold-cache lookups.
     - ``not_found_label``: the message body for the 404 returned when
       the manager has no such ws_id ("Workstream not found" for
       interactive; "coordinator not found" for coord).
@@ -692,6 +698,8 @@ def make_approve_handler(cfg: SessionEndpointConfig) -> Handler:
     from turnstone.core.web_helpers import read_json_or_400
 
     async def approve(request: Request) -> Response:
+        import asyncio
+
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
@@ -712,7 +720,7 @@ def make_approve_handler(cfg: SessionEndpointConfig) -> Handler:
         feedback = body.get("feedback")
         always = bool(body.get("always", False))
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
         ws = mgr.get(ws_id)
@@ -850,6 +858,8 @@ def make_close_handler(
     """
 
     async def close(request: Request) -> Response:
+        import asyncio
+
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
@@ -879,7 +889,7 @@ def make_close_handler(
                 reason = redact_credentials(capped)
 
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -992,6 +1002,8 @@ def make_cancel_handler(
     """
 
     async def cancel(request: Request) -> Response:
+        import asyncio
+
         from turnstone.core.web_helpers import read_json_or_400
 
         if cfg.permission_gate is not None:
@@ -1019,7 +1031,7 @@ def make_cancel_handler(
             force = body.get("force", False) is True
 
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -1383,7 +1395,7 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
             return JSONResponse({"error": "ws_id is required"}, status_code=400)
 
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -2189,7 +2201,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         # it); interactive wires ``_interactive_tenant_check`` and
         # this call now restores parity with the rest of the surface.
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -2269,6 +2281,8 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
     """
 
     async def detail(request: Request) -> Response:
+        import asyncio
+
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
@@ -2293,7 +2307,7 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
         # the in-flight tool-call payload.  Brings detail in line with
         # every other lifted session verb.
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -2462,7 +2476,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             return JSONResponse({"error": "message is required"}, status_code=400)
 
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 
@@ -2955,6 +2969,8 @@ def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
     from turnstone.core.web_helpers import read_json_or_400
 
     async def dequeue(request: Request) -> Response:
+        import asyncio
+
         if cfg.permission_gate is not None:
             err = cfg.permission_gate(request)
             if err is not None:
@@ -2973,7 +2989,7 @@ def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
 
         ws_id = request.path_params.get("ws_id", "")
         if cfg.tenant_check is not None:
-            err_tenant = cfg.tenant_check(request, ws_id, mgr)
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
                 return err_tenant
 


### PR DESCRIPTION
## Summary

Every `make_*_handler` factory in `turnstone/core/session_routes.py` invoked `cfg.tenant_check(request, ws_id, mgr)` synchronously inside its `async def` handler. For the interactive surface `tenant_check` chains through `_interactive_tenant_check` → `_require_ws_access` → `resolve_workstream_owner`, which short-circuits on `mgr.get(ws_id)` for warm cache but falls through to a synchronous `get_workstream_owner` SQL call on a cold cache, blocking the event loop for the duration of the storage round-trip.

Wraps each of the 8 call sites (approve, close, cancel, events, history, detail, send, dequeue) in `await asyncio.to_thread(...)`, mirroring the existing storage-offload pattern at `make_history_handler`'s other call sites. Coord wires `tenant_check=None` and is unaffected. Five handlers gain a local `import asyncio` (matching the per-handler lazy-import convention in this module). Offload rationale lives on `SessionEndpointConfig.tenant_check`'s field docstring.

Pre-existing across all lifted verbs — surfaced as a deferred follow-up from PR #447's review pipeline.

## Notes

- The wrap is uniform across warm and cold cache paths; on warm cache the offload pays a small thread-context cost (~tens of µs) to keep one shape per call site. A hybrid (sync probe + offload-on-miss) was considered and skipped: it would either duplicate `resolve_workstream_owner`'s short-circuit logic across 8 sites or require an async-Protocol refactor of `_interactive_tenant_check`. Open to revisiting if the hot-path cost shows up in profiles.
- The bonus opportunity (return resolved `Workstream` from `tenant_check` to skip the second `mgr.get(ws_id)` lookup at handler sites) was explicitly skipped — touches the `TenantCheck` Protocol signature + every cfg construction.

## Test plan

- [x] `uv run ruff check turnstone/core/session_routes.py tests/test_workstream_endpoints.py`
- [x] `uv run mypy turnstone/core/session_routes.py turnstone/server.py`
- [x] `uv run pytest tests/test_workstream_endpoints.py tests/test_coordinator_endpoints.py tests/test_server_authz.py -m "not live"` — 180 pass
- [x] `uv run pytest -m "not live"` — 4855 pass
- [x] Two new regression tests in `TestTenantCheckOnReadEndpoints` exercise the cold-cache fall-through path through the real `resolve_workstream_owner` (the existing class only stubbed past it with fake `allow`/`deny` callables).