### PR TITLE
Add logout endpoint, dashboard navigation, and isolate server/console cookies

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from turnstone.core.auth import (
+    AUTH_COOKIE,
+    AUTH_COOKIE_CONSOLE,
+    AUTH_COOKIE_SERVER,
     WRITE_PATHS,
     _extract_bearer,
     _extract_cookie,
@@ -364,6 +367,11 @@ class TestMakeSetCookie:
         val = make_set_cookie("tok_abc", secure=True)
         assert "; Secure" in val
 
+    def test_custom_cookie_name(self):
+        val = make_set_cookie("tok_abc", cookie_name="my_cookie")
+        assert "my_cookie=tok_abc" in val
+        assert "HttpOnly" in val
+
 
 class TestMakeClearCookie:
     def test_max_age_zero(self):
@@ -374,6 +382,11 @@ class TestMakeClearCookie:
 
     def test_httponly(self):
         assert "HttpOnly" in make_clear_cookie()
+
+    def test_custom_cookie_name(self):
+        val = make_clear_cookie("my_cookie")
+        assert "my_cookie=;" in val
+        assert "Max-Age=0" in val
 
 
 # ---------------------------------------------------------------------------
@@ -650,6 +663,18 @@ class TestCheckRequestWithCookie:
             None,
         )
         assert allowed is True
+
+    def test_custom_cookie_name(self, read_jwt):
+        allowed, status, _, _r = check_request(
+            "GET",
+            "/api/workstreams",
+            None,
+            cookie_header=f"custom_auth={read_jwt}",
+            jwt_secret=self._SECRET,
+            auth_cookie="custom_auth",
+        )
+        assert allowed is True
+        assert status == 200
 
 
 # ---------------------------------------------------------------------------
@@ -1019,8 +1044,6 @@ class TestServerLogin:
 
     def test_refresh_returns_new_jwt_and_cookie(self):
         """POST /api/auth/refresh re-mints the cookie with a fresh exp."""
-        from turnstone.core.auth import AUTH_COOKIE
-
         # Storage needs get_user_permissions for the refresh re-resolve path.
         # Mock is shared across tests in the class — re-arm here in case a
         # prior test left it default.
@@ -1047,7 +1070,7 @@ class TestServerLogin:
         # and refresh produce identical iat/exp claims and therefore an
         # identical token, which is fine: the cookie still gets re-set.
         cookie_hdr = refresh.headers.get("set-cookie", "")
-        assert AUTH_COOKIE in cookie_hdr
+        assert AUTH_COOKIE_SERVER in cookie_hdr
         assert "HttpOnly" in cookie_hdr
 
         # The refreshed cookie must keep working.
@@ -1158,6 +1181,19 @@ class TestServerLogin:
                 "approve",
             }
 
+    def test_logout_page_redirects_and_clears_cookie(self):
+        """GET /logout clears the server auth cookie and redirects to /."""
+        self.test_client.post(
+            "/v1/api/auth/login",
+            json={"username": "testuser", "password": "testpass"},
+        )
+        resp = self.test_client.get("/logout")
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/?logout=1"
+        cookie = resp.headers.get("set-cookie", "")
+        assert AUTH_COOKIE_SERVER in cookie
+        assert "Max-Age=0" in cookie
+
 
 class TestConsoleLogin:
     """Test login/logout cookie flow on turnstone-console."""
@@ -1222,7 +1258,7 @@ class TestConsoleLogin:
             json={"username": "testuser", "password": "testpass"},
         )
         assert resp.status_code == 200
-        assert "turnstone_auth" in resp.headers.get("set-cookie", "")
+        assert AUTH_COOKIE_CONSOLE in resp.headers.get("set-cookie", "")
 
     def test_cookie_auth_on_api(self):
         self.test_client.post(
@@ -1240,6 +1276,19 @@ class TestConsoleLogin:
         self.test_client.post("/v1/api/auth/logout")
         resp = self.test_client.get("/v1/api/cluster/overview")
         assert resp.status_code == 401
+
+    def test_logout_page_redirects_and_clears_cookie(self):
+        """GET /logout clears the console auth cookie and redirects to /."""
+        self.test_client.post(
+            "/v1/api/auth/login",
+            json={"username": "testuser", "password": "testpass"},
+        )
+        resp = self.test_client.get("/logout")
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/?logout=1"
+        cookie = resp.headers.get("set-cookie", "")
+        assert AUTH_COOKIE_CONSOLE in cookie
+        assert "Max-Age=0" in cookie
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from turnstone.core.auth import (
-    AUTH_COOKIE,
     AUTH_COOKIE_CONSOLE,
     AUTH_COOKIE_SERVER,
     WRITE_PATHS,
@@ -70,6 +69,9 @@ class TestIsPublicPath:
 
     def test_v1_api_logout_public(self):
         assert is_public_path("/v1/api/auth/logout") is True
+
+    def test_logout_page_public(self):
+        assert is_public_path("/logout") is True
 
     def test_v1_api_workstreams_not_public(self):
         assert is_public_path("/v1/api/workstreams") is False
@@ -1187,7 +1189,7 @@ class TestServerLogin:
             "/v1/api/auth/login",
             json={"username": "testuser", "password": "testpass"},
         )
-        resp = self.test_client.get("/logout")
+        resp = self.test_client.get("/logout", follow_redirects=False)
         assert resp.status_code == 302
         assert resp.headers.get("location") == "/?logout=1"
         cookie = resp.headers.get("set-cookie", "")
@@ -1283,7 +1285,7 @@ class TestConsoleLogin:
             "/v1/api/auth/login",
             json={"username": "testuser", "password": "testpass"},
         )
-        resp = self.test_client.get("/logout")
+        resp = self.test_client.get("/logout", follow_redirects=False)
         assert resp.status_code == 302
         assert resp.headers.get("location") == "/?logout=1"
         cookie = resp.headers.get("set-cookie", "")

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1581,6 +1581,7 @@ async def auth_logout(request: Request) -> Response:
 async def logout_page(request: Request) -> Response:
     """GET /logout — clear auth cookie and redirect to home."""
     from starlette.responses import RedirectResponse
+
     from turnstone.core.auth import make_clear_cookie
 
     response = RedirectResponse("/?logout=1", status_code=302)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -46,6 +46,7 @@ from turnstone.console.metrics import ConsoleMetrics
 from turnstone.console.router import ConsoleRouter
 from turnstone.core.audit import record_audit
 from turnstone.core.auth import (
+    AUTH_COOKIE_CONSOLE,
     JWT_AUD_CONSOLE,
     JWT_AUD_SERVER,
     AuthMiddleware,
@@ -1567,14 +1568,24 @@ async def auth_login(request: Request) -> Response:
     """Authenticate via username:password or legacy token, return JWT."""
     from turnstone.core.auth import handle_auth_login
 
-    return await handle_auth_login(request, JWT_AUD_CONSOLE)
+    return await handle_auth_login(request, JWT_AUD_CONSOLE, cookie_name=AUTH_COOKIE_CONSOLE)
 
 
 async def auth_logout(request: Request) -> Response:
     """POST /v1/api/auth/logout — clear auth cookie."""
     from turnstone.core.auth import handle_auth_logout
 
-    return await handle_auth_logout(request)
+    return await handle_auth_logout(request, cookie_name=AUTH_COOKIE_CONSOLE)
+
+
+async def logout_page(request: Request) -> Response:
+    """GET /logout — clear auth cookie and redirect to home."""
+    from starlette.responses import RedirectResponse
+    from turnstone.core.auth import make_clear_cookie
+
+    response = RedirectResponse("/?logout=1", status_code=302)
+    response.headers["Set-Cookie"] = make_clear_cookie(AUTH_COOKIE_CONSOLE)
+    return response
 
 
 async def auth_status(request: Request) -> Response:
@@ -1588,14 +1599,14 @@ async def auth_setup(request: Request) -> Response:
     """POST /v1/api/auth/setup — create first admin user (public, one-time only)."""
     from turnstone.core.auth import handle_auth_setup
 
-    return await handle_auth_setup(request, JWT_AUD_CONSOLE)
+    return await handle_auth_setup(request, JWT_AUD_CONSOLE, cookie_name=AUTH_COOKIE_CONSOLE)
 
 
 async def auth_whoami(request: Request) -> Response:
     """GET /v1/api/auth/whoami — return authenticated user info."""
     from turnstone.core.auth import handle_auth_whoami
 
-    return await handle_auth_whoami(request)
+    return await handle_auth_whoami(request, cookie_name=AUTH_COOKIE_CONSOLE)
 
 
 async def auth_refresh(request: Request) -> Response:
@@ -1606,7 +1617,7 @@ async def auth_refresh(request: Request) -> Response:
     """
     from turnstone.core.auth import handle_auth_refresh
 
-    return await handle_auth_refresh(request, JWT_AUD_CONSOLE)
+    return await handle_auth_refresh(request, JWT_AUD_CONSOLE, cookie_name=AUTH_COOKIE_CONSOLE)
 
 
 async def oidc_authorize(request: Request) -> Response:
@@ -1620,7 +1631,7 @@ async def oidc_callback(request: Request) -> Response:
     """GET /v1/api/auth/oidc/callback — OIDC callback, exchange code for JWT."""
     from turnstone.core.auth import handle_oidc_callback
 
-    return await handle_oidc_callback(request, JWT_AUD_CONSOLE)
+    return await handle_oidc_callback(request, JWT_AUD_CONSOLE, cookie_name=AUTH_COOKIE_CONSOLE)
 
 
 async def mcp_oauth_authorize(request: Request) -> Response:
@@ -11788,6 +11799,7 @@ def create_app(
     app = Starlette(
         routes=[
             Route("/", index),
+            Route("/logout", logout_page),
             Mount(
                 "/v1",
                 routes=[
@@ -12319,7 +12331,12 @@ def _build_console_middleware(cors_origins: list[str] | None = None) -> list[Mid
 
         stack.append(cors_middleware(cors_origins))
     stack.append(
-        Middleware(AuthMiddleware, jwt_audience=JWT_AUD_CONSOLE, jwt_version=jwt_version_slot())
+        Middleware(
+            AuthMiddleware,
+            jwt_audience=JWT_AUD_CONSOLE,
+            jwt_version=jwt_version_slot(),
+            auth_cookie=AUTH_COOKIE_CONSOLE,
+        )
     )
     return stack
 

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -55,6 +55,8 @@ log = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 AUTH_COOKIE = "turnstone_auth"
+AUTH_COOKIE_SERVER = "turnstone_auth_srv"
+AUTH_COOKIE_CONSOLE = "turnstone_auth_con"
 TOKEN_PREFIX = "ts_"
 TOKEN_BYTES = 32  # 64 hex chars after prefix
 
@@ -667,11 +669,12 @@ def check_request(
     jwt_audience: str = "",
     jwt_version: str = "",
     storage: Any = None,
+    auth_cookie: str = AUTH_COOKIE,
 ) -> tuple[bool, int, str, AuthResult | None]:
     """Validate a request.
 
     Checks ``Authorization: Bearer <token>`` first, then falls back to the
-    ``turnstone_auth`` cookie.  Token types are auto-detected:
+    auth cookie.  Token types are auto-detected:
 
     - Contains ``.`` → JWT (validated with *jwt_secret*)
     - Starts with ``ts_`` → API token (looked up in *storage* by hash)
@@ -684,7 +687,7 @@ def check_request(
     # Extract token from header or cookie
     raw_token = _extract_bearer(auth_header)
     if raw_token is None:
-        raw_token = _extract_cookie(cookie_header, AUTH_COOKIE)
+        raw_token = _extract_cookie(cookie_header, auth_cookie)
 
     if not raw_token:
         return False, 401, "Unauthorized: missing or invalid token", None
@@ -798,22 +801,24 @@ def _extract_cookie(cookie_header: str | None, name: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def make_set_cookie(token: str, max_age: int = 86400, *, secure: bool | None = None) -> str:
+def make_set_cookie(
+    token: str, max_age: int = 86400, *, secure: bool | None = None, cookie_name: str = AUTH_COOKIE
+) -> str:
     """Return a ``Set-Cookie`` header value that stores the auth token.
 
     When *secure* is ``None`` (default) the ``Secure`` flag is set
     unconditionally.  Pass ``secure=False`` only for plaintext development.
     *max_age* defaults to 24 hours to match the default JWT expiry.
     """
-    val = f"{AUTH_COOKIE}={token}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age}"
+    val = f"{cookie_name}={token}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age}"
     if secure is None or secure:
         val += "; Secure"
     return val
 
 
-def make_clear_cookie() -> str:
+def make_clear_cookie(cookie_name: str = AUTH_COOKIE) -> str:
     """Return a ``Set-Cookie`` header value that expires the auth cookie."""
-    return f"{AUTH_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+    return f"{cookie_name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
 
 
 def is_secure_request(headers: dict[str, str], scheme: str = "") -> bool:
@@ -960,10 +965,17 @@ class AuthMiddleware:
     server (``JWT_AUD_SERVER``) and the console (``JWT_AUD_CONSOLE``).
     """
 
-    def __init__(self, app: ASGIApp, jwt_audience: str = "", jwt_version: str = "") -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        jwt_audience: str = "",
+        jwt_version: str = "",
+        auth_cookie: str = AUTH_COOKIE,
+    ) -> None:
         self.app = app
         self._jwt_audience = jwt_audience
         self._jwt_version = jwt_version
+        self._auth_cookie = auth_cookie
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -994,6 +1006,7 @@ class AuthMiddleware:
             jwt_audience=self._jwt_audience,
             jwt_version=self._jwt_version,
             storage=storage,
+            auth_cookie=self._auth_cookie,
         )
         if not allowed:
             body: dict[str, Any] = {"error": msg}
@@ -1020,7 +1033,9 @@ class AuthMiddleware:
 # ---------------------------------------------------------------------------
 
 
-async def handle_auth_login(request: Request, audience: str) -> Response:
+async def handle_auth_login(
+    request: Request, audience: str, cookie_name: str = AUTH_COOKIE
+) -> Response:
     """Shared ``POST /api/auth/login`` handler.
 
     Authenticates via username:password or legacy token exchange, returning
@@ -1123,16 +1138,16 @@ async def handle_auth_login(request: Request, audience: str) -> Response:
     response = JSONResponse(resp_body)
     cookie_value = jwt_token if jwt_token else body.get("token", "")
     if cookie_value:
-        response.headers["Set-Cookie"] = make_set_cookie(cookie_value, secure=secure)
+        response.headers["Set-Cookie"] = make_set_cookie(cookie_value, secure=secure, cookie_name=cookie_name)
     return response
 
 
-async def handle_auth_logout(request: Request) -> Response:
+async def handle_auth_logout(request: Request, cookie_name: str = AUTH_COOKIE) -> Response:
     """Shared ``POST /api/auth/logout`` handler — clear auth cookie."""
     from starlette.responses import JSONResponse
 
     response = JSONResponse({"status": "ok"})
-    response.headers["Set-Cookie"] = make_clear_cookie()
+    response.headers["Set-Cookie"] = make_clear_cookie(cookie_name)
     return response
 
 
@@ -1166,7 +1181,9 @@ async def handle_auth_status(request: Request) -> Response:
     return JSONResponse(resp)
 
 
-async def handle_auth_setup(request: Request, audience: str) -> Response:
+async def handle_auth_setup(
+    request: Request, audience: str, cookie_name: str = AUTH_COOKIE
+) -> Response:
     """Shared ``POST /api/auth/setup`` handler — create first admin user.
 
     Only works when zero users exist.  Returns JWT on success.
@@ -1267,11 +1284,13 @@ async def handle_auth_setup(request: Request, audience: str) -> Response:
     secure = is_secure_request(dict(request.headers), request.url.scheme)
     response = JSONResponse(resp_body)
     if jwt_token:
-        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure)
+        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure, cookie_name=cookie_name)
     return response
 
 
-async def handle_auth_whoami(request: Request) -> Response:
+async def handle_auth_whoami(
+    request: Request, cookie_name: str = AUTH_COOKIE
+) -> Response:
     """Shared ``GET /api/auth/whoami`` handler — return authenticated user info.
 
     Includes the JWT ``exp`` claim (epoch seconds) so the frontend can
@@ -1292,7 +1311,7 @@ async def handle_auth_whoami(request: Request) -> Response:
         resp["permissions"] = ",".join(sorted(auth_result.permissions))
     # Surface the cookie/JWT expiry so the client can schedule refresh.
     # Decoded without re-validating (auth middleware already validated).
-    cookie_token = request.cookies.get(AUTH_COOKIE, "")
+    cookie_token = request.cookies.get(cookie_name, "")
     if cookie_token:
         try:
             import jwt as _jwt
@@ -1307,7 +1326,9 @@ async def handle_auth_whoami(request: Request) -> Response:
     return JSONResponse(resp)
 
 
-async def handle_auth_refresh(request: Request, audience: str) -> Response:
+async def handle_auth_refresh(
+    request: Request, audience: str, cookie_name: str = AUTH_COOKIE
+) -> Response:
     """Shared ``POST /api/auth/refresh`` handler — re-mint the auth cookie.
 
     Requires a currently-valid auth cookie (auth middleware enforces).
@@ -1403,7 +1424,7 @@ async def handle_auth_refresh(request: Request, audience: str) -> Response:
 
     response = JSONResponse(resp_body)
     secure = is_secure_request(dict(request.headers), request.url.scheme)
-    response.headers["Set-Cookie"] = make_set_cookie(new_token, secure=secure)
+    response.headers["Set-Cookie"] = make_set_cookie(new_token, secure=secure, cookie_name=cookie_name)
     return response
 
 
@@ -1509,7 +1530,9 @@ async def _refetch_jwks_locked(
         return fresh
 
 
-async def handle_oidc_callback(request: Request, audience: str) -> Response:
+async def handle_oidc_callback(
+    request: Request, audience: str, cookie_name: str = AUTH_COOKIE
+) -> Response:
     """Shared ``GET /api/auth/oidc/callback`` handler — exchange code, provision user, issue JWT."""
     from starlette.responses import JSONResponse, RedirectResponse
 
@@ -1660,5 +1683,5 @@ async def handle_oidc_callback(request: Request, audience: str) -> Response:
     response = RedirectResponse("/?oidc_success=1", status_code=302)
     if jwt_token:
         secure = is_secure_request(dict(request.headers), request.url.scheme)
-        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure)
+        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure, cookie_name=cookie_name)
     return response

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -180,6 +180,7 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         "/metrics",
         "/openapi.json",
         "/docs",
+        "/logout",
         "/api/auth/login",
         "/api/auth/logout",
         "/api/auth/status",
@@ -1138,7 +1139,9 @@ async def handle_auth_login(
     response = JSONResponse(resp_body)
     cookie_value = jwt_token if jwt_token else body.get("token", "")
     if cookie_value:
-        response.headers["Set-Cookie"] = make_set_cookie(cookie_value, secure=secure, cookie_name=cookie_name)
+        response.headers["Set-Cookie"] = make_set_cookie(
+            cookie_value, secure=secure, cookie_name=cookie_name
+        )
     return response
 
 
@@ -1284,13 +1287,13 @@ async def handle_auth_setup(
     secure = is_secure_request(dict(request.headers), request.url.scheme)
     response = JSONResponse(resp_body)
     if jwt_token:
-        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure, cookie_name=cookie_name)
+        response.headers["Set-Cookie"] = make_set_cookie(
+            jwt_token, secure=secure, cookie_name=cookie_name
+        )
     return response
 
 
-async def handle_auth_whoami(
-    request: Request, cookie_name: str = AUTH_COOKIE
-) -> Response:
+async def handle_auth_whoami(request: Request, cookie_name: str = AUTH_COOKIE) -> Response:
     """Shared ``GET /api/auth/whoami`` handler — return authenticated user info.
 
     Includes the JWT ``exp`` claim (epoch seconds) so the frontend can
@@ -1424,7 +1427,9 @@ async def handle_auth_refresh(
 
     response = JSONResponse(resp_body)
     secure = is_secure_request(dict(request.headers), request.url.scheme)
-    response.headers["Set-Cookie"] = make_set_cookie(new_token, secure=secure, cookie_name=cookie_name)
+    response.headers["Set-Cookie"] = make_set_cookie(
+        new_token, secure=secure, cookie_name=cookie_name
+    )
     return response
 
 
@@ -1683,5 +1688,7 @@ async def handle_oidc_callback(
     response = RedirectResponse("/?oidc_success=1", status_code=302)
     if jwt_token:
         secure = is_secure_request(dict(request.headers), request.url.scheme)
-        response.headers["Set-Cookie"] = make_set_cookie(jwt_token, secure=secure, cookie_name=cookie_name)
+        response.headers["Set-Cookie"] = make_set_cookie(
+            jwt_token, secure=secure, cookie_name=cookie_name
+        )
     return response

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2716,6 +2716,7 @@ async def auth_logout(request: Request) -> Response:
 async def logout_page(request: Request) -> Response:
     """GET /logout — clear auth cookie and redirect to home."""
     from starlette.responses import RedirectResponse
+
     from turnstone.core.auth import make_clear_cookie
 
     response = RedirectResponse("/?logout=1", status_code=302)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -46,6 +46,7 @@ from turnstone.api.docs import make_docs_handler, make_openapi_handler
 from turnstone.api.server_spec import build_server_spec
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
 from turnstone.core.auth import (
+    AUTH_COOKIE_SERVER,
     DENY_EMPTY_SUB,
     JWT_AUD_SERVER,
     AuthMiddleware,
@@ -2702,14 +2703,24 @@ async def auth_login(request: Request) -> Response:
     """POST /v1/api/auth/login — authenticate and return JWT."""
     from turnstone.core.auth import handle_auth_login
 
-    return await handle_auth_login(request, JWT_AUD_SERVER)
+    return await handle_auth_login(request, JWT_AUD_SERVER, cookie_name=AUTH_COOKIE_SERVER)
 
 
 async def auth_logout(request: Request) -> Response:
     """POST /v1/api/auth/logout — clear auth cookie."""
     from turnstone.core.auth import handle_auth_logout
 
-    return await handle_auth_logout(request)
+    return await handle_auth_logout(request, cookie_name=AUTH_COOKIE_SERVER)
+
+
+async def logout_page(request: Request) -> Response:
+    """GET /logout — clear auth cookie and redirect to home."""
+    from starlette.responses import RedirectResponse
+    from turnstone.core.auth import make_clear_cookie
+
+    response = RedirectResponse("/?logout=1", status_code=302)
+    response.headers["Set-Cookie"] = make_clear_cookie(AUTH_COOKIE_SERVER)
+    return response
 
 
 async def auth_status(request: Request) -> Response:
@@ -2723,14 +2734,14 @@ async def auth_setup(request: Request) -> Response:
     """POST /v1/api/auth/setup — create first admin user (public, one-time only)."""
     from turnstone.core.auth import handle_auth_setup
 
-    return await handle_auth_setup(request, JWT_AUD_SERVER)
+    return await handle_auth_setup(request, JWT_AUD_SERVER, cookie_name=AUTH_COOKIE_SERVER)
 
 
 async def auth_whoami(request: Request) -> Response:
     """GET /v1/api/auth/whoami — return authenticated user info."""
     from turnstone.core.auth import handle_auth_whoami
 
-    return await handle_auth_whoami(request)
+    return await handle_auth_whoami(request, cookie_name=AUTH_COOKIE_SERVER)
 
 
 async def auth_refresh(request: Request) -> Response:
@@ -2741,7 +2752,7 @@ async def auth_refresh(request: Request) -> Response:
     """
     from turnstone.core.auth import handle_auth_refresh
 
-    return await handle_auth_refresh(request, JWT_AUD_SERVER)
+    return await handle_auth_refresh(request, JWT_AUD_SERVER, cookie_name=AUTH_COOKIE_SERVER)
 
 
 async def oidc_authorize(request: Request) -> Response:
@@ -2755,7 +2766,7 @@ async def oidc_callback(request: Request) -> Response:
     """GET /v1/api/auth/oidc/callback — OIDC callback, exchange code for JWT."""
     from turnstone.core.auth import handle_oidc_callback
 
-    return await handle_oidc_callback(request, JWT_AUD_SERVER)
+    return await handle_oidc_callback(request, JWT_AUD_SERVER, cookie_name=AUTH_COOKIE_SERVER)
 
 
 async def mcp_oauth_authorize(request: Request) -> Response:
@@ -3805,7 +3816,12 @@ def _build_middleware(cors_origins: list[str] | None = None) -> list[Middleware]
         stack.append(cors_middleware(cors_origins))
     stack.extend(
         [
-            Middleware(AuthMiddleware, jwt_audience=JWT_AUD_SERVER, jwt_version=jwt_version_slot()),
+            Middleware(
+                AuthMiddleware,
+                jwt_audience=JWT_AUD_SERVER,
+                jwt_version=jwt_version_slot(),
+                auth_cookie=AUTH_COOKIE_SERVER,
+            ),
             Middleware(RateLimitMiddleware),
         ]
     )
@@ -3998,6 +4014,7 @@ def create_app(
     app = Starlette(
         routes=[
             Route("/", index),
+            Route("/logout", logout_page),
             Mount(
                 "/v1",
                 routes=[

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -762,12 +762,10 @@ function logout() {
       /* AbortController not available; the _loggedOut flag handles it */
     }
   });
-  fetch("/v1/api/auth/logout", { method: "POST" }).then(function () {
-    sessionStorage.removeItem("turnstone_permissions");
-    if (_authChannel) _authChannel.postMessage("logout");
-    if (typeof window.onLogout === "function") window.onLogout();
-    showLogin();
-  });
+  sessionStorage.removeItem("turnstone_permissions");
+  if (_authChannel) _authChannel.postMessage("logout");
+  if (typeof window.onLogout === "function") window.onLogout();
+  window.location.href = "/logout";
 }
 
 // Schedule on initial load if already authenticated.  The whoami

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -90,6 +90,17 @@ Pane.prototype._createDOM = function () {
   var actions = document.createElement("div");
   actions.className = "pane-actions";
 
+  var dashBtn = document.createElement("button");
+  dashBtn.className = "pane-action-btn";
+  dashBtn.title = "Back to dashboard";
+  dashBtn.setAttribute("aria-label", "Back to dashboard");
+  dashBtn.textContent = "\u2190";
+  dashBtn.onclick = function (e) {
+    e.stopPropagation();
+    showDashboard();
+  };
+  actions.appendChild(dashBtn);
+
   var splitRightBtn = document.createElement("button");
   splitRightBtn.className = "pane-action-btn";
   splitRightBtn.title = "Split right";

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -91,6 +91,7 @@ Pane.prototype._createDOM = function () {
   actions.className = "pane-actions";
 
   var dashBtn = document.createElement("button");
+  dashBtn.type = "button";
   dashBtn.className = "pane-action-btn";
   dashBtn.title = "Back to dashboard";
   dashBtn.setAttribute("aria-label", "Back to dashboard");

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -51,6 +51,17 @@
         >
           &#9881;
         </button>
+        <button
+          id="logout-btn"
+          class="header-btn btn"
+          type="button"
+          onclick="logout()"
+          style="display: none"
+          aria-label="Sign out"
+          title="Sign out"
+        >
+          Sign out
+        </button>
       </span>
     </div>
 


### PR DESCRIPTION
Disclaimer: Whole PR was generated by Kimi 2.6, I really appreciate your work but found few issues:
- Electron app for the server doesn't even start up on my Windows 11 machine
- No log out button
- No option to go back from the workstream (even if there's no need to go back yet, I want to be able to)
- Cookies between two separate parts of the server were mixed

At first I gave my agents task to cure the electron app, it worked but I found out these other issues and switched to this PR.
I didn't test these changes myself because I have to build it somehow and I've already hit my daily limits after two massive tasks.
I really hope it will help you to improve the project.

## Summary

This PR adds missing session controls and navigation elements to the web UI, and isolates authentication cookies between the server (port 8080) and console (port 8090). This fixes the cross-port session collision in Electron/Chromium where logging into one app silently overwrites the session of the other because both used the same `turnstone_auth` cookie name on the same host.

## Changes

### 1. Logout endpoint + UI button
- Added `GET /logout` to both **server** and **console** apps:
  - Clears the audience-scoped auth cookie (`Set-Cookie` with `Max-Age=0`).
  - Returns `302 Redirect` to `/?logout=1` (works as a regular link/form submit, avoiding `window.open` issues in Electron).
- Added a **"Sign out"** button (`#logout-btn`) to the Server UI header (`ui/static/index.html`).  
  The Console UI already had this button; no changes were needed there.

### 2. Dashboard navigation inside workstream
- Added a **← "Back to dashboard"** button to the header of every Pane in the Server UI (`ui/static/app.js`).  
  Clicking it calls `showDashboard()` — a regular in-page navigation, not a popup.

### 3. Isolate server vs console sessions
- Introduced audience-scoped cookie names:
  - Server → `turnstone_auth_srv`
  - Console → `turnstone_auth_con`
- Updated `AuthMiddleware`, `check_request`, `make_set_cookie`, `make_clear_cookie`, and all shared auth handlers (`login`, `logout`, `setup`, `whoami`, `refresh`, `oidc_callback`) to accept a configurable `auth_cookie` / `cookie_name` parameter.
- Both `server.py` and `console/server.py` now pass their respective cookie constants into the middleware and route handlers.

## Testing

- Added and updated tests in `tests/test_auth.py`:
  - `test_custom_cookie_name` for `make_set_cookie`, `make_clear_cookie`, and `check_request`
  - `test_logout_page_redirects_and_clears_cookie` covering `GET /logout` for both server and console apps
  - Updated existing `test_refresh_returns_new_jwt_and_cookie` and `test_login_password_ok` to assert the new scoped cookie names (`AUTH_COOKIE_SERVER` / `AUTH_COOKIE_CONSOLE`)
- Ran `python -m py_compile` on all modified Python files — clean.

## Checklist

- [x] PR is focused on one logical change (session controls & navigation)
- [x] Tests added for new functionality
- [x] Follows existing code style and patterns
- [ ] Documentation updated — *no user-facing docs exist for these UI surfaces; the change is self-describing in the UI itself*

