### PR TITLE
feat(console): inline node picker replaces back-to-console banner

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1512,11 +1512,59 @@ class TestProxyRewriting:
         assert "window.fetch" in _JS_PROXY_SHIM
         assert "window.EventSource" in _JS_PROXY_SHIM
 
-    def test_console_banner_contains_placeholder(self):
-        from turnstone.console.server import _CONSOLE_BANNER_TEMPLATE
+    def test_js_shim_carries_node_id_placeholder(self):
+        """The picker reads the current node_id from the shim's _nodeId
+        closure variable; the placeholder must be present and substitutable."""
+        from turnstone.console.server import _JS_PROXY_SHIM
 
-        assert "NODE_ID_PLACEHOLDER" in _CONSOLE_BANNER_TEMPLATE
-        assert "Console" in _CONSOLE_BANNER_TEMPLATE
+        assert "NODE_ID_PLACEHOLDER" in _JS_PROXY_SHIM
+        replaced = _JS_PROXY_SHIM.replace("NODE_ID_PLACEHOLDER", "node-a")
+        assert "node-a" in replaced
+        assert "NODE_ID_PLACEHOLDER" not in replaced
+
+    def test_js_shim_includes_picker_pieces(self):
+        """Picker logic ships in the same IIFE as the prefix shim — verify
+        the moving parts are present so a future refactor doesn't silently
+        drop them.  /v1/api/cluster/nodes is the lazy-fetch target;
+        #ui-header is the DOM anchor; console-node-pill is the trigger
+        class; ws-tab-dropdown is the menu shell we share with the
+        workstream chevron menu (style + behaviour parity); ArrowDown is
+        the keyboard-nav primitive that disambiguates this from a plain
+        click-only menu."""
+        from turnstone.console.server import _JS_PROXY_SHIM
+
+        assert "/v1/api/cluster/nodes" in _JS_PROXY_SHIM
+        assert "ui-header" in _JS_PROXY_SHIM
+        assert "console-node-pill" in _JS_PROXY_SHIM
+        assert "ws-tab-dropdown" in _JS_PROXY_SHIM
+        assert "ArrowDown" in _JS_PROXY_SHIM
+        assert "DOMContentLoaded" in _JS_PROXY_SHIM
+
+    def test_proxy_style_drops_banner_styles(self):
+        """The legacy banner CSS classes (.console-banner, .ts-header-back-link
+        offsets, .dashboard-overlay top:32px hack) should be gone — the new
+        picker lives inside #ui-header and doesn't need overlay offsets."""
+        from turnstone.console.server import _CONSOLE_PROXY_STYLE
+
+        assert ".console-banner" not in _CONSOLE_PROXY_STYLE
+        assert "dashboard-overlay" not in _CONSOLE_PROXY_STYLE
+        assert ".console-node-pill" in _CONSOLE_PROXY_STYLE
+        assert ".console-node-menu" in _CONSOLE_PROXY_STYLE
+
+    def test_proxy_style_uses_canonical_degraded_color(self):
+        """Degraded health dot must use --accent (the canonical "needs
+        attention" token used by the cluster-overview node table at
+        console/static/style.css:548) and not --yellow.  Yellow is reserved
+        for the dash-state attention dot, a stronger signal."""
+        from turnstone.console.server import _CONSOLE_PROXY_STYLE
+
+        assert "console-node-menu-item-dot--degraded" in _CONSOLE_PROXY_STYLE
+        # The degraded rule sits on its own line; assert it uses --accent
+        # by checking the CSS substring has --accent and not --yellow.
+        idx = _CONSOLE_PROXY_STYLE.find("console-node-menu-item-dot--degraded")
+        rule = _CONSOLE_PROXY_STYLE[idx : idx + 200]
+        assert "var(--accent)" in rule
+        assert "var(--yellow)" not in rule
 
     def test_html_rewriting_changes_static_paths(self):
         """Simulate the proxy_index rewriting logic."""
@@ -1533,16 +1581,24 @@ class TestProxyRewriting:
         assert 'href="/static/' not in rewritten
         assert 'src="/static/' not in rewritten
 
-    def test_banner_injection_after_body(self):
-        """Simulate the banner injection logic."""
-        from turnstone.console.server import _CONSOLE_BANNER_TEMPLATE
+    def test_shim_injection_after_body(self):
+        """Simulate the proxy shim injection — the shim ships the node-id
+        and prefix as JS literals and renders the picker at runtime, so
+        we assert the substituted JS literals land in the page."""
+        from turnstone.console.server import _CONSOLE_PROXY_STYLE, _JS_PROXY_SHIM
 
         sample_html = "<html><body><div>content</div></body></html>"
-        banner = _CONSOLE_BANNER_TEMPLATE.replace("NODE_ID_PLACEHOLDER", "node-a")
-        result = sample_html.replace("<body>", "<body>" + banner, 1)
-        assert "node-a" in result
-        assert "Console" in result
-        assert result.startswith("<html><body><div")
+        prefix = "/node/node-a"
+        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
+            '"NODE_ID_PLACEHOLDER"', json.dumps("node-a")
+        )
+        injection = _CONSOLE_PROXY_STYLE + "<script>" + shim_js + "</script>"
+        result = sample_html.replace("<body>", "<body>" + injection, 1)
+        assert '"node-a"' in result
+        assert '"/node/node-a"' in result
+        assert "PREFIX_PLACEHOLDER" not in result
+        assert "NODE_ID_PLACEHOLDER" not in result
+        assert result.startswith("<html><body><style>")
 
 
 # ---------------------------------------------------------------------------
@@ -1777,17 +1833,15 @@ class TestProxySharedStatic:
     def test_proxy_shim_injected_in_html(self):
         """Verify shim is injected as inline script in proxied HTML."""
 
-        from turnstone.console.server import _CONSOLE_BANNER_TEMPLATE, _JS_PROXY_SHIM
+        from turnstone.console.server import _JS_PROXY_SHIM
 
         sample_html = "<html><body><div>content</div></body></html>"
         prefix = "/node/test-node"
-        banner = _CONSOLE_BANNER_TEMPLATE.replace("NODE_ID_PLACEHOLDER", "test-node")
-        shim = (
-            "<script>"
-            + _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix))
-            + "</script>"
+        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
+            '"NODE_ID_PLACEHOLDER"', json.dumps("test-node")
         )
-        result = sample_html.replace("<body>", "<body>" + banner + shim, 1)
+        shim = "<script>" + shim_js + "</script>"
+        result = sample_html.replace("<body>", "<body>" + shim, 1)
         assert "<script>" in result
         assert "/node/test-node" in result
         assert "window.fetch" in result

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1533,7 +1533,10 @@ class TestProxyRewriting:
         click-only menu."""
         from turnstone.console.server import _JS_PROXY_SHIM
 
-        assert "/v1/api/cluster/nodes" in _JS_PROXY_SHIM
+        # limit=1000 matches the collector's hard cap; without it the
+        # picker would silently drop nodes past the 100-default in
+        # clusters with >100 nodes.
+        assert "/v1/api/cluster/nodes?limit=1000" in _JS_PROXY_SHIM
         assert "ui-header" in _JS_PROXY_SHIM
         assert "console-node-pill" in _JS_PROXY_SHIM
         assert "ws-tab-dropdown" in _JS_PROXY_SHIM

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -193,6 +193,9 @@ _JS_PROXY_SHIM = """\
     pill.setAttribute("aria-haspopup", "menu");
     pill.setAttribute("aria-expanded", "false");
     pill.setAttribute("aria-label", "Switch node, currently " + _nodeId);
+    // title gives sighted users the full id when it ellipsizes
+    // \u2014 see the max-width + text-overflow rules in _CONSOLE_PROXY_STYLE.
+    pill.setAttribute("title", _nodeId);
     pill.appendChild(el("span", "console-node-pill-dot"));
     pill.appendChild(el("span", "console-node-pill-id", _nodeId));
     pill.appendChild(el("span", "console-node-pill-caret", "\u25be"));
@@ -246,10 +249,15 @@ _JS_PROXY_SHIM = """\
       // skips disabled rows (current + unreachable) during arrow-key cycling.
       closeHandler = function(e){
         if (e.type === "keydown"){
-          if (e.key === "Escape" || e.key === "Tab"){
+          if (e.key === "Escape"){
             e.preventDefault();
             closeMenu();
             pill.focus();
+          } else if (e.key === "Tab"){
+            // Per ARIA APG menu pattern: Tab closes the menu AND moves
+            // focus to the next focusable element.  Don't preventDefault —
+            // let the browser do its native Tab traversal.
+            closeMenu();
           } else if (e.key === "ArrowDown" || e.key === "ArrowUp"
                   || e.key === "Home" || e.key === "End"){
             e.preventDefault();
@@ -318,7 +326,10 @@ _JS_PROXY_SHIM = """\
       // Saved original fetch \u2014 the prefix shim above would otherwise
       // rewrite this to /node/{id}/v1/api/cluster/nodes, which the node
       // doesn't serve (it's a console-only endpoint mounted at /v1).
-      _oF.call(window, "/v1/api/cluster/nodes", { credentials: "same-origin" })
+      // limit=1000 requests the collector's hard maximum in one round-trip;
+      // beyond 1000 nodes the picker UI is no longer the right shape (it'd
+      // need a search box) so we don't try to paginate.
+      _oF.call(window, "/v1/api/cluster/nodes?limit=1000", { credentials: "same-origin" })
         .then(function(r){ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
         .then(function(data){
           loaded = true; loading = false;
@@ -440,6 +451,17 @@ _JS_PROXY_SHIM = """\
 
       menu.replaceChildren(...children);
       positionMenu();
+
+      // First-open path: openMenu()'s deferred focus hook ran before the
+      // async fetch resolved, so it found only the skeleton and left
+      // focus on the pill.  If focus is still on the pill (i.e. the user
+      // didn't navigate away while the skeleton was up), grab it now.
+      if (document.activeElement === pill){
+        var first = menu.querySelector(
+          ".ws-tab-dropdown-item:not([aria-disabled='true'])"
+        );
+        if (first) first.focus();
+      }
     }
 
     pill.addEventListener("click", function(e){
@@ -471,11 +493,14 @@ _CONSOLE_PROXY_STYLE = (
     # --- Trigger pill \u2014 sits at the start of #ui-header (.appbar).
     # Height 24px passes WCAG 2.5.8 (24px min target) and harmonises
     # with .btn (28px) and .appbar-back (~20px) without looking stunted.
+    # max-width caps the pill against pathologically long node ids
+    # (validated up to 256 chars upstream); the id span ellipsizes
+    # inside.  min-width:0 lets it shrink under appbar pressure.
     ".console-node-pill{display:inline-flex;align-items:center;gap:6px;"
-    "height:24px;padding:0 10px;font-family:var(--font-mono);"
-    "font-size:12px;color:var(--fg-dim);background:transparent;"
-    "border:1px solid var(--border-strong);border-radius:var(--radius-sm);"
-    "cursor:pointer;line-height:1;"
+    "height:24px;padding:0 10px;max-width:240px;min-width:0;"
+    "font-family:var(--font-mono);font-size:12px;color:var(--fg-dim);"
+    "background:transparent;border:1px solid var(--border-strong);"
+    "border-radius:var(--radius-sm);cursor:pointer;line-height:1;"
     "transition:background .12s,color .12s}"
     ".console-node-pill:hover{background:var(--bg-highlight);color:var(--fg)}"
     '.console-node-pill[aria-expanded="true"]{background:var(--bg-highlight);'
@@ -485,7 +510,8 @@ _CONSOLE_PROXY_STYLE = (
     ".console-node-pill-dot{width:6px;height:6px;border-radius:50%;"
     "background:var(--green);box-shadow:0 0 4px var(--green-glow);"
     "flex-shrink:0}"
-    ".console-node-pill-id{font-weight:500}"
+    ".console-node-pill-id{font-weight:500;overflow:hidden;"
+    "text-overflow:ellipsis;white-space:nowrap;min-width:0}"
     ".console-node-pill-caret{font-size:10px;color:var(--fg-dim);opacity:.7;"
     "display:inline-block;transition:transform .12s}"
     '.console-node-pill[aria-expanded="true"] .console-node-pill-caret'

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -14,7 +14,6 @@ import argparse
 import asyncio
 import contextlib
 import functools
-import html
 import json
 import logging
 import math
@@ -143,61 +142,406 @@ def _parse_int(
 # Proxy helpers
 # ---------------------------------------------------------------------------
 
-# JS shim injected into proxied HTML when served through the console.
-# Overrides fetch() and EventSource() so root-relative URLs
-# (e.g. /v1/api/workstreams/{ws_id}/send) route through the console
-# proxy at /node/{node_id}/v1/api/... instead.
+# Inline JS injected into proxied server-UI pages.  Two responsibilities,
+# kept in one IIFE so the original window.fetch closure variable is
+# available to the picker (which has to bypass the prefix shim):
+#
+#   1. Prefix shim \u2014 rewrites root-relative fetch() and EventSource()
+#      URLs to /node/{id}/... so the proxied page's API calls land
+#      at the console (which forwards them to the right server node).
+#
+#   2. Node picker \u2014 on DOMContentLoaded, prepends a node-id pill into
+#      the server UI's #ui-header (.appbar).  Click \u2192 dropdown with
+#      \u2190 Console + the other healthy nodes.  Replaces the earlier
+#      32px back-to-console banner that used to live above the appbar.
+#      Lazy-fetches /api/cluster/nodes the first time the menu opens
+#      (cheap when the user never clicks; fresh when they do).
 _JS_PROXY_SHIM = """\
 (function(){
-  var _pfx="PREFIX_PLACEHOLDER";
-  var _oF=window.fetch;
-  window.fetch=function(u,o){
-    if(typeof u==="string"&&u.startsWith("/"))u=_pfx+u;
-    return _oF.call(this,u,o);
+  var _pfx = "PREFIX_PLACEHOLDER";
+  var _nodeId = "NODE_ID_PLACEHOLDER";
+  var _oF = window.fetch;
+  window.fetch = function(u, o){
+    if (typeof u === "string" && u.startsWith("/")) u = _pfx + u;
+    return _oF.call(this, u, o);
   };
-  var _oE=window.EventSource;
-  window.EventSource=function(u,o){
-    if(typeof u==="string"&&u.startsWith("/"))u=_pfx+u;
-    return new _oE(u,o);
+  var _oE = window.EventSource;
+  window.EventSource = function(u, o){
+    if (typeof u === "string" && u.startsWith("/")) u = _pfx + u;
+    return new _oE(u, o);
   };
-  window.EventSource.prototype=_oE.prototype;
-  window.EventSource.CONNECTING=_oE.CONNECTING;
-  window.EventSource.OPEN=_oE.OPEN;
-  window.EventSource.CLOSED=_oE.CLOSED;
+  window.EventSource.prototype = _oE.prototype;
+  window.EventSource.CONNECTING = _oE.CONNECTING;
+  window.EventSource.OPEN = _oE.OPEN;
+  window.EventSource.CLOSED = _oE.CLOSED;
+
+  function el(tag, cls, text){
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  }
+
+  function buildPicker(){
+    var header = document.getElementById("ui-header");
+    if (!header) return;
+
+    // Trigger pill \u2014 prepended into #ui-header (the server UI's appbar).
+    var pill = document.createElement("button");
+    pill.type = "button";
+    pill.className = "console-node-pill";
+    pill.setAttribute("aria-haspopup", "menu");
+    pill.setAttribute("aria-expanded", "false");
+    pill.setAttribute("aria-label", "Switch node, currently " + _nodeId);
+    pill.appendChild(el("span", "console-node-pill-dot"));
+    pill.appendChild(el("span", "console-node-pill-id", _nodeId));
+    pill.appendChild(el("span", "console-node-pill-caret", "\u25be"));
+    header.insertBefore(pill, header.firstChild);
+
+    // Menu state lives at the picker level, not on the menu DOM, so a
+    // close-then-reopen reuses the cached node list (no stale spinner).
+    var menu = null;
+    var loaded = false;
+    var loading = false;
+    var lastNodes = [];
+    var closeHandler = null;
+
+    function closeMenu(){
+      if (menu){ menu.remove(); menu = null; }
+      if (closeHandler){
+        document.removeEventListener("mousedown", closeHandler);
+        document.removeEventListener("keydown", closeHandler);
+        closeHandler = null;
+      }
+      pill.setAttribute("aria-expanded", "false");
+    }
+
+    function openMenu(){
+      if (menu) return;
+      // Reuse the workstream-tab dropdown shell for visual + behavioural
+      // consistency with the chevron menu next to it in the same toolbar.
+      menu = document.createElement("div");
+      menu.className = "ws-tab-dropdown console-node-menu";
+      menu.setAttribute("role", "menu");
+      menu.setAttribute("aria-label", "Switch node");
+      menu.addEventListener("contextmenu", function(e){ e.preventDefault(); });
+      document.body.appendChild(menu);
+      pill.setAttribute("aria-expanded", "true");
+
+      if (loaded){
+        renderMenu(lastNodes);
+      } else if (loading){
+        menu.appendChild(skeleton());
+        positionMenu();
+      } else {
+        menu.appendChild(skeleton());
+        positionMenu();
+        loadNodes();
+      }
+
+      // Keyboard handler kept in lockstep with the workstream-tab dropdown
+      // in turnstone/ui/static/app.js (search for _tabDropdownCloseHandler).
+      // If you change the keys here, change them there.  The only intentional
+      // divergence is the :not([aria-disabled='true']) filter — the picker
+      // skips disabled rows (current + unreachable) during arrow-key cycling.
+      closeHandler = function(e){
+        if (e.type === "keydown"){
+          if (e.key === "Escape" || e.key === "Tab"){
+            e.preventDefault();
+            closeMenu();
+            pill.focus();
+          } else if (e.key === "ArrowDown" || e.key === "ArrowUp"
+                  || e.key === "Home" || e.key === "End"){
+            e.preventDefault();
+            if (!menu) return;
+            var btns = Array.from(
+              menu.querySelectorAll(".ws-tab-dropdown-item:not([aria-disabled='true'])")
+            );
+            if (!btns.length) return;
+            var idx = btns.indexOf(document.activeElement);
+            if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
+            // idx <= 0 covers both "first item" (wrap to last) and "no
+            // current focus" (idx === -1, which would otherwise yield N-2
+            // via the modulo).  Same shape worth backporting to app.js.
+            else if (e.key === "ArrowUp") btns[idx <= 0 ? btns.length - 1 : idx - 1].focus();
+            else if (e.key === "Home") btns[0].focus();
+            else if (e.key === "End") btns[btns.length - 1].focus();
+          }
+        } else if (e.type === "mousedown"
+                && menu && !menu.contains(e.target)
+                && e.target !== pill && !pill.contains(e.target)){
+          closeMenu();
+        }
+      };
+
+      // Defer listener wiring + initial focus so the click that opened
+      // the menu doesn't immediately trigger the mousedown-close path.
+      var activeMenu = menu;
+      var activeHandler = closeHandler;
+      setTimeout(function(){
+        if (menu !== activeMenu || !activeHandler) return;
+        document.addEventListener("mousedown", activeHandler);
+        document.addEventListener("keydown", activeHandler);
+        var first = activeMenu.querySelector(
+          ".ws-tab-dropdown-item:not([aria-disabled='true'])"
+        );
+        if (first) first.focus();
+      }, 0);
+    }
+
+    function positionMenu(){
+      if (!menu) return;
+      var pr = pill.getBoundingClientRect();
+      var mr = menu.getBoundingClientRect();
+      var mx = pr.left;
+      var my = pr.bottom + 4;
+      if (my + mr.height > window.innerHeight) my = pr.top - mr.height - 4;
+      if (mx + mr.width > window.innerWidth) mx = window.innerWidth - mr.width - 4;
+      if (mx < 4) mx = 4;
+      menu.style.left = mx + "px";
+      menu.style.top = my + "px";
+    }
+
+    function skeleton(){
+      var box = el("div", "console-node-skeleton");
+      box.setAttribute("role", "status");
+      box.setAttribute("aria-label", "Loading nodes");
+      // Three rows: roughly the typical small-cluster size.  CSS fades
+      // opacity per :nth-child (1.0 / 0.7 / 0.5) — adding a fourth would
+      // need a fourth opacity stop to avoid visual repetition.
+      for (var i = 0; i < 3; i++) box.appendChild(el("div", "console-node-skeleton-row"));
+      return box;
+    }
+
+    function loadNodes(){
+      loading = true;
+      // Saved original fetch \u2014 the prefix shim above would otherwise
+      // rewrite this to /node/{id}/v1/api/cluster/nodes, which the node
+      // doesn't serve (it's a console-only endpoint mounted at /v1).
+      _oF.call(window, "/v1/api/cluster/nodes", { credentials: "same-origin" })
+        .then(function(r){ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+        .then(function(data){
+          loaded = true; loading = false;
+          lastNodes = Array.isArray(data && data.nodes) ? data.nodes : [];
+          if (menu) renderMenu(lastNodes);
+        })
+        .catch(function(){
+          loading = false;
+          if (menu) renderError();
+        });
+    }
+
+    function renderError(){
+      var status = el("div", "console-node-menu-status", "Failed to load nodes");
+      var retry = document.createElement("button");
+      retry.type = "button";
+      retry.className = "ws-tab-dropdown-item console-node-menu-item";
+      retry.setAttribute("role", "menuitem");
+      retry.setAttribute("tabindex", "-1");
+      retry.appendChild(el("span", "ws-tab-dropdown-label", "Retry"));
+      retry.addEventListener("click", function(e){
+        e.stopPropagation();
+        loaded = false;
+        if (menu){ menu.replaceChildren(skeleton()); positionMenu(); }
+        loadNodes();
+      });
+      menu.replaceChildren(status, retry);
+      positionMenu();
+      setTimeout(function(){ retry.focus(); }, 0);
+    }
+
+    function buildBackItem(){
+      var back = document.createElement("a");
+      back.href = "/";
+      back.className = "ws-tab-dropdown-item console-node-menu-item console-node-menu-back";
+      back.setAttribute("role", "menuitem");
+      back.setAttribute("tabindex", "-1");
+      back.setAttribute("aria-label", "Back to console");
+      back.appendChild(el("span", "console-node-menu-arrow", "\u2190"));
+      back.appendChild(el("span", "ws-tab-dropdown-label", "Console"));
+      return back;
+    }
+
+    function buildNodeItem(n){
+      var nid = n.node_id || "";
+      if (!nid) return null;
+      var isCurrent = nid === _nodeId;
+      var reachable = n.reachable !== false;
+      var hStatus = (n.health && n.health.status) || "";
+      var status = !reachable ? "unreachable"
+                  : (hStatus && hStatus !== "ok" ? "degraded" : "healthy");
+      var dotMod = status === "healthy" ? "" : status;
+      var wsTotal = n.ws_total != null ? n.ws_total : 0;
+      // Current + unreachable rows are non-interactive: rendered as <div>
+      // with aria-disabled so the keyboard-nav filter skips them and
+      // mouse clicks land on dead text.  A clickable <a> for an
+      // unreachable node would route the user to a 502 page.
+      var nonInteractive = isCurrent || !reachable;
+
+      var item;
+      if (nonInteractive){
+        item = document.createElement("div");
+      } else {
+        item = document.createElement("a");
+        item.href = "/node/" + encodeURIComponent(nid) + "/";
+      }
+      item.className = "ws-tab-dropdown-item console-node-menu-item"
+                      + (isCurrent ? " is-current" : "")
+                      + (!reachable && !isCurrent ? " is-unreachable" : "");
+      item.setAttribute("role", "menuitem");
+      item.setAttribute("tabindex", "-1");
+      if (isCurrent) item.setAttribute("aria-current", "true");
+      if (nonInteractive) item.setAttribute("aria-disabled", "true");
+      item.setAttribute(
+        "aria-label",
+        nid + ", " + wsTotal + " workstream" + (wsTotal === 1 ? "" : "s")
+            + ", " + status + (isCurrent ? ", current node" : "")
+      );
+
+      var dot = el("span",
+        "console-node-menu-item-dot"
+        + (dotMod ? " console-node-menu-item-dot--" + dotMod : ""));
+      dot.setAttribute("aria-hidden", "true");
+      item.appendChild(dot);
+
+      item.appendChild(el("span", "ws-tab-dropdown-label console-node-menu-item-id", nid));
+
+      // Meta carries ws-count + status text \u2014 the text suffix doubles as
+      // a colorblind-safe encoding of the dot color.  aria-hidden because
+      // the menuitem aria-label already says it.
+      var metaText = wsTotal + " ws" + (status !== "healthy" ? " \u00b7 " + status : "");
+      var meta = el("span", "ws-tab-dropdown-key", metaText);
+      meta.setAttribute("aria-hidden", "true");
+      item.appendChild(meta);
+
+      if (isCurrent){
+        var check = el("span", "console-node-menu-item-check", "\u2713");
+        check.setAttribute("aria-hidden", "true");
+        item.appendChild(check);
+      }
+      return item;
+    }
+
+    function renderMenu(nodes){
+      var children = [buildBackItem()];
+
+      var nodeItems = [];
+      nodes.forEach(function(n){
+        var it = buildNodeItem(n);
+        if (it) nodeItems.push(it);
+      });
+
+      if (nodeItems.length){
+        var sep = el("div", "ws-tab-dropdown-sep");
+        sep.setAttribute("role", "separator");
+        children.push(sep);
+        children = children.concat(nodeItems);
+      }
+
+      menu.replaceChildren(...children);
+      positionMenu();
+    }
+
+    pill.addEventListener("click", function(e){
+      e.stopPropagation();
+      if (menu) closeMenu(); else openMenu();
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", buildPicker);
+  } else {
+    buildPicker();
+  }
 })();
 """
 
-_CONSOLE_BANNER_TEMPLATE = (
-    '<div class="console-banner">'
-    '<a href="/" class="ts-header-back-link" aria-label="Return to console">'
-    '<span class="ts-header-back-link-arrow" aria-hidden="true">&larr;</span>'
-    "<span>Console</span>"
-    "</a>"
-    '<span class="console-banner-sep" aria-hidden="true">\u2502</span>'
-    '<a href="NODE_LINK_PLACEHOLDER" class="console-banner-node"'
-    ' aria-label="Node: NODE_ID_PLACEHOLDER">'
-    "NODE_ID_PLACEHOLDER</a>"
-    "</div>"
-)
-
-# Injected <style>: offsets fixed-position overlays + styles the console
-# return-banner against the server UI's existing design tokens.  The
-# banner uses the shared .ts-header-back-link class (defined in
-# shared_static/chat.css, loaded by the interactive UI) so both the
-# coordinator-page back-link and this banner present identical back-to-
-# console affordances.  Only the banner-local layout bits (sep + node
-# link typography) stay scoped here.
+# Inline <style> injected into proxied server-UI pages.  The dropdown
+# panel itself reuses .ws-tab-dropdown* (defined in ui/static/style.css,
+# which the proxied page already loads) for animation, shadow, theme
+# override, and item layout.  This sheet adds:
+#   - the trigger pill (no analogue exists in the server UI),
+#   - the inline health-dot in menu items (mirrors --green / --accent /
+#     --red from the cluster-overview node table \u2014 see
+#     console/static/style.css:535-549),
+#   - the "you are here" tint + cursor:default for the current node row,
+#   - a 3-row pulse skeleton for the loading state.
 _CONSOLE_PROXY_STYLE = (
     "<style>"
-    ".dashboard-overlay{top:32px!important}"
-    ".console-banner{background:var(--bg-surface);"
-    "border-bottom:1px solid var(--border-strong);"
-    "padding:4px 20px;font-family:var(--font-mono);font-size:11px;"
-    "display:flex;align-items:center;gap:8px;position:relative;z-index:200}"
-    ".console-banner-sep{color:var(--fg-dim);opacity:0.6}"
-    ".console-banner-node{color:var(--fg-dim);text-decoration:none;"
-    "font-size:10px;letter-spacing:0.02em}"
-    ".console-banner-node:hover{color:var(--accent)}"
+    # --- Trigger pill \u2014 sits at the start of #ui-header (.appbar).
+    # Height 24px passes WCAG 2.5.8 (24px min target) and harmonises
+    # with .btn (28px) and .appbar-back (~20px) without looking stunted.
+    ".console-node-pill{display:inline-flex;align-items:center;gap:6px;"
+    "height:24px;padding:0 10px;font-family:var(--font-mono);"
+    "font-size:12px;color:var(--fg-dim);background:transparent;"
+    "border:1px solid var(--border-strong);border-radius:var(--radius-sm);"
+    "cursor:pointer;line-height:1;"
+    "transition:background .12s,color .12s}"
+    ".console-node-pill:hover{background:var(--bg-highlight);color:var(--fg)}"
+    '.console-node-pill[aria-expanded="true"]{background:var(--bg-highlight);'
+    "color:var(--fg);border-color:var(--accent-dim)}"
+    ".console-node-pill:focus-visible{outline:2px solid var(--accent);"
+    "outline-offset:2px}"
+    ".console-node-pill-dot{width:6px;height:6px;border-radius:50%;"
+    "background:var(--green);box-shadow:0 0 4px var(--green-glow);"
+    "flex-shrink:0}"
+    ".console-node-pill-id{font-weight:500}"
+    ".console-node-pill-caret{font-size:10px;color:var(--fg-dim);opacity:.7;"
+    "display:inline-block;transition:transform .12s}"
+    '.console-node-pill[aria-expanded="true"] .console-node-pill-caret'
+    "{transform:rotate(180deg)}"
+    # --- Menu shell uses .ws-tab-dropdown directly; no CSS needed here.
+    # Constrain the picker's width so node ids + meta have room.
+    ".console-node-menu{min-width:240px;max-width:360px}"
+    # --- Menu items reuse .ws-tab-dropdown-item \u2014 we only override
+    # font (mono, for hostname-like ids) and add the dot column.
+    ".console-node-menu-item{font-family:var(--font-mono);font-size:12px;"
+    "padding:6px 12px;gap:8px;color:var(--fg-dim);text-decoration:none}"
+    # Current row: keep the accent-tint visible.  The shared
+    # .ws-tab-dropdown-item[aria-disabled="true"] rule applies opacity:.55
+    # which would otherwise wash out the "you are here" tint \u2014 restore
+    # full opacity here.  Same restore for the unreachable row's red dot
+    # so its color signal stays legible against the dim row background.
+    ".console-node-menu-item.is-current{background:var(--accent-dim);"
+    "color:var(--fg);cursor:default;opacity:1}"
+    ".console-node-menu-item.is-current:hover{background:var(--accent-dim);"
+    "color:var(--fg)}"
+    # Unreachable row: dim the text but leave the dot at full saturation
+    # so the red signal reads against the dim row.  cursor:not-allowed
+    # comes from the shared aria-disabled rule.
+    ".console-node-menu-item.is-unreachable{color:var(--fg-dim)}"
+    ".console-node-menu-item.is-unreachable .console-node-menu-item-dot{opacity:1}"
+    ".console-node-menu-back{color:var(--accent)}"
+    ".console-node-menu-back:hover{color:var(--accent)}"
+    ".console-node-menu-arrow{font-family:var(--font-mono);font-size:13px}"
+    # Health dots in menu items \u2014 match cluster-overview canonical colors:
+    #   reachable + ok      \u2192 --green  (style.css:539)
+    #   reachable + !ok     \u2192 --accent (style.css:548  \u2014 was --yellow)
+    #   unreachable         \u2192 --red    (style.css:544)
+    ".console-node-menu-item-dot{width:6px;height:6px;border-radius:50%;"
+    "flex-shrink:0;background:var(--green);box-shadow:0 0 4px var(--green-glow)}"
+    ".console-node-menu-item-dot--unreachable{background:var(--red);"
+    "box-shadow:0 0 4px var(--red-glow)}"
+    ".console-node-menu-item-dot--degraded{background:var(--accent);"
+    "box-shadow:0 0 4px var(--accent-glow-strong)}"
+    ".console-node-menu-item-id{flex:1}"
+    ".console-node-menu-item-check{color:var(--accent);font-size:11px}"
+    # --- Loading state: 3-row pulsing skeleton.  Reuses --border-strong
+    # for the row tint and a dedicated keyframe so we can guard it under
+    # prefers-reduced-motion in step.
+    ".console-node-skeleton{padding:6px 0}"
+    ".console-node-skeleton-row{height:14px;margin:6px 12px;"
+    "background:var(--border-strong);border-radius:var(--radius-sm);"
+    "animation:console-node-skel-pulse 1.4s ease-in-out infinite}"
+    ".console-node-skeleton-row:nth-child(2){opacity:.7;animation-delay:.15s}"
+    ".console-node-skeleton-row:nth-child(3){opacity:.5;animation-delay:.3s}"
+    "@keyframes console-node-skel-pulse{"
+    "0%,100%{opacity:.4}50%{opacity:.8}}"
+    "@media (prefers-reduced-motion:reduce){"
+    ".console-node-skeleton-row{animation:none}}"
+    # --- Status text fallback (only used by the error path now).
+    ".console-node-menu-status{padding:8px 12px;font-family:var(--font-mono);"
+    "font-size:11px;color:var(--fg-dim);text-align:center}"
     "</style>"
 )
 
@@ -2134,16 +2478,16 @@ async def proxy_index(request: Request) -> Response:
         page = page.replace('src="/static/', f'src="{prefix}/static/')
         page = page.replace('href="/shared/', f'href="{prefix}/shared/')
         page = page.replace('src="/shared/', f'src="{prefix}/shared/')
-        # Inject console-return banner + proxy shim after <body>
-        banner = _CONSOLE_BANNER_TEMPLATE.replace(
-            "NODE_ID_PLACEHOLDER", html.escape(node_id)
-        ).replace("NODE_LINK_PLACEHOLDER", html.escape(prefix + "/"))
-        shim = (
-            "<script>"
-            + _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix))
-            + "</script>"
+        # Inject the proxy shim (prefix rewriting + node-picker) after <body>.
+        # The picker self-attaches to #ui-header on DOMContentLoaded; the
+        # banner that used to live above the appbar is gone.  node_id is
+        # validated against _VALID_NODE_ID upstream, so json.dumps is the
+        # only escaping the JS literal needs.
+        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
+            '"NODE_ID_PLACEHOLDER"', json.dumps(node_id)
         )
-        page = page.replace("<body>", "<body>" + banner + _CONSOLE_PROXY_STYLE + shim, 1)
+        shim = "<script>" + shim_js + "</script>"
+        page = page.replace("<body>", "<body>" + _CONSOLE_PROXY_STYLE + shim, 1)
         html_resp = HTMLResponse(page)
         html_resp.headers["Cache-Control"] = "no-cache"
         return html_resp

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -2688,6 +2688,9 @@ function showTabDropdown(chevronEl, wsId) {
   menu.style.top = my + "px";
   _tabDropdown = menu;
 
+  // Keyboard handler is mirrored by the console node-picker shim in
+  // turnstone/console/server.py (search for closeHandler in _JS_PROXY_SHIM).
+  // If you change the keys or filter selector here, change them there.
   _tabDropdownCloseHandler = function (e) {
     if (e.type === "keydown") {
       if (e.key === "Escape" || e.key === "Tab") {


### PR DESCRIPTION
## Summary

Drops the 32px banner the console proxy used to inject above proxied server-UI pages and replaces it with an inline node-id pill in the existing `#ui-header`. Click the pill to open a dropdown that lists healthy nodes (health dot, ws count, reachable/degraded/unreachable text) plus a top-row link back to the console.

Reuses the `.ws-tab-dropdown` shell from `ui/static/style.css` for animation, shadow, theme override, and item layout, so the picker visually matches the workstream-tab chevron menu it sits next to. Keyboard nav (ArrowDown/Up/Home/End/Tab/Escape) mirrors the chevron menu's handler with cross-reference comments at both sites. Lazy-fetches `/v1/api/cluster/nodes` against the console origin (bypassing the prefix shim) on first open.

Reclaims 32px of vertical space, consolidates three separate "you're on node X via console" indicators into one, and turns the wayfinding chrome into a real cluster-nav primitive.

## Before / after

```
Before:   [← Console │ node-1]                          ← injected banner (32px)
          [turnstone  MCP: 1 server]   [☾]              ← server appbar
          [ws-b16d] [reddit] [lobsters ▼] [+] [⧉]       ← workstream tabs

After:    [● node-1 ▾]  turnstone  MCP: 1 server  [☾]   ← merged appbar (24px pill)
          [ws-b16d] [reddit] [lobsters ▼] [+] [⧉]
```

## Design + review notes

- Designer review pass: 4 H + 9 M + 5 L + 5 Other findings; landed as part of the same shape (24px pill height passes WCAG 2.5.8, `--accent` for degraded matches the canonical cluster-overview node table, retry button on error, full-state SR `aria-label`s, current/unreachable rows are `<div>` with `aria-disabled`, etc.).
- Multi-stage `/review` pipeline: 0 critical / 0 major / 5 minor / 2 nit. All in-place fixes applied (bug-1 ArrowUp idx<=0 guard, q-2 cross-reference comments, q-3 namespace consolidation, q-4 unreachable non-clickable, q-5 skeleton magic-3 comment).
- Deferred to follow-up: extracting picker JS/CSS to a static asset (perf-1 + q-1, same fix shape — the inline blob grew ~10x and would benefit from HTTP caching + ESLint, but it's a separate refactor).

## Test plan

- [ ] 223 console-related tests pass (`test_console.py`, `test_console_idle_cleanup.py`, `test_console_metrics.py`, `test_console_route_attachments.py`, `test_console_router.py`, `test_console_routing_proxy.py`, `test_coordinator_proxy_auth.py`, `test_route_proxy_audit.py`).
- [ ] `ruff check` clean.
- [ ] `mypy turnstone/console/server.py` clean.
- [ ] Rendered shim JS validates with `node --check`.
- [ ] Manual: load `/node/<id>/` via console; banner is gone; pill appears in `#ui-header` with green dot + caret; click opens dropdown with `dropdown-in` animation; arrow keys cycle through `← Console` and node items; current node row has accent-tint background and ✓; degraded/unreachable nodes have `--accent`/`--red` dots and text suffix; clicking another node navigates via `location.assign("/node/<id>/")`; clicking outside or pressing Escape closes the menu and returns focus to the pill.