### PR TITLE
feat(console): consolidate role-model settings + live-refresh dropdowns

### DIFF
--- a/tests/test_models_changed_event.py
+++ b/tests/test_models_changed_event.py
@@ -1,0 +1,274 @@
+"""``models_changed`` SSE fanout coverage.
+
+The console pushes a ``models_changed`` cluster event whenever a model
+definition is created / updated / deleted / reloaded, or whenever a
+setting in :data:`turnstone.console.server._MODEL_AFFECTING_SETTING_KEYS`
+is updated or reset.  Connected browsers refetch ``/v1/api/models`` on
+receipt so the home composer dropdown + admin Models → Roles sub-tab
+reflect alias edits without a manual reload.
+
+These tests pin two contracts:
+
+- every model-definition CRUD path emits exactly one ``models_changed``
+  fanout (so the browser stays in sync with the DB);
+- settings PUT / DELETE only emit the fanout when the key is
+  model-affecting — unrelated keys (e.g. ``session.retention_days``)
+  must not trigger spurious dropdown re-renders across the cluster.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tests._coord_test_helpers import _AuthMiddleware
+from turnstone.console.server import (
+    _MODEL_AFFECTING_SETTING_KEYS,
+    admin_create_model_definition,
+    admin_delete_model_definition,
+    admin_delete_setting,
+    admin_model_reload,
+    admin_update_model_definition,
+    admin_update_setting,
+)
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+@pytest.fixture
+def storage(tmp_path: Any) -> SQLiteBackend:
+    return SQLiteBackend(str(tmp_path / "models_changed.db"))
+
+
+def _seed(storage: SQLiteBackend, *, definition_id: str, alias: str) -> None:
+    storage.create_model_definition(
+        definition_id=definition_id,
+        alias=alias,
+        model="model-x",
+        provider="openai-compatible",
+        base_url="http://localhost:8000/v1",
+        api_key="sk-test",
+        context_window=8192,
+        capabilities="{}",
+        enabled=True,
+        created_by="admin",
+    )
+
+
+def _make_client(storage: SQLiteBackend) -> tuple[TestClient, MagicMock]:
+    """Build a TestClient + return the stub collector for assertion.
+
+    Wires the four model-definition CRUD/reload routes plus the two
+    settings mutation routes.  Collector is a MagicMock so each
+    ``emit_models_changed`` call lands as a recorded call without
+    spinning up the full SSE listener queue.
+    """
+    app = Starlette(
+        routes=[
+            Route(
+                "/v1/api/admin/model-definitions",
+                admin_create_model_definition,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/reload",
+                admin_model_reload,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/{definition_id}",
+                admin_update_model_definition,
+                methods=["PUT"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/{definition_id}",
+                admin_delete_model_definition,
+                methods=["DELETE"],
+            ),
+            Route(
+                "/v1/api/admin/settings/{key:path}",
+                admin_update_setting,
+                methods=["PUT"],
+            ),
+            Route(
+                "/v1/api/admin/settings/{key:path}",
+                admin_delete_setting,
+                methods=["DELETE"],
+            ),
+        ],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.auth_storage = storage
+    app.state.coord_registry = None  # CRUD endpoints handle this gracefully
+    collector = MagicMock()
+    collector.get_all_nodes.return_value = []
+    app.state.collector = collector
+    app.state.proxy_client = MagicMock()
+    app.state.config_store = MagicMock()
+    client = TestClient(app)
+    client.headers.update(
+        {
+            "X-Test-User": "admin",
+            "X-Test-Perms": "admin.models,admin.settings",
+        }
+    )
+    return client, collector
+
+
+# ---------------------------------------------------------------------------
+# Model-definition CRUD endpoints fan out ``models_changed``
+# ---------------------------------------------------------------------------
+
+
+def test_create_emits_models_changed(storage: SQLiteBackend) -> None:
+    client, collector = _make_client(storage)
+    resp = client.post(
+        "/v1/api/admin/model-definitions",
+        json={
+            "alias": "fast",
+            "model": "fast-model",
+            "provider": "openai-compatible",
+            "base_url": "http://localhost:9000/v1",
+            "api_key": "sk-x",
+            "context_window": 4096,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+def test_update_emits_models_changed(storage: SQLiteBackend) -> None:
+    _seed(storage, definition_id="m1", alias="local")
+    client, collector = _make_client(storage)
+    resp = client.put(
+        "/v1/api/admin/model-definitions/m1",
+        json={"model": "swapped-model"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+def test_update_with_empty_body_does_not_emit(storage: SQLiteBackend) -> None:
+    """Empty-body PUT writes no rows + skips the registry refresh — no
+    SSE fanout either, since nothing actually changed."""
+    _seed(storage, definition_id="m1", alias="local")
+    client, collector = _make_client(storage)
+    resp = client.put("/v1/api/admin/model-definitions/m1", json={})
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 0
+
+
+def test_delete_emits_models_changed(storage: SQLiteBackend) -> None:
+    _seed(storage, definition_id="m1", alias="local")
+    client, collector = _make_client(storage)
+    resp = client.delete("/v1/api/admin/model-definitions/m1")
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+def test_reload_emits_models_changed(storage: SQLiteBackend) -> None:
+    _seed(storage, definition_id="m1", alias="local")
+    client, collector = _make_client(storage)
+    resp = client.post("/v1/api/admin/model-definitions/reload")
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Settings PUT / DELETE only emit for model-affecting keys
+# ---------------------------------------------------------------------------
+
+
+# Pinned snapshot of the role-related keys we expect the allowlist to
+# cover today.  The frozenset itself is asserted further down so a
+# stray addition doesn't silently bypass coverage.
+_EXPECTED_AFFECTING_KEYS = frozenset(
+    {
+        "model.default_alias",
+        "model.plan_alias",
+        "model.plan_effort",
+        "model.task_alias",
+        "model.task_effort",
+        "coordinator.model_alias",
+        "coordinator.reasoning_effort",
+        "judge.model",
+    }
+)
+
+
+def _value_for_key(key: str) -> str:
+    """Return a registry-valid value for ``key``.
+
+    ``reasoning_effort`` keys have a fixed choice list; alias-shaped
+    keys accept arbitrary strings.  Avoids per-key custom payloads.
+    """
+    if (
+        key.endswith("reasoning_effort")
+        or key.endswith("plan_effort")
+        or key.endswith("task_effort")
+    ):
+        return "low"
+    return "anything"
+
+
+def test_affecting_keys_set_matches_expected() -> None:
+    """Lock in the allowlist so an unintentional removal is caught."""
+    assert _MODEL_AFFECTING_SETTING_KEYS == _EXPECTED_AFFECTING_KEYS
+
+
+@pytest.mark.parametrize("key", sorted(_EXPECTED_AFFECTING_KEYS))
+def test_settings_put_emits_for_model_affecting_key(storage: SQLiteBackend, key: str) -> None:
+    client, collector = _make_client(storage)
+    resp = client.put(
+        f"/v1/api/admin/settings/{key}",
+        json={"value": _value_for_key(key)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+@pytest.mark.parametrize("key", sorted(_EXPECTED_AFFECTING_KEYS))
+def test_settings_delete_emits_for_model_affecting_key(storage: SQLiteBackend, key: str) -> None:
+    client, collector = _make_client(storage)
+    # Seed a row so DELETE has something to remove (otherwise 404).
+    client.put(
+        f"/v1/api/admin/settings/{key}",
+        json={"value": _value_for_key(key)},
+    )
+    collector.emit_models_changed.reset_mock()
+    resp = client.delete(f"/v1/api/admin/settings/{key}")
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 1
+
+
+def test_settings_put_does_not_emit_for_unrelated_key(
+    storage: SQLiteBackend,
+) -> None:
+    """Updating a non-model setting (here: a session retention knob)
+    must not trigger a cluster-wide dropdown refresh."""
+    client, collector = _make_client(storage)
+    resp = client.put(
+        "/v1/api/admin/settings/session.retention_days",
+        json={"value": 30},
+    )
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 0
+
+
+def test_settings_delete_does_not_emit_for_unrelated_key(
+    storage: SQLiteBackend,
+) -> None:
+    client, collector = _make_client(storage)
+    client.put(
+        "/v1/api/admin/settings/session.retention_days",
+        json={"value": 30},
+    )
+    collector.emit_models_changed.reset_mock()
+    resp = client.delete("/v1/api/admin/settings/session.retention_days")
+    assert resp.status_code == 200, resp.text
+    assert collector.emit_models_changed.call_count == 0

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -1258,6 +1258,17 @@ class ClusterCollector:
             entry["name"] = name
         self._fanout({"type": "ws_rename", "ws_id": ws_id, "name": name})
 
+    def emit_models_changed(self) -> None:
+        """Fan out a ``models_changed`` notice to all SSE listeners.
+
+        Browsers re-fetch :http:get:`/v1/api/models` on receipt so the
+        coordinator-composer model dropdown + the admin Models tab
+        reflect alias / underlying-model edits without a manual reload.
+        Body is intentionally empty — listeners refetch authoritative
+        state rather than diffing the event payload.
+        """
+        self._fanout({"type": "models_changed"})
+
     def emit_console_ws_intent_verdict(self, ws_id: str, verdict: dict[str, Any]) -> None:
         """Fan an LLM intent-judge verdict for a console-pseudo-node ws.
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6993,6 +6993,10 @@ def _emit_models_changed(request: Request) -> None:
 _MODEL_AFFECTING_SETTING_KEYS: frozenset[str] = frozenset(
     {
         "model.default_alias",
+        "model.plan_alias",
+        "model.plan_effort",
+        "model.task_alias",
+        "model.task_effort",
         "coordinator.model_alias",
         "coordinator.reasoning_effort",
         "judge.model",

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2413,7 +2413,7 @@ def _require_coord_mgr(request: Request) -> tuple[Any, JSONResponse | None]:
     if coord_mgr is None:
         registry_err = getattr(request.app.state, "coord_registry_error", "") or ""
         msg = "Coordinator subsystem not initialized. " + (
-            registry_err or "Check coordinator.model_alias and Models tab configuration."
+            registry_err or "Add a model definition in the admin Models tab."
         )
         return None, JSONResponse({"error": msg}, status_code=503)
     if config_store is None:
@@ -2444,8 +2444,7 @@ def _require_coord_mgr(request: Request) -> tuple[Any, JSONResponse | None]:
             {
                 "error": (
                     f"{hint} does not resolve: {exc}. "
-                    "Configure a model in the admin Models tab, or set "
-                    "``coordinator.model_alias`` in Settings to an existing alias."
+                    "Add or enable a model in the admin Models tab."
                 )
             },
             status_code=503,
@@ -6976,6 +6975,31 @@ async def admin_delete_memory(request: Request) -> JSONResponse:
 # ---------------------------------------------------------------------------
 
 
+def _emit_models_changed(request: Request) -> None:
+    """Fan a ``models_changed`` SSE notice to connected browsers, if any.
+
+    Best-effort: silently no-ops when the collector isn't attached
+    (e.g. test fixtures that bypass the cluster collector).
+    """
+    collector = getattr(request.app.state, "collector", None)
+    if collector is not None:
+        collector.emit_models_changed()
+
+
+# Settings whose change should refresh the model dropdown / Roles UI in
+# every connected browser — covers the global default plus the per-role
+# overrides surfaced in the admin Models → Roles sub-tab.  Additions
+# here are purely additive (e.g. future ``perception.*.model`` keys).
+_MODEL_AFFECTING_SETTING_KEYS: frozenset[str] = frozenset(
+    {
+        "model.default_alias",
+        "coordinator.model_alias",
+        "coordinator.reasoning_effort",
+        "judge.model",
+    }
+)
+
+
 async def _publish_config_change(request: Request) -> None:
     """Fan out config-reload to all known server nodes (best-effort, async).
 
@@ -7178,6 +7202,8 @@ async def admin_update_setting(request: Request) -> JSONResponse:
     )
 
     await _publish_config_change(request)
+    if key in _MODEL_AFFECTING_SETTING_KEYS:
+        _emit_models_changed(request)
 
     return JSONResponse(
         {
@@ -7233,6 +7259,8 @@ async def admin_delete_setting(request: Request) -> JSONResponse:
     )
 
     await _publish_config_change(request)
+    if key in _MODEL_AFFECTING_SETTING_KEYS:
+        _emit_models_changed(request)
 
     return JSONResponse({"status": "ok", "key": key, "default": defn.default})
 
@@ -8414,6 +8442,7 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
     )
 
     await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
+    _emit_models_changed(request)
 
     created = storage.get_model_definition(definition_id)
     if created is None:
@@ -8574,6 +8603,7 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
 
     if updates:
         await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
+        _emit_models_changed(request)
 
     model_def = storage.get_model_definition(definition_id)
     return JSONResponse(_mask_model_secrets(model_def or {}))
@@ -8611,6 +8641,7 @@ async def admin_delete_model_definition(request: Request) -> JSONResponse:
     )
 
     await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
+    _emit_models_changed(request)
 
     return JSONResponse({"status": "ok", "definition_id": definition_id})
 
@@ -8637,6 +8668,7 @@ async def admin_model_reload(request: Request) -> JSONResponse:
     # otherwise the coord LLM keeps calling the prior model name even
     # after a successful reload.
     await asyncio.to_thread(_refresh_coord_registry, request.app.state, storage)
+    _emit_models_changed(request)
 
     results = await _notify_nodes_model_reload(request)
     return JSONResponse({"status": "ok", "results": results})
@@ -9127,6 +9159,8 @@ async def admin_update_judge_setting(request: Request) -> JSONResponse:
         ip,
     )
     await _publish_config_change(request)
+    if key in _MODEL_AFFECTING_SETTING_KEYS:
+        _emit_models_changed(request)
 
     effective = config_store.get(key, defn.default)
     return JSONResponse(
@@ -9163,6 +9197,8 @@ async def admin_delete_judge_setting(request: Request) -> JSONResponse:
     audit_uid, ip = _audit_context(request)
     record_audit(storage, audit_uid, "setting.delete", "setting", key, {}, ip)
     await _publish_config_change(request)
+    if key in _MODEL_AFFECTING_SETTING_KEYS:
+        _emit_models_changed(request)
 
     return JSONResponse({"status": "ok", "key": key, "default": defn.default})
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -4487,7 +4487,33 @@ var MODEL_ROLES = [
   },
 ];
 
+// Roles sub-tab reads/writes via ``/v1/api/admin/settings`` which
+// requires ``admin.settings`` — different from the ``admin.models``
+// permission gating the Models tab itself.  When the user has Models
+// access but not Settings, hide the sub-tab button + force the
+// Definitions panel visible so they don't see a perpetual 403 loader.
+function _modelRolesAccessible() {
+  var perms = sessionStorage.getItem("turnstone_permissions") || "";
+  return perms.split(",").indexOf("admin.settings") !== -1;
+}
+
+function _applyModelRolesPermission() {
+  var btn = document.getElementById("models-tab-roles");
+  if (!btn) return;
+  if (_modelRolesAccessible()) {
+    btn.style.display = "";
+    return;
+  }
+  btn.style.display = "none";
+  // If Roles was the active sub-tab, snap back to Definitions so the
+  // user isn't staring at a hidden panel.
+  if (btn.classList.contains("active")) {
+    switchModelsSection("models-list");
+  }
+}
+
 function loadAdminModels() {
+  _applyModelRolesPermission();
   authFetch("/v1/api/admin/model-definitions")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed");
@@ -4497,9 +4523,12 @@ function loadAdminModels() {
       _modelDefs = data.models || [];
       _modelDefaultAlias = data.default_alias || "";
       _renderModels(_modelDefs);
-      // Render the Roles sub-tab off the same model list so the
-      // dropdowns stay in sync with the current set of aliases.
-      loadAdminModelRoles();
+      // Roles sub-tab piggybacks on the model list; skip it when the
+      // user has no settings permission since the underlying API will
+      // 403 anyway.
+      if (_modelRolesAccessible()) {
+        loadAdminModelRoles();
+      }
     })
     .catch(function () {
       var el = document.getElementById("admin-models-table");
@@ -4557,10 +4586,12 @@ function _modelRolesError(container, msg) {
 function loadAdminModelRoles() {
   var c = document.getElementById("admin-models-roles-container");
   if (!c) return;
-  // Re-fetch model-definitions alongside settings so the alias dropdown
-  // reflects the live enabled set even if the user toggled a model in
-  // the Definitions sub-tab between renders.  Saving a role also calls
-  // back here, keeping the dropdown in sync without a tab switch.
+  // Reads ``_modelDefs`` / ``_modelDefaultAlias`` populated by the most
+  // recent ``loadAdminModels`` — both entry points into the Models tab
+  // (initial open + ``models_changed`` SSE refresh) go through
+  // ``loadAdminModels`` first, so the cached snapshot is fresh.  Role
+  // saves don't change model definitions, so the snapshot stays
+  // accurate after ``_saveModelRole`` chains back here.
   Promise.all([
     authFetch("/v1/api/admin/settings").then(function (r) {
       if (!r.ok) throw new Error("settings " + r.status);
@@ -4568,10 +4599,6 @@ function loadAdminModelRoles() {
     }),
     authFetch("/v1/api/admin/settings/schema").then(function (r) {
       if (!r.ok) throw new Error("schema " + r.status);
-      return r.json();
-    }),
-    authFetch("/v1/api/admin/model-definitions").then(function (r) {
-      if (!r.ok) throw new Error("models " + r.status);
       return r.json();
     }),
   ])
@@ -4582,8 +4609,6 @@ function loadAdminModelRoles() {
       var schema = {};
       var sa = results[1].schema || [];
       for (var j = 0; j < sa.length; j++) schema[sa[j].key] = sa[j];
-      _modelDefs = results[2].models || _modelDefs;
-      _modelDefaultAlias = results[2].default_alias || _modelDefaultAlias;
       _renderModelRoles(c, values, schema);
     })
     .catch(function () {

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2625,11 +2625,19 @@ function loadSettings() {
         schemaMap[schemaArr[i].key] = schemaArr[i];
       }
 
-      // Merge values + schema
+      // Merge values + schema.  Skip role-assignment settings owned by
+      // the Models tab (judge.* live on the Judge tab; coordinator
+      // model+effort lifted into Models → Roles).
       var merged = {};
       for (var j = 0; j < valuesArr.length; j++) {
         var v = valuesArr[j];
         if (v.key.startsWith("judge.")) continue;
+        if (
+          v.key === "coordinator.model_alias" ||
+          v.key === "coordinator.reasoning_effort"
+        ) {
+          continue;
+        }
         var s = schemaMap[v.key] || {};
         merged[v.key] = {
           key: v.key,
@@ -4440,6 +4448,28 @@ var _modelDefaultAlias = "";
 var _modelCreateTrap = null;
 var _modelCreateTrigger = null;
 
+// Roles surfaced in the Models → Roles sub-tab.  Each entry maps a
+// settings-registry key onto a UX label.  ``effortKey`` is optional —
+// roles whose registry entry has a paired ``*.reasoning_effort``
+// setting render a second selector inline.  Adding a new role (e.g.
+// ``perception.audio.model``) is purely additive: drop a row here once
+// the SettingDef lands in turnstone/core/settings_registry.py.
+var MODEL_ROLES = [
+  {
+    label: "Coordinator",
+    description:
+      "Console-hosted coordinator sessions that drive child workstreams.",
+    aliasKey: "coordinator.model_alias",
+    effortKey: "coordinator.reasoning_effort",
+  },
+  {
+    label: "Judge",
+    description:
+      "Intent-validation judge that scores tool calls before approval.",
+    aliasKey: "judge.model",
+  },
+];
+
 function loadAdminModels() {
   authFetch("/v1/api/admin/model-definitions")
     .then(function (r) {
@@ -4450,6 +4480,9 @@ function loadAdminModels() {
       _modelDefs = data.models || [];
       _modelDefaultAlias = data.default_alias || "";
       _renderModels(_modelDefs);
+      // Render the Roles sub-tab off the same model list so the
+      // dropdowns stay in sync with the current set of aliases.
+      loadAdminModelRoles();
     })
     .catch(function () {
       var el = document.getElementById("admin-models-table");
@@ -4458,6 +4491,227 @@ function loadAdminModels() {
       d.className = "dashboard-empty";
       d.textContent = "Failed to load models";
       el.appendChild(d);
+    });
+}
+
+function switchModelsSection(section) {
+  var sections = document.querySelectorAll("#admin-models .models-section");
+  for (var i = 0; i < sections.length; i++) sections[i].style.display = "none";
+  var switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  var btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
+  for (var k = 0; k < btns.length; k++) {
+    var isActive = btns[k].getAttribute("data-section") === section;
+    btns[k].classList.toggle("active", isActive);
+    btns[k].setAttribute("aria-selected", isActive ? "true" : "false");
+    btns[k].setAttribute("tabindex", isActive ? "0" : "-1");
+  }
+  var target = document.getElementById(section + "-section");
+  if (target) target.style.display = "";
+}
+
+// Arrow key navigation for Models sub-tabs (matches the Judge tab).
+(function () {
+  var switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  if (!switcher) return;
+  switcher.addEventListener("keydown", function (e) {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    var btns = switcher.querySelectorAll(".admin-subtab-btn");
+    var secs = [];
+    for (var i = 0; i < btns.length; i++)
+      secs.push(btns[i].getAttribute("data-section"));
+    var current = switcher.querySelector(".admin-subtab-btn.active");
+    var idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
+    if (e.key === "ArrowRight") idx = (idx + 1) % secs.length;
+    else idx = (idx - 1 + secs.length) % secs.length;
+    e.preventDefault();
+    switchModelsSection(secs[idx]);
+    btns[idx].focus();
+  });
+})();
+
+function _modelRolesError(container, msg) {
+  while (container.firstChild) container.removeChild(container.firstChild);
+  var d = document.createElement("div");
+  d.className = "dashboard-empty";
+  d.textContent = msg;
+  container.appendChild(d);
+}
+
+function loadAdminModelRoles() {
+  var c = document.getElementById("admin-models-roles-container");
+  if (!c) return;
+  // Re-fetch model-definitions alongside settings so the alias dropdown
+  // reflects the live enabled set even if the user toggled a model in
+  // the Definitions sub-tab between renders.  Saving a role also calls
+  // back here, keeping the dropdown in sync without a tab switch.
+  Promise.all([
+    authFetch("/v1/api/admin/settings").then(function (r) {
+      if (!r.ok) throw new Error("settings " + r.status);
+      return r.json();
+    }),
+    authFetch("/v1/api/admin/settings/schema").then(function (r) {
+      if (!r.ok) throw new Error("schema " + r.status);
+      return r.json();
+    }),
+    authFetch("/v1/api/admin/model-definitions").then(function (r) {
+      if (!r.ok) throw new Error("models " + r.status);
+      return r.json();
+    }),
+  ])
+    .then(function (results) {
+      var values = {};
+      var arr = results[0].settings || [];
+      for (var i = 0; i < arr.length; i++) values[arr[i].key] = arr[i];
+      var schema = {};
+      var sa = results[1].schema || [];
+      for (var j = 0; j < sa.length; j++) schema[sa[j].key] = sa[j];
+      _modelDefs = results[2].models || _modelDefs;
+      _modelDefaultAlias = results[2].default_alias || _modelDefaultAlias;
+      _renderModelRoles(c, values, schema);
+    })
+    .catch(function () {
+      _modelRolesError(c, "Failed to load roles");
+    });
+}
+
+function _renderModelRoles(container, values, schema) {
+  var enabledAliases = [];
+  for (var i = 0; i < _modelDefs.length; i++) {
+    if (_modelDefs[i].enabled) enabledAliases.push(_modelDefs[i]);
+  }
+  container.textContent = "";
+  for (var r = 0; r < MODEL_ROLES.length; r++) {
+    var role = MODEL_ROLES[r];
+    var aliasInfo = values[role.aliasKey];
+    if (!aliasInfo) continue; // setting not registered (e.g. older server)
+
+    var row = document.createElement("div");
+    row.className = "model-role-row";
+
+    // The dropdown's selected-option text is the single source of
+    // truth for default vs override — when nothing is set it shows
+    // "(default — <alias>)", otherwise it shows the chosen alias.  No
+    // separate badge: redundant with the select, and prone to
+    // confusing color contrasts on freshly-rendered rows.
+    var head = document.createElement("div");
+    head.className = "model-role-head";
+    var nameEl = document.createElement("span");
+    nameEl.className = "model-role-label";
+    nameEl.textContent = role.label;
+    head.appendChild(nameEl);
+    row.appendChild(head);
+
+    if (role.description) {
+      var desc = document.createElement("div");
+      desc.className = "model-role-desc";
+      desc.textContent = role.description;
+      row.appendChild(desc);
+    }
+
+    var controls = document.createElement("div");
+    controls.className = "model-role-controls";
+
+    // Alias dropdown
+    var aliasWrap = document.createElement("label");
+    aliasWrap.className = "model-role-control";
+    var aliasLabel = document.createElement("span");
+    aliasLabel.className = "model-role-control-label";
+    aliasLabel.textContent = "Model";
+    aliasWrap.appendChild(aliasLabel);
+    var aliasSel = document.createElement("select");
+    aliasSel.setAttribute("data-role-key", role.aliasKey);
+    aliasSel.setAttribute(
+      "aria-label",
+      role.label + " model (empty = default)",
+    );
+    var blank = document.createElement("option");
+    blank.value = "";
+    blank.textContent = _modelDefaultAlias
+      ? "(default — " + _modelDefaultAlias + ")"
+      : "(default)";
+    aliasSel.appendChild(blank);
+    var currentAlias = aliasInfo.value || "";
+    var matched = false;
+    for (var m = 0; m < enabledAliases.length; m++) {
+      var md = enabledAliases[m];
+      var opt = document.createElement("option");
+      opt.value = md.alias;
+      opt.textContent =
+        md.alias === md.model ? md.alias : md.alias + " (" + md.model + ")";
+      if (currentAlias && currentAlias === md.alias) {
+        opt.selected = true;
+        matched = true;
+      }
+      aliasSel.appendChild(opt);
+    }
+    if (currentAlias && !matched) {
+      var manual = document.createElement("option");
+      manual.value = currentAlias;
+      manual.textContent = currentAlias + " (manual)";
+      manual.selected = true;
+      aliasSel.appendChild(manual);
+    }
+    aliasSel.addEventListener("change", function () {
+      _saveModelRole(this.getAttribute("data-role-key"), this.value);
+    });
+    aliasWrap.appendChild(aliasSel);
+    controls.appendChild(aliasWrap);
+
+    // Optional reasoning effort dropdown
+    if (role.effortKey && values[role.effortKey] && schema[role.effortKey]) {
+      var effortWrap = document.createElement("label");
+      effortWrap.className = "model-role-control";
+      var effortLabel = document.createElement("span");
+      effortLabel.className = "model-role-control-label";
+      effortLabel.textContent = "Reasoning effort";
+      effortWrap.appendChild(effortLabel);
+      var effortSel = document.createElement("select");
+      effortSel.setAttribute("data-role-key", role.effortKey);
+      effortSel.setAttribute("aria-label", role.label + " reasoning effort");
+      var choices = schema[role.effortKey].choices || [];
+      var currentEffort = values[role.effortKey].value;
+      for (var c2 = 0; c2 < choices.length; c2++) {
+        var eo = document.createElement("option");
+        eo.value = choices[c2];
+        eo.textContent = choices[c2] === "" ? "(inherit)" : choices[c2];
+        if (currentEffort === choices[c2]) eo.selected = true;
+        effortSel.appendChild(eo);
+      }
+      effortSel.addEventListener("change", function () {
+        _saveModelRole(this.getAttribute("data-role-key"), this.value);
+      });
+      effortWrap.appendChild(effortSel);
+      controls.appendChild(effortWrap);
+    }
+
+    row.appendChild(controls);
+    container.appendChild(row);
+  }
+
+  if (!container.children.length) {
+    _modelRolesError(container, "No model roles configured");
+  }
+}
+
+function _saveModelRole(key, value) {
+  authFetch("/v1/api/admin/settings/" + encodeURIComponent(key), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value: value }),
+  })
+    .then(function (r) {
+      if (!r.ok)
+        return r.json().then(function (d) {
+          throw new Error(d.error || "Failed");
+        });
+      return r.json();
+    })
+    .then(function () {
+      showToast("Saved");
+      loadAdminModelRoles();
+    })
+    .catch(function (e) {
+      showToast("Error: " + (e && e.message ? e.message : "save failed"));
     });
 }
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2626,18 +2626,21 @@ function loadSettings() {
       }
 
       // Merge values + schema.  Skip role-assignment settings owned by
-      // the Models tab (judge.* live on the Judge tab; coordinator
-      // model+effort lifted into Models → Roles).
+      // the Models → Roles sub-tab (judge.* settings still live on the
+      // Judge tab; the four model-tab roles render only there).
       var merged = {};
+      var roleKeys = {
+        "coordinator.model_alias": 1,
+        "coordinator.reasoning_effort": 1,
+        "model.plan_alias": 1,
+        "model.plan_effort": 1,
+        "model.task_alias": 1,
+        "model.task_effort": 1,
+      };
       for (var j = 0; j < valuesArr.length; j++) {
         var v = valuesArr[j];
         if (v.key.startsWith("judge.")) continue;
-        if (
-          v.key === "coordinator.model_alias" ||
-          v.key === "coordinator.reasoning_effort"
-        ) {
-          continue;
-        }
+        if (roleKeys[v.key]) continue;
         var s = schemaMap[v.key] || {};
         merged[v.key] = {
           key: v.key,
@@ -4467,6 +4470,20 @@ var MODEL_ROLES = [
     description:
       "Intent-validation judge that scores tool calls before approval.",
     aliasKey: "judge.model",
+  },
+  {
+    label: "Plan agent",
+    description:
+      "plan_agent sub-agent — produces high-level plans before task dispatch.",
+    aliasKey: "model.plan_alias",
+    effortKey: "model.plan_effort",
+  },
+  {
+    label: "Task agent",
+    description:
+      "task_agent sub-agent — runs autonomous subtasks dispatched by the parent.",
+    aliasKey: "model.task_alias",
+    effortKey: "model.task_effort",
   },
 ];
 

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -5,16 +5,12 @@ window.onLoginSuccess = function () {
   if (typeof _refreshHomeComposerVisibility === "function") {
     _refreshHomeComposerVisibility();
   }
-  // Re-populate the home-composer skill dropdown and re-probe the
-  // coordinator subsystem now that auth has landed.  The initial
-  // page-load pass runs before login completes, so /v1/api/skills
-  // and /v1/api/workstreams both 401; without this re-run the
-  // dropdown stays empty and the 503 banner never flips correctly.
+  // Re-populate the home-composer skill dropdown now that auth has
+  // landed.  The initial page-load pass runs before login completes,
+  // so /v1/api/skills 401s; without this re-run the dropdown stays
+  // empty.
   if (typeof _populateHomeSkillDropdown === "function") {
     _populateHomeSkillDropdown();
-  }
-  if (typeof _probeCoordSubsystem === "function") {
-    _probeCoordSubsystem();
   }
   // Active-coordinators list is SSE-driven via the console pseudo-node
   // (#9) — no poller to restart after login.  The home-view renderer
@@ -426,6 +422,22 @@ function handleClusterEvent(data) {
   }
   if (data.type === "ws_closed" && data.reason === "evicted") {
     showToast("Evicted" + (data.name ? ": " + data.name : "") + " (capacity)");
+  }
+  if (data.type === "models_changed") {
+    // Server emits this when a model definition or a role-assignment
+    // setting (model.default_alias, judge.model, coordinator.model_alias,
+    // coordinator.reasoning_effort) changes.  Refresh anything that
+    // renders model aliases so labels stay accurate without a reload.
+    if (typeof _populateHomeModelDropdowns === "function") {
+      _populateHomeModelDropdowns();
+    }
+    if (
+      typeof _adminTab !== "undefined" &&
+      _adminTab === "models" &&
+      typeof loadAdminModels === "function"
+    ) {
+      loadAdminModels();
+    }
   }
 }
 
@@ -1445,8 +1457,8 @@ function _hasCoordPermission() {
 // POST /v1/api/workstreams/new.  Accepts the three request fields
 // directly + an errEl / setBusy callback so the caller owns the
 // loading-state UX (button label swap, composer disabled flag, etc.).
-// On success redirects to /coordinator/{ws_id}; on 503 invokes on503
-// so the caller can surface the "subsystem not configured" banner.
+// On success redirects to /coordinator/{ws_id}; on failure surfaces
+// the server's error text inline through errEl.
 function _createCoordinator(opts) {
   var name = (opts.name || "").trim();
   var skill = opts.skill || "";
@@ -1455,7 +1467,6 @@ function _createCoordinator(opts) {
   var task = (opts.task || "").trim();
   var errEl = opts.errEl;
   var setBusy = opts.setBusy || function () {};
-  var on503 = opts.on503 || function () {};
   var onSuccess = opts.onSuccess || function () {};
 
   // Error region is always rendered with reserved min-height (see
@@ -1503,10 +1514,6 @@ function _createCoordinator(opts) {
     })
     .then(function (res) {
       setBusy(false);
-      if (res.status === 503) {
-        on503(res);
-        return;
-      }
       if (!res.ok || !res.data || !res.data.ws_id) {
         errEl.textContent =
           (res.data && res.data.error) || "HTTP " + res.status;
@@ -1531,7 +1538,6 @@ function _createCoordinator(opts) {
 // ---------------------------------------------------------------------------
 
 var _homeComposerInit = false;
-var _homeCoordReady = null; // tri-state: null = unknown, true = ready, false = 503
 var _homeCoordComposer = null; // shared Composer instance
 var _homeCoordBusy = false;
 
@@ -1688,15 +1694,10 @@ function _homeClearStagedFiles() {
   _homeRenderChips();
 }
 
-// Single owner for sendBtn.disabled: disabled if EITHER busy OR the
-// subsystem probe flipped to 503.  Every setter for _homeCoordBusy /
-// _homeCoordReady ends with a call here so the two inputs can't drift
-// out of sync (and a probe resolving mid-submit can't re-enable the
-// button under an in-flight request).
+// Sole owner of sendBtn.disabled: disables while a submit is in flight.
 function _refreshHomeCoordSubmitEnabled() {
   if (!_homeCoordComposer) return;
-  _homeCoordComposer.sendBtn.disabled =
-    _homeCoordBusy || _homeCoordReady === false;
+  _homeCoordComposer.sendBtn.disabled = _homeCoordBusy;
 }
 
 function _ensureHomeComposerInit() {
@@ -1705,7 +1706,6 @@ function _ensureHomeComposerInit() {
   _mountHomeCoordComposer();
   _populateHomeSkillDropdown();
   _populateHomeModelDropdowns();
-  _probeCoordSubsystem();
   _refreshHomeComposerVisibility();
 }
 
@@ -1825,40 +1825,6 @@ function _populateHomeModelDropdowns() {
     });
 }
 
-// Probe GET /v1/api/workstreams — 200 = subsystem ready; 503 = no model
-// alias resolvable, show remediation banner.  4xx (auth / permission) is
-// treated as "unknown, don't flip the banner" because the probe cannot
-// actually tell us anything about subsystem readiness in that case —
-// the caller is expected to re-invoke this after login lands so a real
-// answer can arrive.  Leaving the submit button enabled on unknown
-// keeps first-paint usable; a subsequent 503 from the actual submit
-// flips the banner via _createCoordinator's on503 hook.
-//
-// Skip the probe entirely for users without admin.coordinator — they
-// can't see the composer anyway (see _refreshHomeComposerVisibility),
-// and the endpoint returns 403 for them, producing a useless network
-// round-trip on every login.
-function _probeCoordSubsystem() {
-  if (!_hasCoordPermission()) return;
-  authFetch("/v1/api/workstreams")
-    .then(function (r) {
-      if (r.status === 503) {
-        _homeCoordReady = false;
-      } else if (r.ok) {
-        _homeCoordReady = true;
-      } else {
-        _homeCoordReady = null;
-        return;
-      }
-      var banner = document.getElementById("coord-composer-503");
-      if (banner) banner.style.display = _homeCoordReady ? "none" : "";
-      _refreshHomeCoordSubmitEnabled();
-    })
-    .catch(function () {
-      /* network error — leave banner hidden; submit will surface a retryable error */
-    });
-}
-
 function _refreshHomeComposerVisibility() {
   var panel = document.getElementById("coord-composer-panel");
   if (!panel) return;
@@ -1905,12 +1871,6 @@ function submitHomeCoord(textFromComposer) {
       if (_homeCoordComposer) _homeCoordComposer.setBusy(b);
       _refreshHomeCoordSubmitEnabled();
     },
-    on503: function () {
-      _homeCoordReady = false;
-      var banner = document.getElementById("coord-composer-503");
-      if (banner) banner.style.display = "";
-      _refreshHomeCoordSubmitEnabled();
-    },
     onSuccess: function () {
       _homeClearStagedFiles();
     },
@@ -1928,9 +1888,6 @@ document.addEventListener("keydown", function (e) {
   var mount = document.getElementById("home-coord-composer-mount");
   if (!mount || !mount.contains(e.target)) return;
   e.preventDefault();
-  // sendBtn.disabled is the single reconciler of busy + 503-ready —
-  // checking it here is enough to avoid double-submits or submits
-  // while the subsystem is down.
   if (!_homeCoordComposer.sendBtn.disabled) submitHomeCoord();
 });
 

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -2791,7 +2791,8 @@ var _eogpTriggerEl = null;
 function switchJudgeSection(section) {
   var sections = document.querySelectorAll(".judge-section");
   for (var i = 0; i < sections.length; i++) sections[i].style.display = "none";
-  var btns = document.querySelectorAll(".judge-section-btn");
+  var switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
+  var btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
   for (var i = 0; i < btns.length; i++) {
     var isActive = btns[i].getAttribute("data-section") === section;
     btns[i].classList.toggle("active", isActive);
@@ -2804,15 +2805,15 @@ function switchJudgeSection(section) {
 
 // Arrow key navigation for judge sub-section tabs
 (function () {
-  var switcher = document.querySelector(".judge-section-switcher");
+  var switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
   if (!switcher) return;
   switcher.addEventListener("keydown", function (e) {
     if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-    var btns = switcher.querySelectorAll(".judge-section-btn");
+    var btns = switcher.querySelectorAll(".admin-subtab-btn");
     var secs = [];
     for (var i = 0; i < btns.length; i++)
       secs.push(btns[i].getAttribute("data-section"));
-    var current = switcher.querySelector(".judge-section-btn.active");
+    var current = switcher.querySelector(".admin-subtab-btn.active");
     var idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
     if (e.key === "ArrowRight") idx = (idx + 1) % secs.length;
     else idx = (idx - 1 + secs.length) % secs.length;
@@ -2874,6 +2875,7 @@ function renderJudgeSettings() {
   var html = "";
   for (var i = 0; i < _judgeSettings.length; i++) {
     var s = _judgeSettings[i];
+    if (s.key === "judge.model") continue;
     var shortKey = s.key.replace("judge.", "");
     var inputHtml = "";
     var currentVal = s.value;

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -87,33 +87,16 @@
       <div id="view-home">
         <!-- Persistent "start a new coordinator task" composer.  Visibility is
          gated on the admin.coordinator permission (same rule the existing
-         +coordinator header button + modal use).  Shows a remediation
-         banner when the create endpoint would return 503 (no coordinator
-         model alias resolves). -->
+         +coordinator header button + modal use).  Submission errors surface
+         inline via #home-coord-error; the create endpoint falls back to
+         the registry default model when ``coordinator.model_alias`` is
+         unset, so no proactive readiness probe is needed. -->
         <section
           id="coord-composer-panel"
           class="home-panel"
           style="display: none"
           aria-label="Start a new orchestration task"
         >
-          <div
-            id="coord-composer-503"
-            class="home-composer-banner"
-            role="status"
-            style="display: none"
-          >
-            Coordinator subsystem not configured —
-            <a
-              href="#"
-              onclick="
-                showAdmin();
-                switchAdminTab('models');
-                return false;
-              "
-              >open Admin → Models</a
-            >
-            to set <code>coordinator.model_alias</code> or a registry default.
-          </div>
           <!-- Composer DOM is built by shared_static/composer.js into this
            mount — stacked layout (textarea above, options toggle +
            Start button below) with Name + Skill in an Options
@@ -882,13 +865,13 @@
 
               <!-- Sub-panel switcher -->
               <div
-                class="judge-section-switcher"
+                class="admin-subtab-switcher"
                 role="tablist"
                 aria-label="Judge sections"
               >
                 <button
                   id="judge-tab-settings"
-                  class="judge-section-btn active"
+                  class="admin-subtab-btn active"
                   role="tab"
                   aria-selected="true"
                   aria-controls="judge-settings-section"
@@ -900,7 +883,7 @@
                 </button>
                 <button
                   id="judge-tab-heuristic"
-                  class="judge-section-btn"
+                  class="admin-subtab-btn"
                   role="tab"
                   aria-selected="false"
                   aria-controls="judge-heuristic-section"
@@ -912,7 +895,7 @@
                 </button>
                 <button
                   id="judge-tab-output-guard"
-                  class="judge-section-btn"
+                  class="admin-subtab-btn"
                   role="tab"
                   aria-selected="false"
                   aria-controls="judge-output-guard-section"
@@ -1795,37 +1778,106 @@
               style="display: none"
             >
               <div class="admin-toolbar">
-                <span class="section-header">Models</span>
-                <button
-                  id="model-sync-btn"
-                  class="admin-action-btn admin-action-btn-ghost"
-                  onclick="reloadModelNodes()"
-                  title="Push model config to all cluster nodes"
-                >
-                  Sync to Nodes
-                </button>
-                <button
-                  class="admin-action-btn"
-                  onclick="showCreateModelModal()"
-                >
-                  + Add Model
-                </button>
+                <span class="section-header" style="margin: 0">MODELS</span>
               </div>
-              <div class="admin-colheaders models-grid" aria-hidden="true">
-                <span class="admin-col">ALIAS</span>
-                <span class="admin-col">MODEL</span>
-                <span class="admin-col">PROVIDER</span>
-                <span class="admin-col">CTX WINDOW</span>
-                <span class="admin-col">STATUS</span>
-                <span class="admin-col">ACTIONS</span>
-              </div>
+
+              <!-- Sub-panel switcher -->
               <div
-                id="admin-models-table"
-                role="list"
-                aria-label="Model definitions"
-                aria-live="polite"
+                class="admin-subtab-switcher"
+                role="tablist"
+                aria-label="Models sections"
               >
-                <div class="dashboard-empty">Loading...</div>
+                <button
+                  id="models-tab-list"
+                  class="admin-subtab-btn active"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="models-list-section"
+                  tabindex="0"
+                  data-section="models-list"
+                  onclick="switchModelsSection('models-list')"
+                >
+                  Definitions
+                </button>
+                <button
+                  id="models-tab-roles"
+                  class="admin-subtab-btn"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="models-roles-section"
+                  tabindex="-1"
+                  data-section="models-roles"
+                  onclick="switchModelsSection('models-roles')"
+                >
+                  Roles
+                </button>
+              </div>
+
+              <!-- Models list section -->
+              <div
+                id="models-list-section"
+                class="models-section"
+                role="tabpanel"
+                aria-labelledby="models-tab-list"
+              >
+                <div class="admin-toolbar" style="margin-bottom: 12px">
+                  <span style="font-size: 13px; color: var(--fg-dim)"
+                    >Model definitions used by sessions across the cluster</span
+                  >
+                  <button
+                    id="model-sync-btn"
+                    class="admin-action-btn admin-action-btn-ghost"
+                    onclick="reloadModelNodes()"
+                    title="Push model config to all cluster nodes"
+                  >
+                    Sync to Nodes
+                  </button>
+                  <button
+                    class="admin-action-btn"
+                    onclick="showCreateModelModal()"
+                  >
+                    + Add Model
+                  </button>
+                </div>
+                <div class="admin-colheaders models-grid" aria-hidden="true">
+                  <span class="admin-col">ALIAS</span>
+                  <span class="admin-col">MODEL</span>
+                  <span class="admin-col">PROVIDER</span>
+                  <span class="admin-col">CTX WINDOW</span>
+                  <span class="admin-col">STATUS</span>
+                  <span class="admin-col">ACTIONS</span>
+                </div>
+                <div
+                  id="admin-models-table"
+                  role="list"
+                  aria-label="Model definitions"
+                  aria-live="polite"
+                >
+                  <div class="dashboard-empty">Loading...</div>
+                </div>
+              </div>
+
+              <!-- Roles section (Coordinator / Judge / future perception roles) -->
+              <div
+                id="models-roles-section"
+                class="models-section"
+                role="tabpanel"
+                aria-labelledby="models-tab-roles"
+                style="display: none"
+              >
+                <div style="margin-bottom: 12px">
+                  <span style="font-size: 13px; color: var(--fg-dim)"
+                    >Per-role model assignments. Empty = use the default
+                    model.</span
+                  >
+                </div>
+                <div
+                  id="admin-models-roles-container"
+                  aria-live="polite"
+                  style="max-width: 720px"
+                >
+                  <div class="dashboard-empty">Loading&hellip;</div>
+                </div>
               </div>
             </div>
 

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -88,21 +88,6 @@
   text-transform: uppercase;
 }
 
-.home-composer-banner {
-  background: var(--bg-surface);
-  border: 1px solid var(--yellow);
-  border-left-width: 3px;
-  border-radius: var(--radius-sm);
-  padding: 8px 10px;
-  color: var(--fg-bright);
-  font-size: 12px;
-}
-.home-composer-banner a {
-  color: var(--accent);
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-}
-
 .home-composer-error {
   /* Always rendered (no display toggle in JS) so toggling validation
      messages doesn't reflow the active-coordinators list below.  The
@@ -2350,15 +2335,15 @@ textarea.skill-content-area {
 }
 
 /* ==========================================================================
-   Judge sub-section tabs
+   Admin sub-section tabs (used by Judge + Models tabs)
    ========================================================================== */
-.judge-section-switcher {
+.admin-subtab-switcher {
   display: flex;
   gap: 8px;
   margin: 12px 0 16px;
   border-bottom: 1px solid var(--border-strong);
 }
-.judge-section-btn {
+.admin-subtab-btn {
   padding: 6px 14px;
   background: none;
   border: none;
@@ -2371,14 +2356,14 @@ textarea.skill-content-area {
     color 0.15s,
     border-color 0.15s;
 }
-.judge-section-btn:hover {
+.admin-subtab-btn:hover {
   color: var(--fg);
 }
-.judge-section-btn.active {
+.admin-subtab-btn.active {
   border-bottom-color: var(--accent);
   color: var(--fg);
 }
-.judge-section-btn:focus-visible {
+.admin-subtab-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -3841,6 +3826,64 @@ textarea.skill-content-area {
   letter-spacing: 0.02em;
 }
 
+/* Models → Roles sub-tab rows */
+.model-role-row {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-strong);
+}
+.model-role-row:last-child {
+  border-bottom: none;
+}
+.model-role-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.model-role-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.model-role-desc {
+  font-size: 11px;
+  color: var(--fg-dim);
+  margin-bottom: 8px;
+}
+.model-role-controls {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(180px, auto);
+  column-gap: 16px;
+  row-gap: 8px;
+  align-items: end;
+}
+.model-role-control {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.model-role-control-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-dim);
+}
+.model-role-control select {
+  width: 100%;
+  padding: 4px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  color: var(--fg);
+  border-radius: 3px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+}
+.model-role-control select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 /* Modal section divider for field groups */
 .modal-section-divider {
   font-family: var(--font-ui);
@@ -3888,7 +3931,7 @@ textarea.skill-content-area {
   .admin-btn-danger,
   .admin-btn-caution,
   .admin-btn-action,
-  .judge-section-btn {
+  .admin-subtab-btn {
     transition: none;
   }
   .settings-toggle-slider,


### PR DESCRIPTION
## Summary

Lifts judge and coordinator model assignments out of their respective admin tabs and into a new **Models → Roles** sub-tab so role overrides live next to the model definitions they reference. Forward-looking shape for the upcoming `perception.{audio,image,video}` model settings — adding a new role is one entry in the declarative `MODEL_ROLES` array.

Also drops the misleading "Coordinator subsystem not configured" home banner. The session factory (`session_factory.py:109-110`) already falls back to the registry's default model when `coordinator.model_alias` is unset, so the banner was nagging on fresh installs where the system was actually working. The related `_probeCoordSubsystem` / `_homeCoordReady` plumbing went with it.

Wires SSE-driven live refresh: the console now emits a `models_changed` event when a model definition is created / updated / deleted / reloaded, or when a model-affecting setting (`model.default_alias`, `judge.model`, `coordinator.model_alias`, `coordinator.reasoning_effort`) changes. Connected browsers refetch `/v1/api/models` on receipt so the home composer's model dropdown and the Roles sub-tab stay accurate without a manual reload — fixes the case where editing the underlying model for an existing alias left the dropdown showing the old model id.

Companion cleanups:
- Renamed `.judge-section-*` CSS classes to `.admin-subtab-*` and shared them with the Models sub-tab switcher (same a11y attrs, arrow-key nav). Old names had no other callers.
- Filtered `judge.model` out of the Judge Settings sub-tab and `coordinator.model_alias` / `coordinator.reasoning_effort` out of the Settings tab — they live exclusively under Models → Roles now.
- Reworded the `_require_coord_mgr` 503 messages to point operators at the Models tab instead of suggesting they set `coordinator.model_alias`.

## Test plan

- [ ] Fresh install with no models: home composer shows no banner; submitting surfaces inline error from the 503 server response (no proactive nag).
- [ ] Open Admin → Models. Sub-tabs show "Definitions" (existing list) and "Roles" (new). Switching with mouse + arrow keys works; tab order is correct.
- [ ] Roles sub-tab: Coordinator row has alias dropdown + reasoning-effort dropdown; Judge row has alias dropdown only. Empty option in each alias dropdown reads `(default — <alias>)`.
- [ ] Change a role's alias → toast appears, row re-renders, value persists across reload.
- [ ] Reset by selecting the empty `(default — X)` option → setting clears, falls back to default.
- [ ] In a second browser tab, edit a model definition's underlying model id → home composer + Roles sub-tab dropdown labels update without manual reload.
- [ ] Settings tab no longer shows `judge.*` or `coordinator.model_alias` / `coordinator.reasoning_effort`. Other `coordinator.*` settings (max_active, session_jwt_ttl_seconds) still render.
- [ ] Judge tab Settings sub-tab no longer shows `judge.model`; other judge settings render.