### PR TITLE
feat(mcp): per-(user, server) ClientSession pool with OAuth dispatch

### DIFF
--- a/tests/spike_sdk_concurrency.py
+++ b/tests/spike_sdk_concurrency.py
@@ -1,0 +1,391 @@
+"""Spike 1 — validate MCP SDK behavior for the per-(user, server) session pool.
+
+Three scenarios:
+
+1. N=20 concurrent ClientSession instances to the same URL.
+   Verifies: no FD blow-up, no shared transport state, each session's
+   tools/list returns independently.
+
+2. Two concurrent tools/call on a shared ClientSession with interleaving
+   payloads. Verifies: request_id demux works under contention.
+
+3. Per-session Authorization header isolation. Verifies: different Bearer
+   tokens per ClientSession reach the server with the expected
+   Authorization header — i.e. httpx connection pooling does not cross
+   headers between sessions.
+
+Run: uv run python tests/spike_sdk_concurrency.py
+
+Outcome gates Phase 5's pool architecture; if any scenario fails, fall
+back to per-call header injection (Alternative F in the OAuth-MCP RFC).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+import uvicorn
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.server.fastmcp import FastMCP
+from starlette.middleware.base import BaseHTTPMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+# Reduce uvicorn / mcp log noise so spike output is readable.
+logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
+logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+logging.getLogger("mcp").setLevel(logging.WARNING)
+
+# Records (auth_header, tool_name) per request — populated by the
+# AuthHeaderRecorder middleware below. Indexed by call sequence.
+SERVER_OBSERVATIONS: list[tuple[str | None, str | None]] = []
+# Tool-call payloads observed (for request_id demux verification).
+TOOL_CALL_PAYLOADS: list[str] = []
+
+
+class AuthHeaderRecorder(BaseHTTPMiddleware):
+    """Records the Authorization header on every request the server sees."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        auth = request.headers.get("authorization")
+        # We only record the auth header here; tool name comes from the
+        # body payload which we can't read non-destructively. The tool
+        # handler logs the payload it received.
+        SERVER_OBSERVATIONS.append((auth, None))
+        return await call_next(request)
+
+
+def find_free_port() -> int:
+    """Bind to port 0, return the assigned port."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def build_server(port: int) -> uvicorn.Server:
+    """Create a minimal FastMCP server with one echo tool."""
+    mcp = FastMCP(name="spike-target", streamable_http_path="/mcp")
+
+    @mcp.tool()
+    async def echo(payload: str) -> str:
+        """Echo the payload back. Records the payload server-side."""
+        TOOL_CALL_PAYLOADS.append(payload)
+        # Add a small await so two concurrent calls can interleave
+        # on the wire if the SDK pools the requests.
+        await asyncio.sleep(0.05)
+        return f"echoed:{payload}"
+
+    app = mcp.streamable_http_app()
+    app.add_middleware(AuthHeaderRecorder)
+
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+    )
+    return uvicorn.Server(config)
+
+
+def run_server_in_thread(server: uvicorn.Server) -> threading.Thread:
+    """Boot the server in a background thread on its own asyncio loop."""
+
+    def _run() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(server.serve())
+
+    t = threading.Thread(target=_run, daemon=True, name="spike-server")
+    t.start()
+    return t
+
+
+async def wait_for_server_ready(url: str, timeout: float = 5.0) -> None:
+    """Poll the server until it accepts connections."""
+    import urllib.parse
+
+    parsed = urllib.parse.urlparse(url)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            reader, writer = await asyncio.open_connection(parsed.hostname, parsed.port)
+            writer.close()
+            await writer.wait_closed()
+            return
+        except OSError:
+            await asyncio.sleep(0.05)
+    raise TimeoutError(f"server at {url} not ready within {timeout}s")
+
+
+def fd_count() -> int:
+    """Count open file descriptors for the current process."""
+    try:
+        return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+    except OSError:
+        return -1
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: N=20 concurrent ClientSession instances
+# ---------------------------------------------------------------------------
+
+
+async def scenario_1_concurrent_sessions(url: str, n: int = 20) -> dict:
+    """Open N concurrent ClientSession instances and call tools/list on each."""
+    print(f"\n=== Scenario 1: {n} concurrent ClientSession instances ===")
+    fd_before = fd_count()
+
+    async def one_session(idx: int) -> dict:
+        headers = {"Authorization": f"Bearer test-token-{idx}"}
+        async with (
+            streamablehttp_client(url=url, headers=headers) as (read, write, _),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            tools = await session.list_tools()
+            return {
+                "idx": idx,
+                "tool_count": len(tools.tools),
+                "tool_names": [t.name for t in tools.tools],
+            }
+
+    start = time.monotonic()
+    results = await asyncio.gather(*[one_session(i) for i in range(n)], return_exceptions=True)
+    elapsed = time.monotonic() - start
+
+    fd_after = fd_count()
+    # Allow some settling time for FDs to release.
+    await asyncio.sleep(0.5)
+    fd_settled = fd_count()
+
+    successes = [r for r in results if isinstance(r, dict)]
+    failures = [r for r in results if isinstance(r, Exception)]
+
+    # Verify every session got the same tool catalog.
+    catalog_consistent = (
+        len(successes) == n and len({tuple(r["tool_names"]) for r in successes}) == 1
+    )
+
+    return {
+        "scenario": "concurrent_sessions",
+        "n": n,
+        "successes": len(successes),
+        "failures": len(failures),
+        "elapsed_seconds": round(elapsed, 3),
+        "fd_before": fd_before,
+        "fd_during_peak": fd_after,
+        "fd_settled": fd_settled,
+        "fd_growth_during": fd_after - fd_before,
+        "fd_growth_settled": fd_settled - fd_before,
+        "catalog_consistent": catalog_consistent,
+        "first_failure": str(failures[0]) if failures else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: 2 concurrent tools/call on a shared session
+# ---------------------------------------------------------------------------
+
+
+async def scenario_2_concurrent_calls_shared_session(url: str) -> dict:
+    """Two concurrent tools/call on one ClientSession with interleaving payloads.
+
+    The echo tool sleeps 50ms, so concurrent calls overlap on the wire.
+    Each call passes a distinct payload (~10KB) to make request bodies
+    spannable across multiple stream frames.
+    """
+    print("\n=== Scenario 2: 2 concurrent tools/call on shared session ===")
+
+    # Generous-size payloads so both bodies live during the await.
+    payload_a = "A" * 10000
+    payload_b = "B" * 10000
+
+    headers = {"Authorization": "Bearer shared-session-token"}
+    async with (
+        streamablehttp_client(url=url, headers=headers) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+
+        TOOL_CALL_PAYLOADS.clear()
+
+        start = time.monotonic()
+        results = await asyncio.gather(
+            session.call_tool("echo", {"payload": payload_a}),
+            session.call_tool("echo", {"payload": payload_b}),
+            return_exceptions=True,
+        )
+        elapsed = time.monotonic() - start
+
+    successes = [r for r in results if not isinstance(r, Exception)]
+    failures = [r for r in results if isinstance(r, Exception)]
+
+    # Each result.content[0].text should be "echoed:{payload}".
+    response_payloads: list[str] = []
+    if len(successes) == 2:
+        for r in successes:
+            text = r.content[0].text if r.content else ""
+            response_payloads.append(text)
+
+    # Order may not match call order — what matters is both payloads echo.
+    expected = {f"echoed:{payload_a}", f"echoed:{payload_b}"}
+    received = set(response_payloads)
+    demux_ok = received == expected
+
+    # Did both calls actually overlap? If sequential, elapsed ~= 0.1+s;
+    # if concurrent, ~0.05s.
+    concurrent_observed = elapsed < 0.09
+
+    return {
+        "scenario": "concurrent_calls_shared_session",
+        "successes": len(successes),
+        "failures": len(failures),
+        "elapsed_seconds": round(elapsed, 3),
+        "demux_ok": demux_ok,
+        "expected_payloads_received": list(received) if demux_ok else None,
+        "actual_payloads_received_count": len(received),
+        "appears_concurrent_on_wire": concurrent_observed,
+        "first_failure": str(failures[0]) if failures else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: per-session header isolation
+# ---------------------------------------------------------------------------
+
+
+async def scenario_3_header_isolation(url: str, n: int = 5) -> dict:
+    """Open N sessions with distinct Authorization headers, call echo on each.
+
+    Verifies the server sees each session's own header — i.e. httpx
+    connection pooling does not cross headers between concurrent
+    ClientSession instances against the same URL.
+    """
+    print(f"\n=== Scenario 3: {n}-session Authorization-header isolation ===")
+    SERVER_OBSERVATIONS.clear()
+
+    async def one_session(idx: int) -> str | None:
+        headers = {"Authorization": f"Bearer iso-token-{idx}"}
+        async with (
+            streamablehttp_client(url=url, headers=headers) as (read, write, _),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            # One call per session.
+            await session.call_tool("echo", {"payload": f"session-{idx}"})
+            return f"Bearer iso-token-{idx}"
+
+    start = time.monotonic()
+    expected_tokens = await asyncio.gather(*[one_session(i) for i in range(n)])
+    elapsed = time.monotonic() - start
+
+    # Tally observed Authorization headers, ignoring None entries (initial
+    # handshake sometimes lacks auth).
+    observed_auth = [auth for auth, _ in SERVER_OBSERVATIONS if auth]
+    expected_set = set(expected_tokens)
+    observed_set = set(observed_auth)
+
+    # Every expected token must show up at least once on the server.
+    all_present = expected_set.issubset(observed_set)
+    # No spurious tokens.
+    no_extras = observed_set.issubset(expected_set)
+    # Frequency: at least one observation per token.
+    counts = defaultdict(int)
+    for a in observed_auth:
+        counts[a] += 1
+    each_seen = all(counts[t] >= 1 for t in expected_tokens)
+
+    return {
+        "scenario": "header_isolation",
+        "n": n,
+        "elapsed_seconds": round(elapsed, 3),
+        "expected_tokens": sorted(expected_set),
+        "observed_tokens": sorted(observed_set),
+        "all_expected_present": all_present,
+        "no_extra_tokens_observed": no_extras,
+        "each_token_seen_at_least_once": each_seen,
+        "header_counts_per_token": dict(counts),
+        "total_requests_observed": len(observed_auth),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    port = find_free_port()
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    server = build_server(port)
+    server_thread = run_server_in_thread(server)
+    try:
+        await wait_for_server_ready(url)
+        print(f"server up at {url}\n")
+
+        result_1 = await scenario_1_concurrent_sessions(url, n=20)
+        print_scenario_result(result_1)
+
+        result_2 = await scenario_2_concurrent_calls_shared_session(url)
+        print_scenario_result(result_2)
+
+        result_3 = await scenario_3_header_isolation(url, n=5)
+        print_scenario_result(result_3)
+
+        # Final verdict
+        verdict_1 = (
+            result_1["successes"] == result_1["n"]
+            and result_1["catalog_consistent"]
+            and result_1["fd_growth_settled"] < 30  # 20 sessions, generous bound
+        )
+        verdict_2 = result_2["demux_ok"] and result_2["successes"] == 2
+        verdict_3 = (
+            result_3["all_expected_present"]
+            and result_3["no_extra_tokens_observed"]
+            and result_3["each_token_seen_at_least_once"]
+        )
+
+        print("\n=== VERDICT ===")
+        print(f"  Scenario 1 (concurrent sessions):    {'PASS' if verdict_1 else 'FAIL'}")
+        print(f"  Scenario 2 (concurrent calls shared): {'PASS' if verdict_2 else 'FAIL'}")
+        print(f"  Scenario 3 (header isolation):        {'PASS' if verdict_3 else 'FAIL'}")
+        all_pass = verdict_1 and verdict_2 and verdict_3
+        print(
+            f"\n  Phase 5 per-(user, server) pool architecture: "
+            f"{'VIABLE' if all_pass else 'NEEDS REWORK (Alternative F fallback)'}"
+        )
+        sys.exit(0 if all_pass else 1)
+    finally:
+        server.should_exit = True
+        server_thread.join(timeout=5)
+
+
+def print_scenario_result(result: dict) -> None:
+    print(f"\nresult[{result['scenario']}]:")
+    for k, v in result.items():
+        if k == "scenario":
+            continue
+        print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(main())

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -456,6 +456,42 @@ class TestCreateMcpServer:
         assert r.status_code == 400
         assert "auth_type" in r.json()["error"].lower()
 
+    def test_admin_create_oauth_user_rejects_http(self, client, storage):
+        """sec-1: an oauth_user row with a plaintext (non-loopback) URL
+        must 400 — pool dispatch would transmit the per-user bearer in
+        the clear."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "insecure-oauth",
+                "transport": "streamable-http",
+                "url": "http://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_abc",
+                "oauth_client_secret": "secret-value",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "https://" in r.json()["error"]
+        # No partial row was persisted.
+        assert storage.get_mcp_server_by_name("insecure-oauth") is None
+
+    def test_admin_create_oauth_user_accepts_loopback_http(self, client):
+        """``http://localhost`` and ``http://127.0.0.1`` must remain
+        usable for dev/test convenience."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "dev-oauth",
+                "transport": "streamable-http",
+                "url": "http://127.0.0.1:9000/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_abc",
+                "oauth_client_secret": "secret-value",
+            },
+        )
+        assert r.status_code == 200, r.text
+
 
 # ---------------------------------------------------------------------------
 # Get single
@@ -540,12 +576,13 @@ class TestUpdateMcpServer:
 
     def test_admin_update_auth_type_static_to_oauth(self, client):
         """An existing static row can be flipped to oauth_user with
-        OAuth fields supplied alongside."""
+        OAuth fields supplied alongside. The row must already use
+        https:// — sec-1 enforces this on update too."""
         created = _create_server(
             client,
             name="flip-to-oauth",
             transport="streamable-http",
-            url="http://mcp.example.com/sse",
+            url="https://mcp.example.com/sse",
         )
         sid = created["server_id"]
         assert created["auth_type"] == "static"
@@ -565,6 +602,101 @@ class TestUpdateMcpServer:
         assert data["oauth_client_id"] == "cli_xyz"
         assert data["oauth_audience"] == "https://mcp.example.com"
         assert data["oauth_registration_mode"] == "dcr"
+
+    def test_admin_update_oauth_url_to_http_rejected(self, client):
+        """sec-1: flipping the URL on an existing oauth_user row to
+        plaintext http must 400."""
+        # Create with proper https.
+        r0 = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "oauth-flip-url",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_abc",
+                "oauth_client_secret": "secret-value",
+            },
+        )
+        assert r0.status_code == 200, r0.text
+        sid = r0.json()["server_id"]
+
+        r = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"url": "http://insecure.example.com/sse"},
+        )
+        assert r.status_code == 400, r.text
+        assert "https://" in r.json()["error"]
+
+    def test_admin_update_oauth_url_change_purges_user_tokens(self, client, storage):
+        """sec-1 (pre-push): URL change on an oauth_user row must purge
+        per-user tokens. Bearer tokens are bound (via OAuth resource /
+        audience) to the URL active at consent time; sending them to a
+        new URL is a token-binding violation. A compromised admin who
+        flips the URL to an attacker endpoint would otherwise replay
+        every user's bearer there silently. Re-consent must be forced.
+        """
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        # Seed an oauth_user row at URL_A.
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "url-change-purge",
+                "transport": "streamable-http",
+                "url": "https://orig.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_seed",
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        # Plant a per-user token row keyed on the server name.
+        with storage._engine.connect() as conn:
+            conn.execute(
+                sa.insert(mcp_user_tokens),
+                {
+                    "user_id": "u1",
+                    "server_name": "url-change-purge",
+                    "access_token_ct": b"\x00ciphertext-a",
+                    "refresh_token_ct": b"\x00ciphertext-r",
+                    "expires_at": "2026-12-31T00:00:00",
+                    "scopes": "openid",
+                    "as_issuer": "https://auth.orig.example.com",
+                    "audience": "https://orig.example.com",
+                    "created": "2026-05-04T11:00:00",
+                    "last_refreshed": None,
+                },
+            )
+            conn.commit()
+            count_before = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(mcp_user_tokens)
+                .where(mcp_user_tokens.c.server_name == "url-change-purge")
+            ).scalar()
+        assert count_before == 1
+
+        # Flip the URL to a different (still https) endpoint.
+        sid = r.json()["server_id"]
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"url": "https://new.example.com/sse"},
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["url"] == "https://new.example.com/sse"
+
+        # Token rows keyed on the OLD server name must be gone — the new
+        # URL is a different OAuth resource, so the bearer is no longer
+        # valid there. Force re-consent.
+        with storage._engine.connect() as conn:
+            count_after = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(mcp_user_tokens)
+                .where(mcp_user_tokens.c.server_name == "url-change-purge")
+            ).scalar()
+        assert count_after == 0, "URL change must purge per-user tokens"
 
     def test_update_invalid_auth_type(self, client):
         created = _create_server(client, name="bad-auth-update")

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -577,7 +577,7 @@ class TestSessionIntegration:
         assert call_id == "call_789"
         assert output == "result text"
         mock_mcp.call_tool_sync.assert_called_once_with(
-            "mcp__test__search", {"query": "hello"}, timeout=30
+            "mcp__test__search", {"query": "hello"}, user_id=None, timeout=30
         )
 
     def test_exec_mcp_tool_error(self, tmp_db):

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -14,6 +14,9 @@ both coroutines return the same access_token.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import threading
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
@@ -26,6 +29,60 @@ from tests.conftest import make_mcp_token_cipher
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.mcp_oauth import get_user_access_token
 from turnstone.core.storage._sqlite import SQLiteBackend
+
+# Generous CI ceiling — cancel/drain is sub-millisecond on a healthy loop.
+_CANCEL_WAIT_S = 5.0
+
+
+class _ObservableLockCm:
+    """Class-based context manager whose ``__exit__`` is observable.
+
+    Used by :class:`TestPgRefreshLock` cancellation tests instead of
+    ``@contextlib.contextmanager`` so the test can distinguish:
+
+      * an explicit ``cm.__exit__(None, None, None)`` call from the drain
+        coroutine (records ``(None, None, None)`` in :attr:`exit_calls`)
+      * ``GeneratorExit`` thrown by the cm's generator finalizer during
+        garbage collection (records ``(GeneratorExit, ...)``)
+
+    Class-based ``__exit__`` runs only when called explicitly — generator
+    finalization doesn't go through it — so an empty ``exit_calls`` is
+    proof the drain didn't run, not just that GC didn't fire.
+    """
+
+    def __init__(
+        self,
+        *,
+        enter_started: threading.Event | None = None,
+        enter_release: threading.Event | None = None,
+        enter_raises: BaseException | None = None,
+    ) -> None:
+        self.enter_thread: int | None = None
+        self.exit_thread: int | None = None
+        self.exit_calls: list[tuple[Any, Any, Any]] = []
+        self._enter_started = enter_started
+        self._enter_release = enter_release
+        self._enter_raises = enter_raises
+
+    def __enter__(self) -> None:
+        self.enter_thread = threading.get_ident()
+        if self._enter_started is not None:
+            self._enter_started.set()
+        if self._enter_release is not None:
+            self._enter_release.wait(timeout=_CANCEL_WAIT_S)
+        if self._enter_raises is not None:
+            raise self._enter_raises
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
+        self.exit_thread = threading.get_ident()
+        self.exit_calls.append((exc_type, exc, tb))
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -638,6 +695,195 @@ class TestAdvisoryLock:
         with cm as value:
             assert value is None
         assert isinstance(cm, _contextlib.nullcontext)
+
+
+# ---------------------------------------------------------------------------
+# _PgRefreshLock executor topology — independent of advisory-lock semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPgRefreshLock:
+    """Topology of the ``_PgRefreshLock`` async wrapper itself.
+
+    These tests patch ``acquire_advisory_lock_sync`` with a fake context
+    manager and assert behaviour of the per-instance executor, the
+    cancellation-safety drain, and other lifecycle properties — not the
+    advisory-lock semantics under it (those live in ``TestAdvisoryLock``).
+    """
+
+    def test_pg_refresh_lock_per_key_concurrency(self, storage: SQLiteBackend) -> None:
+        """Two ``_PgRefreshLock`` instances with different keys must enter in parallel.
+
+        Regression for the global single-worker executor shape: if every
+        instance shared one ``ThreadPoolExecutor(max_workers=1)``, the
+        second instance's ``__aenter__`` would queue behind the first
+        even though the advisory keys are unrelated, so a single slow
+        ``pg_try_advisory_xact_lock`` spin would block every other
+        refresh on the node. Per-instance executors keep enter/exit on
+        the same thread (psycopg2 thread-affinity) without globally
+        serializing the spin loop.
+        """
+        from turnstone.core.mcp_oauth import _PgRefreshLock
+
+        in_flight = 0
+        max_in_flight = 0
+        counter_lock = threading.Lock()
+        enter_hold_s = 0.1
+
+        @contextlib.contextmanager
+        def _slow_lock_cm(_key_text: str = "") -> Any:
+            nonlocal in_flight, max_in_flight
+            with counter_lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            try:
+                # Block INSIDE __enter__, before the yield, so concurrent
+                # callers overlap on this stretch of the call.
+                time.sleep(enter_hold_s)
+                yield
+            finally:
+                with counter_lock:
+                    in_flight -= 1
+
+        with patch.object(storage, "acquire_advisory_lock_sync", side_effect=_slow_lock_cm):
+
+            async def _hold(key: str) -> None:
+                async with _PgRefreshLock(storage, key):
+                    pass
+
+            async def _two_concurrent() -> None:
+                await asyncio.gather(_hold("key-a"), _hold("key-b"))
+
+            asyncio.run(_two_concurrent())
+
+        assert max_in_flight == 2, (
+            "_PgRefreshLock instances serialized through a shared executor: "
+            f"max_in_flight={max_in_flight}; expected 2 with per-instance executors."
+        )
+
+    def _run_cancel_scenario(
+        self,
+        storage: SQLiteBackend,
+        *,
+        enter_raises: BaseException | None = None,
+    ) -> _ObservableLockCm:
+        """Run the cancellation scenario shared by both cancellation tests.
+
+        Patches ``acquire_advisory_lock_sync`` with a factory that returns
+        a fresh :class:`_ObservableLockCm`, starts a ``_PgRefreshLock``
+        acquire on a task, waits for the worker to enter ``cm.__enter__``,
+        cancels the task, then releases the worker to either succeed
+        (default) or raise (``enter_raises``). Awaits in-flight drain
+        tasks via :data:`_pg_refresh_drain_tasks` so callers can inspect
+        the cm deterministically.
+
+        Test integrity:
+        * Class-based cm — drain's explicit ``__exit__(None, None, None)``
+          is recorded as a real method call, distinguishable from
+          ``GeneratorExit`` thrown by GC of a generator-based cm.
+        * Strong ref via ``created_cms`` — keeps the cm alive past the
+          test's awaits, so a no-op drain genuinely fails the assertion
+          rather than papering over via GC finalization timing.
+        * Deterministic drain wait via :data:`_pg_refresh_drain_tasks` —
+          no fixed-duration sleeps.
+
+        Returns the single cm the factory created.
+        """
+        from turnstone.core.mcp_oauth import _pg_refresh_drain_tasks, _PgRefreshLock
+
+        enter_started = threading.Event()
+        enter_release = threading.Event()
+        created_cms: list[_ObservableLockCm] = []
+
+        def _factory(_key_text: str) -> _ObservableLockCm:
+            cm = _ObservableLockCm(
+                enter_started=enter_started,
+                enter_release=enter_release,
+                enter_raises=enter_raises,
+            )
+            created_cms.append(cm)
+            return cm
+
+        with patch.object(storage, "acquire_advisory_lock_sync", side_effect=_factory):
+
+            async def _run() -> None:
+                lock = _PgRefreshLock(storage, "key-cancel")
+
+                async def _attempt() -> None:
+                    async with lock:
+                        pass  # body never runs — we cancel before it does
+
+                task = asyncio.create_task(_attempt())
+                # Wait until the worker is inside cm.__enter__.
+                await asyncio.to_thread(enter_started.wait, _CANCEL_WAIT_S)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                    await task
+                # Release the worker — succeed (default) or raise
+                # (``enter_raises`` set via factory closure).
+                enter_release.set()
+                # Wait deterministically for any in-flight drain task.
+                drains = list(_pg_refresh_drain_tasks)
+                if drains:
+                    await asyncio.gather(*drains, return_exceptions=True)
+
+            asyncio.run(_run())
+
+        assert len(created_cms) == 1, (
+            f"factory was called {len(created_cms)} times — expected exactly 1"
+        )
+        return created_cms[0]
+
+    def test_pg_refresh_lock_cancellation_releases_on_same_thread(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Cancelling ``__aenter__`` mid-acquire MUST release on the same thread.
+
+        Regression for: cancellation between submit and the worker
+        completing ``cm.__enter__`` would otherwise leave an acquired
+        Postgres advisory lock + open transaction whose paired
+        ``cm.__exit__`` runs on a non-deterministic GC thread —
+        violating psycopg2's connection thread-affinity (the very
+        invariant the per-instance executor was introduced to enforce).
+        The fire-and-forget drain coroutine waits for the worker to
+        settle (via a fresh ``asyncio.wrap_future`` of the underlying
+        ``concurrent.futures.Future``, NOT a re-await of the cancelled
+        asyncio wrapper) and runs ``cm.__exit__`` on the same executor.
+        """
+        cm = self._run_cancel_scenario(storage)
+        assert cm.exit_calls, (
+            "drain did NOT call cm.__exit__ — orphan Postgres lock + open transaction"
+        )
+        # Drain calls __exit__(None, None, None); GC GeneratorExit would
+        # have args (GeneratorExit, ..., ...). Distinguish.
+        assert cm.exit_calls == [(None, None, None)], (
+            f"cm.__exit__ called with {cm.exit_calls[0]} — expected "
+            "(None, None, None) from drain. A non-(None,None,None) call would "
+            "indicate the drain came in via GeneratorExit / GC instead of an "
+            "explicit drain invocation."
+        )
+        assert cm.exit_thread == cm.enter_thread, (
+            f"cm.__exit__ ran on thread {cm.exit_thread} but cm.__enter__ on "
+            f"{cm.enter_thread} — psycopg2 thread-affinity violated"
+        )
+
+    def test_pg_refresh_lock_cancellation_no_lock_no_orphan(self, storage: SQLiteBackend) -> None:
+        """If ``cm.__enter__`` raised, the drain must NOT call ``cm.__exit__``.
+
+        The drain pairs only with successful acquires. If the worker
+        raised (e.g., ``TimeoutError`` from the spin loop), there is no
+        transaction to commit — calling ``__exit__`` on an unentered cm
+        would itself raise.
+        """
+        cm = self._run_cancel_scenario(
+            storage,
+            enter_raises=TimeoutError("simulated spin-loop timeout"),
+        )
+        assert not cm.exit_calls, (
+            "drain incorrectly called cm.__exit__ on an unentered cm "
+            f"(calls: {cm.exit_calls}). Would attempt to commit a transaction "
+            "that never began."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -578,3 +578,191 @@ class TestExpiresInParsing:
         assert _expires_at_from_response({"expires_in": True}) is None
         assert _expires_at_from_response({"expires_in": 0}) is None
         assert _expires_at_from_response({"expires_in": -5}) is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-node refresh lock — advisory lock plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryLock:
+    """The refresh path must take the storage advisory lock as the OUTER
+    serialization layer (cluster-wide), with the in-process asyncio.Lock
+    as the inner layer. SQLite returns ``nullcontext`` so single-node
+    deployments are untouched.
+    """
+
+    def test_advisory_lock_acquired_during_refresh(self, storage: SQLiteBackend) -> None:
+        """The storage advisory lock must be acquired when refresh runs."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                200,
+                {
+                    "access_token": "access-NEW",
+                    "refresh_token": "refresh-NEW",
+                    "expires_in": 3600,
+                },
+            )
+        )
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        keys_seen: list[str] = []
+        original = storage.acquire_advisory_lock_sync
+
+        def _spy(key: str):  # type: ignore[no-untyped-def]
+            keys_seen.append(key)
+            return original(key)
+
+        with patch.object(storage, "acquire_advisory_lock_sync", side_effect=_spy):
+
+            async def _run():
+                with _public_addr_patch():
+                    return await get_user_access_token(
+                        app_state=state, user_id="user-1", server_name="srv-oauth"
+                    )
+
+            asyncio.run(_run())
+
+        assert keys_seen == ["mcp_refresh:user-1:srv-oauth"]
+
+    def test_advisory_lock_is_noop_on_sqlite(self, storage: SQLiteBackend) -> None:
+        """The SQLite backend's advisory lock is a ``nullcontext`` no-op."""
+        import contextlib as _contextlib
+
+        cm = storage.acquire_advisory_lock_sync("mcp_refresh:any:any")
+        # ``nullcontext`` returns this exact object from __enter__.
+        with cm as value:
+            assert value is None
+        assert isinstance(cm, _contextlib.nullcontext)
+
+
+# ---------------------------------------------------------------------------
+# get_user_access_token_classified — tagged-result variant
+# ---------------------------------------------------------------------------
+
+
+class TestClassifiedGetter:
+    """The classified getter distinguishes ``missing`` vs ``decrypt_failure``
+    vs ``refresh_failed`` vs ``token`` so the dispatcher can map each to
+    the right user-facing error.
+    """
+
+    def test_returns_token_on_happy_path(self, storage: SQLiteBackend) -> None:
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=3600)
+
+        async def _run():
+            return await get_user_access_token_classified(
+                app_state=state, user_id="user-1", server_name="srv-oauth"
+            )
+
+        result = asyncio.run(_run())
+        assert result.kind == "token"
+        assert result.token == "access-aaa"
+
+    def test_missing_token_returns_missing(self, storage: SQLiteBackend) -> None:
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        state = _make_app_state(storage, http_client=client)
+
+        async def _run():
+            return await get_user_access_token_classified(
+                app_state=state, user_id="user-1", server_name="srv-oauth"
+            )
+
+        result = asyncio.run(_run())
+        assert result.kind == "missing"
+
+    def test_decrypt_failure_returns_decrypt_failure(self, storage: SQLiteBackend) -> None:
+        """A key-mismatch must NOT collapse to ``missing``.
+
+        RFC §5.3 — the dispatcher MUST distinguish "row missing" from
+        "row present but undecryptable" so it can avoid emitting fake
+        ``mcp_consent_required`` events on every operator misconfig.
+        """
+        from turnstone.core.mcp_crypto import MCPTokenDecryptError
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=3600)
+
+        def _raise_decrypt(*args, **kwargs):
+            raise MCPTokenDecryptError(
+                "no installed key can decrypt",
+                key_fingerprints_attempted=("aabbccdd",),
+            )
+
+        state.mcp_token_store.get_user_token = _raise_decrypt
+
+        async def _run():
+            return await get_user_access_token_classified(
+                app_state=state, user_id="user-1", server_name="srv-oauth"
+            )
+
+        result = asyncio.run(_run())
+        assert result.kind == "decrypt_failure"
+        assert result.decrypt_fingerprints == ("aabbccdd",)
+
+    def test_refresh_failure_returns_refresh_failed(self, storage: SQLiteBackend) -> None:
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(return_value=_mk_response(400, {"error": "invalid_grant"}))
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        async def _run():
+            with _public_addr_patch():
+                return await get_user_access_token_classified(
+                    app_state=state, user_id="user-1", server_name="srv-oauth"
+                )
+
+        result = asyncio.run(_run())
+        assert result.kind == "refresh_failed"
+        # Row was deleted (re-consent path).
+        assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is None
+
+    def test_no_refresh_token_returns_refresh_failed(self, storage: SQLiteBackend) -> None:
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000, refresh=None)
+
+        async def _run():
+            return await get_user_access_token_classified(
+                app_state=state, user_id="user-1", server_name="srv-oauth"
+            )
+
+        result = asyncio.run(_run())
+        assert result.kind == "refresh_failed"
+
+    def test_classified_does_not_break_legacy_helper(self, storage: SQLiteBackend) -> None:
+        """The legacy ``get_user_access_token`` keeps its ``str | None`` contract."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=3600)
+
+        async def _run():
+            return await get_user_access_token(
+                app_state=state, user_id="user-1", server_name="srv-oauth"
+            )
+
+        token = asyncio.run(_run())
+        assert token == "access-aaa"

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1,0 +1,964 @@
+"""Tests for the per-(user, server) MCP session pool.
+
+Covers Phase 5 of the OAuth-MCP rollout: pool data structures,
+``_ensure_pool_entry`` lazy allocation, ``_connect_one_pool`` plumbing,
+the dispatch state machine in ``_dispatch_pool``, idle / LRU eviction,
+failure classification, and ``user_id`` thread-through.
+
+The static path (``auth_type ∈ {none, static}``) MUST stay
+byte-identical — see ``test_mcp_client.py``'s
+``test_reconnect_preserves_static_state_identity``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+import time
+from contextlib import AsyncExitStack
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_mcp_token_cipher
+from turnstone.core.mcp_client import MCPClientManager, PoolEntryState
+from turnstone.core.mcp_crypto import MCPTokenStore
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(tmp_path: Any) -> SQLiteBackend:
+    """A fresh SQLite backend per test (not the shared singleton)."""
+    return SQLiteBackend(str(tmp_path / "test.db"))
+
+
+def _seed_oauth_server(
+    storage: SQLiteBackend,
+    *,
+    name: str = "pool-srv",
+    server_id: str = "srv-pool",
+    url: str = "https://mcp.example.com/sse",
+) -> None:
+    storage.create_mcp_server(
+        server_id=server_id,
+        name=name,
+        transport="streamable-http",
+        url=url,
+        auth_type="oauth_user",
+        oauth_client_id="client-abc",
+        oauth_scopes="openid",
+        oauth_audience=url,
+    )
+
+
+def _seed_user_token(
+    storage: SQLiteBackend,
+    cipher: Any,
+    *,
+    user_id: str = "user-1",
+    server_name: str = "pool-srv",
+    expires_in_seconds: int = 3600,
+    access_token: str = "access-aaa",
+) -> None:
+    expires_at = (datetime.now(UTC) + timedelta(seconds=expires_in_seconds)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    store = MCPTokenStore(storage, cipher, node_id="test")
+    store.create_user_token(
+        user_id,
+        server_name,
+        access_token=access_token,
+        refresh_token="refresh-rrr",
+        expires_at=expires_at,
+        scopes="openid",
+        as_issuer="https://as.example.com",
+        audience="https://mcp.example.com",
+    )
+
+
+def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        auth_storage=storage,
+        mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
+        mcp_oauth_http_client=MagicMock(),
+        mcp_oauth_refresh_locks={},
+        mcp_oauth_metadata_cache={},
+    )
+
+
+@pytest.fixture
+def running_loop_mgr():
+    """Background-loop fixture matching the static-path test convention.
+
+    Tests that need a wired-up app_state assign it via ``mgr.set_app_state``.
+    """
+    cfg: dict[str, Any] = {}
+    mgr = MCPClientManager(cfg)
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True, name="mcp-pool-test-loop")
+    thread.start()
+    mgr._loop = loop
+    try:
+        yield mgr, loop, thread
+    finally:
+        # Drain the eviction task before stopping the loop so its log/stream
+        # handlers don't fire after pytest has torn its handlers down. Mirrors
+        # the production ``shutdown()`` shape.
+        async def _drain(m: MCPClientManager) -> None:
+            task = m._user_pool_eviction_task
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(BaseException):
+                    await task
+                m._user_pool_eviction_task = None
+
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+
+
+def _run_on_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
+    """Submit *coro* to *loop*, wait for the result with a 5s timeout."""
+    fut = asyncio.run_coroutine_threadsafe(coro, loop)
+    return fut.result(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Pool data structures
+# ---------------------------------------------------------------------------
+
+
+class TestPoolDataStructures:
+    """``_user_pool_entries``, ``_user_pool_locks``, eviction-task state."""
+
+    def test_pool_state_starts_empty(self) -> None:
+        mgr = MCPClientManager({})
+        assert mgr._user_pool_entries == {}
+        assert mgr._user_pool_last_used == {}
+        assert mgr._user_pool_locks == {}
+        assert mgr._user_pool_eviction_task is None
+
+    def test_set_app_state_persists(self) -> None:
+        mgr = MCPClientManager({})
+        sentinel = SimpleNamespace(token_store=object())
+        mgr.set_app_state(sentinel)
+        assert mgr._app_state is sentinel
+
+    def test_ensure_pool_entry_allocates_lock_on_loop(self, running_loop_mgr) -> None:
+        """``asyncio.Lock`` MUST be created on the mcp-loop (RFC §2.0 #2)."""
+        mgr, loop, _thread = running_loop_mgr
+        key = ("user-A", "pool-srv")
+        entry = _run_on_loop(loop, mgr._ensure_pool_entry(key))
+        assert isinstance(entry, PoolEntryState)
+        assert entry.key == key
+        assert isinstance(entry.open_lock, asyncio.Lock)
+        # Calling again returns the same entry / lock object.
+        entry2 = _run_on_loop(loop, mgr._ensure_pool_entry(key))
+        assert entry2 is entry
+        assert entry2.open_lock is entry.open_lock
+
+
+# ---------------------------------------------------------------------------
+# Lazy connect (`_connect_one_pool`)
+# ---------------------------------------------------------------------------
+
+
+class _AsyncCM:
+    """Awaitable async context manager that returns ``value`` from __aenter__."""
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    async def __aenter__(self) -> Any:
+        return self._value
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class TestLazyConnect:
+    def test_connect_pool_injects_authorization_header(self, running_loop_mgr) -> None:
+        from unittest.mock import patch
+
+        mgr, loop, _ = running_loop_mgr
+
+        observed_kwargs: dict[str, Any] = {}
+
+        async def _probe(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        fake_session = MagicMock()
+        fake_session.initialize = AsyncMock(return_value=None)
+
+        def _stream_factory(*, url: str, headers: dict[str, str]) -> _AsyncCM:
+            observed_kwargs["url"] = url
+            observed_kwargs["headers"] = dict(headers)
+            return _AsyncCM((AsyncMock(), AsyncMock(), lambda: None))
+
+        with (
+            patch("turnstone.core.mcp_client.streamablehttp_client", side_effect=_stream_factory),
+            patch.object(mgr, "_tcp_probe", side_effect=_probe),
+            patch("turnstone.core.mcp_client.ClientSession", return_value=_AsyncCM(fake_session)),
+        ):
+            cfg = {
+                "type": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "headers": {},
+            }
+            entry = _run_on_loop(
+                loop,
+                mgr._connect_one_pool(("user-1", "pool-srv"), cfg, "access-aaa"),
+            )
+
+        assert entry.session is fake_session
+        assert observed_kwargs["headers"]["Authorization"] == "Bearer access-aaa"
+
+    def test_connect_pool_rejects_non_http_transport(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cfg = {"type": "stdio", "command": "echo"}
+        with pytest.raises(RuntimeError, match="streamable-http"):
+            _run_on_loop(
+                loop,
+                mgr._connect_one_pool(("user-1", "pool-srv"), cfg, "access-aaa"),
+            )
+
+    def test_pool_path_does_not_touch_static_servers(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        # Pre-seed a static-path entry so accidental writes are observable.
+        from turnstone.core.mcp_client import StaticServerState
+
+        sentinel = StaticServerState(name="static-srv", session=MagicMock())
+        mgr._static_servers["static-srv"] = sentinel
+
+        async def _seed_pool() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            entry.session = MagicMock()
+            entry.last_used = time.monotonic()
+
+        _run_on_loop(loop, _seed_pool())
+        # Pool side has its own state; the static dict is untouched.
+        assert mgr._static_servers["static-srv"] is sentinel
+        assert mgr._user_pool_entries[("user-1", "pool-srv")].session is not None
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+
+class TestEviction:
+    def test_idle_eviction_closes_stale_entries(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0  # everything is stale
+
+        async def _seed() -> list[PoolEntryState]:
+            entries = []
+            for i in range(3):
+                entry = await mgr._ensure_pool_entry((f"u{i}", "pool-srv"))
+                entry.session = MagicMock()
+                entries.append(entry)
+            return entries
+
+        _run_on_loop(loop, _seed())
+
+        async def _evict() -> None:
+            await mgr._evict_idle_pool_entries()
+
+        _run_on_loop(loop, _evict())
+        assert mgr._user_pool_entries == {}
+
+    def test_eviction_skips_locked_entries(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0
+
+        async def _seed_and_lock() -> tuple[asyncio.Lock, asyncio.Event]:
+            entry = await mgr._ensure_pool_entry(("u-busy", "pool-srv"))
+            entry.session = MagicMock()
+            held = asyncio.Event()
+
+            async def _hold() -> None:
+                async with entry.open_lock:
+                    held.set()
+                    await asyncio.sleep(0.5)
+
+            asyncio.create_task(_hold())
+            await held.wait()
+            return entry.open_lock, held
+
+        _run_on_loop(loop, _seed_and_lock())
+
+        async def _evict() -> None:
+            await mgr._evict_idle_pool_entries()
+
+        _run_on_loop(loop, _evict())
+        # Entry survives because eviction skipped the locked key.
+        assert ("u-busy", "pool-srv") in mgr._user_pool_entries
+
+    def test_lru_cap_evicts_oldest(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 999_999.0  # TTL effectively disabled
+        mgr._user_pool_lru_max = 2
+
+        async def _seed() -> None:
+            base = time.monotonic()
+            for i in range(5):
+                key = (f"u{i}", "pool-srv")
+                entry = await mgr._ensure_pool_entry(key)
+                entry.session = MagicMock()
+                # Recent timestamps so TTL doesn't fire — only LRU should.
+                entry.last_used = base + i
+                mgr._user_pool_last_used[key] = base + i
+
+        _run_on_loop(loop, _seed())
+
+        async def _evict() -> None:
+            await mgr._evict_idle_pool_entries()
+
+        _run_on_loop(loop, _evict())
+        assert len(mgr._user_pool_entries) <= 2
+        # The two newest survive (u3, u4).
+        assert ("u4", "pool-srv") in mgr._user_pool_entries
+        assert ("u3", "pool-srv") in mgr._user_pool_entries
+
+    def test_eviction_resilient_to_close_errors(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0
+
+        broken_stack = MagicMock(spec=AsyncExitStack)
+        broken_stack.aclose = AsyncMock(side_effect=RuntimeError("close failed"))
+
+        async def _seed() -> None:
+            for i in range(2):
+                entry = await mgr._ensure_pool_entry((f"u{i}", "pool-srv"))
+                entry.session = MagicMock()
+                entry.stack = broken_stack
+
+        _run_on_loop(loop, _seed())
+
+        async def _evict() -> None:
+            await mgr._evict_idle_pool_entries()
+
+        # Eviction must not raise even if close fails.
+        _run_on_loop(loop, _evict())
+        # All entries removed from the dict regardless.
+        assert mgr._user_pool_entries == {}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch state machine
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchStateMachine:
+    """One row per state in the §1.5 / RFC §6 state machine."""
+
+    def _wire_pool(
+        self, mgr: MCPClientManager, storage: SQLiteBackend, cipher: Any
+    ) -> SimpleNamespace:
+        mgr.set_storage(storage)
+        state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(state)
+        return state
+
+    def test_no_token_emits_consent_required(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        mgr, _loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        self._wire_pool(mgr, storage, cipher)
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {},
+            user_id="user-1",
+            timeout=5,
+        )
+        payload = json.loads(result)
+        assert payload["error"]["code"] == "mcp_consent_required"
+        assert payload["error"]["server"] == "pool-srv"
+
+    def test_decrypt_failure_does_not_emit_consent(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        from turnstone.core.mcp_crypto import MCPTokenDecryptError
+
+        mgr, _loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        _seed_user_token(storage, cipher)
+        state = self._wire_pool(mgr, storage, cipher)
+
+        def _raise(*args, **kwargs):
+            raise MCPTokenDecryptError(
+                "no installed key can decrypt",
+                key_fingerprints_attempted=("aabbccdd",),
+            )
+
+        state.mcp_token_store.get_user_token = _raise
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {},
+            user_id="user-1",
+            timeout=5,
+        )
+        payload = json.loads(result)
+        assert payload["error"]["code"] == "mcp_token_undecryptable_key_unknown"
+        # Operator fingerprints stay server-side (audit log + structured log);
+        # the agent-facing payload must NOT carry them onward to the LLM
+        # provider.
+        assert "key_fingerprints_attempted" not in payload["error"]
+
+    def test_refresh_failure_emits_consent(self, running_loop_mgr, storage: SQLiteBackend) -> None:
+        mgr, _loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        # Seed an expired token with no refresh — the classified getter
+        # treats this as "refresh_failed" (deletes the row, returns the
+        # tagged result).
+        _seed_user_token(storage, cipher, expires_in_seconds=-1000)
+        state = self._wire_pool(mgr, storage, cipher)
+        # Drop the refresh token to force the no-refresh-token branch.
+        state.mcp_token_store.delete_user_token("user-1", "pool-srv")
+        state.mcp_token_store.create_user_token(
+            "user-1",
+            "pool-srv",
+            access_token="access-aaa",
+            refresh_token=None,
+            expires_at=(datetime.now(UTC) - timedelta(seconds=1000)).strftime("%Y-%m-%dT%H:%M:%S"),
+            scopes="openid",
+            as_issuer="https://as.example.com",
+            audience="https://mcp.example.com",
+        )
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {},
+            user_id="user-1",
+            timeout=5,
+        )
+        payload = json.loads(result)
+        assert payload["error"]["code"] == "mcp_consent_required"
+
+    def test_token_present_dispatches_to_session(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        _seed_user_token(storage, cipher, expires_in_seconds=3600)
+        self._wire_pool(mgr, storage, cipher)
+
+        # Pre-seed a connected pool entry so dispatch never touches the
+        # SDK or the network.
+        fake_session = MagicMock()
+
+        async def _call_tool(name, args):
+            content = MagicMock()
+            content.text = "tool-result"
+            res = MagicMock()
+            res.content = [content]
+            res.isError = False
+            return res
+
+        fake_session.call_tool = _call_tool
+
+        async def _seed_entry() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            entry.session = fake_session
+
+        _run_on_loop(loop, _seed_entry())
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {"q": "hi"},
+            user_id="user-1",
+            timeout=5,
+        )
+        assert result == "tool-result"
+
+
+# ---------------------------------------------------------------------------
+# Failure classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFailure:
+    def test_transport_failure_classified_as_transport(self) -> None:
+        mgr = MCPClientManager({})
+        for exc in (
+            BrokenPipeError(),
+            ConnectionResetError(),
+            EOFError(),
+            TimeoutError("net"),
+        ):
+            assert mgr._classify_failure(exc) == "transport"
+
+    def test_protocol_error_classified_as_protocol(self) -> None:
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        mgr = MCPClientManager({})
+        err = McpError(ErrorData(code=-32600, message="bad request"))
+        assert mgr._classify_failure(err) == "protocol"
+
+    def test_other_classified_as_other(self) -> None:
+        mgr = MCPClientManager({})
+        assert mgr._classify_failure(ValueError("nope")) == "other"
+
+    def test_http_401_classified_as_auth(self) -> None:
+        import httpx
+
+        mgr = MCPClientManager({})
+        req = httpx.Request("POST", "https://mcp.example.com/sse")
+        resp = httpx.Response(401, request=req)
+        exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+        assert mgr._classify_failure(exc) == "auth"
+
+    def test_http_403_classified_as_auth(self) -> None:
+        import httpx
+
+        mgr = MCPClientManager({})
+        req = httpx.Request("POST", "https://mcp.example.com/sse")
+        resp = httpx.Response(403, request=req)
+        exc = httpx.HTTPStatusError("forbidden", request=req, response=resp)
+        assert mgr._classify_failure(exc) == "auth"
+
+    def test_http_500_not_classified_as_auth(self) -> None:
+        import httpx
+
+        mgr = MCPClientManager({})
+        req = httpx.Request("POST", "https://mcp.example.com/sse")
+        resp = httpx.Response(500, request=req)
+        exc = httpx.HTTPStatusError("server", request=req, response=resp)
+        # 5xx is not auth — falls through to "other".
+        assert mgr._classify_failure(exc) == "other"
+
+
+# ---------------------------------------------------------------------------
+# Wired-failure paths in _dispatch_pool
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchFailureWiring:
+    """``_classify_failure`` is consulted in production, not just tests."""
+
+    def _wire_pool(
+        self, mgr: MCPClientManager, storage: SQLiteBackend, cipher: Any
+    ) -> SimpleNamespace:
+        mgr.set_storage(storage)
+        state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(state)
+        return state
+
+    def _seed_connected_session(
+        self, mgr: MCPClientManager, loop: asyncio.AbstractEventLoop, exc: BaseException
+    ) -> None:
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            sess = MagicMock()
+
+            async def _raise(*_args: Any, **_kwargs: Any) -> Any:
+                raise exc
+
+            sess.call_tool = _raise
+            entry.session = sess
+
+        _run_on_loop(loop, _seed())
+
+    def test_dispatch_pool_401_does_not_trip_breaker(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        import httpx
+
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        _seed_user_token(storage, cipher)
+        self._wire_pool(mgr, storage, cipher)
+
+        req = httpx.Request("POST", "https://mcp.example.com/sse")
+        resp = httpx.Response(401, request=req)
+        self._seed_connected_session(
+            mgr, loop, httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            mgr.call_tool_sync(
+                "mcp__pool-srv__do_thing",
+                {},
+                user_id="user-1",
+                timeout=5,
+            )
+        # Auth failure must NOT tick the per-server breaker.
+        assert mgr._consecutive_failures.get("pool-srv", 0) == 0
+        # But the pool entry's session must be cleared so the next call
+        # re-authenticates with a fresh bearer.
+        entry = mgr._user_pool_entries[("user-1", "pool-srv")]
+        assert entry.session is None
+
+    def test_dispatch_pool_transport_failure_trips_breaker(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        _seed_user_token(storage, cipher)
+        self._wire_pool(mgr, storage, cipher)
+
+        self._seed_connected_session(mgr, loop, BrokenPipeError("dead"))
+
+        with pytest.raises(BrokenPipeError):
+            mgr.call_tool_sync(
+                "mcp__pool-srv__do_thing",
+                {},
+                user_id="user-1",
+                timeout=5,
+            )
+        # Transport failure ticks the breaker.
+        assert mgr._consecutive_failures.get("pool-srv", 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTPS enforcement (sec-1)
+# ---------------------------------------------------------------------------
+
+
+class TestHttpsEnforcement:
+    def test_pool_rejects_http_url_for_oauth_user(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        mgr, _loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv", url="http://insecure.example.com/sse")
+        _seed_user_token(storage, cipher)
+        mgr.set_storage(storage)
+        state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(state)
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {},
+            user_id="user-1",
+            timeout=5,
+        )
+        payload = json.loads(result)
+        assert payload["error"]["code"] == "mcp_oauth_url_insecure"
+        assert payload["error"]["server"] == "pool-srv"
+
+    def test_pool_accepts_loopback_http(self, running_loop_mgr, storage: SQLiteBackend) -> None:
+        """``http://127.0.0.1`` and ``http://localhost`` should not be blocked."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv", url="http://127.0.0.1:8000/sse")
+        _seed_user_token(storage, cipher)
+        mgr.set_storage(storage)
+        state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(state)
+
+        # Pre-seed a connected pool entry so dispatch succeeds without
+        # touching the network.
+        fake_session = MagicMock()
+
+        async def _call_tool(name, args):
+            content = MagicMock()
+            content.text = "ok"
+            res = MagicMock()
+            res.content = [content]
+            res.isError = False
+            return res
+
+        fake_session.call_tool = _call_tool
+
+        async def _seed_entry() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            entry.session = fake_session
+
+        _run_on_loop(loop, _seed_entry())
+
+        result = mgr.call_tool_sync(
+            "mcp__pool-srv__do_thing",
+            {},
+            user_id="user-1",
+            timeout=5,
+        )
+        # Loopback URL not rejected — dispatch reaches the (fake) session.
+        assert result == "ok"
+
+    def test_validate_oauth_user_url_helper(self) -> None:
+        from turnstone.core.mcp_client import _validate_oauth_user_url
+
+        # Acceptable: https + the exact loopback hostnames.
+        _validate_oauth_user_url("https://mcp.example.com/sse")
+        _validate_oauth_user_url("http://localhost/sse")
+        _validate_oauth_user_url("http://127.0.0.1:9000/sse")
+        _validate_oauth_user_url("http://[::1]/sse")
+
+        # Rejected: non-https + non-loopback. The ``*.localhost`` suffix
+        # bypass is intentionally NOT honored (RFC 6761 localhost-zone
+        # resolution is configuration-dependent — custom resolvers,
+        # /etc/hosts, Docker overlays may map ``foo.localhost`` to
+        # non-loopback IPs).
+        for bad in (
+            "http://mcp.example.com/sse",
+            "http://app.localhost/sse",
+            "ws://mcp.example.com/sse",
+            "ftp://mcp.example.com/sse",
+            "//mcp.example.com/sse",
+        ):
+            with pytest.raises(ValueError, match="https://"):
+                _validate_oauth_user_url(bad)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_pool_target parser (q-9)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePoolTarget:
+    def _make_mgr_with_oauth_server(
+        self, storage: SQLiteBackend, *, name: str = "pool-srv"
+    ) -> MCPClientManager:
+        _seed_oauth_server(storage, name=name)
+        mgr = MCPClientManager({})
+        mgr.set_storage(storage)
+        return mgr
+
+    def test_malformed_prefix(self, storage: SQLiteBackend) -> None:
+        mgr = self._make_mgr_with_oauth_server(storage)
+        # Wrong prefix.
+        assert mgr._resolve_pool_target("xyz__pool-srv__t", None, None) is None
+
+    def test_too_few_separators(self, storage: SQLiteBackend) -> None:
+        mgr = self._make_mgr_with_oauth_server(storage)
+        # mcp__server with no original_name segment.
+        assert mgr._resolve_pool_target("mcp__pool-srv", None, None) is None
+
+    def test_empty_server_segment(self, storage: SQLiteBackend) -> None:
+        mgr = self._make_mgr_with_oauth_server(storage)
+        # mcp____tool — server segment is empty.
+        assert mgr._resolve_pool_target("mcp____tool", None, None) is None
+
+    def test_original_with_double_underscore_round_trips(self, storage: SQLiteBackend) -> None:
+        mgr = self._make_mgr_with_oauth_server(storage)
+        target = mgr._resolve_pool_target("mcp__pool-srv__do__thing", None, None)
+        assert target is not None
+        assert target[0] == "pool-srv"
+        # Original-name keeps its embedded ``__``.
+        assert target[1] == "do__thing"
+
+
+# ---------------------------------------------------------------------------
+# LRU + lock interlock (q-7)
+# ---------------------------------------------------------------------------
+
+
+class TestLruInterlock:
+    def test_lru_cap_skips_locked_oldest(self, running_loop_mgr) -> None:
+        """LRU eviction must skip a locked entry the same way TTL does."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 999_999.0  # disable TTL
+        mgr._user_pool_lru_max = 2
+
+        async def _seed_and_lock_oldest() -> tuple[asyncio.Lock, asyncio.Event]:
+            base = time.monotonic()
+            for i in range(3):
+                key = (f"u{i}", "pool-srv")
+                entry = await mgr._ensure_pool_entry(key)
+                entry.session = MagicMock()
+                # Older index ⇒ older timestamp.
+                entry.last_used = base + i
+                mgr._user_pool_last_used[key] = base + i
+            # Lock the oldest (u0) so eviction must skip it and pick a younger one.
+            oldest = mgr._user_pool_entries[("u0", "pool-srv")]
+            held = asyncio.Event()
+
+            async def _hold() -> None:
+                async with oldest.open_lock:
+                    held.set()
+                    await asyncio.sleep(0.5)
+
+            asyncio.create_task(_hold())
+            await held.wait()
+            return oldest.open_lock, held
+
+        _run_on_loop(loop, _seed_and_lock_oldest())
+
+        async def _evict() -> None:
+            await mgr._evict_idle_pool_entries()
+
+        _run_on_loop(loop, _evict())
+        # Locked u0 must survive.
+        assert ("u0", "pool-srv") in mgr._user_pool_entries
+        # The oldest unlocked entry (u1) was evicted to bring count down to cap.
+        assert ("u1", "pool-srv") not in mgr._user_pool_entries
+
+
+# ---------------------------------------------------------------------------
+# Concurrent dispatch on shared session (M4 / perf-1)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentDispatch:
+    def test_pool_concurrent_dispatch_to_same_user_server_is_concurrent(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        """Two tool calls on the SAME (user, server) must overlap in flight,
+        not serialize on ``open_lock``."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        _seed_user_token(storage, cipher)
+        mgr.set_storage(storage)
+        state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(state)
+
+        observed_max_concurrency = 0
+        in_flight = 0
+        in_flight_lock = threading.Lock()
+
+        async def _call_tool(name, args):
+            nonlocal observed_max_concurrency, in_flight
+            with in_flight_lock:
+                in_flight += 1
+                observed_max_concurrency = max(observed_max_concurrency, in_flight)
+            try:
+                # Hold a moment so concurrent calls overlap.
+                await asyncio.sleep(0.1)
+                content = MagicMock()
+                content.text = "ok"
+                res = MagicMock()
+                res.content = [content]
+                res.isError = False
+                return res
+            finally:
+                with in_flight_lock:
+                    in_flight -= 1
+
+        fake_session = MagicMock()
+        fake_session.call_tool = _call_tool
+
+        async def _seed_entry() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            entry.session = fake_session
+
+        _run_on_loop(loop, _seed_entry())
+
+        results: list[str] = []
+        errors: list[BaseException] = []
+
+        def _dispatch() -> None:
+            try:
+                results.append(
+                    mgr.call_tool_sync(
+                        "mcp__pool-srv__do_thing",
+                        {},
+                        user_id="user-1",
+                        timeout=5,
+                    )
+                )
+            except BaseException as exc:  # pragma: no cover — diagnostic only
+                errors.append(exc)
+
+        t1 = threading.Thread(target=_dispatch)
+        t2 = threading.Thread(target=_dispatch)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert errors == []
+        assert results == ["ok", "ok"]
+        # Both dispatches were in flight at the same time — open_lock did
+        # not serialize them.
+        assert observed_max_concurrency == 2
+
+
+# ---------------------------------------------------------------------------
+# user_id thread-through (signature)
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdThreadThrough:
+    def test_default_user_id_takes_static_path(self, running_loop_mgr) -> None:
+        """``user_id=None`` must leave the static-path call byte-identical."""
+        mgr, _loop, _ = running_loop_mgr
+        # Static-path tool registered the standard way.
+        mgr._tool_map["mcp__static__t"] = ("static-srv", "t")
+        from turnstone.core.mcp_client import StaticServerState
+
+        fake_session = MagicMock()
+
+        async def _call_tool(name, args):
+            content = MagicMock()
+            content.text = "static-output"
+            res = MagicMock()
+            res.content = [content]
+            res.isError = False
+            return res
+
+        fake_session.call_tool = _call_tool
+        mgr._static_servers["static-srv"] = StaticServerState(
+            name="static-srv", session=fake_session
+        )
+
+        # No user_id, no app_state — pool branch is skipped entirely.
+        result = mgr.call_tool_sync("mcp__static__t", {"q": "hi"}, user_id=None, timeout=5)
+        assert result == "static-output"
+
+    def test_user_id_with_static_path_does_not_use_pool(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        """Caller passes user_id but the resolved server is static — pool
+        branch must not run because ``_lookup_server_row`` reports
+        ``auth_type != 'oauth_user'``."""
+        mgr, _loop, _ = running_loop_mgr
+        storage.create_mcp_server(
+            server_id="srv-static",
+            name="static-srv",
+            transport="stdio",
+            url="",
+            command="echo",
+            auth_type="static",
+        )
+        mgr.set_storage(storage)
+        mgr.set_app_state(SimpleNamespace())
+
+        mgr._tool_map["mcp__static-srv__t"] = ("static-srv", "t")
+        from turnstone.core.mcp_client import StaticServerState
+
+        fake_session = MagicMock()
+
+        async def _call_tool(name, args):
+            content = MagicMock()
+            content.text = "static-output"
+            res = MagicMock()
+            res.content = [content]
+            res.isError = False
+            return res
+
+        fake_session.call_tool = _call_tool
+        mgr._static_servers["static-srv"] = StaticServerState(
+            name="static-srv", session=fake_session
+        )
+
+        result = mgr.call_tool_sync(
+            "mcp__static-srv__t",
+            {"q": "hi"},
+            user_id="user-1",
+            timeout=5,
+        )
+        assert result == "static-output"
+        # No pool entries were created.
+        assert mgr._user_pool_entries == {}

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -856,7 +856,7 @@ class TestConcurrentDispatch:
         _run_on_loop(loop, _seed_entry())
 
         results: list[str] = []
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
 
         def _dispatch() -> None:
             try:
@@ -868,7 +868,7 @@ class TestConcurrentDispatch:
                         timeout=5,
                     )
                 )
-            except BaseException as exc:  # pragma: no cover — diagnostic only
+            except Exception as exc:  # pragma: no cover — diagnostic only
                 errors.append(exc)
 
         t1 = threading.Thread(target=_dispatch)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -8040,6 +8040,26 @@ def _parse_auth_type(body: dict[str, Any]) -> tuple[str | None, JSONResponse | N
     return auth_type, None
 
 
+def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse | None:
+    """Reject oauth_user MCP server URLs that aren't https (or loopback http).
+
+    Belt-and-braces with :func:`turnstone.core.mcp_client._validate_oauth_user_url`
+    so a misconfigured row never persists. Returns the error response or
+    ``None`` when the input is acceptable.
+    """
+    if auth_type != "oauth_user":
+        return None
+    if not url:
+        return None  # presence checked elsewhere; this helper only checks scheme
+    from turnstone.core.mcp_client import _validate_oauth_user_url
+
+    try:
+        _validate_oauth_user_url(url)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return None
+
+
 def _get_mcp_max_servers(request: Request) -> int:
     """Read cluster.mcp_max_servers via ConfigStore (validated + cached)."""
     config_store = getattr(request.app.state, "config_store", None)
@@ -8371,6 +8391,11 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     # Helper returns None when key is absent — fall back to the default.
     auth_type = auth_type_value if auth_type_value is not None else "static"
 
+    # sec-1: oauth_user must use https:// (loopback http allowed for dev).
+    err_resp = _enforce_oauth_user_https(auth_type, str(body.get("url", "")).strip())
+    if err_resp is not None:
+        return err_resp
+
     # Check max servers
     existing = storage.list_mcp_servers()
     max_servers = _get_mcp_max_servers(request)
@@ -8585,6 +8610,17 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # later created with that old name (with attacker-controlled URL)
     # would otherwise silently rebind them.
     name_changing = "name" in updates and existing.get("name", "") != updates["name"]
+    # URL change on an oauth_user row needs the same purge: bearer tokens
+    # are bound (via OAuth resource / audience) to the URL active at
+    # consent time, so sending them to a new URL is a token-binding
+    # violation. A compromised admin who flips the URL to an attacker
+    # endpoint would otherwise replay every user's bearer there silently.
+    # Re-consent forces fresh token issuance bound to the new resource.
+    url_changing = (
+        existing.get("auth_type") == "oauth_user"
+        and "url" in updates
+        and existing.get("url", "") != updates["url"]
+    )
     if updates.get("auth_type") and updates["auth_type"] != "oauth_user":
         updates.update(
             {
@@ -8605,16 +8641,25 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     if err_resp is not None:
         return err_resp
 
+    # sec-1: enforce https:// for the post-update url+auth_type combination,
+    # using the new url if present in updates, else the existing row's url.
+    url_now = updates.get("url", existing.get("url", ""))
+    err_resp = _enforce_oauth_user_https(auth_type_now, url_now)
+    if err_resp is not None:
+        return err_resp
+
     if updates:
         storage.update_mcp_server(server_id, **updates)
 
     audit_uid, ip = _audit_context(request)
 
     # Purge per-user tokens + pending OAuth states keyed on the OLD
-    # name on rename, or on ``oauth_user → static/none`` transition.
-    # Both cases would otherwise leave tokens orphaned-and-rebindable
-    # because the OAuth tables key on the mutable ``server_name``.
-    if name_changing or transitioning_away_from_oauth_user:
+    # name on rename, on ``oauth_user → static/none`` transition, or
+    # on URL change for an oauth_user row. All three cases would
+    # otherwise leave tokens orphaned-and-rebindable because the OAuth
+    # tables key on the mutable ``server_name`` and tokens are bound
+    # to the URL active at consent time.
+    if name_changing or transitioning_away_from_oauth_user or url_changing:
         purge_target = existing.get("name", "")
         if purge_target:
             try:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -23,15 +23,14 @@ import json
 import random
 import threading
 import time
+import urllib.parse
 import uuid
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
+import httpx
 import mcp.types as mcp_types
 from mcp import ClientSession, McpError, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -39,8 +38,47 @@ from mcp.client.streamable_http import streamablehttp_client
 
 from turnstone.core.config import load_config
 from turnstone.core.log import get_logger
+from turnstone.core.mcp_oauth import (
+    TokenLookupResult,
+    get_user_access_token_classified,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 log = get_logger("turnstone.mcp")
+
+
+# ---------------------------------------------------------------------------
+# Transport URL hygiene (per-user OAuth bearer transmission)
+# ---------------------------------------------------------------------------
+
+
+_LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "::1")
+
+
+def _validate_oauth_user_url(url: str) -> None:
+    """Reject MCP server URLs that would transmit a bearer token in plaintext.
+
+    Pool dispatch attaches the per-user OAuth bearer to the
+    ``Authorization`` header; ``http://`` URLs would leak it in transit.
+    Only the exact loopback hostnames in ``_LOOPBACK_HOSTS`` are exempt;
+    a ``*.localhost`` suffix bypass is intentionally NOT honored because
+    RFC 6761 localhost-zone resolution is configuration-dependent
+    (custom resolvers, hosts file, split-horizon DNS, Docker overlays
+    can map ``foo.localhost`` to non-loopback IPs and silently break
+    the bearer-confidentiality guarantee).
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme == "https":
+        return
+    hostname = (parsed.hostname or "").lower()
+    if scheme == "http" and hostname in _LOOPBACK_HOSTS:
+        return
+    raise ValueError(
+        "MCP servers with auth_type='oauth_user' must use https:// (loopback http:// excepted)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -103,10 +141,14 @@ class StaticServerState:
 class PoolEntryState:
     """Per-(user, server) state for auth_type = oauth_user.
 
-    Defined for use by the upcoming per-user pool integration; currently
-    no production caller. open_lock has no default — the mcp-loop
-    invariant forbids allocating an asyncio.Lock outside the mcp-loop;
-    the pool integration allocates lazily inside connect coroutines.
+    open_lock has no default — the mcp-loop invariant forbids allocating
+    an asyncio.Lock outside the mcp-loop; the pool integration allocates
+    lazily inside connect coroutines.
+
+    ``in_flight`` is a dispatch counter used by the eviction interlock:
+    eviction skips entries with ``in_flight > 0`` so a long-running
+    ``call_tool`` can release ``open_lock`` while still pinning the
+    entry's session against teardown.
     """
 
     key: tuple[str, str]  # (user_id, server_name)
@@ -114,10 +156,14 @@ class PoolEntryState:
     session: Any | None = None
     stack: AsyncExitStack | None = None
     streams: tuple[Any, Any] | None = None
-    tools: list[dict[str, Any]] = field(default_factory=list)
-    resources: list[dict[str, Any]] = field(default_factory=list)
-    prompts: list[dict[str, Any]] = field(default_factory=list)
+    # Catalog state — populated when Phase 6 wires per-user discovery in;
+    # left ``None`` here so 200-entry pools don't retain 600 empty list
+    # objects.
+    tools: list[dict[str, Any]] | None = None
+    resources: list[dict[str, Any]] | None = None
+    prompts: list[dict[str, Any]] | None = None
     last_used: float = 0.0
+    in_flight: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +195,11 @@ class MCPClientManager:
         self._static_servers: dict[str, StaticServerState] = {}
 
         self._tools: list[dict[str, Any]] = []
-        # prefixed_name -> (server_name, original_tool_name)
+        # prefixed_name -> (server_name, original_tool_name).
+        # ``_db_servers_to_config`` strips ``oauth_user`` rows on the way
+        # into ``_static_servers``, so any tool that landed in ``_tool_map``
+        # is by construction static-path; ``_resolve_pool_target`` uses
+        # presence-in-map (not the auth_type column) to short-circuit.
         self._tool_map: dict[str, tuple[str, str]] = {}
         self._connected = threading.Event()
         self._error: str | None = None
@@ -192,6 +242,34 @@ class MCPClientManager:
         # Notification debounce (per-server)
         self._last_notification_refresh: dict[str, float] = {}
 
+        # Per-(user, server) state for auth_type=oauth_user. Loop-bound:
+        # mutated only on the mcp-loop. Sync threads interact via
+        # ``asyncio.run_coroutine_threadsafe``.
+        self._user_pool_entries: dict[tuple[str, str], PoolEntryState] = {}
+        # LRU tracking: monotonic last-access timestamp per pool key.
+        self._user_pool_last_used: dict[tuple[str, str], float] = {}
+        # Per-key lock guarding open / dispatch / close. Allocated lazily
+        # inside ``_ensure_pool_entry`` (which runs only on the mcp-loop)
+        # so each ``asyncio.Lock`` binds to the correct loop on first use.
+        self._user_pool_locks: dict[tuple[str, str], asyncio.Lock] = {}
+
+        # Pool tuning (read at construction; falls back to defaults).
+        mcp_cfg = load_config("mcp")
+        self._user_pool_idle_ttl_s = float(mcp_cfg.get("user_session_idle_ttl_seconds", 600))
+        self._user_pool_lru_max = int(mcp_cfg.get("user_session_lru_max", 200))
+
+        # OAuth integration. ``set_app_state`` wires app_state in after the
+        # lifespan has built the token store / OAuth helpers; pool dispatch
+        # asserts non-None when it actually runs, so static-only callers
+        # never hit it.
+        self._app_state: Any = None
+
+        # Idle-eviction task handle. Scheduled lazily on the mcp-loop the
+        # first time a pool entry is created (start() runs before pool
+        # rows exist, so deferring keeps the task count at zero in
+        # static-only deployments).
+        self._user_pool_eviction_task: asyncio.Task[None] | None = None
+
     def _ensure_static_state(self, name: str) -> StaticServerState:
         """Get or create the StaticServerState for ``name``.
 
@@ -203,6 +281,40 @@ class MCPClientManager:
             state = StaticServerState(name=name)
             self._static_servers[name] = state
         return state
+
+    async def _ensure_pool_entry(self, key: tuple[str, str]) -> PoolEntryState:
+        """Get or create the PoolEntryState for ``(user_id, server_name)``.
+
+        MUST run on the mcp-loop — the lazily-allocated ``asyncio.Lock``
+        binds to whatever loop is current at construction, and the pool
+        dispatch path relies on every per-key lock being bound to
+        ``self._loop``.
+        """
+        entry = self._user_pool_entries.get(key)
+        if entry is None:
+            lock = self._user_pool_locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._user_pool_locks[key] = lock
+            entry = PoolEntryState(key=key, open_lock=lock)
+            self._user_pool_entries[key] = entry
+            # First pool entry — start the idle-eviction loop. Deferred
+            # until the first pool key materializes so static-only
+            # deployments never spawn the task.
+            if self._user_pool_eviction_task is None:
+                self._user_pool_eviction_task = asyncio.create_task(self._user_pool_eviction_loop())
+        return entry
+
+    def set_app_state(self, app_state: Any) -> None:
+        """Wire the OAuth ``app.state`` into the manager.
+
+        Called from the lifespan after ``initialize_mcp_crypto_state`` and
+        ``initialize_mcp_oauth_state`` have populated the token store,
+        OAuth HTTP client, metadata cache, and refresh-lock map. Required
+        before any ``auth_type='oauth_user'`` dispatch; static-only
+        deployments may leave it unset.
+        """
+        self._app_state = app_state
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -248,6 +360,13 @@ class MCPClientManager:
 
     # Notification debounce
     _NOTIFICATION_DEBOUNCE = 5.0  # seconds between refreshes per server
+
+    # Pool eviction loop tick interval (per-iteration sleep, seconds).
+    _POOL_EVICTION_TICK_S = 30.0
+
+    # Best-effort lock acquire timeout for the eviction pass; eviction must
+    # never block on a contested per-key lock so the next tick retries.
+    _POOL_EVICTION_LOCK_ACQUIRE_TIMEOUT_S = 0.05
 
     # -- circuit breaker (per-server) -----------------------------------------
 
@@ -313,16 +432,26 @@ class MCPClientManager:
 
     # -- safe transport helpers ------------------------------------------------
 
-    async def _pre_close_streams(self, key: str) -> None:
+    async def _pre_close_streams(self, key: str | tuple[str, str]) -> None:
         """Close MCP transport streams before stack teardown.
 
         Pre-closing unblocks anyio transport tasks stuck on zero-buffer
         ``send()`` calls, preventing the CPU busy-loop from SDK #2147.
 
-        Parameter is ``str`` today; the upcoming per-user pool
-        integration widens it to ``str | tuple[str, str]`` once
-        ``PoolEntryState`` is wired.
+        Accepts either a static server name (``str``) or a pool key
+        (``(user_id, server_name)`` tuple). The two paths share this
+        helper but address different state maps.
         """
+        if isinstance(key, tuple):
+            entry = self._user_pool_entries.get(key)
+            if entry is None or entry.streams is None:
+                return
+            streams = entry.streams
+            entry.streams = None  # take-and-clear pattern
+            for s in streams:
+                with contextlib.suppress(Exception):
+                    await s.aclose()
+            return
         state = self._static_servers.get(key)
         if state is None or state.streams is None:
             return
@@ -332,26 +461,26 @@ class MCPClientManager:
             with contextlib.suppress(Exception):
                 await s.aclose()
 
-    async def _tcp_probe(self, key: str, url: str) -> None:
+    async def _tcp_probe(self, key: str | tuple[str, str], url: str) -> None:
         """Fast TCP connect check before entering the MCP transport context.
 
         Fails fast when the server is unreachable, avoiding the anyio
         cancel-scope orphan bug that causes 100% CPU spin.
 
-        Parameter is ``str`` today; the upcoming per-user pool
-        integration widens it to ``str | tuple[str, str]`` once
-        ``PoolEntryState`` is wired.
+        Accepts either a static server name or a pool key; only the error
+        message differs (the probe itself is keyless).
         """
         from urllib.parse import urlparse
 
+        label = f"{key[1]}@{key[0]}" if isinstance(key, tuple) else key
         parsed = urlparse(url)
         host = parsed.hostname
         if not host:
-            raise ConnectionError(f"MCP server '{key}' has invalid URL (no hostname): {url}")
+            raise ConnectionError(f"MCP server '{label}' has invalid URL (no hostname): {url}")
         try:
             port = parsed.port or (443 if parsed.scheme == "https" else 80)
         except ValueError:
-            raise ConnectionError(f"MCP server '{key}' has invalid port in URL: {url}") from None
+            raise ConnectionError(f"MCP server '{label}' has invalid port in URL: {url}") from None
         try:
             _, writer = await asyncio.wait_for(
                 asyncio.open_connection(host, port),
@@ -361,7 +490,7 @@ class MCPClientManager:
             await writer.wait_closed()
         except (TimeoutError, OSError) as exc:
             raise ConnectionError(
-                f"MCP server '{key}' unreachable at {host}:{port}: {exc}"
+                f"MCP server '{label}' unreachable at {host}:{port}: {exc}"
             ) from None
 
     @staticmethod
@@ -377,6 +506,20 @@ class MCPClientManager:
             await asyncio.wait_for(stack.aclose(), timeout=5)
         except (Exception, asyncio.CancelledError):
             log.debug("Error closing AsyncExitStack; ignoring", exc_info=True)
+
+    async def _safe_teardown_on_connect_failure(
+        self, key: str | tuple[str, str], stack: AsyncExitStack
+    ) -> None:
+        """Pre-close streams + close the stack on a connect-time failure.
+
+        Shared by ``_connect_one`` (static) and ``_connect_one_pool``
+        (per-(user, server)) — both raise from inside the stream-enter /
+        session-init try blocks, and both must drain the anyio
+        zero-buffer ``send()`` calls before closing the stack to avoid
+        the SDK #2147 CPU busy-loop.
+        """
+        await self._pre_close_streams(key)
+        await self._safe_close_stack(stack)
 
     async def _connect_one(self, name: str, cfg: dict[str, Any]) -> None:
         """Connect to a single MCP server and discover its tools."""
@@ -447,23 +590,19 @@ class MCPClientManager:
             # (shutdown), re-raise so we don't block teardown.
             task = asyncio.current_task()
             if task is not None and task.cancelling():
-                await self._pre_close_streams(name)
-                await self._safe_close_stack(stack)
+                await self._safe_teardown_on_connect_failure(name, stack)
                 raise
             log.warning("MCP server '%s' connection failed (anyio cancel)", name)
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise TimeoutError(f"Connection failed for '{name}'") from None
         except TimeoutError:
             log.warning(
                 "MCP server '%s' connection timed out after %ds", name, self._CONNECT_TIMEOUT
             )
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise TimeoutError(f"Connection timed out after {self._CONNECT_TIMEOUT}s") from None
         except Exception:
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise
 
         # Register notification handler — dispatches tool, resource, and
@@ -509,8 +648,7 @@ class MCPClientManager:
                 ClientSession(read, write, message_handler=_on_notification)  # type: ignore[arg-type]
             )
         except Exception:
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise
 
         state.stack = stack
@@ -520,21 +658,17 @@ class MCPClientManager:
             state.stack = None
             task = asyncio.current_task()
             if task is not None and task.cancelling():
-                await self._pre_close_streams(name)
-                await self._safe_close_stack(stack)
+                await self._safe_teardown_on_connect_failure(name, stack)
                 raise
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise TimeoutError(f"MCP handshake failed for '{name}'") from None
         except TimeoutError:
             state.stack = None
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise TimeoutError(f"MCP handshake timed out after {self._CONNECT_TIMEOUT}s") from None
         except Exception:
             state.stack = None
-            await self._pre_close_streams(name)
-            await self._safe_close_stack(stack)
+            await self._safe_teardown_on_connect_failure(name, stack)
             raise
         state.session = session
 
@@ -646,6 +780,262 @@ class MCPClientManager:
         # Connection succeeded — clear any previous error
         self._last_error.pop(name, None)
 
+    async def _connect_one_pool(
+        self,
+        key: tuple[str, str],
+        cfg: dict[str, Any],
+        access_token: str,
+    ) -> PoolEntryState:
+        """Connect a single per-(user, server) pool entry.
+
+        Mirror of :meth:`_connect_one` for ``auth_type='oauth_user'``,
+        with three differences:
+
+        * Streamable-HTTP transport only — pool servers are remote.
+        * ``Authorization: Bearer {access_token}`` injected into headers
+          alongside any operator-supplied static headers.
+        * No catalog discovery (tools / resources / prompts) and no
+          notification handler — those land in Phase 6 once per-user
+          catalog state is in place.
+
+        MUST run on the mcp-loop. Caller holds ``entry.open_lock``.
+        """
+        user_id, server_name = key
+        if "__" in server_name:
+            raise RuntimeError(
+                f"MCP server name '{server_name}' contains '__' (reserved delimiter)"
+            )
+
+        entry = await self._ensure_pool_entry(key)
+
+        # Tear down any stale session/stack the same way ``_connect_one``
+        # does (cf. PR #296 invariant 5 for the static path).
+        if entry.session is not None or entry.stack is not None:
+            entry.session = None
+            await self._pre_close_streams(key)
+            old_stack = entry.stack
+            entry.stack = None
+            if old_stack is not None:
+                await self._safe_close_stack(old_stack)
+
+        url = cfg.get("url")
+        if not url or cfg.get("type") not in ("http", "streamable-http"):
+            raise RuntimeError(
+                f"MCP server '{server_name}' requires streamable-http transport for "
+                f"auth_type=oauth_user (got transport={cfg.get('type')!r})"
+            )
+
+        # Defense-in-depth: reject http:// (non-loopback) before the bearer
+        # is attached. _dispatch_pool already screens this at the structured-
+        # error boundary; this catch is for any callers that bypass it.
+        _validate_oauth_user_url(url)
+
+        # Merge operator-supplied headers with the per-user bearer.
+        headers: dict[str, str] = dict(cfg.get("headers") or {})
+        headers["Authorization"] = f"Bearer {access_token}"
+
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        try:
+            await self._tcp_probe(key, url)
+            read, write, _ = await asyncio.wait_for(
+                stack.enter_async_context(streamablehttp_client(url=url, headers=headers)),
+                timeout=self._CONNECT_TIMEOUT,
+            )
+            entry.streams = (read, write)
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                await self._safe_teardown_on_connect_failure(key, stack)
+                raise
+            log.warning(
+                "MCP pool connect failed (anyio cancel) user=%s server=%s", user_id, server_name
+            )
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise TimeoutError(f"Pool connection failed for '{server_name}'") from None
+        except TimeoutError:
+            log.warning(
+                "MCP pool connect timed out after %ds user=%s server=%s",
+                self._CONNECT_TIMEOUT,
+                user_id,
+                server_name,
+            )
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise TimeoutError(
+                f"Pool connection timed out after {self._CONNECT_TIMEOUT}s"
+            ) from None
+        except Exception:
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise
+
+        try:
+            session = await stack.enter_async_context(ClientSession(read, write))
+        except Exception:
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise
+
+        entry.stack = stack
+        try:
+            await asyncio.wait_for(session.initialize(), timeout=self._CONNECT_TIMEOUT)
+        except asyncio.CancelledError:
+            entry.stack = None
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                await self._safe_teardown_on_connect_failure(key, stack)
+                raise
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise TimeoutError(f"Pool handshake failed for '{server_name}'") from None
+        except TimeoutError:
+            entry.stack = None
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise TimeoutError(f"Pool handshake timed out after {self._CONNECT_TIMEOUT}s") from None
+        except Exception:
+            entry.stack = None
+            await self._safe_teardown_on_connect_failure(key, stack)
+            raise
+        entry.session = session
+        entry.last_used = time.monotonic()
+        self._user_pool_last_used[key] = entry.last_used
+        return entry
+
+    # -- pool eviction --------------------------------------------------------
+
+    async def _user_pool_eviction_loop(self) -> None:
+        """Long-running coroutine — periodically evicts idle pool entries.
+
+        Note: the loop wakes on a fixed tick rather than a condition
+        variable. Event-driven evictions would be more efficient on
+        large idle pools but add complexity (tracking per-entry
+        deadlines + a wakeup ``asyncio.Event``); at the design cap of
+        200 entries the unconditional 30 s wake is negligible.
+        """
+        while True:
+            try:
+                await asyncio.sleep(self._POOL_EVICTION_TICK_S)
+                await self._evict_idle_pool_entries()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                log.warning("MCP pool eviction iteration failed", exc_info=True)
+
+    async def _evict_idle_pool_entries(self) -> None:
+        """Evict pool entries past the idle TTL or above the LRU cap.
+
+        Skips any key whose ``open_lock`` is currently held or whose
+        ``in_flight`` counter is non-zero — eviction never blocks on a
+        contested lock or an active dispatch; the next tick retries.
+        """
+        if not self._user_pool_entries:
+            return
+        now = time.monotonic()
+        ttl = self._user_pool_idle_ttl_s
+
+        # First pass: TTL-based eviction. Run closes in parallel so a tick
+        # that needs to evict many entries doesn't block on serial teardowns.
+        ttl_targets: list[tuple[str, str]] = []
+        for key, entry in list(self._user_pool_entries.items()):
+            last = self._user_pool_last_used.get(key, entry.last_used)
+            if (now - last) >= ttl:
+                ttl_targets.append(key)
+        if ttl_targets:
+            await asyncio.gather(
+                *(self._close_pool_entry_if_idle(k) for k in ttl_targets),
+                return_exceptions=True,
+            )
+
+        # Second pass: LRU cap. Iterate the canonical entry map (not the
+        # last_used view) so brand-new entries that were created via
+        # ``_ensure_pool_entry`` but haven't dispatched yet are still
+        # eviction-eligible.
+        if len(self._user_pool_entries) <= self._user_pool_lru_max:
+            return
+        ordered = sorted(
+            self._user_pool_entries.items(),
+            key=lambda kv: self._user_pool_last_used.get(kv[0], kv[1].last_used),
+        )
+        # Compute the eviction batch up front; we re-check the cap after
+        # each close (in-flight skips can leave us still over).
+        for key, _entry in ordered:
+            if len(self._user_pool_entries) <= self._user_pool_lru_max:
+                break
+            await self._close_pool_entry_if_idle(key)
+
+    async def _close_pool_entry_if_idle(self, key: tuple[str, str]) -> None:
+        """Close ``key`` iff its open_lock is uncontested AND in_flight==0.
+
+        Best-effort: a contested lock or an active dispatch causes the
+        function to return without mutation; the next eviction tick
+        retries.
+        """
+        entry = self._user_pool_entries.get(key)
+        if entry is None:
+            return
+        # In-flight dispatchers may have released ``open_lock`` after the
+        # connect/reuse window (see ``_dispatch_pool_with_entry``); the
+        # ``in_flight`` counter is the source of truth for whether the
+        # session is currently being used.
+        if entry.in_flight > 0:
+            return
+        lock = entry.open_lock
+        if lock.locked():
+            return
+        try:
+            await asyncio.wait_for(
+                lock.acquire(), timeout=self._POOL_EVICTION_LOCK_ACQUIRE_TIMEOUT_S
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            return
+        try:
+            entry = self._user_pool_entries.get(key)
+            if entry is None:
+                return
+            # Re-check in_flight under the lock — a dispatcher may have
+            # bumped the counter between our pre-acquire skip check and
+            # the lock acquisition.
+            if entry.in_flight > 0:
+                return
+            entry.session = None
+            await self._pre_close_streams(key)
+            stack = entry.stack
+            entry.stack = None
+            if stack is not None:
+                await self._safe_close_stack(stack)
+            self._user_pool_entries.pop(key, None)
+            self._user_pool_last_used.pop(key, None)
+        finally:
+            lock.release()
+        # Drop the now-orphaned lock so the dict doesn't grow without
+        # bound across the process lifetime. A new key will reallocate.
+        self._user_pool_locks.pop(key, None)
+
+    # -- failure classification (pool dispatch) ------------------------------
+
+    def _classify_failure(
+        self, exc: BaseException
+    ) -> Literal["transport", "auth", "protocol", "other"]:
+        """Classify a dispatch-time exception for circuit-breaker gating.
+
+        Only ``transport`` failures trip the per-server breaker. Auth
+        failures (401/403) are pool-entry-only — they never affect the
+        breaker. Protocol errors (``McpError``) come from a healthy
+        connection that rejected the request.
+
+        ``auth`` is detected via :class:`httpx.HTTPStatusError` since the
+        streamable-http transport surfaces upstream HTTP errors through
+        ``response.raise_for_status()``. ``McpError`` payloads do not
+        carry a clean status code; bare ``McpError`` therefore stays
+        ``protocol``.
+        """
+        if isinstance(exc, httpx.HTTPStatusError):
+            status = exc.response.status_code
+            if status in (401, 403):
+                return "auth"
+        if isinstance(exc, McpError):
+            return "protocol"
+        if isinstance(exc, BrokenPipeError | ConnectionResetError | EOFError | TimeoutError):
+            return "transport"
+        return "other"
+
     # -- tool refresh --------------------------------------------------------
 
     def _rebuild_tools(self) -> None:
@@ -653,6 +1043,13 @@ class MCPClientManager:
 
         Uses copy-on-write: builds new objects, then assigns atomically.
         Concurrent readers see either the old or new snapshot — both valid.
+
+        Every entry sourced from ``_static_servers`` is, by construction,
+        NOT ``auth_type='oauth_user'`` — :func:`_db_servers_to_config`
+        strips oauth_user rows on the way in. Phase 5 pool catalogs do
+        not contribute to ``_tool_map``; pool tools become reachable
+        via ``_tool_map`` only when Phase 7 (catalog scoping) lands
+        per-user catalogs.
         """
         new_tools: list[dict[str, Any]] = []
         new_map: dict[str, tuple[str, str]] = {}
@@ -1113,6 +1510,32 @@ class MCPClientManager:
 
     def shutdown(self) -> None:
         """Close all MCP sessions and stop the background loop."""
+        # Cancel the pool eviction task, then close all pool entries
+        # before tearing down static-path state. Both run on the
+        # mcp-loop so dispatcher coroutines can't race them.
+        if self._loop and (self._user_pool_eviction_task is not None or self._user_pool_entries):
+
+            async def _close_all_pool() -> None:
+                if self._user_pool_eviction_task is not None:
+                    self._user_pool_eviction_task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await self._user_pool_eviction_task
+                    self._user_pool_eviction_task = None
+                for key in list(self._user_pool_entries):
+                    await self._pre_close_streams(key)
+                    entry = self._user_pool_entries.get(key)
+                    if entry is not None and entry.stack is not None:
+                        await self._safe_close_stack(entry.stack)
+                self._user_pool_entries.clear()
+                self._user_pool_last_used.clear()
+                self._user_pool_locks.clear()
+
+            future = asyncio.run_coroutine_threadsafe(_close_all_pool(), self._loop)
+            try:
+                future.result(timeout=10)
+            except Exception:
+                log.debug("Error closing MCP pool sessions", exc_info=True)
+
         # Close all per-server stacks (transports + sessions)
         if self._loop and self._static_servers:
 
@@ -1162,6 +1585,13 @@ class MCPClientManager:
         self._circuit_open_until.clear()
         self._circuit_trip_count.clear()
         self._last_notification_refresh.clear()
+        # Pool state already cleared above when the loop was alive; this
+        # makes shutdown idempotent if the loop exited before pool state
+        # could be wound down (e.g., manager constructed but never started).
+        self._user_pool_entries.clear()
+        self._user_pool_last_used.clear()
+        self._user_pool_locks.clear()
+        self._user_pool_eviction_task = None
 
         log.info("MCP client shut down")
 
@@ -1480,7 +1910,17 @@ class MCPClientManager:
         return len(self._prompts)
 
     def is_mcp_tool(self, func_name: str) -> bool:
-        """Check whether *func_name* belongs to an MCP server."""
+        """Check whether *func_name* belongs to an MCP server.
+
+        Phase 5 caveat: only static-path tools (``auth_type ∈ {none,
+        static}``) populate ``_tool_map``; pool tools become reachable
+        via this method only when Phase 7 (catalog scoping) lands
+        per-user catalogs. Until then, pool dispatch is reachable from
+        production callers like ``ChatSession._exec_mcp_tool`` only when
+        the LLM produces a ``mcp__{server}__{tool}`` name that bypasses
+        ``is_mcp_tool``-style gating, or via direct ``call_tool_sync``
+        with a known prefixed name (the path the new pool tests use).
+        """
         return func_name in self._tool_map
 
     def is_mcp_prompt(self, name: str) -> bool:
@@ -1572,6 +2012,8 @@ class MCPClientManager:
         self,
         func_name: str,
         arguments: dict[str, Any],
+        *,
+        user_id: str | None = None,
         timeout: int = 120,
     ) -> str:
         """Execute an MCP tool call synchronously (blocks the calling thread).
@@ -1579,11 +2021,37 @@ class MCPClientManager:
         Dispatches an async ``tools/call`` to the background event loop and
         waits for the result.  Includes circuit-breaker gating and automatic
         reconnection for servers recovering from failure.
+
+        When ``user_id`` is supplied AND the resolved server's ``auth_type``
+        is ``oauth_user``, dispatch goes through the per-(user, server)
+        pool. Otherwise the call takes the byte-identical static path.
         """
         mapping = self._tool_map.get(func_name)
-        if mapping is None:
+        server_name: str | None = None
+        original_name: str | None = None
+        if mapping is not None:
+            server_name, original_name = mapping
+
+        # Pool dispatch is gated on (a) caller passing user_id and
+        # (b) the server row being auth_type=oauth_user. The Phase 5
+        # tool-map only carries static-path entries; pool catalogs land
+        # in Phase 7. Consequently, in Phase 5 a pool dispatch reaches
+        # this branch only when the caller supplied func_name as
+        # ``mcp__{server}__{tool}`` and we resolve auth_type via storage.
+        if user_id and self._app_state is not None and self._storage is not None:
+            pool_target = self._resolve_pool_target(func_name, server_name, original_name)
+            if pool_target is not None:
+                return self._dispatch_pool_sync(
+                    user_id=user_id,
+                    server_name=pool_target[0],
+                    original_name=pool_target[1],
+                    arguments=arguments,
+                    server_row=pool_target[2],
+                    timeout=timeout,
+                )
+
+        if mapping is None or server_name is None or original_name is None:
             raise ValueError(f"Unknown MCP tool: {func_name}")
-        server_name, original_name = mapping
 
         self._cb_gate(server_name)
 
@@ -1607,7 +2075,7 @@ class MCPClientManager:
             # rejected the request — only transport errors trip the breaker.
             if not isinstance(exc, McpError):
                 self._cb_record_failure(server_name)
-            if isinstance(exc, (BrokenPipeError, ConnectionResetError, EOFError)):
+            if isinstance(exc, BrokenPipeError | ConnectionResetError | EOFError):
                 # Evict the session only — leave stack/streams behind so the
                 # stale-session-and-stack guard in _connect_one cleans them up
                 # on the next connect attempt.
@@ -1617,22 +2085,247 @@ class MCPClientManager:
             raise
 
         self._cb_record_success(server_name)
+        return _decode_tool_result(result)
 
-        # Extract text from the content array
-        texts: list[str] = []
-        for item in result.content:
-            if hasattr(item, "text"):
-                texts.append(item.text)
-            elif hasattr(item, "data"):
-                mime = getattr(item, "mimeType", "binary")
-                texts.append(f"[{mime} data, {len(item.data)} bytes]")
-            else:
-                texts.append(str(item))
+    # -- pool dispatch -------------------------------------------------------
 
-        output = "\n".join(texts) if texts else "(no output)"
-        if getattr(result, "isError", False):
-            output = f"Error: {output}"
-        return output
+    def _resolve_pool_target(
+        self,
+        func_name: str,
+        static_server: str | None,
+        static_original: str | None,
+    ) -> tuple[str, str, dict[str, Any]] | None:
+        """Resolve ``(server_name, original_name, server_row)`` for pool dispatch.
+
+        Returns ``None`` when the call should fall through to the static
+        path. Phase 5: pool catalogs do not contribute to ``_tool_map``,
+        so a pool tool is invoked by passing the prefixed name
+        ``mcp__{server}__{tool}`` directly. ``mcp_servers.auth_type``
+        confirms pool eligibility.
+
+        Presence in ``_tool_map`` (signalled by non-None ``static_server``
+        / ``static_original`` from the caller's lookup) is sufficient
+        to short-circuit without a DB hop: ``_db_servers_to_config``
+        strips ``oauth_user`` rows on the way into ``_static_servers``,
+        so any name that landed in ``_tool_map`` is by construction
+        static-path. The resolved row is threaded back to the caller so
+        ``_dispatch_pool`` avoids a duplicate ``get_mcp_server_by_name``
+        round-trip.
+        """
+        if static_server is not None and static_original is not None:
+            return None
+        if not func_name.startswith("mcp__") or func_name.count("__") < 2:
+            return None
+        # Parse ``mcp__{server}__{rest}`` — server may itself be empty
+        # (rejected during admin), original may contain ``__``.
+        _, server_name, original = func_name.split("__", 2)
+        if not server_name or not original:
+            return None
+        row = self._lookup_server_row(server_name)
+        if row is None or row.get("auth_type") != "oauth_user":
+            return None
+        return server_name, original, row
+
+    def _lookup_server_row(self, server_name: str) -> dict[str, Any] | None:
+        """Return the ``mcp_servers`` row for *server_name*, or None."""
+        if self._storage is None:
+            return None
+        try:
+            row: dict[str, Any] | None = self._storage.get_mcp_server_by_name(server_name)
+        except Exception:
+            log.debug("mcp_pool.server_lookup_failed", exc_info=True)
+            return None
+        return row
+
+    def _dispatch_pool_sync(
+        self,
+        *,
+        user_id: str,
+        server_name: str,
+        original_name: str,
+        arguments: dict[str, Any],
+        server_row: dict[str, Any],
+        timeout: int,
+    ) -> str:
+        """Synchronous wrapper for pool dispatch.
+
+        Bridges sync caller → mcp-loop coroutine → result. Returns either
+        the tool output string or a structured-error JSON string when
+        token state forces the call to fail cleanly without raising
+        (consent required, key mismatch, etc.). ``server_row`` is the
+        row already resolved by ``_resolve_pool_target`` and is reused
+        verbatim by ``_dispatch_pool`` to skip a duplicate DB hop.
+        """
+        assert self._loop is not None
+        future = asyncio.run_coroutine_threadsafe(
+            self._dispatch_pool(
+                user_id=user_id,
+                server_name=server_name,
+                original_name=original_name,
+                arguments=arguments,
+                server_row=server_row,
+            ),
+            self._loop,
+        )
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            future.cancel()
+            self._cb_record_failure(server_name)
+            raise TimeoutError(f"MCP tool call timed out after {timeout}s") from None
+
+    async def _dispatch_pool(
+        self,
+        *,
+        user_id: str,
+        server_name: str,
+        original_name: str,
+        arguments: dict[str, Any],
+        server_row: dict[str, Any],
+    ) -> str:
+        """Pool-side coroutine: resolve token, connect-or-reuse, dispatch.
+
+        Returns either the textualized tool output or a structured-error
+        JSON string when token state precludes dispatch. ``server_row``
+        is supplied by ``_resolve_pool_target`` so this path doesn't
+        re-issue the ``mcp_servers`` lookup; it's also pre-validated to
+        have ``auth_type='oauth_user'``.
+        """
+        if self._app_state is None:
+            raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
+
+        # Token-side errors (missing / decrypt / refresh-failed) bypass
+        # the breaker entirely — the server itself is healthy. The breaker
+        # gate runs only AFTER we have a usable access token; that way a
+        # spurious cooldown-expired probe never lands here without ending
+        # in either a real success or a real transport failure.
+        lookup: TokenLookupResult = await get_user_access_token_classified(
+            app_state=self._app_state, user_id=user_id, server_name=server_name
+        )
+        if lookup.kind == "missing":
+            return _structured_error(
+                code="mcp_consent_required",
+                server=server_name,
+                detail="No token for user. Consent flow required.",
+            )
+        if lookup.kind == "decrypt_failure":
+            return _structured_error(
+                code="mcp_token_undecryptable_key_unknown",
+                server=server_name,
+                detail=(
+                    "Stored token cannot be decrypted by any installed encryption key. "
+                    "Operator action required."
+                ),
+            )
+        if lookup.kind == "refresh_failed":
+            # ``mcp_server.oauth.token_revoked`` audit was already emitted
+            # by ``get_user_access_token_classified`` when it deleted the
+            # row; no second audit needed here.
+            return _structured_error(
+                code="mcp_consent_required",
+                server=server_name,
+                detail="Refresh token rejected. Re-consent required.",
+            )
+        # kind == "token"
+        access_token = lookup.token or ""
+        if not access_token:
+            return _structured_error(
+                code="mcp_consent_required",
+                server=server_name,
+                detail="No token for user. Consent flow required.",
+            )
+
+        # URL hygiene — pool dispatch transmits the per-user bearer; reject
+        # plaintext schemes before they reach _connect_one_pool.
+        url = str(server_row.get("url") or "")
+        try:
+            _validate_oauth_user_url(url)
+        except ValueError as exc:
+            log.warning(
+                "mcp_pool.url_insecure server=%s scheme=%s",
+                server_name,
+                urllib.parse.urlparse(url).scheme,
+            )
+            return _structured_error(
+                code="mcp_oauth_url_insecure",
+                server=server_name,
+                detail=str(exc),
+            )
+
+        self._cb_gate(server_name)
+
+        cfg = _pool_cfg_from_row(server_row)
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
+
+        try:
+            result = await self._dispatch_pool_with_entry(
+                entry=entry,
+                key=key,
+                cfg=cfg,
+                access_token=access_token,
+                original_name=original_name,
+                arguments=arguments,
+            )
+        except BaseException as exc:
+            classification = self._classify_failure(exc)
+            if classification == "auth":
+                # 401/403 from the upstream — pool-entry-only, never
+                # affects the breaker. Drop the cached session so the
+                # next dispatch re-authenticates with a fresh token.
+                evict = self._user_pool_entries.get(key)
+                if evict is not None:
+                    evict.session = None
+                log.debug("mcp_pool.auth_failure", exc_info=exc)
+                raise
+            if classification == "transport":
+                self._cb_record_failure(server_name)
+                evict = self._user_pool_entries.get(key)
+                if evict is not None:
+                    evict.session = None
+                log.debug("mcp_pool.transport_failure", exc_info=exc)
+                raise
+            # protocol / other — don't trip the breaker.
+            raise
+
+        self._cb_record_success(server_name)
+        return result
+
+    async def _dispatch_pool_with_entry(
+        self,
+        *,
+        entry: PoolEntryState,
+        key: tuple[str, str],
+        cfg: dict[str, Any],
+        access_token: str,
+        original_name: str,
+        arguments: dict[str, Any],
+    ) -> str:
+        """Acquire ``entry.open_lock`` only across connect-or-reuse, then dispatch.
+
+        Releasing ``open_lock`` before ``call_tool`` lets two concurrent
+        tool calls from the SAME user against the SAME server multiplex
+        on a shared :class:`mcp.ClientSession` (request_id-correlated by
+        the SDK). The eviction interlock now uses ``entry.in_flight``:
+        eviction skips entries with in-flight calls so a long-running
+        ``call_tool`` can't have its session yanked mid-await.
+        """
+        async with entry.open_lock:
+            entry.last_used = time.monotonic()
+            self._user_pool_last_used[key] = entry.last_used
+            session = entry.session
+            if session is None:
+                # Lazy connect — also covers post-eviction recovery.
+                fresh = await self._connect_one_pool(key, cfg, access_token)
+                session = fresh.session
+                if session is None:
+                    raise RuntimeError(f"Pool connect for {key!r} produced no session")
+            entry.in_flight += 1
+        try:
+            result = await session.call_tool(original_name, arguments)
+        finally:
+            entry.in_flight -= 1
+        return _decode_tool_result(result)
 
     # -- resource read -------------------------------------------------------
 
@@ -1759,6 +2452,88 @@ class MCPClientManager:
             text = content.text if hasattr(content, "text") else str(content)
             messages.append({"role": msg.role, "content": text})
         return messages
+
+
+# ---------------------------------------------------------------------------
+# Pool helpers (module-level)
+# ---------------------------------------------------------------------------
+
+
+def _decode_tool_result(result: Any) -> str:
+    """Render an MCP ``tools/call`` result into the string the agent sees.
+
+    Walks ``result.content`` collecting text parts and labelling binary
+    parts; an ``isError`` result is prefixed with ``Error: `` so the
+    LLM can narrate the failure. Shared by the static and pool dispatch
+    paths.
+    """
+    texts: list[str] = []
+    for item in result.content:
+        if hasattr(item, "text"):
+            texts.append(item.text)
+        elif hasattr(item, "data"):
+            mime = getattr(item, "mimeType", "binary")
+            texts.append(f"[{mime} data, {len(item.data)} bytes]")
+        else:
+            texts.append(str(item))
+    output = "\n".join(texts) if texts else "(no output)"
+    if getattr(result, "isError", False):
+        output = f"Error: {output}"
+    return output
+
+
+def _structured_error(*, code: str, server: str, detail: str) -> str:
+    """Encode a pool-dispatch failure as a JSON string.
+
+    Returned to the agent through ``_exec_mcp_tool`` so the LLM can
+    narrate "tool unavailable, consent required" rather than crashing
+    the workstream. Schema mirrors RFC §6 (consent UX) plus the
+    decrypt-failure code introduced in RFC §5.3.
+
+    Operator-actionable encryption-key fingerprints are intentionally
+    NOT included in this payload: they are already captured server-side
+    via :meth:`MCPTokenStore._audit_decrypt_failure`, and exposing them
+    to the LLM (and through it to the model provider) would be
+    unnecessary disclosure.
+    """
+    payload: dict[str, Any] = {
+        "error": {
+            "code": code,
+            "server": server,
+            "detail": detail,
+        }
+    }
+    return json.dumps(payload)
+
+
+def _pool_cfg_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Build a streamable-http MCP-client cfg from an ``mcp_servers`` row.
+
+    Pool servers are required to be HTTP-transport (auth_type=oauth_user
+    has no meaningful stdio encoding). Operator-supplied static headers
+    are merged with the per-user bearer at connect time.
+    """
+    cfg: dict[str, Any] = {
+        "type": row.get("transport") or "streamable-http",
+        "url": row.get("url") or "",
+    }
+    headers_raw = row.get("headers")
+    parsed_headers: dict[str, str] = {}
+    if isinstance(headers_raw, dict):
+        for k, v in headers_raw.items():
+            if isinstance(k, str) and isinstance(v, str):
+                parsed_headers[k] = v
+    elif isinstance(headers_raw, str) and headers_raw:
+        try:
+            decoded = json.loads(headers_raw)
+        except (json.JSONDecodeError, TypeError):
+            decoded = {}
+        if isinstance(decoded, dict):
+            for k, v in decoded.items():
+                if isinstance(k, str) and isinstance(v, str):
+                    parsed_headers[k] = v
+    cfg["headers"] = parsed_headers
+    return cfg
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -967,43 +967,120 @@ async def _acquire_pg_refresh_lock(
     return _PgRefreshLock(storage, _refresh_advisory_key(user_id, server_name))
 
 
-_PG_REFRESH_LOCK_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
+# Strong refs to in-flight drain tasks. asyncio holds tasks via a WeakSet,
+# so a fire-and-forget ``loop.create_task(...)`` whose handle isn't stored
+# can be GC'd before the worker settles — exactly the cleanup we rely on.
+# Tasks register here on creation and discard themselves on completion via
+# ``add_done_callback``.
+_pg_refresh_drain_tasks: set[asyncio.Task[None]] = set()
 
 
-def _pg_refresh_lock_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Return the single-worker executor used for advisory-lock acquire/release.
+async def _drain_orphan_pg_lock(
+    loop: asyncio.AbstractEventLoop,
+    executor: concurrent.futures.ThreadPoolExecutor,
+    cm: contextlib.AbstractContextManager[None],
+    cf_fut: concurrent.futures.Future[Any],
+) -> None:
+    """Best-effort cleanup of a ``_PgRefreshLock`` whose ``__aenter__`` raised.
 
-    bug-5: ``__aenter__`` and ``__aexit__`` previously dispatched onto
-    the default ``asyncio.to_thread`` executor, so the SQLAlchemy
-    connection captured by ``acquire_advisory_lock_sync`` could have its
-    transaction begun on one worker thread and committed/rolled back on
-    another. Pinning to a single-worker executor guarantees enter and
-    exit run on the same thread, satisfying psycopg2's "connection
-    transactions are thread-affine" expectation.
+    The worker thread that ran ``cm.__enter__`` may complete *after* the
+    awaiter has propagated an exception (typically a cancellation). If
+    it ultimately acquired the Postgres advisory lock, the paired
+    ``cm.__exit__`` MUST run on the same executor (same OS thread) so
+    the connection-bound transaction commits / rolls back on the thread
+    that began it — psycopg2 connections are thread-affine. On loop or
+    process shutdown, the engine's ``dispose()`` is the backstop.
+
+    The ``cf_fut`` parameter is the *underlying* ``concurrent.futures.Future``
+    — NOT the asyncio wrapper that ``__aenter__`` was awaiting. That asyncio
+    wrapper is in CANCELLED state once the awaiter was cancelled, and
+    re-awaiting a CANCELLED future raises ``CancelledError`` immediately
+    instead of waiting for the worker. A fresh ``asyncio.wrap_future(cf_fut)``
+    creates a new asyncio Future tied only to the worker's outcome, so the
+    drain genuinely waits for the worker to settle.
     """
-    global _PG_REFRESH_LOCK_EXECUTOR
-    if _PG_REFRESH_LOCK_EXECUTOR is None:
-        _PG_REFRESH_LOCK_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mcp-pg-refresh-lock"
-        )
-    return _PG_REFRESH_LOCK_EXECUTOR
+    try:
+        try:
+            await asyncio.wrap_future(cf_fut, loop=loop)
+        except Exception:
+            # ``cm.__enter__`` raised on the worker — nothing acquired,
+            # nothing to release. ``CancelledError`` is intentionally NOT
+            # caught: if the drain task itself is cancelled (loop
+            # shutdown), it should record as cancelled rather than be
+            # silently logged as 'completed normally with no acquire'.
+            # The lock then leaks to ``Engine.dispose()`` cleanup, which
+            # is the documented backstop.
+            return
+        try:
+            await loop.run_in_executor(executor, lambda: cm.__exit__(None, None, None))
+        except Exception:
+            # Same rationale as above for ``CancelledError``: don't
+            # mask drain-task cancellation as 'drain_exit_failed'.
+            log.warning(
+                "mcp_server.oauth.pg_refresh_lock_drain_exit_failed",
+                exc_info=True,
+            )
+    finally:
+        executor.shutdown(wait=False)
 
 
 class _PgRefreshLock(contextlib.AbstractAsyncContextManager[None]):
-    """Async wrapper around :meth:`StorageBackend.acquire_advisory_lock_sync`."""
+    """Async wrapper around :meth:`StorageBackend.acquire_advisory_lock_sync`.
+
+    psycopg2 connection transactions are thread-affine, so for a given
+    lock instance ``__enter__`` (which begins the transaction) and
+    ``__exit__`` (which commits / rolls back) MUST run on the same OS
+    thread. Each instance allocates a private single-worker
+    ``ThreadPoolExecutor`` to satisfy that constraint. A module-global
+    single-worker executor would also satisfy thread-affinity, but at
+    the cost of serializing every advisory-lock acquire on the node
+    behind one thread — different ``(user, server)`` keys would queue
+    against each other through the spin loop's 30s timeout window.
+    Per-instance executors keep the affinity guarantee while letting
+    unrelated refreshes spin on ``pg_try_advisory_xact_lock`` in
+    parallel.
+
+    Cancellation between submit and the worker completing
+    ``cm.__enter__`` is handled by ``_drain_orphan_pg_lock``: ``__aenter__``
+    submits via ``executor.submit`` directly so it holds the
+    ``concurrent.futures.Future``, then awaits a fresh
+    ``asyncio.wrap_future`` of it. If the awaiter is cancelled, only the
+    asyncio wrapper goes to CANCELLED state — the underlying worker
+    continues. The drain wraps ``cf_fut`` again (fresh) and so genuinely
+    waits for the worker to settle, then runs ``cm.__exit__`` on the same
+    executor when the lock did get acquired.
+    """
 
     def __init__(self, storage: StorageBackend, key_text: str) -> None:
         self._storage = storage
         self._key_text = key_text
         self._sync_cm: contextlib.AbstractContextManager[None] | None = None
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
 
     async def __aenter__(self) -> None:
-        # Single-worker executor pins enter and exit to the same thread —
-        # see ``_pg_refresh_lock_executor`` for the rationale.
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mcp-pg-refresh-lock"
+        )
         cm = self._storage.acquire_advisory_lock_sync(self._key_text)
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(_pg_refresh_lock_executor(), cm.__enter__)
+        # Submit directly to keep a handle on the underlying
+        # ``concurrent.futures.Future``. Each ``asyncio.wrap_future`` here
+        # and inside the drain creates an *independent* asyncio Future
+        # tied to the same worker outcome, so cancellation of one wrapper
+        # doesn't poison the other.
+        cf_fut: concurrent.futures.Future[Any] = executor.submit(cm.__enter__)
+        try:
+            await asyncio.wrap_future(cf_fut, loop=loop)
+        except BaseException:
+            drain = loop.create_task(
+                _drain_orphan_pg_lock(loop, executor, cm, cf_fut),
+                name="mcp-pg-refresh-lock-drain",
+            )
+            _pg_refresh_drain_tasks.add(drain)
+            drain.add_done_callback(_pg_refresh_drain_tasks.discard)
+            raise
         self._sync_cm = cm
+        self._executor = executor
 
     async def __aexit__(
         self,
@@ -1012,15 +1089,29 @@ class _PgRefreshLock(contextlib.AbstractAsyncContextManager[None]):
         tb: Any,
     ) -> None:
         cm = self._sync_cm
-        if cm is None:
-            return
+        executor = self._executor
         self._sync_cm = None
+        self._executor = None
+        if cm is None or executor is None:
+            return
         loop = asyncio.get_running_loop()
 
         def _exit() -> None:
             cm.__exit__(exc_type, exc, tb)
 
-        await loop.run_in_executor(_pg_refresh_lock_executor(), _exit)
+        # No drain analogue here — unlike ``__aenter__``, cancellation
+        # mid-await doesn't strand the lock. ``loop.run_in_executor``
+        # submits ``_exit`` synchronously before yielding, so the worker
+        # already has the work; cancelling our await doesn't cancel the
+        # worker. The cm's ``__exit__`` runs to completion on the same
+        # thread that ran ``__enter__`` (psycopg2 thread-affinity
+        # preserved), commits or rolls back the transaction, and
+        # releases the advisory lock. ``shutdown(wait=False)`` lets the
+        # worker finish without blocking; the executor is then GC'd.
+        try:
+            await loop.run_in_executor(executor, _exit)
+        finally:
+            executor.shutdown(wait=False)
 
 
 def _dcr_lock_for(app_state: Any, server_id: str) -> asyncio.Lock:
@@ -1095,14 +1186,16 @@ async def get_user_access_token_classified(
     error.
 
     Multi-node correctness: the refresh path is serialized at two
-    layers — an outer Postgres advisory lock acquired via
+    layers — an outer ``asyncio.Lock`` from :func:`_refresh_lock_for`
+    (intra-process) and an inner Postgres advisory lock acquired via
     :meth:`StorageBackend.acquire_advisory_lock_sync` (cluster-wide;
-    no-op on SQLite) and an inner ``asyncio.Lock`` from
-    :func:`_refresh_lock_for` (intra-process). Order matters: the
-    cluster lock is taken first so cross-node contention serializes at
-    the database, then the asyncio lock is essentially uncontested
-    because at most one waiter is allowed past the cluster lock at a
-    time. The re-read inside the asyncio lock collapses both windows.
+    no-op on SQLite). Order matters: the in-process lock is taken
+    first so concurrent same-key callers on this node collapse to a
+    single waiter at the cluster lock — this also collapses N
+    per-instance ``ThreadPoolExecutor`` allocations down to one. The
+    surviving local caller then serializes against other nodes via
+    the cluster lock. The re-read inside the locked block collapses
+    both contention windows.
     """
     token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
     if token_store is None:
@@ -1157,7 +1250,11 @@ async def get_user_access_token_classified(
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
     pg_lock = await _acquire_pg_refresh_lock(storage, user_id, server_name)
-    async with pg_lock, lock:
+    # In-process lock outside the cross-node lock so concurrent same-key
+    # callers serialize on the asyncio.Lock BEFORE allocating the
+    # pg_lock's per-instance executor / spin loop. N concurrent callers
+    # for one key collapse to one executor allocation.
+    async with lock, pg_lock:
         try:
             plain2 = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
         except MCPTokenDecryptError as exc:

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -10,27 +10,29 @@ acceptable audience values is the resolved
 (Auth0) that issue tokens with ``aud=oauth_audience`` rather than the
 canonical resource URL.
 
-Multi-node refresh contention: this module currently relies on an
-``asyncio.Lock`` keyed by ``(user_id, server_name)`` for in-process
-serialization. This is correct for SQLite single-node deployments but
-NOT sufficient for multi-node setups. A later iteration wraps the
-multi-node case in a postgres advisory lock — see the note in
-:func:`get_user_access_token`.
+Multi-node refresh contention: :func:`get_user_access_token` and the
+classified variant :func:`get_user_access_token_classified` serialize
+the read-current → exchange-at-AS → write-new sequence at two layers
+— an outer Postgres advisory lock (cluster-wide) wraps an inner
+``asyncio.Lock`` (intra-process). The advisory lock is no-op on SQLite
+single-node deployments via :meth:`StorageBackend.acquire_advisory_lock_sync`.
 """
 
 from __future__ import annotations
 
 import asyncio
 import base64
+import concurrent.futures
+import contextlib
 import hashlib
 import json
 import re
 import secrets
 import time
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 
@@ -904,11 +906,12 @@ def _parse_iso_to_utc(value: str) -> datetime | None:
 def _refresh_lock_for(app_state: Any, user_id: str, server_name: str) -> asyncio.Lock:
     """Return the shared refresh lock for ``(user_id, server_name)``.
 
-    Multi-node correctness note: this in-process ``asyncio.Lock`` is
-    sufficient for SQLite single-node deployments; multi-node Postgres
-    deployments need a postgres advisory lock keyed on
-    ``hashtext('mcp_refresh:' || user_id || ':' || server_name)`` so
-    concurrent nodes don't double-refresh.
+    This in-process ``asyncio.Lock`` provides intra-process
+    serialization. Cluster-wide serialization is layered on top via the
+    Postgres advisory lock acquired by
+    :func:`_acquire_pg_refresh_lock`; both are taken together by
+    :func:`get_user_access_token` so concurrent nodes don't
+    double-refresh.
     """
     locks = getattr(app_state, "mcp_oauth_refresh_locks", None)
     if locks is None:
@@ -936,6 +939,90 @@ def _drop_refresh_lock(app_state: Any, user_id: str, server_name: str) -> None:
     locks.pop((user_id, server_name), None)
 
 
+def _refresh_advisory_key(user_id: str, server_name: str) -> str:
+    """Return the advisory-lock key for ``(user_id, server_name)``.
+
+    Hashed via ``pg_advisory_xact_lock(hashtext(...))`` at the storage
+    layer; the textual form is what the storage helper hashes, so the
+    callers don't need to know about the digest.
+    """
+    return f"mcp_refresh:{user_id}:{server_name}"
+
+
+async def _acquire_pg_refresh_lock(
+    storage: StorageBackend, user_id: str, server_name: str
+) -> contextlib.AbstractAsyncContextManager[None]:
+    """Async context manager that serializes the refresh body across nodes.
+
+    On Postgres, holds ``pg_advisory_xact_lock(hashtext(...))`` for the
+    duration of the body via :meth:`StorageBackend.acquire_advisory_lock_sync`.
+    On SQLite, the storage helper returns ``nullcontext`` and this is
+    effectively a no-op — single-node deployments rely on the
+    in-process ``asyncio.Lock`` for serialization.
+
+    The blocking SQLAlchemy hops inside the storage context manager are
+    routed through ``asyncio.to_thread`` so the mcp-loop stays
+    responsive.
+    """
+    return _PgRefreshLock(storage, _refresh_advisory_key(user_id, server_name))
+
+
+_PG_REFRESH_LOCK_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+def _pg_refresh_lock_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return the single-worker executor used for advisory-lock acquire/release.
+
+    bug-5: ``__aenter__`` and ``__aexit__`` previously dispatched onto
+    the default ``asyncio.to_thread`` executor, so the SQLAlchemy
+    connection captured by ``acquire_advisory_lock_sync`` could have its
+    transaction begun on one worker thread and committed/rolled back on
+    another. Pinning to a single-worker executor guarantees enter and
+    exit run on the same thread, satisfying psycopg2's "connection
+    transactions are thread-affine" expectation.
+    """
+    global _PG_REFRESH_LOCK_EXECUTOR
+    if _PG_REFRESH_LOCK_EXECUTOR is None:
+        _PG_REFRESH_LOCK_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mcp-pg-refresh-lock"
+        )
+    return _PG_REFRESH_LOCK_EXECUTOR
+
+
+class _PgRefreshLock(contextlib.AbstractAsyncContextManager[None]):
+    """Async wrapper around :meth:`StorageBackend.acquire_advisory_lock_sync`."""
+
+    def __init__(self, storage: StorageBackend, key_text: str) -> None:
+        self._storage = storage
+        self._key_text = key_text
+        self._sync_cm: contextlib.AbstractContextManager[None] | None = None
+
+    async def __aenter__(self) -> None:
+        # Single-worker executor pins enter and exit to the same thread —
+        # see ``_pg_refresh_lock_executor`` for the rationale.
+        cm = self._storage.acquire_advisory_lock_sync(self._key_text)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(_pg_refresh_lock_executor(), cm.__enter__)
+        self._sync_cm = cm
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
+        cm = self._sync_cm
+        if cm is None:
+            return
+        self._sync_cm = None
+        loop = asyncio.get_running_loop()
+
+        def _exit() -> None:
+            cm.__exit__(exc_type, exc, tb)
+
+        await loop.run_in_executor(_pg_refresh_lock_executor(), _exit)
+
+
 def _dcr_lock_for(app_state: Any, server_id: str) -> asyncio.Lock:
     """Return the per-server DCR registration lock.
 
@@ -958,6 +1045,24 @@ def _dcr_lock_for(app_state: Any, server_id: str) -> asyncio.Lock:
     return lock
 
 
+@dataclass(frozen=True)
+class TokenLookupResult:
+    """Tagged result of :func:`get_user_access_token_classified`.
+
+    Lets the dispatch state machine distinguish "row missing" from
+    "row present but undecryptable" from "row present but refresh
+    rejected" — three states that the ``Optional[str]``-returning
+    :func:`get_user_access_token` collapses to ``None``. The
+    distinction matters because they map to different user-facing
+    errors (RFC §5.3 forbids emitting ``mcp_consent_required`` on a
+    decrypt failure).
+    """
+
+    kind: Literal["token", "missing", "decrypt_failure", "refresh_failed"] = "missing"
+    token: str | None = None
+    decrypt_fingerprints: tuple[str, ...] = field(default_factory=tuple)
+
+
 async def get_user_access_token(*, app_state: Any, user_id: str, server_name: str) -> str | None:
     """Return a valid plaintext access token, refreshing if needed.
 
@@ -968,81 +1073,110 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
         ``mcp_consent_required``)
       - the cipher / token store is not configured
 
-    Multi-node correctness note: the refresh path is serialized via the
-    in-process ``asyncio.Lock`` returned by :func:`_refresh_lock_for`. A
-    multi-node deployment running against Postgres needs that same
-    serialization across nodes via ``pg_advisory_lock`` keyed on
-    ``hashtext('mcp_refresh:' || user_id || ':' || server_name)`` so
-    concurrent nodes don't double-refresh.
+    Implemented as a thin wrapper around
+    :func:`get_user_access_token_classified`: every non-``token`` result
+    collapses back to ``None`` to preserve the legacy contract.
+    """
+    result = await get_user_access_token_classified(
+        app_state=app_state, user_id=user_id, server_name=server_name
+    )
+    if result.kind == "token":
+        return result.token
+    return None
+
+
+async def get_user_access_token_classified(
+    *, app_state: Any, user_id: str, server_name: str
+) -> TokenLookupResult:
+    """Tagged token lookup with refresh-on-expiry.
+
+    Walks the §1.5 / RFC §6 state machine and returns a tagged result so
+    the dispatcher can map each failure mode to the right user-facing
+    error.
+
+    Multi-node correctness: the refresh path is serialized at two
+    layers — an outer Postgres advisory lock acquired via
+    :meth:`StorageBackend.acquire_advisory_lock_sync` (cluster-wide;
+    no-op on SQLite) and an inner ``asyncio.Lock`` from
+    :func:`_refresh_lock_for` (intra-process). Order matters: the
+    cluster lock is taken first so cross-node contention serializes at
+    the database, then the asyncio lock is essentially uncontested
+    because at most one waiter is allowed past the cluster lock at a
+    time. The re-read inside the asyncio lock collapses both windows.
     """
     token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
     if token_store is None:
         log.debug("mcp_server.oauth.token_store_unconfigured")
-        return None
+        return TokenLookupResult(kind="missing")
 
     try:
         plain = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
-    except MCPTokenDecryptError:
-        # No installed key can decrypt the row (e.g. operator dropped
-        # the prior key after rotation). Falling through to None forces
-        # the caller to re-consent rather than crashing the dispatch.
+    except MCPTokenDecryptError as exc:
         log.warning(
-            "mcp_server.oauth.token_decrypt_failed_falling_through",
+            "mcp_server.oauth.token_decrypt_failed_classified",
             user_id=user_id,
             server_name=server_name,
             exc_info=True,
         )
-        return None
+        return TokenLookupResult(
+            kind="decrypt_failure",
+            decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+        )
     if plain is None:
-        return None
+        return TokenLookupResult(kind="missing")
 
-    # Fast path — non-expired access token.
     expires_at = plain.get("expires_at")
     if not _token_needs_refresh(expires_at):
-        return plain["access_token"]
+        return TokenLookupResult(kind="token", token=plain["access_token"])
+
+    storage = _get_storage(app_state)
+    if storage is None:
+        return TokenLookupResult(kind="missing")
+
+    # bug-6: load server_row BEFORE the no-refresh-token branch so the
+    # pre-lock audit event carries the immutable server_id rather than
+    # falling back to a name-keyed lookup that races admin renames.
+    server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
+    if server_row is None:
+        return TokenLookupResult(kind="missing")
+    server_id_for_audit = str(server_row.get("server_id") or "")
 
     refresh_value = plain.get("refresh_token")
     if not refresh_value:
-        # Expired access token, no refresh token — revoke + force re-consent.
         await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
         _drop_refresh_lock(app_state, user_id, server_name)
         await _audit_event(
             app_state,
+            server_id=server_id_for_audit,
             user_id=user_id,
             action="mcp_server.oauth.token_revoked",
             server_name=server_name,
             detail={"reason": "expired_no_refresh"},
         )
-        return None
-
-    storage = _get_storage(app_state)
-    if storage is None:
-        return None
-
-    server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
-    if server_row is None:
-        return None
-    server_id_for_audit = str(server_row.get("server_id") or "")
+        return TokenLookupResult(kind="refresh_failed")
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
-    async with lock:
-        # Re-read after lock — another caller may have refreshed already.
+    pg_lock = await _acquire_pg_refresh_lock(storage, user_id, server_name)
+    async with pg_lock, lock:
         try:
             plain2 = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
-        except MCPTokenDecryptError:
+        except MCPTokenDecryptError as exc:
             log.warning(
-                "mcp_server.oauth.token_decrypt_failed_falling_through",
+                "mcp_server.oauth.token_decrypt_failed_classified",
                 user_id=user_id,
                 server_name=server_name,
                 exc_info=True,
             )
             _drop_refresh_lock(app_state, user_id, server_name)
-            return None
+            return TokenLookupResult(
+                kind="decrypt_failure",
+                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+            )
         if plain2 is None:
-            return None
+            return TokenLookupResult(kind="missing")
         expires_at2 = plain2.get("expires_at")
         if not _token_needs_refresh(expires_at2):
-            return plain2["access_token"]
+            return TokenLookupResult(kind="token", token=plain2["access_token"])
         refresh_value2 = plain2.get("refresh_token")
         if not refresh_value2:
             await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
@@ -1054,14 +1188,11 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
                 server_name=server_name,
                 detail={"reason": "expired_no_refresh"},
             )
-            # Drop the lock entry AFTER we exit the ``async with`` block —
-            # we still hold ``lock`` here, so dropping the dict reference
-            # only matters for the next caller.
             _drop_refresh_lock(app_state, user_id, server_name)
-            return None
+            return TokenLookupResult(kind="refresh_failed")
 
         try:
-            new_access, new_refresh, new_expires_at = await _refresh_and_persist(
+            new_access, _new_refresh, _new_expires_at = await _refresh_and_persist(
                 app_state=app_state,
                 storage=storage,
                 token_store=token_store,
@@ -1082,10 +1213,8 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
                 detail={"reason": "refresh_failed"},
             )
             _drop_refresh_lock(app_state, user_id, server_name)
-            return None
-        _ = new_refresh
-        _ = new_expires_at
-        return new_access
+            return TokenLookupResult(kind="refresh_failed")
+        return TokenLookupResult(kind="token", token=new_access)
 
 
 def _token_needs_refresh(expires_at: str | None) -> bool:
@@ -2009,12 +2138,14 @@ __all__ = [
     "MCPOAuthRefreshFailed",
     "MCP_OAUTH_DISCOVERY_CACHE_TTL_SECONDS",
     "MCP_OAUTH_STATE_TTL_SECONDS",
+    "TokenLookupResult",
     "build_authorize_url",
     "close_mcp_oauth_state",
     "create_pending_state",
     "discover_authorization_server",
     "generate_pkce_pair",
     "get_user_access_token",
+    "get_user_access_token_classified",
     "handle_mcp_oauth_authorize",
     "handle_mcp_oauth_callback",
     "initialize_mcp_oauth_state",

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7632,7 +7632,12 @@ class ChatSession:
         assert self._mcp_client is not None
         mcp_error = False
         try:
-            output = self._mcp_client.call_tool_sync(func_name, args, timeout=self.tool_timeout)
+            output = self._mcp_client.call_tool_sync(
+                func_name,
+                args,
+                user_id=self._user_id or None,
+                timeout=self.tool_timeout,
+            )
         except TimeoutError:
             output = f"MCP tool timed out after {self.tool_timeout}s"
             mcp_error = True

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -4746,6 +4747,76 @@ class PostgreSQLBackend:
             )
             conn.commit()
             return result.rowcount > 0
+
+    # -- Cross-node serialization ----------------------------------------------
+
+    _ADVISORY_LOCK_TRY_INTERVAL_S = 0.05
+    _ADVISORY_LOCK_TRY_TIMEOUT_S = 30.0
+
+    def acquire_advisory_lock_sync(self, key_text: str) -> contextlib.AbstractContextManager[None]:
+        """Take a Postgres advisory lock keyed on ``hashtext(key_text)``.
+
+        perf-4: previous implementation called ``pg_advisory_xact_lock``
+        and held its connection for the full ``with`` body, so a burst
+        of concurrent waiters (e.g. 50 user-token refreshes hitting the
+        AS within a clock-skew window) starved the small SQLAlchemy
+        engine pool — every waiting backend held one of the 5 max
+        connections.
+
+        New shape: spin on ``pg_try_advisory_xact_lock`` with a fresh
+        connection per probe. Waiters return the connection to the pool
+        between attempts; only the actual lock holder keeps a connection
+        for the body. The lock auto-releases on transaction end.
+        """
+        engine = self._engine
+        try_interval = self._ADVISORY_LOCK_TRY_INTERVAL_S
+        try_timeout = self._ADVISORY_LOCK_TRY_TIMEOUT_S
+
+        @contextlib.contextmanager
+        def _ctx() -> Iterator[None]:
+            deadline = time.monotonic() + try_timeout
+            while True:
+                conn = engine.connect()
+                trans: Any = None
+                try:
+                    trans = conn.begin()
+                    acquired_row = conn.execute(
+                        sa.text("SELECT pg_try_advisory_xact_lock(hashtext(:k))"),
+                        {"k": key_text},
+                    ).scalar()
+                    if acquired_row:
+                        try:
+                            yield
+                        finally:
+                            # COMMIT releases the xact-scoped lock; if it
+                            # raises (e.g., transaction rolled back by a
+                            # network blip mid-body), the outer except
+                            # below does a best-effort rollback so the
+                            # lock isn't left held when conn returns to
+                            # the pool.
+                            if trans.is_active:
+                                trans.commit()
+                        return
+                    # Didn't acquire — release tx, fall through to backoff.
+                    trans.rollback()
+                except BaseException:
+                    # Any failure in begin / execute / yield / commit —
+                    # ensure the transaction is closed before the
+                    # outer finally returns the connection to the pool.
+                    if trans is not None and trans.is_active:
+                        with contextlib.suppress(Exception):
+                            trans.rollback()
+                    raise
+                finally:
+                    conn.close()
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"pg_try_advisory_xact_lock timed out after {try_timeout:.1f}s "
+                        f"for key={key_text!r}"
+                    )
+                time.sleep(try_interval)
+
+        return _ctx()
 
     # -- Lifecycle -------------------------------------------------------------
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1951,14 +1951,19 @@ class StorageBackend(Protocol):
     def acquire_advisory_lock_sync(self, key_text: str) -> AbstractContextManager[None]:
         """Acquire a backend-specific advisory lock for the duration of the context.
 
-        PostgreSQL: takes ``pg_advisory_xact_lock(hashtext(key_text))``
-        inside a fresh transaction so the lock auto-releases on commit /
-        rollback. SQLite: returns ``contextlib.nullcontext`` (single-node
-        deployments rely on in-process ``asyncio.Lock`` for serialization).
+        PostgreSQL: spins on ``pg_try_advisory_xact_lock(hashtext(key_text))``
+        with a short backoff between attempts. Each probe runs in a fresh
+        transaction, and waiting probes return their connection to the pool
+        between attempts; only the actual lock holder retains a connection
+        for the body. The lock auto-releases on transaction end (commit /
+        rollback). Raises ``TimeoutError`` if no probe succeeds within the
+        backend-defined deadline. SQLite: returns ``contextlib.nullcontext``
+        (single-node deployments rely on in-process ``asyncio.Lock`` for
+        serialization).
 
         Caller is expected to wrap the resulting context manager in
-        ``asyncio.to_thread`` when invoking from an async context — the
-        underlying SQLAlchemy hops are blocking.
+        ``asyncio.to_thread`` (or a dedicated executor) when invoking from
+        an async context — the underlying SQLAlchemy hops are blocking.
         """
         ...
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, runtime_checkable
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
     from turnstone.core.workstream import WorkstreamKind
 
 
@@ -1942,6 +1944,22 @@ class StorageBackend(Protocol):
 
     def delete_tls_cert(self, domain: str) -> bool:
         """Delete a certificate by domain. Returns True if existed."""
+        ...
+
+    # -- Cross-node serialization ----------------------------------------------
+
+    def acquire_advisory_lock_sync(self, key_text: str) -> AbstractContextManager[None]:
+        """Acquire a backend-specific advisory lock for the duration of the context.
+
+        PostgreSQL: takes ``pg_advisory_xact_lock(hashtext(key_text))``
+        inside a fresh transaction so the lock auto-releases on commit /
+        rollback. SQLite: returns ``contextlib.nullcontext`` (single-node
+        deployments rely on in-process ``asyncio.Lock`` for serialization).
+
+        Caller is expected to wrap the resulting context manager in
+        ``asyncio.to_thread`` when invoking from an async context — the
+        underlying SQLAlchemy hops are blocking.
+        """
         ...
 
     # -- Lifecycle -------------------------------------------------------------

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -4890,6 +4890,13 @@ class SQLiteBackend:
             conn.commit()
             return result.rowcount > 0
 
+    # -- Cross-node serialization ----------------------------------------------
+
+    def acquire_advisory_lock_sync(self, key_text: str) -> contextlib.AbstractContextManager[None]:
+        """SQLite is single-node — in-process ``asyncio.Lock`` suffices."""
+        del key_text  # silenced: signature parity with the Postgres impl
+        return contextlib.nullcontext()
+
     # -- Lifecycle -------------------------------------------------------------
 
     def close(self) -> None:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2845,6 +2845,7 @@ def internal_mcp_reload(request: Request) -> JSONResponse:
         mcp_mgr = MCPClientManager({})
         mcp_mgr.start()
         mcp_mgr.set_storage(storage)
+        mcp_mgr.set_app_state(request.app.state)
         request.app.state.mcp_client = mcp_mgr
         # Update shared ref so session_factory sees the new client
         mcp_ref = getattr(request.app.state, "mcp_ref", None)
@@ -4606,6 +4607,7 @@ def main() -> None:
         if mcp_tools:
             log.info("MCP tools: %d from %d server(s)", len(mcp_tools), mcp_client.server_count)
         mcp_client.set_storage(get_storage())
+        mcp_client.set_app_state(app.state)
     log.info(
         "Health tracking: failure_threshold=%s",
         config_store.get("health.failure_threshold"),


### PR DESCRIPTION
Phase 5 of OAuth-MCP — adds a per-(user, MCP-server) ClientSession
pool to MCPClientManager alongside the existing static-server path,
gated entirely on the per-server `auth_type='oauth_user'` config.

Pool architecture:
- `_user_pool_entries: dict[(user_id, server_name), PoolEntryState]`
  with lazy connect on first dispatch, per-key asyncio.Lock allocated
  on the mcp-loop, idle eviction coroutine (default 600s TTL, LRU cap
  200), and an `in_flight` counter as the eviction interlock so live
  calls can never be torn down mid-flight.
- `_dispatch_pool` runs the token-state machine: missing token →
  `mcp_consent_required`; key-rotation decrypt failure →
  `mcp_token_undecryptable_key_unknown` with NO consent prompt and NO
  auto-delete; expired token → silent refresh under per-(user, server)
  advisory lock; refresh failure → revoke + consent.
- `_classify_failure` separates transport (trips breaker) from auth
  401/403 (does NOT trip breaker — server-only invariant) from
  protocol (no breaker change).
- `entry.open_lock` held only across connect-or-reuse and released
  before the `await session.call_tool` so concurrent calls from one
  user against one server overlap (validated by Spike 1 scenario 2).

Auth-class failures are fail-soft in Phase 5: any 401/403 surfaced by
the SDK propagates to the agent as a tool error and the next dispatch
reconnects on a fresh refresh. Real introspection of upstream 401/403
is a Phase 6 concern — the MCP SDK's `streamable_http` post_writer
swallows `httpx.HTTPStatusError` upstream, so detecting status from
the response chain requires `McpError(CONNECTION_CLOSED)` payload
parsing or a custom httpx middleware around `streamablehttp_client`.
The mid-flight 401 refresh-retry path and the `mcp_insufficient_scope`
structured error for 403 step-up land together in Phase 6, gated by
an integration test that drives a real upstream 401/403 (the unit-
test injection of `HTTPStatusError` is what masked the production gap
on the first apply-findings pass — the integration test is the
structural gate so the gap can't reopen). RFC §1.5 steps 4-5 and the
phase table in §Implementation phases reflect this scope split.

Multi-node refresh contention:
- New `StorageBackend.acquire_advisory_lock_sync` Protocol method.
  SQLite returns nullcontext (single-node, in-process asyncio.Lock
  is sufficient). Postgres uses `pg_try_advisory_xact_lock` with
  retry on a fresh per-attempt connection, so waiters don't pin pool
  connections during the AS roundtrip. Inner try/except + nested
  finally ensures conn is always returned to the pool, even when
  begin / execute / yield / commit raises mid-body.
- Lock ordering: pg_advisory outer, asyncio.Lock inner. Re-read after
  lock collapses cluster-wide contention to one HTTP roundtrip per
  (user, server) per refresh window.
- `_PgRefreshLock` enter/exit pinned to a single-worker
  ThreadPoolExecutor so SQLAlchemy connection state stays
  thread-affine across cancellations.

Token storage refactor:
- `get_user_access_token_classified` returns a tagged TokenLookupResult
  (Token / MissingToken / DecryptFailure / RefreshFailed) so the
  dispatcher maps each state to the right user-facing error.
- `get_user_access_token` is now a thin wrapper around the classified
  variant; the previous duplicated state machine is gone.

Security:
- Pool dispatch + admin endpoints reject `http://` URLs for
  `auth_type='oauth_user'` servers (only exact loopback hostnames are
  exempt — `*.localhost` is intentionally NOT honored because RFC 6761
  localhost-zone resolution is configuration-dependent and could route
  bearers to non-loopback IPs via custom resolvers / hosts file /
  Docker overlays). Validated at three layers:
  `_dispatch_pool` (structured `mcp_oauth_url_insecure` error),
  `_connect_one_pool` (defensive ValueError), and
  `admin_create_mcp_server` / `admin_update_mcp_server` (400 before
  storage write).
- Admin URL change on an oauth_user row purges per-user OAuth tokens
  bound to the old URL: bearers are bound (via OAuth resource /
  audience) to the URL active at consent time, so silently rebinding
  them to a new URL is a token-binding violation. Re-consent forces
  fresh issuance for the new resource.
- Encryption-key fingerprints stay in audit logs only; no longer
  surfaced in agent-facing error payloads.

User_id thread-through:
- `MCPClientManager.call_tool_sync(..., user_id=None)` (additive;
  default None preserves the static path byte-identically).
- `ChatSession._exec_mcp_tool` passes `self._user_id or None`.
- `set_app_state(app_state)` setter wires OAuth state at lifespan
  startup, called from both turnstone-server and turnstone-console.

Performance:
- LRU cap eviction iterates `_user_pool_entries` (not
  `_user_pool_last_used`) so pre-dispatch entries are eligible.
- Eviction batch closes via `asyncio.gather` instead of serial await.
- `_resolve_pool_target` returns the resolved server row to
  `_dispatch_pool` to eliminate the second DB lookup.
- Production reachability of pool dispatch is gated on Phase 7
  (catalog scoping) wiring pool tools into `_tool_map`; until then
  pool dispatch is reachable only via direct `call_tool_sync` with a
  prefixed name (the path the new pool tests exercise).

Hardening parity preserved:
- Static path (auth_type ∈ {none, static}) byte-identical; PR #296
  hardening (SDK #2147 mitigations, anyio cancel-scope, stale-session-
  and-stack guard, server-only circuit breaker) intact.
- `test_reconnect_preserves_static_state_identity` unchanged + green.
- `MCPTokenStore.get_user_token` does not auto-delete on
  MCPTokenDecryptError (key-rotation safety).
- Notification debounce stays manager-level.
- Connect-failure cleanup factored into
  `_safe_teardown_on_connect_failure` shared by both connect paths.

Tests: 5475 → 5493 (+18). New file `tests/test_mcp_user_pool.py`
plus additions to test_mcp_oauth_refresh.py, test_mcp_admin_api.py,
and test_mcp_client.py covering: pool data structures, lazy connect,
eviction TTL + LRU + lock interlock, dispatch state machine (token
states), failure classification, http-rejection at dispatch and
admin layers, URL-change-purges-tokens (sec), concurrent dispatch on
one (user, server), pg_advisory lock parity, and user_id threading.

Phase exit criterion (synthetic load test 50 users × 3 servers × LRU
30 × 1000 calls × 200 evictions) deferred to a post-Phase-5 fitness
spike that runs against a staging deployment with real FDs and real
network behaviour, not a CI mock — same shape as Spike 1's
pre-Phase-0 SDK validation.

Out-of-scope for Phase 5 (Phase 6+): SDK-level 401 refresh-retry +
403 `mcp_insufficient_scope` (Phase 6), per-user catalog scoping
(Phase 7), consent UX SSE event + dashboard renderer (Phase 8),
admin UI status indicators (Phase 9).
