### PR TITLE
fix(skills): switch skills.sh install to /api/download endpoint

### DIFF
--- a/tests/test_governance_storage.py
+++ b/tests/test_governance_storage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
 import sqlalchemy as sa
 
 # ---------------------------------------------------------------------------
@@ -316,6 +317,13 @@ class TestPromptTemplateCRUD:
 
     def test_get_prompt_template_nonexistent(self, db):
         assert db.get_prompt_template("missing") is None
+
+    def test_create_prompt_template_duplicate_id_raises_conflict(self, db):
+        from turnstone.core.storage._protocol import StorageConflictError
+
+        db.create_prompt_template("dup", "first", "general", "A")
+        with pytest.raises(StorageConflictError, match="prompt_template conflict"):
+            db.create_prompt_template("dup", "second", "general", "B")
 
     def test_list_prompt_templates_ordered_by_name(self, db):
         db.create_prompt_template("t2", "beta", "general", "B")

--- a/tests/test_skill_discovery_api.py
+++ b/tests/test_skill_discovery_api.py
@@ -256,19 +256,13 @@ class TestSkillInstall:
     def test_install_from_skills_sh(self, client: TestClient) -> None:
         package = _sample_package()
 
-        with (
-            patch("turnstone.core.skill_sources.SkillsShClient") as mock_cls,
-            patch(
-                "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
-            ) as mock_fetch,
-        ):
+        with patch("turnstone.core.skill_sources.SkillsShClient") as mock_cls:
             instance = mock_cls.return_value
-            instance.resolve_github_url = AsyncMock(return_value="https://github.com/owner/repo")
-            mock_fetch.return_value = package
+            instance.download_skill = AsyncMock(return_value=package)
 
             resp = client.post(
                 "/v1/api/admin/skills/install",
-                json={"source": "skills.sh", "skill_id": "owner/test-skill"},
+                json={"source": "skills.sh", "skill_id": "owner/repo/test-skill"},
             )
 
         assert resp.status_code == 200

--- a/tests/test_skill_sources.py
+++ b/tests/test_skill_sources.py
@@ -12,8 +12,39 @@ from turnstone.core.skill_sources import (
     SkillSourceError,
     SkillsShClient,
     _parse_github_url,
+    _split_skills_sh_id,
     fetch_skill_from_github,
 )
+
+
+class TestSplitSkillsShId:
+    """skills.sh canonical id parsing."""
+
+    def test_three_segments(self) -> None:
+        assert _split_skills_sh_id("owner/repo/leaf") == ("owner", "repo", "leaf")
+
+    def test_strips_surrounding_slashes(self) -> None:
+        assert _split_skills_sh_id("/owner/repo/leaf/") == ("owner", "repo", "leaf")
+
+    def test_rejects_two_segments(self) -> None:
+        with pytest.raises(SkillSourceError, match="expected"):
+            _split_skills_sh_id("owner/repo")
+
+    def test_rejects_four_segments(self) -> None:
+        with pytest.raises(SkillSourceError, match="expected"):
+            _split_skills_sh_id("a/b/c/d")
+
+    def test_rejects_empty_segment(self) -> None:
+        with pytest.raises(SkillSourceError, match="expected"):
+            _split_skills_sh_id("owner//leaf")
+
+    def test_rejects_internal_whitespace(self) -> None:
+        with pytest.raises(SkillSourceError, match="expected"):
+            _split_skills_sh_id("owner/repo/leaf with space")
+
+    def test_rejects_url_hostile_chars(self) -> None:
+        with pytest.raises(SkillSourceError, match="expected"):
+            _split_skills_sh_id("owner/repo/leaf?query=x")
 
 
 class TestParseGitHubUrl:
@@ -166,11 +197,18 @@ class TestSkillsShClient:
             assert "custom.registry.io" in str(call_args)
 
     @pytest.mark.anyio
-    async def test_resolve_github_url(self) -> None:
+    async def test_search_derives_source_url_when_missing(self) -> None:
+        # Real skills.sh /api/search responses don't carry source_url.
+        # We synthesise one from the canonical id so the discover-UI
+        # "already installed" check matches what download_skill persists.
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {"source_url": "https://github.com/owner/skill-repo"}
+        mock_response.json.return_value = {
+            "skills": [
+                {"id": "owner/repo/leaf", "name": "leaf"},
+            ]
+        }
 
         with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
             instance = AsyncMock()
@@ -180,9 +218,210 @@ class TestSkillsShClient:
             mock_client_cls.return_value = instance
 
             client = SkillsShClient()
-            url = await client.resolve_github_url("owner/skill")
+            results = await client.search()
 
-        assert url == "https://github.com/owner/skill-repo"
+        assert len(results) == 1
+        assert results[0].source_url == "https://skills.sh/skills/owner/repo/leaf"
+
+    @pytest.mark.anyio
+    async def test_download_skill_success(self) -> None:
+        skill_md = """---
+name: leaf
+description: A leaf skill
+author: Owner
+tags: [demo]
+---
+body
+"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "files": [
+                {"path": "SKILL.md", "contents": skill_md},
+                {"path": "scripts/run.sh", "contents": "#!/bin/sh\necho hi\n"},
+                # Filtered out: not in _RESOURCE_DIRS
+                {"path": "README.md", "contents": "ignored"},
+            ]
+        }
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            package = await client.download_skill("owner/repo/leaf")
+
+            # Confirm the request hit /api/download/{owner}/{repo}/{skill}
+            url_called = instance.get.call_args.args[0]
+            assert url_called == "https://skills.sh/api/download/owner/repo/leaf"
+
+        assert package.parsed.name == "leaf"
+        assert package.parsed.author == "Owner"
+        assert package.listing.id == "owner/repo/leaf"
+        assert package.listing.source == "skills.sh"
+        assert package.listing.source_url == "https://skills.sh/skills/owner/repo/leaf"
+        assert package.resources == {"scripts/run.sh": "#!/bin/sh\necho hi\n"}
+
+    @pytest.mark.anyio
+    async def test_download_skill_invalid_id(self) -> None:
+        client = SkillsShClient()
+        with pytest.raises(SkillSourceError, match="expected 'owner/repo/skill-name'"):
+            await client.download_skill("not-a-three-segment-id")
+
+    @pytest.mark.anyio
+    async def test_download_skill_404(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillNotFoundError, match="has no skill"):
+                await client.download_skill("owner/repo/missing")
+
+    @pytest.mark.anyio
+    async def test_download_skill_no_skill_md(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "files": [{"path": "scripts/run.sh", "contents": "x"}],
+        }
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillNotFoundError, match="no SKILL.md"):
+                await client.download_skill("owner/repo/leaf")
+
+    @pytest.mark.anyio
+    async def test_download_skill_empty_files(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"files": []}
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillSourceError, match="returned no files"):
+                await client.download_skill("owner/repo/leaf")
+
+    @pytest.mark.anyio
+    async def test_download_skill_files_not_a_list(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"files": "oops"}
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillSourceError, match="returned no files"):
+                await client.download_skill("owner/repo/leaf")
+
+    @pytest.mark.anyio
+    async def test_download_skill_oversized_skill_md(self) -> None:
+        from turnstone.core.skill_sources import _MAX_SKILL_MD_SIZE
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "files": [{"path": "SKILL.md", "contents": "x" * (_MAX_SKILL_MD_SIZE + 1)}],
+        }
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillSourceError, match="exceeds size cap"):
+                await client.download_skill("owner/repo/leaf")
+
+    @pytest.mark.anyio
+    async def test_download_skill_resource_cap(self) -> None:
+        from turnstone.core.skill_sources import _MAX_RESOURCE_FILES
+
+        skill_md = """---
+name: leaf
+description: caps test
+---
+"""
+        # 12 valid resources — only the first _MAX_RESOURCE_FILES should land.
+        files = [{"path": "SKILL.md", "contents": skill_md}]
+        for i in range(_MAX_RESOURCE_FILES + 2):
+            files.append({"path": f"scripts/r{i}.sh", "contents": f"#{i}\n"})
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"files": files}
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            package = await client.download_skill("owner/repo/leaf")
+
+        assert len(package.resources) == _MAX_RESOURCE_FILES
+
+    @pytest.mark.anyio
+    async def test_download_skill_filters_non_text_extension(self) -> None:
+        skill_md = """---
+name: leaf
+description: ext test
+---
+"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "files": [
+                {"path": "SKILL.md", "contents": skill_md},
+                # Right dir, wrong extension — must be dropped.
+                {"path": "scripts/binary.exe", "contents": "MZ..."},
+                # Right dir + right extension — kept.
+                {"path": "scripts/keep.sh", "contents": "echo\n"},
+            ]
+        }
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            package = await client.download_skill("owner/repo/leaf")
+
+        assert package.resources == {"scripts/keep.sh": "echo\n"}
 
 
 class TestFetchSkillFromGithub:

--- a/tests/test_skill_sources.py
+++ b/tests/test_skill_sources.py
@@ -197,6 +197,18 @@ class TestSkillsShClient:
             assert "custom.registry.io" in str(call_args)
 
     @pytest.mark.anyio
+    async def test_source_url_normalizes_dirty_id(self) -> None:
+        # Whitespace-bearing id from /api/search must produce the same
+        # source_url that download_skill persists, so the discover-UI
+        # "already installed" check matches.
+        from turnstone.core.skill_sources import _skills_sh_source_url
+
+        clean = _skills_sh_source_url("https://skills.sh", "owner/repo/leaf")
+        dirty = _skills_sh_source_url("https://skills.sh", " owner/repo/leaf ")
+        leading_slash = _skills_sh_source_url("https://skills.sh", "/owner/repo/leaf/")
+        assert clean == dirty == leading_slash == "https://skills.sh/skills/owner/repo/leaf"
+
+    @pytest.mark.anyio
     async def test_search_derives_source_url_when_missing(self) -> None:
         # Real skills.sh /api/search responses don't carry source_url.
         # We synthesise one from the canonical id so the discover-UI
@@ -349,6 +361,36 @@ body
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "files": [{"path": "SKILL.md", "contents": "x" * (_MAX_SKILL_MD_SIZE + 1)}],
+        }
+
+        with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.get = AsyncMock(return_value=mock_response)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            client = SkillsShClient()
+            with pytest.raises(SkillSourceError, match="exceeds size cap"):
+                await client.download_skill("owner/repo/leaf")
+
+    @pytest.mark.anyio
+    async def test_download_skill_oversized_multibyte_skill_md(self) -> None:
+        # 4-byte emoji × N: code-point count stays under the cap, but UTF-8
+        # byte length is 4× higher. Catches the regression where the size
+        # cap was measured in code points rather than bytes.
+        from turnstone.core.skill_sources import _MAX_SKILL_MD_SIZE
+
+        # Half the cap in code points → 2× the cap in encoded bytes.
+        emoji_count = (_MAX_SKILL_MD_SIZE // 2) + 1
+        payload = "🎉" * emoji_count
+        assert len(payload) <= _MAX_SKILL_MD_SIZE  # would pass code-point check
+        assert len(payload.encode("utf-8")) > _MAX_SKILL_MD_SIZE  # but exceeds byte cap
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "files": [{"path": "SKILL.md", "contents": payload}],
         }
 
         with patch("turnstone.core.skill_sources.httpx.AsyncClient") as mock_client_cls:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7332,7 +7332,22 @@ async def admin_skill_discover(request: Request) -> JSONResponse:
     try:
         listings = await client.search(query=q, limit=limit)
     except SkillSourceError as exc:
+        log.warning(
+            "skill.discover.source_error q=%s discovery_url=%s err=%s",
+            q,
+            discovery_url,
+            exc,
+            exc_info=True,
+        )
         return JSONResponse({"error": f"Discovery error: {exc}"}, status_code=502)
+    except Exception as exc:
+        log.exception(
+            "skill.discover.unexpected q=%s discovery_url=%s err=%s",
+            q,
+            discovery_url,
+            exc,
+        )
+        return JSONResponse({"error": f"Unexpected discovery error: {exc}"}, status_code=500)
 
     # Mark which skills are already installed (by source_url match)
     installed_map: dict[str, dict[str, str]] = {}
@@ -7395,31 +7410,62 @@ async def admin_skill_install(request: Request) -> JSONResponse:
     if source not in ("skills.sh", "github"):
         return JSONResponse({"error": "source must be 'skills.sh' or 'github'"}, status_code=400)
 
+    skill_id_param = str(body.get("skill_id", "")).strip()
+    url_param = str(body.get("url", "")).strip()
+    log.debug(
+        "skill.install.start source=%s skill_id=%s url=%s",
+        source,
+        skill_id_param or "-",
+        url_param or "-",
+    )
+
+    def _log_install_failure(level: int, event: str, exc: BaseException) -> None:
+        log.log(
+            level,
+            "%s source=%s skill_id=%s url=%s err=%s",
+            event,
+            source,
+            skill_id_param or "-",
+            url_param or "-",
+            exc,
+            exc_info=True,
+        )
+
     try:
         if source == "skills.sh":
-            skill_id_param = str(body.get("skill_id", "")).strip()
             if not skill_id_param:
                 return JSONResponse({"error": "skill_id is required"}, status_code=400)
 
             discovery_url = _get_discovery_url(request)
             client = SkillsShClient(base_url=discovery_url)
-            github_url = await client.resolve_github_url(skill_id_param)
-            packages = [await fetch_skill_from_github(github_url)]
+            packages = [await client.download_skill(skill_id_param)]
+            log.debug(
+                "skill.install.downloaded skill_id=%s name=%s resources=%d",
+                skill_id_param,
+                packages[0].parsed.name,
+                len(packages[0].resources),
+            )
         else:
-            url = str(body.get("url", "")).strip()
-            if not url:
+            if not url_param:
                 return JSONResponse({"error": "url is required"}, status_code=400)
             try:
-                packages = [await fetch_skill_from_github(url)]
+                packages = [await fetch_skill_from_github(url_param)]
             except SkillNotFoundError:
                 # No root SKILL.md — try scanning for a multi-skill repo
-                packages = await fetch_skills_from_github_repo(url)
+                log.debug("skill.install.repo_scan url=%s", url_param)
+                packages = await fetch_skills_from_github_repo(url_param)
     except SkillNotFoundError as exc:
+        _log_install_failure(logging.WARNING, "skill.install.not_found", exc)
         return JSONResponse({"error": str(exc)}, status_code=404)
     except SkillSourceError as exc:
+        _log_install_failure(logging.WARNING, "skill.install.source_error", exc)
         return JSONResponse({"error": str(exc)}, status_code=502)
     except ValueError as exc:
+        _log_install_failure(logging.WARNING, "skill.install.value_error", exc)
         return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception as exc:
+        _log_install_failure(logging.ERROR, "skill.install.unexpected", exc)
+        return JSONResponse({"error": f"Unexpected error fetching skill: {exc}"}, status_code=500)
 
     import json as _json
 
@@ -7432,11 +7478,20 @@ async def admin_skill_install(request: Request) -> JSONResponse:
 
         # Check for duplicate by source_url
         if pkg_source_url and storage.get_skill_by_source_url(pkg_source_url):
+            log.debug(
+                "skill.install.skip name=%s reason=already_installed source_url=%s",
+                package.parsed.name,
+                pkg_source_url,
+            )
             skipped.append({"name": package.parsed.name, "reason": "already installed"})
             continue
 
         # Check for duplicate by name
         if storage.get_prompt_template_by_name(package.parsed.name):
+            log.debug(
+                "skill.install.skip name=%s reason=name_exists",
+                package.parsed.name,
+            )
             skipped.append({"name": package.parsed.name, "reason": "name exists"})
             continue
 
@@ -7476,18 +7531,39 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 token_estimate=token_estimate,
                 allowed_tools=allowed_tools_str,
             )
-        except Exception:
+        except Exception as exc:
+            log.warning(
+                "skill.install.create_failed name=%s skill_id=%s err=%s",
+                parsed.name,
+                skill_id,
+                exc,
+                exc_info=True,
+            )
             skipped.append({"name": parsed.name, "reason": "conflict"})
             continue
 
-        # Store bundled resources
+        # Store bundled resources, tallying any failures so the caller can
+        # see that the skill row was committed but is missing some assets
+        # (the SKILL.md is still usable on its own — we don't roll back).
+        failed_resources: list[str] = []
         for res_path, res_content in package.resources.items():
-            storage.create_skill_resource(
-                resource_id=uuid.uuid4().hex,
-                skill_id=skill_id,
-                path=res_path,
-                content=res_content,
-            )
+            try:
+                storage.create_skill_resource(
+                    resource_id=uuid.uuid4().hex,
+                    skill_id=skill_id,
+                    path=res_path,
+                    content=res_content,
+                )
+            except Exception as exc:
+                failed_resources.append(res_path)
+                log.warning(
+                    "skill.install.resource_failed name=%s skill_id=%s path=%s err=%s",
+                    parsed.name,
+                    skill_id,
+                    res_path,
+                    exc,
+                    exc_info=True,
+                )
 
         record_audit(
             storage,
@@ -7495,16 +7571,38 @@ async def admin_skill_install(request: Request) -> JSONResponse:
             "skill.install",
             "skill",
             skill_id,
-            {"name": parsed.name, "source": source, "source_url": pkg_source_url},
+            {
+                "name": parsed.name,
+                "source": source,
+                "source_url": pkg_source_url,
+                "failed_resources": failed_resources,
+            },
             ip,
         )
 
         skill = storage.get_prompt_template(skill_id)
         if skill:
-            installed.append(_skill_to_response(skill, resource_count=len(package.resources)))
+            stored_resources = len(package.resources) - len(failed_resources)
+            entry = _skill_to_response(skill, resource_count=stored_resources)
+            if failed_resources:
+                entry["failed_resources"] = failed_resources
+            installed.append(entry)
+            log.info(
+                "skill.install.ok name=%s skill_id=%s resources=%d failed_resources=%d",
+                parsed.name,
+                skill_id,
+                stored_resources,
+                len(failed_resources),
+            )
 
     if not installed and skipped:
         # All skills were duplicates
+        log.debug(
+            "skill.install.done source=%s installed=0 skipped=%d total=%d",
+            source,
+            len(skipped),
+            len(packages),
+        )
         return JSONResponse(
             {
                 "error": "All skills already installed",
@@ -7515,6 +7613,13 @@ async def admin_skill_install(request: Request) -> JSONResponse:
             status_code=409,
         )
 
+    log.debug(
+        "skill.install.done source=%s installed=%d skipped=%d total=%d",
+        source,
+        len(installed),
+        len(skipped),
+        len(packages),
+    )
     # Consistent envelope for both single and batch installs
     return JSONResponse(
         {

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7393,6 +7393,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
         fetch_skill_from_github,
         fetch_skills_from_github_repo,
     )
+    from turnstone.core.storage._protocol import StorageConflictError
     from turnstone.core.web_helpers import read_json_or_400, require_storage_or_503
 
     storage, err = require_storage_or_503(request)
@@ -7531,15 +7532,28 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 token_estimate=token_estimate,
                 allowed_tools=allowed_tools_str,
             )
-        except Exception as exc:
+        except StorageConflictError as exc:
+            # Genuine uniqueness/constraint violation racing past the
+            # pre-checks above — operator can re-try.
             log.warning(
-                "skill.install.create_failed name=%s skill_id=%s err=%s",
+                "skill.install.create_conflict name=%s skill_id=%s err=%s",
                 parsed.name,
                 skill_id,
                 exc,
                 exc_info=True,
             )
             skipped.append({"name": parsed.name, "reason": "conflict"})
+            continue
+        except Exception as exc:
+            # Anything else — DB connection, disk full, permission — is
+            # operational and shouldn't be relabeled "conflict".
+            log.exception(
+                "skill.install.create_failed name=%s skill_id=%s err=%s",
+                parsed.name,
+                skill_id,
+                exc,
+            )
+            skipped.append({"name": parsed.name, "reason": "internal error"})
             continue
 
         # Store bundled resources, tallying any failures so the caller can

--- a/turnstone/core/skill_sources.py
+++ b/turnstone/core/skill_sources.py
@@ -11,7 +11,6 @@ import os
 import re
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import quote
 
 import httpx
 
@@ -34,6 +33,40 @@ _RESOURCE_DIRS = ("scripts", "references", "assets")
 _TEXT_EXTENSIONS = frozenset(
     {".md", ".txt", ".sh", ".py", ".js", ".ts", ".json", ".yaml", ".yml", ".toml", ".cfg", ".ini"}
 )
+# Per-segment charset for skills.sh ids — matches what GitHub permits in
+# owner/repo/path-segment names. Rejects whitespace, control chars, and any
+# URL-hostile content that would break the dedupe-by-source_url contract.
+_SKILLS_SH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _accept_resource(rel_path: str, byte_size: int) -> bool:
+    """Gate predicate shared by GitHub and skills.sh resource ingestion."""
+    first_seg = rel_path.split("/", 1)[0]
+    if first_seg not in _RESOURCE_DIRS:
+        return False
+    ext = os.path.splitext(rel_path)[1].lower()
+    if ext not in _TEXT_EXTENSIONS:
+        return False
+    return byte_size <= _MAX_RESOURCE_SIZE
+
+
+def _split_skills_sh_id(skill_id: str) -> tuple[str, str, str]:
+    """Split a skills.sh canonical id into (owner, repo, skill_name).
+
+    skills.sh ids are 3-segment paths like ``tavily-ai/skills/tavily-search``
+    that map directly to its REST routes (``/api/download/[owner]/[repo]/[skill]``).
+    """
+    parts = skill_id.strip().strip("/").split("/")
+    if len(parts) != 3 or not all(_SKILLS_SH_SEGMENT_RE.match(p) for p in parts):
+        raise SkillSourceError(
+            f"Invalid skills.sh skill id {skill_id!r}: expected 'owner/repo/skill-name'"
+        )
+    return parts[0], parts[1], parts[2]
+
+
+def _skills_sh_source_url(base_url: str, skill_id: str) -> str:
+    """Canonical, dedup-stable URL for a skills.sh skill."""
+    return f"{base_url.rstrip('/')}/skills/{skill_id}"
 
 
 @dataclass(frozen=True)
@@ -91,34 +124,109 @@ class SkillsShClient:
         data = resp.json()
         results: list[SkillListing] = []
         for item in data.get("skills", data.get("results", [])):
+            skill_id = str(item.get("id", item.get("name", "")))
+            # The /api/search response does not carry source_url. Derive a
+            # canonical, dedup-stable URL from the skill id so the discover
+            # UI's "already installed" check matches what download_skill
+            # persists.
+            raw_source_url = str(item.get("source_url", item.get("url", ""))).strip()
+            source_url = raw_source_url or (
+                _skills_sh_source_url(self._base_url, skill_id) if skill_id else ""
+            )
             results.append(
                 SkillListing(
-                    id=str(item.get("id", item.get("name", ""))),
+                    id=skill_id,
                     name=str(item.get("name", "")),
                     description=str(item.get("description", "")),
                     author=str(item.get("author", "")),
                     source="skills.sh",
-                    source_url=str(item.get("source_url", item.get("url", ""))),
+                    source_url=source_url,
                     install_count=int(item.get("install_count", item.get("installs", 0))),
                     tags=[str(t) for t in item.get("tags", []) if isinstance(t, str)],
                 )
             )
         return results
 
-    async def resolve_github_url(self, skill_id: str) -> str:
-        """Resolve a skills.sh skill ID to its GitHub URL."""
+    async def download_skill(self, skill_id: str) -> SkillPackage:
+        """Download a skill bundle from skills.sh and return a ready-to-install package.
+
+        Hits ``/api/download/{owner}/{repo}/{skill}`` (the unauthenticated
+        install endpoint) which returns ``{"files": [{"path", "contents"}, ...]}``
+        with the SKILL.md and any bundled resources inline. No GitHub round-trip.
+        """
+        owner, repo, name = _split_skills_sh_id(skill_id)
+
+        url = f"{self._base_url}/api/download/{owner}/{repo}/{name}"
         async with httpx.AsyncClient(follow_redirects=True, timeout=10.0) as client:
             try:
-                resp = await client.get(f"{self._base_url}/api/skills/{quote(skill_id, safe='')}")
-                resp.raise_for_status()
+                resp = await client.get(url)
             except httpx.HTTPError as exc:
-                raise SkillSourceError(f"Failed to resolve skill {skill_id}: {exc}") from exc
+                raise SkillSourceError(f"Failed to download skill {skill_id}: {exc}") from exc
 
-        data = resp.json()
-        url = str(data.get("source_url", data.get("github_url", data.get("url", ""))))
-        if not url:
-            raise SkillSourceError(f"No source URL for skill {skill_id}")
-        return url
+        if resp.status_code == 404:
+            raise SkillNotFoundError(f"skills.sh has no skill {skill_id}")
+        if resp.status_code >= 400:
+            raise SkillSourceError(
+                f"skills.sh download failed for {skill_id}: HTTP {resp.status_code}"
+            )
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise SkillSourceError(
+                f"skills.sh returned non-JSON for {skill_id}: {resp.text[:200]}"
+            ) from exc
+
+        files = payload.get("files")
+        if not isinstance(files, list) or not files:
+            raise SkillSourceError(f"skills.sh returned no files for {skill_id}")
+
+        skill_md_content = ""
+        resource_pairs: list[tuple[str, str]] = []
+        for entry in files:
+            if not isinstance(entry, dict):
+                continue
+            path = str(entry.get("path", "")).strip().lstrip("/")
+            contents = entry.get("contents")
+            if not path or not isinstance(contents, str):
+                continue
+            if path == "SKILL.md":
+                # `len(contents)` is a cheap upper bound on the encoded byte
+                # size (every char encodes to >=1 UTF-8 byte) — using it
+                # avoids errors='ignore' silently dropping invalid units and
+                # bypassing the cap.
+                if len(contents) > _MAX_SKILL_MD_SIZE:
+                    raise SkillSourceError(
+                        f"SKILL.md for {skill_id} exceeds size cap ({_MAX_SKILL_MD_SIZE} bytes)"
+                    )
+                skill_md_content = contents
+            else:
+                resource_pairs.append((path, contents))
+
+        if not skill_md_content:
+            raise SkillNotFoundError(f"skills.sh bundle for {skill_id} has no SKILL.md")
+
+        parsed = parse_skill_md(skill_md_content)
+
+        resources: dict[str, str] = {}
+        for path, contents in resource_pairs:
+            if len(resources) >= _MAX_RESOURCE_FILES:
+                break
+            if not _accept_resource(path, len(contents.encode("utf-8"))):
+                continue
+            resources[path] = contents
+
+        listing = SkillListing(
+            id=skill_id,
+            name=parsed.name or name,
+            description=parsed.description,
+            author=parsed.author,
+            source="skills.sh",
+            source_url=_skills_sh_source_url(self._base_url, skill_id),
+            install_count=0,
+            tags=list(parsed.tags),
+        )
+        return SkillPackage(listing=listing, parsed=parsed, resources=resources)
 
 
 def _parse_github_url(url: str) -> tuple[str, str, str, str, bool]:
@@ -152,14 +260,7 @@ def _find_resource_files(
             if not item_path.startswith(f"{skill_md_dir}/"):
                 continue
             rel_path = item_path[len(skill_md_dir) + 1 :]
-        first_seg = rel_path.split("/")[0] if "/" in rel_path else ""
-        if first_seg not in _RESOURCE_DIRS:
-            continue
-        ext = os.path.splitext(rel_path)[1].lower()
-        if ext not in _TEXT_EXTENSIONS:
-            continue
-        size = item.get("size", 0)
-        if size > _MAX_RESOURCE_SIZE:
+        if not _accept_resource(rel_path, item.get("size", 0)):
             continue
         resource_files.append({"path": rel_path, "full_path": item_path})
     return resource_files[:_MAX_RESOURCE_FILES]

--- a/turnstone/core/skill_sources.py
+++ b/turnstone/core/skill_sources.py
@@ -65,8 +65,15 @@ def _split_skills_sh_id(skill_id: str) -> tuple[str, str, str]:
 
 
 def _skills_sh_source_url(base_url: str, skill_id: str) -> str:
-    """Canonical, dedup-stable URL for a skills.sh skill."""
-    return f"{base_url.rstrip('/')}/skills/{skill_id}"
+    """Canonical, dedup-stable URL for a skills.sh skill.
+
+    Normalizes the skill_id (strips outer whitespace and slashes) so
+    `search()` and `download_skill()` agree on the persisted URL even
+    when upstream returns sloppy ids — the discover-UI's
+    "already installed" check matches against this exact string.
+    """
+    canonical = skill_id.strip().strip("/")
+    return f"{base_url.rstrip('/')}/skills/{canonical}"
 
 
 @dataclass(frozen=True)
@@ -191,11 +198,18 @@ class SkillsShClient:
             if not path or not isinstance(contents, str):
                 continue
             if path == "SKILL.md":
-                # `len(contents)` is a cheap upper bound on the encoded byte
-                # size (every char encodes to >=1 UTF-8 byte) — using it
-                # avoids errors='ignore' silently dropping invalid units and
-                # bypassing the cap.
-                if len(contents) > _MAX_SKILL_MD_SIZE:
+                # Measure UTF-8 bytes (not code points). `len(str)` is a
+                # *lower* bound on encoded size — multi-byte chars (emoji,
+                # CJK) inflate by up to 4×, so a code-point check would let
+                # an oversized SKILL.md slip past the cap. Strict encoding
+                # surfaces lone surrogates as a clear error.
+                try:
+                    skill_md_size = len(contents.encode("utf-8"))
+                except UnicodeEncodeError as exc:
+                    raise SkillSourceError(
+                        f"SKILL.md for {skill_id} contains invalid Unicode: {exc}"
+                    ) from exc
+                if skill_md_size > _MAX_SKILL_MD_SIZE:
                     raise SkillSourceError(
                         f"SKILL.md for {skill_id} exceeds size cap ({_MAX_SKILL_MD_SIZE} bytes)"
                     )
@@ -216,13 +230,16 @@ class SkillsShClient:
                 continue
             resources[path] = contents
 
+        # Reconstruct from validated parts so the listing carries the
+        # canonical id, never the raw caller input.
+        canonical_id = f"{owner}/{repo}/{name}"
         listing = SkillListing(
-            id=skill_id,
+            id=canonical_id,
             name=parsed.name or name,
             description=parsed.description,
             author=parsed.author,
             source="skills.sh",
-            source_url=_skills_sh_source_url(self._base_url, skill_id),
+            source_url=_skills_sh_source_url(self._base_url, canonical_id),
             install_count=0,
             tags=list(parsed.tags),
         )

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2397,49 +2397,58 @@ class PostgreSQLBackend:
         # Scan skill content for risk signals
         risk_level, scan_report, scan_version = _scan_skill_content(content, allowed_tools)
 
+        from turnstone.core.storage._protocol import StorageConflictError
+
         with self._conn() as conn:
-            conn.execute(
-                sa.insert(prompt_templates),
-                {
-                    "template_id": template_id,
-                    "name": name,
-                    "category": category,
-                    "content": content,
-                    "variables": variables,
-                    "is_default": 1 if is_default else 0,
-                    "org_id": org_id,
-                    "created_by": created_by,
-                    "origin": origin,
-                    "mcp_server": mcp_server,
-                    "readonly": 1 if readonly else 0,
-                    "description": description,
-                    "tags": tags,
-                    "source_url": source_url,
-                    "version": version,
-                    "author": author,
-                    "activation": activation,
-                    "token_estimate": token_estimate,
-                    "allowed_tools": allowed_tools,
-                    "license": skill_license,
-                    "compatibility": compatibility,
-                    "kind": kind,
-                    "risk_level": risk_level,
-                    "scan_report": scan_report,
-                    "scan_version": scan_version,
-                    "model": model,
-                    "auto_approve": 1 if auto_approve else 0,
-                    "temperature": temperature,
-                    "reasoning_effort": reasoning_effort,
-                    "max_tokens": max_tokens,
-                    "token_budget": token_budget,
-                    "agent_max_turns": agent_max_turns,
-                    "notify_on_complete": notify_on_complete,
-                    "enabled": 1 if enabled else 0,
-                    "priority": priority,
-                    "created": now,
-                    "updated": now,
-                },
-            )
+            try:
+                conn.execute(
+                    sa.insert(prompt_templates),
+                    {
+                        "template_id": template_id,
+                        "name": name,
+                        "category": category,
+                        "content": content,
+                        "variables": variables,
+                        "is_default": 1 if is_default else 0,
+                        "org_id": org_id,
+                        "created_by": created_by,
+                        "origin": origin,
+                        "mcp_server": mcp_server,
+                        "readonly": 1 if readonly else 0,
+                        "description": description,
+                        "tags": tags,
+                        "source_url": source_url,
+                        "version": version,
+                        "author": author,
+                        "activation": activation,
+                        "token_estimate": token_estimate,
+                        "allowed_tools": allowed_tools,
+                        "license": skill_license,
+                        "compatibility": compatibility,
+                        "kind": kind,
+                        "risk_level": risk_level,
+                        "scan_report": scan_report,
+                        "scan_version": scan_version,
+                        "model": model,
+                        "auto_approve": 1 if auto_approve else 0,
+                        "temperature": temperature,
+                        "reasoning_effort": reasoning_effort,
+                        "max_tokens": max_tokens,
+                        "token_budget": token_budget,
+                        "agent_max_turns": agent_max_turns,
+                        "notify_on_complete": notify_on_complete,
+                        "enabled": 1 if enabled else 0,
+                        "priority": priority,
+                        "created": now,
+                        "updated": now,
+                    },
+                )
+            except sa.exc.IntegrityError as exc:
+                conn.rollback()
+                msg = str(exc.orig) if exc.orig is not None else str(exc)
+                raise StorageConflictError(
+                    f"prompt_template conflict ({template_id}/{name}): {msg}"
+                ) from exc
             conn.commit()
 
     def get_prompt_template(self, template_id: str) -> dict[str, Any] | None:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2550,49 +2550,58 @@ class SQLiteBackend:
         # Scan skill content for risk signals
         risk_level, scan_report, scan_version = _scan_skill_content(content, allowed_tools)
 
+        from turnstone.core.storage._protocol import StorageConflictError
+
         with self._conn() as conn:
-            conn.execute(
-                sa.insert(prompt_templates),
-                {
-                    "template_id": template_id,
-                    "name": name,
-                    "category": category,
-                    "content": content,
-                    "variables": variables,
-                    "is_default": 1 if is_default else 0,
-                    "org_id": org_id,
-                    "created_by": created_by,
-                    "origin": origin,
-                    "mcp_server": mcp_server,
-                    "readonly": 1 if readonly else 0,
-                    "description": description,
-                    "tags": tags,
-                    "source_url": source_url,
-                    "version": version,
-                    "author": author,
-                    "activation": activation,
-                    "token_estimate": token_estimate,
-                    "allowed_tools": allowed_tools,
-                    "license": skill_license,
-                    "compatibility": compatibility,
-                    "kind": kind,
-                    "risk_level": risk_level,
-                    "scan_report": scan_report,
-                    "scan_version": scan_version,
-                    "model": model,
-                    "auto_approve": 1 if auto_approve else 0,
-                    "temperature": temperature,
-                    "reasoning_effort": reasoning_effort,
-                    "max_tokens": max_tokens,
-                    "token_budget": token_budget,
-                    "agent_max_turns": agent_max_turns,
-                    "notify_on_complete": notify_on_complete,
-                    "enabled": 1 if enabled else 0,
-                    "priority": priority,
-                    "created": now,
-                    "updated": now,
-                },
-            )
+            try:
+                conn.execute(
+                    sa.insert(prompt_templates),
+                    {
+                        "template_id": template_id,
+                        "name": name,
+                        "category": category,
+                        "content": content,
+                        "variables": variables,
+                        "is_default": 1 if is_default else 0,
+                        "org_id": org_id,
+                        "created_by": created_by,
+                        "origin": origin,
+                        "mcp_server": mcp_server,
+                        "readonly": 1 if readonly else 0,
+                        "description": description,
+                        "tags": tags,
+                        "source_url": source_url,
+                        "version": version,
+                        "author": author,
+                        "activation": activation,
+                        "token_estimate": token_estimate,
+                        "allowed_tools": allowed_tools,
+                        "license": skill_license,
+                        "compatibility": compatibility,
+                        "kind": kind,
+                        "risk_level": risk_level,
+                        "scan_report": scan_report,
+                        "scan_version": scan_version,
+                        "model": model,
+                        "auto_approve": 1 if auto_approve else 0,
+                        "temperature": temperature,
+                        "reasoning_effort": reasoning_effort,
+                        "max_tokens": max_tokens,
+                        "token_budget": token_budget,
+                        "agent_max_turns": agent_max_turns,
+                        "notify_on_complete": notify_on_complete,
+                        "enabled": 1 if enabled else 0,
+                        "priority": priority,
+                        "created": now,
+                        "updated": now,
+                    },
+                )
+            except sa.exc.IntegrityError as exc:
+                conn.rollback()
+                msg = str(exc.orig) if exc.orig is not None else str(exc)
+                raise StorageConflictError(
+                    f"prompt_template conflict ({template_id}/{name}): {msg}"
+                ) from exc
             conn.commit()
 
     def get_prompt_template(self, template_id: str) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary

The skills.sh install path was failing with 404s because their public API surface changed: `/api/skills/{id}` is gone, replaced by `/api/skill/[owner]/[repo]/[skill]` (auth-walled) and `/api/download/[owner]/[repo]/[skill]` (unauthenticated, returns the SKILL.md + bundled resources inline as JSON). The error wasn't visible in logs because `admin_skill_install` had a silent `except Exception:` around `create_prompt_template` that relabeled every storage failure as "conflict" with no log entry.

## What changed

- **API rewrite.** Replaced `SkillsShClient.resolve_github_url` with `download_skill` that hits `/api/download/{owner}/{repo}/{skill}` and returns a `SkillPackage` directly. No GitHub round-trip; no rate-limit surface.
- **Strict id validation.** `_split_skills_sh_id` now enforces a per-segment charset (`[A-Za-z0-9._-]+`) so URL-hostile content can't produce a malformed request or divergent persisted `source_url`.
- **Size-cap correctness.** SKILL.md size is now measured by `len(contents)` (cheap UTF-8 byte upper bound). The previous `errors="ignore"` encode silently dropped invalid units and made the cap bypassable.
- **De-duped resource gating.** Extracted `_accept_resource(rel_path, byte_size)` predicate; shared between `download_skill` and `_find_resource_files`.
- **Search dedup fix.** `search()` derives a deterministic `source_url` from the skill id when `/api/search` omits one (which it always does today), so the discover-UI "already installed" check matches what `download_skill` persists.
- **Logging.** Added structured logging across `admin_skill_install` and `admin_skill_discover`, including a shared `_log_install_failure` helper used by all four except branches (replaces four near-duplicate log calls with one drift). Per-resource failures now tally into `failed_resources` on the response and audit record — partial-resource installs no longer return success silently.

## Test plan

- [x] `pytest tests/test_skill_sources.py tests/test_skill_discovery_api.py tests/test_skills.py` — 158 passing
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on touched modules
- [x] End-to-end live install of `tavily-ai/skills/tavily-search` against production skills.sh succeeds and persists the skill row + bundled resources
- [ ] Manual smoke: install a skill from the admin Skills tab, confirm it appears in the list with `readonly=true` and the source url shows `https://skills.sh/skills/{id}`
- [ ] Manual smoke: search the discover UI for a skill that's already installed and confirm the "Installed" badge shows