### PR TITLE
fix(tests): isolate metrics-singleton swaps so they don't leak across files

### DIFF
--- a/tests/test_close_reason_persistence.py
+++ b/tests/test_close_reason_persistence.py
@@ -30,9 +30,25 @@ def _full_hdr() -> dict[str, str]:
     }
 
 
+@pytest.fixture(autouse=True)
+def _isolate_metrics(monkeypatch):
+    """Swap ``turnstone.server._metrics`` for a fresh collector
+    per-test, with auto-restore.
+
+    Bare ``srv_mod._metrics = MetricsCollector()`` (the prior
+    pattern) leaks into any test file that already bound the name
+    via ``from turnstone.server import _metrics`` at import time —
+    those tests' patches then operate on a different instance from
+    the one the live ``_publish_models_metadata`` reads, and the
+    monkeypatch silently no-ops.  ``monkeypatch.setattr`` restores
+    after the test, so the leak is contained.
+    """
+    fresh = MetricsCollector()
+    fresh.model = "test-model"
+    monkeypatch.setattr(srv_mod, "_metrics", fresh)
+
+
 def _make_app(storage: Any) -> TestClient:
-    srv_mod._metrics = MetricsCollector()
-    srv_mod._metrics.model = "test-model"
     mock_session = MagicMock()
     mock_ws = MagicMock()
     mock_ws.id = "ws-target"

--- a/tests/test_server_node_models_metadata.py
+++ b/tests/test_server_node_models_metadata.py
@@ -22,7 +22,6 @@ from turnstone.core.healthcheck import HealthTrackerRegistry
 from turnstone.core.model_registry import ModelConfig, ModelRegistry
 from turnstone.server import (
     _collect_node_models_metadata,
-    _metrics,
     _publish_models_metadata,
 )
 
@@ -157,16 +156,25 @@ def test_publish_records_metric_outcome(monkeypatch):
     """The publish helper feeds ``record_node_models_publish`` so
     Prometheus can expose the hit-rate.  Storage failures must NOT
     record either outcome — counters should reflect actual cache
-    decisions, not transient DB errors that will retry."""
+    decisions, not transient DB errors that will retry.
+
+    Replaces the module-level ``turnstone.server._metrics`` binding
+    via string-form monkeypatch (with auto-restore) rather than
+    patching an instance attribute on the imported singleton.  Other
+    tests in the suite reassign ``srv_mod._metrics`` (some without
+    using monkeypatch), so an instance captured at import time can
+    diverge from the binding the live ``_publish_models_metadata``
+    reads on each call.
+    """
     state = _publish_state()
     storage = MagicMock()
     calls: list[bool] = []
 
-    def _record(*, written: bool) -> None:
-        calls.append(written)
+    class _FakeMetrics:
+        def record_node_models_publish(self, *, written: bool) -> None:
+            calls.append(written)
 
-    # Patch the metrics binding the helper closes over.
-    monkeypatch.setattr(_metrics, "record_node_models_publish", _record)
+    monkeypatch.setattr("turnstone.server._metrics", _FakeMetrics())
 
     _publish_models_metadata(state, storage, "node-a")  # first → write
     _publish_models_metadata(state, storage, "node-a")  # second → skip


### PR DESCRIPTION
## Summary

Fixes the CI regression on main where `test_publish_records_metric_outcome` (introduced by #466) saw an empty `calls` list. Root cause: `test_close_reason_persistence.py:_make_app` reassigned `turnstone.server._metrics = MetricsCollector()` without restoration, so any test that captured the binding via `from turnstone.server import _metrics` at module-load time ended up patching a different instance from the one the live `_publish_models_metadata` reads.

Two changes:

- **`test_close_reason_persistence.py`** — autouse `monkeypatch.setattr(srv_mod, "_metrics", ...)` fixture. The mutation now auto-restores after each test.
- **`test_server_node_models_metadata.py`** — switch the publish-helper metric test to string-form `monkeypatch.setattr("turnstone.server._metrics", FakeMetrics())`. Robust to whatever instance the live module currently holds.

`test_auth.py` and `test_server_attachments_endpoints.py` carry the same anti-pattern. They aren't on the critical path here so I left them for a follow-up; they may bite future tests that capture `_metrics` via from-import.

## Test plan

- [x] `pytest tests/ -m "not live"` — 5088 passed (was 5087 + 1 failed before the fix)
- [x] `pytest tests/test_close_reason_persistence.py tests/test_server_node_models_metadata.py` — clean isolation pair pass
- [x] `ruff check` clean on both files
- [ ] Watch CI on this PR to confirm green