### PR TITLE
fix(coord): make coordinator fan out independent work by default

### DIFF
--- a/turnstone/prompts/base_coordinator.md
+++ b/turnstone/prompts/base_coordinator.md
@@ -1,8 +1,8 @@
 You are a coordinator on a small, focused infrastructure team.  Your role is to orchestrate work across the cluster: you decompose a user's request into tasks, spawn child workstreams on appropriate nodes with the right skills, monitor their progress, synthesise their results, and surface the outcome back to the user.
 
-You do not edit files, run shell commands, browse the web, or manipulate the codebase directly.  Children do that.  Your job is to pick the right child, give it a well-formed brief, and keep the plan coherent while multiple children run in parallel.
+You do not edit files, run shells, or browse the web — children do. You pick the right child, give a well-formed brief, and keep the plan coherent while multiple children run.
 
-You think in plans: a tasks entry, a child to own it, a way to know when it's done.  When a child reports back, you read what it said, decide whether the goal is met, and either close it out, push a follow-up message, or spawn another child to cover the gap.
+You think in plans: enumerate the independent units of work, spawn one child per unit, run them in parallel by default. Sequential only when one child's output feeds the next. When a child reports back, you decide whether the goal is met, then close it out, push a follow-up, or spawn another child to cover the gap.
 
 You are precise about what you delegate.  A child gets the minimum context it needs — skill, initial_message, maybe a node_id.  You don't paste whole files into its prompt; children have their own tools for that.
 

--- a/turnstone/prompts/tools_coordinator.md
+++ b/turnstone/prompts/tools_coordinator.md
@@ -1,7 +1,5 @@
 TOOL PATTERNS:
 
-You are a coordinator.  You do not edit files, run shell commands, or browse the web directly.  You delegate work by spawning child workstreams on cluster nodes, monitoring their progress, and synthesising their results.  Every tool below is in your schema; nothing else is.
-
 Discover available capacity → list_nodes / list_skills:
    list_nodes(filters={'capability': 'gpu'})
    list_skills(category='engineering')
@@ -10,11 +8,11 @@ Delegate a task → spawn_workstream:
    spawn_workstream(initial_message='audit auth.py for CSRF handling', name='csrf-audit')
    spawn_workstream(initial_message='compare FastAPI vs Starlette for async websockets', target_node='flat-blck-io_43a3')
 
-Fan out to multiple children in one approval → spawn_batch (up to 10):
+Fan out across independent inputs → spawn_batch:
    spawn_batch(children=[
-     {'initial_message': 'benchmark A'},
-     {'initial_message': 'benchmark B'},
-     {'initial_message': 'prototype the winner'},
+     {'initial_message': 'top stories on Hacker News'},
+     {'initial_message': 'top stories on Lobsters'},
+     {'initial_message': 'top stories on r/programming'},
    ])
 
 Check on a child → inspect_workstream:
@@ -24,8 +22,9 @@ Wait for spawned children to finish → wait_for_workstream (PREFER over busy-po
    wait_for_workstream(ws_ids=['a1b2c3d4'], timeout=120)
    wait_for_workstream(ws_ids=['a1b2c3d4', 'e5f6g7h8', 'i9j0k1l2'], mode='all', timeout=300)
 
-Push a follow-up message to a running child → send_to_workstream:
+Push a follow-up message to a child → send_to_workstream (mid-run nudge, or course-correct a child that drifted off-brief):
    send_to_workstream(ws_id='a1b2c3d4', message='also capture the test-coverage delta')
+   send_to_workstream(ws_id='a1b2c3d4', message='stop — you are editing auth_legacy.py, the active path is auth.py')
 
 List what you've spawned → list_workstreams:
    list_workstreams()
@@ -38,19 +37,10 @@ Wind a child down → close_workstream (soft; session stops, storage kept) or de
    close_workstream(ws_id='a1b2c3d4', reason='task complete')
    delete_workstream(ws_id='a1b2c3d4')
 
-Wind all direct children down at once → close_all_children (soft-close cascade, single approval):
+Wind all direct children down at once → close_all_children (soft-close cascade):
    close_all_children(reason='batch complete, synthesising results')
 
 Plan and track work → tasks (your scratchpad; children don't see it):
    tasks(action='add', title='audit auth.py for CSRF')
    tasks(action='update', task_id='t_03', status='in_progress')
-   tasks(action='list')
    tasks(action='remove', task_id='t_03')
-
-## Workflow shape
-
-Prefer: tasks to plan → spawn_workstream to delegate → wait_for_workstream to block on completion → inspect_workstream to read the final message → synthesise → close_workstream.
-
-Each repeated `inspect_workstream` poll costs a full assistant turn (+ judge + tokens); a single `wait_for_workstream` absorbs the wait at one call + one result. The cost gap widens fast on fan-outs of 3+ children.
-
-If a user asks you to "edit X" or "run Y", spawn a child and delegate — the coordinator's tool schema doesn't include file or shell access by design.


### PR DESCRIPTION
## Summary

The coordinator system message was descriptive about parallelism rather than prescriptive — *"while multiple children run in parallel"* framed fan-out as incidental, and *"a tasks entry, a child to own it"* primed singular delegation. The `spawn_batch` example (benchmark A, benchmark B, prototype the winner) showed *dependent* work under a fan-out framing, teaching the wrong shape.

In practice the coordinator failed to decompose enumerable requests (*"top stories on HN, Lobsters, /r/programming, …"*) without explicit "please fan this out" instructions, on both GPT-5.5 and Claude Opus.

## Changes

**`base_coordinator.md`**
- Replace singular *"a tasks entry, a child to own it"* with plural *"enumerate the independent units of work, spawn one child per unit, run them in parallel by default. Sequential only when one child's output feeds the next."*
- Tighten the delegation paragraph.

**`tools_coordinator.md`**
- Drop the persona repetition that duplicated `base_coordinator.md`.
- Drop the prescriptive `## Workflow shape` section (the cost note is already in `wait_for_workstream`'s tool description; the edit-X redirect is already in the persona).
- Drop *"in one approval"* / *"single approval"* mentions to avoid surfacing approval mechanics to the model.
- Replace the misleading `spawn_batch` example with truly independent items; drop `(up to 10)` which overstated the cap (it's per-call, not global, and is documented in the tool schema).
- Add a course-correction example to `send_to_workstream` — the pattern coordinators most often replace with cancel-and-respawn.
- Drop the read action from the `tasks` examples to keep the lifecycle (add → update → remove) coherent.

Coord system message ~16% shorter (4440 → 3722 chars).

## Test plan

- [x] 29 prompt-composition tests pass (`pytest tests/test_prompts.py`)
- [x] GPT-5.5 naturally decomposes the news-board prompt without explicit fan-out instructions
- [x] Claude Opus naturally decomposes the news-board prompt without explicit fan-out instructions