### PR TITLE
fix(server): accept --skip-permissions CLI flag

### DIFF
--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3544,6 +3544,11 @@ def main() -> None:
         default=8080,
         help="Port to listen on (default: 8080)",
     )
+    parser.add_argument(
+        "--skip-permissions",
+        action="store_true",
+        help="Auto-approve all tool calls (no confirmation prompts)",
+    )
     # MCP config path is bootstrap-critical (needed before ConfigStore for tool loading)
     parser.add_argument(
         "--mcp-config",
@@ -3971,7 +3976,7 @@ def main() -> None:
         ws = manager.create(user_id="", name="resumed")
         if not isinstance(ws.ui, WebUI):
             raise TypeError(f"Expected WebUI, got {type(ws.ui).__name__}")
-        if config_store.get("tools.skip_permissions"):
+        if args.skip_permissions or config_store.get("tools.skip_permissions"):
             ws.ui.auto_approve = True
         assert ws.session is not None
         ws.session.set_watch_runner(
@@ -4009,7 +4014,7 @@ def main() -> None:
         _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.gethostname()
         _advertise_url = f"http://{_advertise_host}:{args.port}"
 
-    _skip_perms = config_store.get("tools.skip_permissions")
+    _skip_perms = args.skip_permissions or config_store.get("tools.skip_permissions")
     app = create_app(
         workstreams=manager,
         global_queue=global_queue,


### PR DESCRIPTION
## Summary

The server's `--help` epilog (`turnstone/server.py:3501`) and `compose.yaml` (lines 81, 204) both reference `--skip-permissions`, but the argparser never defined it. Any container started with `SKIP_PERMISSIONS=1` exited immediately with:

```
turnstone-server: error: unrecognized arguments: --skip-permissions
```

## Change

Wires the flag through to `app.state.skip_permissions`, OR-ing it with the existing `tools.skip_permissions` config-store setting so the stored value still works on its own. CLI-first ordering matches the prevailing idiom in `main()` (e.g. `args.api_key or os.environ.get(...)`, `mcp_config_cli or config_store.get(...)`).

One file, ~7 added / 2 modified lines. No schema, migration, API, or wire-format changes.

## Test plan

- [x] Reproduced the original `unrecognized arguments` crash with `SKIP_PERMISSIONS=1 docker compose --profile production up`
- [x] Rebuilt image with this patch — server accepts the flag, no crash
- [ ] Verify `--skip-permissions` alone (without env var) still works
- [ ] Verify `tools.skip_permissions=true` in config store still works without the flag