### PR TITLE
feat(metacog): structured watch-card UX + persistent reminder side-channels

### DIFF
--- a/tests/test_build_history_reminders.py
+++ b/tests/test_build_history_reminders.py
@@ -1,0 +1,143 @@
+"""Tests for ``turnstone.server._build_history`` reminder + source surfacing.
+
+The replay path (``_build_history``) projects the ``_source`` and
+``_reminders`` side-channels onto the wire entry the frontend
+consumes.  Persisted via migration 050 (Commit 1) so multi-tab /
+multi-device replay sees the same metacognitive bubble shape the
+originating tab saw live.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from turnstone.server import _build_history
+
+
+def _make_stub_session(messages: list[dict[str, Any]]) -> Any:
+    """Minimal ChatSession-shaped stub.  ``_build_history`` only reads
+    ``session.messages`` plus calls ``_load_verdict_indexes(ws_id)`` —
+    the latter we patch out below.
+    """
+    return SimpleNamespace(messages=messages, _ws_id="ws-test")
+
+
+def _build(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Run ``_build_history`` against a stub session, bypassing the
+    verdicts / output-assessment storage round-trip (no tool_calls in
+    these tests, so the indexes are unused anyway).
+    """
+    session = _make_stub_session(messages)
+    with patch(
+        "turnstone.server._load_verdict_indexes",
+        return_value=({}, {}),
+    ):
+        return _build_history(session)
+
+
+class TestSourceSurfacing:
+    def test_source_surfaces_when_set(self) -> None:
+        msg = {
+            "role": "user",
+            "content": "",
+            "_source": "system_nudge",
+        }
+        history = _build([msg])
+        assert len(history) == 1
+        assert history[0]["source"] == "system_nudge"
+
+    def test_source_absent_when_unset(self) -> None:
+        msg = {"role": "user", "content": "hello"}
+        history = _build([msg])
+        assert "source" not in history[0]
+
+
+class TestRemindersWidening:
+    def test_watch_triggered_optional_fields_propagate(self) -> None:
+        """The widened payload (Commit 2) carries watch_name / command /
+        poll_count / max_polls / is_final on each ``watch_triggered``
+        reminder so the frontend renders ``.msg.watch-result``.
+        """
+        msg = {
+            "role": "user",
+            "content": "",
+            "_source": "system_nudge",
+            "_reminders": [
+                {
+                    "type": "watch_triggered",
+                    "text": "$ ls\nfile.txt",
+                    "watch_name": "w1",
+                    "command": "ls",
+                    "poll_count": 2,
+                    "max_polls": 100,
+                    "is_final": False,
+                }
+            ],
+        }
+        history = _build([msg])
+        assert history[0]["source"] == "system_nudge"
+        assert history[0]["reminders"] == [
+            {
+                "type": "watch_triggered",
+                "text": "$ ls\nfile.txt",
+                "watch_name": "w1",
+                "command": "ls",
+                "poll_count": 2,
+                "max_polls": 100,
+                "is_final": False,
+            }
+        ]
+
+    def test_legacy_two_field_reminders_still_work(self) -> None:
+        """Producers without optional fields (correction / denial /
+        idle_children) keep the legacy ``{type, text}`` shape — the
+        widened filter just doesn't add anything beyond that."""
+        msg = {
+            "role": "user",
+            "content": "noted",
+            "_reminders": [{"type": "correction", "text": "watch out"}],
+        }
+        history = _build([msg])
+        assert history[0]["reminders"] == [{"type": "correction", "text": "watch out"}]
+
+    def test_unknown_keys_are_dropped(self) -> None:
+        """The wire-layer filter projects on a known set of keys so a
+        future producer accidentally stuffing arbitrary fields can't
+        leak them through replay.
+        """
+        msg = {
+            "role": "user",
+            "content": "x",
+            "_reminders": [
+                {
+                    "type": "correction",
+                    "text": "hi",
+                    "secret": "leak-me",
+                    "internal_id": 42,
+                }
+            ],
+        }
+        history = _build([msg])
+        clean = history[0]["reminders"][0]
+        assert "secret" not in clean
+        assert "internal_id" not in clean
+        assert clean == {"type": "correction", "text": "hi"}
+
+    def test_malformed_reminder_skipped(self) -> None:
+        """A non-dict / empty entry is filtered out instead of breaking
+        the rest of the list (mirrors the defensive filter in
+        ``_apply_reminders_for_provider``).
+        """
+        msg = {
+            "role": "user",
+            "content": "x",
+            "_reminders": [
+                "garbage string",
+                {"type": "", "text": ""},  # empty type + text → drop
+                {"type": "denial", "text": "ok"},
+            ],
+        }
+        history = _build([msg])
+        assert history[0]["reminders"] == [{"type": "denial", "text": "ok"}]

--- a/tests/test_idle_nudge_wake_integration.py
+++ b/tests/test_idle_nudge_wake_integration.py
@@ -64,8 +64,8 @@ class _FakeUI:
     def on_state_change(self, state: str) -> None:
         self.events.append(("state", state))
 
-    def on_user_reminder(self, reminders: Any) -> None:
-        self.events.append(("user_reminder", reminders))
+    def on_user_reminder(self, reminders: Any, source: str | None = None) -> None:
+        self.events.append(("user_reminder", reminders, source))
 
     def on_error(self, message: str) -> None:
         pass

--- a/tests/test_nudge_queue.py
+++ b/tests/test_nudge_queue.py
@@ -17,7 +17,9 @@ class TestEnqueueDrain:
         q.enqueue("c", "3", "any")
         # Drain everything regardless of channel — preserves insertion order.
         out = q.drain({"user", "tool", "any"})
-        assert out == [("a", "1"), ("b", "2"), ("c", "3")]
+        # Drain returns ``(nudge_type, text, metadata)``; producers
+        # without ``metadata`` see ``None`` in the third slot.
+        assert out == [("a", "1", None), ("b", "2", None), ("c", "3", None)]
         assert len(q) == 0
 
     def test_drain_filter_keeps_non_matching(self):
@@ -26,22 +28,22 @@ class TestEnqueueDrain:
         q.enqueue("b", "y", "tool")
         # Drain only user → tool entry stays.
         out = q.drain(USER_DRAIN)
-        assert out == [("a", "x")]
+        assert out == [("a", "x", None)]
         assert len(q) == 1
         # Now drain tool — gets the remaining entry.
         out = q.drain(TOOL_DRAIN)
-        assert out == [("b", "y")]
+        assert out == [("b", "y", None)]
         assert len(q) == 0
 
     def test_any_channel_drains_on_either_seam(self):
         q = NudgeQueue()
         q.enqueue("c", "z", "any")
         # User-seam drain pulls "any".
-        assert q.drain(USER_DRAIN) == [("c", "z")]
+        assert q.drain(USER_DRAIN) == [("c", "z", None)]
         assert len(q) == 0
         # Re-enqueue and prove tool-seam also drains "any".
         q.enqueue("d", "w", "any")
-        assert q.drain(TOOL_DRAIN) == [("d", "w")]
+        assert q.drain(TOOL_DRAIN) == [("d", "w", None)]
         assert len(q) == 0
 
     def test_drain_empty_filter_no_op(self):
@@ -65,9 +67,9 @@ class TestEnqueueDrain:
         q.enqueue("c", "3", "user")
         q.enqueue("d", "4", "tool")
         # Drain user — should get "a" then "c" in order; "b","d" stay.
-        assert q.drain({"user"}) == [("a", "1"), ("c", "3")]
+        assert q.drain({"user"}) == [("a", "1", None), ("c", "3", None)]
         # Tool drain follows insertion order on remaining.
-        assert q.drain({"tool"}) == [("b", "2"), ("d", "4")]
+        assert q.drain({"tool"}) == [("b", "2", None), ("d", "4", None)]
 
 
 class TestLenAndClear:
@@ -279,6 +281,70 @@ class TestPending:
         assert len(q) == 2
 
 
+class TestMetadata:
+    """Producer-supplied ``metadata`` rides alongside ``(type, text)`` on
+    drain.  Today only ``watch_triggered`` populates it; the wire shape
+    accommodates future producers (e.g. structured tool_error context)
+    without another schema bump.
+    """
+
+    def test_drain_returns_metadata_when_set(self):
+        q = NudgeQueue()
+        meta = {"watch_name": "w1", "command": "ls", "poll_count": 2}
+        q.enqueue("watch_triggered", "$ ls\nfile.txt", "any", metadata=meta)
+        out = q.drain({"any"})
+        assert out == [("watch_triggered", "$ ls\nfile.txt", meta)]
+
+    def test_drain_returns_none_when_metadata_unset(self):
+        q = NudgeQueue()
+        q.enqueue("idle_children", "kids", "any")  # no metadata kwarg
+        out = q.drain({"any"})
+        assert out == [("idle_children", "kids", None)]
+
+    def test_pending_with_metadata_projects_third_field(self):
+        q = NudgeQueue()
+        q.enqueue("a", "1", "user")
+        q.enqueue("watch_triggered", "out", "any", metadata={"watch_name": "w"})
+        snapshot = q.pending_with_metadata()
+        assert snapshot == [
+            ("a", "1", None),
+            ("watch_triggered", "out", {"watch_name": "w"}),
+        ]
+        # ``pending`` (without metadata) keeps the legacy 2-tuple shape.
+        assert q.pending() == [("a", "1"), ("watch_triggered", "out")]
+
+    def test_metadata_survives_partial_drain(self):
+        """A ``user``-channel drain leaves an unaffected ``tool``-channel
+        entry — its metadata must still be present on the next drain."""
+        q = NudgeQueue()
+        q.enqueue("user_thing", "u", "user")
+        q.enqueue("watch_triggered", "w-out", "tool", metadata={"watch_name": "w1"})
+        # User drain doesn't touch the tool entry.
+        assert q.drain({"user"}) == [("user_thing", "u", None)]
+        # Tool drain still has the metadata.
+        assert q.drain({"tool"}) == [
+            ("watch_triggered", "w-out", {"watch_name": "w1"}),
+        ]
+
+    def test_metadata_with_valid_until_predicate(self):
+        """Metadata + ``valid_until`` co-exist on the same entry; the
+        predicate gate runs as before, and on a True result the metadata
+        rides the drained tuple.
+        """
+        q = NudgeQueue()
+        q.enqueue(
+            "watch_triggered",
+            "w-out",
+            "any",
+            valid_until=lambda: True,
+            metadata={"watch_name": "w1", "is_final": True},
+        )
+        out = q.drain({"any"})
+        assert out == [
+            ("watch_triggered", "w-out", {"watch_name": "w1", "is_final": True}),
+        ]
+
+
 class TestHasPending:
     def test_has_pending_returns_false_on_empty_queue(self):
         q = NudgeQueue()
@@ -343,7 +409,7 @@ class TestValidUntil:
         q = NudgeQueue()
         q.enqueue("a", "1", "any", valid_until=lambda: True)
         out = q.drain({"any"})
-        assert out == [("a", "1")]
+        assert out == [("a", "1", None)]
 
     def test_valid_until_false_drops_silently(self):
         q = NudgeQueue()
@@ -386,7 +452,7 @@ class TestValidUntil:
         # Outer's predicate ran outside the lock, enqueued "inner";
         # outer's True return delivered "outer".  "inner" was enqueued
         # AFTER the partition snapshot, so it stays in the queue.
-        assert out == [("outer", "1")]
+        assert out == [("outer", "1", None)]
         assert q.pending() == [("inner", "from-predicate")]
 
     def test_valid_until_only_evaluated_for_matching_channel(self):
@@ -412,7 +478,7 @@ class TestValidUntil:
         # No predicate → entry behaves identically to pre-PR-3 entries.
         q = NudgeQueue()
         q.enqueue("a", "1", "any")  # no valid_until kwarg
-        assert q.drain({"any"}) == [("a", "1")]
+        assert q.drain({"any"}) == [("a", "1", None)]
 
 
 class TestConcurrency:
@@ -444,7 +510,11 @@ class TestConcurrency:
                 drained = q.drain({"user"})
                 if drained:
                     with observed_lock:
-                        observed.extend(drained)
+                        # Drop the trailing ``metadata`` slot — every
+                        # entry here was enqueued without metadata, so
+                        # the comparison set / count matches the produced
+                        # ``(type, text)`` shape.
+                        observed.extend((nt, txt) for nt, txt, _meta in drained)
 
         consumer = threading.Thread(target=consume, daemon=True)
         consumer.start()

--- a/tests/test_reconstruct_messages.py
+++ b/tests/test_reconstruct_messages.py
@@ -15,9 +15,26 @@ def _row(
     tc_id=None,
     pdata=None,
     tool_calls=None,
+    source=None,
+    reminders=None,
 ):
-    """Build a 7-element conversation row tuple (id, role, ...)."""
-    return (next(_row_ids), role, content, tool_name, tc_id, pdata, tool_calls)
+    """Build a 9-element conversation row tuple (id, role, ...).
+
+    Trailing ``source`` / ``reminders`` mirror the persisted twins of
+    the in-memory ``_source`` / ``_reminders`` side-channels added in
+    migration 050.
+    """
+    return (
+        next(_row_ids),
+        role,
+        content,
+        tool_name,
+        tc_id,
+        pdata,
+        tool_calls,
+        source,
+        reminders,
+    )
 
 
 class TestAssistantWithToolCalls:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3362,6 +3362,62 @@ class TestReminderSidechannelIsolation:
         assert "HISTORICAL_REMINDER_BODY" not in rendered
         assert "<system-reminder>" not in rendered
 
+    def test_fork_preserves_source_and_reminders(self, tmp_db):
+        """``ChatSession.resume(..., fork=True)`` bulk-inserts the source
+        workstream's messages into the fork's own ws_id.  The bulk-row
+        builder must carry the persisted side-channels (``_source`` /
+        ``_reminders``) — both backends' ``save_messages_bulk`` accept
+        them post-migration 050.  Dropping them was the original bug:
+        the fork's resumed transcript lost every wake marker and every
+        reminder bubble that survived to disk on the source, so the
+        resumed transcript looked like the assistant turn answered out
+        of nowhere.
+        """
+        from turnstone.core.memory import register_workstream, save_message
+
+        # Stage a source workstream with both a wake row (``_source =
+        # system_nudge``) and a reminders-bearing row.
+        register_workstream("fork_source")
+        save_message("fork_source", "user", "real turn")
+        save_message("fork_source", "user", "", source="system_nudge")
+        save_message(
+            "fork_source",
+            "user",
+            "advised turn",
+            reminders=json.dumps(
+                [{"type": "denial", "text": "FORKED_REMINDER_BODY"}],
+                separators=(",", ":"),
+            ),
+        )
+        save_message("fork_source", "assistant", "ok")
+
+        # Fork into a fresh session — keeps its own ws_id, copies the
+        # messages.  Then resume the fork (no fork=True) into a second
+        # fresh session and assert the side-channels round-tripped.
+        forking_session = _make_session()
+        fork_ws_id = forking_session._ws_id
+        assert forking_session.resume("fork_source", fork=True) is True
+
+        resumed_fork = _make_session()
+        assert resumed_fork.resume(fork_ws_id) is True
+
+        # Wake row's ``_source`` survived.
+        wake_msgs = [
+            m
+            for m in resumed_fork.messages
+            if m.get("role") == "user" and m.get("_source") == "system_nudge"
+        ]
+        assert len(wake_msgs) == 1
+        assert wake_msgs[0].get("content") == ""
+
+        # Reminders survived.
+        advised_msg = next(
+            m
+            for m in resumed_fork.messages
+            if m.get("role") == "user" and m.get("content") == "advised turn"
+        )
+        assert advised_msg.get("_reminders") == [{"type": "denial", "text": "FORKED_REMINDER_BODY"}]
+
 
 class TestSessionUIBaseUserReminderHook:
     """``on_user_reminder`` enqueues a ``user_reminder`` SSE event with

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3362,15 +3362,11 @@ class TestReminderSidechannelIsolation:
         assert "<system-reminder>" not in rendered
 
     def test_fork_preserves_source_and_reminders(self, tmp_db):
-        """``ChatSession.resume(..., fork=True)`` bulk-inserts the source
-        workstream's messages into the fork's own ws_id.  The bulk-row
-        builder must carry the persisted side-channels (``_source`` /
-        ``_reminders``) — both backends' ``save_messages_bulk`` accept
-        them post-migration 050.  Dropping them was the original bug:
-        the fork's resumed transcript lost every wake marker and every
-        reminder bubble that survived to disk on the source, so the
-        resumed transcript looked like the assistant turn answered out
-        of nowhere.
+        """A forked workstream's resumed transcript carries both wake
+        markers (``_source = "system_nudge"``) and reminder bubbles
+        (``_reminders``).  The bulk-row builder threads the side-channels
+        onto every fork row so reconnecting tabs see the same shape the
+        source workstream's originating tab rendered live.
         """
         from turnstone.core.memory import register_workstream, save_message
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3191,11 +3191,10 @@ class TestDeliverWakeNudge:
         assert session._wake_source_tag == ""
 
     def test_wake_row_persists_with_source_column(self, tmp_db):
-        """The wake's synthesised empty user turn now persists with
-        ``_source = "system_nudge"`` (post-#484 the skip at
-        ``session.py:2685-2686`` is dropped).  Without persistence,
-        a second tab connecting via /history would see the assistant
-        turn with no preceding wake context.
+        """The wake's synthesised empty user turn persists with
+        ``_source = "system_nudge"``.  Without persistence, a second
+        tab connecting via /history would see the assistant turn with
+        no preceding wake context.
         """
         from turnstone.core.storage import get_storage
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -50,7 +50,7 @@ class NullUI:
     def on_error(self, message):
         pass
 
-    def on_user_reminder(self, reminders):
+    def on_user_reminder(self, reminders, source=None):
         pass
 
     def on_tool_reminder(self, reminders, tool_call_id):
@@ -2240,10 +2240,13 @@ class TestMetacognitiveBuffers:
         msg = {"role": "user", "content": "noted"}
         session._attach_pending_user_reminders(msg)
         # on_user_reminder called with the same shape as _build_history
-        # surfaces — list of {type, text} dicts.
+        # surfaces — list of {type, text} dicts.  ``source`` rides as
+        # a kwarg (None for non-wake correction nudges); inspect via
+        # ``call_args.args`` for the positional reminders payload only.
         assert session.ui.on_user_reminder.call_count == 1
-        (reminders_arg,) = session.ui.on_user_reminder.call_args.args
+        reminders_arg = session.ui.on_user_reminder.call_args.args[0]
         assert reminders_arg == [{"type": "correction", "text": "watch out"}]
+        assert session.ui.on_user_reminder.call_args.kwargs.get("source") is None
 
     def test_attach_swallows_on_user_reminder_failure(self, tmp_db):
         """A UI hook implementation that raises (queue full, unexpected
@@ -3328,7 +3331,35 @@ class TestSessionUIBaseUserReminderHook:
         ui = _RecordingUI()
         reminders = [{"type": "correction", "text": "watch out"}]
         ui.on_user_reminder(reminders)
+        # ``source`` omitted from the payload when not provided —
+        # absent vs. None on the wire should mean the same thing.
         assert ui.events == [{"type": "user_reminder", "reminders": reminders}]
+
+    def test_on_user_reminder_carries_source_when_set(self):
+        """Wake-driven reminders fire with ``source="system_nudge"`` so
+        non-originating SSE consumers can render the thin
+        ``.msg.user.system-nudge`` marker before the reminder bubble.
+        """
+        from turnstone.core.session_ui_base import SessionUIBase
+
+        class _RecordingUI(SessionUIBase):
+            def __init__(self) -> None:
+                super().__init__()
+                self.events: list[dict] = []
+
+            def _enqueue(self, data: dict) -> None:  # type: ignore[override]
+                self.events.append(data)
+
+        ui = _RecordingUI()
+        reminders = [{"type": "idle_children", "text": "kids"}]
+        ui.on_user_reminder(reminders, source="system_nudge")
+        assert ui.events == [
+            {
+                "type": "user_reminder",
+                "reminders": reminders,
+                "source": "system_nudge",
+            }
+        ]
 
 
 class TestSessionUIBaseToolReminderHook:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3187,6 +3187,72 @@ class TestDeliverWakeNudge:
         # Wake tag cleared even on exception (finally block).
         assert session._wake_source_tag == ""
 
+    def test_wake_row_persists_with_source_column(self, tmp_db):
+        """The wake's synthesised empty user turn now persists with
+        ``_source = "system_nudge"`` (post-#484 the skip at
+        ``session.py:2685-2686`` is dropped).  Without persistence,
+        a second tab connecting via /history would see the assistant
+        turn with no preceding wake context.
+        """
+        from turnstone.core.storage import get_storage
+
+        session = _make_session()
+        session._title_generated = True
+        session._queue_user_advisory("denial", "leftover")
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        rows = get_storage().load_messages(session._ws_id)
+        wake_rows = [
+            r for r in rows if r.get("role") == "user" and r.get("_source") == "system_nudge"
+        ]
+        assert len(wake_rows) == 1
+        assert wake_rows[0]["content"] == ""
+
+    def test_user_reminder_persists_with_widened_payload(self, tmp_db):
+        """User-channel reminders attached to the wake's synthetic
+        empty turn round-trip through storage including their full
+        payload (the ``denial`` text here; later steps add optional
+        fields like ``watch_name`` for ``watch_triggered``).
+        """
+        from turnstone.core.storage import get_storage
+
+        session = _make_session()
+        session._title_generated = True
+        session._queue_user_advisory("denial", "do not do that")
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session,
+                "_stream_response",
+                return_value={"role": "assistant", "content": "ok"},
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        rows = get_storage().load_messages(session._ws_id)
+        wake_rows = [
+            r for r in rows if r.get("role") == "user" and r.get("_source") == "system_nudge"
+        ]
+        assert len(wake_rows) == 1
+        reminders = wake_rows[0].get("_reminders")
+        assert reminders == [{"type": "denial", "text": "do not do that"}]
+
 
 class TestReminderSidechannelIsolation:
     """The side-channel design's load-bearing guarantee: any reader of

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3311,6 +3311,57 @@ class TestReminderSidechannelIsolation:
         assert extracted_user == "first message body"
         assert "SECRET_NUDGE_TEXT" not in extracted_user
 
+    def test_resume_does_not_re_splice_persisted_reminders(self, tmp_db):
+        """Persisted reminders survive ``load_messages`` but the
+        in-memory ``_reminders_delivered`` flag does not (it's
+        session-scoped — the post-stream hook flips it after each
+        successful provider call, and persistence skips
+        leading-underscore siblings).  Without a re-splice guard at
+        resume time, ``_apply_reminders_for_provider`` would walk every
+        loaded message, see ``_reminders`` set + ``_reminders_delivered``
+        falsy, and splice every historical ``<system-reminder>`` envelope
+        onto the wire on the very next user turn — leaking each
+        reminder a second time, the turn after it had already advised.
+        """
+        from turnstone.core.memory import register_workstream, save_message
+
+        # Stage a workstream with a persisted user-channel reminder.
+        # Direct save_message so we control the exact reminders payload
+        # without driving a real send().
+        register_workstream("resume_no_resplice")
+        save_message("resume_no_resplice", "user", "first turn", source="system_nudge")
+        save_message(
+            "resume_no_resplice",
+            "user",
+            "second turn",
+            reminders=json.dumps(
+                [{"type": "denial", "text": "HISTORICAL_REMINDER_BODY"}],
+                separators=(",", ":"),
+            ),
+        )
+        save_message("resume_no_resplice", "assistant", "ok")
+
+        # Resume into a fresh session.
+        session = _make_session()
+        assert session.resume("resume_no_resplice") is True
+
+        # Sanity: the historical reminder is on the loaded message dict.
+        loaded_user = next(
+            m for m in session.messages if m.get("role") == "user" and m.get("_reminders")
+        )
+        assert loaded_user["_reminders"] == [{"type": "denial", "text": "HISTORICAL_REMINDER_BODY"}]
+
+        # Append a new live user turn (no reminders) and run the wire
+        # transform.  The output must NOT carry the historical reminder
+        # body — every loaded message that had _reminders should already
+        # be flagged delivered, so _apply_reminders_for_provider skips
+        # them on the pass-through path.
+        session.messages.append({"role": "user", "content": "live new turn"})
+        wire = session._apply_reminders_for_provider(session.messages)
+        rendered = "\n".join(m["content"] for m in wire if isinstance(m.get("content"), str))
+        assert "HISTORICAL_REMINDER_BODY" not in rendered
+        assert "<system-reminder>" not in rendered
+
 
 class TestSessionUIBaseUserReminderHook:
     """``on_user_reminder`` enqueues a ``user_reminder`` SSE event with

--- a/tests/test_storage_source_reminders.py
+++ b/tests/test_storage_source_reminders.py
@@ -105,6 +105,35 @@ class TestRemindersRoundtrip:
         assert len(tool_msgs) == 1
         assert tool_msgs[0].get("_reminders") == payload
 
+    def test_nul_bytes_stripped_from_source_and_reminders(self, backend):
+        """NUL bytes must be stripped at the storage layer.
+
+        Producers (``sanitize_payload`` on the watch dispatch path,
+        constants for non-watch nudges) already strip NUL today so
+        nothing in production reaches this clamp — but the layer is
+        the tripwire if a future producer forgets, mirroring how
+        ``content`` and ``provider_data`` are sanitized.  PostgreSQL
+        TEXT columns reject NUL outright, so the sanitization is also
+        a hard correctness invariant on that backend.
+
+        ``json.dumps`` already escapes NUL inside string values to
+        ``\\u0000`` so a real NUL byte can't enter ``_reminders`` via
+        the normal encode path — the test feeds a raw NUL directly to
+        cover the bypass case (a future producer that hand-builds the
+        column string).
+        """
+        backend.register_workstream("s1")
+        backend.save_message(
+            "s1",
+            "user",
+            "",
+            source="system_nudge\x00",
+            reminders='[{"type":"watch_triggered","text":"ok\x00bad"}]',
+        )
+        msgs = backend.load_messages("s1")
+        assert msgs[0].get("_source") == "system_nudge"
+        assert msgs[0].get("_reminders") == [{"type": "watch_triggered", "text": "okbad"}]
+
     def test_malformed_reminders_json_does_not_crash_load(self, backend):
         """A garbage string in the column must not abort the whole
         load — mirrors the ``provider_data`` JSON-decode-suppress

--- a/tests/test_storage_source_reminders.py
+++ b/tests/test_storage_source_reminders.py
@@ -1,0 +1,129 @@
+"""Tests for ``_source`` / ``_reminders`` round-tripping through both
+storage backends.
+
+Persisting the in-memory side-channels lets multi-tab / multi-device
+replay show the same metacognitive bubble shape the originating tab
+saw live — see ``docs/design/watch-card-ux.md`` §1.
+"""
+
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+
+from turnstone.core.storage._schema import conversations
+
+
+class TestSourceRoundtrip:
+    def test_source_roundtrip(self, backend):
+        backend.register_workstream("s1")
+        backend.save_message("s1", "user", "", source="system_nudge")
+        msgs = backend.load_messages("s1")
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == ""
+        assert msgs[0].get("_source") == "system_nudge"
+
+    def test_source_absent_when_not_set(self, backend):
+        backend.register_workstream("s1")
+        backend.save_message("s1", "user", "hello")
+        msgs = backend.load_messages("s1")
+        assert "_source" not in msgs[0]
+
+
+class TestRemindersRoundtrip:
+    def test_reminders_roundtrip(self, backend):
+        backend.register_workstream("s1")
+        payload = [
+            {
+                "type": "watch_triggered",
+                "text": "$ ls\nfile.txt\n",
+                "watch_name": "w1",
+                "command": "ls",
+                "poll_count": 2,
+                "max_polls": 100,
+                "is_final": False,
+            }
+        ]
+        backend.save_message(
+            "s1",
+            "user",
+            "",
+            source="system_nudge",
+            reminders=json.dumps(payload, separators=(",", ":")),
+        )
+        msgs = backend.load_messages("s1")
+        assert msgs[0].get("_reminders") == payload
+        # Optional fields preserved verbatim.
+        rem = msgs[0]["_reminders"][0]
+        assert rem["watch_name"] == "w1"
+        assert rem["command"] == "ls"
+        assert rem["poll_count"] == 2
+        assert rem["max_polls"] == 100
+        assert rem["is_final"] is False
+
+    def test_reminders_null_renders_as_no_key(self, backend):
+        """Absent vs. empty-list should map to the same shape on the
+        load side: ``_reminders`` simply not present in the dict.
+        Mirrors the ``_attachments_meta`` precedent in
+        ``reconstruct_messages``.
+        """
+        backend.register_workstream("s1")
+        backend.save_message("s1", "user", "hello")
+        msgs = backend.load_messages("s1")
+        assert "_reminders" not in msgs[0]
+
+    def test_tool_reminders_roundtrip(self, backend):
+        backend.register_workstream("s1")
+        # Build a minimal valid history: assistant turn with one
+        # tool_call followed by the tool result that carries the
+        # tool-channel reminder.  Without the assistant turn the
+        # tool row would be orphaned and stripped by the repair pass.
+        tc_json = json.dumps(
+            [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{}"},
+                }
+            ]
+        )
+        backend.save_message("s1", "user", "go")
+        backend.save_message("s1", "assistant", None, tool_calls=tc_json)
+        payload = [{"type": "tool_error", "text": "command failed"}]
+        backend.save_message(
+            "s1",
+            "tool",
+            "boom",
+            tool_call_id="c1",
+            reminders=json.dumps(payload, separators=(",", ":")),
+        )
+        msgs = backend.load_messages("s1")
+        # Find the tool message and assert reminders survived load.
+        tool_msgs = [m for m in msgs if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].get("_reminders") == payload
+
+    def test_malformed_reminders_json_does_not_crash_load(self, backend):
+        """A garbage string in the column must not abort the whole
+        load — mirrors the ``provider_data`` JSON-decode-suppress
+        pattern.  Concretely: write a row with valid columns BUT a
+        corrupted ``_reminders`` value via raw SQL, then verify the
+        load returns the message with no ``_reminders`` key (rather
+        than raising or surfacing the garbage).
+        """
+        backend.register_workstream("s1")
+        msg_id = backend.save_message("s1", "user", "hello")
+        with backend._engine.connect() as conn:
+            conn.execute(
+                sa.update(conversations)
+                .where(conversations.c.id == msg_id)
+                .values(_reminders="this is not json {{")
+            )
+            conn.commit()
+        msgs = backend.load_messages("s1")
+        assert len(msgs) == 1
+        # Garbage suppressed silently — key absent, content intact.
+        assert "_reminders" not in msgs[0]
+        assert msgs[0]["content"] == "hello"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -9,6 +9,7 @@ import pytest
 
 from turnstone.core.watch import (
     WatchRunner,
+    build_watch_reminder,
     evaluate_condition,
     format_interval,
     format_watch_message,
@@ -302,6 +303,62 @@ class TestFormatWatchMessage:
 
 
 # ---------------------------------------------------------------------------
+# build_watch_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWatchReminder:
+    """The structured-reminder builder lifts ``format_watch_message``'s
+    args into a dict the dispatch closure can pass to
+    ``WatchRunner._dispatch_result``.  ``text`` matches the formatter's
+    output verbatim (so compaction / channel adapters / wire splice
+    keep their behaviour), and the optional fields ride alongside for
+    the frontend's ``.msg.watch-result`` card.
+    """
+
+    def test_emits_text_body_and_fields(self):
+        kwargs = dict(
+            name="pr-review",
+            command="gh pr view --json state",
+            output='{"state": "MERGED"}',
+            poll_count=5,
+            max_polls=100,
+            elapsed_secs=1500,
+            stop_on='data["state"] == "MERGED"',
+            is_final=True,
+            reason='condition met: data["state"] == "MERGED"',
+        )
+        reminder = build_watch_reminder(**kwargs)
+        # Round-trip with format_watch_message — text is the same body
+        # the wire splice + channel adapters have always seen.
+        assert reminder["text"] == format_watch_message(**kwargs)
+        # Optional fields ride alongside.
+        assert reminder["type"] == "watch_triggered"
+        assert reminder["watch_name"] == "pr-review"
+        assert reminder["command"] == "gh pr view --json state"
+        assert reminder["poll_count"] == 5
+        assert reminder["max_polls"] == 100
+        assert reminder["is_final"] is True
+
+    def test_non_final_carries_is_final_false(self):
+        reminder = build_watch_reminder(
+            name="deploy",
+            command="curl -s http://localhost/health",
+            output="ok",
+            poll_count=3,
+            max_polls=50,
+            elapsed_secs=90,
+            stop_on=None,
+            is_final=False,
+            reason="",
+        )
+        assert reminder["is_final"] is False
+        assert reminder["poll_count"] == 3
+        # No "auto-cancelled" body for non-final fires.
+        assert "auto-cancelled" not in reminder["text"].lower()
+
+
+# ---------------------------------------------------------------------------
 # WatchRunner
 # ---------------------------------------------------------------------------
 
@@ -450,13 +507,17 @@ class TestWatchRunner:
         runner.set_dispatch_fn("ws-1", fn1)
         runner.set_dispatch_fn("ws-2", fn2)
 
-        runner._dispatch_result("ws-1", "msg1", "watch-a")
-        fn1.assert_called_once_with("msg1", "watch-a")
+        # Post-Step-7 dispatch surface: ``_dispatch_result`` takes a
+        # structured reminder dict, not a bare string.
+        reminder1 = {"type": "watch_triggered", "text": "msg1"}
+        runner._dispatch_result("ws-1", reminder1, "watch-a")
+        fn1.assert_called_once_with(reminder1, "watch-a")
         fn2.assert_not_called()
 
         runner.remove_dispatch_fn("ws-1")
         # After removal, dispatch should try restore_fn
-        runner._dispatch_result("ws-1", "msg2", "watch-b")
+        reminder2 = {"type": "watch_triggered", "text": "msg2"}
+        runner._dispatch_result("ws-1", reminder2, "watch-b")
         fn1.assert_called_once()  # still just the one call
 
     def test_restore_fn_called_for_evicted(self):
@@ -464,9 +525,10 @@ class TestWatchRunner:
         restore_fn = MagicMock(return_value=restored_fn)
         runner = self._make_runner(restore_fn=restore_fn)
 
-        runner._dispatch_result("ws-evicted", "hello", "watch-x")
+        reminder = {"type": "watch_triggered", "text": "hello"}
+        runner._dispatch_result("ws-evicted", reminder, "watch-x")
         restore_fn.assert_called_once_with("ws-evicted")
-        restored_fn.assert_called_once_with("hello", "watch-x")
+        restored_fn.assert_called_once_with(reminder, "watch-x")
 
     def test_get_dispatch_fn_returns_registered_fn(self):
         """``get_dispatch_fn`` is the public accessor used by the

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -507,8 +507,8 @@ class TestWatchRunner:
         runner.set_dispatch_fn("ws-1", fn1)
         runner.set_dispatch_fn("ws-2", fn2)
 
-        # Post-Step-7 dispatch surface: ``_dispatch_result`` takes a
-        # structured reminder dict, not a bare string.
+        # ``_dispatch_result`` takes a structured reminder dict, not a
+        # bare string.
         reminder1 = {"type": "watch_triggered", "text": "msg1"}
         runner._dispatch_result("ws-1", reminder1, "watch-a")
         fn1.assert_called_once_with(reminder1, "watch-a")

--- a/tests/test_watch_dispatch.py
+++ b/tests/test_watch_dispatch.py
@@ -1,8 +1,8 @@
 """Tests for the watch dispatch closure built inside ``set_watch_runner``.
 
 The closure routes watch results onto the per-session :class:`NudgeQueue`
-under the unified pull-model surface (post-#482).  Each test focuses on
-one assertion: enqueue shape, sanitisation, soft-cap drop-oldest,
+under the unified pull-model surface.  Each test focuses on one
+assertion: enqueue shape, sanitisation, soft-cap drop-oldest,
 ``valid_until`` predicate, and concurrent-enqueue safety.
 
 Tests in this file replace the pre-switchover suite that pinned the
@@ -357,11 +357,11 @@ def test_dispatch_no_op_for_empty_payloads(tmp_db, payload: str):
 
 
 class TestMetadataPropagation:
-    """Step 7 of the watch-card UX plan: the dispatch closure pulls
-    optional fields out of the structured ``reminder`` dict and
-    attaches them to the queue entry's ``metadata``.  Drain seams later
-    merge ``metadata`` into the rendered reminder dict so the frontend
-    can display a structured ``.msg.watch-result`` card.
+    """The dispatch closure pulls optional fields out of the structured
+    ``reminder`` dict and attaches them to the queue entry's
+    ``metadata``.  Drain seams later merge ``metadata`` into the
+    rendered reminder dict so the frontend can display a structured
+    ``.msg.watch-result`` card.
     """
 
     def test_dispatch_attaches_watch_metadata_on_enqueue(self, tmp_db):

--- a/tests/test_watch_dispatch.py
+++ b/tests/test_watch_dispatch.py
@@ -69,6 +69,19 @@ def _register_runner(session: ChatSession) -> tuple[Any, Any]:
     return runner, captured["fn"]
 
 
+def _reminder(text: str, **extra: Any) -> dict[str, Any]:
+    """Build a structured ``watch_triggered`` reminder dict for tests.
+
+    Mirrors the shape produced by :func:`turnstone.core.watch.build_watch_reminder`
+    — ``text`` is the formatted body, optional fields ride alongside.
+    Tests that don't care about the optional fields can call with
+    ``text`` only.
+    """
+    out: dict[str, Any] = {"type": "watch_triggered", "text": text}
+    out.update(extra)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Enqueue shape
 # ---------------------------------------------------------------------------
@@ -83,7 +96,7 @@ class TestEnqueueShape:
         session = _make_session_for_dispatch()
         _runner, dispatch = _register_runner(session)
 
-        dispatch("watch fired body", "watch-1")
+        dispatch(_reminder("watch fired body"), "watch-1")
 
         # One entry, "watch_triggered" type, on "any" channel.
         assert len(session._nudge_queue) == 1
@@ -114,7 +127,7 @@ class TestSanitisation:
         # Build a payload with: BEL (\x07), zero-width space (U+200B),
         # bidi RTL override (U+202E), and angle-bracket tag breakers.
         raw = "before\x07middle​after‮more<thinking>tail"
-        dispatch(raw, "watch-1")
+        dispatch(_reminder(raw), "watch-1")
 
         pending = session._nudge_queue.pending(channel="any")
         assert len(pending) == 1
@@ -136,7 +149,7 @@ class TestSanitisation:
         session = _make_session_for_dispatch()
         _runner, dispatch = _register_runner(session)
 
-        dispatch("line1\nline2\n\tindented\n\rline3", "watch-1")
+        dispatch(_reminder("line1\nline2\n\tindented\n\rline3"), "watch-1")
 
         pending = session._nudge_queue.pending(channel="any")
         assert len(pending) == 1
@@ -151,7 +164,7 @@ class TestSanitisation:
         _runner, dispatch = _register_runner(session)
 
         # All-control + DEL + zero-width — strips to empty.
-        dispatch("\x07\x0b\x7f​", "watch-1")
+        dispatch(_reminder("\x07\x0b\x7f​"), "watch-1")
 
         assert len(session._nudge_queue) == 0
 
@@ -174,11 +187,11 @@ class TestSoftCap:
         # Pre-fill at the cap.  Each entry has a unique body so we can
         # tell which one(s) survived a drop.
         for i in range(_WATCH_QUEUE_SOFT_CAP):
-            dispatch(f"body-{i}", "watch-1")
+            dispatch(_reminder(f"body-{i}"), "watch-1")
         assert len(session._nudge_queue) == _WATCH_QUEUE_SOFT_CAP
 
         with caplog.at_level("WARNING"):
-            dispatch("overflow", "watch-1")
+            dispatch(_reminder("overflow"), "watch-1")
 
         # Total stays at cap (one dropped, one added).
         assert len(session._nudge_queue) == _WATCH_QUEUE_SOFT_CAP
@@ -205,9 +218,9 @@ class TestSoftCap:
 
         # Saturate watches up to cap (queue holds cap+2 total).
         for i in range(_WATCH_QUEUE_SOFT_CAP):
-            dispatch(f"body-{i}", "watch-1")
+            dispatch(_reminder(f"body-{i}"), "watch-1")
         # One more triggers drop-oldest of a "watch_triggered" entry.
-        dispatch("overflow", "watch-1")
+        dispatch(_reminder("overflow"), "watch-1")
 
         # Both idle_children entries survived — no collateral eviction.
         idle_bodies = [
@@ -236,7 +249,7 @@ class TestValidUntil:
         # Storage stub returns False at drain time.
         is_active_calls = patch_session_storage(monkeypatch, active=False)
 
-        dispatch("body", "watch-1")
+        dispatch(_reminder("body"), "watch-1")
         # Drain fires the predicate; entry should NOT be delivered.
         out = session._nudge_queue.drain({"any"})
         assert out == []
@@ -254,7 +267,7 @@ class TestValidUntil:
 
         patch_session_storage(monkeypatch, raise_on_is_active=True)
 
-        dispatch("body", "watch-bound-id")
+        dispatch(_reminder("body"), "watch-bound-id")
         out = session._nudge_queue.drain({"any"})
         assert out == []
 
@@ -267,7 +280,7 @@ class TestValidUntil:
 
         patch_session_storage(monkeypatch, active=True)
 
-        dispatch("body", "watch-1")
+        dispatch(_reminder("body"), "watch-1")
         out = session._nudge_queue.drain({"any"})
         assert len(out) == 1
         assert out[0][0] == "watch_triggered"
@@ -302,7 +315,7 @@ class TestConcurrency:
 
         def fire(label: str) -> None:
             for i in range(per_thread):
-                dispatch(f"{label}-{i}", f"watch-{label}")
+                dispatch(_reminder(f"{label}-{i}"), f"watch-{label}")
 
         threads = [threading.Thread(target=fire, args=(label,), daemon=True) for label in labels]
         for t in threads:
@@ -333,6 +346,64 @@ def test_dispatch_no_op_for_empty_payloads(tmp_db, payload: str):
     session = _make_session_for_dispatch()
     _runner, dispatch = _register_runner(session)
 
-    dispatch(payload, "watch-1")
+    dispatch(_reminder(payload), "watch-1")
 
     assert len(session._nudge_queue) == 0
+
+
+# ---------------------------------------------------------------------------
+# Metadata propagation
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataPropagation:
+    """Step 7 of the watch-card UX plan: the dispatch closure pulls
+    optional fields out of the structured ``reminder`` dict and
+    attaches them to the queue entry's ``metadata``.  Drain seams later
+    merge ``metadata`` into the rendered reminder dict so the frontend
+    can display a structured ``.msg.watch-result`` card.
+    """
+
+    def test_dispatch_attaches_watch_metadata_on_enqueue(self, tmp_db):
+        session = _make_session_for_dispatch()
+        _runner, dispatch = _register_runner(session)
+
+        reminder = _reminder(
+            "$ ls\nfile.txt",
+            watch_name="my-watch",
+            command="ls",
+            poll_count=2,
+            max_polls=100,
+            is_final=False,
+        )
+        dispatch(reminder, "watch-1")
+
+        # Snapshot via ``pending_with_metadata`` to inspect the full
+        # entry shape.  Exactly one entry, with the optional fields
+        # carried verbatim onto ``metadata``.
+        snapshot = session._nudge_queue.pending_with_metadata(channel="any")
+        assert len(snapshot) == 1
+        nt, _text, meta = snapshot[0]
+        assert nt == "watch_triggered"
+        assert meta == {
+            "watch_name": "my-watch",
+            "command": "ls",
+            "poll_count": 2,
+            "max_polls": 100,
+            "is_final": False,
+        }
+
+    def test_dispatch_omits_metadata_when_optional_fields_missing(self, tmp_db):
+        """A bare ``{type, text}`` reminder produces an entry with no
+        metadata — the closure builds an empty dict, sees nothing to
+        carry, and falls through to ``metadata=None``.
+        """
+        session = _make_session_for_dispatch()
+        _runner, dispatch = _register_runner(session)
+
+        dispatch(_reminder("just a body"), "watch-1")
+
+        snapshot = session._nudge_queue.pending_with_metadata(channel="any")
+        assert len(snapshot) == 1
+        _nt, _text, meta = snapshot[0]
+        assert meta is None

--- a/tests/test_watch_integration.py
+++ b/tests/test_watch_integration.py
@@ -248,8 +248,8 @@ def test_watch_dispatch_through_restore_fn_lands_on_rehydrated_session(tmp_db, m
     assert runner.get_dispatch_fn(original_ws_id) is None
 
     # Stage 3 — fire a watch result.  ``_dispatch_result`` should fall
-    # through to the restore branch.  Post-Step-7 dispatch surface uses
-    # a structured reminder dict.
+    # through to the restore branch.  The dispatch surface takes a
+    # structured reminder dict.
     runner._dispatch_result(
         original_ws_id,
         {"type": "watch_triggered", "text": "post-restore body"},

--- a/tests/test_watch_integration.py
+++ b/tests/test_watch_integration.py
@@ -83,7 +83,11 @@ def test_watch_fires_then_user_send_drains_envelope(tmp_db, monkeypatch):
     session.set_watch_runner(runner)
 
     # 1. Fire a watch result synchronously.
-    runner._dispatch_result(session._ws_id, "watch payload body", "watch-1")
+    runner._dispatch_result(
+        session._ws_id,
+        {"type": "watch_triggered", "text": "watch payload body"},
+        "watch-1",
+    )
 
     # 2. The queue holds one entry on the "any" channel.
     assert len(session._nudge_queue) == 1
@@ -143,9 +147,15 @@ def test_three_back_to_back_watch_fires_drain_into_one_turn(tmp_db, monkeypatch)
     runner = WatchRunner(storage=MagicMock(), node_id="test-node")
     session.set_watch_runner(runner)
 
-    runner._dispatch_result(session._ws_id, "fire one", "watch-1")
-    runner._dispatch_result(session._ws_id, "fire two", "watch-1")
-    runner._dispatch_result(session._ws_id, "fire three", "watch-1")
+    runner._dispatch_result(
+        session._ws_id, {"type": "watch_triggered", "text": "fire one"}, "watch-1"
+    )
+    runner._dispatch_result(
+        session._ws_id, {"type": "watch_triggered", "text": "fire two"}, "watch-1"
+    )
+    runner._dispatch_result(
+        session._ws_id, {"type": "watch_triggered", "text": "fire three"}, "watch-1"
+    )
     assert len(session._nudge_queue) == 3
 
     with (
@@ -238,8 +248,13 @@ def test_watch_dispatch_through_restore_fn_lands_on_rehydrated_session(tmp_db, m
     assert runner.get_dispatch_fn(original_ws_id) is None
 
     # Stage 3 — fire a watch result.  ``_dispatch_result`` should fall
-    # through to the restore branch.
-    runner._dispatch_result(original_ws_id, "post-restore body", "watch-1")
+    # through to the restore branch.  Post-Step-7 dispatch surface uses
+    # a structured reminder dict.
+    runner._dispatch_result(
+        original_ws_id,
+        {"type": "watch_triggered", "text": "post-restore body"},
+        "watch-1",
+    )
 
     # The restore fn ran exactly once and produced a fresh session that
     # adopted the original ws_id.

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -312,7 +312,7 @@ class TerminalUI(SessionUI):
         sys.stdout.write(f"{RED}{message}{RESET}\n")
         sys.stdout.flush()
 
-    def _print_reminder(self, reminders: list[dict[str, str]]) -> None:
+    def _print_reminder(self, reminders: list[dict[str, Any]]) -> None:
         """Render a metacognitive reminder list as ``[metacognition · type] text``
         lines in the terminal — the CLI's equivalent of the web UI's
         yellow themed bubble.  Used by both ``on_user_reminder`` and
@@ -326,10 +326,10 @@ class TerminalUI(SessionUI):
             sys.stdout.write(f"{YELLOW}[{label}]{RESET} {text}\n")
         sys.stdout.flush()
 
-    def on_user_reminder(self, reminders: list[dict[str, str]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
         self._print_reminder(reminders)
 
-    def on_tool_reminder(self, reminders: list[dict[str, str]], tool_call_id: str) -> None:
+    def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:
         # tool_call_id ignored — the CLI anchors by output sequence
         # (the line lands directly after the tool result that
         # triggered the batch's reminder).

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -329,7 +329,6 @@ class TerminalUI(SessionUI):
     def on_user_reminder(self, reminders: list[dict[str, Any]], source: str | None = None) -> None:
         # ``source`` ignored — the CLI doesn't render a wake marker
         # (terminal output is anchored by sequence, not anchor element).
-        del source
         self._print_reminder(reminders)
 
     def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -326,7 +326,10 @@ class TerminalUI(SessionUI):
             sys.stdout.write(f"{YELLOW}[{label}]{RESET} {text}\n")
         sys.stdout.flush()
 
-    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]], source: str | None = None) -> None:
+        # ``source`` ignored — the CLI doesn't render a wake marker
+        # (terminal output is anchored by sequence, not anchor element).
+        del source
         self._print_reminder(reminders)
 
     def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -368,34 +368,89 @@
     return el;
   }
 
+  // Build a structured ``.msg.watch-result`` card for a
+  // ``watch_triggered`` reminder — full-width treatment with
+  // command preview header + shell output body + poll counter footer.
+  // First-pass functional rendering; bespoke design polish lives in a
+  // future workstream.  All text goes through ``textContent`` so shell
+  // output containing angle brackets / scripts / steering bytes
+  // renders inertly.
+  function buildWatchResultBubble(r) {
+    const el = document.createElement("div");
+    el.className = "msg watch-result";
+    el.setAttribute("role", "article");
+    el.setAttribute("data-ts-role", "watch");
+    el.setAttribute("aria-label", "watch");
+    const header = document.createElement("div");
+    header.className = "msg-watch-header";
+    header.textContent =
+      "watch" + (r.watch_name ? " · " + String(r.watch_name) : "");
+    el.appendChild(header);
+    if (r.command) {
+      const cmd = document.createElement("div");
+      cmd.className = "msg-watch-cmd";
+      cmd.textContent = "$ " + String(r.command);
+      el.appendChild(cmd);
+    }
+    const body = document.createElement("pre");
+    body.className = "msg-watch-body";
+    body.textContent = r.text || "";
+    el.appendChild(body);
+    if (r.poll_count != null && r.max_polls != null) {
+      const footer = document.createElement("div");
+      footer.className = "msg-watch-footer";
+      const finalSuffix = r.is_final ? " · final" : "";
+      footer.textContent =
+        "poll " +
+        String(r.poll_count) +
+        "/" +
+        String(r.max_polls) +
+        finalSuffix;
+      el.appendChild(footer);
+    }
+    return el;
+  }
+
+  // Default ``.msg.user-reminder`` bubble — yellow themed advisory used
+  // for every metacog nudge other than ``watch_triggered``.
+  function buildDefaultReminderBubble(r) {
+    const el = document.createElement("div");
+    el.className = "msg user-reminder";
+    el.setAttribute("role", "article");
+    el.setAttribute("data-ts-role", "metacognition");
+    el.setAttribute("aria-label", "metacognition");
+    const body = document.createElement("div");
+    body.className = "msg-body";
+    const labelEl = document.createElement("span");
+    labelEl.className = "msg-user-reminder-label";
+    labelEl.textContent =
+      "metacognition" + (r.type ? " · " + String(r.type) : "");
+    const textEl = document.createElement("span");
+    textEl.className = "msg-user-reminder-text";
+    textEl.textContent = r.text || "";
+    body.appendChild(labelEl);
+    body.appendChild(textEl);
+    el.appendChild(body);
+    return el;
+  }
+
   // Metacognitive reminder bubble (user-channel correction / denial /
   // resume / start / completion AND tool-channel tool_error / repeat).
   // Mirrors Pane.prototype.addUserReminder / addToolReminder in the
   // interactive UI — yellow themed bubble slotted directly below the
-  // message it advises.  ``anchor`` is the DOM element to anchor below;
-  // when null, append at the bottom of messagesEl.
+  // message it advises.  ``watch_triggered`` reminders branch off into
+  // the structured ``.msg.watch-result`` card.  ``anchor`` is the DOM
+  // element to anchor below; when null, append at the bottom of
+  // messagesEl.
   function appendReminderBubble(reminders, anchor) {
     if (!Array.isArray(reminders) || !reminders.length) return;
     let cursor = anchor;
     for (let i = 0; i < reminders.length; i++) {
       const r = reminders[i] || {};
-      const el = document.createElement("div");
-      el.className = "msg user-reminder";
-      el.setAttribute("role", "article");
-      el.setAttribute("data-ts-role", "metacognition");
-      el.setAttribute("aria-label", "metacognition");
-      const body = document.createElement("div");
-      body.className = "msg-body";
-      const labelEl = document.createElement("span");
-      labelEl.className = "msg-user-reminder-label";
-      labelEl.textContent =
-        "metacognition" + (r.type ? " · " + String(r.type) : "");
-      const textEl = document.createElement("span");
-      textEl.className = "msg-user-reminder-text";
-      textEl.textContent = r.text || "";
-      body.appendChild(labelEl);
-      body.appendChild(textEl);
-      el.appendChild(body);
+      const el =
+        r.type === "watch_triggered"
+          ? buildWatchResultBubble(r)
+          : buildDefaultReminderBubble(r);
       if (cursor) {
         cursor.insertAdjacentElement("afterend", el);
         cursor = el;
@@ -406,11 +461,37 @@
     _scheduleScroll();
   }
 
+  // Thin ``.msg.user.system-nudge`` marker rendered as the anchor for
+  // wake-driven reminder bubbles.  Replaces the previously-invisible
+  // synthetic empty user turn with a visible-but-subtle DOM element so
+  // the bubble below it lands in the right place even when the wake
+  // fires long after the user's last real message.
+  function appendSystemNudgeMarker() {
+    const el = document.createElement("div");
+    el.className = "msg user system-nudge";
+    el.setAttribute("data-source", "system_nudge");
+    el.setAttribute("aria-label", "system nudge");
+    el.textContent = "system nudge";
+    messagesEl.appendChild(el);
+    return el;
+  }
+
   // Live SSE for user-channel reminders — anchors below the most
   // recent user message.  On a non-originating tab there may be no
   // user message rendered yet; we append and the next /history reload
   // corrects.  (Same caveat as the interactive UI; tracked there.)
-  function appendUserReminderLive(reminders) {
+  //
+  // ``source`` widens the live SSE event to carry the wake's
+  // ``"system_nudge"`` tag so the marker renders on every connected
+  // tab — without this, only the originating tab (which sees the
+  // synthesised empty user turn live) would render the wake bubble in
+  // the right place.
+  function appendUserReminderLive(reminders, source) {
+    if (source === "system_nudge") {
+      const marker = appendSystemNudgeMarker();
+      appendReminderBubble(reminders, marker);
+      return;
+    }
     const userMsgs = messagesEl.querySelectorAll(".msg.user");
     const anchor = userMsgs.length ? userMsgs[userMsgs.length - 1] : null;
     appendReminderBubble(reminders, anchor);
@@ -2028,9 +2109,11 @@
       case "user_reminder":
         // Metacognitive user-channel nudge — render below the most
         // recent user message as a yellow themed bubble.  Same shape
-        // as the interactive UI's case.
+        // as the interactive UI's case.  When ``source === "system_nudge"``
+        // (wake-driven), render the thin .msg.user.system-nudge
+        // marker first so the bubble anchors below it.
         if (Array.isArray(ev.reminders) && ev.reminders.length) {
-          appendUserReminderLive(ev.reminders);
+          appendUserReminderLive(ev.reminders, ev.source || "");
         }
         break;
       case "tool_reminder":
@@ -4053,6 +4136,17 @@
           // text when the message carried attachments — even when the
           // text portion is empty (image-only sends).
           if (role === "user") {
+            const isSystemNudge = m.source === "system_nudge";
+            if (isSystemNudge) {
+              // Wake-driven empty user turn: render the thin marker
+              // (replaces the previously-skipped synthetic empty
+              // bubble) and anchor reminder bubbles below it.
+              const marker = appendSystemNudgeMarker();
+              if (Array.isArray(m.reminders) && m.reminders.length) {
+                appendReminderBubble(m.reminders, marker);
+              }
+              return;
+            }
             if (!content && userAttachments.length === 0) return;
             appendUserMessageWithAttachments(content, userAttachments, {
               label: role,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -492,7 +492,9 @@
       appendReminderBubble(reminders, marker);
       return;
     }
-    const userMsgs = messagesEl.querySelectorAll(".msg.user");
+    const userMsgs = messagesEl.querySelectorAll(
+      ".msg.user:not(.system-nudge)",
+    );
     const anchor = userMsgs.length ? userMsgs[userMsgs.length - 1] : null;
     appendReminderBubble(reminders, anchor);
   }

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -79,15 +79,10 @@ def save_messages_bulk(rows: list[dict[str, Any]]) -> None:
         log.warning("Failed to bulk-save %d messages", len(rows), exc_info=True)
 
 
-def load_messages(ws_id: str, *, limit: int | None = None) -> list[dict[str, Any]]:
-    """Load messages for a workstream and reconstruct OpenAI message format.
-
-    *limit* tail-loads the most recent N rows when set; the storage
-    backend already accepts the kwarg.  Used by callers that don't
-    need the full transcript (e.g. browsing a long-running coord).
-    """
+def load_messages(ws_id: str) -> list[dict[str, Any]]:
+    """Load messages for a workstream and reconstruct OpenAI message format."""
     try:
-        return get_storage().load_messages(ws_id, limit=limit)
+        return get_storage().load_messages(ws_id)
     except Exception:
         log.warning("Failed to load messages for ws=%s", ws_id, exc_info=True)
         return []

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -79,10 +79,15 @@ def save_messages_bulk(rows: list[dict[str, Any]]) -> None:
         log.warning("Failed to bulk-save %d messages", len(rows), exc_info=True)
 
 
-def load_messages(ws_id: str) -> list[dict[str, Any]]:
-    """Load messages for a workstream and reconstruct OpenAI message format."""
+def load_messages(ws_id: str, *, limit: int | None = None) -> list[dict[str, Any]]:
+    """Load messages for a workstream and reconstruct OpenAI message format.
+
+    *limit* tail-loads the most recent N rows when set; the storage
+    backend already accepts the kwarg.  Used by callers that don't
+    need the full transcript (e.g. browsing a long-running coord).
+    """
     try:
-        return get_storage().load_messages(ws_id)
+        return get_storage().load_messages(ws_id, limit=limit)
     except Exception:
         log.warning("Failed to load messages for ws=%s", ws_id, exc_info=True)
         return []

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -41,11 +41,18 @@ def save_message(
     tool_call_id: str | None = None,
     provider_data: str | None = None,
     tool_calls: str | None = None,
+    source: str | None = None,
+    reminders: str | None = None,
 ) -> int:
     """Log a message to the conversations table.
 
     Returns the inserted row id, or ``0`` on failure (preserving the
     module's no-raise contract).
+
+    ``source`` / ``reminders`` mirror the in-memory ``_source`` /
+    ``_reminders`` side-channels (``reminders`` JSON-encoded).  Both
+    default to ``None`` for the common case where no metacog payload
+    rides the row.
     """
     try:
         return get_storage().save_message(
@@ -56,6 +63,8 @@ def save_message(
             tool_call_id,
             provider_data,
             tool_calls=tool_calls,
+            source=source,
+            reminders=reminders,
         )
     except Exception:
         log.warning("Failed to save message for ws=%s role=%s", ws_id, role, exc_info=True)

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import threading
 from collections import deque
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -49,6 +49,16 @@ class _Entry(NamedTuple):
     text: str
     channel: Channel
     valid_until: Callable[[], bool] | None = None
+    # Producer-supplied optional fields that ride alongside ``text`` when
+    # drained — used by ``watch_triggered`` to carry ``watch_name`` /
+    # ``command`` / ``poll_count`` / ``max_polls`` / ``is_final`` into the
+    # rendered reminder dict so the frontend can render a structured
+    # ``.msg.watch-result`` card instead of a plain advisory bubble.
+    # Other producers leave it ``None`` and consumers see only
+    # ``{type, text}``.  Atomicity guarantee: text + metadata land on the
+    # same enqueue call, so a concurrent drain can't observe text without
+    # the matching metadata.
+    metadata: dict[str, Any] | None = None
 
 
 class NudgeQueue:
@@ -65,6 +75,7 @@ class NudgeQueue:
         channel: Channel,
         *,
         valid_until: Callable[[], bool] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Append a nudge.  ``channel`` MUST be in :data:`_VALID_CHANNELS`.
 
@@ -79,17 +90,27 @@ class NudgeQueue:
         stale).  The predicate is called outside the queue lock so
         producers can do non-trivial work (e.g. re-querying storage
         for active children) without blocking other producers.
+
+        ``metadata`` carries optional producer-specific fields that
+        drain returns alongside ``(nudge_type, text)``.  ``watch_triggered``
+        uses it for ``watch_name`` / ``command`` / ``poll_count`` /
+        ``max_polls`` / ``is_final`` so the frontend can render a
+        structured card; other producers leave it ``None``.
         """
         if channel not in _VALID_CHANNELS:
             raise ValueError(f"channel={channel!r}; expected one of {sorted(_VALID_CHANNELS)}")
         with self._lock:
-            self._items.append(_Entry(nudge_type, text, channel, valid_until))
+            self._items.append(_Entry(nudge_type, text, channel, valid_until, metadata))
 
-    def drain(self, channels: frozenset[str] | set[str]) -> list[tuple[str, str]]:
+    def drain(
+        self, channels: frozenset[str] | set[str]
+    ) -> list[tuple[str, str, dict[str, Any] | None]]:
         """Drain entries whose channel is in ``channels``.
 
         Entries with non-matching channels stay in the queue, in order.
-        Returns ``(nudge_type, text)`` tuples in insertion order.
+        Returns ``(nudge_type, text, metadata)`` tuples in insertion
+        order; ``metadata`` is the producer-supplied dict (or ``None``
+        when unset).
 
         Entries with a ``valid_until`` predicate get re-checked outside
         the queue lock; falsy / raising predicates drop the entry
@@ -119,14 +140,14 @@ class NudgeQueue:
         # Predicates evaluate outside the lock — they may do storage
         # I/O or other work that shouldn't block other producers /
         # the drain consumer's other queues.
-        out: list[tuple[str, str]] = []
+        out: list[tuple[str, str, dict[str, Any] | None]] = []
         for entry in candidates:
             if entry.valid_until is None:
-                out.append((entry.nudge_type, entry.text))
+                out.append((entry.nudge_type, entry.text, entry.metadata))
                 continue
             try:
                 if entry.valid_until():
-                    out.append((entry.nudge_type, entry.text))
+                    out.append((entry.nudge_type, entry.text, entry.metadata))
             except Exception:
                 # Predicate raising is treated as "no longer valid" —
                 # drop silently rather than letting one bad predicate
@@ -227,11 +248,30 @@ class NudgeQueue:
         code that wants to *consume* entries should call :meth:`drain`
         instead — pending entries are by definition unconsumed and
         will redraw at the next matching seam.
+
+        ``metadata`` is intentionally NOT projected here — tests that
+        need to assert producer-specific fields call
+        :meth:`pending_with_metadata` (or :meth:`drain` directly).
         """
         with self._lock:
             if channel is None:
                 return [(e.nudge_type, e.text) for e in self._items]
             return [(e.nudge_type, e.text) for e in self._items if e.channel == channel]
+
+    def pending_with_metadata(
+        self, channel: Channel | None = None
+    ) -> list[tuple[str, str, dict[str, Any] | None]]:
+        """Non-mutating snapshot including each entry's ``metadata``.
+
+        Used by tests / introspection paths that need to assert
+        producer-specific optional fields (e.g. the watch dispatcher's
+        ``watch_name`` / ``command`` / ``poll_count`` payload).  Production
+        consumers should still call :meth:`drain`.
+        """
+        with self._lock:
+            if channel is None:
+                return [(e.nudge_type, e.text, e.metadata) for e in self._items]
+            return [(e.nudge_type, e.text, e.metadata) for e in self._items if e.channel == channel]
 
     def has_pending(self, channels: frozenset[str] | set[str]) -> bool:
         """Short-circuiting existence check.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -109,6 +109,7 @@ from turnstone.core.tools import (
     TASK_AUTO_TOOLS,
     merge_mcp_tools,
 )
+from turnstone.core.watch import WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web import check_ssrf, strip_html
 from turnstone.core.workstream import WorkstreamKind
 from turnstone.prompts import ClientType, SessionContext, compose_system_message
@@ -1456,14 +1457,12 @@ class ChatSession:
                 except Exception:
                     return False
 
-            from turnstone.core.watch import _WATCH_REMINDER_OPTIONAL_KEYS
-
             def _maybe_sanitize(v: Any) -> Any:
                 return sanitize_payload(v) if isinstance(v, str) else v
 
             metadata = {
                 k: _maybe_sanitize(reminder[k])
-                for k in _WATCH_REMINDER_OPTIONAL_KEYS
+                for k in WATCH_REMINDER_OPTIONAL_KEYS
                 if k in reminder
             }
             nudge_queue.enqueue(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2771,15 +2771,6 @@ class ChatSession:
                 }
                 for a in attachments
             ]
-        # Metacognitive user-channel drain: any nudges queued via
-        # _queue_user_advisory (correction/start/completion from this
-        # turn, denial from the previous tool batch, resume from
-        # rehydrate) attach to the user message dict's ``_reminders``
-        # side-channel — content stays clean.  The wire-side splice
-        # happens later in _apply_reminders_for_provider against a
-        # transient copy.  The DB row stores ``user_input`` only (line
-        # below) so reminders stay in-memory only and don't persist
-        # across reloads.
         self._attach_pending_user_reminders(user_msg)
         self.messages.append(user_msg)
         self._msg_tokens.append(max(1, int(self._msg_char_count(user_msg) / self._chars_per_token)))

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1728,6 +1728,21 @@ class ChatSession:
         if not fork:
             self._ws_id = ws_id
         self.messages = messages
+        # Persisted reminders ride the ``_reminders`` side-channel but
+        # carry no in-memory ``_reminders_delivered`` flag (the flag is
+        # session-scoped — set by ``_mark_reminders_delivered`` after
+        # each successful provider stream, never persisted).  Without
+        # this re-splice guard, the very next user turn after resume
+        # would walk the loaded history and re-render every historical
+        # ``<system-reminder>`` block onto the wire — leaking each one a
+        # second time, the turn after it had already advised.  Mirror
+        # the post-stream hook here: every loaded message that carries
+        # reminders has already been delivered (it survived to disk),
+        # so flag it accordingly so ``_apply_reminders_for_provider``
+        # short-circuits on the pass-through path.
+        for msg in self.messages:
+            if msg.get("_reminders"):
+                msg["_reminders_delivered"] = True
         self._read_files.clear()
         self._repeat_detector.clear()
         self._last_usage = None

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1398,7 +1398,7 @@ class ChatSession:
         """Inject the server-level WatchRunner and register a dispatch fn
         that routes watch results onto this session's NudgeQueue.
 
-        The dispatch closure is the post-#482 unified path: each watch
+        The dispatch closure is the unified pull-model path: each watch
         fire enqueues a ``"watch_triggered"`` entry on ``"any"`` channel,
         and the existing drain seams (USER_DRAIN, TOOL_DRAIN,
         ``IdleNudgeWatcher`` IDLE wake) splice it into a
@@ -1457,10 +1457,15 @@ class ChatSession:
                 except Exception:
                     return False
 
+            from turnstone.core.watch import _WATCH_REMINDER_OPTIONAL_KEYS
+
+            def _maybe_sanitize(v: Any) -> Any:
+                return sanitize_payload(v) if isinstance(v, str) else v
+
             metadata = {
-                k: reminder[k]
-                for k in ("watch_name", "command", "poll_count", "max_polls", "is_final")
-                if isinstance(reminder, dict) and k in reminder
+                k: _maybe_sanitize(reminder[k])
+                for k in _WATCH_REMINDER_OPTIONAL_KEYS
+                if k in reminder
             }
             nudge_queue.enqueue(
                 "watch_triggered",

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -591,8 +591,8 @@ class SessionUI(Protocol):
     def on_plan_review(self, content: str) -> str: ...
     def on_info(self, message: str) -> None: ...
     def on_error(self, message: str) -> None: ...
-    def on_user_reminder(self, reminders: list[dict[str, str]]) -> None: ...
-    def on_tool_reminder(self, reminders: list[dict[str, str]], tool_call_id: str) -> None: ...
+    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None: ...
+    def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None: ...
     def on_state_change(self, state: str) -> None: ...
     def on_rename(self, name: str) -> None: ...
     def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
@@ -813,7 +813,7 @@ class ChatSession:
         # — handed to ``_attach_pending_user_reminders`` so the synthesized
         # send doesn't re-drain (and so we can bail out before send when
         # every entry's ``valid_until`` predicate dropped its item).
-        self._wake_drained_reminders: list[dict[str, str]] | None = None
+        self._wake_drained_reminders: list[dict[str, Any]] | None = None
         # User message queue: messages sent while model is executing.
         # OrderedDict preserves FIFO order and supports O(1) removal by ID.
         # Queued user turns never carry attachments — see
@@ -4288,7 +4288,7 @@ class ChatSession:
         assessment: OutputAssessment | None,
         func_name: str,
         is_last_in_batch: bool,
-    ) -> tuple[list[ToolAdvisory], list[dict[str, str]]]:
+    ) -> tuple[list[ToolAdvisory], list[dict[str, Any]]]:
         """Gather advisories to attach to a tool result message.
 
         Returns ``(persistent, metacog_reminders)``:
@@ -4297,10 +4297,12 @@ class ChatSession:
           inside the tool-result envelope via ``wrap_tool_result``.
           These are conversation history and must persist in
           ``self.messages``.
-        - ``metacog_reminders`` — list of ``{"type", "text"}`` dicts for
-          ``tool_error`` / ``repeat`` nudges that the caller attaches to
-          the tool message dict's ``_reminders`` side-channel.  Like
-          user-channel reminders, they are spliced into ``content`` only
+        - ``metacog_reminders`` — list of ``{"type", "text", ...optional}``
+          dicts for ``tool_error`` / ``repeat`` nudges that the caller
+          attaches to the tool message dict's ``_reminders`` side-channel.
+          The optional fields ride from the producer's ``metadata`` dict
+          (today only ``watch_triggered`` populates it).  Like user-
+          channel reminders, the dicts are spliced into ``content`` only
           at the wire boundary by ``_apply_reminders_for_provider`` and
           surfaced separately on the UI as a themed bubble below the
           tool result.
@@ -4312,7 +4314,7 @@ class ChatSession:
         from turnstone.core.tool_advisory import GuardAdvisory, UserInterjection
 
         persistent: list[ToolAdvisory] = []
-        metacog_reminders: list[dict[str, str]] = []
+        metacog_reminders: list[dict[str, Any]] = []
 
         # Output guard advisory — persists with the tool result.
         if assessment is not None:
@@ -4326,7 +4328,11 @@ class ChatSession:
         # and rides the wire only via the transient-copy splice.
         if is_last_in_batch:
             drained = self._nudge_queue.drain(TOOL_DRAIN)
-            metacog_reminders.extend({"type": nt, "text": text} for nt, text in drained)
+            for nt, text, meta in drained:
+                entry: dict[str, Any] = {"type": nt, "text": text}
+                if meta:
+                    entry.update(meta)
+                metacog_reminders.append(entry)
 
         # Drain queued user messages on the last result in the batch.
         # Items are always text-only (attachments rejected at
@@ -5995,7 +6001,12 @@ class ChatSession:
             items = self._nudge_queue.drain(USER_DRAIN)
             if not items:
                 return
-            reminders = [{"type": nudge_type, "text": text} for nudge_type, text in items]
+            reminders = []
+            for nudge_type, text, meta in items:
+                entry: dict[str, Any] = {"type": nudge_type, "text": text}
+                if meta:
+                    entry.update(meta)
+                reminders.append(entry)
         if not reminders:
             return
         user_msg["_reminders"] = reminders
@@ -6068,9 +6079,13 @@ class ChatSession:
             return
         pre_len = len(self.messages)
         self._wake_source_tag = "system_nudge"
-        self._wake_drained_reminders = [
-            {"type": nudge_type, "text": text} for nudge_type, text in items
-        ]
+        wake_reminders: list[dict[str, Any]] = []
+        for nudge_type, text, meta in items:
+            entry: dict[str, Any] = {"type": nudge_type, "text": text}
+            if meta:
+                entry.update(meta)
+            wake_reminders.append(entry)
+        self._wake_drained_reminders = wake_reminders
         try:
             self.send("", from_wake=True)
         except Exception:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2692,15 +2692,26 @@ class ChatSession:
         # leaves pending rows that the UI's chip rehydration can still
         # surface so the user can clear or resend them.
         #
-        # Skip the persist for the wake's synthesized empty turn — the
-        # row would carry no content (the system-reminder lives on the
-        # ``_reminders`` sibling, stripped before persist) and the
-        # ``_source`` audit tag isn't column-backed.  Replays can
-        # re-derive the wake event from the conversation flow without
-        # this empty row.
-        if from_wake and not user_input and not attachments:
-            return 0
-        message_id = save_message(self._ws_id, "user", user_input)
+        # The wake's synthesised empty turn DOES persist now: the
+        # ``_source`` and ``_reminders`` columns mirror the in-memory
+        # side-channels so a tab reconnecting via /history sees the
+        # same system-nudge marker + reminder bubbles the originating
+        # tab rendered live.  Without persistence, multi-tab / multi-
+        # device replay shows the assistant's response with no
+        # preceding context — the wake event looks like it came out of
+        # nowhere.
+        source = user_msg.get("_source")
+        reminders_payload = user_msg.get("_reminders")
+        reminders_json = (
+            json.dumps(reminders_payload, separators=(",", ":")) if reminders_payload else None
+        )
+        message_id = save_message(
+            self._ws_id,
+            "user",
+            user_input,
+            source=source if isinstance(source, str) and source else None,
+            reminders=reminders_json,
+        )
         if attachments and message_id:
             mark_attachments_consumed(
                 [a.attachment_id for a in attachments],
@@ -3027,12 +3038,23 @@ class ChatSession:
                         )[:TOOL_RESULT_STORAGE_CAP]
                     else:
                         store_text = raw_output[:TOOL_RESULT_STORAGE_CAP]
+                    # Mirror the user-channel persistence: tool-channel
+                    # reminders (``tool_error`` / ``repeat``) ride the same
+                    # ``_reminders`` JSON column so a tab reconnecting via
+                    # /history sees the below-the-tool bubble the
+                    # originating tab rendered live.
+                    tool_reminders_json = (
+                        json.dumps(metacog_reminders, separators=(",", ":"))
+                        if metacog_reminders
+                        else None
+                    )
                     save_message(
                         self._ws_id,
                         "tool",
                         store_text,
                         _tname,
                         tool_call_id=tc_id,
+                        reminders=tool_reminders_json,
                     )
                 # Inject user feedback from approval prompt (e.g. "y, use full path")
                 if user_feedback:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1744,18 +1744,10 @@ class ChatSession:
         if not fork:
             self._ws_id = ws_id
         self.messages = messages
-        # Persisted reminders ride the ``_reminders`` side-channel but
-        # carry no in-memory ``_reminders_delivered`` flag (the flag is
-        # session-scoped — set by ``_mark_reminders_delivered`` after
-        # each successful provider stream, never persisted).  Without
-        # this re-splice guard, the very next user turn after resume
-        # would walk the loaded history and re-render every historical
-        # ``<system-reminder>`` block onto the wire — leaking each one a
-        # second time, the turn after it had already advised.  Mirror
-        # the post-stream hook here: every loaded message that carries
-        # reminders has already been delivered (it survived to disk),
-        # so flag it accordingly so ``_apply_reminders_for_provider``
-        # short-circuits on the pass-through path.
+        # Loaded reminders are already delivered — the flag is
+        # session-scoped and not persisted, so without this guard the
+        # next user turn would re-splice every historical reminder onto
+        # the wire.
         for msg in self.messages:
             if msg.get("_reminders"):
                 msg["_reminders_delivered"] = True
@@ -1855,14 +1847,6 @@ class ChatSession:
                     pd_str = json.dumps(pd) if pd and not isinstance(pd, str) else pd
                 except (TypeError, ValueError):
                     pd_str = None
-                # Carry the persisted side-channels (``_source`` /
-                # ``_reminders``) onto the fork's rows.  Both backends'
-                # ``save_messages_bulk`` accept them post-migration 050;
-                # without them, a fork dropped every wake marker and
-                # every reminder bubble that survived to disk on the
-                # source workstream — the resumed fork's transcript
-                # would then look like the assistant turn answered out
-                # of nowhere.
                 src = msg.get("_source")
                 bulk_rows.append(
                     {
@@ -2786,14 +2770,9 @@ class ChatSession:
         # leaves pending rows that the UI's chip rehydration can still
         # surface so the user can clear or resend them.
         #
-        # The wake's synthesised empty turn DOES persist now: the
-        # ``_source`` and ``_reminders`` columns mirror the in-memory
-        # side-channels so a tab reconnecting via /history sees the
-        # same system-nudge marker + reminder bubbles the originating
-        # tab rendered live.  Without persistence, multi-tab / multi-
-        # device replay shows the assistant's response with no
-        # preceding context — the wake event looks like it came out of
-        # nowhere.
+        # The wake's synthesised empty turn carries ``_source`` /
+        # ``_reminders`` onto the row so reconnecting tabs render the
+        # marker + bubbles instead of an unanchored assistant reply.
         source = user_msg.get("_source")
         reminders_payload = user_msg.get("_reminders")
         reminders_json = self._encode_reminders(reminders_payload)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -591,7 +591,9 @@ class SessionUI(Protocol):
     def on_plan_review(self, content: str) -> str: ...
     def on_info(self, message: str) -> None: ...
     def on_error(self, message: str) -> None: ...
-    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None: ...
+    def on_user_reminder(
+        self, reminders: list[dict[str, Any]], source: str | None = None
+    ) -> None: ...
     def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None: ...
     def on_state_change(self, state: str) -> None: ...
     def on_rename(self, name: str) -> None: ...
@@ -6032,8 +6034,15 @@ class ChatSession:
             return
         user_msg["_reminders"] = reminders
 
+        # Forward ``_source`` (today only ``"system_nudge"`` for wake
+        # turns) so non-originating SSE consumers can render the thin
+        # ``.msg.user.system-nudge`` marker before the reminder bubble.
+        # Without it, a non-originating tab anchors the bubble below
+        # whichever stale prior user message exists.
+        source_tag = user_msg.get("_source")
+        source_arg: str | None = source_tag if isinstance(source_tag, str) and source_tag else None
         try:
-            self.ui.on_user_reminder(reminders)
+            self.ui.on_user_reminder(reminders, source=source_arg)
         except Exception:
             log.warning("ui.on_user_reminder failed; reminder still attached", exc_info=True)
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -547,16 +547,15 @@ _TEMPLATE_VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 # not its earliest.
 _WATCH_QUEUE_SOFT_CAP = 50
 
-# Per-reminder ``text`` field clamp at storage time.  The conversations
-# row's ``_reminders`` JSON column persists every metacog nudge a tab
-# rendered live so reconnecting tabs see the same bubbles, but a single
-# pathological producer — a watch streaming unbounded shell output, a
-# corrupted steering payload — should not blow the row width or the
-# FTS5 index.  8 KiB matches ``docs/design/watch-card-ux-briefing.md``'s
-# spec for the reminder body.  Mirrors ``TOOL_RESULT_STORAGE_CAP`` on
-# tool result rows; the in-memory side-channel keeps the full body so
-# the live splice and UI render see the same shape, only the persisted
-# JSON is clamped.
+# Per-reminder ``text`` field clamp on the persisted ``_reminders``
+# JSON column.  Bounds row width and the FTS5 index against pathological
+# producers (a watch streaming unbounded shell output, a corruption-class
+# steering payload).  The in-memory side-channel keeps the full body —
+# only the persisted JSON is clamped — so the live splice and UI render
+# see the same shape.  Mirrors ``TOOL_RESULT_STORAGE_CAP`` on tool
+# result rows.  Cap is in UTF-8 bytes so non-ASCII payloads (CJK, emoji)
+# can't blow the byte ceiling 4x by living entirely under the codepoint
+# count.
 REMINDER_TEXT_STORAGE_CAP = 8192
 
 
@@ -2139,14 +2138,12 @@ class ChatSession:
         feed the result straight into ``save_message(..., reminders=...)``
         without a separate empty check.
 
-        **Per-reminder text cap.**  Each entry's ``text`` field is
-        clamped to :data:`REMINDER_TEXT_STORAGE_CAP` characters before
-        encoding so a single rogue producer (a watch streaming an
-        unbounded shell command, a corruption-class steering payload)
-        can't blow the conversations row width or the FTS5 index.  The
-        in-memory dict on the message side-channel keeps the full body
-        — only the persisted JSON is clamped.  Mirrors
-        ``TOOL_RESULT_STORAGE_CAP``'s row-level clamp on tool results.
+        Each entry's ``text`` field is clamped to
+        :data:`REMINDER_TEXT_STORAGE_CAP` UTF-8 bytes before encoding;
+        the in-memory dict keeps the full body so the live splice and
+        UI render see the same shape, only the persisted JSON is
+        clamped.  Byte-clamping (rather than codepoint-clamping) keeps
+        the row-width / FTS5-index bound tight for non-ASCII payloads.
         """
         if not reminders:
             return None
@@ -2155,12 +2152,16 @@ class ChatSession:
             if not isinstance(r, dict):
                 continue
             text = r.get("text")
-            if isinstance(text, str) and len(text) > REMINDER_TEXT_STORAGE_CAP:
-                clamped = dict(r)
-                clamped["text"] = text[:REMINDER_TEXT_STORAGE_CAP]
-                capped.append(clamped)
-            else:
-                capped.append(r)
+            if isinstance(text, str):
+                encoded = text.encode("utf-8")
+                if len(encoded) > REMINDER_TEXT_STORAGE_CAP:
+                    clamped = dict(r)
+                    clamped["text"] = encoded[:REMINDER_TEXT_STORAGE_CAP].decode(
+                        "utf-8", errors="ignore"
+                    )
+                    capped.append(clamped)
+                    continue
+            capped.append(r)
         if not capped:
             return None
         return json.dumps(capped, separators=(",", ":"))

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1406,8 +1406,18 @@ class ChatSession:
         nudge_queue = self._nudge_queue
         ws_id = self._ws_id
 
-        def _dispatch(msg: str, watch_id: str) -> None:
-            sanitized = sanitize_payload(msg)
+        def _dispatch(reminder: dict[str, Any], watch_id: str) -> None:
+            # ``reminder`` is the structured dict produced by
+            # :func:`build_watch_reminder`.  ``text`` carries the
+            # formatted body — sanitised here over the full string so
+            # steering-vector / control-char payloads sourced from
+            # arbitrary shell output can't tamper with the envelope at
+            # interpolation time.  The remaining fields ride as the
+            # queue entry's ``metadata`` so the frontend can render a
+            # ``.msg.watch-result`` card with command preview + poll
+            # counter.
+            text = reminder.get("text", "") if isinstance(reminder, dict) else ""
+            sanitized = sanitize_payload(text)
             if not sanitized:
                 # All control chars / empty after strip — silently drop.
                 return
@@ -1433,7 +1443,18 @@ class ChatSession:
                 except Exception:
                     return False
 
-            nudge_queue.enqueue("watch_triggered", sanitized, "any", valid_until=_still_active)
+            metadata = {
+                k: reminder[k]
+                for k in ("watch_name", "command", "poll_count", "max_polls", "is_final")
+                if isinstance(reminder, dict) and k in reminder
+            }
+            nudge_queue.enqueue(
+                "watch_triggered",
+                sanitized,
+                "any",
+                valid_until=_still_active,
+                metadata=metadata or None,
+            )
 
         runner.set_dispatch_fn(self._ws_id, _dispatch)
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -547,6 +547,18 @@ _TEMPLATE_VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 # not its earliest.
 _WATCH_QUEUE_SOFT_CAP = 50
 
+# Per-reminder ``text`` field clamp at storage time.  The conversations
+# row's ``_reminders`` JSON column persists every metacog nudge a tab
+# rendered live so reconnecting tabs see the same bubbles, but a single
+# pathological producer — a watch streaming unbounded shell output, a
+# corrupted steering payload — should not blow the row width or the
+# FTS5 index.  8 KiB matches ``docs/design/watch-card-ux-briefing.md``'s
+# spec for the reminder body.  Mirrors ``TOOL_RESULT_STORAGE_CAP`` on
+# tool result rows; the in-memory side-channel keeps the full body so
+# the live splice and UI render see the same shape, only the persisted
+# JSON is clamped.
+REMINDER_TEXT_STORAGE_CAP = 8192
+
 
 def _without_tool(tools: list[dict[str, Any]], name: str) -> list[dict[str, Any]]:
     """Return *tools* with the named tool removed."""
@@ -1839,6 +1851,15 @@ class ChatSession:
                     pd_str = json.dumps(pd) if pd and not isinstance(pd, str) else pd
                 except (TypeError, ValueError):
                     pd_str = None
+                # Carry the persisted side-channels (``_source`` /
+                # ``_reminders``) onto the fork's rows.  Both backends'
+                # ``save_messages_bulk`` accept them post-migration 050;
+                # without them, a fork dropped every wake marker and
+                # every reminder bubble that survived to disk on the
+                # source workstream — the resumed fork's transcript
+                # would then look like the assistant turn answered out
+                # of nowhere.
+                src = msg.get("_source")
                 bulk_rows.append(
                     {
                         "ws_id": self._ws_id,
@@ -1848,6 +1869,8 @@ class ChatSession:
                         "tool_call_id": msg.get("tool_call_id"),
                         "tool_calls": tc_json,
                         "provider_data": pd_str,
+                        "source": src if isinstance(src, str) and src else None,
+                        "reminders": self._encode_reminders(msg.get("_reminders")),
                     }
                 )
             save_messages_bulk(bulk_rows)
@@ -2100,6 +2123,42 @@ class ChatSession:
     def _full_messages(self) -> list[dict[str, Any]]:
         """System messages + conversation history."""
         return self.system_messages + self.messages
+
+    @staticmethod
+    def _encode_reminders(
+        reminders: list[dict[str, Any]] | None,
+    ) -> str | None:
+        """JSON-encode a ``_reminders`` list for the storage column.
+
+        Returns ``None`` when *reminders* is empty / falsy so callers can
+        feed the result straight into ``save_message(..., reminders=...)``
+        without a separate empty check.
+
+        **Per-reminder text cap.**  Each entry's ``text`` field is
+        clamped to :data:`REMINDER_TEXT_STORAGE_CAP` characters before
+        encoding so a single rogue producer (a watch streaming an
+        unbounded shell command, a corruption-class steering payload)
+        can't blow the conversations row width or the FTS5 index.  The
+        in-memory dict on the message side-channel keeps the full body
+        — only the persisted JSON is clamped.  Mirrors
+        ``TOOL_RESULT_STORAGE_CAP``'s row-level clamp on tool results.
+        """
+        if not reminders:
+            return None
+        capped: list[dict[str, Any]] = []
+        for r in reminders:
+            if not isinstance(r, dict):
+                continue
+            text = r.get("text")
+            if isinstance(text, str) and len(text) > REMINDER_TEXT_STORAGE_CAP:
+                clamped = dict(r)
+                clamped["text"] = text[:REMINDER_TEXT_STORAGE_CAP]
+                capped.append(clamped)
+            else:
+                capped.append(r)
+        if not capped:
+            return None
+        return json.dumps(capped, separators=(",", ":"))
 
     def _apply_reminders_for_provider(
         self,
@@ -2740,9 +2799,7 @@ class ChatSession:
         # nowhere.
         source = user_msg.get("_source")
         reminders_payload = user_msg.get("_reminders")
-        reminders_json = (
-            json.dumps(reminders_payload, separators=(",", ":")) if reminders_payload else None
-        )
+        reminders_json = self._encode_reminders(reminders_payload)
         message_id = save_message(
             self._ws_id,
             "user",
@@ -3081,11 +3138,7 @@ class ChatSession:
                     # ``_reminders`` JSON column so a tab reconnecting via
                     # /history sees the below-the-tool bubble the
                     # originating tab rendered live.
-                    tool_reminders_json = (
-                        json.dumps(metacog_reminders, separators=(",", ":"))
-                        if metacog_reminders
-                        else None
-                    )
+                    tool_reminders_json = self._encode_reminders(metacog_reminders)
                     save_message(
                         self._ws_id,
                         "tool",

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1319,7 +1319,7 @@ class SessionUIBase:
     def on_error(self, message: str) -> None:
         self._enqueue({"type": "error", "message": message})
 
-    def on_user_reminder(self, reminders: list[dict[str, str]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
         """Surface a metacognitive user-channel nudge as its own UI
         element.
 
@@ -1334,7 +1334,7 @@ class SessionUIBase:
         """
         self._enqueue({"type": "user_reminder", "reminders": reminders})
 
-    def on_tool_reminder(self, reminders: list[dict[str, str]], tool_call_id: str) -> None:
+    def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:
         """Surface a metacognitive tool-channel nudge (``tool_error`` /
         ``repeat``) as its own UI element below the tool result that
         triggered it.

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1319,7 +1319,7 @@ class SessionUIBase:
     def on_error(self, message: str) -> None:
         self._enqueue({"type": "error", "message": message})
 
-    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]], source: str | None = None) -> None:
         """Surface a metacognitive user-channel nudge as its own UI
         element.
 
@@ -1331,8 +1331,16 @@ class SessionUIBase:
         originating tab.  The history-replay path surfaces the same
         shape via ``_build_history`` so a tab reconnecting later
         renders the same bubble.
+
+        ``source`` mirrors the user-message dict's ``_source`` field
+        (today only ``"system_nudge"`` for wake-driven reminders).  The
+        frontend uses it to render the thin ``.msg.user.system-nudge``
+        marker before anchoring the reminder bubbles below it.
         """
-        self._enqueue({"type": "user_reminder", "reminders": reminders})
+        evt: dict[str, Any] = {"type": "user_reminder", "reminders": reminders}
+        if source:
+            evt["source"] = source
+        self._enqueue(evt)
 
     def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:
         """Surface a metacognitive tool-channel nudge (``tool_error`` /

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -178,6 +178,8 @@ class PostgreSQLBackend:
         tool_call_id: str | None = None,
         provider_data: str | None = None,
         tool_calls: str | None = None,
+        source: str | None = None,
+        reminders: str | None = None,
     ) -> int:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         content = sanitize_text(content)
@@ -194,6 +196,8 @@ class PostgreSQLBackend:
                     tool_call_id=tool_call_id,
                     provider_data=provider_data,
                     tool_calls=tool_calls,
+                    _source=source,
+                    _reminders=reminders,
                 )
                 .returning(conversations.c.id)
             )
@@ -223,6 +227,8 @@ class PostgreSQLBackend:
                     "tool_call_id": row.get("tool_call_id"),
                     "provider_data": sanitize_text(row.get("provider_data")),
                     "tool_calls": row.get("tool_calls"),
+                    "_source": row.get("source"),
+                    "_reminders": row.get("reminders"),
                 }
             )
         with self._conn() as conn:
@@ -245,6 +251,8 @@ class PostgreSQLBackend:
                         conversations.c.tool_call_id,
                         conversations.c.provider_data,
                         conversations.c.tool_calls,
+                        conversations.c._source,
+                        conversations.c._reminders,
                     )
                     .where(conversations.c.ws_id == ws_id)
                     .order_by(conversations.c.id.desc())
@@ -261,6 +269,8 @@ class PostgreSQLBackend:
                         conversations.c.tool_call_id,
                         conversations.c.provider_data,
                         conversations.c.tool_calls,
+                        conversations.c._source,
+                        conversations.c._reminders,
                     )
                     .where(conversations.c.ws_id == ws_id)
                     .order_by(conversations.c.id)

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -184,6 +184,8 @@ class PostgreSQLBackend:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         content = sanitize_text(content)
         provider_data = sanitize_text(provider_data)
+        source = sanitize_text(source)
+        reminders = sanitize_text(reminders)
         with self._conn() as conn:
             result = conn.execute(
                 sa.insert(conversations)
@@ -227,8 +229,8 @@ class PostgreSQLBackend:
                     "tool_call_id": row.get("tool_call_id"),
                     "provider_data": sanitize_text(row.get("provider_data")),
                     "tool_calls": row.get("tool_calls"),
-                    "_source": row.get("source"),
-                    "_reminders": row.get("reminders"),
+                    "_source": sanitize_text(row.get("source")),
+                    "_reminders": sanitize_text(row.get("reminders")),
                 }
             )
         with self._conn() as conn:

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -115,12 +115,20 @@ class StorageBackend(Protocol):
         tool_call_id: str | None = None,
         provider_data: str | None = None,
         tool_calls: str | None = None,
+        source: str | None = None,
+        reminders: str | None = None,
     ) -> int:
         """Log a message to the conversations table.
 
         Returns the inserted row's ``id`` (autoincrement PK).  Callers
         that need to link side tables (e.g. ``workstream_attachments``)
         use this to associate the row after save.
+
+        ``source`` is the persisted twin of the in-memory ``_source``
+        side-channel (today only ``"system_nudge"`` for wake-driven
+        empty user turns).  ``reminders`` is a JSON-encoded list mirroring
+        ``_reminders``; both are NULL for the common case where a
+        message carries no metacog payload.
         """
         ...
 
@@ -130,8 +138,8 @@ class StorageBackend(Protocol):
         Each dict must include ``ws_id``, ``role``, and ``content``
         (which may be ``None`` for assistant messages with only tool_calls).
         Optional keys: ``tool_name``, ``tool_call_id``, ``provider_data``,
-        ``tool_calls``.  Timestamp and workstream
-        updated-at are handled internally.
+        ``tool_calls``, ``source``, ``reminders``.  Timestamp and
+        workstream updated-at are handled internally.
         """
         ...
 

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -38,6 +38,14 @@ conversations = sa.Table(
     sa.Column("tool_call_id", sa.Text),
     sa.Column("provider_data", sa.Text),
     sa.Column("tool_calls", sa.Text),
+    # Sibling-key columns mirroring the in-memory ``_source`` /
+    # ``_reminders`` side-channels.  ``_source`` audits which producer
+    # synthesised the row (today only ``"system_nudge"`` for wake-driven
+    # empty user turns); ``_reminders`` stores the JSON-encoded reminder
+    # list ``[{type, text, ...optional}]`` so multi-tab / multi-device
+    # replay sees the same bubble shape the originating tab saw live.
+    sa.Column("_source", sa.Text),
+    sa.Column("_reminders", sa.Text),
 )
 
 sa.Index("idx_conversations_timestamp", conversations.c.timestamp)

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -218,6 +218,8 @@ class SQLiteBackend:
         tool_call_id: str | None = None,
         provider_data: str | None = None,
         tool_calls: str | None = None,
+        source: str | None = None,
+        reminders: str | None = None,
     ) -> int:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         content = sanitize_text(content)
@@ -234,6 +236,8 @@ class SQLiteBackend:
                     "tool_call_id": tool_call_id,
                     "provider_data": provider_data,
                     "tool_calls": tool_calls,
+                    "_source": source,
+                    "_reminders": reminders,
                 },
             )
             if result.lastrowid is None:
@@ -277,6 +281,8 @@ class SQLiteBackend:
                     "tool_call_id": row.get("tool_call_id"),
                     "provider_data": sanitize_text(row.get("provider_data")),
                     "tool_calls": row.get("tool_calls"),
+                    "_source": row.get("source"),
+                    "_reminders": row.get("reminders"),
                 }
             )
         with self._conn() as conn:
@@ -312,6 +318,8 @@ class SQLiteBackend:
                         conversations.c.tool_call_id,
                         conversations.c.provider_data,
                         conversations.c.tool_calls,
+                        conversations.c._source,
+                        conversations.c._reminders,
                     )
                     .where(conversations.c.ws_id == ws_id)
                     .order_by(conversations.c.id.desc())
@@ -328,6 +336,8 @@ class SQLiteBackend:
                         conversations.c.tool_call_id,
                         conversations.c.provider_data,
                         conversations.c.tool_calls,
+                        conversations.c._source,
+                        conversations.c._reminders,
                     )
                     .where(conversations.c.ws_id == ws_id)
                     .order_by(conversations.c.id)

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -224,6 +224,8 @@ class SQLiteBackend:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         content = sanitize_text(content)
         provider_data = sanitize_text(provider_data)
+        source = sanitize_text(source)
+        reminders = sanitize_text(reminders)
         with self._conn() as conn:
             result = conn.execute(
                 sa.insert(conversations),
@@ -281,8 +283,8 @@ class SQLiteBackend:
                     "tool_call_id": row.get("tool_call_id"),
                     "provider_data": sanitize_text(row.get("provider_data")),
                     "tool_calls": row.get("tool_calls"),
-                    "_source": row.get("source"),
-                    "_reminders": row.get("reminders"),
+                    "_source": sanitize_text(row.get("source")),
+                    "_reminders": sanitize_text(row.get("reminders")),
                 }
             )
         with self._conn() as conn:

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -289,9 +289,12 @@ def reconstruct_messages(
 ) -> list[dict[str, Any]]:
     """Reconstruct OpenAI message format from stored conversation rows.
 
-    Each *row* is a 7-tuple ``(id, role, content, tool_name,
-    tool_call_id, provider_data, tool_calls_json)``, ordered
-    chronologically by row id.
+    Each *row* is a 9-tuple ``(id, role, content, tool_name,
+    tool_call_id, provider_data, tool_calls_json, source,
+    reminders_json)``, ordered chronologically by row id.  The trailing
+    two columns mirror the ``_source`` / ``_reminders`` in-memory side
+    channels so multi-tab / multi-device replay sees the same bubble
+    shape the originating tab saw live.
 
     When ``attachments_by_msg`` is provided, any user row whose id has
     attachments is rebuilt with multipart list content (text +
@@ -299,7 +302,17 @@ def reconstruct_messages(
     """
     messages: list[dict[str, Any]] = []
     for row in rows:
-        row_id, role, content, _tool_name, tc_id, provider_data, tool_calls_json = row
+        (
+            row_id,
+            role,
+            content,
+            _tool_name,
+            tc_id,
+            provider_data,
+            tool_calls_json,
+            source,
+            reminders_json,
+        ) = row
 
         if role == "user":
             parts: list[dict[str, Any]] = []
@@ -325,9 +338,17 @@ def reconstruct_messages(
                 umsg: dict[str, Any] = {"role": "user", "content": user_content}
                 if meta:
                     umsg["_attachments_meta"] = meta
-                messages.append(umsg)
             else:
-                messages.append({"role": "user", "content": content or ""})
+                umsg = {"role": "user", "content": content or ""}
+            if source:
+                umsg["_source"] = str(source)
+            if reminders_json:
+                # Mirrors the ``provider_data`` / ``tool_calls`` JSON
+                # decode pattern below: malformed JSON in the column is
+                # swallowed silently rather than aborting load.
+                with contextlib.suppress(json.JSONDecodeError, TypeError):
+                    umsg["_reminders"] = json.loads(reminders_json)
+            messages.append(umsg)
 
         elif role == "assistant":
             msg: dict[str, Any] = {"role": "assistant", "content": content or ""}
@@ -340,13 +361,18 @@ def reconstruct_messages(
             messages.append(msg)
 
         elif role == "tool":
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tc_id or "",
-                    "content": content or "",
-                }
-            )
+            tmsg: dict[str, Any] = {
+                "role": "tool",
+                "tool_call_id": tc_id or "",
+                "content": content or "",
+            }
+            if reminders_json:
+                # Tool-channel reminders (``tool_error`` / ``repeat``)
+                # ride the same column so replay shows the same below-
+                # the-tool bubble the originating tab rendered live.
+                with contextlib.suppress(json.JSONDecodeError, TypeError):
+                    tmsg["_reminders"] = json.loads(reminders_json)
+            messages.append(tmsg)
 
     # Repair: strip trailing incomplete tool call turns
     while messages:

--- a/turnstone/core/storage/migrations/versions/050_conversations_source_and_reminders.py
+++ b/turnstone/core/storage/migrations/versions/050_conversations_source_and_reminders.py
@@ -1,0 +1,40 @@
+"""Add ``_source`` and ``_reminders`` columns to ``conversations``.
+
+Persisting these two fields lets multi-tab / multi-device replay show
+the same metacognitive bubble shape the originating tab saw live.
+Until now, the side-channel keys lived only in the in-memory
+``ChatSession.messages`` list, so a second browser tab connecting via
+``/history`` saw a synthetic empty wake row missing entirely (skipped
+at save time) and any preceding tab's reminder bubbles missing as well.
+
+* ``_source`` — TEXT NULL.  Today only ``"system_nudge"`` is written
+  (the wake-driven empty user turn marker).  Future producers can
+  extend (e.g. ``"external_webhook"``) without another migration.
+* ``_reminders`` — TEXT NULL holding a JSON array of reminder dicts
+  ``{type, text, ...optional}``.  Empty / missing column means no
+  reminders for that row.
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-05-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "050"
+down_revision = "049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("conversations", sa.Column("_source", sa.Text, nullable=True))
+    op.add_column("conversations", sa.Column("_reminders", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    # Reverse order of upgrade.  ``op.drop_column`` works on SQLite via
+    # Alembic batch-mode auto-rebuild and on PostgreSQL natively.
+    op.drop_column("conversations", "_reminders")
+    op.drop_column("conversations", "_source")

--- a/turnstone/core/storage/migrations/versions/050_conversations_source_and_reminders.py
+++ b/turnstone/core/storage/migrations/versions/050_conversations_source_and_reminders.py
@@ -14,6 +14,13 @@ at save time) and any preceding tab's reminder bubbles missing as well.
   ``{type, text, ...optional}``.  Empty / missing column means no
   reminders for that row.
 
+**SQLite upgrade cost.**  Alembic env.py runs migrations with
+``render_as_batch=True``, which on SQLite implements ``add_column`` by
+recreating the table.  Two ``add_column`` calls = two full-table
+copies on first deployment after upgrade.  For installs with months
+of chat history (millions of rows) the migration takes seconds to
+minutes.  PostgreSQL is unaffected (metadata-only ALTER).
+
 Revision ID: 050
 Revises: 049
 Create Date: 2026-05-06

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -195,7 +195,7 @@ def format_watch_message(
     return "\n".join(lines)
 
 
-_WATCH_REMINDER_OPTIONAL_KEYS = (
+WATCH_REMINDER_OPTIONAL_KEYS = (
     "watch_name",
     "command",
     "poll_count",

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -195,6 +195,48 @@ def format_watch_message(
     return "\n".join(lines)
 
 
+def build_watch_reminder(
+    name: str,
+    command: str,
+    output: str,
+    poll_count: int,
+    max_polls: int,
+    elapsed_secs: float,
+    stop_on: str | None,
+    is_final: bool,
+    reason: str,
+) -> dict[str, Any]:
+    """Build a structured ``watch_triggered`` reminder dict.
+
+    Returns a dict with ``{type, text, watch_name, command, poll_count,
+    max_polls, is_final}`` so the frontend can render a structured
+    ``.msg.watch-result`` card with command preview + poll counter
+    instead of a plain advisory bubble.  The ``text`` field is the
+    formatted body (same content :func:`format_watch_message` produces)
+    so compaction / channel adapters / ``_apply_reminders_for_provider``
+    keep seeing the human-readable shell output as before.
+    """
+    return {
+        "type": "watch_triggered",
+        "text": format_watch_message(
+            name=name,
+            command=command,
+            output=output,
+            poll_count=poll_count,
+            max_polls=max_polls,
+            elapsed_secs=elapsed_secs,
+            stop_on=stop_on,
+            is_final=is_final,
+            reason=reason,
+        ),
+        "watch_name": name,
+        "command": command,
+        "poll_count": poll_count,
+        "max_polls": max_polls,
+        "is_final": is_final,
+    }
+
+
 def format_interval(secs: float) -> str:
     """Human-readable duration (e.g. ``'5m'``, ``'1h30m'``)."""
     if secs < 60:
@@ -227,7 +269,7 @@ class WatchRunner:
         *,
         check_interval: float = 15.0,
         tool_timeout: float = 30.0,
-        restore_fn: Callable[[str], Callable[[str, str], None] | None] | None = None,
+        restore_fn: Callable[[str], Callable[[dict[str, Any], str], None] | None] | None = None,
     ) -> None:
         self._storage = storage
         self._node_id = node_id
@@ -235,7 +277,7 @@ class WatchRunner:
         self._tool_timeout = tool_timeout
         self._restore_fn = restore_fn
 
-        self._dispatch_fns: dict[str, Callable[[str, str], None]] = {}
+        self._dispatch_fns: dict[str, Callable[[dict[str, Any], str], None]] = {}
         self._dispatch_lock = threading.Lock()
 
         self._stop_event = threading.Event()
@@ -260,14 +302,17 @@ class WatchRunner:
 
     # -- Dispatch function registry ------------------------------------------
 
-    def set_dispatch_fn(self, ws_id: str, fn: Callable[[str, str], None]) -> None:
+    def set_dispatch_fn(self, ws_id: str, fn: Callable[[dict[str, Any], str], None]) -> None:
         """Register a per-workstream dispatch fn.
 
-        The fn signature is ``(message, watch_id)`` — the runner passes
+        The fn signature is ``(reminder, watch_id)`` — the runner passes
         the originating ``watch_id`` so dispatch closures can capture
         per-watch metadata (e.g. a ``valid_until`` predicate that
         re-checks ``storage.is_watch_active(watch_id)`` before
-        delivering a stale entry).
+        delivering a stale entry).  ``reminder`` is the structured dict
+        returned by :func:`build_watch_reminder` — ``text`` carries the
+        formatted body, the remaining fields ride as queue-entry
+        metadata so the frontend can render a ``.msg.watch-result`` card.
         """
         with self._dispatch_lock:
             self._dispatch_fns[ws_id] = fn
@@ -276,7 +321,7 @@ class WatchRunner:
         with self._dispatch_lock:
             self._dispatch_fns.pop(ws_id, None)
 
-    def get_dispatch_fn(self, ws_id: str) -> Callable[[str, str], None] | None:
+    def get_dispatch_fn(self, ws_id: str) -> Callable[[dict[str, Any], str], None] | None:
         """Public accessor for the registered dispatch fn (used by
         server-side restore paths to thread the closure through
         ``WatchRunner.restore_fn`` after the workstream is rehydrated).
@@ -388,7 +433,7 @@ class WatchRunner:
                 except (ValueError, TypeError):
                     pass  # elapsed stays 0.0
 
-            message = format_watch_message(
+            reminder = build_watch_reminder(
                 name=watch_row["name"],
                 command=command,
                 output=output,
@@ -399,7 +444,7 @@ class WatchRunner:
                 is_final=is_final,
                 reason=reason,
             )
-            self._dispatch_result(ws_id, message, watch_id)
+            self._dispatch_result(ws_id, reminder, watch_id)
 
         log.debug(
             "watch_runner.polled",
@@ -434,14 +479,20 @@ class WatchRunner:
         except Exception as exc:
             return f"[command failed: {exc}]", -1
 
-    def _dispatch_result(self, ws_id: str, message: str, watch_id: str) -> None:
-        """Deliver a watch result to the owning workstream."""
+    def _dispatch_result(self, ws_id: str, reminder: dict[str, Any], watch_id: str) -> None:
+        """Deliver a watch result to the owning workstream.
+
+        ``reminder`` is the structured dict produced by
+        :func:`build_watch_reminder` — ``text`` is the formatted body
+        (matched by the dispatch closure's :func:`sanitize_payload`
+        pass) and the optional fields ride as queue-entry metadata.
+        """
         with self._dispatch_lock:
             fn = self._dispatch_fns.get(ws_id)
 
         if fn is not None:
             try:
-                fn(message, watch_id)
+                fn(reminder, watch_id)
                 return
             except Exception:
                 log.exception("watch_runner.dispatch_error", extra={"ws_id": ws_id})
@@ -451,7 +502,7 @@ class WatchRunner:
             try:
                 restored_fn = self._restore_fn(ws_id)
                 if restored_fn is not None:
-                    restored_fn(message, watch_id)
+                    restored_fn(reminder, watch_id)
                     return
             except Exception:
                 log.exception("watch_runner.restore_error", extra={"ws_id": ws_id})

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -195,6 +195,15 @@ def format_watch_message(
     return "\n".join(lines)
 
 
+_WATCH_REMINDER_OPTIONAL_KEYS = (
+    "watch_name",
+    "command",
+    "poll_count",
+    "max_polls",
+    "is_final",
+)
+
+
 def build_watch_reminder(
     name: str,
     command: str,

--- a/turnstone/eval.py
+++ b/turnstone/eval.py
@@ -139,10 +139,10 @@ class NullUI:
     def on_error(self, message: str) -> None:
         pass
 
-    def on_user_reminder(self, reminders: list[dict[str, str]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
         pass
 
-    def on_tool_reminder(self, reminders: list[dict[str, str]], tool_call_id: str) -> None:
+    def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:
         pass
 
     def on_state_change(self, state: str) -> None:

--- a/turnstone/eval.py
+++ b/turnstone/eval.py
@@ -139,7 +139,7 @@ class NullUI:
     def on_error(self, message: str) -> None:
         pass
 
-    def on_user_reminder(self, reminders: list[dict[str, Any]]) -> None:
+    def on_user_reminder(self, reminders: list[dict[str, Any]], source: str | None = None) -> None:
         pass
 
     def on_tool_reminder(self, reminders: list[dict[str, Any]], tool_call_id: str) -> None:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -92,7 +92,7 @@ from turnstone.core.session_ui_base import (
     fire_judge_verdict_metric,
 )
 from turnstone.core.tools import TOOLS  # noqa: F401 — available for introspection
-from turnstone.core.watch import _WATCH_REMINDER_OPTIONAL_KEYS
+from turnstone.core.watch import WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web_helpers import version_html as _version_html
 from turnstone.core.workstream import (
     Workstream,
@@ -550,7 +550,7 @@ def _build_history(
                 if not rtype and not rtext:
                     continue
                 clean: dict[str, Any] = {"type": rtype, "text": rtext}
-                for opt_key in _WATCH_REMINDER_OPTIONAL_KEYS:
+                for opt_key in WATCH_REMINDER_OPTIONAL_KEYS:
                     if opt_key in r:
                         clean[opt_key] = r[opt_key]
                 clean_reminders.append(clean)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -515,22 +515,51 @@ def _build_history(
         entry = {"role": msg["role"], "content": content}
         if attachments_meta:
             entry["attachments"] = attachments_meta
+        # Surface the ``_source`` side-channel so the frontend can apply
+        # the ``.msg.user.system-nudge`` class on history replay (today
+        # only the wake-driven empty user turn carries ``"system_nudge"``).
+        # Persisted via the conversations._source column added in
+        # migration 050; legacy rows without the column lack the key
+        # entirely.
+        if msg.get("_source"):
+            entry["source"] = str(msg["_source"])
         # Surface the ``_reminders`` side-channel so a tab reconnecting
         # via /history renders the same metacognitive nudge bubble the
         # originating tab saw live (user-channel reminders via
         # ``user_reminder`` SSE; tool-channel via ``tool_reminder``).
-        # Reminders are in-memory only (not persisted to DB), so this
-        # only fires for the originating session.
+        # Persisted via the conversations._reminders column added in
+        # migration 050 — multi-tab / multi-device tabs reconnecting
+        # later see the same shape now, not just the originating tab.
         reminders = msg.get("_reminders")
         if isinstance(reminders, list):
             # Filter first so an all-malformed _reminders doesn't set the
             # field to []; absent vs. empty-list should mean the same
-            # thing on the wire.
-            clean_reminders = [
-                {"type": str(r.get("type") or ""), "text": str(r.get("text") or "")}
-                for r in reminders
-                if isinstance(r, dict)
-            ]
+            # thing on the wire.  Project on a known set of keys —
+            # narrows the blast radius if a future producer accidentally
+            # stuffs sensitive fields into the dict.  ``watch_triggered``
+            # carries the structured watch-card fields (watch_name,
+            # command, poll_count, max_polls, is_final) and other
+            # producers leave them unset.
+            clean_reminders: list[dict[str, Any]] = []
+            for r in reminders:
+                if not isinstance(r, dict):
+                    continue
+                rtype = str(r.get("type") or "")
+                rtext = str(r.get("text") or "")
+                if not rtype and not rtext:
+                    continue
+                clean: dict[str, Any] = {"type": rtype, "text": rtext}
+                # Preserve watch-card optional fields verbatim.
+                for opt_key in (
+                    "watch_name",
+                    "command",
+                    "poll_count",
+                    "max_polls",
+                    "is_final",
+                ):
+                    if opt_key in r:
+                        clean[opt_key] = r[opt_key]
+                clean_reminders.append(clean)
             if clean_reminders:
                 entry["reminders"] = clean_reminders
         if msg.get("tool_calls"):

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -92,6 +92,7 @@ from turnstone.core.session_ui_base import (
     fire_judge_verdict_metric,
 )
 from turnstone.core.tools import TOOLS  # noqa: F401 — available for introspection
+from turnstone.core.watch import _WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web_helpers import version_html as _version_html
 from turnstone.core.workstream import (
     Workstream,
@@ -549,14 +550,7 @@ def _build_history(
                 if not rtype and not rtext:
                     continue
                 clean: dict[str, Any] = {"type": rtype, "text": rtext}
-                # Preserve watch-card optional fields verbatim.
-                for opt_key in (
-                    "watch_name",
-                    "command",
-                    "poll_count",
-                    "max_polls",
-                    "is_final",
-                ):
+                for opt_key in _WATCH_REMINDER_OPTIONAL_KEYS:
                     if opt_key in r:
                         clean[opt_key] = r[opt_key]
                 clean_reminders.append(clean)

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -915,6 +915,73 @@
   margin-right: 6px;
   text-transform: lowercase;
 }
+/* Newline preservation for every metacog reminder bubble.
+   `.msg.user-reminder` sets `white-space: pre-wrap` on the outer
+   element but the shared `.msg-body` rule below explicitly resets to
+   `normal` for markdown-friendly spacing.  Restoring `pre-wrap` for
+   the reminder body keeps multi-line shell output (watch_triggered)
+   and bulleted lists (idle_children) readable instead of collapsing
+   newlines into single spaces. */
+.msg.user-reminder .msg-body {
+  white-space: pre-wrap;
+}
+
+/* Watch-result card — full-width structured rendering for the
+   `watch_triggered` reminder type.  First-pass functional treatment
+   (no bespoke design polish yet) — the goal is making 50-line
+   `gh pr view` shell output legible inside the chat flow rather than
+   buried in a small advisory bubble. */
+.msg.watch-result {
+  border-left-color: var(--cyan);
+  background: var(--panel);
+  padding: 8px 12px;
+  margin: 6px 0;
+  width: 100%;
+}
+.msg.watch-result .msg-watch-header {
+  color: var(--cyan);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  text-transform: lowercase;
+}
+.msg.watch-result .msg-watch-cmd {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+.msg.watch-result .msg-watch-body {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin: 0;
+  white-space: pre-wrap;
+  /* Shell output can be wide (URLs, JSON, file lists) — break inside
+     long words so the off-canvas mobile drawer doesn't blow horizontal
+     layout.  R7 in the plan's risk register. */
+  word-break: break-word;
+}
+.msg.watch-result .msg-watch-footer {
+  color: var(--ink-3);
+  font-size: 11px;
+  margin-top: 6px;
+}
+
+/* System-nudge marker — visible-but-thin replacement for the wake's
+   synthetic empty user turn.  Rendered above wake-driven reminder
+   bubbles so they anchor to a real DOM element instead of falling
+   below an old user message (the §3.4 misalignment in the briefing).
+   Today only `_source = "system_nudge"` triggers it; future producers
+   can add their own thin marker via the same pattern. */
+.msg.user.system-nudge {
+  border-left-color: var(--yellow);
+  color: var(--ink-3);
+  font-size: 11px;
+  padding: 2px 10px;
+  background: transparent;
+  text-transform: lowercase;
+}
 .msg.assistant {
   border-left-color: var(--hair-2);
 }

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -753,6 +753,8 @@ function _buildWatchResultBubble(r) {
 function _buildDefaultReminderBubble(r) {
   var el = document.createElement("div");
   el.className = "msg user-reminder";
+  var body = document.createElement("div");
+  body.className = "msg-body";
   var labelEl = document.createElement("span");
   labelEl.className = "msg-user-reminder-label";
   labelEl.textContent =
@@ -760,8 +762,9 @@ function _buildDefaultReminderBubble(r) {
   var textEl = document.createElement("span");
   textEl.className = "msg-user-reminder-text";
   textEl.textContent = r.text || "";
-  el.appendChild(labelEl);
-  el.appendChild(textEl);
+  body.appendChild(labelEl);
+  body.appendChild(textEl);
+  el.appendChild(body);
   return el;
 }
 
@@ -803,7 +806,9 @@ Pane.prototype.addUserReminder = function (reminders, source) {
   if (source === "system_nudge") {
     anchor = this.addSystemNudgeMarker();
   } else {
-    var userBubbles = this.messagesEl.querySelectorAll(".msg.user");
+    var userBubbles = this.messagesEl.querySelectorAll(
+      ".msg.user:not(.system-nudge)",
+    );
     anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
   }
   for (var i = 0; i < reminders.length; i++) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -568,17 +568,20 @@ Pane.prototype.handleEvent = function (evt) {
       // insertAdjacentElement('afterend', el) call drops the bubble
       // immediately below.
       //
-      // Multi-tab caveat: the server emits no user_message SSE event
-      // today, so a non-originating tab open on the same workstream
+      // Wake-driven reminders (``evt.source === "system_nudge"``)
+      // render the thin .msg.user.system-nudge marker first and
+      // anchor below it, so non-originating tabs see the same shape
+      // the originating tab does.
+      //
+      // Multi-tab caveat (non-wake): the server emits no user_message
+      // SSE event for real user input today, so a non-originating tab
       // sees the reminder without a paired user-message render — the
       // anchor falls on a stale prior user bubble, mis-positioning
-      // the reminder.  The next /history reload corrects it (the
-      // entry["reminders"] propagation in _build_history is
-      // anchor-stable because replayHistory runs addUserMessage first
-      // for every turn).  Acceptable cost for stage 1; closing the
-      // gap is a follow-up that adds a user_message SSE event.
+      // the reminder.  The next /history reload corrects it.
+      // Acceptable cost for stage 1; closing the gap is a follow-up
+      // that adds a user_message SSE event.
       if (Array.isArray(evt.reminders) && evt.reminders.length) {
-        this.addUserReminder(evt.reminders);
+        this.addUserReminder(evt.reminders, evt.source || "");
       }
       break;
 
@@ -707,7 +710,78 @@ Pane.prototype.removeThinkingIndicator = function () {
   if (el) el.remove();
 };
 
-Pane.prototype.addUserReminder = function (reminders) {
+// Build a structured ``.msg.watch-result`` card for a
+// ``watch_triggered`` reminder — full-width treatment with command
+// preview header + shell output body + poll counter footer.  Mirrors
+// the coordinator pane's buildWatchResultBubble; first-pass functional
+// rendering only.  All text goes through textContent so shell output
+// containing angle brackets / scripts / steering bytes renders inertly.
+function _buildWatchResultBubble(r) {
+  var el = document.createElement("div");
+  el.className = "msg watch-result";
+  el.setAttribute("role", "article");
+  el.setAttribute("data-ts-role", "watch");
+  el.setAttribute("aria-label", "watch");
+  var header = document.createElement("div");
+  header.className = "msg-watch-header";
+  header.textContent =
+    "watch" + (r.watch_name ? " · " + String(r.watch_name) : "");
+  el.appendChild(header);
+  if (r.command) {
+    var cmd = document.createElement("div");
+    cmd.className = "msg-watch-cmd";
+    cmd.textContent = "$ " + String(r.command);
+    el.appendChild(cmd);
+  }
+  var body = document.createElement("pre");
+  body.className = "msg-watch-body";
+  body.textContent = r.text || "";
+  el.appendChild(body);
+  if (r.poll_count != null && r.max_polls != null) {
+    var footer = document.createElement("div");
+    footer.className = "msg-watch-footer";
+    var finalSuffix = r.is_final ? " · final" : "";
+    footer.textContent =
+      "poll " + String(r.poll_count) + "/" + String(r.max_polls) + finalSuffix;
+    el.appendChild(footer);
+  }
+  return el;
+}
+
+// Default ``.msg.user-reminder`` bubble — yellow themed advisory used
+// for every metacog nudge other than ``watch_triggered``.
+function _buildDefaultReminderBubble(r) {
+  var el = document.createElement("div");
+  el.className = "msg user-reminder";
+  var labelEl = document.createElement("span");
+  labelEl.className = "msg-user-reminder-label";
+  labelEl.textContent =
+    "metacognition" + (r.type ? " · " + String(r.type) : "");
+  var textEl = document.createElement("span");
+  textEl.className = "msg-user-reminder-text";
+  textEl.textContent = r.text || "";
+  el.appendChild(labelEl);
+  el.appendChild(textEl);
+  return el;
+}
+
+Pane.prototype.addSystemNudgeMarker = function () {
+  // Thin .msg.user.system-nudge marker rendered as the anchor for
+  // wake-driven reminder bubbles.  Replaces the previously-invisible
+  // synthetic empty user turn with a visible-but-subtle DOM element so
+  // the bubble below it lands in the right place even when the wake
+  // fires long after the user's last real message.
+  this.removeEmptyState();
+  var el = document.createElement("div");
+  el.className = "msg user system-nudge";
+  el.setAttribute("data-source", "system_nudge");
+  el.setAttribute("aria-label", "system nudge");
+  el.textContent = "system nudge";
+  this.messagesEl.appendChild(el);
+  return el;
+};
+
+Pane.prototype.addUserReminder = function (reminders, source) {
   // Render each metacognitive reminder as its own bubble immediately
   // BELOW the user message it advises — semantically the reminder is
   // a hint to the model right before the assistant turn.  Always
@@ -719,22 +793,25 @@ Pane.prototype.addUserReminder = function (reminders) {
   // exists at all (e.g. a non-originating tab receiving a reminder
   // before any user turn has rendered) we append; the next /history
   // reload corrects any anchor anomaly.
+  //
+  // ``source === "system_nudge"`` is the wake-driven case: render
+  // a thin .msg.user.system-nudge marker first and anchor below it.
+  // ``watch_triggered`` reminders branch off into a structured
+  // .msg.watch-result card.
   this.removeEmptyState();
-  var userBubbles = this.messagesEl.querySelectorAll(".msg.user");
-  var anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
+  var anchor;
+  if (source === "system_nudge") {
+    anchor = this.addSystemNudgeMarker();
+  } else {
+    var userBubbles = this.messagesEl.querySelectorAll(".msg.user");
+    anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
+  }
   for (var i = 0; i < reminders.length; i++) {
     var r = reminders[i] || {};
-    var el = document.createElement("div");
-    el.className = "msg user-reminder";
-    var labelEl = document.createElement("span");
-    labelEl.className = "msg-user-reminder-label";
-    labelEl.textContent =
-      "metacognition" + (r.type ? " · " + String(r.type) : "");
-    var textEl = document.createElement("span");
-    textEl.className = "msg-user-reminder-text";
-    textEl.textContent = r.text || "";
-    el.appendChild(labelEl);
-    el.appendChild(textEl);
+    var el =
+      r.type === "watch_triggered"
+        ? _buildWatchResultBubble(r)
+        : _buildDefaultReminderBubble(r);
     if (anchor) {
       anchor.insertAdjacentElement("afterend", el);
       // Anchor advances so multiple reminders stack below the user
@@ -757,7 +834,9 @@ Pane.prototype.addToolReminder = function (reminders, toolCallId) {
   // to "last .ts-approval block in messagesEl", which is correct
   // because messages render in order — the assistant block carrying
   // the tool batch is always the most recent approval block by the
-  // time we hit the tool message that owns the reminder.
+  // time we hit the tool message that owns the reminder.  Tool-channel
+  // reminders also branch on r.type so a watch_triggered drained at
+  // the tool seam (channel="any") renders the structured card.
   this.removeEmptyState();
   var anchor = null;
   if (toolCallId) {
@@ -775,19 +854,10 @@ Pane.prototype.addToolReminder = function (reminders, toolCallId) {
   }
   for (var i = 0; i < reminders.length; i++) {
     var r = reminders[i] || {};
-    var el = document.createElement("div");
-    // Same .msg.user-reminder class — visual treatment is shared
-    // across user and tool channels (both are metacog nudges).
-    el.className = "msg user-reminder";
-    var labelEl = document.createElement("span");
-    labelEl.className = "msg-user-reminder-label";
-    labelEl.textContent =
-      "metacognition" + (r.type ? " · " + String(r.type) : "");
-    var textEl = document.createElement("span");
-    textEl.className = "msg-user-reminder-text";
-    textEl.textContent = r.text || "";
-    el.appendChild(labelEl);
-    el.appendChild(textEl);
+    var el =
+      r.type === "watch_triggered"
+        ? _buildWatchResultBubble(r)
+        : _buildDefaultReminderBubble(r);
     if (anchor) {
       anchor.insertAdjacentElement("afterend", el);
       anchor = el;
@@ -1053,6 +1123,17 @@ Pane.prototype.replayHistory = function (messages) {
   for (var i = 0; i < messages.length; i++) {
     var msg = messages[i];
     if (msg.role === "user") {
+      if (msg.source === "system_nudge") {
+        // Wake-driven empty user turn: render the thin marker
+        // (replaces the previously-skipped synthetic empty bubble)
+        // and anchor reminder bubbles below it.
+        this.addUserReminder(
+          Array.isArray(msg.reminders) ? msg.reminders : [],
+          "system_nudge",
+        );
+        lastToolBlock = null;
+        continue;
+      }
       // addUserMessage first so addUserReminder's "anchor to most
       // recent .msg.user" lookup finds THIS message's bubble (not the
       // previous user message's, which would associate the reminder


### PR DESCRIPTION
## Summary

User-visible UX upgrade for watch results, plus the persistence foundation that makes multi-tab / multi-device replay show the same metacog bubbles every connected tab saw live.

- `watch_triggered` reminders now render as a structured `.msg.watch-result` card (full-width, command preview + poll counter) instead of a small advisory bubble — the pre-switchover UX downgrade is reversed.
- The synthetic empty wake user turn renders as a thin `.msg.user.system-nudge` marker so wake-driven reminders anchor below it instead of falling under an old user message.
- Reminder payload widens from `{type, text}` to `{type, text, watch_name?, command?, poll_count?, max_polls?, is_final?}`. Other producers leave the optional fields unset; the wider shape is invisible at the wire boundary.
- Conversations table gains `_source` (TEXT NULL — wake marker, today only `"system_nudge"`) and `_reminders` (TEXT NULL — JSON array of reminder dicts). Single Alembic revision 050 adds both. Wake-row persist skip dropped.
- Bonus CSS fix: `.msg.user-reminder .msg-body { white-space: pre-wrap }` stops newline collapse on every metacog reminder, with the interactive UI's bubble structure reconciled to coord's so the rule fires for both.

## Behavioural delta

The wake's empty user turn now persists. One row per IDLE→wake cycle. Long-running coords with saturating watches are bounded only by the existing soft cap on `watch_triggered` queue depth (50 entries × 8 KiB UTF-8 byte clamp per persisted text — see `REMINDER_TEXT_STORAGE_CAP`). A hard cap on wake-row volume is deferred for soak data per round-1 perf-3.

## Out of scope

- Shared `cards.js` extraction for the duplicated bubble builders across coord + interactive (DOM shapes reconciled in this PR; helper extraction is a follow-up).
- Wake-row volume cap / coalesce policy — deferred for soak data.
- Tail-load consumers for `storage.load_messages(limit=...)` — kwarg surface left to its existing single caller; can be wired through `session.resume` if a heuristic warrants.

## Review

Two-round multi-stage `/review` pipeline ran on the branch.

- **Round 1** surfaced 17 unique findings (3 major, 6 minor, 8 nit, 0 critical, 0 security major). The apply-pass closed 16; perf-3 (wake-row volume bound) explicitly deferred.
- **Round 2** ran on the apply-pass state and found 9 polish items (3 minor, 6 nit, 0 major, 0 critical) — the apply-pass converged cleanly. All 9 closed in this branch.

## Test plan

- [x] `ruff check turnstone/ tests/` — clean
- [x] `mypy turnstone/` — clean (189 source files)
- [x] `pytest -m "not live" -q` — 5783 passed, 3 deselected
- [x] Migration 050 upgrade + downgrade
- [x] Round 1 of `/review` (4 finders + verify + dedupe)
- [x] Apply-pass for round 1 findings
- [x] Round 2 of `/review` — converged
- [x] Apply-pass for round 2 findings
- [x] Rebase onto current `origin/main` — clean
- [ ] Live browser pass: wake marker + structured watch card render with the right anchor on both interactive and coord; mobile drawer doesn't blow `<pre>` layout

## Recommended merge mode

Squash. The 14-commit history is for bisect-friendliness during review; the substantive landing point is "watch-card UX with persistent reminder side-channels."