### PR TITLE
fix(skills-ui): show validation errors via .is-visible class

### DIFF
--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1072,7 +1072,9 @@ function showCreateTemplateModal() {
   document.getElementById("csk-auto-approve").onchange = function () {
     document.getElementById("csk-allowed-tools").disabled = this.checked;
   };
-  document.getElementById("create-template-error").style.display = "none";
+  document
+    .getElementById("create-template-error")
+    .classList.remove("is-visible");
   // Clear resource list
   _pendingResources = [];
   _renderPendingResources();
@@ -1115,7 +1117,7 @@ function submitCreateTemplate() {
   if (!name || !content) {
     var e = document.getElementById("create-template-error");
     e.textContent = "Name and content are required";
-    e.style.display = "";
+    e.classList.add("is-visible");
     return;
   }
   var varList = _detectTemplateVars(content);
@@ -1157,7 +1159,7 @@ function submitCreateTemplate() {
     } catch (ne) {
       var ne2 = document.getElementById("create-template-error");
       ne2.textContent = "Notify on completion: " + ne.message;
-      ne2.style.display = "";
+      ne2.classList.add("is-visible");
       return;
     }
   }
@@ -1240,7 +1242,7 @@ function submitCreateTemplate() {
     .catch(function (e) {
       var el = document.getElementById("create-template-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("ctm-submit").disabled = false;
@@ -1322,7 +1324,9 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("esk-auto-approve").onchange = function () {
     document.getElementById("esk-allowed-tools").disabled = this.checked;
   };
-  document.getElementById("edit-template-error").style.display = "none";
+  // The CSS contract for .admin-modal [role="alert"] is hide-by-default,
+  // .is-visible to show — so toggling style.display does nothing here.
+  document.getElementById("edit-template-error").classList.remove("is-visible");
   // Scan report section
   var scanSection = document.getElementById("etm-scan-section");
   if (scanSection) {
@@ -1883,7 +1887,7 @@ function submitEditTemplate() {
     } catch (ne) {
       var ne3 = document.getElementById("edit-template-error");
       ne3.textContent = "Notify on completion: " + ne.message;
-      ne3.style.display = "";
+      ne3.classList.add("is-visible");
       return;
     }
   }
@@ -1937,7 +1941,7 @@ function submitEditTemplate() {
     .catch(function (e) {
       var el = document.getElementById("edit-template-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("etm-submit").disabled = false;

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1112,6 +1112,15 @@ function hideCreateTemplateModal() {
 }
 
 function submitCreateTemplate() {
+  // Clear any prior error before re-validating — a successful submit shouldn't
+  // leave stale red text on-screen, and the in-flight PUT period shouldn't
+  // either. Cheaper than reasoning about every catch path remembering to
+  // clear on success.
+  var prevErr = document.getElementById("create-template-error");
+  if (prevErr) {
+    prevErr.classList.remove("is-visible");
+    prevErr.textContent = "";
+  }
   var name = document.getElementById("ctm-name").value.trim();
   var content = document.getElementById("ctm-content").value;
   if (!name || !content) {
@@ -1846,6 +1855,15 @@ function _addPendingResource() {
 }
 
 function submitEditTemplate() {
+  // Clear any prior error before re-validating — a successful submit shouldn't
+  // leave stale red text visible during the in-flight PUT, and a successful
+  // PUT shouldn't either. Cheaper than reasoning about every catch path
+  // remembering to clear on success.
+  var prevErr = document.getElementById("edit-template-error");
+  if (prevErr) {
+    prevErr.classList.remove("is-visible");
+    prevErr.textContent = "";
+  }
   var id = document.getElementById("etm-id").value;
   var content = document.getElementById("etm-content").value;
   var varList = _detectTemplateVars(content);


### PR DESCRIPTION
## Summary

Smoke-testing the just-merged unlock flow (#493) surfaced a latent bug: clicking **Save** on the edit-skill modal silently no-op'd whenever the `notify-on-complete` field had non-JSON content. The error div was DOM-correct (text set, `role="alert"`, `aria-live="assertive"`) — but **invisible**.

## Root cause

The project's modal-error CSS contract is:

```css
.admin-modal [role="alert"]              { display: none; }
.admin-modal [role="alert"].is-visible   { display: block; }
```

The JS in `submitEditTemplate` / `submitCreateTemplate` was clearing the **inline** `display: none` via `el.style.display = ""`. That falls back to the CSS rule — which still says `display: none` — so the error never rendered. The user saw no feedback and the click felt unresponsive (compounded by an early-return path that bypassed the Save-button disabled-state reset).

## Fix

Toggle the canonical `.is-visible` class instead. Six sites in `governance.js`:

| Site | Before | After |
|---|---|---|
| `submitEditTemplate` notify-on-complete catch | `style.display = ""` | `classList.add("is-visible")` |
| `submitEditTemplate` PUT .catch | `style.display = ""` | `classList.add("is-visible")` |
| `showEditTemplateModal` clear-error | `style.display = "none"` | `classList.remove("is-visible")` |
| `submitCreateTemplate` validation catch | `style.display = ""` | `classList.add("is-visible")` |
| `submitCreateTemplate` POST .catch | `style.display = ""` | `classList.add("is-visible")` |
| `showCreateTemplateModal` clear-error | `style.display = "none"` | `classList.remove("is-visible")` |

## Scope note

This same bug pattern exists across ~20 other modal-error sites I haven't touched in this PR:

- `governance.js`: create-role, edit-role, create-policy, edit-policy, github-import, cpp, epp, create-hr, edit-hr, create-ogp, edit-ogp
- `admin.js`: mcp-create, mcp-import, mcp-install (the user/token/channel/schedule modals go through `_showModalError` which uses `style.display = "block"` — that *does* work, but isn't using the canonical class)

All pre-existing — broken silently for some time. Out of scope for this PR. **Recommend a follow-up sweep PR** that also normalizes `_showModalError`'s `style.display = "block"` to `classList.add("is-visible")` for project-wide consistency.

## Test plan

- [x] No tests affected (frontend bug, no unit-testable behavior)
- [ ] Manual smoke: open edit-skill modal, set notify-on-complete to invalid JSON (e.g. `not-json`), click Save → red error message renders inline
- [ ] Manual smoke: clicking Save again after correcting the field clears the error and submits successfully (Save button re-enables)
- [ ] Manual smoke: same flow on the Create Skill modal