### PR TITLE
fix(console): home composer attachments + coord chat user-message pills

### DIFF
--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -157,6 +157,16 @@ def test_coordinator_js_exposes_inline_approval_helpers():
     # any prior denial.  bug-1 / bug-3 from the second /review pass.
     assert "Denied by user" in body
     assert "callOutcomes" in body
+    # User-message attachment pills — both live send (coordSend) and
+    # history replay route through appendUserMessageWithAttachments.
+    # Renaming or dropping the helper would silently regress the
+    # attachment affordance to the pre-fix plain-text bubble, which
+    # would only surface in manual testing of an attached-file flow.
+    # The CSS class is the visual anchor (coordinator.css) — keeping
+    # both literals in the smoke layer covers JS↔CSS drift in either
+    # direction.
+    assert "function appendUserMessageWithAttachments" in body
+    assert "msg-user-attach" in body
 
 
 def test_coordinator_js_handle_child_state_no_longer_reads_sse_pending_approval_detail():

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1881,6 +1881,17 @@ function submitHomeCoord(textFromComposer) {
   // the multipart payload (the actual reset only fires on the success
   // branch, after the response lands).
   var files = _homeStagedFiles.slice();
+  // Files-without-text would upload pending attachment rows but the
+  // server's _coord_create_post_install only reserves+dispatches when
+  // initial_message is non-empty — uploaded files would orphan as
+  // pending storage rows until the GC sweep.  Require text whenever
+  // attachments are staged so the first turn always picks them up.
+  if (files.length > 0 && !(task || "").trim()) {
+    _homeShowError(
+      "Add a task message — attachments need an initial turn to dispatch on.",
+    );
+    return;
+  }
   _createCoordinator({
     name: opts.name || "",
     skill: opts.skill || "",

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1458,7 +1458,10 @@ function _createCoordinator(opts) {
   var on503 = opts.on503 || function () {};
   var onSuccess = opts.onSuccess || function () {};
 
-  errEl.style.display = "none";
+  // Error region is always rendered with reserved min-height (see
+  // .home-composer-error in style.css) so toggling validation messages
+  // doesn't reflow the active-coordinators list below — clear the
+  // textContent only, no display toggle.
   errEl.textContent = "";
   setBusy(true);
 
@@ -1469,11 +1472,30 @@ function _createCoordinator(opts) {
   if (judgeModel) body.judge_model = judgeModel;
   if (task) body.initial_message = task;
 
-  authFetch("/v1/api/workstreams/new", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
+  // Multipart when files are staged — the coord create endpoint
+  // accepts a `meta` JSON field plus zero-or-more `file` parts and
+  // reserves attachments for the very first turn (same flow the
+  // interactive UI's new-ws modal uses against the server).  Plain
+  // JSON stays the default when no files are attached.
+  var files = Array.isArray(opts.files) ? opts.files : [];
+  var fetchOpts;
+  if (files.length > 0) {
+    var form = new FormData();
+    form.append("meta", JSON.stringify(body));
+    for (var i = 0; i < files.length; i++) {
+      form.append("file", files[i], files[i].name);
+    }
+    // Don't set Content-Type — the browser adds the correct boundary.
+    fetchOpts = { method: "POST", body: form };
+  } else {
+    fetchOpts = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    };
+  }
+
+  authFetch("/v1/api/workstreams/new", fetchOpts)
     .then(function (r) {
       return r.json().then(function (data) {
         return { ok: r.ok, status: r.status, data: data };
@@ -1488,7 +1510,6 @@ function _createCoordinator(opts) {
       if (!res.ok || !res.data || !res.data.ws_id) {
         errEl.textContent =
           (res.data && res.data.error) || "HTTP " + res.status;
-        errEl.style.display = "block";
         return;
       }
       onSuccess(res);
@@ -1498,7 +1519,6 @@ function _createCoordinator(opts) {
     .catch(function () {
       setBusy(false);
       errEl.textContent = "Request failed";
-      errEl.style.display = "block";
     });
 }
 
@@ -1514,6 +1534,159 @@ var _homeComposerInit = false;
 var _homeCoordReady = null; // tri-state: null = unknown, true = ready, false = 503
 var _homeCoordComposer = null; // shared Composer instance
 var _homeCoordBusy = false;
+
+// Attachment staging for the home coord composer.  The coord ws_id
+// doesn't exist until the create POST resolves, so we hold File
+// objects in memory and ship them as multipart parts on submit (same
+// pattern interactive uses for its new-ws modal + dashboard composer).
+var _homeStagedFiles = [];
+
+// Per-kind size caps + allowlist mirrored from turnstone/core/attachments.py
+// so the browser can fail fast.  Keep in sync with the interactive
+// UI's _ATTACH_* constants in turnstone/ui/static/app.js.
+var _HOME_IMAGE_CAP = 4 * 1024 * 1024;
+var _HOME_TEXT_CAP = 512 * 1024;
+var _HOME_MAX_FILES = 10;
+var _HOME_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+var _HOME_TEXT_APP_MIMES = [
+  "application/json",
+  "application/xml",
+  "application/x-yaml",
+  "application/yaml",
+  "application/toml",
+];
+var _HOME_TEXT_EXTENSIONS = [
+  ".c",
+  ".conf",
+  ".cpp",
+  ".css",
+  ".go",
+  ".h",
+  ".hpp",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".jsx",
+  ".md",
+  ".py",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+];
+
+function _homeFormatSize(n) {
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  return (n / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+function _homeIsAttachmentAllowed(file) {
+  var mime = (file.type || "").toLowerCase();
+  if (_HOME_IMAGE_MIMES.indexOf(mime) !== -1) return true;
+  if (mime.indexOf("text/") === 0) return true;
+  if (_HOME_TEXT_APP_MIMES.indexOf(mime) !== -1) return true;
+  var name = (file.name || "").toLowerCase();
+  var dot = name.lastIndexOf(".");
+  if (dot >= 0 && _HOME_TEXT_EXTENSIONS.indexOf(name.substr(dot)) !== -1) {
+    return true;
+  }
+  return false;
+}
+
+function _homeShowError(msg) {
+  var errEl = document.getElementById("home-coord-error");
+  if (!errEl) return;
+  // Element is always rendered (min-height reserves the row); just
+  // toggle the message text so layout doesn't shift on validation.
+  errEl.textContent = msg || "";
+}
+
+function _homeRenderChips() {
+  if (!_homeCoordComposer || !_homeCoordComposer.chipsEl) return;
+  var chipsEl = _homeCoordComposer.chipsEl;
+  chipsEl.textContent = "";
+  for (var i = 0; i < _homeStagedFiles.length; i++) {
+    (function (idx) {
+      var f = _homeStagedFiles[idx];
+      var isImage = (f.type || "").indexOf("image/") === 0;
+      var chip = document.createElement("span");
+      chip.className =
+        "composer-chip composer-chip-" + (isImage ? "image" : "text");
+      chip.setAttribute("role", "listitem");
+
+      var icon = document.createElement("span");
+      icon.className = "composer-chip-icon";
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = isImage ? "🖼" : "📄";
+      chip.appendChild(icon);
+
+      var name = document.createElement("span");
+      name.className = "composer-chip-name";
+      name.textContent = f.name;
+      name.title = f.name + " (" + f.size + " bytes)";
+      chip.appendChild(name);
+
+      var size = document.createElement("span");
+      size.className = "composer-chip-size";
+      size.textContent = _homeFormatSize(f.size);
+      chip.appendChild(size);
+
+      var rm = document.createElement("button");
+      rm.type = "button";
+      rm.className = "composer-chip-remove";
+      rm.setAttribute("aria-label", "Remove " + f.name);
+      rm.title = "Remove";
+      rm.textContent = "×";
+      rm.onclick = function () {
+        _homeStagedFiles.splice(idx, 1);
+        _homeRenderChips();
+      };
+      chip.appendChild(rm);
+      chipsEl.appendChild(chip);
+    })(i);
+  }
+}
+
+function _homeStageFile(file) {
+  if (!file) return;
+  if (_homeStagedFiles.length >= _HOME_MAX_FILES) {
+    _homeShowError(
+      "At most " + _HOME_MAX_FILES + " attachments per coordinator",
+    );
+    return;
+  }
+  if (!_homeIsAttachmentAllowed(file)) {
+    _homeShowError(
+      "Unsupported file type: " +
+        file.name +
+        " (allowed: png/jpeg/gif/webp images, text)",
+    );
+    return;
+  }
+  var isImage = (file.type || "").indexOf("image/") === 0;
+  var cap = isImage ? _HOME_IMAGE_CAP : _HOME_TEXT_CAP;
+  if (file.size > cap) {
+    _homeShowError(file.name + " exceeds the " + _homeFormatSize(cap) + " cap");
+    return;
+  }
+  _homeShowError("");
+  _homeStagedFiles.push(file);
+  _homeRenderChips();
+}
+
+function _homeClearStagedFiles() {
+  _homeStagedFiles = [];
+  _homeRenderChips();
+}
 
 // Single owner for sendBtn.disabled: disabled if EITHER busy OR the
 // subsystem probe flipped to 503.  Every setter for _homeCoordBusy /
@@ -1596,6 +1769,12 @@ function _mountHomeCoordComposer() {
         },
       ],
     },
+    attachments: {
+      onAttach: function (file) {
+        _homeStageFile(file);
+      },
+    },
+    dragDrop: { targetEl: mount, dropClass: "home-coord-drop" },
     onSend: function (text) {
       submitHomeCoord(text);
     },
@@ -1698,12 +1877,17 @@ function submitHomeCoord(textFromComposer) {
   var task =
     textFromComposer != null ? textFromComposer : _homeCoordComposer.value;
   var opts = _homeCoordComposer.getOptionValues();
+  // Snapshot at submit time so a chip remove mid-request can't race
+  // the multipart payload (the actual reset only fires on the success
+  // branch, after the response lands).
+  var files = _homeStagedFiles.slice();
   _createCoordinator({
     name: opts.name || "",
     skill: opts.skill || "",
     model: opts.model || "",
     judge_model: opts.judge_model || "",
     task: task,
+    files: files,
     errEl: document.getElementById("home-coord-error"),
     setBusy: function (b) {
       _homeCoordBusy = b;
@@ -1715,6 +1899,9 @@ function submitHomeCoord(textFromComposer) {
       var banner = document.getElementById("coord-composer-503");
       if (banner) banner.style.display = "";
       _refreshHomeCoordSubmitEnabled();
+    },
+    onSuccess: function () {
+      _homeClearStagedFiles();
     },
   });
 }

--- a/turnstone/console/static/coordinator/coordinator.css
+++ b/turnstone/console/static/coordinator/coordinator.css
@@ -618,6 +618,43 @@
   color: var(--ink-3);
 }
 
+/* User-message attachment pills — rendered beneath the bubble for
+   live sends and on history replay.  Mirrors the .msg-user-attach*
+   rules in turnstone/ui/static/style.css so coord and interactive
+   surfaces show the same affordance for attached files. */
+.msg-user-attach {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+.msg-user-attach-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* --panel (not --panel-2) — the .msg bubble is already --panel-2,
+     so pulling the pill onto the alternate surface keeps it visible
+     against the bubble in both themes (WCAG 1.4.11 non-text contrast).
+     Mirrors the interactive UI's --bg-surface vs .msg --panel-2 split. */
+  background: var(--panel);
+  color: var(--ink-2);
+  border: 1px solid var(--hair);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.msg-user-attach-icon {
+  font-size: 11px;
+  opacity: 0.7;
+}
+.msg-user-attach-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Mobile (<700px) — keep action targets ≥44px for WCAG 2.5.5. */
 @media (max-width: 700px) {
   .coord-tool-actions {

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -335,6 +335,39 @@
     return appendMsg(role, esc(text), opts);
   }
 
+  // User-message bubble with attachment-pill cluster appended below
+  // the text.  Mirrors Pane.prototype.addUserMessage in the
+  // interactive UI so live-send and history-replay both render the
+  // same chip strip the composer staged on submit.  Attachments is a
+  // list of {kind, filename}; falsy/empty falls through to plain text.
+  function appendUserMessageWithAttachments(text, attachments, opts) {
+    const el = appendText("user", text, opts);
+    if (!Array.isArray(attachments) || attachments.length === 0) return el;
+    const pills = document.createElement("div");
+    pills.className = "msg-user-attach";
+    pills.setAttribute("role", "list");
+    attachments.forEach((a) => {
+      const kind = (a && a.kind) || "other";
+      const pill = document.createElement("span");
+      pill.className = "msg-user-attach-pill msg-user-attach-pill-" + kind;
+      pill.setAttribute("role", "listitem");
+      const icon = document.createElement("span");
+      icon.className = "msg-user-attach-icon";
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = kind === "image" ? "🖼" : "📄";
+      pill.appendChild(icon);
+      const name = document.createElement("span");
+      name.className = "msg-user-attach-name";
+      name.textContent =
+        (a && a.filename) || (kind === "image" ? "image" : "document");
+      pill.appendChild(name);
+      pills.appendChild(pill);
+    });
+    el.appendChild(pills);
+    _scheduleScroll();
+    return el;
+  }
+
   // Metacognitive reminder bubble (user-channel correction / denial /
   // resume / start / completion AND tool-channel tool_error / repeat).
   // Mirrors Pane.prototype.addUserReminder / addToolReminder in the
@@ -1514,7 +1547,13 @@
       queuedEl = queue.addQueuedMessage(displayText, priority);
     } else {
       setBusy(true);
-      appendText("user", trimmed, { label: "you" });
+      // snap.attachments carries the chip metadata (kind + filename)
+      // for every stable chip the composer holds; pass it through so
+      // the optimistic user bubble shows the same pill cluster the
+      // history-replay path renders below.
+      appendUserMessageWithAttachments(trimmed, snap.attachments, {
+        label: "you",
+      });
     }
     composer.clear();
 
@@ -3897,13 +3936,12 @@
 
         // User messages with attachments arrive as multipart list
         // content (text + image_url/document parts) and may carry an
-        // ``_attachments_meta`` side-channel with display metadata.
-        // Extract the text portion + attachment count for a readable
-        // history replay; chip-rendering parity with the interactive
-        // pane is deferred (the coord dashboard is diagnostic-leaning
-        // — primary use is monitoring, not authoring).
+        // ``_attachments_meta`` side-channel with display metadata
+        // (kind + filename + mime_type).  Extract the text portion and
+        // build a structured attachment list so the user bubble can
+        // render the same pill cluster the interactive pane shows.
         let content;
-        let attachmentCount = 0;
+        const userAttachments = [];
         if (typeof m.content === "string") {
           content = m.content;
         } else if (Array.isArray(m.content)) {
@@ -3912,8 +3950,14 @@
             if (!part || typeof part !== "object") continue;
             if (part.type === "text") {
               textParts.push(String(part.text || ""));
-            } else if (part.type === "image_url" || part.type === "document") {
-              attachmentCount += 1;
+            } else if (part.type === "image_url") {
+              userAttachments.push({ kind: "image", filename: "" });
+            } else if (part.type === "document") {
+              const doc = (part && part.document) || {};
+              userAttachments.push({
+                kind: "text",
+                filename: String(doc.name || ""),
+              });
             }
           }
           content = textParts.join("\n");
@@ -3923,19 +3967,18 @@
         const meta = Array.isArray(m._attachments_meta)
           ? m._attachments_meta
           : null;
-        if (meta && meta.length > attachmentCount) {
-          // Prefer the side-channel count when present — it covers
-          // attachments whose multipart parts couldn't be reconstructed.
-          attachmentCount = meta.length;
-        }
-        if (attachmentCount > 0) {
-          const noun = attachmentCount === 1 ? "attachment" : "attachments";
-          content =
-            (content ? content + "\n\n" : "") +
-            "📎 " +
-            attachmentCount +
-            " " +
-            noun;
+        if (meta && meta.length) {
+          // Side-channel is authoritative — it carries filenames that
+          // image_url data URIs can't express, and covers attachments
+          // whose multipart parts couldn't be reconstructed.
+          userAttachments.length = 0;
+          for (const a of meta) {
+            if (!a || typeof a !== "object") continue;
+            userAttachments.push({
+              kind: String(a.kind || "other"),
+              filename: String(a.filename || ""),
+            });
+          }
         }
         if (role === "tool") {
           // Tool result content can legitimately be empty (e.g. a
@@ -3991,20 +4034,26 @@
             body.textContent = content;
           }
         } else {
-          if (!content) return;
           // user / reasoning / system / other roles render as plain
           // text on history replay — matches the live-streaming paths
           // (appendReasoningToken uses textContent; user/system are
-          // typed verbatim and don't carry markdown structure).
-          appendText(role, content, { label: role });
-          // User-channel metacog reminders attach to the just-appended
-          // user bubble (the most recent .msg.user in messagesEl).
-          if (
-            role === "user" &&
-            Array.isArray(m.reminders) &&
-            m.reminders.length
-          ) {
-            appendUserReminderLive(m.reminders);
+          // typed verbatim and don't carry markdown structure).  User
+          // bubbles additionally render the pill strip beneath the
+          // text when the message carried attachments — even when the
+          // text portion is empty (image-only sends).
+          if (role === "user") {
+            if (!content && userAttachments.length === 0) return;
+            appendUserMessageWithAttachments(content, userAttachments, {
+              label: role,
+            });
+            // User-channel metacog reminders attach to the just-appended
+            // user bubble (the most recent .msg.user in messagesEl).
+            if (Array.isArray(m.reminders) && m.reminders.length) {
+              appendUserReminderLive(m.reminders);
+            }
+          } else {
+            if (!content) return;
+            appendText(role, content, { label: role });
           }
         }
       });

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -3953,7 +3953,7 @@
             } else if (part.type === "image_url") {
               userAttachments.push({ kind: "image", filename: "" });
             } else if (part.type === "document") {
-              const doc = (part && part.document) || {};
+              const doc = part.document || {};
               userAttachments.push({
                 kind: "text",
                 filename: String(doc.name || ""),

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -122,9 +122,8 @@
           <div
             id="home-coord-error"
             class="home-composer-error"
-            role="alert"
-            aria-live="assertive"
-            style="display: none"
+            role="status"
+            aria-live="polite"
           ></div>
         </section>
 

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -129,11 +129,12 @@
 
 /* Cap chip filename width inside the home composer so a long-name
    attachment doesn't push the strip wider than the textarea or wrap
-   unpredictably across multiple rows.  The shared chip rule
-   (shared_static/chat.css `.composer-chip-name`) doesn't truncate by
-   default — chat panes have wider real estate.  The home creator sits
-   in a narrower column, so apply the same ellipsis cap the
-   .msg-user-attach-pill already uses. */
+   unpredictably across multiple rows.  shared_static/chat.css defines
+   .composer-chip / .composer-chip-size / .composer-chip-remove but
+   leaves .composer-chip-name unstyled — the span just inherits the
+   .composer-chip font with no width cap, fine for chat-pane width but
+   too loose for the narrower home column.  Apply the same ellipsis
+   cap the .msg-user-attach-pill rule uses on the user bubble. */
 #home-coord-composer-mount .composer-chip-name {
   max-width: 200px;
   overflow: hidden;

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -104,9 +104,41 @@
 }
 
 .home-composer-error {
+  /* Always rendered (no display toggle in JS) so toggling validation
+     messages doesn't reflow the active-coordinators list below.  The
+     min-height holds a single 12px line + padding so an empty state
+     reserves the same space the rendered error will occupy. */
+  min-height: 20px;
   color: var(--red);
   font-size: 12px;
   padding: 4px 2px 0;
+}
+
+/* Drag-over feedback for the home coord composer — wired by Composer's
+   dragDrop option (dropClass: home-coord-drop) on the composer mount.
+   Mirrors the dashed-outline affordance on coord-main so users see the
+   same drop visual the in-coord composer uses. */
+#home-coord-composer-mount {
+  position: relative;
+}
+#home-coord-composer-mount.home-coord-drop {
+  outline: 2px dashed var(--accent);
+  outline-offset: -6px;
+  border-radius: var(--radius);
+}
+
+/* Cap chip filename width inside the home composer so a long-name
+   attachment doesn't push the strip wider than the textarea or wrap
+   unpredictably across multiple rows.  The shared chip rule
+   (shared_static/chat.css `.composer-chip-name`) doesn't truncate by
+   default — chat panes have wider real estate.  The home creator sits
+   in a narrower column, so apply the same ellipsis cap the
+   .msg-user-attach-pill already uses. */
+#home-coord-composer-mount .composer-chip-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .home-section {


### PR DESCRIPTION
## Summary

Two parity gaps in the console's coordinator surface:

- The embedded creator on the home page accepted only text — the paperclip / paste / drop pipeline that the in-coord composer and the interactive new-ws modal both expose was missing, so a user couldn't attach files at create time. Stage \`File\` objects in memory (no ws_id yet) and ship them multipart on Start; the coord create endpoint already accepts multipart via \`create_supports_attachments=True\`.

- User messages with attachments rendered as plain text on both live send and history replay — no chip cluster like the interactive pane. Added \`appendUserMessageWithAttachments\` and a structured \`userAttachments\` list built from \`_attachments_meta\` (preferred) or the multipart parts themselves, then rendered the same \`.msg-user-attach\` pill strip the interactive pane uses.

## Polish from a designer pass

- Pill background was \`--panel-2\`, equal to the \`.msg\` bubble background in both themes (border contrast ≈1.4:1, below WCAG 1.4.11). Switched to \`--panel\` so the pill sits on a different surface than the bubble.
- Capped chip filename width inside the home composer (\`max-width: 200px\` + ellipsis) so a long filename doesn't push the strip past the textarea.
- \`aria-live="assertive"\` → \`"polite"\` on \`#home-coord-error\`; client-side validation isn't an interrupt-level event.
- Reserved \`min-height\` on \`.home-composer-error\` and dropped the \`display: none/block\` toggling so validation messages no longer reflow the active-coordinators list below.

## Test plan

- [ ] Drag a PNG onto the home composer → chip appears, Start creates a coord with the image attached on turn 0
- [ ] Paperclip + multi-select on home composer → chips render, multipart submit succeeds
- [ ] Long filename (>40 chars) renders truncated with ellipsis
- [ ] Reject unsupported file type → red error appears in-place without shifting the coord list below
- [ ] Reject oversized file → same in-place behavior
- [ ] Send a message with an attachment in the coord chat → user bubble shows pill cluster live
- [ ] Reload coord page → history replay renders the same pill cluster
- [ ] Image-only user message (empty text) → pills still render
- [ ] Verify pill contrast against \`.msg.user\` bubble in both light and dark themes