### PR TITLE
feat(skills): unlock action lets operators customize installed skills

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -705,6 +705,7 @@ def api_client(api_storage):
         admin_create_skill,
         admin_delete_skill,
         admin_list_skills,
+        admin_unlock_skill,
         admin_update_skill,
     )
 
@@ -716,6 +717,11 @@ def api_client(api_storage):
                 Route("/api/admin/skills", admin_create_skill, methods=["POST"]),
                 Route("/api/admin/skills/{skill_id}", admin_update_skill, methods=["PUT"]),
                 Route("/api/admin/skills/{skill_id}", admin_delete_skill, methods=["DELETE"]),
+                Route(
+                    "/api/admin/skills/{skill_id}/unlock",
+                    admin_unlock_skill,
+                    methods=["POST"],
+                ),
             ],
         ),
     ]
@@ -1057,6 +1063,95 @@ class TestSkillAPI:
         )
         resp = api_client.delete("/v1/api/admin/skills/s1")
         assert resp.status_code == 200
+
+    def test_unlock_skill_flips_readonly(self, api_client, api_storage):
+        """POST /unlock on a readonly skill flips readonly to False."""
+        _create_template(
+            api_storage,
+            "s1",
+            "installed",
+            "upstream content",
+            origin="source",
+            source_url="https://skills.sh/skills/owner/repo/leaf",
+            readonly=True,
+        )
+
+        resp = api_client.post("/v1/api/admin/skills/s1/unlock")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["readonly"] is False
+        # Origin preserved so the UI can still surface "Customized from upstream".
+        assert data["origin"] == "source"
+        assert data["source_url"] == "https://skills.sh/skills/owner/repo/leaf"
+
+    def test_unlock_skill_persists(self, api_client, api_storage):
+        """Unlock side-effects survive a fresh load from storage."""
+        _create_template(api_storage, "s1", "installed", "x", origin="source", readonly=True)
+
+        api_client.post("/v1/api/admin/skills/s1/unlock")
+
+        row = api_storage.get_prompt_template("s1")
+        assert row is not None
+        assert bool(row["readonly"]) is False
+
+    def test_unlock_skill_snapshots_pre_unlock_state(self, api_client, api_storage):
+        """Pre-unlock skill state is snapshotted to skill_versions for rollback."""
+        _create_template(
+            api_storage, "s1", "installed", "upstream content", origin="source", readonly=True
+        )
+        assert api_storage.list_skill_versions("s1") == []
+
+        api_client.post("/v1/api/admin/skills/s1/unlock")
+
+        versions = api_storage.list_skill_versions("s1")
+        assert len(versions) == 1
+        assert versions[0]["version"] == 1
+
+    def test_unlock_skill_already_unlocked(self, api_client, api_storage):
+        """Unlocking an already-unlocked skill returns 400."""
+        _create_template(api_storage, "s1", "local", "content", origin="manual", readonly=False)
+
+        resp = api_client.post("/v1/api/admin/skills/s1/unlock")
+
+        assert resp.status_code == 400
+        assert "already unlocked" in resp.json()["error"].lower()
+
+    def test_unlock_skill_not_found(self, api_client):
+        """Unlocking a nonexistent skill returns 404."""
+        resp = api_client.post("/v1/api/admin/skills/missing/unlock")
+        assert resp.status_code == 404
+
+    def test_unlock_then_edit_spec_fields_succeeds(self, api_client, api_storage):
+        """After unlock, PUT can edit spec fields the readonly gate previously rejected."""
+        _create_template(
+            api_storage,
+            "s1",
+            "installed",
+            "upstream content",
+            description="upstream description",
+            origin="source",
+            readonly=True,
+        )
+
+        api_client.post("/v1/api/admin/skills/s1/unlock")
+
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={
+                "name": "customized",
+                "content": "tuned content",
+                "description": "tuned description",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "customized"
+        assert data["content"] == "tuned content"
+        assert data["description"] == "tuned description"
+        # Origin still records that this came from upstream.
+        assert data["origin"] == "source"
 
     def test_skill_field_on_workstream_create(self, api_storage):
         """Console workstream creation accepts 'skill' field in request body."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1108,6 +1108,28 @@ class TestSkillAPI:
         assert len(versions) == 1
         assert versions[0]["version"] == 1
 
+    def test_unlock_skill_versions_after_existing_history(self, api_client, api_storage):
+        """Unlock picks the next version number based on max(version), not list length.
+
+        Defends against regressions where len(list)+1 racing with a concurrent
+        update could produce a (skill_id, version) collision. Seeds an
+        out-of-order version (3) and verifies unlock chooses 4, not 2.
+        """
+        import json as _json
+
+        _create_template(
+            api_storage, "s1", "installed", "v0 content", origin="source", readonly=True
+        )
+        api_storage.create_skill_version(
+            skill_id="s1", version=3, snapshot=_json.dumps({"v": 3}), changed_by="prior"
+        )
+
+        resp = api_client.post("/v1/api/admin/skills/s1/unlock")
+        assert resp.status_code == 200
+
+        versions = sorted(api_storage.list_skill_versions("s1"), key=lambda v: v["version"])
+        assert [v["version"] for v in versions] == [3, 4]
+
     def test_unlock_skill_already_unlocked(self, api_client, api_storage):
         """Unlocking an already-unlocked skill returns 400."""
         _create_template(api_storage, "s1", "local", "content", origin="manual", readonly=False)

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -703,6 +703,13 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "Re-scan a skill for security signals",
         tags=["Admin"],
     ),
+    EndpointSpec(
+        "/v1/api/admin/skills/{skill_id}/unlock",
+        "POST",
+        "Unlock a readonly (installed) skill so spec fields and resources can be edited",
+        error_codes=[400, 404],
+        tags=["Admin"],
+    ),
     # --- Governance: Skill Resources ---
     EndpointSpec(
         "/v1/api/admin/skills/{skill_id}/resources",

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7052,16 +7052,12 @@ async def admin_unlock_skill(request: Request) -> JSONResponse:
 
     audit_uid, ip = _audit_context(request)
 
-    existing_versions = storage.list_skill_versions(skill_id)
-    version_int = len(existing_versions) + 1
-    storage.create_skill_version(
-        skill_id=skill_id,
-        version=version_int,
-        snapshot=_json.dumps(existing, default=str),
-        changed_by=audit_uid,
-    )
-
-    storage.set_skill_readonly(skill_id, False)
+    snapshot = _json.dumps(existing, default=str)
+    version_int = storage.unlock_skill(skill_id, snapshot, audit_uid)
+    if version_int is None:
+        # Row vanished between the existence check and the atomic unlock —
+        # treat as 404 rather than 500.
+        return JSONResponse({"error": "Skill not found"}, status_code=404)
 
     record_audit(
         storage,
@@ -7070,14 +7066,17 @@ async def admin_unlock_skill(request: Request) -> JSONResponse:
         "skill",
         skill_id,
         {
-            "name": existing.get("name", ""),
-            "source_url": existing.get("source_url", ""),
-            "origin": existing.get("origin", ""),
+            "name": existing.get("name") or "",
+            "source_url": existing.get("source_url") or "",
+            "origin": existing.get("origin") or "",
+            "snapshot_version": version_int,
         },
         ip,
     )
 
     updated = storage.get_prompt_template(skill_id)
+    if updated is None:
+        return JSONResponse({"error": "Skill not found"}, status_code=404)
     rc_map = storage.count_skill_resources_bulk([skill_id])
     return JSONResponse(_skill_to_response(updated, resource_count=rc_map.get(skill_id, 0)))
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -7021,6 +7021,67 @@ async def admin_rescan_skill(request: Request) -> JSONResponse:
     )
 
 
+async def admin_unlock_skill(request: Request) -> JSONResponse:
+    """POST /v1/api/admin/skills/{skill_id}/unlock — detach an installed skill from upstream.
+
+    Flips ``readonly`` False so spec fields and resources become editable. The
+    pre-unlock state is snapshotted into ``skill_versions`` so an operator can
+    diff against — or restore — what we got from the upstream source. ``origin``
+    stays ``"source"`` so the UI can still surface "modified from upstream"
+    against unlocked installs.
+    """
+    import json as _json
+
+    from turnstone.core.audit import record_audit
+    from turnstone.core.auth import require_permission
+    from turnstone.core.web_helpers import require_storage_or_503
+
+    storage, err = require_storage_or_503(request)
+    if err:
+        return err
+    err = require_permission(request, "admin.skills")
+    if err:
+        return err
+
+    skill_id = request.path_params["skill_id"]
+    existing = storage.get_prompt_template(skill_id)
+    if existing is None:
+        return JSONResponse({"error": "Skill not found"}, status_code=404)
+    if not existing.get("readonly"):
+        return JSONResponse({"error": "Skill is already unlocked"}, status_code=400)
+
+    audit_uid, ip = _audit_context(request)
+
+    existing_versions = storage.list_skill_versions(skill_id)
+    version_int = len(existing_versions) + 1
+    storage.create_skill_version(
+        skill_id=skill_id,
+        version=version_int,
+        snapshot=_json.dumps(existing, default=str),
+        changed_by=audit_uid,
+    )
+
+    storage.set_skill_readonly(skill_id, False)
+
+    record_audit(
+        storage,
+        audit_uid,
+        "skill.unlock",
+        "skill",
+        skill_id,
+        {
+            "name": existing.get("name", ""),
+            "source_url": existing.get("source_url", ""),
+            "origin": existing.get("origin", ""),
+        },
+        ip,
+    )
+
+    updated = storage.get_prompt_template(skill_id)
+    rc_map = storage.count_skill_resources_bulk([skill_id])
+    return JSONResponse(_skill_to_response(updated, resource_count=rc_map.get(skill_id, 0)))
+
+
 # ---------------------------------------------------------------------------
 # Admin: Skill Resources
 # ---------------------------------------------------------------------------
@@ -12314,6 +12375,11 @@ def create_app(
                     Route(
                         "/api/admin/skills/{skill_id}/rescan",
                         admin_rescan_skill,
+                        methods=["POST"],
+                    ),
+                    Route(
+                        "/api/admin/skills/{skill_id}/unlock",
+                        admin_unlock_skill,
                         methods=["POST"],
                     ),
                     # Node metadata

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -664,7 +664,7 @@ function submitEditPolicy() {
 // ---------------------------------------------------------------------------
 
 function loadGovSkills() {
-  authFetch("/v1/api/admin/skills")
+  return authFetch("/v1/api/admin/skills")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed");
       return r.json();
@@ -1248,7 +1248,14 @@ function submitCreateTemplate() {
 }
 
 function showEditTemplateModal(tmplId) {
-  _etmTriggerEl = document.activeElement;
+  var ov = document.getElementById("edit-template-overlay");
+  // When called against an already-open modal (e.g. mutate-in-place after
+  // unlock), preserve the original trigger so focus restores to the row
+  // launcher on close, and don't reinstall the focus trap.
+  var alreadyOpen = ov && ov.style.display === "flex";
+  if (!alreadyOpen) {
+    _etmTriggerEl = document.activeElement;
+  }
   var tmpl = null;
   for (var i = 0; i < _govSkills.length; i++) {
     if (_govSkills[i].template_id === tmplId) {
@@ -1257,7 +1264,6 @@ function showEditTemplateModal(tmplId) {
     }
   }
   if (!tmpl) return;
-  var ov = document.getElementById("edit-template-overlay");
   ov.style.display = "flex";
   document.getElementById("etm-id").value = tmplId;
   document.getElementById("etm-name").value = tmpl.name;
@@ -1431,7 +1437,7 @@ function showEditTemplateModal(tmplId) {
       originBadge.textContent = "Installed skill";
       originBadge.style.display = "inline-flex";
     } else if (isUnlockedInstall && tmpl.source_url) {
-      originBadge.textContent = "Customized from  " + tmpl.source_url;
+      originBadge.textContent = "Customized from \u00a0" + tmpl.source_url;
       originBadge.style.display = "inline-flex";
     } else if (isUnlockedInstall) {
       originBadge.textContent = "Customized from upstream";
@@ -1451,7 +1457,9 @@ function showEditTemplateModal(tmplId) {
     submitBtn.style.display = "";
     submitBtn.textContent = isReadonly ? "Save Config" : "Save";
   }
-  // Spec/content fields: locked for installed skills (preserve source fidelity)
+  // Spec/content fields: locked for installed skills (preserve source fidelity).
+  // Point screen readers at the origin badge so the "why is this disabled?"
+  // affordance sighted users see is also announced.
   [
     "etm-name",
     "etm-category",
@@ -1466,7 +1474,13 @@ function showEditTemplateModal(tmplId) {
     "etm-default",
   ].forEach(function (id) {
     var el = document.getElementById(id);
-    if (el) el.disabled = isReadonly;
+    if (!el) return;
+    el.disabled = isReadonly;
+    if (isReadonly) {
+      el.setAttribute("aria-describedby", "etm-origin-badge");
+    } else {
+      el.removeAttribute("aria-describedby");
+    }
   });
   // Runtime config fields: always editable (local settings, not part of SKILL.md spec)
   [
@@ -1499,12 +1513,18 @@ function showEditTemplateModal(tmplId) {
   if (resSection) {
     _loadSkillResources(tmplId, isReadonly);
   }
-  _etmTrapHandler = _installTrap("edit-template-overlay", "edit-template-box");
-  // Focus management
-  if (isReadonly) {
-    if (cancelBtn) cancelBtn.focus();
-  } else {
-    document.getElementById("etm-name").focus();
+  if (!alreadyOpen) {
+    _etmTrapHandler = _installTrap(
+      "edit-template-overlay",
+      "edit-template-box",
+    );
+    // Focus management — only on the initial open. Re-renders preserve
+    // wherever focus was so a screen reader doesn't get a transition.
+    if (isReadonly) {
+      if (cancelBtn) cancelBtn.focus();
+    } else {
+      document.getElementById("etm-name").focus();
+    }
   }
 }
 
@@ -1523,15 +1543,25 @@ function unlockSkill() {
   var skillId = btn.dataset.skillId;
   var skillName = btn.dataset.skillName || "this skill";
   if (!skillId) return;
-  var ok = window.confirm(
-    "Customize " +
-      skillName +
-      "?\n\nThis detaches the skill from its upstream source so you can edit content, description, and resources locally. The pre-customization state is saved to the skill's version history — you can review it from the History tab.\n\nUpstream updates will not flow into this skill after customization.",
+  showConfirmModal(
+    "Customize " + skillName + "?",
+    "This detaches the skill from its upstream source so you can edit " +
+      "content, description, and resources locally. The current version is " +
+      "saved to History — you can revert from there. Future updates from " +
+      "the upstream source will not be applied.",
+    "Customize",
+    function () {
+      _performUnlockSkill(skillId);
+    },
   );
-  if (!ok) return;
-  btn.disabled = true;
-  var prevText = btn.textContent;
-  btn.textContent = "Customizing…";
+}
+
+function _performUnlockSkill(skillId) {
+  var btn = document.getElementById("etm-unlock");
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = "Customizing…";
+  }
   authFetch("/v1/api/admin/skills/" + skillId + "/unlock", {
     method: "POST",
   })
@@ -1544,17 +1574,21 @@ function unlockSkill() {
       return r.json();
     })
     .then(function () {
-      showToast("Skill unlocked");
-      hideEditTemplateModal();
-      loadGovSkills();
-      showEditTemplateModal(skillId);
+      showToast("Skill unlocked — fields are now editable");
+      // Refresh the cached list, then re-render the open modal in place from
+      // the fresh row. No close/reopen → no flicker, no focus bounce.
+      return loadGovSkills().then(function () {
+        showEditTemplateModal(skillId);
+      });
     })
     .catch(function (e) {
       showToast(e.message || "Unlock failed");
     })
     .finally(function () {
-      btn.disabled = false;
-      btn.textContent = prevText;
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = "Customize…";
+      }
     });
 }
 

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1446,16 +1446,23 @@ function showEditTemplateModal(tmplId) {
       originBadge.style.display = "none";
     }
   }
-  var unlockBtn = document.getElementById("etm-unlock");
-  if (unlockBtn) {
-    unlockBtn.style.display = isReadonly ? "" : "none";
-    unlockBtn.dataset.skillId = tmplId;
-    unlockBtn.dataset.skillName = tmpl.name || "";
+  var lockBtn = document.getElementById("etm-lock-btn");
+  if (lockBtn) {
+    // Inline-flex (not "") so display: none doesn't bleed into a
+    // browser-default block reflow on re-show.
+    lockBtn.style.display = isReadonly ? "inline-flex" : "none";
+    lockBtn.dataset.skillId = tmplId;
+    lockBtn.dataset.skillName = tmpl.name || "";
   }
   var submitBtn = document.getElementById("etm-submit");
   if (submitBtn) {
     submitBtn.style.display = "";
     submitBtn.textContent = isReadonly ? "Save Config" : "Save";
+    // Always reset to enabled — submitEditTemplate disables this on click
+    // and re-enables in .finally, but a stale disabled=true survives a
+    // mutate-in-place re-render (e.g. after unlock) and would leave the
+    // button non-functional otherwise.
+    submitBtn.disabled = false;
   }
   // Spec/content fields: locked for installed skills (preserve source fidelity).
   // Point screen readers at the origin badge so the "why is this disabled?"
@@ -1538,7 +1545,7 @@ function hideEditTemplateModal() {
 }
 
 function unlockSkill() {
-  var btn = document.getElementById("etm-unlock");
+  var btn = document.getElementById("etm-lock-btn");
   if (!btn) return;
   var skillId = btn.dataset.skillId;
   var skillName = btn.dataset.skillName || "this skill";
@@ -1557,11 +1564,8 @@ function unlockSkill() {
 }
 
 function _performUnlockSkill(skillId) {
-  var btn = document.getElementById("etm-unlock");
-  if (btn) {
-    btn.disabled = true;
-    btn.textContent = "Customizing…";
-  }
+  var btn = document.getElementById("etm-lock-btn");
+  if (btn) btn.disabled = true;
   authFetch("/v1/api/admin/skills/" + skillId + "/unlock", {
     method: "POST",
   })
@@ -1585,10 +1589,9 @@ function _performUnlockSkill(skillId) {
       showToast(e.message || "Unlock failed");
     })
     .finally(function () {
-      if (btn) {
-        btn.disabled = false;
-        btn.textContent = "Customize…";
-      }
+      // Re-enable in case the re-render didn't happen (error path); the
+      // success path hides the button anyway via showEditTemplateModal.
+      if (btn) btn.disabled = false;
     });
 }
 

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1414,6 +1414,10 @@ function showEditTemplateModal(tmplId) {
 
   // --- Readonly mode for imported skills ---
   var isReadonly = tmpl.readonly || false;
+  // An unlocked install retains origin="source" — combined with !readonly it
+  // means the operator detached the skill from upstream and may have edits.
+  var isUnlockedInstall =
+    !isReadonly && tmpl.origin && tmpl.origin === "source";
   var editTitle = document.getElementById("edit-template-title");
   if (editTitle)
     editTitle.textContent = isReadonly ? "View Skill" : "Edit Skill";
@@ -1426,9 +1430,21 @@ function showEditTemplateModal(tmplId) {
     } else if (isReadonly && tmpl.origin && tmpl.origin !== "manual") {
       originBadge.textContent = "Installed skill";
       originBadge.style.display = "inline-flex";
+    } else if (isUnlockedInstall && tmpl.source_url) {
+      originBadge.textContent = "Customized from  " + tmpl.source_url;
+      originBadge.style.display = "inline-flex";
+    } else if (isUnlockedInstall) {
+      originBadge.textContent = "Customized from upstream";
+      originBadge.style.display = "inline-flex";
     } else {
       originBadge.style.display = "none";
     }
+  }
+  var unlockBtn = document.getElementById("etm-unlock");
+  if (unlockBtn) {
+    unlockBtn.style.display = isReadonly ? "" : "none";
+    unlockBtn.dataset.skillId = tmplId;
+    unlockBtn.dataset.skillName = tmpl.name || "";
   }
   var submitBtn = document.getElementById("etm-submit");
   if (submitBtn) {
@@ -1499,6 +1515,47 @@ function hideEditTemplateModal() {
     _etmTriggerEl.focus();
   }
   _etmTriggerEl = null;
+}
+
+function unlockSkill() {
+  var btn = document.getElementById("etm-unlock");
+  if (!btn) return;
+  var skillId = btn.dataset.skillId;
+  var skillName = btn.dataset.skillName || "this skill";
+  if (!skillId) return;
+  var ok = window.confirm(
+    "Customize " +
+      skillName +
+      "?\n\nThis detaches the skill from its upstream source so you can edit content, description, and resources locally. The pre-customization state is saved to the skill's version history — you can review it from the History tab.\n\nUpstream updates will not flow into this skill after customization.",
+  );
+  if (!ok) return;
+  btn.disabled = true;
+  var prevText = btn.textContent;
+  btn.textContent = "Customizing…";
+  authFetch("/v1/api/admin/skills/" + skillId + "/unlock", {
+    method: "POST",
+  })
+    .then(function (r) {
+      if (!r.ok) {
+        return r.json().then(function (data) {
+          throw new Error((data && data.error) || "Unlock failed");
+        });
+      }
+      return r.json();
+    })
+    .then(function () {
+      showToast("Skill unlocked");
+      hideEditTemplateModal();
+      loadGovSkills();
+      showEditTemplateModal(skillId);
+    })
+    .catch(function (e) {
+      showToast(e.message || "Unlock failed");
+    })
+    .finally(function () {
+      btn.disabled = false;
+      btn.textContent = prevText;
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1527,8 +1527,15 @@ function showEditTemplateModal(tmplId) {
     );
     // Focus management — only on the initial open. Re-renders preserve
     // wherever focus was so a screen reader doesn't get a transition.
+    // For readonly skills, prefer the lock button so keyboard users land
+    // on the unlock affordance instead of having to Tab past every
+    // disabled spec field to reach it. Cancel is still one Shift-Tab away.
     if (isReadonly) {
-      if (cancelBtn) cancelBtn.focus();
+      if (lockBtn && lockBtn.style.display !== "none") {
+        lockBtn.focus();
+      } else if (cancelBtn) {
+        cancelBtn.focus();
+      }
     } else {
       document.getElementById("etm-name").focus();
     }

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3307,7 +3307,7 @@
           aria-label="Customize skill (detach from upstream and unlock editing)"
           title="Customize — detach from upstream and unlock editing"
         >
-          <span aria-hidden="true">🔒</span>
+          <span aria-hidden="true">🔒︎</span>
         </button>
         <div
           id="etm-origin-badge"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3298,6 +3298,17 @@
         class="admin-modal admin-modal-wide admin-modal-skill"
       >
         <h2 id="edit-template-title">Edit Skill</h2>
+        <button
+          id="etm-lock-btn"
+          class="skill-lock-btn"
+          type="button"
+          style="display: none"
+          onclick="unlockSkill()"
+          aria-label="Customize skill (detach from upstream and unlock editing)"
+          title="Customize — detach from upstream and unlock editing"
+        >
+          <span aria-hidden="true">🔒</span>
+        </button>
         <div
           id="etm-origin-badge"
           class="skill-origin-badge"
@@ -3579,15 +3590,6 @@
           <button class="modal-cancel" onclick="hideEditTemplateModal()">
             Cancel
           </button>
-          <button
-            id="etm-unlock"
-            class="modal-secondary"
-            style="display: none"
-            onclick="unlockSkill()"
-          >
-            Customize…
-          </button>
-          <span class="modal-buttons-spacer" aria-hidden="true"></span>
           <button
             id="etm-submit"
             class="modal-submit"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3587,6 +3587,7 @@
           >
             Customize…
           </button>
+          <span class="modal-buttons-spacer" aria-hidden="true"></span>
           <button
             id="etm-submit"
             class="modal-submit"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3580,6 +3580,14 @@
             Cancel
           </button>
           <button
+            id="etm-unlock"
+            class="modal-secondary"
+            style="display: none"
+            onclick="unlockSkill()"
+          >
+            Customize…
+          </button>
+          <button
             id="etm-submit"
             class="modal-submit"
             onclick="submitEditTemplate()"

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -1855,6 +1855,11 @@
 .admin-modal-skill {
   padding: 28px 28px 24px;
 }
+/* Reserve space for the absolute-positioned lock button (top-right) so a
+   long title can never collide with it. */
+.admin-modal-skill > h2 {
+  padding-right: 44px;
+}
 
 .skill-spec-body {
   display: grid;
@@ -2085,36 +2090,46 @@ textarea.skill-content-area {
   cursor: not-allowed;
   filter: none;
 }
-.modal-secondary {
-  /* Sized to content so the primary action (Save) keeps a stable footprint
-     whether or not Customize is rendered. The spacer below pushes Save right. */
-  padding: 9px 14px;
+/* Lock-icon affordance in the top-right of an installed (readonly) skill's
+   edit modal — clicking detaches the skill from upstream so spec fields
+   become editable. Reserved for the modal it lives in; not a generic
+   button class. */
+.skill-lock-btn {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
   background: transparent;
   color: var(--fg);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
-  font: inherit;
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 14px;
+  /* Render the lock glyph as text where supported (keeps the monochrome
+     instrument-panel aesthetic instead of a coloured emoji). Browsers
+     that don't support font-variant-emoji fall back gracefully. */
+  font-variant-emoji: text;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
+  z-index: 2;
 }
-.modal-secondary:hover {
+.skill-lock-btn:hover {
   background: var(--bg-highlight);
+  border-color: var(--accent);
+  color: var(--accent);
 }
-.modal-secondary:focus-visible {
+.skill-lock-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.modal-secondary:disabled {
+.skill-lock-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
-}
-.modal-buttons-spacer {
-  flex: 1;
-  min-width: 0;
 }
 
 #create-user-overlay,
@@ -2154,6 +2169,14 @@ textarea.skill-content-area {
   align-items: center;
   justify-content: center;
   z-index: 600;
+}
+/* Confirm dialogs are launched FROM other overlays (e.g. unlock-skill from
+   the edit-template modal). They share z-index 600, so DOM order picks the
+   winner — and confirm-overlay is earlier in the DOM, so it would render
+   underneath. Bump it above the per-feature overlays but keep it below
+   toasts (z-index 700). */
+#confirm-overlay {
+  z-index: 650;
 }
 
 /* Token display (show-once) */
@@ -4008,7 +4031,7 @@ textarea.skill-content-area {
   .admin-action-btn,
   .modal-cancel,
   .modal-submit,
-  .modal-secondary {
+  .skill-lock-btn {
     transition: none;
   }
   .admin-modal input,

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -2074,6 +2074,9 @@ textarea.skill-content-area {
   filter: brightness(1.1);
 }
 .modal-submit:focus-visible {
+  /* fg-bright (not accent) — modal-submit has an accent background, so
+     accent-on-accent would be invisible. Cancel/secondary use --accent
+     because their backgrounds are transparent / highlight. */
   outline: 2px solid var(--fg-bright);
   outline-offset: 2px;
 }
@@ -2083,8 +2086,9 @@ textarea.skill-content-area {
   filter: none;
 }
 .modal-secondary {
-  flex: 1;
-  padding: 9px;
+  /* Sized to content so the primary action (Save) keeps a stable footprint
+     whether or not Customize is rendered. The spacer below pushes Save right. */
+  padding: 9px 14px;
   background: transparent;
   color: var(--fg);
   border: 1px solid var(--border-strong);
@@ -2107,6 +2111,10 @@ textarea.skill-content-area {
   opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
+}
+.modal-buttons-spacer {
+  flex: 1;
+  min-width: 0;
 }
 
 #create-user-overlay,

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -2028,6 +2028,16 @@ textarea.skill-content-area {
   .skill-config-grid {
     grid-template-columns: 1fr 1fr;
   }
+  /* Touch target: 44×44 minimum on mobile (WCAG 2.5.5 / Apple HIG). */
+  .skill-lock-btn {
+    width: 44px;
+    height: 44px;
+    top: 8px;
+    right: 8px;
+  }
+  .admin-modal-skill > h2 {
+    padding-right: 56px;
+  }
 }
 
 .modal-buttons {
@@ -2096,7 +2106,9 @@ textarea.skill-content-area {
    button class. */
 .skill-lock-btn {
   position: absolute;
-  top: 14px;
+  /* top: 18px (not 14px) so the button drops below the modal's accent-line
+     decoration's visual zone instead of competing with it horizontally. */
+  top: 18px;
   right: 14px;
   width: 32px;
   height: 32px;

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -2082,6 +2082,32 @@ textarea.skill-content-area {
   cursor: not-allowed;
   filter: none;
 }
+.modal-secondary {
+  flex: 1;
+  padding: 9px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.modal-secondary:hover {
+  background: var(--bg-highlight);
+}
+.modal-secondary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.modal-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 
 #create-user-overlay,
 #create-token-overlay,
@@ -3973,7 +3999,8 @@ textarea.skill-content-area {
   }
   .admin-action-btn,
   .modal-cancel,
-  .modal-submit {
+  .modal-submit,
+  .modal-secondary {
     transition: none;
   }
   .admin-modal input,

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2564,6 +2564,17 @@ class PostgreSQLBackend:
             conn.commit()
             return result.rowcount > 0
 
+    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(prompt_templates)
+                .where(prompt_templates.c.template_id == template_id)
+                .values(readonly=bool(readonly), updated=now)
+            )
+            conn.commit()
+            return result.rowcount > 0
+
     def delete_prompt_template(self, template_id: str) -> bool:
         with self._conn() as conn:
             result = conn.execute(

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2564,16 +2564,39 @@ class PostgreSQLBackend:
             conn.commit()
             return result.rowcount > 0
 
-    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
+    def unlock_skill(self, template_id: str, snapshot: str, changed_by: str) -> int | None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
-            result = conn.execute(
+            row = conn.execute(
+                sa.select(prompt_templates.c.template_id).where(
+                    prompt_templates.c.template_id == template_id
+                )
+            ).first()
+            if row is None:
+                return None
+            current_max = conn.execute(
+                sa.select(sa.func.coalesce(sa.func.max(skill_versions.c.version), 0)).where(
+                    skill_versions.c.skill_id == template_id
+                )
+            ).scalar()
+            next_version = int(current_max or 0) + 1
+            conn.execute(
+                sa.insert(skill_versions),
+                {
+                    "skill_id": template_id,
+                    "version": next_version,
+                    "snapshot": snapshot,
+                    "changed_by": changed_by,
+                    "created": now,
+                },
+            )
+            conn.execute(
                 sa.update(prompt_templates)
                 .where(prompt_templates.c.template_id == template_id)
-                .values(readonly=bool(readonly), updated=now)
+                .values(readonly=False, updated=now)
             )
             conn.commit()
-            return result.rowcount > 0
+            return next_version
 
     def delete_prompt_template(self, template_id: str) -> bool:
         with self._conn() as conn:

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2593,7 +2593,9 @@ class PostgreSQLBackend:
             conn.execute(
                 sa.update(prompt_templates)
                 .where(prompt_templates.c.template_id == template_id)
-                .values(readonly=False, updated=now)
+                # readonly is an Integer column (see _schema.py); match the
+                # 0/1 idiom create_prompt_template uses for the same flag.
+                .values(readonly=0, updated=now)
             )
             conn.commit()
             return next_version

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1254,6 +1254,16 @@ class StorageBackend(Protocol):
         """Update specified fields on a prompt template. Returns True if found."""
         ...
 
+    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
+        """Toggle the readonly flag on a skill. Returns True if the row exists.
+
+        Dedicated writer because ``readonly`` is intentionally absent from
+        :data:`SKILL_MUTABLE` — flipping provenance state is a deliberate
+        admin action (skill.unlock) that should not piggyback on the generic
+        update path.
+        """
+        ...
+
     def delete_prompt_template(self, template_id: str) -> bool:
         """Delete a prompt template. Returns True if found."""
         ...

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1254,13 +1254,19 @@ class StorageBackend(Protocol):
         """Update specified fields on a prompt template. Returns True if found."""
         ...
 
-    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
-        """Toggle the readonly flag on a skill. Returns True if the row exists.
+    def unlock_skill(self, template_id: str, snapshot: str, changed_by: str) -> int | None:
+        """Atomically snapshot a readonly skill and flip ``readonly=False``.
 
-        Dedicated writer because ``readonly`` is intentionally absent from
-        :data:`SKILL_MUTABLE` — flipping provenance state is a deliberate
-        admin action (skill.unlock) that should not piggyback on the generic
-        update path.
+        Writes ``snapshot`` into ``skill_versions`` with the next sequential
+        version number, then sets ``readonly=False`` on the template row, all
+        in a single transaction so concurrent updates can't produce
+        ``(skill_id, version)`` collisions or a snapshot whose state is out of
+        sync with the row at the moment readonly is flipped.
+
+        Returns the assigned version number, or ``None`` if the template row
+        does not exist. ``readonly`` is intentionally absent from
+        :data:`SKILL_MUTABLE` — this dedicated writer is the only path for
+        flipping it (matching the ``set_mcp_oauth_client_secret_ct`` pattern).
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2717,6 +2717,17 @@ class SQLiteBackend:
             conn.commit()
             return result.rowcount > 0
 
+    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(prompt_templates)
+                .where(prompt_templates.c.template_id == template_id)
+                .values(readonly=int(bool(readonly)), updated=now)
+            )
+            conn.commit()
+            return result.rowcount > 0
+
     def delete_prompt_template(self, template_id: str) -> bool:
         with self._conn() as conn:
             result = conn.execute(

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2717,16 +2717,39 @@ class SQLiteBackend:
             conn.commit()
             return result.rowcount > 0
 
-    def set_skill_readonly(self, template_id: str, readonly: bool) -> bool:
+    def unlock_skill(self, template_id: str, snapshot: str, changed_by: str) -> int | None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
-            result = conn.execute(
+            row = conn.execute(
+                sa.select(prompt_templates.c.template_id).where(
+                    prompt_templates.c.template_id == template_id
+                )
+            ).first()
+            if row is None:
+                return None
+            current_max = conn.execute(
+                sa.select(sa.func.coalesce(sa.func.max(skill_versions.c.version), 0)).where(
+                    skill_versions.c.skill_id == template_id
+                )
+            ).scalar()
+            next_version = int(current_max or 0) + 1
+            conn.execute(
+                sa.insert(skill_versions),
+                {
+                    "skill_id": template_id,
+                    "version": next_version,
+                    "snapshot": snapshot,
+                    "changed_by": changed_by,
+                    "created": now,
+                },
+            )
+            conn.execute(
                 sa.update(prompt_templates)
                 .where(prompt_templates.c.template_id == template_id)
-                .values(readonly=int(bool(readonly)), updated=now)
+                .values(readonly=0, updated=now)
             )
             conn.commit()
-            return result.rowcount > 0
+            return next_version
 
     def delete_prompt_template(self, template_id: str) -> bool:
         with self._conn() as conn:


### PR DESCRIPTION
## Summary

skills.sh / GitHub installs land with `readonly=True` so admins can only tune runtime config (model, temperature, etc.); the SKILL.md spec is locked. In practice, upstream skills aren't always tuned for turnstone, so locking the spec adds friction without a real safety win — every edit is audited and version-snapshotted regardless.

This adds an explicit **unlock** action so the boundary stays visible. The multi-user audit trail benefits from a discrete event (vs. silently dropping the gate), and operators get a clear "yes, I'm detaching this from upstream" moment.

## Behaviour

- `POST /v1/api/admin/skills/{id}/unlock` — flips `readonly=False` on a readonly row. Snapshots the pre-unlock state into `skill_versions` so the upstream-pristine version is recoverable from the History tab. Records `skill.unlock` audit with `{name, source_url, origin}`. Returns 400 on already-unlocked, 404 on missing.
- `origin` stays `"source"` after unlock so the UI keeps a "Customized from upstream" provenance badge — `readonly` is the gate, `origin` is the lineage.
- After unlock the existing `admin_update_skill` handler accepts spec edits naturally (its `if is_readonly:` allowlist filter no longer fires). Resource upload/delete same story.

## Storage

- Dedicated `set_skill_readonly(template_id, readonly)` writer on the protocol + sqlite + postgres backends.
- `readonly` is intentionally absent from `SKILL_MUTABLE` so the generic `update_prompt_template` path can't piggyback on a provenance flip — the dedicated-writer pattern matches what's already used for `set_mcp_oauth_client_secret_ct`. (`update_prompt_template` was silently warning + dropping `readonly` if you tried.)

## Frontend

- "Customize…" button in the edit-skill modal (visible only when `readonly`), with a confirm dialog explaining the upstream-detach and pointing operators at the History tab for rollback.
- Origin badge updates to "Customized from {source_url}" when a `source`-origin row is unlocked, so the lineage stays visible after the lock comes off.
- New `.modal-secondary` button style for the in-between-Cancel-and-Save slot.

## Test plan

- [x] `pytest tests/test_skills.py tests/test_skill_sources.py tests/test_skill_discovery_api.py tests/test_skill_resources_storage.py tests/test_governance_storage.py` — 239 passing
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on touched modules
- [ ] Manual smoke: install a skills.sh skill → click "Customize…" → confirm → modal flips to edit mode → edit description → Save → reload → edits persist + "Customized from upstream" badge shows
- [ ] Manual smoke: open History tab on the unlocked skill → confirm v1 snapshot is the pre-unlock upstream state
- [ ] Manual smoke: try to unlock an already-unlocked skill via `curl` → 400
- [ ] Manual smoke: confirm the readonly runtime-config save path still works on a fresh install (regression check)

## Out of scope (future)

- "Reset to upstream" inverse action — for v1 you can roll back via the existing `skill_versions` API + a manual restore. A button is a follow-up.
- "Pull updates from upstream" when source skills.sh changes — same future PR.