### PR TITLE
fix(coord): auto-refresh console coord_registry on model-definition changes

### DIFF
--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -1,0 +1,373 @@
+"""Console-side coord_registry auto-refresh on model-definition CRUD + reload.
+
+The console builds ``app.state.coord_registry`` once at lifespan startup
+and the coordinator session factory closes over that exact instance.
+Without these refresh hooks, an admin who edits a model definition
+through the UI sees the DB change immediately but coordinator sessions
+keep calling the prior model name — the on-disk truth diverges from the
+in-process registry until the console is restarted.
+
+These tests cover both the helper (``_refresh_console_coord_registry``)
+and the four wired endpoints (create / update / delete / explicit reload)
+to lock in:
+
+- in-place mutation: ``coord_registry`` object identity is preserved
+  across refreshes (factory closure must not be invalidated);
+- failure isolation: a load or reload failure leaves the existing
+  registry intact rather than tearing down a working coordinator;
+- no-op safety: the helper short-circuits when ``coord_registry`` is
+  ``None`` so a coord-less console (no model rows at boot) doesn't
+  500 on routine model-definition CRUD.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from turnstone.console.server import (
+    _refresh_console_coord_registry,
+    admin_create_model_definition,
+    admin_delete_model_definition,
+    admin_model_reload,
+    admin_update_model_definition,
+)
+from turnstone.core.auth import AuthResult
+from turnstone.core.model_registry import ModelConfig, ModelRegistry
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(tmp_path: Any) -> SQLiteBackend:
+    return SQLiteBackend(str(tmp_path / "models.db"))
+
+
+def _seed_model_def(
+    storage: SQLiteBackend,
+    *,
+    definition_id: str,
+    alias: str,
+    model: str,
+    base_url: str = "http://localhost:8000/v1",
+    enabled: bool = True,
+) -> None:
+    """Insert a model definition row directly via the storage API."""
+    storage.create_model_definition(
+        definition_id=definition_id,
+        alias=alias,
+        model=model,
+        provider="openai-compatible",
+        base_url=base_url,
+        api_key="sk-test",
+        context_window=8192,
+        capabilities="{}",
+        enabled=enabled,
+        created_by="admin",
+    )
+
+
+def _make_registry(*, alias: str = "local", model: str = "old-model") -> ModelRegistry:
+    """Build a real ModelRegistry seeded with one alias.
+
+    ModelRegistry.__init__ rejects an empty model dict so tests that
+    want to exercise the helper need at least one entry.
+    """
+    cfg = ModelConfig(
+        alias=alias,
+        base_url="http://localhost:8000/v1",
+        api_key="sk-test",
+        model=model,
+        context_window=8192,
+        provider="openai-compatible",
+        source="db",
+    )
+    return ModelRegistry({alias: cfg}, default=alias)
+
+
+class _AppState:
+    """Shim mirroring Starlette's ``app.state`` for direct helper tests."""
+
+    coord_registry: ModelRegistry | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests — ``_refresh_console_coord_registry`` semantics
+# ---------------------------------------------------------------------------
+
+
+def test_helper_rebuilds_registry_from_db(storage: SQLiteBackend) -> None:
+    """Helper pulls the latest DB rows into the existing registry."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="new-model")
+    state = _AppState()
+    state.coord_registry = _make_registry(alias="local", model="old-model")
+
+    _refresh_console_coord_registry(state, storage)
+
+    assert state.coord_registry is not None
+    assert state.coord_registry.get_config("local").model == "new-model"
+
+
+def test_helper_preserves_object_identity(storage: SQLiteBackend) -> None:
+    """The factory closes over the registry object — refresh must mutate
+    in place rather than swap the attribute."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="new-model")
+    state = _AppState()
+    state.coord_registry = _make_registry()
+    before = id(state.coord_registry)
+
+    _refresh_console_coord_registry(state, storage)
+
+    assert id(state.coord_registry) == before
+
+
+def test_helper_noop_when_coord_registry_none(storage: SQLiteBackend) -> None:
+    """Console boot with no model rows leaves coord_registry = None.
+    The helper must not 500 in that state — CRUD that lands the FIRST
+    row would otherwise fail before the operator can recover."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="m")
+    state = _AppState()
+    state.coord_registry = None
+
+    _refresh_console_coord_registry(state, storage)  # must not raise
+
+    assert state.coord_registry is None
+
+
+def test_helper_preserves_registry_when_load_fails(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Storage failure during rebuild must not tear down a working
+    registry — log + leave the existing instance intact."""
+    state = _AppState()
+    state.coord_registry = _make_registry(alias="local", model="old-model")
+
+    def _boom(**_kw: Any) -> ModelRegistry:
+        raise RuntimeError("simulated storage outage")
+
+    monkeypatch.setattr("turnstone.core.model_registry.load_model_registry", _boom)
+    _refresh_console_coord_registry(state, storage)
+
+    assert state.coord_registry is not None
+    assert state.coord_registry.get_config("local").model == "old-model"
+
+
+def test_helper_preserves_registry_when_no_enabled_rows(storage: SQLiteBackend) -> None:
+    """All rows disabled/deleted: ModelRegistry.__init__ rejects an empty
+    model dict (raises ValueError).  Helper must catch and preserve the
+    existing registry so coord stays usable while admin restores rows."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="m", enabled=False)
+    state = _AppState()
+    state.coord_registry = _make_registry(alias="local", model="cached-model")
+
+    _refresh_console_coord_registry(state, storage)
+
+    assert state.coord_registry is not None
+    assert state.coord_registry.get_config("local").model == "cached-model"
+
+
+def test_helper_preserves_registry_on_reload_validation_error(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reload that raises mid-mutation (e.g. validation guard) must
+    leave the existing registry instance functional."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="new-model")
+    state = _AppState()
+    state.coord_registry = _make_registry(alias="local", model="old-model")
+
+    def _broken_reload(*_a: Any, **_kw: Any) -> None:
+        raise ValueError("simulated reload validation failure")
+
+    monkeypatch.setattr(state.coord_registry, "reload", _broken_reload)
+    _refresh_console_coord_registry(state, storage)
+
+    # Existing registry still reachable; the broken reload was a no-op
+    # at the public-facing level.
+    assert state.coord_registry is not None
+    assert state.coord_registry.get_config("local").model == "old-model"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level integration tests — verify wiring
+# ---------------------------------------------------------------------------
+
+
+class _AuthMiddleware(BaseHTTPMiddleware):
+    """Inject an admin AuthResult so the permission gate passes."""
+
+    async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+        request.state.auth_result = AuthResult(
+            user_id="admin",
+            scopes=frozenset({"approve"}),
+            token_source="test",
+            permissions=frozenset({"admin.models"}),
+        )
+        return await call_next(request)
+
+
+def _make_client(storage: SQLiteBackend, registry: ModelRegistry | None) -> TestClient:
+    """Build a TestClient wired to the four model-definition endpoints."""
+    app = Starlette(
+        routes=[
+            Route(
+                "/v1/api/admin/model-definitions",
+                admin_create_model_definition,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/reload",
+                admin_model_reload,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/{definition_id}",
+                admin_update_model_definition,
+                methods=["PUT"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/{definition_id}",
+                admin_delete_model_definition,
+                methods=["DELETE"],
+            ),
+        ],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.auth_storage = storage
+    app.state.coord_registry = registry
+    # Reload endpoint also touches these — stub them so the test focuses
+    # on the registry-refresh behaviour without dragging in a full
+    # collector / proxy_client wiring.
+    app.state.collector = MagicMock()
+    app.state.collector.get_all_nodes.return_value = []
+    app.state.proxy_client = MagicMock()
+    app.state.config_store = MagicMock()
+    return TestClient(app)
+
+
+def test_create_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
+    """POST /api/admin/model-definitions bumps the in-process registry
+    so newly-spawned coord sessions see the new alias immediately."""
+    # Pre-existing alias (registry needs at least one row)
+    _seed_model_def(storage, definition_id="m1", alias="local", model="m")
+    registry = _make_registry(alias="local", model="m")
+    client = _make_client(storage, registry)
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions",
+        json={
+            "alias": "fast",
+            "model": "fast-model",
+            "provider": "openai-compatible",
+            "base_url": "http://localhost:9000/v1",
+            "api_key": "sk-x",
+            "context_window": 4096,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert registry.has_alias("fast")
+    assert registry.get_config("fast").model == "fast-model"
+
+
+def test_update_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
+    """PUT swaps the underlying model name behind a stable alias — the
+    user's reported regression."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="old-model")
+    registry = _make_registry(alias="local", model="old-model")
+    client = _make_client(storage, registry)
+
+    resp = client.put(
+        "/v1/api/admin/model-definitions/m1",
+        json={"model": "new-model"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert registry.get_config("local").model == "new-model"
+
+
+def test_update_endpoint_with_empty_body_does_not_blow_up(
+    storage: SQLiteBackend,
+) -> None:
+    """An empty PUT body skips the storage write (``if updates:``) and
+    therefore the registry refresh — registry stays at the prior state.
+    Locks the conditional so we don't accidentally do a no-op refresh
+    on every PUT (load_model_registry is non-trivial)."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="locked-in")
+    registry = _make_registry(alias="local", model="locked-in")
+    client = _make_client(storage, registry)
+
+    resp = client.put("/v1/api/admin/model-definitions/m1", json={})
+    assert resp.status_code == 200, resp.text
+    assert registry.get_config("local").model == "locked-in"
+
+
+def test_delete_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
+    """DELETE drops the alias from the in-process registry too — a
+    coord session that tried to resolve the deleted alias would
+    otherwise hit a stale cached client."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="m")
+    _seed_model_def(storage, definition_id="m2", alias="extra", model="x")
+    # Registry seeded with both so the post-delete state is checkable
+    cfg_local = ModelConfig(
+        alias="local",
+        base_url="http://localhost:8000/v1",
+        api_key="sk-test",
+        model="m",
+        context_window=8192,
+        provider="openai-compatible",
+        source="db",
+    )
+    cfg_extra = ModelConfig(
+        alias="extra",
+        base_url="http://localhost:8000/v1",
+        api_key="sk-test",
+        model="x",
+        context_window=8192,
+        provider="openai-compatible",
+        source="db",
+    )
+    registry = ModelRegistry({"local": cfg_local, "extra": cfg_extra}, default="local")
+    client = _make_client(storage, registry)
+
+    resp = client.delete("/v1/api/admin/model-definitions/m2")
+    assert resp.status_code == 200, resp.text
+    assert not registry.has_alias("extra")
+    assert registry.has_alias("local")  # default alias unaffected
+
+
+def test_reload_endpoint_refreshes_registry(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The explicit reload button must refresh the console's own
+    registry — until this PR it only fanned out to nodes."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="initial")
+    registry = _make_registry(alias="local", model="initial")
+    client = _make_client(storage, registry)
+
+    # Bypass the CRUD endpoints to mimic an out-of-band DB change (e.g.
+    # an operator psql session) and verify the explicit reload path
+    # still pulls the change in.
+    storage.update_model_definition("m1", model="reloaded-model")
+
+    # Stub the async cluster fan-out helpers — they require a fully-wired
+    # collector / proxy_client which is orthogonal to the helper under test.
+    async def _noop_publish(_request: Any) -> None:
+        return None
+
+    async def _noop_notify(_request: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr("turnstone.console.server._publish_config_change", _noop_publish)
+    monkeypatch.setattr("turnstone.console.server._notify_nodes_model_reload", _noop_notify)
+
+    resp = client.post("/v1/api/admin/model-definitions/reload")
+    assert resp.status_code == 200, resp.text
+    assert registry.get_config("local").model == "reloaded-model"

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -318,20 +318,32 @@ def test_update_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
     assert registry.get_config("local").model == "new-model"
 
 
-def test_update_endpoint_with_empty_body_does_not_blow_up(
-    storage: SQLiteBackend,
+def test_update_endpoint_skips_refresh_on_empty_body(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An empty PUT body skips the storage write (``if updates:``) and
-    therefore the registry refresh — registry stays at the prior state.
-    Locks the conditional so we don't accidentally do a no-op refresh
-    on every PUT (load_model_registry is non-trivial)."""
+    """An empty PUT body must skip the registry refresh — the
+    ``if updates:`` gate exists because ``load_model_registry`` is
+    non-trivial and a no-op refresh on every PUT would burn cycles
+    rebuilding state that hasn't changed.  Spy on the helper to lock
+    the gate down: a regression that drops the conditional would
+    register a call here and trip the assertion.
+    """
+    from turnstone.console import server as server_module
+
     _seed_model_def(storage, definition_id="m1", alias="local", model="locked-in")
     registry = _make_registry(alias="local", model="locked-in")
     client = _make_client(storage, registry)
 
+    calls: list[tuple[Any, Any]] = []
+
+    def _spy(app_state: Any, storage: Any) -> None:
+        calls.append((app_state, storage))
+
+    monkeypatch.setattr(server_module, "_refresh_console_coord_registry", _spy)
+
     resp = client.put("/v1/api/admin/model-definitions/m1", json={})
     assert resp.status_code == 200, resp.text
-    assert registry.get_config("local").model == "locked-in"
+    assert calls == []  # gate held: empty body did not trigger a refresh
 
 
 def test_delete_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -173,14 +173,15 @@ def test_helper_preserves_registry_when_load_fails(
     assert state.coord_registry.get_config("local").model == "old-model"
 
 
-def test_helper_preserves_registry_when_db_probe_fails(
+def test_helper_preserves_registry_when_strict_load_fails(
     storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``load_model_registry`` swallows storage read errors internally
-    and would return a config.toml-only registry on a transient DB
-    outage — applying that via ``reload()`` would silently drop every
-    DB-sourced alias.  The explicit probe in the helper turns that
-    failure into a no-op so the existing registry survives."""
+    """``load_model_registry`` normally swallows storage read errors and
+    would return a config.toml-only registry on a transient DB outage —
+    applying that via ``reload()`` would silently drop every DB-sourced
+    alias.  The helper passes ``strict=True`` so the loader re-raises
+    instead, the helper's outer except catches it, and the existing
+    registry survives intact."""
     _seed_model_def(storage, definition_id="m1", alias="local", model="db-model")
     state = _AppState()
     state.coord_registry = _make_registry(alias="local", model="db-model")
@@ -192,8 +193,9 @@ def test_helper_preserves_registry_when_db_probe_fails(
     _refresh_coord_registry(state, storage)
 
     assert state.coord_registry is not None
-    # Existing registry untouched — the probe caught the failure before
-    # the loader's silent fallback could mutate registry state.
+    # Existing registry untouched — strict=True surfaced the storage
+    # error to the helper before the loader's silent fallback could
+    # produce a truncated registry for reload().
     assert state.coord_registry.get_config("local").model == "db-model"
 
 

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -7,7 +7,7 @@ through the UI sees the DB change immediately but coordinator sessions
 keep calling the prior model name — the on-disk truth diverges from the
 in-process registry until the console is restarted.
 
-These tests cover both the helper (``_refresh_console_coord_registry``)
+These tests cover both the helper (``_refresh_coord_registry``)
 and the four wired endpoints (create / update / delete / explicit reload)
 to lock in:
 
@@ -28,18 +28,17 @@ from unittest.mock import MagicMock
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from tests._coord_test_helpers import _AuthMiddleware
 from turnstone.console.server import (
-    _refresh_console_coord_registry,
+    _refresh_coord_registry,
     admin_create_model_definition,
     admin_delete_model_definition,
     admin_model_reload,
     admin_update_model_definition,
 )
-from turnstone.core.auth import AuthResult
 from turnstone.core.model_registry import ModelConfig, ModelRegistry
 from turnstone.core.storage._sqlite import SQLiteBackend
 
@@ -77,13 +76,8 @@ def _seed_model_def(
     )
 
 
-def _make_registry(*, alias: str = "local", model: str = "old-model") -> ModelRegistry:
-    """Build a real ModelRegistry seeded with one alias.
-
-    ModelRegistry.__init__ rejects an empty model dict so tests that
-    want to exercise the helper need at least one entry.
-    """
-    cfg = ModelConfig(
+def _make_config(alias: str, model: str) -> ModelConfig:
+    return ModelConfig(
         alias=alias,
         base_url="http://localhost:8000/v1",
         api_key="sk-test",
@@ -92,7 +86,23 @@ def _make_registry(*, alias: str = "local", model: str = "old-model") -> ModelRe
         provider="openai-compatible",
         source="db",
     )
-    return ModelRegistry({alias: cfg}, default=alias)
+
+
+def _make_registry(
+    *,
+    alias: str = "local",
+    model: str = "old-model",
+    extras: dict[str, str] | None = None,
+) -> ModelRegistry:
+    """Build a real ModelRegistry seeded with ``alias`` (the default) plus
+    any ``extras`` (alias → model).  ``ModelRegistry.__init__`` rejects an
+    empty model dict so tests that exercise the helper need at least one
+    entry; pass ``extras`` for multi-alias scenarios (e.g. delete-by-alias).
+    """
+    configs = {alias: _make_config(alias, model)}
+    for extra_alias, extra_model in (extras or {}).items():
+        configs[extra_alias] = _make_config(extra_alias, extra_model)
+    return ModelRegistry(configs, default=alias)
 
 
 class _AppState:
@@ -102,7 +112,7 @@ class _AppState:
 
 
 # ---------------------------------------------------------------------------
-# Helper-level tests — ``_refresh_console_coord_registry`` semantics
+# Helper-level tests — ``_refresh_coord_registry`` semantics
 # ---------------------------------------------------------------------------
 
 
@@ -112,7 +122,7 @@ def test_helper_rebuilds_registry_from_db(storage: SQLiteBackend) -> None:
     state = _AppState()
     state.coord_registry = _make_registry(alias="local", model="old-model")
 
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     assert state.coord_registry is not None
     assert state.coord_registry.get_config("local").model == "new-model"
@@ -126,7 +136,7 @@ def test_helper_preserves_object_identity(storage: SQLiteBackend) -> None:
     state.coord_registry = _make_registry()
     before = id(state.coord_registry)
 
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     assert id(state.coord_registry) == before
 
@@ -139,7 +149,7 @@ def test_helper_noop_when_coord_registry_none(storage: SQLiteBackend) -> None:
     state = _AppState()
     state.coord_registry = None
 
-    _refresh_console_coord_registry(state, storage)  # must not raise
+    _refresh_coord_registry(state, storage)  # must not raise
 
     assert state.coord_registry is None
 
@@ -157,7 +167,7 @@ def test_helper_preserves_registry_when_load_fails(
         raise RuntimeError("simulated loader failure")
 
     monkeypatch.setattr("turnstone.core.model_registry.load_model_registry", _boom)
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     assert state.coord_registry is not None
     assert state.coord_registry.get_config("local").model == "old-model"
@@ -179,7 +189,7 @@ def test_helper_preserves_registry_when_db_probe_fails(
         raise RuntimeError("simulated transient DB outage")
 
     monkeypatch.setattr(storage, "list_model_definitions", _broken)
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     assert state.coord_registry is not None
     # Existing registry untouched — the probe caught the failure before
@@ -195,7 +205,7 @@ def test_helper_preserves_registry_when_no_enabled_rows(storage: SQLiteBackend) 
     state = _AppState()
     state.coord_registry = _make_registry(alias="local", model="cached-model")
 
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     assert state.coord_registry is not None
     assert state.coord_registry.get_config("local").model == "cached-model"
@@ -214,7 +224,7 @@ def test_helper_preserves_registry_on_reload_validation_error(
         raise ValueError("simulated reload validation failure")
 
     monkeypatch.setattr(state.coord_registry, "reload", _broken_reload)
-    _refresh_console_coord_registry(state, storage)
+    _refresh_coord_registry(state, storage)
 
     # Existing registry still reachable; the broken reload was a no-op
     # at the public-facing level.
@@ -227,21 +237,13 @@ def test_helper_preserves_registry_on_reload_validation_error(
 # ---------------------------------------------------------------------------
 
 
-class _AuthMiddleware(BaseHTTPMiddleware):
-    """Inject an admin AuthResult so the permission gate passes."""
-
-    async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
-        request.state.auth_result = AuthResult(
-            user_id="admin",
-            scopes=frozenset({"approve"}),
-            token_source="test",
-            permissions=frozenset({"admin.models"}),
-        )
-        return await call_next(request)
-
-
 def _make_client(storage: SQLiteBackend, registry: ModelRegistry | None) -> TestClient:
-    """Build a TestClient wired to the four model-definition endpoints."""
+    """Build a TestClient wired to the four model-definition endpoints.
+
+    Uses the shared header-driven ``_AuthMiddleware`` from
+    ``tests/_coord_test_helpers``; default headers below grant
+    ``admin.models`` permission so the endpoint gate passes.
+    """
     app = Starlette(
         routes=[
             Route(
@@ -276,7 +278,9 @@ def _make_client(storage: SQLiteBackend, registry: ModelRegistry | None) -> Test
     app.state.collector.get_all_nodes.return_value = []
     app.state.proxy_client = MagicMock()
     app.state.config_store = MagicMock()
-    return TestClient(app)
+    client = TestClient(app)
+    client.headers.update({"X-Test-User": "admin", "X-Test-Perms": "admin.models"})
+    return client
 
 
 def test_create_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
@@ -339,7 +343,7 @@ def test_update_endpoint_skips_refresh_on_empty_body(
     def _spy(app_state: Any, storage: Any) -> None:
         calls.append((app_state, storage))
 
-    monkeypatch.setattr(server_module, "_refresh_console_coord_registry", _spy)
+    monkeypatch.setattr(server_module, "_refresh_coord_registry", _spy)
 
     resp = client.put("/v1/api/admin/model-definitions/m1", json={})
     assert resp.status_code == 200, resp.text
@@ -352,26 +356,7 @@ def test_delete_endpoint_refreshes_registry(storage: SQLiteBackend) -> None:
     otherwise hit a stale cached client."""
     _seed_model_def(storage, definition_id="m1", alias="local", model="m")
     _seed_model_def(storage, definition_id="m2", alias="extra", model="x")
-    # Registry seeded with both so the post-delete state is checkable
-    cfg_local = ModelConfig(
-        alias="local",
-        base_url="http://localhost:8000/v1",
-        api_key="sk-test",
-        model="m",
-        context_window=8192,
-        provider="openai-compatible",
-        source="db",
-    )
-    cfg_extra = ModelConfig(
-        alias="extra",
-        base_url="http://localhost:8000/v1",
-        api_key="sk-test",
-        model="x",
-        context_window=8192,
-        provider="openai-compatible",
-        source="db",
-    )
-    registry = ModelRegistry({"local": cfg_local, "extra": cfg_extra}, default="local")
+    registry = _make_registry(alias="local", model="m", extras={"extra": "x"})
     client = _make_client(storage, registry)
 
     resp = client.delete("/v1/api/admin/model-definitions/m2")

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -147,19 +147,44 @@ def test_helper_noop_when_coord_registry_none(storage: SQLiteBackend) -> None:
 def test_helper_preserves_registry_when_load_fails(
     storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Storage failure during rebuild must not tear down a working
+    """An unexpected error from ``load_model_registry`` (e.g. config.toml
+    parse failure, programming bug) must not tear down a working
     registry — log + leave the existing instance intact."""
     state = _AppState()
     state.coord_registry = _make_registry(alias="local", model="old-model")
 
     def _boom(**_kw: Any) -> ModelRegistry:
-        raise RuntimeError("simulated storage outage")
+        raise RuntimeError("simulated loader failure")
 
     monkeypatch.setattr("turnstone.core.model_registry.load_model_registry", _boom)
     _refresh_console_coord_registry(state, storage)
 
     assert state.coord_registry is not None
     assert state.coord_registry.get_config("local").model == "old-model"
+
+
+def test_helper_preserves_registry_when_db_probe_fails(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``load_model_registry`` swallows storage read errors internally
+    and would return a config.toml-only registry on a transient DB
+    outage — applying that via ``reload()`` would silently drop every
+    DB-sourced alias.  The explicit probe in the helper turns that
+    failure into a no-op so the existing registry survives."""
+    _seed_model_def(storage, definition_id="m1", alias="local", model="db-model")
+    state = _AppState()
+    state.coord_registry = _make_registry(alias="local", model="db-model")
+
+    def _broken(**_kw: Any) -> Any:
+        raise RuntimeError("simulated transient DB outage")
+
+    monkeypatch.setattr(storage, "list_model_definitions", _broken)
+    _refresh_console_coord_registry(state, storage)
+
+    assert state.coord_registry is not None
+    # Existing registry untouched — the probe caught the failure before
+    # the loader's silent fallback could mutate registry state.
+    assert state.coord_registry.get_config("local").model == "db-model"
 
 
 def test_helper_preserves_registry_when_no_enabled_rows(storage: SQLiteBackend) -> None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -770,16 +770,76 @@ class TestRegistryReload:
         assert reg.has_alias("b")
         assert reg.default == "b"
 
-    def test_reload_clears_clients(self) -> None:
-        models = {"a": ModelConfig("a", "http://x/v1", "key", "m")}
+    def test_reload_keeps_clients_when_connection_target_unchanged(self) -> None:
+        """Selective teardown: a model edit that leaves base_url / api_key /
+        provider intact (e.g. admin tweaks the underlying ``model`` name or
+        ``temperature``) keeps the cached HTTP client warm — no need to
+        re-establish TLS+pool when the endpoint is the same."""
+        models = {"a": ModelConfig("a", "http://x/v1", "key", "m1", provider="openai")}
         reg = ModelRegistry(models=models, default="a")
-        # Force client creation
         reg.get_client("a")
-        assert "a" in reg._clients
+        client_before = reg._clients["a"]
+        provider_before = reg.get_provider("a")
 
-        # Reload with same models — clients should be cleared
-        reg.reload(dict(models), "a")
+        # Same endpoint (base_url, api_key, provider), only ``model`` changed.
+        new_models = {"a": ModelConfig("a", "http://x/v1", "key", "m2", provider="openai")}
+        reg.reload(new_models, "a")
+
+        assert "a" in reg._clients
+        assert reg._clients["a"] is client_before
+        assert "a" in reg._providers
+        assert reg._providers["a"] is provider_before
+
+    def test_reload_drops_client_when_base_url_changes(self) -> None:
+        """A ``base_url`` change drops the cached client (different
+        endpoint = new connection) but keeps the cached provider —
+        ``LLMProvider`` is keyed only on the provider string, which
+        didn't change."""
+        models = {"a": ModelConfig("a", "http://x/v1", "key", "m", provider="openai")}
+        reg = ModelRegistry(models=models, default="a")
+        reg.get_client("a")
+        provider_before = reg.get_provider("a")
+
+        new_models = {"a": ModelConfig("a", "http://y/v1", "key", "m", provider="openai")}
+        reg.reload(new_models, "a")
+
         assert "a" not in reg._clients
+        assert "a" in reg._providers
+        assert reg._providers["a"] is provider_before
+
+    def test_reload_drops_provider_when_provider_string_changes(self) -> None:
+        """A provider-type swap (e.g. openai → anthropic) drops both the
+        client AND the provider so the next resolve picks up the right
+        ``LLMProvider`` implementation against the new SDK."""
+        models = {"a": ModelConfig("a", "http://x/v1", "key", "m", provider="openai")}
+        reg = ModelRegistry(models=models, default="a")
+        reg.get_client("a")
+        reg.get_provider("a")
+
+        new_models = {"a": ModelConfig("a", "http://x/v1", "key", "m", provider="anthropic")}
+        reg.reload(new_models, "a")
+
+        assert "a" not in reg._clients
+        assert "a" not in reg._providers
+
+    def test_reload_drops_clients_for_removed_aliases(self) -> None:
+        """Aliases removed from the registry must release their cached
+        clients — otherwise a deleted endpoint's connection pool would
+        outlive the alias indefinitely."""
+        models = {
+            "a": ModelConfig("a", "http://x/v1", "key", "m"),
+            "b": ModelConfig("b", "http://y/v1", "key", "m"),
+        }
+        reg = ModelRegistry(models=models, default="a")
+        reg.get_client("a")
+        reg.get_client("b")
+
+        # Drop "b" entirely.
+        new_models = {"a": ModelConfig("a", "http://x/v1", "key", "m")}
+        reg.reload(new_models, "a")
+
+        assert "a" in reg._clients  # unchanged endpoint, kept warm
+        assert "b" not in reg._clients
 
     def test_reload_validates_default(self) -> None:
         models_a = {"a": ModelConfig("a", "x", "x", "m")}

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7996,6 +7996,71 @@ async def _collect_model_status(
     return {nid: models for nid, models in results if models is not None}
 
 
+def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
+    """Rebuild ``app_state.coord_registry`` in place from DB model definitions.
+
+    The console-side coordinator session factory closes over the
+    ``coord_registry`` instance built at lifespan startup
+    (see ``console/server.py``'s lifespan setup and
+    ``console/session_factory.py``).  Replacing the attribute would
+    orphan the closure — new sessions would still resolve through the
+    stale object.  Mutating in place via ``ModelRegistry.reload()``
+    preserves identity, so:
+
+    - new coordinator sessions see the new state at create-time;
+    - active coordinator sessions auto-pick up the swap at next ``send()``
+      via ``ChatSession._refresh_model_from_registry`` (the per-send
+      check compares ``cfg.model`` against ``self.model`` and re-resolves
+      on mismatch).
+
+    No-op when ``coord_registry`` is ``None`` — lifespan typically leaves
+    it unset only when no model rows existed at boot; admins fix that
+    via the model-definitions UI, then click reload (which has its own
+    boot-from-empty story).
+
+    Errors are logged + swallowed.  The DB write that triggered this
+    refresh has already succeeded, and the explicit reload button
+    remains the user-facing recovery path.  Validation failures
+    (e.g. admin deleted the alias that ``registry.default`` points at)
+    leave the existing registry intact rather than tearing down a
+    working coordinator.
+    """
+    from turnstone.core.model_registry import load_model_registry
+
+    existing = getattr(app_state, "coord_registry", None)
+    if existing is None:
+        return
+    try:
+        new_registry = load_model_registry(storage=storage)
+    except ValueError:
+        # All rows disabled/deleted — ModelRegistry.__init__ rejects an
+        # empty model dict.  Leave the existing registry in place so
+        # active coord sessions stay usable; the operator will see the
+        # empty state in the model-definitions UI.
+        log.warning("console.coord_registry_refresh_skipped reason=no_enabled_rows")
+        return
+    except Exception:
+        log.warning("console.coord_registry_refresh_load_failed", exc_info=True)
+        return
+    try:
+        existing.reload(
+            new_registry.models,
+            new_registry.default,
+            new_registry.fallback,
+            new_registry.agent_model,
+            plan_model=new_registry.plan_model,
+            task_model=new_registry.task_model,
+            plan_effort=new_registry.plan_effort,
+            task_effort=new_registry.task_effort,
+        )
+    except Exception:
+        log.warning("console.coord_registry_refresh_reload_failed", exc_info=True)
+    finally:
+        # Close any clients the throwaway registry created during DB
+        # load, regardless of whether the in-place reload succeeded.
+        new_registry.shutdown()
+
+
 async def _notify_nodes_model_reload(request: Request) -> dict[str, Any]:
     """Tell all nodes to re-read model definitions from DB and rebuild registry."""
     collector: ClusterCollector = request.app.state.collector
@@ -8232,6 +8297,8 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         ip,
     )
 
+    _refresh_console_coord_registry(request.app.state, storage)
+
     created = storage.get_model_definition(definition_id)
     if created is None:
         return JSONResponse(
@@ -8389,6 +8456,9 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
         ip,
     )
 
+    if updates:
+        _refresh_console_coord_registry(request.app.state, storage)
+
     model_def = storage.get_model_definition(definition_id)
     return JSONResponse(_mask_model_secrets(model_def or {}))
 
@@ -8424,6 +8494,8 @@ async def admin_delete_model_definition(request: Request) -> JSONResponse:
         ip,
     )
 
+    _refresh_console_coord_registry(request.app.state, storage)
+
     return JSONResponse({"status": "ok", "definition_id": definition_id})
 
 
@@ -8442,6 +8514,13 @@ async def admin_model_reload(request: Request) -> JSONResponse:
     # Ensure config (including model.default_alias) is fresh on all nodes
     # before they rebuild their model registries.
     await _publish_config_change(request)
+
+    # Refresh the console's own coord_registry first.  The node fan-out
+    # below carries DB→nodes propagation; the console hosts coordinator
+    # sessions itself and must mutate its in-process registry too —
+    # otherwise the coord LLM keeps calling the prior model name even
+    # after a successful reload.
+    _refresh_console_coord_registry(request.app.state, storage)
 
     results = await _notify_nodes_model_reload(request)
     return JSONResponse({"status": "ok", "results": results})

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -8013,10 +8013,13 @@ def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
       check compares ``cfg.model`` against ``self.model`` and re-resolves
       on mismatch).
 
-    No-op when ``coord_registry`` is ``None`` — lifespan typically leaves
-    it unset only when no model rows existed at boot; admins fix that
-    via the model-definitions UI, then click reload (which has its own
-    boot-from-empty story).
+    No-op when ``coord_registry`` is ``None``.  Lifespan only sets it
+    when DB model rows existed at boot; with no rows the entire coord
+    subsystem stays disabled (no ``coord_mgr``, no ``coord_adapter``,
+    no ``session_factory`` — see the lifespan setup in this module).
+    Bootstrapping that whole stack on the fly is out of scope for this
+    helper, so a console restart remains required after the operator
+    adds the first model row.
 
     Errors are logged + swallowed.  The DB write that triggered this
     refresh has already succeeded, and the explicit reload button
@@ -8024,11 +8027,26 @@ def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
     (e.g. admin deleted the alias that ``registry.default`` points at)
     leave the existing registry intact rather than tearing down a
     working coordinator.
+
+    DB read failures are detected by an explicit probe before calling
+    ``load_model_registry``: the loader swallows storage errors
+    internally and would otherwise return a config.toml-only registry,
+    which would silently drop DB-sourced aliases when applied via
+    ``ModelRegistry.reload``.
     """
     from turnstone.core.model_registry import load_model_registry
 
     existing = getattr(app_state, "coord_registry", None)
     if existing is None:
+        return
+    # Strict DB probe — load_model_registry swallows storage errors
+    # internally (logs + continues with config.toml-only models).  Without
+    # this fail-fast, a transient DB outage would let the helper apply a
+    # truncated registry that drops every DB-sourced alias.
+    try:
+        storage.list_model_definitions(enabled_only=True)
+    except Exception:
+        log.warning("console.coord_registry_refresh_db_probe_failed", exc_info=True)
         return
     try:
         new_registry = load_model_registry(storage=storage)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7996,7 +7996,7 @@ async def _collect_model_status(
     return {nid: models for nid, models in results if models is not None}
 
 
-def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
+def _refresh_coord_registry(app_state: Any, storage: Any) -> None:
     """Rebuild ``app_state.coord_registry`` in place from DB model definitions.
 
     The console-side coordinator session factory closes over the
@@ -8303,7 +8303,7 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         ip,
     )
 
-    _refresh_console_coord_registry(request.app.state, storage)
+    await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
 
     created = storage.get_model_definition(definition_id)
     if created is None:
@@ -8463,7 +8463,7 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
     )
 
     if updates:
-        _refresh_console_coord_registry(request.app.state, storage)
+        await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
 
     model_def = storage.get_model_definition(definition_id)
     return JSONResponse(_mask_model_secrets(model_def or {}))
@@ -8500,7 +8500,7 @@ async def admin_delete_model_definition(request: Request) -> JSONResponse:
         ip,
     )
 
-    _refresh_console_coord_registry(request.app.state, storage)
+    await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
 
     return JSONResponse({"status": "ok", "definition_id": definition_id})
 
@@ -8526,7 +8526,7 @@ async def admin_model_reload(request: Request) -> JSONResponse:
     # sessions itself and must mutate its in-process registry too —
     # otherwise the coord LLM keeps calling the prior model name even
     # after a successful reload.
-    _refresh_console_coord_registry(request.app.state, storage)
+    await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
 
     results = await _notify_nodes_model_reload(request)
     return JSONResponse({"status": "ok", "results": results})

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -8033,12 +8033,13 @@ def _refresh_coord_registry(app_state: Any, storage: Any) -> None:
         # and ``existing.reload()`` would silently drop every DB-sourced
         # alias.
         new_registry = load_model_registry(storage=storage, strict=True)
-    except ValueError:
-        # All rows disabled/deleted — ModelRegistry.__init__ rejects an
-        # empty model dict.  Leave the existing registry in place so
-        # active coord sessions stay usable; the operator will see the
-        # empty state in the model-definitions UI.
-        log.warning("console.coord_registry_refresh_skipped reason=no_enabled_rows")
+    except ValueError as exc:
+        # ModelRegistry.__init__ raises ValueError for several distinct
+        # config issues — empty models, default/fallback/agent/plan/task
+        # alias not present in the loaded set.  Log the actual reason so
+        # operators can tell "no enabled rows" from "default alias typo
+        # in config.toml".  Existing registry stays in place either way.
+        log.warning("console.coord_registry_refresh_skipped reason=%s", exc)
         return
     except Exception:
         log.warning("console.coord_registry_refresh_load_failed", exc_info=True)
@@ -8057,10 +8058,14 @@ def _refresh_coord_registry(app_state: Any, storage: Any) -> None:
     except Exception:
         log.warning("console.coord_registry_refresh_reload_failed", exc_info=True)
     finally:
-        # Close any clients the throwaway registry created during DB load.
-        # An exception here would otherwise escape after a successful
-        # in-place reload, surfacing as 500 with the registry actually
-        # mutated and the audit row recording success.
+        # Defensive — load_model_registry doesn't eagerly create clients
+        # (ModelRegistry.__init__ leaves _clients/_providers empty; they
+        # populate lazily on first resolve), so shutdown() iterates empty
+        # dicts in practice.  Kept against the day the loader grows
+        # eager-init or a future caller pre-warms the throwaway, and
+        # wrapped because shutdown() in finally would otherwise escape
+        # after a successful in-place reload — surfacing as 500 with the
+        # registry actually mutated and the audit row recording success.
         try:
             new_registry.shutdown()
         except Exception:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -8001,11 +8001,10 @@ def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
 
     The console-side coordinator session factory closes over the
     ``coord_registry`` instance built at lifespan startup
-    (see ``console/server.py``'s lifespan setup and
-    ``console/session_factory.py``).  Replacing the attribute would
-    orphan the closure — new sessions would still resolve through the
-    stale object.  Mutating in place via ``ModelRegistry.reload()``
-    preserves identity, so:
+    (see this module's lifespan setup and ``console/session_factory.py``).
+    Replacing the attribute would orphan the closure — new sessions would
+    still resolve through the stale object.  Mutating in place via
+    ``ModelRegistry.reload()`` preserves identity, so:
 
     - new coordinator sessions see the new state at create-time;
     - active coordinator sessions auto-pick up the swap at next ``send()``
@@ -8013,43 +8012,27 @@ def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
       check compares ``cfg.model`` against ``self.model`` and re-resolves
       on mismatch).
 
-    No-op when ``coord_registry`` is ``None``.  Lifespan only sets it
-    when DB model rows existed at boot; with no rows the entire coord
-    subsystem stays disabled (no ``coord_mgr``, no ``coord_adapter``,
-    no ``session_factory`` — see the lifespan setup in this module).
-    Bootstrapping that whole stack on the fly is out of scope for this
-    helper, so a console restart remains required after the operator
-    adds the first model row.
-
     Errors are logged + swallowed.  The DB write that triggered this
     refresh has already succeeded, and the explicit reload button
     remains the user-facing recovery path.  Validation failures
     (e.g. admin deleted the alias that ``registry.default`` points at)
     leave the existing registry intact rather than tearing down a
     working coordinator.
-
-    DB read failures are detected by an explicit probe before calling
-    ``load_model_registry``: the loader swallows storage errors
-    internally and would otherwise return a config.toml-only registry,
-    which would silently drop DB-sourced aliases when applied via
-    ``ModelRegistry.reload``.
     """
     from turnstone.core.model_registry import load_model_registry
 
     existing = getattr(app_state, "coord_registry", None)
     if existing is None:
-        return
-    # Strict DB probe — load_model_registry swallows storage errors
-    # internally (logs + continues with config.toml-only models).  Without
-    # this fail-fast, a transient DB outage would let the helper apply a
-    # truncated registry that drops every DB-sourced alias.
-    try:
-        storage.list_model_definitions(enabled_only=True)
-    except Exception:
-        log.warning("console.coord_registry_refresh_db_probe_failed", exc_info=True)
+        # Lifespan didn't build a coord_registry (no DB model rows at boot)
+        # — the entire coord subsystem stayed uninitialized, so a console
+        # restart is required after the operator adds the first row.
         return
     try:
-        new_registry = load_model_registry(storage=storage)
+        # ``strict=True`` so a transient DB read error surfaces here.
+        # Without it, the loader degrades to a config.toml-only registry
+        # and ``existing.reload()`` would silently drop every DB-sourced
+        # alias.
+        new_registry = load_model_registry(storage=storage, strict=True)
     except ValueError:
         # All rows disabled/deleted — ModelRegistry.__init__ rejects an
         # empty model dict.  Leave the existing registry in place so
@@ -8074,9 +8057,14 @@ def _refresh_console_coord_registry(app_state: Any, storage: Any) -> None:
     except Exception:
         log.warning("console.coord_registry_refresh_reload_failed", exc_info=True)
     finally:
-        # Close any clients the throwaway registry created during DB
-        # load, regardless of whether the in-place reload succeeded.
-        new_registry.shutdown()
+        # Close any clients the throwaway registry created during DB load.
+        # An exception here would otherwise escape after a successful
+        # in-place reload, surfacing as 500 with the registry actually
+        # mutated and the audit row recording success.
+        try:
+            new_registry.shutdown()
+        except Exception:
+            log.warning("console.coord_registry_refresh_shutdown_failed", exc_info=True)
 
 
 async def _notify_nodes_model_reload(request: Request) -> dict[str, Any]:

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -230,6 +230,7 @@ class ModelRegistry:
         if task_model and task_model not in models:
             raise ValueError(f"Task model '{task_model}' not found in registry")
         with self._client_lock:
+            old_models = self._models
             self._models = dict(models)
             self.default = default
             self.fallback = list(fallback) if fallback else []
@@ -238,11 +239,32 @@ class ModelRegistry:
             self.task_model = task_model
             self.plan_effort = plan_effort
             self.task_effort = task_effort
-            for client in self._clients.values():
-                if hasattr(client, "close"):
-                    client.close()
-            self._clients.clear()
-            self._providers.clear()
+            # Selective teardown — close + drop only clients whose
+            # connection target actually changed (alias removed, or
+            # base_url / api_key / provider differs).  Keeps connection
+            # pools warm for the common admin-edit case where only
+            # ``model`` / ``temperature`` / ``context_window`` changed.
+            for alias, client in list(self._clients.items()):
+                old_cfg = old_models.get(alias)
+                new_cfg = self._models.get(alias)
+                if (
+                    new_cfg is None
+                    or old_cfg is None
+                    or old_cfg.base_url != new_cfg.base_url
+                    or old_cfg.api_key != new_cfg.api_key
+                    or old_cfg.provider != new_cfg.provider
+                ):
+                    if hasattr(client, "close"):
+                        client.close()
+                    del self._clients[alias]
+            # Providers are keyed on alias but only depend on
+            # ``cfg.provider`` — drop only when the provider string
+            # changed or the alias was removed.
+            for alias in list(self._providers.keys()):
+                old_cfg = old_models.get(alias)
+                new_cfg = self._models.get(alias)
+                if new_cfg is None or old_cfg is None or old_cfg.provider != new_cfg.provider:
+                    del self._providers[alias]
 
     def shutdown(self) -> None:
         """Close all cached client connections."""

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -300,6 +300,7 @@ def load_model_registry(
     context_window: int = 32768,
     provider: str = "openai",
     storage: Any | None = None,
+    strict: bool = False,
 ) -> ModelRegistry:
     """Build a ModelRegistry from CLI args, ``config.toml``, and database.
 
@@ -317,6 +318,15 @@ def load_model_registry(
        ``[model].plan_effort``, ``[model].task_effort`` control routing.
        ``plan_model``/``task_model`` override ``agent_model`` per sub-agent
        role; both fall back to it when unset.
+
+    ``strict``: when True, a storage read failure during the DB-rows step
+    re-raises instead of degrading to a config.toml-only registry.
+    Callers that hot-reload an existing registry need this so a transient
+    DB outage doesn't silently drop every DB-sourced alias when the
+    truncated result is applied via ``ModelRegistry.reload``.  Callers
+    that build a fresh registry from scratch (CLI, lifespan startup) want
+    the default behaviour — boot succeeds with a config-only fallback
+    rather than crashing on a flaky DB.
     """
     import json as _json
 
@@ -370,6 +380,8 @@ def load_model_registry(
                     server_compat=row_server_compat,
                 )
         except Exception:
+            if strict:
+                raise
             log.warning("Failed to load model definitions from storage", exc_info=True)
 
     # 2. Build configs from [models.*] sections (overrides DB for same alias)


### PR DESCRIPTION
## Summary

The console builds `app.state.coord_registry` once at lifespan startup and the coordinator session factory closes over that exact instance. Until this PR, the model-definition admin endpoints (create / update / delete) wrote to the DB but never touched the in-process registry — and the explicit reload button only fanned out to **nodes** via HTTP, also leaving the console's own registry stale.

**Symptom**: an operator who changed the underlying model name behind a local-LLM alias (same alias, same endpoint) saw the DB row update immediately, but coordinator sessions kept calling the prior model name until the console process was restarted.

## Approach

A new helper `_refresh_console_coord_registry` rebuilds a fresh `ModelRegistry` from DB and applies it to `app.state.coord_registry` via the existing thread-safe `ModelRegistry.reload()` — **in-place mutation preserves object identity** so the factory closure keeps working, and active coord sessions auto-pick up the swap on their next `send()` via `ChatSession._refresh_model_from_registry` (the per-send check compares `cfg.model` against `self.model` and re-resolves on mismatch).

### Wired into

- `admin_create_model_definition` — after the DB write
- `admin_update_model_definition` — after the DB write, gated on `if updates:` so a no-op PUT skips the rebuild
- `admin_delete_model_definition` — after the DB write
- `admin_model_reload` — between `_publish_config_change` and `_notify_nodes_model_reload`, so the console mirrors what the reload broadcasts to nodes

### Failure isolation

A load or reload error leaves the existing registry intact (logged + swallowed). Coord stays usable while the operator investigates; the explicit reload remains the user-facing recovery path.

### Not in scope

**No node fan-out on CRUD.** The explicit reload button continues to gate cluster-wide HTTP propagation, preserving today's UX semantics on shared clusters. CRUD endpoints write-only-to-DB; admins still click reload to push to nodes.

## Test plan

- [x] **Helper-level** (`tests/test_admin_model_registry_refresh.py`):
  - rebuild from DB
  - object-identity preservation (factory closure invariant)
  - no-op when `coord_registry is None` (coord-less console)
  - preserve existing on `load_model_registry` failure
  - preserve existing on no-enabled-rows `ValueError`
  - preserve existing on `reload()` validation error
- [x] **Endpoint-level**: create / update / delete / explicit-reload all refresh the registry; an empty PUT skips the rebuild
- [x] `pytest tests/test_admin_model_registry_refresh.py` — 11 passed
- [x] `pytest tests/test_coordinator_endpoints.py tests/test_coordinator_governance.py tests/test_coordinator_close_all_children.py tests/test_phase6_endpoints.py tests/test_model_registry.py tests/test_model_definition_storage.py tests/test_admin_model_registry_refresh.py` — 306 passed
- [x] `ruff check` clean
- [x] `mypy turnstone/console/server.py tests/test_admin_model_registry_refresh.py` clean