### PR TITLE
fix(session): properly inject queued user messages mid-loop

### DIFF
--- a/tests/test_server_attachments_endpoints.py
+++ b/tests/test_server_attachments_endpoints.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import queue
 import threading
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
@@ -707,22 +708,26 @@ class TestQueuedAttachmentReservation:
         mgr.get.return_value = ws
         return ws, session
 
-    def _queue_with_attachment(self, client, mgr, ws_id: str, filename: str = "q.md"):
+    def _reserve_attachment(self, client, mgr, ws_id: str, filename: str = "q.md"):
+        """Set up a reserved attachment for the busy-worker tests below.
+
+        The queue-with-attachments path was removed (queued user turns
+        can't carry attachments — see ``AttachmentsNotQueueableError``),
+        so the tests reserve directly via ``reserve_attachments`` to
+        produce the same on-disk state without going through the
+        rejected route path.
+        """
+        from turnstone.core.memory import reserve_attachments
+
         aid = _upload(client, ws_id, "userA", filename, b"Q", "text/markdown")
         ws, session = self._wire_busy_ws(mgr, ws_id)
-        resp = client.post(
-            f"/v1/api/workstreams/{ws_id}/send",
-            json={"message": "queued", "attachment_ids": [aid]},
-            headers=_auth("userA"),
-        )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["status"] == "queued"
-        return aid, body["msg_id"], session
+        msg_id = uuid.uuid4().hex
+        reserve_attachments([aid], msg_id, ws_id, "userA")
+        return aid, msg_id, session
 
     def test_reserved_attachment_hidden_from_pending_listing(self, app_client):
         client, mgr = app_client
-        aid, _mid, _session = self._queue_with_attachment(client, mgr, "ws-A")
+        aid, _mid, _session = self._reserve_attachment(client, mgr, "ws-A")
         resp = client.get("/v1/api/workstreams/ws-A/attachments", headers=_auth("userA"))
         # Reserved attachment is not in the pending listing
         ids = [a["attachment_id"] for a in resp.json()["attachments"]]
@@ -730,7 +735,7 @@ class TestQueuedAttachmentReservation:
 
     def test_reserved_attachment_cannot_be_deleted(self, app_client):
         client, mgr = app_client
-        aid, _mid, _session = self._queue_with_attachment(client, mgr, "ws-A")
+        aid, _mid, _session = self._reserve_attachment(client, mgr, "ws-A")
         resp = client.delete(
             f"/v1/api/workstreams/ws-A/attachments/{aid}",
             headers=_auth("userA"),
@@ -745,7 +750,7 @@ class TestQueuedAttachmentReservation:
 
     def test_reserved_attachment_not_auto_consumed_by_later_send(self, app_client):
         client, mgr = app_client
-        aid, _mid, session = self._queue_with_attachment(client, mgr, "ws-A")
+        aid, _mid, session = self._reserve_attachment(client, mgr, "ws-A")
 
         # Swap the busy worker for an idle one and capture the next
         # session.send call so we can assert on its attachment list.
@@ -781,7 +786,7 @@ class TestQueuedAttachmentReservation:
 
     def test_reserved_attachment_rejected_in_explicit_ids(self, app_client):
         client, mgr = app_client
-        aid, _mid, session = self._queue_with_attachment(client, mgr, "ws-A")
+        aid, _mid, session = self._reserve_attachment(client, mgr, "ws-A")
 
         captured: dict = {}
 
@@ -813,29 +818,26 @@ class TestQueuedAttachmentReservation:
         if atts is not None:
             assert aid not in [a.attachment_id for a in atts]
 
-    def test_dequeue_releases_reservation(self, app_client):
+    def test_send_with_attachments_to_busy_worker_returns_attachments_busy(self, app_client):
+        """An attempt to attach mid-tool-call returns ``attachments_busy``;
+        attachments stay pending so the client can retry once idle."""
         client, mgr = app_client
-        aid, mid, session = self._queue_with_attachment(client, mgr, "ws-A")
-
-        # Cancel the queued message — DELETE /api/send with msg_id
-        resp = client.request(
-            "DELETE",
+        aid = _upload(client, "ws-A", "userA", "x.md", b"X", "text/markdown")
+        self._wire_busy_ws(mgr, "ws-A")
+        resp = client.post(
             "/v1/api/workstreams/ws-A/send",
-            json={"msg_id": mid},
+            json={"message": "with file", "attachment_ids": [aid]},
             headers=_auth("userA"),
         )
         assert resp.status_code == 200
-        assert resp.json().get("status") == "removed"
-
-        # Attachment is back to pending — visible + deletable
+        body = resp.json()
+        assert body["status"] == "attachments_busy"
+        assert body["attached_ids"] == []
+        assert body["dropped_attachment_ids"] == [aid]
+        # Reservation released — attachment is still pending and visible.
         resp = client.get("/v1/api/workstreams/ws-A/attachments", headers=_auth("userA"))
         ids = [a["attachment_id"] for a in resp.json()["attachments"]]
         assert aid in ids
-        resp = client.delete(
-            f"/v1/api/workstreams/ws-A/attachments/{aid}",
-            headers=_auth("userA"),
-        )
-        assert resp.status_code == 200
 
 
 class TestReserveThenDispatchRace:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1984,13 +1984,6 @@ class TestMetacognitiveBuffers:
         assert session._pending_user_advisories == [("correction", "USER_NUDGE_MARK")]
         assert session._pending_tool_advisories == [("tool_error", "TOOL_NUDGE_MARK")]
 
-    def _patch_caps(self, session, *, supports_tool_advisories: bool):
-        """Force capability flag for advisory-aware tests."""
-        caps = MagicMock()
-        caps.supports_tool_advisories = supports_tool_advisories
-        with patch.object(session, "_get_capabilities", return_value=caps):
-            return caps
-
     def test_collect_advisories_drains_tool_buffer_on_last_result(self, tmp_db):
         """Tool-channel metacog reminders no longer ride the persistent
         advisory list (which would write them into tool content via
@@ -2000,12 +1993,9 @@ class TestMetacognitiveBuffers:
         channel."""
         session = _make_session()
         session._queue_tool_advisory("tool_error", "ALERT")
-        caps = MagicMock()
-        caps.supports_tool_advisories = True
-        with patch.object(session, "_get_capabilities", return_value=caps):
-            persistent, metacog = session._collect_advisories(
-                assessment=None, func_name="bash", is_last_in_batch=True
-            )
+        persistent, metacog = session._collect_advisories(
+            assessment=None, func_name="bash", is_last_in_batch=True
+        )
         # Persistent list is empty (no guard / interjection here);
         # MetacognitiveAdvisory does NOT appear among persistent
         # advisories anymore.
@@ -2017,32 +2007,41 @@ class TestMetacognitiveBuffers:
     def test_collect_advisories_holds_tool_buffer_until_last_result(self, tmp_db):
         session = _make_session()
         session._queue_tool_advisory("repeat", "STOP_REPEATING")
-        caps = MagicMock()
-        caps.supports_tool_advisories = True
-        with patch.object(session, "_get_capabilities", return_value=caps):
-            persistent, metacog = session._collect_advisories(
-                assessment=None, func_name="bash", is_last_in_batch=False
-            )
+        persistent, metacog = session._collect_advisories(
+            assessment=None, func_name="bash", is_last_in_batch=False
+        )
         # Not yet drained — only fires on the last result.
         assert persistent == []
         assert metacog == []
         assert len(session._pending_tool_advisories) == 1
 
-    def test_collect_advisories_drops_tool_buffer_when_caps_unsupported(self, tmp_db):
-        """When the model can't parse advisory tags, drop the metacognitive
-        nudge silently rather than embedding raw XML the model will choke on."""
+    def test_collect_advisories_drains_text_queued_messages_to_persistent(self, tmp_db):
+        """Text-only queued user messages drain into the ``persistent``
+        advisory list as ``UserInterjection`` on the last result of a
+        batch — they ride INSIDE the tool result envelope via
+        ``wrap_tool_result`` rather than becoming a separate user turn
+        appended to ``self.messages`` (which would inject ``user``
+        between ``assistant(tool_calls)`` and ``tool`` and break role
+        validation on Mistral / mistral-common and similar strict
+        templates)."""
+        from turnstone.core.tool_advisory import UserInterjection
+
         session = _make_session()
-        session._queue_tool_advisory("tool_error", "ALERT")
-        caps = MagicMock()
-        caps.supports_tool_advisories = False
-        with patch.object(session, "_get_capabilities", return_value=caps):
-            persistent, metacog = session._collect_advisories(
-                assessment=None, func_name="bash", is_last_in_batch=True
-            )
-        assert persistent == []
+        pre_count = len(session.messages)
+        session.queue_message("hows it going?", queue_msg_id="q1")
+        persistent, metacog = session._collect_advisories(
+            assessment=None, func_name="bash", is_last_in_batch=True
+        )
         assert metacog == []
-        # And the buffer is cleared so no stale nudge sticks around.
-        assert session._pending_tool_advisories == []
+        assert len(persistent) == 1
+        assert isinstance(persistent[0], UserInterjection)
+        assert persistent[0].message == "hows it going?"
+        # Queue drained.
+        assert session._queued_messages == {}
+        # Crucially: NO separate user turn was appended to history —
+        # the message rides inside the tool envelope, preserving the
+        # `assistant(tool_calls) → tool` role sequence on the wire.
+        assert len(session.messages) == pre_count
 
     def test_start_nudge_fires_through_send(self, tmp_db):
         """Pin the +1 count-shift invariant — `start` must still fire on the
@@ -2112,10 +2111,7 @@ class TestMetacognitiveBuffers:
         session = _make_session()
         session.ui = MagicMock()
         session._queue_tool_advisory("tool_error", "alert")
-        caps = MagicMock()
-        caps.supports_tool_advisories = True
-        with patch.object(session, "_get_capabilities", return_value=caps):
-            session._collect_advisories(assessment=None, func_name="bash", is_last_in_batch=True)
+        session._collect_advisories(assessment=None, func_name="bash", is_last_in_batch=True)
         info_lines = [call.args[0] for call in session.ui.on_info.call_args_list if call.args]
         assert not any("metacognition: nudge injected" in line for line in info_lines), (
             f"expected NO legacy ping, got {info_lines!r}"
@@ -2785,6 +2781,74 @@ class TestUserAdvisoryCancelClear:
         ):
             session.send("user input")
         assert session._pending_user_advisories == []
+
+    def test_send_continues_when_messages_queued_during_streaming(self, tmp_db):
+        """A user message queued while the assistant is streaming a
+        non-tool response must trigger another model turn — not orphan
+        in history until the next user send.
+
+        Pre-fix bug: after the no-tool branch ran ``_flush_queued_messages``,
+        the loop ``break``-d unconditionally, leaving the queued user
+        message at the tail of ``self.messages`` with no model response.
+        The next outside ``send()`` would finally pick it up alongside
+        the new message — visible as the "two sends to get one reply"
+        symptom.
+
+        Fix: ``_flush_queued_messages`` returns whether anything drained;
+        the no-tool branch ``continue``-s when it did."""
+        session = _make_session()
+        # Suppress the auto-title daemon thread the no-tool branch
+        # would spawn — irrelevant to this test and would otherwise
+        # call the mocked client from a background thread.
+        session._title_generated = True
+        stream_calls = 0
+
+        def mock_create_stream(msgs):
+            nonlocal stream_calls
+            stream_calls += 1
+            if stream_calls == 1:
+                # Simulate a queued message arriving mid-stream — by the
+                # time the no-tool branch runs ``_flush_queued_messages``,
+                # this item is in the queue waiting to be drained.
+                session.queue_message("late arrival", queue_msg_id="q-late")
+            return iter([])
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=mock_create_stream),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("first message")
+
+        # Loop continued: a second stream call happened after the
+        # queued message drained into history.  Pre-fix: 1 call.
+        assert stream_calls == 2, (
+            f"expected loop to continue after drain (2 stream calls); got {stream_calls}"
+        )
+        # The queued message landed in history before the second turn.
+        user_texts: list[str] = []
+        for m in session.messages:
+            if m.get("role") != "user":
+                continue
+            content = m.get("content")
+            if isinstance(content, str):
+                user_texts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and "text" in part:
+                        user_texts.append(part["text"])
+        assert any("late arrival" in t for t in user_texts), (
+            f"queued message must appear in history; got user texts: {user_texts!r}"
+        )
 
 
 class TestReminderSidechannelIsolation:

--- a/tests/test_session_attachments.py
+++ b/tests/test_session_attachments.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from turnstone.core.attachments import Attachment
 from turnstone.core.memory import (
     get_attachment,
@@ -273,149 +275,29 @@ class TestProviderIntegration:
         assert "DO THE THING" in parts[1]["text"]
 
 
-class TestQueuedWithAttachments:
-    """Queued user turns must carry their attachments through to dequeue."""
+class TestQueuedAttachmentsRejected:
+    """Queued user messages can't carry attachments — see
+    :class:`AttachmentsNotQueueableError` for the role-ordering reason
+    (an attachment-bearing queued item would have to be appended as a
+    separate user turn, injecting ``user`` between
+    ``assistant(tool_calls)`` and ``tool``)."""
 
-    def test_queue_message_stores_attachment_ids(self, tmp_db, mock_openai_client):
+    def test_queue_message_rejects_attachments(self, tmp_db, mock_openai_client):
+        from turnstone.core.session import AttachmentsNotQueueableError
+
         s = _make_session(mock_openai_client)
-        # Seed a pending attachment owned by the session user
         save_attachment("a-q1", s._ws_id, "u1", "q.md", "text/markdown", 1, "text", b"q")
-        cleaned, priority, msg_id = s.queue_message("queued text", attachment_ids=["a-q1"])
-        assert cleaned == "queued text"
+        with pytest.raises(AttachmentsNotQueueableError):
+            s.queue_message("queued text", attachment_ids=["a-q1"])
+        # Queue stayed empty — nothing partially committed.
+        assert s._queued_messages == {}
+
+    def test_queue_message_accepts_text_only(self, tmp_db, mock_openai_client):
+        s = _make_session(mock_openai_client)
+        cleaned, priority, msg_id = s.queue_message("plain text")
+        assert cleaned == "plain text"
         with s._queued_lock:
-            entry = s._queued_messages[msg_id]
-        # Entry shape is (cleaned, priority, attachment_ids_tuple)
-        assert entry[0] == "queued text"
-        assert entry[2] == ("a-q1",)
-
-    def test_flush_queued_injects_multipart_user_turn(self, tmp_db, mock_openai_client):
-        from turnstone.core.memory import reserve_attachments
-
-        s = _make_session(mock_openai_client)
-        save_attachment("a-f1", s._ws_id, "u1", "f.md", "text/markdown", 3, "text", b"DAT")
-        _c, _p, msg_id = s.queue_message("please review", attachment_ids=["a-f1"])
-        # Server-side would have reserved before queueing; mirror that
-        # so consume's token match succeeds on flush.
-        reserve_attachments(["a-f1"], msg_id, s._ws_id, "u1")
-        s._flush_queued_messages()
-
-        msgs = s.messages
-        assert len(msgs) == 1
-        msg = msgs[0]
-        assert msg["role"] == "user"
-        # Multipart shape — text + document parts
-        assert isinstance(msg["content"], list)
-        assert msg["content"][0] == {"type": "text", "text": "please review"}
-        doc = msg["content"][1]
-        assert doc["type"] == "document"
-        assert doc["document"]["name"] == "f.md"
-        assert doc["document"]["data"] == "DAT"
-        # And the attachment is now consumed (not pending)
-        assert get_attachment("a-f1")["message_id"] is not None
-        assert list_pending_attachments(s._ws_id, "u1") == []
-
-    def test_flush_mixed_attachment_and_text_items(self, tmp_db, mock_openai_client):
-        # Text-only items should combine into one turn while
-        # attachment-bearing items flush as separate multipart turns.
-        from turnstone.core.memory import reserve_attachments
-
-        s = _make_session(mock_openai_client)
-        save_attachment("a-mx", s._ws_id, "u1", "x.md", "text/markdown", 1, "text", b"x")
-        s.queue_message("first plain")
-        _c, _p, mid = s.queue_message("with file", attachment_ids=["a-mx"])
-        reserve_attachments(["a-mx"], mid, s._ws_id, "u1")
-        s.queue_message("another plain")
-        s._flush_queued_messages()
-
-        # We expect at least two user messages: one combining the plain
-        # items flanking the multipart turn is allowed, but the
-        # multipart turn must remain its own message.
-        user_msgs = [m for m in s.messages if m.get("role") == "user"]
-        multipart = [m for m in user_msgs if isinstance(m["content"], list)]
-        assert len(multipart) == 1
-        assert "with file" in multipart[0]["content"][0]["text"]
-
-    def test_flush_drops_cross_user_attachment_silently(self, tmp_db, mock_openai_client):
-        # A forged attachment_id belonging to another user must not
-        # produce an attached part — dequeue resolution re-scopes.
-        s = _make_session(mock_openai_client, user_id="u1")
-        save_attachment("a-other", s._ws_id, "u2", "other.md", "text/plain", 1, "text", b"o")
-        s.queue_message("hi", attachment_ids=["a-other"])
-        s._flush_queued_messages()
-        # Flushed as plain text-only turn — the forged id was scope-dropped.
-        msgs = s.messages
-        assert len(msgs) == 1
-        assert msgs[0]["content"] == "hi"
-
-
-class TestQueueReservationLifecycle:
-    """session.queue_message + dequeue_message lifecycle with reservations."""
-
-    def test_dequeue_unreserves_attachments(self, tmp_db, mock_openai_client):
-        from turnstone.core.memory import get_attachment, reserve_attachments
-
-        s = _make_session(mock_openai_client)
-        save_attachment("a-deq", s._ws_id, "u1", "x.md", "text/plain", 1, "text", b"x")
-        _cleaned, _priority, msg_id = s.queue_message("queued", attachment_ids=["a-deq"])
-        # Simulate the server reserving after queue_message
-        reserve_attachments(["a-deq"], msg_id, s._ws_id, "u1")
-        assert get_attachment("a-deq")["reserved_for_msg_id"] == msg_id
-
-        # Dequeue (user cancelled the queued send)
-        assert s.dequeue_message(msg_id) is True
-        # Reservation is released — back to pending
-        assert get_attachment("a-deq")["reserved_for_msg_id"] is None
-        assert len(list_pending_attachments(s._ws_id, "u1")) == 1
-
-    def test_flush_consumes_reserved_attachment(self, tmp_db, mock_openai_client):
-        from turnstone.core.memory import get_attachment, reserve_attachments
-
-        s = _make_session(mock_openai_client)
-        save_attachment("a-flush", s._ws_id, "u1", "y.md", "text/plain", 1, "text", b"y")
-        _c, _p, msg_id = s.queue_message("go", attachment_ids=["a-flush"])
-        reserve_attachments(["a-flush"], msg_id, s._ws_id, "u1")
-
-        # Flush — queue drain must accept the reserved-for-this-msg attachment
-        s._flush_queued_messages()
-        row = get_attachment("a-flush")
-        assert row["message_id"] is not None
-        assert row["reserved_for_msg_id"] is None  # cleared on consume
-        # And the in-memory message is multipart with the doc attached
-        assert isinstance(s.messages[-1]["content"], list)
-        assert any(p.get("type") == "document" for p in s.messages[-1]["content"])
-
-    def test_resolve_rejects_reservation_for_other_msg(self, tmp_db, mock_openai_client):
-        from turnstone.core.memory import reserve_attachments
-
-        s = _make_session(mock_openai_client)
-        save_attachment("a-other", s._ws_id, "u1", "z.md", "text/plain", 1, "text", b"z")
-        reserve_attachments(["a-other"], "q-OTHER", s._ws_id, "u1")
-        # allow_reserved_for=None (default) → reserved rows are skipped
-        assert s._resolve_attachment_ids(["a-other"]) == []
-        # allow_reserved_for matches → accepted
-        out = s._resolve_attachment_ids(["a-other"], allow_reserved_for="q-OTHER")
-        assert [a.attachment_id for a in out] == ["a-other"]
-
-
-class TestExplicitAttachmentIdsOrderPreserved:
-    """session._resolve_attachment_ids must honour request order."""
-
-    def test_resolve_preserves_request_order(self, tmp_db, mock_openai_client):
-        s = _make_session(mock_openai_client)
-        # Insert in one order, request in the reverse order — resolver
-        # must reflect the request, not the DB's INSERT order.
-        save_attachment("a-1", s._ws_id, "u1", "first.md", "text/plain", 1, "text", b"1")
-        save_attachment("a-2", s._ws_id, "u1", "second.md", "text/plain", 1, "text", b"2")
-        save_attachment("a-3", s._ws_id, "u1", "third.md", "text/plain", 1, "text", b"3")
-
-        out = s._resolve_attachment_ids(["a-3", "a-1", "a-2"])
-        assert [a.attachment_id for a in out] == ["a-3", "a-1", "a-2"]
-
-    def test_resolve_skips_unknown_and_keeps_order(self, tmp_db, mock_openai_client):
-        s = _make_session(mock_openai_client)
-        save_attachment("a-k", s._ws_id, "u1", "k.md", "text/plain", 1, "text", b"k")
-        out = s._resolve_attachment_ids(["unknown", "a-k", ""])
-        assert [a.attachment_id for a in out] == ["a-k"]
+            assert s._queued_messages[msg_id] == ("plain text", priority)
 
 
 class TestTokenAccounting:

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -22,6 +22,7 @@ from turnstone.core.adapters._ui_cleanup import cleanup_session_ui
 from turnstone.core.child_source import ClusterChildSource
 from turnstone.core.children_registry import ChildrenRegistry
 from turnstone.core.log import get_logger
+from turnstone.core.session import AttachmentsNotQueueableError
 from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
 
 if TYPE_CHECKING:
@@ -310,13 +311,34 @@ class CoordinatorAdapter:
                 # logging) above.
 
         def _enqueue() -> None:
-            # ``queue_message`` takes attachment *ids* + ``queue_msg_id``
-            # (which doubles as the cross-table reservation token); the
-            # send_id we hold IS that token. Convert Attachment objects
-            # to id list at enqueue time so the queued turn picks the
-            # files up at dequeue.
+            # Queued user turns can't carry attachments (see
+            # ``AttachmentsNotQueueableError``). The route handler's
+            # _enqueue catches the rejection and surfaces an
+            # ``attachments_busy`` status to the caller; the coord
+            # adapter's caller has no equivalent return channel, so
+            # we mirror the cleanup (release the reservation taken
+            # for ``_send_id``) and let session_worker.send return
+            # False — the only call site today
+            # (``_coord_create_post_install``) hits the spawn branch
+            # on a fresh workstream so the catch is defense-in-depth.
             att_ids = [a.attachment_id for a in _attachments] if _attachments else None
-            session.queue_message(message, attachment_ids=att_ids, queue_msg_id=_send_id)
+            try:
+                session.queue_message(message, attachment_ids=att_ids, queue_msg_id=_send_id)
+            except AttachmentsNotQueueableError:
+                if _attachments and _send_id:
+                    from turnstone.core.memory import (
+                        unreserve_attachments as _unreserve,
+                    )
+
+                    try:
+                        _unreserve(_send_id, ws_ref.id, _user_id)
+                    except Exception:
+                        log.debug(
+                            "coord_adapter.attachment_unreserve_failed ws=%s",
+                            ws_ref.id[:8],
+                            exc_info=True,
+                        )
+                raise
 
         return session_worker.send(
             ws,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1591,6 +1591,17 @@
           appendText("error", "Message queue full. Please wait.", {
             label: "error",
           });
+        } else if (data && data.status === "attachments_busy") {
+          // Attachments can't ride a queued user turn — server held
+          // the reservations long enough to bounce the request and
+          // released them. Chips stay in the composer; user retries
+          // once the assistant finishes.
+          if (queuedEl) queue.remove(queuedEl);
+          appendText(
+            "error",
+            "Attachments can't be sent while the assistant is working. Send a text-only message now, or wait and resend with attachments.",
+            { label: "error" },
+          );
         } else {
           attachments.consume(
             data && data.attached_ids,

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -182,7 +182,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
 }
 
 # Default for unknown models (local servers: vLLM, llama.cpp, etc.)
-OPENAI_DEFAULT = ModelCapabilities(supports_tool_advisories=False)
+OPENAI_DEFAULT = ModelCapabilities()
 
 
 def lookup_openai_capabilities(model: str) -> ModelCapabilities:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -86,7 +86,6 @@ class ModelCapabilities:
     supports_web_search: bool = False
     supports_tool_search: bool = False
     supports_vision: bool = False
-    supports_tool_advisories: bool = True
     thinking_display: str = ""  # "summarized" for models that omit thinking by default
 
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2475,7 +2475,12 @@ class ChatSession:
                         threading.Thread(target=self._generate_title, daemon=True).start()
                     # Flush any queued messages that weren't injected
                     # (no tool calls → no advisory seam to inject at).
-                    self._flush_queued_messages()
+                    # If anything drained, the model hasn't seen those
+                    # messages yet — keep the loop alive so it gets a
+                    # turn over the extended history rather than
+                    # orphaning them until the next user send.
+                    if self._flush_queued_messages():
+                        continue
                     self._emit_state("idle")
                     # Dispatch any pending watch results (chains into
                     # a new send() within the same worker thread).
@@ -3863,7 +3868,7 @@ class ChatSession:
             )
         return resolved
 
-    def _flush_queued_messages(self) -> None:
+    def _flush_queued_messages(self) -> bool:
         """Drain queued messages.
 
         Items without attachments are combined into a single user turn
@@ -3871,6 +3876,8 @@ class ChatSession:
         poorly.  Items with attachments flush as separate multipart user
         turns (combining text+files across distinct queued sends would
         misrepresent ordering).
+
+        Returns ``True`` when any items drained, ``False`` otherwise.
         """
         from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
 
@@ -3879,7 +3886,7 @@ class ChatSession:
             items = list(self._queued_messages.items())
             self._queued_messages.clear()
         if not items:
-            return
+            return False
 
         # Collapse contiguous attachment-free items into one combined text
         # to preserve the prior behaviour; flush attachment-bearing items
@@ -3905,6 +3912,7 @@ class ChatSession:
             else:
                 text_run.append((cleaned, priority))
         _flush_text_run()
+        return True
 
     def _collect_advisories(
         self,
@@ -3933,20 +3941,6 @@ class ChatSession:
         metacognitive nudges drain on the last result in the batch only.
         """
         from turnstone.core.tool_advisory import GuardAdvisory, UserInterjection
-
-        caps = self._get_capabilities()
-
-        # When the model doesn't support advisory tags, still drain queued
-        # messages so they aren't silently orphaned — flush them as regular
-        # user messages instead. Metacognitive tool advisories (tool_error
-        # / repeat) are dropped silently: the model wouldn't reliably parse
-        # them anyway, and the user-channel nudges still fire on the next
-        # user turn.
-        if not caps.supports_tool_advisories:
-            if is_last_in_batch:
-                self._pending_tool_advisories.clear()
-                self._flush_queued_messages()
-            return [], []
 
         persistent: list[ToolAdvisory] = []
         metacog_reminders: list[dict[str, str]] = []

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -51,7 +51,6 @@ from turnstone.core.memory import (
     delete_messages_after,
     delete_structured_memory,
     delete_workstream,
-    get_attachments,
     get_skill_by_name,
     get_structured_memory_by_name,
     get_workstream_display_name,
@@ -74,7 +73,6 @@ from turnstone.core.memory import (
     search_structured_memories,
     search_visible_structured_memories,
     set_workstream_alias,
-    unreserve_attachments,
     update_workstream_title,
 )
 from turnstone.core.memory_relevance import (
@@ -143,6 +141,24 @@ class GenerationCancelled(BaseException):
 
     Subclasses ``BaseException`` so that broad ``except Exception`` handlers
     in tool execution code do not accidentally swallow it.
+    """
+
+
+class AttachmentsNotQueueableError(Exception):
+    """Raised by ``ChatSession.queue_message`` when called with non-empty
+    ``attachment_ids``.
+
+    Queued messages are injected at the next tool-result advisory seam
+    where they ride inside the tool envelope as text-only
+    ``UserInterjection`` advisories.  Attachments can't ride that path
+    (advisories don't carry image / file blocks), so an attachment-
+    bearing queued item would have to be appended as a separate
+    ``user`` turn — which would inject ``user`` between
+    ``assistant(tool_calls)`` and ``tool``, a role sequence strict
+    providers (Mistral, Anthropic) reject.
+
+    Callers surface this to the user as "wait for the current turn
+    before attaching".
     """
 
 
@@ -475,15 +491,10 @@ class ChatSession:
         self._pending_user_advisories: list[tuple[str, str]] = []  # (type, text)
         # User message queue: messages sent while model is executing.
         # OrderedDict preserves FIFO order and supports O(1) removal by ID.
-        #
-        # Entry shape: ``(cleaned_text, priority, attachment_ids)``.
-        # Attachment lifecycle:
-        #     pending   — uploaded, not tied to any turn
-        #     reserved  — soft-locked at queue time (reserved_for_msg_id = queue id)
-        #     consumed  — committed to a saved message (message_id = conv row id)
-        # queue_message transitions pending → reserved for its attachments;
-        # _flush_queued_messages (dequeue) transitions reserved → consumed.
-        self._queued_messages: collections.OrderedDict[str, tuple[str, str, tuple[str, ...]]] = (
+        # Queued user turns never carry attachments — see
+        # ``AttachmentsNotQueueableError`` for the role-ordering reason —
+        # so the entry tuple is just ``(cleaned, priority)``.
+        self._queued_messages: collections.OrderedDict[str, tuple[str, str]] = (
             collections.OrderedDict()
         )
         self._queued_lock = threading.Lock()
@@ -3781,15 +3792,25 @@ class ChatSession:
 
         Thread-safe — called from the HTTP handler while the worker thread
         is executing.  Returns ``(cleaned_text, priority, msg_id)``.
-        Raises ``queue.Full`` if the queue is saturated.
+        Raises ``queue.Full`` if the queue is saturated.  Raises
+        :class:`AttachmentsNotQueueableError` when ``attachment_ids`` is
+        non-empty: attachments cannot ride the advisory seam (which is
+        text-only), and appending them as a separate user turn would
+        violate strict-provider role-ordering rules.  Callers surface
+        this rejection to the user — interactive UIs typically wait for
+        the current turn to finish before allowing an attached send.
 
-        ``attachment_ids`` (ordered) are resolved and consumed at dequeue
-        time so queued multimodal turns don't silently lose their files.
         ``queue_msg_id`` lets the caller supply the id (so it matches the
         attachment-reservation token already taken server-side) — when
         omitted, an id is generated.
         """
         from turnstone.core.tool_advisory import parse_priority
+
+        if attachment_ids:
+            raise AttachmentsNotQueueableError(
+                "Cannot queue a message with attachments — wait for the "
+                "current turn to finish before sending an attachment."
+            )
 
         cleaned, priority = parse_priority(text)
         # Cap individual message length to prevent context bloat
@@ -3800,118 +3821,38 @@ class ChatSession:
         # workstream_attachments, and a 48-bit truncation narrows the
         # birthday bound unnecessarily.
         msg_id = queue_msg_id or uuid.uuid4().hex
-        att_ids = tuple(attachment_ids or ())
         with self._queued_lock:
             if len(self._queued_messages) >= self._QUEUE_MAX:
                 raise queue.Full()
-            self._queued_messages[msg_id] = (cleaned, priority, att_ids)
+            self._queued_messages[msg_id] = (cleaned, priority)
         return cleaned, priority, msg_id
 
     def dequeue_message(self, msg_id: str) -> bool:
-        """Remove a queued message by ID.  Returns True if removed.
-
-        Releases any attachment reservation held by the queued message
-        so the user can re-use or delete those files.
-        """
+        """Remove a queued message by ID.  Returns True if removed."""
         with self._queued_lock:
             popped = self._queued_messages.pop(msg_id, None)
-        if popped is None:
-            return False
-        # popped == (cleaned, priority, attachment_ids_tuple)
-        if popped[2]:
-            unreserve_attachments(msg_id, self._ws_id, self._user_id)
-        return True
-
-    def _resolve_attachment_ids(
-        self,
-        attachment_ids: tuple[str, ...] | list[str],
-        allow_reserved_for: str | None = None,
-    ) -> list[Attachment]:
-        """Fetch+scope-check attachment ids, preserving request order.
-
-        Silently drops ids that don't belong to this session's ws+user,
-        are already consumed, or are reserved for a different queued
-        message.  When ``allow_reserved_for`` is set, attachments whose
-        ``reserved_for_msg_id`` matches are accepted (dequeue path
-        passes the originating queue msg id so its own reservation
-        releases cleanly).
-        """
-        ids = [str(x) for x in attachment_ids if x]
-        if not ids:
-            return []
-        rows = get_attachments(ids)
-        by_id = {str(r["attachment_id"]): r for r in rows}
-        resolved: list[Attachment] = []
-        for aid in ids:
-            r = by_id.get(aid)
-            if (
-                not r
-                or r.get("ws_id") != self._ws_id
-                or r.get("user_id") != self._user_id
-                or r.get("message_id") is not None
-            ):
-                continue
-            reserved = r.get("reserved_for_msg_id")
-            if reserved and reserved != allow_reserved_for:
-                continue
-            content = r.get("content")
-            if not isinstance(content, bytes):
-                continue
-            resolved.append(
-                Attachment(
-                    attachment_id=str(r["attachment_id"]),
-                    filename=str(r.get("filename") or ""),
-                    mime_type=str(r.get("mime_type") or "application/octet-stream"),
-                    kind=str(r.get("kind") or ""),
-                    content=content,
-                )
-            )
-        return resolved
+        return popped is not None
 
     def _flush_queued_messages(self) -> bool:
-        """Drain queued messages.
+        """Drain queued messages into a single combined user turn.
 
-        Items without attachments are combined into a single user turn
-        to avoid back-to-back user messages that some models handle
-        poorly.  Items with attachments flush as separate multipart user
-        turns (combining text+files across distinct queued sends would
-        misrepresent ordering).
+        Queued items are always text-only (attachments are rejected at
+        ``queue_message`` time — see :class:`AttachmentsNotQueueableError`),
+        so a single combined turn avoids back-to-back user messages
+        that some models handle poorly.
 
         Returns ``True`` when any items drained, ``False`` otherwise.
         """
         from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
 
         with self._queued_lock:
-            # .items() so we keep the queue msg id for reservation lookup
-            items = list(self._queued_messages.items())
+            items = list(self._queued_messages.values())
             self._queued_messages.clear()
         if not items:
             return False
 
-        # Collapse contiguous attachment-free items into one combined text
-        # to preserve the prior behaviour; flush attachment-bearing items
-        # inline as their own multipart turns.
-        text_run: list[tuple[str, str]] = []
-
-        def _flush_text_run() -> None:
-            if not text_run:
-                return
-            parts = [
-                f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in text_run
-            ]
-            combined = "\n\n".join(parts)
-            self._append_user_turn(combined, ())
-            text_run.clear()
-
-        for queue_msg_id, (cleaned, priority, att_ids) in items:
-            if att_ids:
-                _flush_text_run()
-                text = f"[IMPORTANT] {cleaned}" if priority == PRIORITY_IMPORTANT else cleaned
-                resolved = self._resolve_attachment_ids(att_ids, allow_reserved_for=queue_msg_id)
-                self._append_user_turn(text, resolved, send_id=queue_msg_id)
-            else:
-                text_run.append((cleaned, priority))
-        _flush_text_run()
+        parts = [f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in items]
+        self._append_user_turn("\n\n".join(parts), ())
         return True
 
     def _collect_advisories(
@@ -3961,27 +3902,16 @@ class ChatSession:
             metacog_reminders.extend({"type": nt, "text": text} for nt, text in drained)
 
         # Drain queued user messages on the last result in the batch.
-        # Attachment-bearing items fall back to a full multipart user
-        # turn (advisories are text-only and can't carry image blocks).
+        # Items are always text-only (attachments rejected at
+        # queue_message time), so they ride inside the tool envelope
+        # as text advisories — preserves the assistant→tool role
+        # sequence on the wire.
         if is_last_in_batch:
             with self._queued_lock:
-                items = list(self._queued_messages.items())
+                items = list(self._queued_messages.values())
                 self._queued_messages.clear()
-            attachment_items: list[tuple[str, str, str, tuple[str, ...]]] = []
-            for queue_msg_id, (msg, priority, att_ids) in items:
-                if att_ids:
-                    attachment_items.append((queue_msg_id, msg, priority, att_ids))
-                else:
-                    persistent.append(UserInterjection(message=msg, priority=priority))
-            if attachment_items:
-                from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
-
-                for queue_msg_id, msg, priority, att_ids in attachment_items:
-                    text = f"[IMPORTANT] {msg}" if priority == PRIORITY_IMPORTANT else msg
-                    resolved = self._resolve_attachment_ids(
-                        att_ids, allow_reserved_for=queue_msg_id
-                    )
-                    self._append_user_turn(text, resolved, send_id=queue_msg_id)
+            for msg, priority in items:
+                persistent.append(UserInterjection(message=msg, priority=priority))
 
         return persistent, metacog_reminders
 

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2513,7 +2513,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     import uuid
 
     from turnstone.core import session_worker
-    from turnstone.core.session import GenerationCancelled
+    from turnstone.core.session import AttachmentsNotQueueableError, GenerationCancelled
     from turnstone.core.web_helpers import read_json_or_400
 
     async def send(request: Request) -> Response:
@@ -2676,11 +2676,15 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         queue_outcome: dict[str, Any] = {}
 
         def _enqueue() -> None:
-            cleaned, priority, msg_id = session.queue_message(
-                message,
-                attachment_ids=list(ordered_reserved),
-                queue_msg_id=send_id or None,
-            )
+            try:
+                cleaned, priority, msg_id = session.queue_message(
+                    message,
+                    attachment_ids=list(ordered_reserved),
+                    queue_msg_id=send_id or None,
+                )
+            except AttachmentsNotQueueableError:
+                queue_outcome["rejected"] = "attachments_busy"
+                return
             queue_outcome["cleaned"] = cleaned
             queue_outcome["priority"] = priority
             queue_outcome["msg_id"] = msg_id
@@ -2758,6 +2762,20 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             return JSONResponse(
                 {
                     "status": "queue_full",
+                    "attached_ids": [],
+                    "dropped_attachment_ids": list(requested_ids),
+                }
+            )
+
+        if queue_outcome.get("rejected") == "attachments_busy":
+            # Attachments can't ride a queued user turn (see
+            # AttachmentsNotQueueableError for the role-ordering reason).
+            # Release reservations and surface to the caller so the
+            # client can hold the file and retry once the worker idles.
+            _release_reservation_on_fail()
+            return JSONResponse(
+                {
+                    "status": "attachments_busy",
                     "attached_ids": [],
                     "dropped_attachment_ids": list(requested_ids),
                 }
@@ -3023,8 +3041,9 @@ def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
     Removes a previously-queued message identified by ``msg_id`` from
     the workstream's pending queue. Returns ``status: removed`` when
     the queue had the entry and ``status: not_found`` otherwise.
-    Reservations attached to the dequeued message are released by
-    ``ChatSession.dequeue_message`` so attachments can be reused.
+    Queued messages don't carry attachments (see
+    :class:`AttachmentsNotQueueableError`), so there's no reservation
+    side-effect to undo here.
     """
     from turnstone.core.web_helpers import read_json_or_400
 

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -354,6 +354,15 @@
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
+.composer-attach:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.composer-attach:disabled:hover {
+  background: transparent;
+  color: var(--fg-dim);
+  border-color: var(--border-strong);
+}
 
 .composer-input {
   flex: 1;

--- a/turnstone/shared_static/composer.js
+++ b/turnstone/shared_static/composer.js
@@ -576,6 +576,19 @@
       this.sendBtn.disabled = !!b && !opts.queueWhileBusy;
     }
 
+    // Paperclip is disabled whenever busy, even in queueWhileBusy mode:
+    // attachments can't ride a queued user turn (would inject a `user`
+    // turn between assistant(tool_calls) and tool — see backend
+    // AttachmentsNotQueueableError).
+    if (this.attachBtn) {
+      this.attachBtn.disabled = !!b;
+      var attachLabel = b
+        ? "Attach files (available once the current turn finishes)"
+        : "Attach files";
+      this.attachBtn.title = attachLabel;
+      this.attachBtn.setAttribute("aria-label", attachLabel);
+    }
+
     // Stop button visibility + label reset — reset every transition so
     // cancelGeneration's transient "Cancelling…" label doesn't stick.
     if (this.stopBtn) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1921,6 +1921,16 @@ Pane.prototype.sendMessage = function () {
       } else if (data.status === "queue_full") {
         if (queuedEl) self.queue.remove(queuedEl);
         self.addErrorMessage("Message queue full. Please wait.");
+      } else if (data.status === "attachments_busy") {
+        // Attachments can't ride a queued user turn — server held the
+        // chips' reservations long enough to bounce the request and
+        // released them. Surface to the user; chips stay in the
+        // composer so they can retry once the assistant finishes.
+        if (queuedEl) self.queue.remove(queuedEl);
+        self.addErrorMessage(
+          "Attachments can't be sent while the assistant is working. " +
+            "Send a text-only message now, or wait and resend with attachments.",
+        );
       } else {
         self.attachments.consume(
           data.attached_ids,


### PR DESCRIPTION
## Summary

Two queued-user-message bugs in `ChatSession.send()`.

### Mid-tool-call: `Unexpected role 'tool' after role 'user'` on Mistral

The `supports_tool_advisories` capability flag (default False for unknown openai-compatible models) routed cap-off providers down a short-circuit branch in `_collect_advisories` that called `_flush_queued_messages` directly. That appended a `user` turn between `assistant(tool_calls)` and `tool`, which mistral-common's `_validate_message_order` rejects with a 400.

Drop the flag. All providers now run the unified path: queued user messages become `UserInterjection` advisories that ride inside the tool result envelope via `wrap_tool_result`, splicing `<system-reminder>` text into the tool message's content. Role sequence stays `assistant → tool`.

Live-confirmed on Mistral medium and Qwen3 — both correctly distinguish system-reminder from tool stdout in their reasoning. Sample reasoning trace from Mistral after the fix:

> "The system reminder indicates that the user sent a message while I was processing the previous request. This is a meta-message from the system, not actual tool output."

### Mid-stream: queued message orphaned until next user send

After a no-tool assistant turn, `_flush_queued_messages` would append the queued user message to history and the loop would `break`, leaving the message at the tail with no model response. Visible as "two sends to get one reply".

`_flush_queued_messages` now returns `bool`. The no-tool branch `continue`s on drain instead of `break`ing, so the model gets a turn over the extended history.

## Test plan

- [x] `tests/test_session.py` (152 passed) — covers existing advisory drain + the two new regression tests
- [x] `test_collect_advisories_drains_text_queued_messages_to_persistent` — text-only queue → `UserInterjection`, no separate user turn appended
- [x] `test_send_continues_when_messages_queued_during_streaming` — fails with 1 stream call pre-fix, passes with 2 post-fix
- [x] Live: Mistral medium 3.5 on vLLM — repro'd the original 400 (queued message during `bash sleep 30`), confirmed fix returns clean response
- [x] Live: Qwen3 — same flow, clean response and correct system-reminder framing in reasoning
- [x] Live: mid-stream queued message now triggers an immediate model turn instead of orphaning
- [x] ruff + mypy clean