### PR TITLE
feat(metacog): NudgeQueue + wake trigger + idle-children nudge

### DIFF
--- a/tests/test_coordinator_idle_observer.py
+++ b/tests/test_coordinator_idle_observer.py
@@ -1,0 +1,489 @@
+"""Unit tests for :class:`CoordinatorIdleObserver`.
+
+Drives a fake :class:`SessionManager` that mirrors the real one's
+``subscribe_to_state`` / ``get`` contract, plus a fake storage with the
+``list_workstreams`` slice the observer queries.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from turnstone.console.coordinator_idle_observer import CoordinatorIdleObserver
+from turnstone.core.nudge_queue import NudgeQueue
+from turnstone.core.workstream import WorkstreamKind, WorkstreamState
+
+
+class _FakeRow:
+    """SQLAlchemy-Row-like wrapper exposing ``_mapping``."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._mapping = kwargs
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.children: list[dict[str, Any]] = []
+        self.list_calls: list[dict[str, Any]] = []
+        self.count_calls: list[dict[str, Any]] = []
+        self.list_raises: bool = False
+        self.count_raises: bool = False
+
+    def list_workstreams(
+        self,
+        node_id: str | None = None,
+        limit: int = 100,
+        *,
+        parent_ws_id: str | None = None,
+        kind: WorkstreamKind | str | None = None,
+        user_id: str | None = None,
+    ) -> list[Any]:
+        self.list_calls.append(
+            {
+                "limit": limit,
+                "parent_ws_id": parent_ws_id,
+                "kind": kind,
+                "user_id": user_id,
+            }
+        )
+        if self.list_raises:
+            raise RuntimeError("storage forced failure")
+        return [_FakeRow(**c) for c in self.children]
+
+    def count_workstreams_by_state(
+        self,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, int]:
+        self.count_calls.append({"parent_ws_id": parent_ws_id, "user_id": user_id})
+        if self.count_raises:
+            raise RuntimeError("count forced failure")
+        counts: dict[str, int] = {}
+        for c in self.children:
+            counts[c["state"]] = counts.get(c["state"], 0) + 1
+        return counts
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self._nudge_queue = NudgeQueue()
+        self.messages: list[dict[str, Any]] = []
+        self._wake_source_tag: str = ""
+        self._metacog_state: dict[str, float] = {}
+        self._mem_cfg = MagicMock(nudge_cooldown=300)
+
+    def _visible_memory_count(self) -> int:
+        return 0
+
+
+class _FakeWorkstream:
+    def __init__(
+        self,
+        ws_id: str = "ws-coord",
+        kind: WorkstreamKind = WorkstreamKind.COORDINATOR,
+        user_id: str = "u1",
+    ) -> None:
+        self.id = ws_id
+        self.kind = kind
+        self.user_id = user_id
+        self.session: _FakeSession | None = _FakeSession()
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self._workstreams: dict[str, _FakeWorkstream] = {}
+        self._subscribers: list[Any] = []
+        self._lock = threading.Lock()
+
+    def add_ws(self, ws: _FakeWorkstream) -> None:
+        self._workstreams[ws.id] = ws
+
+    def remove_ws(self, ws_id: str) -> None:
+        self._workstreams.pop(ws_id, None)
+
+    def get(self, ws_id: str) -> _FakeWorkstream | None:
+        return self._workstreams.get(ws_id)
+
+    def subscribe_to_state(self, callback: Any) -> None:
+        with self._lock:
+            self._subscribers.append(callback)
+
+    def unsubscribe_from_state(self, callback: Any) -> None:
+        with self._lock, contextlib.suppress(ValueError):
+            self._subscribers.remove(callback)
+
+    def fire_state(self, ws_id: str, state: WorkstreamState) -> None:
+        with self._lock:
+            subs = list(self._subscribers)
+        for cb in subs:
+            with contextlib.suppress(Exception):
+                cb(ws_id, state)
+
+
+@pytest.fixture
+def coord_setup() -> tuple[_FakeManager, _FakeStorage, _FakeWorkstream]:
+    mgr = _FakeManager()
+    storage = _FakeStorage()
+    ws = _FakeWorkstream()
+    mgr.add_ws(ws)
+    return mgr, storage, ws
+
+
+def _add_active_child(storage: _FakeStorage, **overrides: Any) -> None:
+    storage.children.append(
+        {
+            "ws_id": overrides.get("ws_id", "child-1"),
+            "name": overrides.get("name", "research"),
+            "state": overrides.get("state", "running"),
+        }
+    )
+
+
+class TestEnqueueOnIdle:
+    def test_idle_with_active_children_enqueues(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage, ws_id="child-a", state="running")
+        _add_active_child(storage, ws_id="child-b", state="thinking")
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+
+        snap = ws.session._nudge_queue.pending("any")
+        assert len(snap) == 1
+        nudge_type, text = snap[0]
+        assert nudge_type == "idle_children"
+        assert "child-a" in text
+        assert "child-b" in text
+
+    def test_idle_with_no_active_children_no_enqueue(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        # storage.children is empty
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 0
+
+    def test_idle_only_idle_state_children_no_enqueue(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        # All children "idle" — terminal-from-coord-perspective; not active.
+        _add_active_child(storage, state="idle")
+        _add_active_child(storage, state="closed")
+        _add_active_child(storage, state="error")
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 0
+
+    def test_non_idle_state_no_enqueue(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        for state in (
+            WorkstreamState.RUNNING,
+            WorkstreamState.THINKING,
+            WorkstreamState.ATTENTION,
+            WorkstreamState.ERROR,
+        ):
+            mgr.fire_state(ws.id, state)
+        assert len(ws.session._nudge_queue) == 0
+
+
+class TestKindFilter:
+    def test_interactive_workstream_skipped(self):
+        mgr = _FakeManager()
+        storage = _FakeStorage()
+        _add_active_child(storage)
+        ws = _FakeWorkstream(kind=WorkstreamKind.INTERACTIVE)
+        mgr.add_ws(ws)
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        # Observer ignored the non-coord workstream entirely.
+        assert len(ws.session._nudge_queue) == 0
+        # Storage was NOT queried — kind check happens before list_workstreams.
+        assert storage.list_calls == []
+
+
+class TestWaitForWorkstreamSkip:
+    def test_skips_when_last_assistant_used_wait(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        ws.session.messages = [
+            {"role": "user", "content": "kick off"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "wait_for_workstream", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        # Don't pile on — model is already using the right tool.
+        assert len(ws.session._nudge_queue) == 0
+
+    def test_fires_when_last_assistant_used_different_tool(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call-1", "function": {"name": "spawn_workstream", "arguments": "{}"}}
+                ],
+            },
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 1
+
+
+class TestHardCap:
+    def test_hard_cap_blocks_after_n_fires(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+
+        # Bypass cooldown for this test: each call burns a per-type slot
+        # in ``_metacog_state`` so we need to clear it between fires.
+        for _ in range(3):
+            ws.session._metacog_state.clear()
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+
+        # Cap = 3 fires.  Even with cooldown bypassed, the 4th doesn't fire.
+        ws.session._metacog_state.clear()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        # We enqueued 3 entries total; cap blocked the 4th.
+        snap = ws.session._nudge_queue.pending("any")
+        assert len(snap) == 3
+
+    def test_cap_resets_when_state_leaves_idle_without_wake(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+
+        # Burn the cap.
+        for _ in range(3):
+            ws.session._metacog_state.clear()
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue.pending("any")) == 3
+
+        # Drain the queue (simulate the watcher delivering them).
+        ws.session._nudge_queue.drain({"any"})
+
+        # Real (non-wake) leave-IDLE: tag is empty.  Cap resets.
+        ws.session._wake_source_tag = ""
+        mgr.fire_state(ws.id, WorkstreamState.RUNNING)
+
+        # New IDLE — cap is fresh, fires again.
+        ws.session._metacog_state.clear()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue.pending("any")) == 1
+
+    def test_cap_does_not_reset_during_wake_driven_exit(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+
+        # Burn the cap.
+        for _ in range(3):
+            ws.session._metacog_state.clear()
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        ws.session._nudge_queue.drain({"any"})
+
+        # Wake-driven leave-IDLE: tag is set during the wake send.
+        ws.session._wake_source_tag = "system_nudge"
+        mgr.fire_state(ws.id, WorkstreamState.RUNNING)
+        ws.session._wake_source_tag = ""  # tag cleared at end of wake send
+
+        # Cap should NOT have reset — re-IDLE shouldn't fire.
+        ws.session._metacog_state.clear()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue.pending("any")) == 0
+
+
+class TestCooldown:
+    def test_cooldown_blocks_within_window(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue.pending("any")) == 1
+
+        # Drain so the queue isn't the gate.
+        ws.session._nudge_queue.drain({"any"})
+
+        # Second fire within the cooldown window → should_nudge returns False.
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue.pending("any")) == 0
+
+
+class TestStorageFailure:
+    def test_storage_exception_is_swallowed(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        storage.list_raises = True
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        # Must not raise / propagate.
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 0
+
+
+class TestValidUntilPredicate:
+    def test_predicate_drops_when_children_finish_before_drain(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage, ws_id="child-a", state="running")
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 1
+
+        # Children now complete (storage shows none active).
+        storage.children.clear()
+
+        # Drain at the user seam — predicate re-queries, finds 0 active,
+        # drops the entry without delivering.
+        from turnstone.core.nudge_queue import USER_DRAIN
+
+        delivered = ws.session._nudge_queue.drain(USER_DRAIN)
+        assert delivered == []
+        assert len(ws.session._nudge_queue) == 0
+
+    def test_predicate_delivers_when_children_still_active(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage, ws_id="child-a", state="running")
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+
+        # Children still active → predicate returns True → entry delivers.
+        from turnstone.core.nudge_queue import USER_DRAIN
+
+        delivered = ws.session._nudge_queue.drain(USER_DRAIN)
+        assert len(delivered) == 1
+        assert delivered[0][0] == "idle_children"
+
+    def test_predicate_drops_on_storage_failure(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+
+        # Storage failure at drain time.  Predicate treats raises as
+        # "no longer valid" (drop) — see NudgeQueue.drain's predicate
+        # exception handling.
+        storage.count_raises = True
+
+        from turnstone.core.nudge_queue import USER_DRAIN
+
+        delivered = ws.session._nudge_queue.drain(USER_DRAIN)
+        assert delivered == []
+
+
+class TestLifecycle:
+    def test_start_idempotent(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        observer.start()  # no-op
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        # Double-subscribe would have produced 2 entries.
+        assert len(ws.session._nudge_queue.pending("any")) == 1
+
+    def test_shutdown_unsubscribes(self, coord_setup):
+        mgr, storage, ws = coord_setup
+        _add_active_child(storage)
+        # ≥2 messages so should_nudge's message_count > 1 gate clears.
+        ws.session.messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        observer = CoordinatorIdleObserver(mgr, storage)
+        observer.start()
+        observer.shutdown()
+        mgr.fire_state(ws.id, WorkstreamState.IDLE)
+        assert len(ws.session._nudge_queue) == 0
+
+    def test_shutdown_idempotent(self, coord_setup):
+        mgr, _storage, _ws = coord_setup
+        observer = CoordinatorIdleObserver(mgr, _storage)
+        observer.start()
+        observer.shutdown()
+        observer.shutdown()  # no error

--- a/tests/test_idle_nudge_wake_integration.py
+++ b/tests/test_idle_nudge_wake_integration.py
@@ -30,7 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests.test_session_manager import FakeStorage
-from turnstone.core.metacognition import IdleNudgeWatcher
+from turnstone.core.idle_nudge_watcher import IdleNudgeWatcher
 from turnstone.core.session import ChatSession
 from turnstone.core.session_manager import SessionManager
 from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
@@ -90,8 +90,8 @@ class _BuildRealSessionAdapter:
     that production ``WebUI`` / coord adapters expose.
     """
 
-    def __init__(self) -> None:
-        self.kind = WorkstreamKind.INTERACTIVE
+    def __init__(self, kind: WorkstreamKind = WorkstreamKind.INTERACTIVE) -> None:
+        self.kind = kind
         self.events: list[str] = []
         self.cleaned_up: list[str] = []
 
@@ -270,3 +270,116 @@ def test_idle_event_with_empty_queue_does_not_dispatch_wake(real_mgr, tmp_db):
             assert mock_send.call_count == 0, "wake must not dispatch for an empty queue"
     finally:
         watcher.shutdown()
+
+
+@pytest.fixture
+def coord_mgr() -> tuple[SessionManager, _BuildRealSessionAdapter, FakeStorage]:
+    """Real coord-side SessionManager with the adapter's kind set to
+    COORDINATOR.  Same shape as ``real_mgr`` but for the coord half of
+    the lifespan.  No StateWriter wired so subscriber dispatch fires
+    synchronously on the test thread.
+    """
+    adapter = _BuildRealSessionAdapter(kind=WorkstreamKind.COORDINATOR)
+    storage = FakeStorage()
+    mgr = SessionManager(
+        adapter,
+        storage=storage,
+        max_active=5,
+        event_emitter=adapter,
+    )
+    return mgr, adapter, storage
+
+
+def test_coord_idle_with_active_children_emits_envelope_via_real_managers(coord_mgr, tmp_db):
+    """Full coord-path integration test (matches design doc §7.4).
+
+    Drives the production install order — ``CoordinatorIdleObserver``
+    registered FIRST, then ``IdleNudgeWatcher`` — and asserts the
+    full chain: observer enqueues on IDLE → watcher peeks → wake
+    spawns a worker → ``deliver_wake_nudge_from_queue`` drains and
+    runs the synthetic empty-user turn → reminder envelope reaches
+    the synthesized user message via the side-channel.
+
+    The boundary-crossing path tested here mirrors what
+    ``console/server.py``'s lifespan does at production startup; if
+    the install order is ever reversed, this test fails.
+    """
+    from turnstone.console.coordinator_idle_observer import CoordinatorIdleObserver
+    from turnstone.core.workstream import WorkstreamKind as _Kind
+
+    mgr, adapter, storage = coord_mgr
+    # Observer FIRST, then watcher.  Same order as
+    # ``console/server.py:4435-4443`` — production correctness depends
+    # on subscribers firing in registration order on the same IDLE.
+    observer = CoordinatorIdleObserver(mgr, storage)
+    observer.start()
+    watcher = IdleNudgeWatcher(mgr)
+    watcher.start()
+
+    try:
+        coord = mgr.create(user_id="u1", name="parent-coord", skill=None)
+        assert coord.session is not None
+
+        # Two interactive children of the coord, both running.  Use
+        # the storage's register_workstream API so the rows match
+        # production shape (the observer queries via list_workstreams).
+        storage.register_workstream(
+            "child-a",
+            user_id="u1",
+            name="research-pricing",
+            kind=_Kind.INTERACTIVE,
+            parent_ws_id=coord.id,
+            state="running",
+        )
+        storage.register_workstream(
+            "child-b",
+            user_id="u1",
+            name="draft-rfc",
+            kind=_Kind.INTERACTIVE,
+            parent_ws_id=coord.id,
+            state="thinking",
+        )
+
+        # Pretend the coord has already had a real conversation so
+        # ``should_nudge``'s message_count > 1 gate passes.
+        coord.session.messages.append({"role": "user", "content": "spawn 2"})
+        coord.session.messages.append({"role": "assistant", "content": "ok"})
+
+        with (
+            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                coord.session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ack"},
+            ),
+            patch.object(coord.session, "_full_messages", return_value=[]),
+            patch.object(coord.session, "_update_token_table"),
+            patch.object(coord.session, "_print_status_line"),
+            patch.object(coord.session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            coord.session._title_generated = True
+            mgr.set_state(coord.id, WorkstreamState.IDLE)
+            _wait_for_worker_done(coord)
+
+        # Queue drained — the wake delivered the observer's enqueue.
+        assert len(coord.session._nudge_queue) == 0
+        # The synthetic empty-user turn landed with a reminder containing
+        # both children.
+        user_msgs = [m for m in coord.session.messages if m.get("role") == "user"]
+        # Two real msgs (user + assistant context above) plus the wake.
+        wake_msg = user_msgs[-1]
+        assert wake_msg["content"] == ""
+        assert wake_msg.get("_source") == "system_nudge"
+        reminders = wake_msg.get("_reminders") or []
+        assert len(reminders) == 1
+        assert reminders[0]["type"] == "idle_children"
+        text = reminders[0]["text"]
+        assert "research-pricing" in text
+        assert "draft-rfc" in text
+        assert "child-a" in text
+        assert "child-b" in text
+        assert "wait_for_workstream" in text
+    finally:
+        watcher.shutdown()
+        observer.shutdown()

--- a/tests/test_idle_nudge_wake_integration.py
+++ b/tests/test_idle_nudge_wake_integration.py
@@ -1,0 +1,272 @@
+"""Boundary-crossing integration test for the wake trigger pipeline.
+
+Drives a *real* :class:`SessionManager` + a *real* :class:`ChatSession`
++ a *real* :class:`IdleNudgeWatcher` end-to-end.  The only stub is the
+LLM provider (patched ``_create_stream_with_retry``); every other layer
+is production code:
+
+* ``SessionManager.set_state`` snapshotting + iterating subscribers
+* ``IdleNudgeWatcher._on_state`` peeking the queue
+* ``session_worker.send`` atomic-spawn + daemon thread
+* ``ChatSession.deliver_wake_nudge_from_queue`` opening / closing
+  ``_wake_source_tag``
+* ``ChatSession.send`` chat loop short-circuiting metacog detection
+* ``_append_user_turn`` stamping ``_source = "system_nudge"``
+* ``_attach_pending_user_reminders`` draining ``USER_DRAIN``
+* ``_apply_reminders_for_provider`` splicing the rendered envelope
+  onto empty content
+
+Per ``feedback_tests_through_boundaries.md``: direct injection tests
+that bypass these boundaries silently mask wiring bugs.  This test is
+the structural integration gate.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.test_session_manager import FakeStorage
+from turnstone.core.metacognition import IdleNudgeWatcher
+from turnstone.core.session import ChatSession
+from turnstone.core.session_manager import SessionManager
+from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
+
+# ---------------------------------------------------------------------------
+# Minimal fake adapter / UI for this integration test.  Storage reuses
+# the canonical FakeStorage from test_session_manager.py to avoid the
+# drift risk of a parallel fake.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUI:
+    """Minimal UI surface for ChatSession + SessionManager.cleanup_ui."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any]] = []
+
+    def _unblock(self) -> None:  # SessionManager.close calls this
+        pass
+
+    def broadcast_ws_closed(self) -> None:
+        pass
+
+    # ChatSession callbacks (no-op for this test)
+    def on_thinking_start(self) -> None:
+        pass
+
+    def on_thinking_end(self) -> None:
+        pass
+
+    def on_state_change(self, state: str) -> None:
+        self.events.append(("state", state))
+
+    def on_user_reminder(self, reminders: Any) -> None:
+        self.events.append(("user_reminder", reminders))
+
+    def on_error(self, message: str) -> None:
+        pass
+
+    def on_rename(self, name: str) -> None:
+        pass
+
+    def on_output_warning(self, call_id: Any, assessment: Any) -> None:
+        pass
+
+    def __getattr__(self, name: str) -> Any:
+        # Catch-all for any UI hook not enumerated above so the chat
+        # loop's ``self.ui.<something>()`` call doesn't blow up.
+        return MagicMock()
+
+
+class _BuildRealSessionAdapter:
+    """Adapter that returns a real :class:`ChatSession` instead of a stub.
+
+    Tracks emit_* events the integration test asserts on.  Mirrors the
+    ``SessionKindAdapter`` + ``SessionEventEmitter`` Protocol surface
+    that production ``WebUI`` / coord adapters expose.
+    """
+
+    def __init__(self) -> None:
+        self.kind = WorkstreamKind.INTERACTIVE
+        self.events: list[str] = []
+        self.cleaned_up: list[str] = []
+
+    def emit_created(self, ws: Workstream) -> None:
+        self.events.append(f"created:{ws.id}")
+
+    def emit_rehydrated(self, ws: Workstream) -> None:
+        self.events.append(f"rehydrated:{ws.id}")
+
+    def emit_state(self, ws: Workstream, state: WorkstreamState) -> None:
+        self.events.append(f"state:{ws.id}:{state.value}")
+
+    def emit_closed(self, ws_id: str, *, reason: str = "closed", name: str = "") -> None:
+        self.events.append(f"closed:{ws_id}")
+
+    def cleanup_ui(self, ws: Workstream) -> None:
+        # Real production cleanup_ui calls ws.session.cancel() + close().
+        # We don't need that here — the test exits cleanly via pytest
+        # teardown without exercising the cleanup path.  Just record
+        # the call for any test that wants to assert on it.
+        self.cleaned_up.append(ws.id)
+
+    def build_ui(self, ws: Workstream) -> Any:
+        return _FakeUI()
+
+    def build_session(
+        self,
+        ws: Workstream,
+        *,
+        skill: Any = None,
+        model: Any = None,
+        client_type: Any = None,
+        **extra: Any,
+    ) -> Any:
+        # Mirror SessionManager.create's keyword set so config-threading
+        # bugs surface here rather than being silently swallowed by
+        # **kwargs.  ``model`` flows to the real ChatSession; the rest
+        # are accepted but not used by this test.
+        client = MagicMock()
+        return ChatSession(
+            client=client,
+            model=str(model) if model else "test-model",
+            ui=ws.ui,
+            instructions=None,
+            temperature=0.5,
+            max_tokens=4096,
+            tool_timeout=30,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_mgr() -> tuple[SessionManager, _BuildRealSessionAdapter]:
+    """Real SessionManager wired to an adapter that builds real ChatSessions.
+
+    No StateWriter is wired so ``set_state`` writes directly to storage
+    on the calling thread (we want subscriber dispatch to fire in the
+    same thread the test invokes ``set_state`` on).
+    """
+    adapter = _BuildRealSessionAdapter()
+    storage = FakeStorage()
+    mgr = SessionManager(
+        adapter,
+        storage=storage,
+        max_active=5,
+        event_emitter=adapter,
+    )
+    return mgr, adapter
+
+
+def _wait_for_worker_done(ws: Workstream, timeout: float = 5.0) -> None:
+    """Poll ``ws._worker_running`` until it clears or timeout elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with ws._lock:
+            if not ws._worker_running:
+                return
+        time.sleep(0.01)
+    raise AssertionError(f"worker thread for ws={ws.id[:8]} didn't exit within {timeout}s")
+
+
+def test_idle_event_through_real_session_manager_drives_wake_send(real_mgr, tmp_db):
+    """The full wake pipeline, no direct-injection shortcuts.
+
+    Boundary path under test:
+      enqueue → mgr.set_state(IDLE)
+        → SessionManager._state_subscribers iteration (real)
+        → IdleNudgeWatcher._on_state (real)
+        → session_worker.send (real)
+        → real daemon thread
+        → ChatSession.deliver_wake_nudge_from_queue (real)
+        → ChatSession.send("") (real, with patched LLM stream)
+        → _append_user_turn stamps ``_source``
+        → _attach_pending_user_reminders drains ``{"user","any"}``
+        → _apply_reminders_for_provider splices envelope onto empty content
+    """
+    mgr, _adapter = real_mgr
+    watcher = IdleNudgeWatcher(mgr)
+    watcher.start()
+
+    try:
+        ws = mgr.create(user_id="u1", name="wake-int", skill=None)
+        assert ws.session is not None
+        # Patch the LLM-facing surface so send() runs the chat loop end-to-end
+        # without any real provider.  We patch on the just-built ChatSession;
+        # the patches are reverted by the `with` block.
+        with (
+            patch.object(ws.session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                ws.session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(ws.session, "_update_token_table"),
+            patch.object(ws.session, "_print_status_line"),
+            patch.object(ws.session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            # Suppress the auto-title side-thread; orthogonal to wake.
+            ws.session._title_generated = True
+
+            # Enqueue an any-channel nudge — the future ``idle_children`` shape.
+            ws.session._nudge_queue.enqueue("idle_children", "your kids", "any")
+            assert len(ws.session._nudge_queue) == 1
+
+            # Trigger IDLE.  This runs subscriber dispatch synchronously on
+            # the calling thread → IdleNudgeWatcher._on_state → session_worker.send
+            # → spawn daemon thread → deliver_wake_nudge_from_queue.
+            mgr.set_state(ws.id, WorkstreamState.IDLE)
+
+            # Wait for the daemon thread to clear ``_worker_running`` so the
+            # post-conditions are stable.
+            _wait_for_worker_done(ws)
+
+        # Queue fully drained by the wake.
+        assert len(ws.session._nudge_queue) == 0
+
+        # The synthesized empty user message landed in history with the
+        # ``_source`` audit tag and the reminder side-channel populated.
+        user_msgs = [m for m in ws.session.messages if m.get("role") == "user"]
+        assert user_msgs, "expected a synthesized user message from the wake"
+        wake_msg = user_msgs[-1]
+        assert wake_msg["content"] == ""
+        assert wake_msg.get("_source") == "system_nudge"
+        assert wake_msg.get("_reminders") == [{"type": "idle_children", "text": "your kids"}]
+
+        # The wake-source tag is reset post-send so subsequent activity
+        # behaves normally.
+        assert ws.session._wake_source_tag == ""
+    finally:
+        watcher.shutdown()
+
+
+def test_idle_event_with_empty_queue_does_not_dispatch_wake(real_mgr, tmp_db):
+    """Non-empty queue is the gate.  An IDLE event on a workstream with
+    nothing queued must NOT call ``session_worker.send``.
+
+    Patches the dispatch primitive directly rather than racing a
+    ``time.sleep`` against an erroneous spawn — the question is
+    whether the watcher's gate fired, which is a deterministic
+    decision the patch captures.
+    """
+    mgr, _adapter = real_mgr
+    watcher = IdleNudgeWatcher(mgr)
+    watcher.start()
+
+    try:
+        ws = mgr.create(user_id="u1", name="empty-int", skill=None)
+        # No enqueue.
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.set_state(ws.id, WorkstreamState.IDLE)
+            assert mock_send.call_count == 0, "wake must not dispatch for an empty queue"
+    finally:
+        watcher.shutdown()

--- a/tests/test_idle_nudge_watcher.py
+++ b/tests/test_idle_nudge_watcher.py
@@ -1,0 +1,165 @@
+"""Unit tests for :class:`IdleNudgeWatcher`.
+
+Drives a fake :class:`SessionManager` that mimics the real one's
+``subscribe_to_state`` / ``get`` contract.  The watcher itself
+dispatches via ``turnstone.core.session_worker.send``; we patch that
+module-level function to capture calls without spawning real threads.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from turnstone.core.metacognition import IdleNudgeWatcher
+from turnstone.core.nudge_queue import NudgeQueue
+from turnstone.core.workstream import WorkstreamState
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self._nudge_queue = NudgeQueue()
+        self.deliver_wake_nudge_from_queue_called = 0
+
+    def deliver_wake_nudge_from_queue(self) -> None:
+        self.deliver_wake_nudge_from_queue_called += 1
+
+
+class _FakeWorkstream:
+    def __init__(self, ws_id: str = "ws-test") -> None:
+        self.id = ws_id
+        self.session: _FakeSession | None = _FakeSession()
+        self._lock = threading.Lock()
+        self._worker_running = False
+        self._closed = False
+        self.worker_thread: Any = None
+
+
+class _FakeManager:
+    """Mimics SessionManager's subscribe-to-state surface without a DB."""
+
+    def __init__(self) -> None:
+        self._workstreams: dict[str, _FakeWorkstream] = {}
+        self._subscribers: list[Any] = []
+        self._subscribers_lock = threading.Lock()
+
+    def add_ws(self, ws: _FakeWorkstream) -> None:
+        self._workstreams[ws.id] = ws
+
+    def get(self, ws_id: str) -> _FakeWorkstream | None:
+        return self._workstreams.get(ws_id)
+
+    def subscribe_to_state(self, callback: Any) -> None:
+        with self._subscribers_lock:
+            self._subscribers.append(callback)
+
+    def unsubscribe_from_state(self, callback: Any) -> None:
+        with self._subscribers_lock, contextlib.suppress(ValueError):
+            self._subscribers.remove(callback)
+
+    def fire_state(self, ws_id: str, state: WorkstreamState) -> None:
+        """Mirror SessionManager.set_state's subscriber-fan-out behaviour."""
+        with self._subscribers_lock:
+            subs = list(self._subscribers)
+        for cb in subs:
+            # Match contextlib.suppress(Exception) in real SessionManager.
+            with contextlib.suppress(Exception):
+                cb(ws_id, state)
+
+
+@pytest.fixture
+def fake_mgr_and_ws() -> tuple[_FakeManager, _FakeWorkstream]:
+    mgr = _FakeManager()
+    ws = _FakeWorkstream()
+    mgr.add_ws(ws)
+    return mgr, ws
+
+
+class TestIdleNudgeWatcher:
+    def test_idle_event_with_empty_queue_no_op(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+            assert mock_send.call_count == 0
+
+    def test_idle_event_with_pending_nudge_dispatches(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        ws.session._nudge_queue.enqueue("idle_children", "your kids", "any")
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+            assert mock_send.call_count == 1
+            kwargs = mock_send.call_args.kwargs
+            # `enqueue=lambda: None` — verify by calling and checking no-op.
+            assert kwargs["enqueue"]() is None
+            # `run` should call deliver_wake_nudge_from_queue when invoked.
+            kwargs["run"]()
+            assert ws.session.deliver_wake_nudge_from_queue_called == 1
+            assert kwargs["thread_name"].startswith("wake-nudge-")
+
+    def test_non_idle_state_ignored(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        ws.session._nudge_queue.enqueue("foo", "bar", "any")
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            for state in (
+                WorkstreamState.RUNNING,
+                WorkstreamState.THINKING,
+                WorkstreamState.ATTENTION,
+                WorkstreamState.ERROR,
+            ):
+                mgr.fire_state(ws.id, state)
+            assert mock_send.call_count == 0
+
+    def test_unknown_ws_ignored(self, fake_mgr_and_ws):
+        mgr, _ws = fake_mgr_and_ws
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state("ghost", WorkstreamState.IDLE)
+            assert mock_send.call_count == 0
+
+    def test_session_none_ignored(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        ws.session = None  # workstream loaded but session not yet built
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+            assert mock_send.call_count == 0
+
+    def test_start_is_idempotent(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        watcher.start()  # no-op
+        ws.session._nudge_queue.enqueue("foo", "bar", "any")
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+            # Only one subscriber was registered despite the double-start.
+            assert mock_send.call_count == 1
+
+    def test_shutdown_unsubscribes(self, fake_mgr_and_ws):
+        mgr, ws = fake_mgr_and_ws
+        ws.session._nudge_queue.enqueue("foo", "bar", "any")
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        watcher.shutdown()
+        with patch("turnstone.core.session_worker.send") as mock_send:
+            mgr.fire_state(ws.id, WorkstreamState.IDLE)
+            assert mock_send.call_count == 0
+
+    def test_shutdown_is_idempotent(self, fake_mgr_and_ws):
+        mgr, _ws = fake_mgr_and_ws
+        watcher = IdleNudgeWatcher(mgr)
+        watcher.start()
+        watcher.shutdown()
+        watcher.shutdown()  # no error

--- a/tests/test_idle_nudge_watcher.py
+++ b/tests/test_idle_nudge_watcher.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from turnstone.core.metacognition import IdleNudgeWatcher
+from turnstone.core.idle_nudge_watcher import IdleNudgeWatcher
 from turnstone.core.nudge_queue import NudgeQueue
 from turnstone.core.workstream import WorkstreamState
 

--- a/tests/test_load_skill.py
+++ b/tests/test_load_skill.py
@@ -420,8 +420,9 @@ class TestSkillCatalogDisclosure:
         session.system_messages = []
         session._agent_system_messages = []
         session.reasoning_effort = "medium"
-        session._pending_tool_advisories = []
-        session._pending_user_advisories = []
+        from turnstone.core.nudge_queue import NudgeQueue
+
+        session._nudge_queue = NudgeQueue()
         session._tool_search = None
         session._mcp_client = None
         session._notify_on_complete = "{}"

--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -4,6 +4,8 @@ from turnstone.core.metacognition import (
     NUDGE_COMPLETION,
     NUDGE_CORRECTION,
     NUDGE_DENIAL,
+    NUDGE_IDLE_CHILDREN_DISPLAY_CAP,
+    NUDGE_IDLE_CHILDREN_WAIT_CAP,
     NUDGE_REPEAT,
     NUDGE_RESUME,
     NUDGE_START,
@@ -11,6 +13,7 @@ from turnstone.core.metacognition import (
     RepeatDetector,
     detect_completion,
     detect_correction,
+    format_idle_children_nudge,
     format_nudge,
     should_nudge,
 )
@@ -376,3 +379,94 @@ class TestRepeatDetector:
     def test_threshold_one_fires_immediately(self):
         det = RepeatDetector(threshold=1)
         assert det.record("a") is True
+
+
+class TestFormatIdleChildrenNudge:
+    """``format_idle_children_nudge`` renders the wake-driven idle_children
+    body — no ``<system-reminder>`` envelope (the side-channel splice
+    wraps it at the wire boundary).
+    """
+
+    def test_empty_list_returns_empty_string(self):
+        # Caller short-circuits on `if not text: return` — so empty
+        # input MUST produce empty output, not a header-only stub.
+        assert format_idle_children_nudge([]) == ""
+
+    def test_single_child_renders(self):
+        children = [{"ws_id": "ws-abc12345", "name": "research-task", "state": "running"}]
+        text = format_idle_children_nudge(children)
+        assert "ws-abc12" in text  # short-id form (8 chars)
+        assert "research-task" in text
+        assert "running" in text
+        assert "wait_for_workstream" in text
+        assert "ws-abc12345" in text  # full id appears in the suggestion's ws_ids list
+
+    def test_under_display_cap_no_overflow_line(self):
+        children = [
+            {"ws_id": f"ws-{i:08d}", "name": f"task-{i}", "state": "running"} for i in range(3)
+        ]
+        text = format_idle_children_nudge(children)
+        assert "...and" not in text
+        for i in range(3):
+            assert f"task-{i}" in text
+
+    def test_over_display_cap_renders_overflow_line(self):
+        n = NUDGE_IDLE_CHILDREN_DISPLAY_CAP + 4
+        children = [
+            {"ws_id": f"ws-{i:08d}", "name": f"task-{i}", "state": "thinking"} for i in range(n)
+        ]
+        text = format_idle_children_nudge(children)
+        assert f"...and {n - NUDGE_IDLE_CHILDREN_DISPLAY_CAP} more" in text
+        # First N children are inline; later ones are folded into "...and N more".
+        for i in range(NUDGE_IDLE_CHILDREN_DISPLAY_CAP):
+            assert f"task-{i}" in text
+        for i in range(NUDGE_IDLE_CHILDREN_DISPLAY_CAP, n):
+            # Names beyond the display cap aren't visible; only counted.
+            assert f"task-{i}" not in text
+
+    def test_over_wait_cap_truncates_suggestion_ws_ids(self):
+        n = NUDGE_IDLE_CHILDREN_WAIT_CAP + 5
+        children = [
+            {"ws_id": f"ws-{i:08d}", "name": f"task-{i}", "state": "running"} for i in range(n)
+        ]
+        text = format_idle_children_nudge(children)
+        # The first WAIT_CAP ids appear in the suggestion; later ones don't.
+        first_in_suggestion = f"ws-{NUDGE_IDLE_CHILDREN_WAIT_CAP - 1:08d}"
+        first_excluded = f"ws-{NUDGE_IDLE_CHILDREN_WAIT_CAP:08d}"
+        assert first_in_suggestion in text
+        assert first_excluded not in text
+
+    def test_unnamed_child_falls_back(self):
+        children = [{"ws_id": "ws-deadbeef", "name": "", "state": "attention"}]
+        text = format_idle_children_nudge(children)
+        assert "(unnamed)" in text
+        assert "attention" in text
+
+    def test_missing_state_renders_question_mark(self):
+        children = [{"ws_id": "ws-12345678", "name": "x"}]
+        text = format_idle_children_nudge(children)
+        # Defensive default — exotic state keys / partial dicts shouldn't crash.
+        assert "?" in text
+
+    def test_no_system_reminder_envelope(self):
+        # The side-channel ``_apply_reminders_for_provider`` splice
+        # adds ``<system-reminder>`` at the wire boundary; the formatter
+        # MUST NOT wrap, or the model would see a doubled envelope.
+        text = format_idle_children_nudge([{"ws_id": "ws-x", "name": "y", "state": "running"}])
+        assert "<system-reminder>" not in text
+        assert "</system-reminder>" not in text
+
+    def test_format_nudge_returns_empty_for_idle_children(self):
+        # The static map's idle_children entry is the empty string by
+        # design — format_idle_children_nudge produces the real body.
+        assert format_nudge("idle_children") == ""
+
+    def test_should_nudge_recognises_idle_children_type(self, monkeypatch):
+        # Type registration in ``_NUDGE_MAP`` makes ``should_nudge``
+        # recognise it for cooldown gating; without the entry it would
+        # silently return False on every call.
+        state: dict[str, float] = {}
+        # message_count > 1 to clear the first-message gate.
+        assert should_nudge("idle_children", state, message_count=4, memory_count=0) is True
+        # Cooldown set on success → second immediate call returns False.
+        assert should_nudge("idle_children", state, message_count=5, memory_count=0) is False

--- a/tests/test_nudge_queue.py
+++ b/tests/test_nudge_queue.py
@@ -126,6 +126,44 @@ class TestPending:
         assert len(q) == 2
 
 
+class TestHasPending:
+    def test_has_pending_returns_false_on_empty_queue(self):
+        q = NudgeQueue()
+        assert q.has_pending({"user", "any"}) is False
+        assert q.has_pending({"tool"}) is False
+
+    def test_has_pending_short_circuits_on_first_match(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "tool")
+        q.enqueue("b", "2", "user")
+        # First entry doesn't match, second does — true after walking 2.
+        assert q.has_pending({"user"}) is True
+
+    def test_has_pending_returns_false_when_no_match(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "tool")
+        q.enqueue("b", "2", "tool")
+        assert q.has_pending({"user", "any"}) is False
+
+    def test_has_pending_matches_any_channel(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "any")
+        # USER_DRAIN-shaped filter pulls "any" entries.
+        assert q.has_pending(USER_DRAIN) is True
+        # TOOL_DRAIN-shaped filter also pulls "any" entries.
+        assert q.has_pending(TOOL_DRAIN) is True
+
+    def test_has_pending_does_not_mutate(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        before = q.pending()
+        q.has_pending({"user"})
+        q.has_pending({"tool"})
+        q.has_pending(set())
+        assert q.pending() == before
+
+
 class TestValidation:
     def test_invalid_channel_raises(self):
         q = NudgeQueue()

--- a/tests/test_nudge_queue.py
+++ b/tests/test_nudge_queue.py
@@ -181,6 +181,87 @@ class TestValidation:
             q.enqueue("a", "1")  # type: ignore[call-arg]
 
 
+class TestValidUntil:
+    """``valid_until`` predicate: drain re-checks freshness; falsy /
+    raising predicates drop the entry without delivery.
+    """
+
+    def test_valid_until_true_delivers(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "any", valid_until=lambda: True)
+        out = q.drain({"any"})
+        assert out == [("a", "1")]
+
+    def test_valid_until_false_drops_silently(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "any", valid_until=lambda: False)
+        out = q.drain({"any"})
+        assert out == []
+        # Already removed from queue (drain partition removes BEFORE
+        # predicate check — falsy doesn't return to queue).
+        assert len(q) == 0
+
+    def test_valid_until_exception_drops_silently(self):
+        q = NudgeQueue()
+
+        def boom() -> bool:
+            raise RuntimeError("predicate crash")
+
+        q.enqueue("a", "1", "any", valid_until=boom)
+        out = q.drain({"any"})
+        assert out == []
+        # Crash-on-predicate is treated as "no longer valid" — drop, not propagate.
+        assert len(q) == 0
+
+    def test_valid_until_evaluated_outside_lock(self):
+        """The predicate may do non-trivial work (e.g. storage I/O)
+        without blocking other producers.  Verify the predicate runs
+        outside the queue's internal lock by enqueueing from inside
+        the predicate — would deadlock if the lock was still held.
+        """
+        q = NudgeQueue()
+
+        def reentrant() -> bool:
+            # If the lock is held during predicate eval, this enqueue
+            # would block forever (RLock would let it through, but the
+            # queue uses a plain Lock).
+            q.enqueue("inner", "from-predicate", "any", valid_until=lambda: True)
+            return True
+
+        q.enqueue("outer", "1", "any", valid_until=reentrant)
+        out = q.drain({"any"})
+        # Outer's predicate ran outside the lock, enqueued "inner";
+        # outer's True return delivered "outer".  "inner" was enqueued
+        # AFTER the partition snapshot, so it stays in the queue.
+        assert out == [("outer", "1")]
+        assert q.pending() == [("inner", "from-predicate")]
+
+    def test_valid_until_only_evaluated_for_matching_channel(self):
+        """A non-matching entry's predicate must NOT fire — that would
+        be wasted work (or worse, a side-effecting predicate would run
+        when the entry is supposed to stay queued).
+        """
+        q = NudgeQueue()
+        calls = []
+
+        def track() -> bool:
+            calls.append(1)
+            return True
+
+        # Tool-channel entry; we drain user-channel.  Predicate must not run.
+        q.enqueue("a", "1", "tool", valid_until=track)
+        q.drain({"user", "any"})
+        assert calls == []
+        # Entry stays queued.
+        assert q.pending("tool") == [("a", "1")]
+
+    def test_valid_until_default_none_always_delivers(self):
+        # No predicate → entry behaves identically to pre-PR-3 entries.
+        q = NudgeQueue()
+        q.enqueue("a", "1", "any")  # no valid_until kwarg
+        assert q.drain({"any"}) == [("a", "1")]
+
+
 class TestConcurrency:
     def test_concurrent_enqueue_drain_no_loss(self):
         """16 producer threads × 64 nudges = 1024 total; one consumer

--- a/tests/test_nudge_queue.py
+++ b/tests/test_nudge_queue.py
@@ -1,0 +1,191 @@
+"""Unit tests for :class:`NudgeQueue`."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from turnstone.core.nudge_queue import TOOL_DRAIN, USER_DRAIN, NudgeQueue
+
+
+class TestEnqueueDrain:
+    def test_enqueue_drain_fifo_order(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        q.enqueue("c", "3", "any")
+        # Drain everything regardless of channel — preserves insertion order.
+        out = q.drain({"user", "tool", "any"})
+        assert out == [("a", "1"), ("b", "2"), ("c", "3")]
+        assert len(q) == 0
+
+    def test_drain_filter_keeps_non_matching(self):
+        q = NudgeQueue()
+        q.enqueue("a", "x", "user")
+        q.enqueue("b", "y", "tool")
+        # Drain only user → tool entry stays.
+        out = q.drain(USER_DRAIN)
+        assert out == [("a", "x")]
+        assert len(q) == 1
+        # Now drain tool — gets the remaining entry.
+        out = q.drain(TOOL_DRAIN)
+        assert out == [("b", "y")]
+        assert len(q) == 0
+
+    def test_any_channel_drains_on_either_seam(self):
+        q = NudgeQueue()
+        q.enqueue("c", "z", "any")
+        # User-seam drain pulls "any".
+        assert q.drain(USER_DRAIN) == [("c", "z")]
+        assert len(q) == 0
+        # Re-enqueue and prove tool-seam also drains "any".
+        q.enqueue("d", "w", "any")
+        assert q.drain(TOOL_DRAIN) == [("d", "w")]
+        assert len(q) == 0
+
+    def test_drain_empty_filter_no_op(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        # Empty filter drains nothing.
+        assert q.drain(set()) == []
+        assert len(q) == 1
+
+    def test_drain_empty_queue_returns_empty_list(self):
+        q = NudgeQueue()
+        # Fast-path: no items → no kept-deque allocation, just `[]`.
+        assert q.drain(USER_DRAIN) == []
+        assert q.drain({"user", "tool", "any"}) == []
+        assert len(q) == 0
+
+    def test_drain_preserves_order_across_partial_drain(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        q.enqueue("c", "3", "user")
+        q.enqueue("d", "4", "tool")
+        # Drain user — should get "a" then "c" in order; "b","d" stay.
+        assert q.drain({"user"}) == [("a", "1"), ("c", "3")]
+        # Tool drain follows insertion order on remaining.
+        assert q.drain({"tool"}) == [("b", "2"), ("d", "4")]
+
+
+class TestLenAndClear:
+    def test_len_does_not_mutate(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        assert len(q) == 1
+        assert len(q) == 1  # second call still 1; not consumed
+        assert q.pending() == [("a", "1")]
+
+    def test_len_empty_is_zero(self):
+        q = NudgeQueue()
+        assert len(q) == 0
+
+    def test_clear_returns_count(self):
+        q = NudgeQueue()
+        assert q.clear() == 0
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        q.enqueue("c", "3", "any")
+        assert q.clear() == 3
+        assert len(q) == 0
+
+    def test_clear_empty_returns_zero(self):
+        q = NudgeQueue()
+        assert q.clear() == 0
+
+
+class TestPending:
+    def test_pending_no_filter_returns_all_in_order(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        q.enqueue("c", "3", "any")
+        # All three, in insertion order, as (nudge_type, text) tuples.
+        assert q.pending() == [("a", "1"), ("b", "2"), ("c", "3")]
+
+    def test_pending_channel_filter(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        q.enqueue("c", "3", "user")
+        q.enqueue("d", "4", "any")
+        assert q.pending("user") == [("a", "1"), ("c", "3")]
+        assert q.pending("tool") == [("b", "2")]
+        assert q.pending("any") == [("d", "4")]
+
+    def test_pending_does_not_mutate(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("b", "2", "tool")
+        # Two pending calls return same content; nothing consumed.
+        first = q.pending()
+        second = q.pending()
+        assert first == second
+        assert len(q) == 2
+
+
+class TestValidation:
+    def test_invalid_channel_raises(self):
+        q = NudgeQueue()
+        with pytest.raises(ValueError, match="channel"):
+            q.enqueue("a", "1", "wake")  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            q.enqueue("b", "2", "")  # type: ignore[arg-type]
+        # Queue is unaffected by the failed enqueues.
+        assert len(q) == 0
+
+    def test_channel_is_required(self):
+        q = NudgeQueue()
+        # No default — caller MUST pick a seam consciously.
+        with pytest.raises(TypeError):
+            q.enqueue("a", "1")  # type: ignore[call-arg]
+
+
+class TestConcurrency:
+    def test_concurrent_enqueue_drain_no_loss(self):
+        """16 producer threads × 64 nudges = 1024 total; one consumer
+        drains in a loop until producers finish + queue empty.  Verify
+        every produced item is observed exactly once.
+        """
+        q = NudgeQueue()
+        producers = 16
+        per_producer = 64
+        total = producers * per_producer
+
+        produced: set[tuple[str, str]] = set()
+        produced_lock = threading.Lock()
+        observed: list[tuple[str, str]] = []
+        observed_lock = threading.Lock()
+        done_event = threading.Event()
+
+        def produce(pid: int) -> None:
+            for i in range(per_producer):
+                key = (f"p{pid}", f"i{i}")
+                with produced_lock:
+                    produced.add(key)
+                q.enqueue(key[0], key[1], "user")
+
+        def consume() -> None:
+            while not done_event.is_set() or len(q) > 0:
+                drained = q.drain({"user"})
+                if drained:
+                    with observed_lock:
+                        observed.extend(drained)
+
+        consumer = threading.Thread(target=consume, daemon=True)
+        consumer.start()
+        threads = [threading.Thread(target=produce, args=(i,)) for i in range(producers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        done_event.set()
+        consumer.join(timeout=5.0)
+        assert not consumer.is_alive(), "consumer didn't finish in time"
+
+        # Every produced key observed; no duplicates.
+        assert set(observed) == produced
+        assert len(observed) == total
+        assert len(q) == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2888,6 +2888,215 @@ class TestUserAdvisoryCancelClear:
         )
 
 
+class TestDeliverWakeNudge:
+    """:meth:`ChatSession.deliver_wake_nudge_from_queue` — synthesizes
+    an empty-user-turn ``send`` so any-channel queued nudges drain via
+    the existing ``_attach_pending_user_reminders`` side-channel and
+    splice into wire content via ``_apply_reminders_for_provider``.
+    """
+
+    def test_no_op_when_queue_has_no_drainable_entries(self, tmp_db):
+        session = _make_session()
+        # Queue has only a tool-channel entry — wake's user-seam drain
+        # won't match.  Bail before synthesizing an empty user turn.
+        session._queue_tool_advisory("tool_error", "stale")
+        before_len = len(session.messages)
+        with patch.object(session, "_create_stream_with_retry") as stream:
+            session.deliver_wake_nudge_from_queue()
+        # No send → no message appended → stream untouched.
+        assert len(session.messages) == before_len
+        assert stream.call_count == 0
+        # Tool entry still queued (would orphan in production today; the
+        # bail just protects against the empty-envelope failure mode).
+        assert _tool_pending(session) == [("tool_error", "stale")]
+        # Wake tag never set.
+        assert session._wake_source_tag == ""
+
+    def test_no_op_when_queue_is_empty(self, tmp_db):
+        session = _make_session()
+        before_len = len(session.messages)
+        with patch.object(session, "_create_stream_with_retry") as stream:
+            session.deliver_wake_nudge_from_queue()
+        assert len(session.messages) == before_len
+        assert stream.call_count == 0
+        assert session._wake_source_tag == ""
+
+    def test_drains_any_channel_onto_synthetic_empty_user_turn(self, tmp_db):
+        """Any-channel entries (the future ``idle_children`` shape) drain
+        at the synthesized user seam.  The empty content + spliced
+        ``_reminders`` is what reaches the provider via
+        ``_apply_reminders_for_provider``.
+        """
+        session = _make_session()
+        session._title_generated = True  # suppress auto-title thread
+        session._nudge_queue.enqueue("idle_children", "your kids", "any")
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        # Queue drained.
+        assert _user_pending(session) == []
+        # Empty-content user message was appended with the reminder side-channel.
+        user_msgs = [m for m in session.messages if m.get("role") == "user"]
+        assert user_msgs, "wake should append a synthetic user message"
+        wake_msg = user_msgs[-1]
+        assert wake_msg["content"] == ""
+        assert wake_msg["_reminders"] == [{"type": "idle_children", "text": "your kids"}]
+
+    def test_marks_source_tag_on_synthesized_user_msg(self, tmp_db):
+        session = _make_session()
+        session._title_generated = True
+        session._queue_user_advisory("denial", "leftover")
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        user_msgs = [m for m in session.messages if m.get("role") == "user"]
+        wake_msg = user_msgs[-1]
+        assert wake_msg.get("_source") == "system_nudge"
+
+    def test_clears_wake_tag_after_success(self, tmp_db):
+        session = _make_session()
+        session._title_generated = True
+        session._queue_user_advisory("denial", "x")
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        # `finally` block resets the tag; production code outside the
+        # wake send sees the field empty and behaves normally.
+        assert session._wake_source_tag == ""
+
+    def test_skips_metacog_check_on_synthetic_send(self, tmp_db):
+        """Wake-channel content with regex-matching trigger words must
+        NOT re-fire correction / completion nudges on top of the
+        envelope.  The ``_wake_source_tag`` guard at the top of
+        ``_check_metacognitive_nudge`` covers this; verify by enqueuing
+        text that *would* trigger ``detect_correction`` (contains
+        "don't") and asserting no fresh ``correction`` entry lands in
+        the queue post-wake.
+        """
+        session = _make_session()
+        session._title_generated = True
+        # NUDGE_DENIAL contains "don't modify that file" — would match
+        # the strong-correction `\bdon'?t\b` pattern if re-detected.
+        session._queue_user_advisory("denial", "don't do that next time")
+        # Force enough memory + message context that should_nudge would
+        # otherwise fire a fresh correction nudge.
+        session.messages.append({"role": "user", "content": "earlier"})
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=10),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        # No fresh correction entry was enqueued during the wake send.
+        # (The original `denial` entry was drained as the wake's
+        # _reminders payload, not re-queued.)
+        assert all(t != "correction" for t, _ in _user_pending(session))
+
+    def test_dispatch_pending_watch_clears_wake_tag_during_recursive_send(self, tmp_db):
+        """Watch turns chained off a wake send via ``_dispatch_pending_watch``
+        must run as normal user turns — not inherit the wake's
+        ``_wake_source_tag``.
+
+        Without this, a watch chained off a wake send would (a) skip
+        ``_check_metacognitive_nudge`` on the watch's actual user
+        text, (b) stamp ``_source = "system_nudge"`` on the watch's
+        user message, and (c) suppress denial / repeat / tool_error
+        nudges during the watch's tool dispatch.  All wrong — the
+        watch is a separate event.
+        """
+        session = _make_session()
+        session._wake_source_tag = "system_nudge"  # simulate wake context
+        session._watch_pending.put_nowait({"message": "watch fired"})
+        observed_tag: list[str] = []
+
+        original_send = session.send
+
+        def capture_tag_during_send(msg, *args, **kwargs):
+            observed_tag.append(session._wake_source_tag)
+            # Don't actually run the chat loop — just capture.
+
+        with patch.object(session, "send", side_effect=capture_tag_during_send):
+            session._dispatch_pending_watch(depth=0)
+
+        # The recursive send saw an empty tag, not "system_nudge".
+        assert observed_tag == [""]
+        # Tag is restored after the recursive send completes.
+        assert session._wake_source_tag == "system_nudge"
+        # Cleanup so the test doesn't bleed state into subsequent tests.
+        _ = original_send
+
+    def test_exception_marks_appended_reminders_delivered(self, tmp_db):
+        """Post-retry stream failure: the just-appended user message's
+        ``_reminders`` must be flagged delivered so the next real user
+        turn doesn't re-render the same envelope.
+        """
+        session = _make_session()
+        session._queue_user_advisory("denial", "leftover")
+        with (
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=RuntimeError("boom"),
+            ),
+            contextlib.suppress(RuntimeError),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        # Synthetic user message landed; reminders flagged delivered so
+        # _apply_reminders_for_provider's next pass skips them.
+        user_msgs = [m for m in session.messages if m.get("role") == "user"]
+        wake_msg = user_msgs[-1]
+        assert wake_msg.get("_reminders") is not None
+        assert wake_msg.get("_reminders_delivered") is True
+        # Wake tag cleared even on exception (finally block).
+        assert session._wake_source_tag == ""
+
+
 class TestReminderSidechannelIsolation:
     """The side-channel design's load-bearing guarantee: any reader of
     ``self.messages`` that goes through ``content`` cannot see reminders.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3070,6 +3070,55 @@ class TestDeliverWakeNudge:
         # Cleanup so the test doesn't bleed state into subsequent tests.
         _ = original_send
 
+    def test_flushed_user_msg_during_wake_does_not_inherit_source_tag(self, tmp_db):
+        """A real user message queued via ``queue_message`` while a wake
+        send is in flight, then drained by ``_flush_queued_messages`` at
+        the IDLE seam, must NOT be stamped ``_source = "system_nudge"``.
+
+        Pre-fix bug: ``_append_user_turn`` stamped ``_source`` whenever
+        ``_wake_source_tag`` was set, but the tag stays set throughout
+        the wake's chat loop — including the moment ``_flush_queued_messages``
+        funnels a real user-queued message back through
+        ``_append_user_turn``.  Result: real user input mis-attributed
+        to the system in audit / replay metadata.
+
+        Fix: ``_append_user_turn`` only stamps when ``from_wake=True``
+        is passed explicitly (the wake's synthesized first turn);
+        ``_flush_queued_messages``'s default-False call leaves the tag
+        unset on the flushed message.
+        """
+        session = _make_session()
+        session._title_generated = True
+        session._nudge_queue.enqueue("idle_children", "kids", "any")
+        # Queue a real user message that will be flushed at the IDLE seam.
+        session.queue_message("real user input", queue_msg_id="q-1")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.deliver_wake_nudge_from_queue()
+
+        user_msgs = [m for m in session.messages if m.get("role") == "user"]
+        # Two user messages: the wake's synthetic empty turn (with
+        # _source) AND the flushed real user input (without _source).
+        wake_msg = next(m for m in user_msgs if m.get("content") == "")
+        flushed_msg = next(
+            m for m in user_msgs if m.get("content") and "real user input" in m["content"]
+        )
+        assert wake_msg.get("_source") == "system_nudge"
+        assert flushed_msg.get("_source") is None
+
     def test_exception_marks_appended_reminders_delivered(self, tmp_db):
         """Post-retry stream failure: the just-appended user message's
         ``_reminders`` must be flagged delivered so the next real user

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -86,6 +86,21 @@ def _make_session(
     return ChatSession(**defaults)
 
 
+def _user_pending(session) -> list[tuple[str, str]]:
+    """Return user-channel queued nudges as ``(type, text)`` tuples.
+
+    Replaces direct introspection of the legacy
+    ``_pending_user_advisories`` list with a non-mutating
+    :meth:`NudgeQueue.pending` lookup filtered to the user channel.
+    """
+    return session._nudge_queue.pending("user")
+
+
+def _tool_pending(session) -> list[tuple[str, str]]:
+    """Return tool-channel queued nudges as ``(type, text)`` tuples."""
+    return session._nudge_queue.pending("tool")
+
+
 def _run_exec_search(session, capture_return):
     """Patch ``_search_capture`` to ``capture_return`` and run ``_exec_search``.
 
@@ -1918,13 +1933,13 @@ class TestMetacognitiveBuffers:
 
     def test_pending_buffers_initialised_empty(self, tmp_db):
         session = _make_session()
-        assert session._pending_user_advisories == []
-        assert session._pending_tool_advisories == []
+        assert _user_pending(session) == []
+        assert _tool_pending(session) == []
 
     def test_queue_user_advisory_stashes(self, tmp_db):
         session = _make_session()
         session._queue_user_advisory("correction", "watch your step")
-        assert session._pending_user_advisories == [("correction", "watch your step")]
+        assert _user_pending(session) == [("correction", "watch your step")]
 
     def test_queue_tool_advisory_stashes_tuple(self, tmp_db):
         session = _make_session()
@@ -1933,7 +1948,7 @@ class TestMetacognitiveBuffers:
         # constructs MetacognitiveAdvisory at drain time inside
         # _collect_advisories so wrap_tool_result sees a proper advisory
         # while readers of the buffer don't have to unbox.
-        assert session._pending_tool_advisories == [("tool_error", "check memories")]
+        assert _tool_pending(session) == [("tool_error", "check memories")]
 
     def test_attach_writes_reminders_sidechannel_for_string_content(self, tmp_db):
         session = _make_session()
@@ -1948,7 +1963,7 @@ class TestMetacognitiveBuffers:
         assert msg["content"] == "hello there"
         assert "<system-reminder>" not in msg["content"]
         assert msg["_reminders"] == [{"type": "correction", "text": "ALERT_TEXT"}]
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_attach_writes_reminders_sidechannel_for_list_content(self, tmp_db):
         session = _make_session()
@@ -1990,7 +2005,7 @@ class TestMetacognitiveBuffers:
             {"type": "correction", "text": "SECOND"},
         ]
         # Both nudges drained.
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_init_system_messages_no_longer_renders_nudges(self, tmp_db):
         """System message must not include nudge text even with both buffers populated."""
@@ -2003,8 +2018,8 @@ class TestMetacognitiveBuffers:
         assert "TOOL_NUDGE_MARK" not in joined
         # And the buffers are not drained by system rebuild — they wait
         # for their respective drain points (next user turn / tool batch).
-        assert session._pending_user_advisories == [("correction", "USER_NUDGE_MARK")]
-        assert session._pending_tool_advisories == [("tool_error", "TOOL_NUDGE_MARK")]
+        assert _user_pending(session) == [("correction", "USER_NUDGE_MARK")]
+        assert _tool_pending(session) == [("tool_error", "TOOL_NUDGE_MARK")]
 
     def test_collect_advisories_drains_tool_buffer_on_last_result(self, tmp_db):
         """Tool-channel metacog reminders no longer ride the persistent
@@ -2024,7 +2039,7 @@ class TestMetacognitiveBuffers:
         assert persistent == []
         assert metacog == [{"type": "tool_error", "text": "ALERT"}]
         # Buffer drained.
-        assert session._pending_tool_advisories == []
+        assert _tool_pending(session) == []
 
     def test_collect_advisories_holds_tool_buffer_until_last_result(self, tmp_db):
         session = _make_session()
@@ -2035,7 +2050,7 @@ class TestMetacognitiveBuffers:
         # Not yet drained — only fires on the last result.
         assert persistent == []
         assert metacog == []
-        assert len(session._pending_tool_advisories) == 1
+        assert len(_tool_pending(session)) == 1
 
     def test_collect_advisories_drains_text_queued_messages_to_persistent(self, tmp_db):
         """Text-only queued user messages drain into the ``persistent``
@@ -2108,7 +2123,7 @@ class TestMetacognitiveBuffers:
             "saved memories from prior sessions" in r.get("text", "") for r in reminders
         )  # NUDGE_START body
         # And the buffer drained.
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_attach_does_not_emit_visibility_ping(self, tmp_db):
         """The themed reminder bubble (via ``on_user_reminder``) is now
@@ -2170,7 +2185,7 @@ class TestMetacognitiveBuffers:
         # Side-channel write completed despite the hook raising.
         assert msg["_reminders"] == [{"type": "correction", "text": "watch out"}]
         # Buffer drained.
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_cancel_handler_clears_tool_advisory_buffer(self, tmp_db):
         """A tool_error/repeat advisory queued before a cancel must not
@@ -2190,7 +2205,7 @@ class TestMetacognitiveBuffers:
             session.send("user input")
 
         # Buffer cleared by the cancel handler — no leak into next send().
-        assert session._pending_tool_advisories == []
+        assert _tool_pending(session) == []
 
 
 class TestApplyPostExecuteAdvisories:
@@ -2229,10 +2244,10 @@ class TestApplyPostExecuteAdvisories:
             if i < 2:
                 # Streak below threshold — no inline warning, no advisory yet.
                 assert results[0][1] == "file contents"
-                assert all(t != "repeat" for t, _ in session._pending_tool_advisories)
+                assert all(t != "repeat" for t, _ in _tool_pending(session))
             else:
                 assert "⚠ Warning: this is an identical repeat" in results[0][1]
-        assert any(t == "repeat" for t, _ in session._pending_tool_advisories)
+        assert any(t == "repeat" for t, _ in _tool_pending(session))
 
     def test_errored_calls_count_toward_streak(self, tmp_db):
         """Regression: when metacog was split out of the system message,
@@ -2249,7 +2264,7 @@ class TestApplyPostExecuteAdvisories:
                     [self._tc(tc_id, "bash", '{"command": "ls /missing"}')],
                     [(tc_id, "ls: cannot access /missing")],
                 )
-        assert any(t == "repeat" for t, _ in session._pending_tool_advisories)
+        assert any(t == "repeat" for t, _ in _tool_pending(session))
 
     def test_intervening_different_sig_resets_streak(self, tmp_db):
         """Streak semantics: [A, A, B, A] does NOT fire — B breaks the run."""
@@ -2268,7 +2283,7 @@ class TestApplyPostExecuteAdvisories:
                     [self._tc(tc_id, name, args)],
                     [(tc_id, "ok")],
                 )
-        assert all(t != "repeat" for t, _ in session._pending_tool_advisories)
+        assert all(t != "repeat" for t, _ in _tool_pending(session))
 
     def test_intervening_different_call_resets_streak(self, tmp_db):
         """Streak detection is consecutive-only: any intervening call
@@ -2298,7 +2313,7 @@ class TestApplyPostExecuteAdvisories:
                     [self._tc(tc_id, "read_file", '{"path": "x"}')],
                     [(tc_id, "contents")],
                 )
-        assert all(t != "repeat" for t, _ in session._pending_tool_advisories)
+        assert all(t != "repeat" for t, _ in _tool_pending(session))
 
     def test_sequential_bash_same_command_fires_repeat(self, tmp_db):
         """Regression: small local models flaking out and looping on the
@@ -2322,7 +2337,7 @@ class TestApplyPostExecuteAdvisories:
                     [self._tc(tc_id, "bash", '{"command": "echo test"}')],
                     [(tc_id, "test\n")],
                 )
-        assert any(t == "repeat" for t, _ in session._pending_tool_advisories)
+        assert any(t == "repeat" for t, _ in _tool_pending(session))
 
     def test_sequential_bash_failures_fire_repeat(self, tmp_db):
         """Same shape as the success case, but with each call setting
@@ -2340,7 +2355,7 @@ class TestApplyPostExecuteAdvisories:
                     [self._tc(tc_id, "bash", '{"command": "ls /missing"}')],
                     [(tc_id, "ls: cannot access /missing")],
                 )
-        assert any(t == "repeat" for t, _ in session._pending_tool_advisories)
+        assert any(t == "repeat" for t, _ in _tool_pending(session))
 
     def test_json_output_tracked_but_not_inline_warned(self, tmp_db):
         """MCP-shape JSON outputs are tracked toward the streak but the
@@ -2359,7 +2374,7 @@ class TestApplyPostExecuteAdvisories:
                 if i == 2:
                     # JSON content untouched even though streak fired.
                     assert results[0][1] == json_out
-        assert any(t == "repeat" for t, _ in session._pending_tool_advisories)
+        assert any(t == "repeat" for t, _ in _tool_pending(session))
 
     def test_tool_error_nudge_fires_when_memories_exist(self, tmp_db):
         session = _make_session()
@@ -2371,7 +2386,7 @@ class TestApplyPostExecuteAdvisories:
                 [self._tc(tc_id, "bash", '{"command": "false"}')],
                 [(tc_id, "command failed")],
             )
-        assert any(t == "tool_error" for t, _ in session._pending_tool_advisories)
+        assert any(t == "tool_error" for t, _ in _tool_pending(session))
 
     def test_tool_error_nudge_skipped_with_zero_memories(self, tmp_db):
         """Without memories the tool_error nudge has nothing useful to point
@@ -2385,7 +2400,7 @@ class TestApplyPostExecuteAdvisories:
                 [self._tc(tc_id, "bash", '{"command": "false"}')],
                 [(tc_id, "command failed")],
             )
-        assert all(t != "tool_error" for t, _ in session._pending_tool_advisories)
+        assert all(t != "tool_error" for t, _ in _tool_pending(session))
 
     def test_no_legacy_repeat_info_line_on_streak_fire(self, tmp_db):
         """The legacy gray ``[repeat: tool() called with same arguments]``
@@ -2752,10 +2767,10 @@ class TestUpdateTokenTableMsgsParam:
 
 class TestUserAdvisoryCancelClear:
     """Pre-existing bug surfaced by the side-channel audit — cancel
-    handlers cleared ``_pending_tool_advisories`` but not the user-channel
-    buffer, so a queued user-channel nudge from a cancelled batch leaked
-    into the next user turn.  Stage 1 fix lives at the three cancel
-    branches inside ``send``.
+    handlers cleared the tool channel but not the user-channel buffer,
+    so a queued user-channel nudge from a cancelled batch leaked into
+    the next user turn.  Stage 1 fix lives at the three cancel branches
+    inside ``send`` (now via the unified :class:`NudgeQueue.clear`).
     """
 
     def test_generation_cancelled_clears_user_advisory_buffer(self, tmp_db):
@@ -2772,7 +2787,7 @@ class TestUserAdvisoryCancelClear:
             ),
         ):
             session.send("user input")
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_keyboard_interrupt_clears_user_advisory_buffer(self, tmp_db):
         session = _make_session()
@@ -2787,7 +2802,7 @@ class TestUserAdvisoryCancelClear:
             contextlib.suppress(KeyboardInterrupt),
         ):
             session.send("user input")
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_unexpected_exception_clears_user_advisory_buffer(self, tmp_db):
         session = _make_session()
@@ -2802,7 +2817,7 @@ class TestUserAdvisoryCancelClear:
             contextlib.suppress(RuntimeError),
         ):
             session.send("user input")
-        assert session._pending_user_advisories == []
+        assert _user_pending(session) == []
 
     def test_send_continues_when_messages_queued_during_streaming(self, tmp_db):
         """A user message queued while the assistant is streaming a

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -163,6 +163,28 @@ class FakeAdapter:
             return [e for e in self.events if e.kind == kind]
 
 
+class _FakeRowMapping:
+    """SQLAlchemy-Row-like wrapper exposing ``_mapping`` over a ``_Row``.
+
+    The real backends return ``Row`` objects with a ``_mapping`` attribute;
+    consumers (e.g. ``CoordinatorIdleObserver._active_children``) prefer
+    ``row._mapping[<col>]`` access.  This shim mirrors that contract so
+    fakes are interchangeable with real Rows in tests.
+    """
+
+    def __init__(self, row: _Row) -> None:
+        self._mapping = {
+            "ws_id": row.ws_id,
+            "user_id": row.user_id,
+            "name": row.name,
+            "kind": row.kind,
+            "state": row.state,
+            "parent_ws_id": row.parent_ws_id,
+            "updated": row.updated,
+            "node_id": row.node_id,
+        }
+
+
 @dataclass
 class _Row:
     ws_id: str
@@ -299,6 +321,47 @@ class FakeStorage:
                 "state": row.state,
                 "parent_ws_id": row.parent_ws_id,
             }
+
+    def list_workstreams(
+        self,
+        node_id: str | None = None,
+        limit: int = 100,
+        *,
+        parent_ws_id: str | None = None,
+        kind: WorkstreamKind | str | None = None,
+        user_id: str | None = None,
+    ) -> list[Any]:
+        kind_str = kind.value if isinstance(kind, WorkstreamKind) else kind
+        with self.lock:
+            matched: list[_FakeRowMapping] = []
+            for row in self.rows.values():
+                if parent_ws_id is not None and row.parent_ws_id != parent_ws_id:
+                    continue
+                if kind_str is not None and row.kind != kind_str:
+                    continue
+                if user_id is not None and row.user_id != user_id:
+                    continue
+                matched.append(_FakeRowMapping(row))
+            # Order by updated DESC so the consumer's LIMIT semantics match
+            # production (storage backends order this way).
+            matched.sort(key=lambda r: r._mapping["updated"], reverse=True)
+            return matched[:limit]
+
+    def count_workstreams_by_state(
+        self,
+        *,
+        parent_ws_id: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        with self.lock:
+            for row in self.rows.values():
+                if parent_ws_id is not None and row.parent_ws_id != parent_ws_id:
+                    continue
+                if user_id is not None and row.user_id != user_id:
+                    continue
+                counts[row.state] = counts.get(row.state, 0) + 1
+        return counts
 
     def delete_workstream(self, ws_id: str) -> None:
         with self.lock:

--- a/turnstone/console/coordinator_idle_observer.py
+++ b/turnstone/console/coordinator_idle_observer.py
@@ -1,0 +1,289 @@
+"""Observer that nudges idle coordinators with active children.
+
+Subscribes to a coordinator-side :class:`SessionManager`'s state events.
+When a coord transitions to :class:`WorkstreamState.IDLE` while still
+having active interactive children, enqueues an ``idle_children`` nudge
+on the coord's :class:`NudgeQueue`.  The
+:class:`turnstone.core.metacognition.IdleNudgeWatcher` (registered
+*after* this observer in the lifespan, so subscriber-order has the
+observer fire first on the same IDLE event) then peeks the queue and
+dispatches the wake send.
+
+Gates (in order):
+
+1. **Coordinator-only.**  Skip non-coord workstreams.  Watcher is
+   kind-agnostic; this observer is the kind-aware piece.
+2. **Skip if last assistant turn used ``wait_for_workstream``.** The
+   coord is already using the right tool — don't pile on with a nudge
+   suggesting the same tool.
+3. **Per-(ws_id, nudge_type) hard cap** (default 3).  Resets when the
+   ws leaves IDLE for any non-wake-driven reason (tracked by
+   :class:`ChatSession._wake_source_tag` — see below).
+4. **Active children query.**  ``storage.list_workstreams`` filtered to
+   interactive kind under the coord's user, with state in
+   :data:`_ACTIVE_CHILD_STATES`.  Empty result → no nudge.
+5. **Cooldown** via :func:`should_nudge` — default 300s per nudge type.
+
+The enqueue passes ``valid_until`` that re-queries active children at
+drain time; if every child finished while the queue waited, the entry
+drops without delivering a stale snapshot.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from typing import TYPE_CHECKING, Any
+
+from turnstone.core.log import get_logger
+from turnstone.core.metacognition import (
+    format_idle_children_nudge,
+    should_nudge,
+)
+from turnstone.core.workstream import WorkstreamKind, WorkstreamState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from turnstone.core.session_manager import SessionManager
+    from turnstone.core.storage._protocol import StorageBackend
+    from turnstone.core.workstream import Workstream
+
+log = get_logger(__name__)
+
+# Active = the model can act on the child (it's still working,
+# streaming, or waiting on user attention).  Excludes "idle" (the
+# child is now waiting and can't be unblocked by the coord), "closed"
+# (gone), "deleted" (gone), and "error" (the model can't unblock an
+# errored child without operator intervention; cooldown handles repeat
+# fires for stuck-error children).
+_ACTIVE_CHILD_STATES: frozenset[str] = frozenset(
+    {
+        WorkstreamState.THINKING.value,
+        WorkstreamState.RUNNING.value,
+        WorkstreamState.ATTENTION.value,
+    }
+)
+
+# Hard cap on per-session ``idle_children`` fires.  Even with the
+# cooldown and wait-tool skip gate, a coord that ignores every nudge
+# shouldn't be hammered indefinitely.  Resets when the ws leaves IDLE
+# for a non-wake reason (real user input).
+_HARD_CAP_PER_SESSION = 3
+
+# Soft cap on the snapshot query.  Higher than ``WAIT_MAX_WS_IDS`` so
+# the SQL ``LIMIT`` (applied before the Python state filter) doesn't
+# clip genuinely-active children whose ``updated`` timestamp is older
+# than recently-closed siblings.  Realistic coord histories are far
+# smaller than this; if a coord ever exceeds it, the formatter still
+# truncates to ``WAIT_MAX_WS_IDS`` for the model-facing suggestion.
+_ACTIVE_CHILDREN_QUERY_LIMIT = 200
+
+
+class CoordinatorIdleObserver:
+    """Subscribe to a coord SessionManager's IDLE events and enqueue
+    ``idle_children`` nudges when active children remain.
+    """
+
+    def __init__(self, manager: SessionManager, storage: StorageBackend) -> None:
+        self._manager = manager
+        self._storage = storage
+        self._callback: Callable[[str, WorkstreamState], None] | None = None
+        # Per-(ws_id, nudge_type) fire counts.  Lock protects against
+        # race with the leave-IDLE reset path running on a different
+        # thread (state events fire on the calling thread of
+        # ``set_state`` — currently always the worker thread that did
+        # the transition, but the lock keeps the contract robust).
+        self._fire_counts: dict[tuple[str, str], int] = {}
+        self._fire_counts_lock = threading.Lock()
+
+    def start(self) -> None:
+        """Idempotent — registering twice is a no-op."""
+        if self._callback is not None:
+            return
+
+        def _on_state(ws_id: str, state: WorkstreamState) -> None:
+            if state is not WorkstreamState.IDLE:
+                # Reset hard-cap when leaving IDLE for a *real* reason
+                # (not a wake-driven exit).  Skip the manager-lock /
+                # session-attribute walk entirely when no caps are
+                # accumulated for this ws — the common case for the
+                # vast majority of state transitions.
+                with self._fire_counts_lock:
+                    has_caps = any(k[0] == ws_id for k in self._fire_counts)
+                if not has_caps:
+                    return
+                ws = self._manager.get(ws_id)
+                if ws is None or ws.session is None:
+                    return
+                # ``_wake_source_tag`` is set on the session iff a
+                # wake send is in flight; if set, leaving IDLE is the
+                # wake's own IDLE→THINKING→RUNNING transition and the
+                # cap should NOT reset.  If unset, the user / a real
+                # producer drove the coord forward and the cap should
+                # clear so the next genuine idle bracket is fresh.
+                if not ws.session._wake_source_tag:
+                    self._reset_caps_for(ws_id)
+                return
+
+            # state == IDLE branch.
+            try:
+                self._maybe_enqueue(ws_id)
+            except Exception:
+                log.exception("coord_idle_observer.maybe_enqueue_failed ws=%s", ws_id[:8])
+
+        self._callback = _on_state
+        self._manager.subscribe_to_state(_on_state)
+
+    def shutdown(self) -> None:
+        """Unsubscribe; idempotent."""
+        cb = self._callback
+        if cb is None:
+            return
+        with contextlib.suppress(Exception):
+            self._manager.unsubscribe_from_state(cb)
+        self._callback = None
+
+    def _maybe_enqueue(self, ws_id: str) -> None:
+        ws = self._manager.get(ws_id)
+        if ws is None or ws.session is None:
+            return
+        if ws.kind is not WorkstreamKind.COORDINATOR:
+            return
+        session = ws.session
+
+        # Gate: skip if the coord's last assistant turn already used
+        # ``wait_for_workstream``.  Don't nudge toward a tool the
+        # model is already using.
+        if self._last_assistant_used_wait(session):
+            return
+
+        # Gate: per-session hard cap on idle_children fires.
+        key = (ws_id, "idle_children")
+        with self._fire_counts_lock:
+            if self._fire_counts.get(key, 0) >= _HARD_CAP_PER_SESSION:
+                return
+
+        # Gate: query active children.  Empty → nothing to nudge about.
+        active = self._active_children(ws)
+        if not active:
+            return
+
+        # Gate: cooldown via should_nudge (handles 300s rate-limit + the
+        # message-count > 1 / memory-count > 0 sanity checks).
+        cooldown_secs = getattr(session._mem_cfg, "nudge_cooldown", 300)
+        if not should_nudge(
+            "idle_children",
+            session._metacog_state,
+            message_count=len(session.messages),
+            memory_count=session._visible_memory_count(),
+            cooldown_secs=cooldown_secs,
+        ):
+            return
+
+        text = format_idle_children_nudge(active)
+        if not text:  # belt-and-braces: formatter empty-input guard
+            return
+
+        # Bind ws.id + user_id by closure so the predicate captures the
+        # workstream identity (not the live ``ws`` reference, which
+        # could mutate).  The predicate runs at drain time outside the
+        # queue lock.  Use ``count_workstreams_by_state`` rather than
+        # ``list_workstreams`` since the predicate only needs a
+        # boolean — saves a row fetch on the chat-loop user-attach
+        # path.
+        bound_ws_id = ws.id
+        bound_user_id = ws.user_id
+
+        def _still_has_active_children() -> bool:
+            try:
+                counts = self._storage.count_workstreams_by_state(
+                    parent_ws_id=bound_ws_id,
+                    user_id=bound_user_id,
+                )
+            except Exception:
+                log.debug(
+                    "coord_idle_observer.predicate_count_failed ws=%s",
+                    bound_ws_id[:8],
+                    exc_info=True,
+                )
+                return False
+            return any(counts.get(s, 0) > 0 for s in _ACTIVE_CHILD_STATES)
+
+        session._nudge_queue.enqueue(
+            "idle_children",
+            text,
+            "any",
+            valid_until=_still_has_active_children,
+        )
+        with self._fire_counts_lock:
+            self._fire_counts[key] = self._fire_counts.get(key, 0) + 1
+
+        log.info(
+            "coord_idle_observer.enqueued ws=%s active_children=%d",
+            ws_id[:8],
+            len(active),
+        )
+
+    def _last_assistant_used_wait(self, session: Any) -> bool:
+        """Walk back to the most recent assistant turn; if it issued a
+        ``wait_for_workstream`` tool call, return ``True``.
+        """
+        for msg in reversed(session.messages):
+            if msg.get("role") != "assistant":
+                continue
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function", {}) or {}
+                if fn.get("name") == "wait_for_workstream":
+                    return True
+            return False  # found the most recent assistant turn — done
+        return False
+
+    def _active_children(self, ws: Workstream) -> list[dict[str, str]]:
+        """Query storage for the coord's interactive children whose state
+        is in :data:`_ACTIVE_CHILD_STATES`.  Returns row-mapping shape.
+
+        ``list_workstreams`` orders by ``updated DESC`` and applies its
+        ``LIMIT`` in SQL before any state filter, so a coord with many
+        recently-closed children could clip out genuinely-active rows
+        whose ``updated`` timestamp is older.  We bump the limit well
+        above ``NUDGE_IDLE_CHILDREN_WAIT_CAP`` to absorb that —
+        realistic coord histories are far smaller than the bumped
+        limit.  Pushing the state filter into SQL would be the
+        structural fix, but that requires a storage-protocol change;
+        flagged as a follow-up.
+        """
+        try:
+            rows = self._storage.list_workstreams(
+                limit=_ACTIVE_CHILDREN_QUERY_LIMIT,
+                parent_ws_id=ws.id,
+                kind=WorkstreamKind.INTERACTIVE,
+                user_id=ws.user_id,
+            )
+        except Exception:
+            log.debug("coord_idle_observer.list_failed ws=%s", ws.id[:8], exc_info=True)
+            return []
+
+        out: list[dict[str, str]] = []
+        for row in rows:
+            mapping = getattr(row, "_mapping", row)
+            state = mapping["state"]
+            if state not in _ACTIVE_CHILD_STATES:
+                continue
+            out.append(
+                {
+                    "ws_id": mapping["ws_id"],
+                    "name": mapping["name"] or "",
+                    "state": state,
+                }
+            )
+        return out
+
+    def _reset_caps_for(self, ws_id: str) -> None:
+        """Drop every per-(ws_id, *) cap counter on a real (non-wake)
+        leave-IDLE event — the next genuine idle bracket starts fresh.
+        """
+        with self._fire_counts_lock:
+            for key in list(self._fire_counts.keys()):
+                if key[0] == ws_id:
+                    del self._fire_counts[key]

--- a/turnstone/console/coordinator_idle_observer.py
+++ b/turnstone/console/coordinator_idle_observer.py
@@ -33,10 +33,11 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from turnstone.core.log import get_logger
 from turnstone.core.metacognition import (
+    _cooldown_allows,
     format_idle_children_nudge,
     should_nudge,
 )
@@ -45,6 +46,7 @@ from turnstone.core.workstream import WorkstreamKind, WorkstreamState
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from turnstone.core.session import ChatSession
     from turnstone.core.session_manager import SessionManager
     from turnstone.core.storage._protocol import StorageBackend
     from turnstone.core.workstream import Workstream
@@ -89,12 +91,16 @@ class CoordinatorIdleObserver:
         self._manager = manager
         self._storage = storage
         self._callback: Callable[[str, WorkstreamState], None] | None = None
-        # Per-(ws_id, nudge_type) fire counts.  Lock protects against
-        # race with the leave-IDLE reset path running on a different
-        # thread (state events fire on the calling thread of
-        # ``set_state`` — currently always the worker thread that did
-        # the transition, but the lock keeps the contract robust).
-        self._fire_counts: dict[tuple[str, str], int] = {}
+        # Per-ws fire counts keyed by ``ws_id`` → ``{nudge_type: count}``.
+        # Two-level dict makes the "any caps for this ws?" check at
+        # leave-IDLE an O(1) ``ws_id in self._fire_counts`` lookup
+        # instead of an O(N_caps) scan over a flat tuple-keyed map.
+        # Lock protects against race with the leave-IDLE reset path
+        # running on a different thread (state events fire on the
+        # calling thread of ``set_state`` — currently always the
+        # worker thread that did the transition, but the lock keeps
+        # the contract robust).
+        self._fire_counts: dict[str, dict[str, int]] = {}
         self._fire_counts_lock = threading.Lock()
 
     def start(self) -> None:
@@ -110,7 +116,7 @@ class CoordinatorIdleObserver:
                 # accumulated for this ws — the common case for the
                 # vast majority of state transitions.
                 with self._fire_counts_lock:
-                    has_caps = any(k[0] == ws_id for k in self._fire_counts)
+                    has_caps = ws_id in self._fire_counts
                 if not has_caps:
                     return
                 ws = self._manager.get(ws_id)
@@ -152,26 +158,39 @@ class CoordinatorIdleObserver:
             return
         session = ws.session
 
+        # Gate ordering matters: cheap checks first, expensive checks
+        # last.  The cooldown peek + per-session hard cap are
+        # microsecond-cheap dict lookups; ``_last_assistant_used_wait``
+        # walks ``session.messages`` reversed; ``_active_children`` and
+        # ``_visible_memory_count`` round-trip to storage.  With a 300s
+        # cooldown most idle events will short-circuit at the peek.
+        cooldown_secs = getattr(session._mem_cfg, "nudge_cooldown", 300)
+        if not _cooldown_allows(
+            "idle_children", session._metacog_state, cooldown_secs=cooldown_secs
+        ):
+            return
+
+        # Gate: per-session hard cap on idle_children fires.
+        with self._fire_counts_lock:
+            ws_caps = self._fire_counts.get(ws_id, {})
+            if ws_caps.get("idle_children", 0) >= _HARD_CAP_PER_SESSION:
+                return
+
         # Gate: skip if the coord's last assistant turn already used
         # ``wait_for_workstream``.  Don't nudge toward a tool the
         # model is already using.
         if self._last_assistant_used_wait(session):
             return
 
-        # Gate: per-session hard cap on idle_children fires.
-        key = (ws_id, "idle_children")
-        with self._fire_counts_lock:
-            if self._fire_counts.get(key, 0) >= _HARD_CAP_PER_SESSION:
-                return
-
         # Gate: query active children.  Empty → nothing to nudge about.
         active = self._active_children(ws)
         if not active:
             return
 
-        # Gate: cooldown via should_nudge (handles 300s rate-limit + the
-        # message-count > 1 / memory-count > 0 sanity checks).
-        cooldown_secs = getattr(session._mem_cfg, "nudge_cooldown", 300)
+        # ``should_nudge`` re-checks cooldown AND records the timestamp
+        # on success (the peek above only checks; record happens here).
+        # Also enforces the message-count > 1 / memory-count > 0 sanity
+        # gates we couldn't apply at the cheap-peek stage.
         if not should_nudge(
             "idle_children",
             session._metacog_state,
@@ -217,7 +236,8 @@ class CoordinatorIdleObserver:
             valid_until=_still_has_active_children,
         )
         with self._fire_counts_lock:
-            self._fire_counts[key] = self._fire_counts.get(key, 0) + 1
+            ws_caps = self._fire_counts.setdefault(ws_id, {})
+            ws_caps["idle_children"] = ws_caps.get("idle_children", 0) + 1
 
         log.info(
             "coord_idle_observer.enqueued ws=%s active_children=%d",
@@ -225,7 +245,7 @@ class CoordinatorIdleObserver:
             len(active),
         )
 
-    def _last_assistant_used_wait(self, session: Any) -> bool:
+    def _last_assistant_used_wait(self, session: ChatSession) -> bool:
         """Walk back to the most recent assistant turn; if it issued a
         ``wait_for_workstream`` tool call, return ``True``.
         """
@@ -280,10 +300,9 @@ class CoordinatorIdleObserver:
         return out
 
     def _reset_caps_for(self, ws_id: str) -> None:
-        """Drop every per-(ws_id, *) cap counter on a real (non-wake)
-        leave-IDLE event — the next genuine idle bracket starts fresh.
+        """Drop every nudge-type cap counter for ``ws_id`` on a real
+        (non-wake) leave-IDLE event — the next genuine idle bracket
+        starts fresh.  O(1) with the per-ws nested-dict layout.
         """
         with self._fire_counts_lock:
-            for key in list(self._fire_counts.keys()):
-                if key[0] == ws_id:
-                    del self._fire_counts[key]
+            self._fire_counts.pop(ws_id, None)

--- a/turnstone/console/coordinator_idle_observer.py
+++ b/turnstone/console/coordinator_idle_observer.py
@@ -4,7 +4,7 @@ Subscribes to a coordinator-side :class:`SessionManager`'s state events.
 When a coord transitions to :class:`WorkstreamState.IDLE` while still
 having active interactive children, enqueues an ``idle_children`` nudge
 on the coord's :class:`NudgeQueue`.  The
-:class:`turnstone.core.metacognition.IdleNudgeWatcher` (registered
+:class:`turnstone.core.idle_nudge_watcher.IdleNudgeWatcher` (registered
 *after* this observer in the lifespan, so subscriber-order has the
 observer fire first on the same IDLE event) then peeks the queue and
 dispatches the wake send.

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4432,7 +4432,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 from turnstone.console.coordinator_idle_observer import (
                     CoordinatorIdleObserver,
                 )
-                from turnstone.core.metacognition import install_idle_nudge_watcher
+                from turnstone.core.idle_nudge_watcher import install_idle_nudge_watcher
 
                 coord_idle_observer = CoordinatorIdleObserver(coord_mgr, storage)
                 coord_idle_observer.start()
@@ -4492,7 +4492,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_mgr.stop_renewal()
     if scheduler is not None:
         scheduler.stop()
-    from turnstone.core.metacognition import shutdown_idle_nudge_watchers
+    from turnstone.core.idle_nudge_watcher import shutdown_idle_nudge_watchers
 
     shutdown_idle_nudge_watchers(app)
     coord_idle_observer_shutdown = getattr(app.state, "coord_idle_observer", None)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4424,6 +4424,15 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 ConsoleCoordinatorUI._console_metrics = app.state.console_metrics
                 app.state.coord_mgr = coord_mgr
                 app.state.coord_adapter = coord_adapter
+                # Idle wake-trigger for coords.  Subscribes to coord IDLE
+                # transitions and dispatches a synthetic empty-user-turn
+                # send when the coord's NudgeQueue is non-empty.  PR 3
+                # registers the CoordinatorIdleObserver BEFORE this so
+                # subscriber fire order on the same IDLE event has the
+                # observer enqueueing first, then this watcher peeking.
+                from turnstone.core.metacognition import install_idle_nudge_watcher
+
+                install_idle_nudge_watcher(app, coord_mgr)
                 # Wire the cluster-event subscription so the coordinator's
                 # SSE stream fans out filtered child_ws_* events.  Safe to
                 # call even when the collector has no nodes yet — the
@@ -4475,6 +4484,9 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_mgr.stop_renewal()
     if scheduler is not None:
         scheduler.stop()
+    from turnstone.core.metacognition import shutdown_idle_nudge_watchers
+
+    shutdown_idle_nudge_watchers(app)
     coord_adapter_shutdown = getattr(app.state, "coord_adapter", None)
     if coord_adapter_shutdown is not None:
         try:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -4424,14 +4424,22 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 ConsoleCoordinatorUI._console_metrics = app.state.console_metrics
                 app.state.coord_mgr = coord_mgr
                 app.state.coord_adapter = coord_adapter
-                # Idle wake-trigger for coords.  Subscribes to coord IDLE
-                # transitions and dispatches a synthetic empty-user-turn
-                # send when the coord's NudgeQueue is non-empty.  PR 3
-                # registers the CoordinatorIdleObserver BEFORE this so
-                # subscriber fire order on the same IDLE event has the
-                # observer enqueueing first, then this watcher peeking.
+                # Coord-side observer: when a coord goes IDLE with active
+                # children still running, enqueues an idle_children
+                # nudge.  MUST register BEFORE the IdleNudgeWatcher so
+                # subscriber-fire order on the same IDLE event has the
+                # observer enqueueing first, then the watcher peeking.
+                from turnstone.console.coordinator_idle_observer import (
+                    CoordinatorIdleObserver,
+                )
                 from turnstone.core.metacognition import install_idle_nudge_watcher
 
+                coord_idle_observer = CoordinatorIdleObserver(coord_mgr, storage)
+                coord_idle_observer.start()
+                app.state.coord_idle_observer = coord_idle_observer
+                # Idle wake-trigger for coords.  Subscribes to coord IDLE
+                # transitions and dispatches a synthetic empty-user-turn
+                # send when the coord's NudgeQueue is non-empty.
                 install_idle_nudge_watcher(app, coord_mgr)
                 # Wire the cluster-event subscription so the coordinator's
                 # SSE stream fans out filtered child_ws_* events.  Safe to
@@ -4487,6 +4495,12 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     from turnstone.core.metacognition import shutdown_idle_nudge_watchers
 
     shutdown_idle_nudge_watchers(app)
+    coord_idle_observer_shutdown = getattr(app.state, "coord_idle_observer", None)
+    if coord_idle_observer_shutdown is not None:
+        try:
+            coord_idle_observer_shutdown.shutdown()
+        except Exception:
+            log.debug("console.coord_idle_observer_shutdown_failed", exc_info=True)
     coord_adapter_shutdown = getattr(app.state, "coord_adapter", None)
     if coord_adapter_shutdown is not None:
         try:

--- a/turnstone/core/idle_nudge_watcher.py
+++ b/turnstone/core/idle_nudge_watcher.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from turnstone.core import session_worker
 from turnstone.core.log import get_logger
+from turnstone.core.nudge_queue import USER_DRAIN
 from turnstone.core.workstream import WorkstreamState
 
 if TYPE_CHECKING:
@@ -32,8 +33,14 @@ class IdleNudgeWatcher:
 
     Subscribes to :meth:`SessionManager.subscribe_to_state` and listens
     for ``WorkstreamState.IDLE``.  If the workstream's
-    :class:`NudgeQueue` is non-empty, dispatches via
-    ``session_worker.send`` with a no-op ``enqueue`` callback.
+    :class:`NudgeQueue` has any drainable entry for the wake's drain
+    filter (``USER_DRAIN`` — channels ``"user"`` or ``"any"``),
+    dispatches via ``session_worker.send`` with a no-op ``enqueue``
+    callback.  Tool-only entries don't fire the wake — they belong to
+    the next tool-result seam, not a synthetic empty user turn —
+    otherwise every IDLE event with a queued tool advisory would spawn
+    a wake daemon that immediately no-ops at
+    ``deliver_wake_nudge_from_queue``'s drain guard.
 
     **Race semantics.**  ``session_worker.send`` decides atomically
     under ``ws._lock`` whether a worker thread already owns the
@@ -78,7 +85,7 @@ class IdleNudgeWatcher:
             if ws is None or ws.session is None:
                 return
             session = ws.session
-            if len(session._nudge_queue) == 0:
+            if not session._nudge_queue.has_pending(USER_DRAIN):
                 return
             session_worker.send(
                 ws,

--- a/turnstone/core/idle_nudge_watcher.py
+++ b/turnstone/core/idle_nudge_watcher.py
@@ -1,0 +1,138 @@
+"""Idle wake-trigger for the metacog NudgeQueue pipeline.
+
+Hosts :class:`IdleNudgeWatcher` plus the
+:func:`install_idle_nudge_watcher` / :func:`shutdown_idle_nudge_watchers`
+lifespan helpers.  Pulled out of :mod:`turnstone.core.metacognition`
+because the watcher is subscriber-lifecycle / runtime-orchestration
+code with different concerns from the static nudge-text templates and
+detection heuristics that live in metacognition; mixing them grew the
+metacog module past its single-responsibility line.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+from turnstone.core import session_worker
+from turnstone.core.log import get_logger
+from turnstone.core.workstream import WorkstreamState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from turnstone.core.session_manager import SessionManager
+
+log = get_logger(__name__)
+
+
+class IdleNudgeWatcher:
+    """Convert a workstream IDLE transition into a wake send when the
+    session has queued nudges.
+
+    Subscribes to :meth:`SessionManager.subscribe_to_state` and listens
+    for ``WorkstreamState.IDLE``.  If the workstream's
+    :class:`NudgeQueue` is non-empty, dispatches via
+    ``session_worker.send`` with a no-op ``enqueue`` callback.
+
+    **Race semantics.**  ``session_worker.send`` decides atomically
+    under ``ws._lock`` whether a worker thread already owns the
+    workstream.  Three outcomes:
+
+    * No worker → spawn a new daemon that calls
+      :meth:`ChatSession.deliver_wake_nudge_from_queue` (the wake
+      drains its own queue and runs the synthetic empty-user turn).
+    * Worker running → call our ``enqueue`` lambda, which is a no-op.
+      The wake is silently dropped; the queued nudge stays in
+      ``NudgeQueue`` and the in-flight worker picks it up at its next
+      user-message-attach or tool-result seam (whichever fires first
+      for the entry's channel).  This is the load-bearing fallback —
+      we never spawn a competing worker.
+    * Workstream gone (``ws is None``) or session not built
+      (``ws.session is None``) → bail.
+
+    **Subscription order matters.**  When a workstream-kind-specific
+    observer (e.g. ``CoordinatorIdleObserver``) needs to *enqueue* a
+    nudge on the same IDLE event before this watcher *peeks* the
+    queue, the observer must register first so that
+    ``SessionManager.set_state``'s subscriber loop fires it earlier in
+    the same synchronous fan-out.
+
+    **Kind-agnostic.**  Fires for any workstream regardless of
+    :class:`WorkstreamKind`.  Producers decide what to enqueue.
+    """
+
+    def __init__(self, manager: SessionManager) -> None:
+        self._manager = manager
+        self._callback: Callable[[str, WorkstreamState], None] | None = None
+
+    def start(self) -> None:
+        """Idempotent — registering twice is a no-op."""
+        if self._callback is not None:
+            return
+
+        def _on_state(ws_id: str, state: WorkstreamState) -> None:
+            if state is not WorkstreamState.IDLE:
+                return
+            ws = self._manager.get(ws_id)
+            if ws is None or ws.session is None:
+                return
+            session = ws.session
+            if len(session._nudge_queue) == 0:
+                return
+            session_worker.send(
+                ws,
+                enqueue=lambda: None,
+                run=session.deliver_wake_nudge_from_queue,
+                thread_name=f"wake-nudge-{ws.id[:8]}",
+            )
+
+        self._callback = _on_state
+        self._manager.subscribe_to_state(_on_state)
+
+    def shutdown(self) -> None:
+        """Unsubscribe; idempotent."""
+        cb = self._callback
+        if cb is None:
+            return
+        with contextlib.suppress(Exception):
+            self._manager.unsubscribe_from_state(cb)
+        self._callback = None
+
+
+_APP_STATE_ATTR = "_idle_nudge_watchers"
+
+
+def install_idle_nudge_watcher(app: Any, manager: SessionManager) -> IdleNudgeWatcher:
+    """Construct + start an :class:`IdleNudgeWatcher` and register it
+    for lifespan teardown via :func:`shutdown_idle_nudge_watchers`.
+
+    Multiple watchers may be installed against different
+    :class:`SessionManager` instances on the same ``app`` (e.g. the
+    interactive manager + the coord manager on a multi-kind host).
+    All of them get torn down by a single
+    :func:`shutdown_idle_nudge_watchers` call.
+
+    Returns the watcher so the caller can run additional setup
+    against the same manager — but the typical site doesn't need
+    the return value.
+    """
+    watcher = IdleNudgeWatcher(manager)
+    watcher.start()
+    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
+    if not watchers:
+        # First watcher on this app — initialise the list.  Avoids
+        # mutating a default arg or sharing the list across apps.
+        setattr(app.state, _APP_STATE_ATTR, watchers)
+    watchers.append(watcher)
+    return watcher
+
+
+def shutdown_idle_nudge_watchers(app: Any) -> None:
+    """Shut down every watcher installed via
+    :func:`install_idle_nudge_watcher`.  No-op if none.
+    """
+    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
+    for watcher in watchers:
+        watcher.shutdown()
+    watchers.clear()

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -1,25 +1,19 @@
 """Metacognitive prompting — situational nudges for proactive memory use.
 
-Also hosts :class:`IdleNudgeWatcher`, the wake-trigger that converts a
-workstream's transition to ``WorkstreamState.IDLE`` into a synthetic
-empty-user-turn ``send`` whenever the session has any-channel nudges
-queued (typically the ``idle_children`` nudge enqueued by the
-coordinator-side observer).  Race analysis lives on
-:class:`IdleNudgeWatcher` itself.
+Static nudge text templates (``NUDGE_*``), detection heuristics
+(``detect_correction``, ``detect_completion``), the :class:`RepeatDetector`
+streak counter, and the cooldown-aware :func:`should_nudge` /
+:func:`format_nudge` / :func:`format_idle_children_nudge` helpers.
+
+The wake-trigger lifecycle (``IdleNudgeWatcher`` plus the
+``install_idle_nudge_watcher`` / ``shutdown_idle_nudge_watchers``
+lifespan helpers) lives in :mod:`turnstone.core.idle_nudge_watcher`.
 """
 
 from __future__ import annotations
 
-import contextlib
 import re
 import time
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from turnstone.core.session_manager import SessionManager
-    from turnstone.core.workstream import WorkstreamState
 
 # Default cooldown (s) between nudges of the same type.  Production
 # paths pass ``cooldown_secs`` explicitly from
@@ -148,7 +142,24 @@ NUDGE_IDLE_CHILDREN_HEADER = (
 )
 
 
-_NAME_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+# ASCII control chars + Unicode steering vectors (bidi-override,
+# zero-width, line/paragraph separators, BOM, tag chars).  Treated
+# uniformly as control chars and replaced with a space; angle-bracket
+# tag-breakers are stripped separately below.  Defense-in-depth today
+# (self-injection within one user's tenant — children inherit parent
+# ``user_id``); becomes load-bearing the moment a producer ingests
+# names from a different boundary (a future watch trigger consuming
+# external webhook bodies into ``ws.name``, etc).
+_NAME_CONTROL_CHARS = re.compile(
+    r"[\x00-\x1f\x7f"  # ASCII control + DEL
+    r"​-‏"  # zero-width / LRM / RLM
+    r"‪-‮"  # bidi overrides
+    r"⁦-⁩"  # bidi isolates
+    r"  "  # line / paragraph separator
+    r"﻿"  # BOM
+    r"]"
+    r"|[\U000e0000-\U000e007f]"  # Unicode tag chars (separate range above BMP)
+)
 _NAME_TAG_BREAKERS = re.compile(r"[<>]")
 
 
@@ -158,8 +169,9 @@ def _sanitize_child_name(name: str) -> str:
     The wire-boundary :func:`escape_wrapper_tags` only protects the
     ``<system-reminder>`` and ``<tool_output>`` envelopes; other
     angle-bracketed markers (``</thinking>``, ``<answer>``,
-    ``<artifact>``, …) and control chars can still steer some models.
-    Strip both before interpolation — self-injection only today
+    ``<artifact>``, …) and Unicode steering vectors (RTL override,
+    zero-width chars, tag chars) can still steer some models.  Strip
+    both classes before interpolation — self-injection only today
     (children inherit parent ``user_id``), but the cost is one
     ``re.sub`` per child.
     """
@@ -294,6 +306,26 @@ def detect_completion(message: str) -> bool:
     return any(p.search(message) for p in _WEAK_COMPLETION)
 
 
+def _cooldown_allows(
+    nudge_type: str,
+    state: dict[str, float],
+    *,
+    cooldown_secs: int = _COOLDOWN_SECS,
+) -> bool:
+    """Read-only cooldown peek — does NOT record a fire timestamp.
+
+    Use this as a cheap pre-gate before expensive work (storage queries,
+    message walks).  The follow-up :func:`should_nudge` call re-checks
+    cooldown AND records the timestamp atomically.  A producer that
+    races between this peek and ``should_nudge`` would just lose the
+    fire to the other producer — benign.
+    """
+    last = state.get(nudge_type)
+    if last is None:
+        return True
+    return time.monotonic() - last >= cooldown_secs
+
+
 def should_nudge(
     nudge_type: str,
     state: dict[str, float],
@@ -329,121 +361,3 @@ def should_nudge(
 def format_nudge(nudge_type: str) -> str:
     """Return the nudge text for the given type."""
     return _NUDGE_MAP.get(nudge_type, "")
-
-
-class IdleNudgeWatcher:
-    """Convert a workstream IDLE transition into a wake send when the
-    session has queued nudges.
-
-    Subscribes to :meth:`SessionManager.subscribe_to_state` and listens
-    for ``WorkstreamState.IDLE``.  If the workstream's
-    :class:`NudgeQueue` is non-empty, dispatches via
-    ``session_worker.send`` with a no-op ``enqueue`` callback.
-
-    **Race semantics.**  ``session_worker.send`` decides atomically
-    under ``ws._lock`` whether a worker thread already owns the
-    workstream.  Three outcomes:
-
-    * No worker → spawn a new daemon that calls
-      :meth:`ChatSession.deliver_wake_nudge_from_queue` (the wake
-      drains its own queue and runs the synthetic empty-user turn).
-    * Worker running → call our ``enqueue`` lambda, which is a no-op.
-      The wake is silently dropped; the queued nudge stays in
-      ``NudgeQueue`` and the in-flight worker picks it up at its next
-      user-message-attach or tool-result seam (whichever fires first
-      for the entry's channel).  This is the load-bearing fallback —
-      we never spawn a competing worker.
-    * Workstream gone (``ws is None``) or session not built
-      (``ws.session is None``) → bail.
-
-    **Subscription order matters.**  When a workstream-kind-specific
-    observer (e.g. ``CoordinatorIdleObserver`` in PR 3) needs to
-    *enqueue* a nudge on the same IDLE event before this watcher
-    *peeks* the queue, the observer must register first so that
-    ``SessionManager.set_state``'s subscriber loop fires it earlier in
-    the same synchronous fan-out.
-
-    **Kind-agnostic.**  Fires for any workstream regardless of
-    :class:`WorkstreamKind`.  Producers decide what to enqueue.
-    """
-
-    def __init__(self, manager: SessionManager) -> None:
-        self._manager = manager
-        self._callback: Callable[[str, WorkstreamState], None] | None = None
-
-    def start(self) -> None:
-        """Idempotent — registering twice is a no-op."""
-        if self._callback is not None:
-            return
-        # Local import to avoid a circular import at module load time
-        # (session_manager imports from session, which already pulls
-        # metacognition, so a top-level import here would cycle).
-        from turnstone.core.workstream import WorkstreamState
-
-        def _on_state(ws_id: str, state: WorkstreamState) -> None:
-            if state is not WorkstreamState.IDLE:
-                return
-            ws = self._manager.get(ws_id)
-            if ws is None or ws.session is None:
-                return
-            session = ws.session
-            if len(session._nudge_queue) == 0:
-                return
-            from turnstone.core import session_worker
-
-            session_worker.send(
-                ws,
-                enqueue=lambda: None,
-                run=session.deliver_wake_nudge_from_queue,
-                thread_name=f"wake-nudge-{ws.id[:8]}",
-            )
-
-        self._callback = _on_state
-        self._manager.subscribe_to_state(_on_state)
-
-    def shutdown(self) -> None:
-        """Unsubscribe; idempotent."""
-        cb = self._callback
-        if cb is None:
-            return
-        with contextlib.suppress(Exception):
-            self._manager.unsubscribe_from_state(cb)
-        self._callback = None
-
-
-_APP_STATE_ATTR = "_idle_nudge_watchers"
-
-
-def install_idle_nudge_watcher(app: Any, manager: SessionManager) -> IdleNudgeWatcher:
-    """Construct + start an :class:`IdleNudgeWatcher` and register it
-    for lifespan teardown via :func:`shutdown_idle_nudge_watchers`.
-
-    Multiple watchers may be installed against different
-    :class:`SessionManager` instances on the same ``app`` (e.g. the
-    interactive manager + the coord manager on a multi-kind host).
-    All of them get torn down by a single
-    :func:`shutdown_idle_nudge_watchers` call.
-
-    Returns the watcher so the caller can run additional setup
-    against the same manager — but the typical site doesn't need
-    the return value.
-    """
-    watcher = IdleNudgeWatcher(manager)
-    watcher.start()
-    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
-    if not watchers:
-        # First watcher on this app — initialise the list.  Avoids
-        # mutating a default arg or sharing the list across apps.
-        setattr(app.state, _APP_STATE_ATTR, watchers)
-    watchers.append(watcher)
-    return watcher
-
-
-def shutdown_idle_nudge_watchers(app: Any) -> None:
-    """Shut down every watcher installed via
-    :func:`install_idle_nudge_watcher`.  No-op if none.
-    """
-    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
-    for watcher in watchers:
-        watcher.shutdown()
-    watchers.clear()

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -124,7 +124,91 @@ _NUDGE_MAP: dict[str, str] = {
     "start": NUDGE_START,
     "tool_error": NUDGE_TOOL_ERROR,
     "repeat": NUDGE_REPEAT,
+    # idle_children carries no static body — :func:`format_idle_children_nudge`
+    # produces the per-fire text from the active-children snapshot.  Empty
+    # string here keeps :func:`format_nudge` round-tripping honestly while
+    # still letting :func:`should_nudge` recognise the type.
+    "idle_children": "",
 }
+
+
+# Display cap for the ``idle_children`` body — list at most this many
+# children inline, append "...and N more" overflow line beyond that.
+NUDGE_IDLE_CHILDREN_DISPLAY_CAP = 6
+
+# Suggested ``wait_for_workstream(ws_ids=[...])`` cap — matches
+# ``WAIT_MAX_WS_IDS`` in :mod:`turnstone.core.coordinator_client` so the
+# emitted suggestion is callable as-is.
+NUDGE_IDLE_CHILDREN_WAIT_CAP = 32
+
+NUDGE_IDLE_CHILDREN_HEADER = (
+    "You went idle but still have active child workstreams.  Either "
+    "continue the user's work or block on the listed children "
+    "explicitly:"
+)
+
+
+_NAME_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_NAME_TAG_BREAKERS = re.compile(r"[<>]")
+
+
+def _sanitize_child_name(name: str) -> str:
+    """Neutralize prompt-structural markers in user-controlled child names.
+
+    The wire-boundary :func:`escape_wrapper_tags` only protects the
+    ``<system-reminder>`` and ``<tool_output>`` envelopes; other
+    angle-bracketed markers (``</thinking>``, ``<answer>``,
+    ``<artifact>``, …) and control chars can still steer some models.
+    Strip both before interpolation — self-injection only today
+    (children inherit parent ``user_id``), but the cost is one
+    ``re.sub`` per child.
+    """
+    if not name:
+        return ""
+    cleaned = _NAME_CONTROL_CHARS.sub(" ", name)
+    cleaned = _NAME_TAG_BREAKERS.sub("", cleaned)
+    return cleaned.strip()
+
+
+def format_idle_children_nudge(children: list[dict[str, str]]) -> str:
+    """Render the ``idle_children`` reminder body.
+
+    *children* is a list of dicts with ``ws_id``, ``name``, ``state``
+    keys — the row-mapping shape coordinator-side storage exposes.
+    Returns raw text *without* the ``<system-reminder>`` envelope; the
+    side-channel :func:`_apply_reminders_for_provider` splice wraps it
+    at the wire boundary.
+
+    User-controlled ``name`` strings get sanitized via
+    :func:`_sanitize_child_name` before interpolation so a workstream
+    named ``</thinking>...`` can't steer the model's reasoning
+    channels through the rendered body.
+
+    Display caps at :data:`NUDGE_IDLE_CHILDREN_DISPLAY_CAP` with an
+    overflow line; the trailing ``wait_for_workstream`` suggestion's
+    ``ws_ids`` list caps at :data:`NUDGE_IDLE_CHILDREN_WAIT_CAP`.
+    Empty input returns the empty string so callers can short-circuit
+    on ``if not text: return``.
+    """
+    if not children:
+        return ""
+    lines = [NUDGE_IDLE_CHILDREN_HEADER, ""]
+    shown = children[:NUDGE_IDLE_CHILDREN_DISPLAY_CAP]
+    for c in shown:
+        ws_id = c.get("ws_id", "")
+        name = _sanitize_child_name(c.get("name", "")) or "(unnamed)"
+        state = c.get("state", "?")
+        lines.append(f"  - {ws_id[:8]} ({state}): {name}")
+    overflow = len(children) - len(shown)
+    if overflow > 0:
+        lines.append(f"  ...and {overflow} more")
+    lines.append("")
+    wait_ids = [c.get("ws_id", "") for c in children[:NUDGE_IDLE_CHILDREN_WAIT_CAP]]
+    lines.append(
+        f'To block on them: wait_for_workstream(ws_ids={wait_ids!r}, mode="any", timeout=120).'
+    )
+    return "\n".join(lines)
+
 
 # ---------------------------------------------------------------------------
 # Detection heuristics — strong/weak tiers

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -1,9 +1,25 @@
-"""Metacognitive prompting — situational nudges for proactive memory use."""
+"""Metacognitive prompting — situational nudges for proactive memory use.
+
+Also hosts :class:`IdleNudgeWatcher`, the wake-trigger that converts a
+workstream's transition to ``WorkstreamState.IDLE`` into a synthetic
+empty-user-turn ``send`` whenever the session has any-channel nudges
+queued (typically the ``idle_children`` nudge enqueued by the
+coordinator-side observer).  Race analysis lives on
+:class:`IdleNudgeWatcher` itself.
+"""
 
 from __future__ import annotations
 
+import contextlib
 import re
 import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from turnstone.core.session_manager import SessionManager
+    from turnstone.core.workstream import WorkstreamState
 
 # Default cooldown (s) between nudges of the same type.  Production
 # paths pass ``cooldown_secs`` explicitly from
@@ -229,3 +245,121 @@ def should_nudge(
 def format_nudge(nudge_type: str) -> str:
     """Return the nudge text for the given type."""
     return _NUDGE_MAP.get(nudge_type, "")
+
+
+class IdleNudgeWatcher:
+    """Convert a workstream IDLE transition into a wake send when the
+    session has queued nudges.
+
+    Subscribes to :meth:`SessionManager.subscribe_to_state` and listens
+    for ``WorkstreamState.IDLE``.  If the workstream's
+    :class:`NudgeQueue` is non-empty, dispatches via
+    ``session_worker.send`` with a no-op ``enqueue`` callback.
+
+    **Race semantics.**  ``session_worker.send`` decides atomically
+    under ``ws._lock`` whether a worker thread already owns the
+    workstream.  Three outcomes:
+
+    * No worker → spawn a new daemon that calls
+      :meth:`ChatSession.deliver_wake_nudge_from_queue` (the wake
+      drains its own queue and runs the synthetic empty-user turn).
+    * Worker running → call our ``enqueue`` lambda, which is a no-op.
+      The wake is silently dropped; the queued nudge stays in
+      ``NudgeQueue`` and the in-flight worker picks it up at its next
+      user-message-attach or tool-result seam (whichever fires first
+      for the entry's channel).  This is the load-bearing fallback —
+      we never spawn a competing worker.
+    * Workstream gone (``ws is None``) or session not built
+      (``ws.session is None``) → bail.
+
+    **Subscription order matters.**  When a workstream-kind-specific
+    observer (e.g. ``CoordinatorIdleObserver`` in PR 3) needs to
+    *enqueue* a nudge on the same IDLE event before this watcher
+    *peeks* the queue, the observer must register first so that
+    ``SessionManager.set_state``'s subscriber loop fires it earlier in
+    the same synchronous fan-out.
+
+    **Kind-agnostic.**  Fires for any workstream regardless of
+    :class:`WorkstreamKind`.  Producers decide what to enqueue.
+    """
+
+    def __init__(self, manager: SessionManager) -> None:
+        self._manager = manager
+        self._callback: Callable[[str, WorkstreamState], None] | None = None
+
+    def start(self) -> None:
+        """Idempotent — registering twice is a no-op."""
+        if self._callback is not None:
+            return
+        # Local import to avoid a circular import at module load time
+        # (session_manager imports from session, which already pulls
+        # metacognition, so a top-level import here would cycle).
+        from turnstone.core.workstream import WorkstreamState
+
+        def _on_state(ws_id: str, state: WorkstreamState) -> None:
+            if state is not WorkstreamState.IDLE:
+                return
+            ws = self._manager.get(ws_id)
+            if ws is None or ws.session is None:
+                return
+            session = ws.session
+            if len(session._nudge_queue) == 0:
+                return
+            from turnstone.core import session_worker
+
+            session_worker.send(
+                ws,
+                enqueue=lambda: None,
+                run=session.deliver_wake_nudge_from_queue,
+                thread_name=f"wake-nudge-{ws.id[:8]}",
+            )
+
+        self._callback = _on_state
+        self._manager.subscribe_to_state(_on_state)
+
+    def shutdown(self) -> None:
+        """Unsubscribe; idempotent."""
+        cb = self._callback
+        if cb is None:
+            return
+        with contextlib.suppress(Exception):
+            self._manager.unsubscribe_from_state(cb)
+        self._callback = None
+
+
+_APP_STATE_ATTR = "_idle_nudge_watchers"
+
+
+def install_idle_nudge_watcher(app: Any, manager: SessionManager) -> IdleNudgeWatcher:
+    """Construct + start an :class:`IdleNudgeWatcher` and register it
+    for lifespan teardown via :func:`shutdown_idle_nudge_watchers`.
+
+    Multiple watchers may be installed against different
+    :class:`SessionManager` instances on the same ``app`` (e.g. the
+    interactive manager + the coord manager on a multi-kind host).
+    All of them get torn down by a single
+    :func:`shutdown_idle_nudge_watchers` call.
+
+    Returns the watcher so the caller can run additional setup
+    against the same manager — but the typical site doesn't need
+    the return value.
+    """
+    watcher = IdleNudgeWatcher(manager)
+    watcher.start()
+    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
+    if not watchers:
+        # First watcher on this app — initialise the list.  Avoids
+        # mutating a default arg or sharing the list across apps.
+        setattr(app.state, _APP_STATE_ATTR, watchers)
+    watchers.append(watcher)
+    return watcher
+
+
+def shutdown_idle_nudge_watchers(app: Any) -> None:
+    """Shut down every watcher installed via
+    :func:`install_idle_nudge_watcher`.  No-op if none.
+    """
+    watchers: list[IdleNudgeWatcher] = getattr(app.state, _APP_STATE_ATTR, [])
+    for watcher in watchers:
+        watcher.shutdown()
+    watchers.clear()

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -2,11 +2,11 @@
 
 Replaces the dual ``_pending_user_advisories`` / ``_pending_tool_advisories``
 list pair with a single channel-tagged queue per session.  Producers
-(`_queue_user_advisory`, `_queue_tool_advisory`, the future
+(`_queue_user_advisory`, `_queue_tool_advisory`,
 `CoordinatorIdleObserver`, the future watch dispatcher) all enqueue onto
 the same queue with an explicit ``channel``; consumers
 (`_attach_pending_user_reminders` on user-message attach,
-`_collect_advisories` on tool-result wrap, the future
+`_collect_advisories` on tool-result wrap,
 `IdleNudgeWatcher` on workstream-IDLE) drain by channel filter.
 
 Channels:
@@ -16,15 +16,24 @@ Channels:
       wake-trigger-driven nudges that should not be pinned to a
       specific drain seam).
 
-Drain preserves FIFO order; non-matching entries stay queued.  All
-operations are atomic under an internal :class:`threading.Lock`.
+Drain preserves FIFO order; non-matching entries stay queued.  Each
+entry can carry an optional ``valid_until`` predicate that drain
+evaluates outside the queue lock; entries whose predicate returns
+``False`` (or raises) are silently dropped without delivery — used by
+producers whose payload becomes stale if the underlying state changes
+between enqueue and drain (e.g. ``idle_children`` re-checks the active
+child set, dropping the nudge if every child finished while the queue
+sat).  Operations are atomic under an internal :class:`threading.Lock`.
 """
 
 from __future__ import annotations
 
 import threading
 from collections import deque
-from typing import Literal, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 Channel = Literal["user", "tool", "any"]
 _VALID_CHANNELS: frozenset[str] = frozenset({"user", "tool", "any"})
@@ -39,6 +48,7 @@ class _Entry(NamedTuple):
     nudge_type: str
     text: str
     channel: Channel
+    valid_until: Callable[[], bool] | None = None
 
 
 class NudgeQueue:
@@ -48,36 +58,71 @@ class NudgeQueue:
         self._items: deque[_Entry] = deque()
         self._lock = threading.Lock()
 
-    def enqueue(self, nudge_type: str, text: str, channel: Channel) -> None:
+    def enqueue(
+        self,
+        nudge_type: str,
+        text: str,
+        channel: Channel,
+        *,
+        valid_until: Callable[[], bool] | None = None,
+    ) -> None:
         """Append a nudge.  ``channel`` MUST be in :data:`_VALID_CHANNELS`.
 
         ``channel`` is required so producers ingesting untrusted text
         (future child workstream names, watch payloads) must pick a
         seam consciously rather than silently routing to whichever
         seam drains first via an implicit default.
+
+        If ``valid_until`` is provided, drain re-evaluates it before
+        delivering the entry; a falsy result drops the entry silently
+        (the producer's signal that the snapshot it enqueued is now
+        stale).  The predicate is called outside the queue lock so
+        producers can do non-trivial work (e.g. re-querying storage
+        for active children) without blocking other producers.
         """
         if channel not in _VALID_CHANNELS:
             raise ValueError(f"channel={channel!r}; expected one of {sorted(_VALID_CHANNELS)}")
         with self._lock:
-            self._items.append(_Entry(nudge_type, text, channel))
+            self._items.append(_Entry(nudge_type, text, channel, valid_until))
 
     def drain(self, channels: frozenset[str] | set[str]) -> list[tuple[str, str]]:
         """Drain entries whose channel is in ``channels``.
 
         Entries with non-matching channels stay in the queue, in order.
         Returns ``(nudge_type, text)`` tuples in insertion order.
+
+        Entries with a ``valid_until`` predicate get re-checked outside
+        the queue lock; falsy / raising predicates drop the entry
+        without delivering it.  Already-removed-from-queue either way —
+        dropped entries don't ride a future drain.
         """
         with self._lock:
             if not self._items:
                 return []
             kept: deque[_Entry] = deque()
-            out: list[tuple[str, str]] = []
+            candidates: list[_Entry] = []
             for entry in self._items:
                 if entry.channel in channels:
-                    out.append((entry.nudge_type, entry.text))
+                    candidates.append(entry)
                 else:
                     kept.append(entry)
             self._items = kept
+        # Predicates evaluate outside the lock — they may do storage
+        # I/O or other work that shouldn't block other producers /
+        # the drain consumer's other queues.
+        out: list[tuple[str, str]] = []
+        for entry in candidates:
+            if entry.valid_until is None:
+                out.append((entry.nudge_type, entry.text))
+                continue
+            try:
+                if entry.valid_until():
+                    out.append((entry.nudge_type, entry.text))
+            except Exception:
+                # Predicate raising is treated as "no longer valid" —
+                # drop silently rather than letting one bad predicate
+                # poison the whole drain batch.
+                pass
         return out
 
     def __len__(self) -> int:

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -99,14 +99,23 @@ class NudgeQueue:
         with self._lock:
             if not self._items:
                 return []
-            kept: deque[_Entry] = deque()
-            candidates: list[_Entry] = []
-            for entry in self._items:
-                if entry.channel in channels:
-                    candidates.append(entry)
-                else:
-                    kept.append(entry)
-            self._items = kept
+            # Fast path: every entry matches → swap deque rather than
+            # walk + partition + per-entry append.  This is the common
+            # case in practice since the chat loop's drain seams use
+            # ``USER_DRAIN`` / ``TOOL_DRAIN`` (channel + "any") and
+            # most queues hold only one channel's entries at a time.
+            if all(entry.channel in channels for entry in self._items):
+                candidates: list[_Entry] = list(self._items)
+                self._items = deque()
+            else:
+                kept: deque[_Entry] = deque()
+                candidates = []
+                for entry in self._items:
+                    if entry.channel in channels:
+                        candidates.append(entry)
+                    else:
+                        kept.append(entry)
+                self._items = kept
         # Predicates evaluate outside the lock — they may do storage
         # I/O or other work that shouldn't block other producers /
         # the drain consumer's other queues.

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -166,9 +166,11 @@ class NudgeQueue:
 
         Returns ``True`` as soon as a queued entry's channel matches
         ``channels``.  Cheaper than :meth:`pending` for callers that
-        only need a boolean (e.g. the wake-path defense in
-        :meth:`ChatSession.deliver_wake_nudge_from_queue`) — no list
-        allocation, lock released on first match.
+        only need a boolean — used by
+        :class:`turnstone.core.idle_nudge_watcher.IdleNudgeWatcher` to
+        gate wake dispatch on whether ``USER_DRAIN`` would actually
+        deliver anything before paying the worker-thread spawn.  No
+        list allocation, lock released on first match.
         """
         with self._lock:
             return any(e.channel in channels for e in self._items)

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -106,3 +106,15 @@ class NudgeQueue:
             if channel is None:
                 return [(e.nudge_type, e.text) for e in self._items]
             return [(e.nudge_type, e.text) for e in self._items if e.channel == channel]
+
+    def has_pending(self, channels: frozenset[str] | set[str]) -> bool:
+        """Short-circuiting existence check.
+
+        Returns ``True`` as soon as a queued entry's channel matches
+        ``channels``.  Cheaper than :meth:`pending` for callers that
+        only need a boolean (e.g. the wake-path defense in
+        :meth:`ChatSession.deliver_wake_nudge_from_queue`) — no list
+        allocation, lock released on first match.
+        """
+        with self._lock:
+            return any(e.channel in channels for e in self._items)

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -1,0 +1,108 @@
+"""Thread-safe FIFO queue for metacognitive nudges with channel filtering.
+
+Replaces the dual ``_pending_user_advisories`` / ``_pending_tool_advisories``
+list pair with a single channel-tagged queue per session.  Producers
+(`_queue_user_advisory`, `_queue_tool_advisory`, the future
+`CoordinatorIdleObserver`, the future watch dispatcher) all enqueue onto
+the same queue with an explicit ``channel``; consumers
+(`_attach_pending_user_reminders` on user-message attach,
+`_collect_advisories` on tool-result wrap, the future
+`IdleNudgeWatcher` on workstream-IDLE) drain by channel filter.
+
+Channels:
+    * ``"user"`` — only drains at user-turn seams.
+    * ``"tool"`` — only drains at tool-result seams.
+    * ``"any"``  — drains at whichever seam fires first (used for
+      wake-trigger-driven nudges that should not be pinned to a
+      specific drain seam).
+
+Drain preserves FIFO order; non-matching entries stay queued.  All
+operations are atomic under an internal :class:`threading.Lock`.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Literal, NamedTuple
+
+Channel = Literal["user", "tool", "any"]
+_VALID_CHANNELS: frozenset[str] = frozenset({"user", "tool", "any"})
+
+# Module-level filter constants — most callers want one of these and
+# pre-allocating spares us a frozenset construction at every drain seam.
+USER_DRAIN: frozenset[str] = frozenset({"user", "any"})
+TOOL_DRAIN: frozenset[str] = frozenset({"tool", "any"})
+
+
+class _Entry(NamedTuple):
+    nudge_type: str
+    text: str
+    channel: Channel
+
+
+class NudgeQueue:
+    """Single-session FIFO queue with channel-tagged entries."""
+
+    def __init__(self) -> None:
+        self._items: deque[_Entry] = deque()
+        self._lock = threading.Lock()
+
+    def enqueue(self, nudge_type: str, text: str, channel: Channel) -> None:
+        """Append a nudge.  ``channel`` MUST be in :data:`_VALID_CHANNELS`.
+
+        ``channel`` is required so producers ingesting untrusted text
+        (future child workstream names, watch payloads) must pick a
+        seam consciously rather than silently routing to whichever
+        seam drains first via an implicit default.
+        """
+        if channel not in _VALID_CHANNELS:
+            raise ValueError(f"channel={channel!r}; expected one of {sorted(_VALID_CHANNELS)}")
+        with self._lock:
+            self._items.append(_Entry(nudge_type, text, channel))
+
+    def drain(self, channels: frozenset[str] | set[str]) -> list[tuple[str, str]]:
+        """Drain entries whose channel is in ``channels``.
+
+        Entries with non-matching channels stay in the queue, in order.
+        Returns ``(nudge_type, text)`` tuples in insertion order.
+        """
+        with self._lock:
+            if not self._items:
+                return []
+            kept: deque[_Entry] = deque()
+            out: list[tuple[str, str]] = []
+            for entry in self._items:
+                if entry.channel in channels:
+                    out.append((entry.nudge_type, entry.text))
+                else:
+                    kept.append(entry)
+            self._items = kept
+        return out
+
+    def __len__(self) -> int:
+        """Current depth.  Used by the future IdleNudgeWatcher gate."""
+        with self._lock:
+            return len(self._items)
+
+    def clear(self) -> int:
+        """Drop every entry; return the count cleared.  Used in cancel paths."""
+        with self._lock:
+            n = len(self._items)
+            self._items.clear()
+            return n
+
+    def pending(self, channel: Channel | None = None) -> list[tuple[str, str]]:
+        """Non-mutating snapshot for tests / introspection.
+
+        With ``channel=None`` returns every queued entry as
+        ``(nudge_type, text)`` tuples in insertion order; with a
+        specific channel filters to that channel only.  Production
+        code that wants to *consume* entries should call :meth:`drain`
+        instead — pending entries are by definition unconsumed and
+        will redraw at the next matching seam.
+        """
+        with self._lock:
+            if channel is None:
+                return [(e.nudge_type, e.text) for e in self._items]
+            return [(e.nudge_type, e.text) for e in self._items if e.channel == channel]

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -770,6 +770,15 @@ class ChatSession:
         # ``should_nudge`` gating.
         self._metacog_state: dict[str, float] = {}
         self._nudge_queue = NudgeQueue()
+        # Wake-trigger plumbing: ``deliver_wake_nudge_from_queue`` sets
+        # this tag while sending a synthetic empty user turn so that
+        # ``_check_metacognitive_nudge`` and the ``_queue_*_advisory``
+        # producers short-circuit (the wake's reminder text contains
+        # trigger words like "don't" that would otherwise re-fire
+        # correction nudges on top of the envelope) and so the
+        # synthesized user message gets stamped ``_source`` for
+        # audit / replay distinction.
+        self._wake_source_tag: str = ""
         # User message queue: messages sent while model is executing.
         # OrderedDict preserves FIFO order and supports O(1) removal by ID.
         # Queued user turns never carry attachments — see
@@ -2543,6 +2552,14 @@ class ChatSession:
             user_content = user_input
 
         user_msg: dict[str, Any] = {"role": "user", "content": user_content}
+        if self._wake_source_tag:
+            # Sibling tag for audit / replay: the synthetic empty user
+            # message emitted by ``deliver_wake_nudge_from_queue`` is
+            # marked so UI can render it distinctly (or hide it) and
+            # log consumers can tell self-prompted turns from real
+            # user input.  Stripped at the sanitize boundary by the
+            # leading-underscore filter.
+            user_msg["_source"] = self._wake_source_tag
         if attachments:
             # Sibling metadata so live history replay has the same shape
             # as reloaded-from-DB (filenames are not recoverable from an
@@ -5723,6 +5740,13 @@ class ChatSession:
 
         Returns ``(nudge_type, nudge_text)`` or ``None``.
         """
+        # Wake-channel guard: don't re-detect nudges on the synthetic
+        # empty input emitted by ``deliver_wake_nudge_from_queue``.
+        # Belt-and-braces with the "" → no-match short-circuit in
+        # ``detect_correction`` / ``detect_completion`` since future
+        # text changes shouldn't be load-bearing for correctness.
+        if self._wake_source_tag:
+            return None
         if not self._mem_cfg.nudges:
             return None
         mem_count = self._visible_memory_count()
@@ -5765,7 +5789,16 @@ class ChatSession:
         message dict's ``_reminders`` side-channel.  Used for nudges
         that respond to user behaviour: ``correction``, ``denial``,
         ``resume``, ``start``, ``completion``.
+
+        No-ops while the session is inside a wake-driven turn
+        (``_wake_source_tag`` set) so model behaviour during the wake
+        send (e.g. denying a tool the wake suggested, hitting a
+        repeat / tool_error) doesn't queue a nudge that would land on
+        top of the wake's own envelope or on the user's next real
+        turn referencing a context the user never saw.
         """
+        if self._wake_source_tag:
+            return
         self._nudge_queue.enqueue(nudge_type, text, "user")
 
     def _attach_pending_user_reminders(self, user_msg: dict[str, Any]) -> None:
@@ -5817,8 +5850,67 @@ class ChatSession:
         user interjections; ``wrap_tool_result`` then renders it inside
         the tool-result envelope. Used for nudges that respond to model
         behaviour at a tool boundary: ``tool_error``, ``repeat``.
+
+        No-ops while the session is inside a wake-driven turn (see
+        ``_queue_user_advisory`` for the rationale).
         """
+        if self._wake_source_tag:
+            return
         self._nudge_queue.enqueue(nudge_type, text, "tool")
+
+    def deliver_wake_nudge_from_queue(self) -> None:
+        """Drive a synthetic empty user turn so any-channel nudges drain.
+
+        The standard side-channel pipeline does the rendering: the
+        ``send("")`` we trigger lands at ``_append_user_turn`` which
+        attaches drained reminders onto the empty user message via
+        ``_attach_pending_user_reminders``.  ``_apply_reminders_for_provider``
+        then splices the rendered ``<system-reminder>`` block onto the
+        trailing edge of the empty content — wire content becomes the
+        envelope alone, providers accept it as a normal user turn.
+        See foundation §F4 of the design doc.
+
+        ``_wake_source_tag`` is set for the duration of the synthetic
+        send so:
+
+        * ``_check_metacognitive_nudge`` short-circuits (no
+          recursive correction / completion detection on the
+          envelope text)
+        * ``_queue_user_advisory`` / ``_queue_tool_advisory`` short-
+          circuit if model behaviour during the wake (e.g. a denied
+          tool call) would otherwise queue a fresh nudge on top of
+          the wake itself
+        * ``_append_user_turn`` stamps ``_source = "system_nudge"``
+          on the synthesized user message for audit / replay parity
+
+        On post-retry stream failure the just-attached ``_reminders``
+        get marked delivered before the exception propagates, so a
+        stale envelope doesn't re-fire on the user's next real turn —
+        operator intervention is required for the underlying failure
+        anyway and a haunted nudge would be noise.
+
+        Bails early if nothing in the queue would drain at the user
+        seam (only stale ``"tool"``-channel entries, say): without
+        the guard we'd synthesize an empty-content user turn whose
+        ``<system-reminder>`` envelope is empty and which providers
+        reject for missing content.  The :class:`IdleNudgeWatcher`
+        peeks total queue length and may dispatch us for a tool-only
+        queue; this defense covers that race plus any future direct
+        caller.
+        """
+        if not self._nudge_queue.has_pending(USER_DRAIN):
+            return
+        pre_len = len(self.messages)
+        self._wake_source_tag = "system_nudge"
+        try:
+            self.send("")
+        except Exception:
+            for msg in self.messages[pre_len:]:
+                if msg.get("_reminders"):
+                    msg["_reminders_delivered"] = True
+            raise
+        finally:
+            self._wake_source_tag = ""
 
     def _apply_post_execute_advisories(
         self,
@@ -9427,6 +9519,16 @@ class ChatSession:
         Each ``send()`` chains back here on IDLE, so multiple queued results
         are processed sequentially.  Depth is capped to prevent unbounded
         stack growth.
+
+        Clears ``_wake_source_tag`` for the duration of the recursive
+        ``send`` so the watch turn is processed as a normal user turn:
+        ``_check_metacognitive_nudge`` runs against the watch message,
+        ``_append_user_turn`` does NOT stamp ``_source = "system_nudge"``
+        on the watch user-message, and ``_queue_*_advisory`` calls
+        during the watch's tool execution are not suppressed.  Without
+        this, a watch chained off a wake-driven send inherits the
+        wake-source guards inappropriately — the watch is its own
+        separate event from the wake.
         """
         if depth >= self._MAX_WATCH_CHAIN:
             self._watch_dispatch_depth = 0
@@ -9439,7 +9541,12 @@ class ChatSession:
         message = result.get("message", "")
         if message:
             self._watch_dispatch_depth = depth + 1
-            self.send(message)
+            saved_wake_tag = self._wake_source_tag
+            self._wake_source_tag = ""
+            try:
+                self.send(message)
+            finally:
+                self._wake_source_tag = saved_wake_tag
 
     def _exec_write_file(self, item: dict[str, Any]) -> tuple[str, str]:
         """Write content to a file, creating parent directories as needed."""

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -779,6 +779,11 @@ class ChatSession:
         # synthesized user message gets stamped ``_source`` for
         # audit / replay distinction.
         self._wake_source_tag: str = ""
+        # Reminders pre-drained by ``deliver_wake_nudge_from_queue``
+        # — handed to ``_attach_pending_user_reminders`` so the synthesized
+        # send doesn't re-drain (and so we can bail out before send when
+        # every entry's ``valid_until`` predicate dropped its item).
+        self._wake_drained_reminders: list[dict[str, str]] | None = None
         # User message queue: messages sent while model is executing.
         # OrderedDict preserves FIFO order and supports O(1) removal by ID.
         # Queued user turns never carry attachments — see
@@ -5822,6 +5827,12 @@ class ChatSession:
         ``_provider_content``); ``sanitize_messages`` strips it before
         the wire on its own pass.
 
+        When ``deliver_wake_nudge_from_queue`` is the caller, it has
+        already drained the queue and stashed the reminders on
+        ``self._wake_drained_reminders``; we use that list directly
+        rather than draining again (the predicate-aware drain runs
+        once, in deliver_wake_nudge_from_queue).
+
         Also fires the live ``on_user_reminder`` UI hook so any open
         SSE consumers (other browser tabs, CLI mirrors, eventual
         channel adapters) can render the reminder bubble in lockstep
@@ -5831,11 +5842,16 @@ class ChatSession:
         not abort the user's send (which would otherwise drop both the
         user message and the queued nudges).
         """
-        items = self._nudge_queue.drain(USER_DRAIN)
-        if not items:
+        if self._wake_drained_reminders is not None:
+            reminders = self._wake_drained_reminders
+            self._wake_drained_reminders = None  # consume — only delivered once
+        else:
+            items = self._nudge_queue.drain(USER_DRAIN)
+            if not items:
+                return
+            reminders = [{"type": nudge_type, "text": text} for nudge_type, text in items]
+        if not reminders:
             return
-
-        reminders = [{"type": nudge_type, "text": text} for nudge_type, text in items]
         user_msg["_reminders"] = reminders
 
         try:
@@ -5889,19 +5905,26 @@ class ChatSession:
         operator intervention is required for the underlying failure
         anyway and a haunted nudge would be noise.
 
-        Bails early if nothing in the queue would drain at the user
-        seam (only stale ``"tool"``-channel entries, say): without
-        the guard we'd synthesize an empty-content user turn whose
-        ``<system-reminder>`` envelope is empty and which providers
-        reject for missing content.  The :class:`IdleNudgeWatcher`
-        peeks total queue length and may dispatch us for a tool-only
-        queue; this defense covers that race plus any future direct
-        caller.
+        Drains the queue inline (running every entry's ``valid_until``
+        predicate) BEFORE synthesizing the empty user turn — bails if
+        no entry survives the predicate check.  Without this, the
+        watcher's ``has_pending`` peek can succeed on entries whose
+        predicate later drops them inside
+        ``_attach_pending_user_reminders``'s drain, leaving us
+        synthesizing an empty user turn with no reminder context (and
+        risking provider rejection of empty user content).  The
+        drained items get handed to ``_attach_pending_user_reminders``
+        via ``_wake_drained_reminders`` instead of re-draining the
+        queue from inside ``send``.
         """
-        if not self._nudge_queue.has_pending(USER_DRAIN):
+        items = self._nudge_queue.drain(USER_DRAIN)
+        if not items:
             return
         pre_len = len(self.messages)
         self._wake_source_tag = "system_nudge"
+        self._wake_drained_reminders = [
+            {"type": nudge_type, "text": text} for nudge_type, text in items
+        ]
         try:
             self.send("")
         except Exception:
@@ -5911,6 +5934,7 @@ class ChatSession:
             raise
         finally:
             self._wake_source_tag = ""
+            self._wake_drained_reminders = None
 
     def _apply_post_execute_advisories(
         self,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2495,6 +2495,8 @@ class ChatSession:
         user_input: str,
         attachments: list[Attachment] | tuple[Attachment, ...],
         send_id: str | None = None,
+        *,
+        from_wake: bool = False,
     ) -> int:
         """Append a user turn (plain or multipart) and persist it.
 
@@ -2557,13 +2559,18 @@ class ChatSession:
             user_content = user_input
 
         user_msg: dict[str, Any] = {"role": "user", "content": user_content}
-        if self._wake_source_tag:
+        if from_wake and self._wake_source_tag:
             # Sibling tag for audit / replay: the synthetic empty user
             # message emitted by ``deliver_wake_nudge_from_queue`` is
             # marked so UI can render it distinctly (or hide it) and
             # log consumers can tell self-prompted turns from real
             # user input.  Stripped at the sanitize boundary by the
-            # leading-underscore filter.
+            # leading-underscore filter.  ``from_wake`` is required
+            # explicitly because :meth:`_flush_queued_messages` also
+            # calls this method during a wake's chat loop — those
+            # messages are real user input that happens to be
+            # delivered while a wake is in flight, NOT synthetic, so
+            # they must not inherit the wake tag.
             user_msg["_source"] = self._wake_source_tag
         if attachments:
             # Sibling metadata so live history replay has the same shape
@@ -2595,6 +2602,15 @@ class ChatSession:
         # consume are two separate transactions; a crash between them
         # leaves pending rows that the UI's chip rehydration can still
         # surface so the user can clear or resend them.
+        #
+        # Skip the persist for the wake's synthesized empty turn — the
+        # row would carry no content (the system-reminder lives on the
+        # ``_reminders`` sibling, stripped before persist) and the
+        # ``_source`` audit tag isn't column-backed.  Replays can
+        # re-derive the wake event from the conversation flow without
+        # this empty row.
+        if from_wake and not user_input and not attachments:
+            return 0
         message_id = save_message(self._ws_id, "user", user_input)
         if attachments and message_id:
             mark_attachments_consumed(
@@ -2613,6 +2629,8 @@ class ChatSession:
         user_input: str,
         attachments: list[Attachment] | None = None,
         send_id: str | None = None,
+        *,
+        from_wake: bool = False,
     ) -> None:
         """Send user input and handle the response loop (including tool calls).
 
@@ -2662,7 +2680,7 @@ class ChatSession:
         if nudge:
             self._queue_user_advisory(*nudge)
 
-        self._append_user_turn(user_input, attachments or (), send_id=send_id)
+        self._append_user_turn(user_input, attachments or (), send_id=send_id, from_wake=from_wake)
 
         try:
             while True:
@@ -5908,7 +5926,7 @@ class ChatSession:
         Drains the queue inline (running every entry's ``valid_until``
         predicate) BEFORE synthesizing the empty user turn — bails if
         no entry survives the predicate check.  Without this, the
-        watcher's ``has_pending`` peek can succeed on entries whose
+        watcher's ``len(queue)`` peek can succeed on entries whose
         predicate later drops them inside
         ``_attach_pending_user_reminders``'s drain, leaving us
         synthesizing an empty user turn with no reminder context (and
@@ -5926,7 +5944,7 @@ class ChatSession:
             {"type": nudge_type, "text": text} for nudge_type, text in items
         ]
         try:
-            self.send("")
+            self.send("", from_wake=True)
         except Exception:
             for msg in self.messages[pre_len:]:
                 if msg.get("_reminders"):

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -89,6 +89,7 @@ from turnstone.core.metacognition import (
     format_nudge,
     should_nudge,
 )
+from turnstone.core.nudge_queue import TOOL_DRAIN, USER_DRAIN, NudgeQueue
 from turnstone.core.providers import create_provider
 from turnstone.core.safety import is_command_blocked, sanitize_command
 from turnstone.core.sandbox import execute_math_sandboxed
@@ -754,19 +755,21 @@ class ChatSession:
         self._watch_pending: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=20)
         self._watch_dispatch_depth = 0
         # Metacognitive nudges: ephemeral prompts for proactive memory use.
-        # Two buffers, one per delivery channel — the system message no
-        # longer carries nudges, so neither buffer triggers a system-prefix
-        # rebuild (and therefore neither busts the prompt cache):
-        #   - tool advisories drain into the next tool-result envelope via
-        #     _collect_advisories (alongside GuardAdvisory / UserInterjection)
-        #   - user advisories splice as <system-reminder> blocks at the
-        #     end of the next user message in _append_user_turn
-        # Both store ``(nudge_type, text)`` so readers don't have to track
-        # which channel boxes its payload — the tool channel constructs
-        # ``MetacognitiveAdvisory`` at drain time inside _collect_advisories.
+        # One ``NudgeQueue`` per session; producers tag each entry with a
+        # channel and consumers drain by filter:
+        #   - "user" entries drain at the next user-message seam via
+        #     ``_attach_pending_user_reminders`` and splice as
+        #     <system-reminder> blocks
+        #   - "tool" entries drain at the next tool-result batch via
+        #     ``_collect_advisories`` (alongside GuardAdvisory and
+        #     UserInterjection)
+        #   - "any" entries drain at whichever seam fires first; used for
+        #     wake-trigger-driven nudges that should not pin to a
+        #     specific seam
+        # Cooldown timestamps live separately in ``_metacog_state`` for
+        # ``should_nudge`` gating.
         self._metacog_state: dict[str, float] = {}
-        self._pending_tool_advisories: list[tuple[str, str]] = []  # (type, text)
-        self._pending_user_advisories: list[tuple[str, str]] = []  # (type, text)
+        self._nudge_queue = NudgeQueue()
         # User message queue: messages sent while model is executing.
         # OrderedDict preserves FIFO order and supports O(1) removal by ID.
         # Queued user turns never carry attachments — see
@@ -2993,18 +2996,17 @@ class ChatSession:
             raise
 
     def _drain_pending_advisories(self) -> None:
-        """Drop both advisory channels' pending buffers.
+        """Drop every pending nudge regardless of channel.
 
-        Both channels are scoped to the current generation: tool-channel
-        nudges (``tool_error``, ``repeat``) queued earlier in this batch
-        and user-channel nudges (``correction``, ``denial``, …) queued
-        during ``_check_metacognitive_nudge`` but not yet drained.  When
-        a generation is abandoned (cancel, KeyboardInterrupt, unexpected
-        exception) both must drop so they don't bleed into the next
-        send's tool loop or next user turn.
+        Tool-channel nudges (``tool_error``, ``repeat``) queued earlier
+        in this batch and user-channel nudges (``correction``,
+        ``denial``, …) queued during ``_check_metacognitive_nudge`` but
+        not yet drained share the same per-session :class:`NudgeQueue`.
+        When a generation is abandoned (cancel, KeyboardInterrupt,
+        unexpected exception) the entire queue drops so nothing bleeds
+        into the next send's tool loop or next user turn.
         """
-        self._pending_tool_advisories.clear()
-        self._pending_user_advisories.clear()
+        self._nudge_queue.clear()
 
     def _synthesize_cancelled_results(self, reason: str) -> None:
         """Synthesize tool_result messages for orphaned tool_calls after cancel.
@@ -4174,9 +4176,8 @@ class ChatSession:
         # Lands on the tool message dict's ``_reminders`` side-channel
         # (caller's responsibility) so it stays out of persisted content
         # and rides the wire only via the transient-copy splice.
-        if is_last_in_batch and self._pending_tool_advisories:
-            drained = list(self._pending_tool_advisories)
-            self._pending_tool_advisories.clear()
+        if is_last_in_batch:
+            drained = self._nudge_queue.drain(TOOL_DRAIN)
             metacog_reminders.extend({"type": nt, "text": text} for nt, text in drained)
 
         # Drain queued user messages on the last result in the batch.
@@ -5760,16 +5761,20 @@ class ChatSession:
     def _queue_user_advisory(self, nudge_type: str, text: str) -> None:
         """Queue a metacognitive nudge for the next user turn.
 
-        Drains in ``_append_user_turn`` onto the user message dict's
-        ``_reminders`` side-channel.  Used for nudges that respond to
-        user behaviour: ``correction``, ``denial``, ``resume``,
-        ``start``, ``completion``.
+        Drains in ``_attach_pending_user_reminders`` onto the user
+        message dict's ``_reminders`` side-channel.  Used for nudges
+        that respond to user behaviour: ``correction``, ``denial``,
+        ``resume``, ``start``, ``completion``.
         """
-        self._pending_user_advisories.append((nudge_type, text))
+        self._nudge_queue.enqueue(nudge_type, text, "user")
 
     def _attach_pending_user_reminders(self, user_msg: dict[str, Any]) -> None:
-        """Drain ``_pending_user_advisories`` onto *user_msg*'s ``_reminders``
-        sibling key (a side-channel, never inside ``content``).
+        """Drain user-channel nudges from :class:`NudgeQueue` onto
+        *user_msg*'s ``_reminders`` sibling key (a side-channel, never
+        inside ``content``).
+
+        Drains entries whose ``channel`` is in ``{"user", "any"}``;
+        ``"tool"`` entries stay queued for the next tool-result batch.
 
         Mutates *user_msg* in place — the caller appends it after.  The
         rendered ``<system-reminder>`` envelope is built later in
@@ -5793,11 +5798,9 @@ class ChatSession:
         not abort the user's send (which would otherwise drop both the
         user message and the queued nudges).
         """
-        if not self._pending_user_advisories:
+        items = self._nudge_queue.drain(USER_DRAIN)
+        if not items:
             return
-
-        items = list(self._pending_user_advisories)
-        self._pending_user_advisories.clear()
 
         reminders = [{"type": nudge_type, "text": text} for nudge_type, text in items]
         user_msg["_reminders"] = reminders
@@ -5815,7 +5818,7 @@ class ChatSession:
         the tool-result envelope. Used for nudges that respond to model
         behaviour at a tool boundary: ``tool_error``, ``repeat``.
         """
-        self._pending_tool_advisories.append((nudge_type, text))
+        self._nudge_queue.enqueue(nudge_type, text, "tool")
 
     def _apply_post_execute_advisories(
         self,
@@ -5826,8 +5829,9 @@ class ChatSession:
 
         Mutates *results* in place when an identical-repeat warning is
         appended to a tool's text output.  Updates ``self._repeat_detector``,
-        ``self._pending_tool_advisories``, and ``self._metacog_state``
-        (cooldown timestamp via ``should_nudge``).  The operator-visible
+        ``self._nudge_queue`` (via ``_queue_tool_advisory``), and
+        ``self._metacog_state`` (cooldown timestamp via ``should_nudge``).
+        The operator-visible
         signal is the themed ``tool_reminder`` bubble below the tool
         block — emitted by the per-result loop downstream when the
         drained metacog reminders attach to the tool message dict's

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3683,7 +3683,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_client.stop_renewal()
     if app.state.watch_runner:
         app.state.watch_runner.stop()
-    from turnstone.core.metacognition import shutdown_idle_nudge_watchers
+    from turnstone.core.idle_nudge_watcher import shutdown_idle_nudge_watchers
 
     shutdown_idle_nudge_watchers(app)
     # Drain + stop the buffered state-writer. shutdown() joins a
@@ -3996,7 +3996,7 @@ def create_app(
     # Feature-inert until a producer enqueues against the interactive
     # SessionManager (PR 4 watch switchover); installed here for
     # symmetry with the coord-side install in console/server.py.
-    from turnstone.core.metacognition import install_idle_nudge_watcher
+    from turnstone.core.idle_nudge_watcher import install_idle_nudge_watcher
 
     install_idle_nudge_watcher(app, workstreams)
     app.state.global_queue = global_queue

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3683,6 +3683,9 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
         await tls_client.stop_renewal()
     if app.state.watch_runner:
         app.state.watch_runner.stop()
+    from turnstone.core.metacognition import shutdown_idle_nudge_watchers
+
+    shutdown_idle_nudge_watchers(app)
     # Drain + stop the buffered state-writer. shutdown() joins a
     # daemon thread and runs synchronous DB writes; offload to a
     # worker thread so we don't block the lifespan event loop and
@@ -3988,6 +3991,14 @@ def create_app(
     )
     app.state.workstreams = workstreams
     app.state.state_writer = state_writer
+    # Idle-driven wake trigger: dispatches a synthetic empty-user-turn
+    # send when an interactive workstream goes IDLE with queued nudges.
+    # Feature-inert until a producer enqueues against the interactive
+    # SessionManager (PR 4 watch switchover); installed here for
+    # symmetry with the coord-side install in console/server.py.
+    from turnstone.core.metacognition import install_idle_nudge_watcher
+
+    install_idle_nudge_watcher(app, workstreams)
     app.state.global_queue = global_queue
     app.state.global_listeners = global_listeners
     app.state.global_listeners_lock = global_listeners_lock


### PR DESCRIPTION
## Summary

Introduces a metacognition wake channel that lets the system originate a model turn when something noteworthy happens while the session is idle. First concrete consumer: a coordinator-side observer that nudges idle coordinators with active children to consider \`wait_for_workstream\` rather than replying prematurely.

The work landed as four commits, each independently reviewable:

1. **`refactor(metacog)`** — Replaces dual `_pending_user_advisories` / `_pending_tool_advisories` lists with a single channel-tagged `NudgeQueue` per session. Producers tag entries `"user"` / `"tool"` / `"any"`; consumers drain by channel filter at their existing seams. Zero behavior change for existing nudges (`start`, `correction`, `completion`, `denial`, `resume`, `tool_error`, `repeat`).

2. **`feat(metacog) wake trigger`** — Adds `IdleNudgeWatcher` (subscribes to `SessionManager.subscribe_to_state`) plus `ChatSession.deliver_wake_nudge_from_queue`. On a workstream IDLE transition with queued nudges, dispatches via `session_worker.send` with a no-op `enqueue` closure so a busy-worker race silently drops without spawning a competing worker. Synthesizes an empty user turn whose `_reminders` side-channel carries the rendered envelope; `_apply_reminders_for_provider` splices the system-reminder onto the trailing edge of empty content for the wire. `_wake_source_tag` guards prevent recursive nudge generation during the wake's own tool dispatch and are saved/restored across `_dispatch_pending_watch` so chained watch sends behave normally.

3. **`feat(metacog) coord idle-children`** — `CoordinatorIdleObserver` subscribes to coord IDLE events; on coords with active children, enqueues an `idle_children` nudge listing the children and suggesting `wait_for_workstream`. Per-(ws, type) hard cap of 3 fires resets only on non-wake leave-IDLE. `valid_until` predicate (new on `NudgeQueue.enqueue`) re-checks active children at drain time via the cheap `count_workstreams_by_state`, dropping the entry if the snapshot has gone stale. User-controlled child names sanitized (ASCII control chars, Unicode bidi/zero-width/separator/tag chars, angle brackets) before interpolation.

4. **`fix(metacog) apply-pass`** — 11 confirmed findings from the pre-push full-stack review. Most important: bug-1 fixed a cross-PR integration leak where `_append_user_turn` was stamping `_source = "system_nudge"` on real user messages flushed via `_flush_queued_messages` during a wake send. Now both `send` and `_append_user_turn` take an explicit `from_wake: bool` so only the synthesized first turn carries the audit tag. Also reordered observer gates so the cooldown peek runs before storage queries; added the missing coord-path integration test; split `IdleNudgeWatcher` into `turnstone/core/idle_nudge_watcher.py` so `metacognition.py` stays a static-template module.

## Architecture invariants

- Both wake-triggered worker spawns and real user-send spawns funnel through `session_worker.send`; whichever wins the per-workstream lock spawns, the loser's intent is queued via `_queued_messages` (real send) or stays in `NudgeQueue` (wake) — no message loss in either direction.
- Observer registers BEFORE watcher in console lifespan so on the same IDLE event the observer enqueues first, then the watcher peeks.
- The wake's synthetic empty user turn is not persisted to the conversations table (would carry no content).

## Test plan

- [x] 5571 non-live tests pass (added 56 across new test files: `test_nudge_queue.py`, `test_idle_nudge_watcher.py`, `test_coordinator_idle_observer.py`, `test_idle_nudge_wake_integration.py`, plus `TestDeliverWakeNudge` and `TestFormatIdleChildrenNudge` in existing files)
- [x] Boundary-crossing integration tests drive through real \`SessionManager\` + real \`ChatSession\` + real \`IdleNudgeWatcher\` (interactive path) and real \`SessionManager\` + real \`ChatSession\` + \`CoordinatorIdleObserver\` + \`IdleNudgeWatcher\` in production install order (coord path)
- [x] ruff clean across the diff
- [x] mypy clean across all 187 source files

## Deferred

- **PR 4 (watch dispatcher switchover)** — replace `session.send(msg)` in `_make_watch_dispatch` with `session._nudge_queue.enqueue("watch_triggered", msg, "any")`. One-line change once we want it.
- Storage state-filter pushdown (currently observer fetches up to 200 children then filters state in Python — bumped limit covers realistic histories; the structural fix would add a `states=` kwarg to `list_workstreams`).
- Test fake consolidation across `test_idle_nudge_watcher.py` + `test_coordinator_idle_observer.py` — cosmetic.