### PR TITLE
fix(man): accept canonical name(section) page notation

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -532,6 +532,81 @@ class TestAgentModelOverride:
 
 
 # ---------------------------------------------------------------------------
+# man tool
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareMan:
+    """``ChatSession._prepare_man`` argument parsing."""
+
+    def test_plain_page(self, tmp_db) -> None:
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "grep"})
+        assert "error" not in item
+        assert item["page"] == "grep"
+        assert item["section"] == ""
+
+    def test_explicit_section_arg(self, tmp_db) -> None:
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "printf", "section": "3"})
+        assert "error" not in item
+        assert item["page"] == "printf"
+        assert item["section"] == "3"
+
+    def test_parenthesized_section_in_page(self, tmp_db) -> None:
+        # Models commonly emit canonical man-page notation; we should
+        # parse the section out instead of rejecting the call.
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "printf(3)"})
+        assert "error" not in item
+        assert item["page"] == "printf"
+        assert item["section"] == "3"
+        assert "printf(3)" in item["header"]
+
+    def test_parenthesized_section_with_letter_suffix(self, tmp_db) -> None:
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "perlfunc(3pm)"})
+        assert "error" not in item
+        assert item["page"] == "perlfunc"
+        assert item["section"] == "3pm"
+
+    def test_explicit_section_arg_wins_over_parsed(self, tmp_db) -> None:
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "open(2)", "section": "3"})
+        assert "error" not in item
+        assert item["page"] == "open"
+        assert item["section"] == "3"
+
+    def test_invalid_section_in_parens_falls_through_to_error(self, tmp_db) -> None:
+        # Parens that don't match the section pattern aren't parsed away,
+        # so the page-name sanitizer rejects the literal string.
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "grep(bogus)"})
+        assert "error" in item
+        assert "invalid page name" in item["error"]
+
+    def test_empty_page(self, tmp_db) -> None:
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": ""})
+        assert "error" in item
+        assert "no page name" in item["error"]
+
+    def test_parsed_section_reaches_subprocess_argv(self, tmp_db) -> None:
+        # End-to-end check that page="printf(3)" produces the right
+        # ``man`` argv — guards against future drift between
+        # ``_prepare_man``'s output keys and ``_exec_man``'s reads.
+        session = _make_session()
+        item = session._prepare_man("c1", {"page": "printf(3)"})
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="MAN PAGE TEXT", stderr=""
+        )
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            session._exec_man(item)
+        argv = mock_run.call_args_list[0].args[0]
+        assert argv == ["man", "3", "printf"]
+
+
+# ---------------------------------------------------------------------------
 # Plan validation
 # ---------------------------------------------------------------------------
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5237,6 +5237,16 @@ class ChatSession:
                 "needs_approval": False,
                 "error": "Error: no page name provided",
             }
+        section = (args.get("section") or "").strip()
+        # Accept the canonical "name(section)" notation that the model often
+        # emits (e.g. printf(3), open(2), perlfunc(3pm)) \u2014 the parens are
+        # otherwise rejected by the page-name sanitizer below. An explicit
+        # ``section`` arg, if provided, takes precedence over the parsed one.
+        m = re.match(r"^([a-zA-Z0-9._-]+)\(([1-9][a-z]*)\)$", page)
+        if m:
+            page = m.group(1)
+            if not section:
+                section = m.group(2)
         # Sanitize: only allow alphanumeric, dash, underscore, dot
         if not re.match(r"^[a-zA-Z0-9._-]+$", page):
             return {
@@ -5247,8 +5257,7 @@ class ChatSession:
                 "needs_approval": False,
                 "error": f"Error: invalid page name {page!r}",
             }
-        section = (args.get("section") or "").strip()
-        if section and not re.match(r"^[1-9][a-z]?$", section):
+        if section and not re.match(r"^[1-9][a-z]*$", section):
             section = ""
         label = f"{page}({section})" if section else page
         preview = f"    {DIM}{label}{RESET}"


### PR DESCRIPTION
## Summary
- `_prepare_man` now parses `printf(3)` / `open(2)` / `perlfunc(3pm)`-style page names and lifts the section out before the sanitizer sees the parens. Explicit `section` arg still wins.
- Section validator widened from `[1-9][a-z]?` to `[1-9][a-z]*` so suffixes like `3pm`, `3perl` survive.

## Why
Models naturally emit canonical man-page references (`printf(3)`) instead of splitting into `page="printf"` + `section="3"`. The sanitizer regex `^[a-zA-Z0-9._-]+$` was rejecting the parens, killing the call.

## Safety
`_exec_man` shells out via `subprocess.run([...], shell=False)` with an argv list — the parsed section/page can't escape into shell metacharacters even if the regexes were laxer. New test covers the full path through `_exec_man` and asserts `argv == ["man", "3", "printf"]` for `page="printf(3)"`.

## Test plan
- [x] `pytest tests/test_session.py::TestPrepareMan` — 8 cases (plain, explicit section, parsed parens, letter suffix, explicit-wins, invalid section fallthrough, empty page, argv reaches subprocess)
- [x] `ruff check` clean
- [x] `mypy turnstone/core/session.py` clean