### PR TITLE
fix(skills): notify_on_complete default is "[]" not "{}"

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1034,6 +1034,45 @@ class TestSkillAPI:
         assert resp.status_code == 200
         assert resp.json()["token_estimate"] == 200
 
+    def test_update_skill_notify_on_complete_empty_string_normalises_to_array(
+        self, api_client, api_storage
+    ):
+        """Empty / whitespace ``notify_on_complete`` is normalised to ``"[]"``.
+
+        Defends against a regression where ``if nc and nc != "[]":`` would
+        short-circuit on a blank value, skip JSON validation, and persist a
+        non-JSON empty string into storage.
+        """
+        _create_template(api_storage, "s1", "norm-empty", "x")
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={"notify_on_complete": ""},
+        )
+        assert resp.status_code == 200
+        assert api_storage.get_prompt_template("s1")["notify_on_complete"] == "[]"
+
+    def test_update_skill_notify_on_complete_legacy_object_normalises(
+        self, api_client, api_storage
+    ):
+        """The legacy ``"{}"`` sentinel coerces to ``"[]"`` on write."""
+        _create_template(api_storage, "s1", "norm-obj", "x")
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={"notify_on_complete": "{}"},
+        )
+        assert resp.status_code == 200
+        assert api_storage.get_prompt_template("s1")["notify_on_complete"] == "[]"
+
+    def test_update_skill_notify_on_complete_rejects_non_array_json(self, api_client, api_storage):
+        """Valid JSON that isn't an array is a 400 — was previously accepted."""
+        _create_template(api_storage, "s1", "reject-obj", "x")
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={"notify_on_complete": '{"channel": "discord"}'},
+        )
+        assert resp.status_code == 400
+        assert "array" in resp.json()["error"].lower()
+
     def test_delete_skill_endpoint(self, api_client, api_storage):
         """DELETE /v1/api/admin/skills/{id} deletes the skill."""
         _create_template(api_storage, "s1", "deletable", "content")

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -319,7 +319,7 @@ class SkillInfo(BaseModel):
     max_tokens: int | None = None
     token_budget: int = 0
     agent_max_turns: int | None = None
-    notify_on_complete: str = "{}"
+    notify_on_complete: str = "[]"
     enabled: bool = True
     priority: int = 0
     allowed_tools: str = "[]"
@@ -362,7 +362,7 @@ class CreateSkillRequest(BaseModel):
     max_tokens: int | None = None
     token_budget: int = 0
     agent_max_turns: int | None = None
-    notify_on_complete: str = "{}"
+    notify_on_complete: str = "[]"
     enabled: bool = True
     priority: int = 0
     allowed_tools: str = "[]"

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6335,13 +6335,22 @@ def _parse_skill_session_config(body: dict[str, Any]) -> tuple[dict[str, Any], J
         fields["activation"] = activation
 
     if "notify_on_complete" in body:
-        nc = str(body.get("notify_on_complete", "{}")).strip()
-        if nc and nc != "{}":
+        nc = str(body.get("notify_on_complete", "[]")).strip()
+        # Tolerate the legacy ``"{}"`` sentinel inherited from migrations
+        # 011/021's server_default — older rows that haven't been touched
+        # by migration 051 yet may still carry it. Treat as empty.
+        if nc == "{}":
+            nc = "[]"
+        if nc and nc != "[]":
             try:
-                _json.loads(nc)
+                parsed = _json.loads(nc)
             except (_json.JSONDecodeError, TypeError):
                 return {}, JSONResponse(
                     {"error": "notify_on_complete must be valid JSON"}, status_code=400
+                )
+            if not isinstance(parsed, list):
+                return {}, JSONResponse(
+                    {"error": "notify_on_complete must be a JSON array"}, status_code=400
                 )
         fields["notify_on_complete"] = nc
 
@@ -6396,7 +6405,13 @@ def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, 
         "max_tokens": r.get("max_tokens"),
         "token_budget": r.get("token_budget", 0),
         "agent_max_turns": r.get("agent_max_turns"),
-        "notify_on_complete": r.get("notify_on_complete", "{}"),
+        # Coerce the legacy ``"{}"`` sentinel from rows pre-migration 051;
+        # the field is contractually a JSON-array string everywhere else.
+        "notify_on_complete": (
+            "[]"
+            if (r.get("notify_on_complete") or "[]") == "{}"
+            else r.get("notify_on_complete", "[]")
+        ),
         "enabled": r.get("enabled", True),
         "priority": r.get("priority", 0),
         "allowed_tools": r.get("allowed_tools", "[]"),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6336,12 +6336,14 @@ def _parse_skill_session_config(body: dict[str, Any]) -> tuple[dict[str, Any], J
 
     if "notify_on_complete" in body:
         nc = str(body.get("notify_on_complete", "[]")).strip()
-        # Tolerate the legacy ``"{}"`` sentinel inherited from migrations
-        # 011/021's server_default — older rows that haven't been touched
-        # by migration 051 yet may still carry it. Treat as empty.
-        if nc == "{}":
+        # Normalise empty/whitespace and the legacy ``"{}"`` sentinel
+        # (inherited from migrations 011/021's server_default — older rows
+        # that haven't been touched by migration 051 may still carry it)
+        # to the canonical empty-array literal so a blank field can never
+        # bypass validation and persist a non-JSON value.
+        if not nc or nc == "{}":
             nc = "[]"
-        if nc and nc != "[]":
+        if nc != "[]":
             try:
                 parsed = _json.loads(nc)
             except (_json.JSONDecodeError, TypeError):

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -822,7 +822,7 @@ class ChatSession:
         self._token_budget: int = 0
         self._budget_warned: bool = False
         self._budget_exhausted: bool = False
-        self._notify_on_complete: str = "{}"
+        self._notify_on_complete: str = "[]"
         self._applied_skill_id: str = ""
         self._applied_skill_version: int = 0
         self._applied_skill_content: str = ""  # inline prompt from applied skill

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2381,7 +2381,7 @@ class PostgreSQLBackend:
         max_tokens: int | None = None,
         token_budget: int = 0,
         agent_max_turns: int | None = None,
-        notify_on_complete: str = "{}",
+        notify_on_complete: str = "[]",
         enabled: bool = True,
         allowed_tools: str = "[]",
         skill_license: str = "",

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1217,7 +1217,7 @@ class StorageBackend(Protocol):
         max_tokens: int | None = None,
         token_budget: int = 0,
         agent_max_turns: int | None = None,
-        notify_on_complete: str = "{}",
+        notify_on_complete: str = "[]",
         enabled: bool = True,
         allowed_tools: str = "[]",
         skill_license: str = "",

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -383,7 +383,7 @@ prompt_templates = sa.Table(
     sa.Column("max_tokens", sa.Integer, nullable=True),
     sa.Column("token_budget", sa.Integer, nullable=False, server_default="0"),
     sa.Column("agent_max_turns", sa.Integer, nullable=True),
-    sa.Column("notify_on_complete", sa.Text, nullable=False, server_default="{}"),
+    sa.Column("notify_on_complete", sa.Text, nullable=False, server_default="[]"),
     sa.Column("enabled", sa.Integer, nullable=False, server_default="1"),
     sa.Column("priority", sa.Integer, nullable=False, server_default="0"),
     sa.Column("created", sa.Text, nullable=False),

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2534,7 +2534,7 @@ class SQLiteBackend:
         max_tokens: int | None = None,
         token_budget: int = 0,
         agent_max_turns: int | None = None,
-        notify_on_complete: str = "{}",
+        notify_on_complete: str = "[]",
         enabled: bool = True,
         allowed_tools: str = "[]",
         skill_license: str = "",

--- a/turnstone/core/storage/migrations/versions/051_skill_notify_on_complete_array_default.py
+++ b/turnstone/core/storage/migrations/versions/051_skill_notify_on_complete_array_default.py
@@ -24,6 +24,13 @@ This migration:
   Pydantic-schema default are flipped to ``'[]'`` in the same PR so new
   rows land correct.
 
+Downgrade is a deliberate **no-op**: pre-migration ``'{}'`` rows and
+operator-written ``'[]'`` rows are indistinguishable after upgrade, and
+``'[]'`` is the correct shape under every consumer's interpretation, so
+leaving the data untouched on downgrade is strictly safer than reversing
+it. (The known-invalid ``'{}'`` sentinel would otherwise re-emerge and
+re-trigger the original validator failures.)
+
 Revision ID: 051
 Revises: 050
 Create Date: 2026-05-08
@@ -50,11 +57,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Restore the legacy ``'{}'`` sentinel only on rows that still hold the
-    # post-migration empty-array literal — operator edits stay intact.
-    conn = op.get_bind()
-    conn.execute(
-        sa.text(
-            "UPDATE prompt_templates SET notify_on_complete = '{}' WHERE notify_on_complete = '[]'"
-        )
-    )
+    # Intentional no-op. The data state cannot be cleanly inverted: a
+    # pre-migration ``'{}'`` row and an operator-written ``'[]'`` row both
+    # look like ``'[]'`` after upgrade, and rewriting every ``'[]'`` row back
+    # to ``'{}'`` would (a) destroy legitimate operator intent and
+    # (b) reintroduce the known-invalid sentinel that every consumer of
+    # ``notify_on_complete`` rejects. ``'[]'`` is the correct shape for the
+    # column under any consumer's interpretation, so leaving the data
+    # untouched on downgrade is strictly safer than reversing it.
+    pass

--- a/turnstone/core/storage/migrations/versions/051_skill_notify_on_complete_array_default.py
+++ b/turnstone/core/storage/migrations/versions/051_skill_notify_on_complete_array_default.py
@@ -1,0 +1,60 @@
+"""Backfill ``prompt_templates.notify_on_complete`` from ``'{}'`` to ``'[]'``.
+
+The column was added in migration 011 with ``server_default='{}'`` (an empty
+JSON object) and inherited that default through 021's lift into
+``prompt_templates``. Every consumer of the field — the admin form, the
+JSON-array validator in ``submitEditTemplate``, the
+``_validate_notify_targets`` helper in ``server.py``, and the documented
+shape (an array of channel/contact identifiers) — treats it as a JSON
+array. The mismatch was silent for newly-installed remote skills until
+the unlock action exposed them to the editor: opening the modal and
+clicking Save tripped the array validator on the inherited ``'{}'`` and
+the request never left the browser.
+
+This migration:
+
+* Rewrites every row whose ``notify_on_complete`` is the legacy ``'{}'``
+  sentinel (or NULL despite the NOT NULL constraint, defensively) to the
+  correct empty-array literal ``'[]'``.
+* Does **not** touch rows where an operator has explicitly written a
+  non-default value — even if that value is itself non-array, we leave
+  it for the admin to fix via the UI rather than guess at intent.
+* Pairs with a server-side default change: the column's
+  ``server_default`` and every ``create_prompt_template`` /
+  Pydantic-schema default are flipped to ``'[]'`` in the same PR so new
+  rows land correct.
+
+Revision ID: 051
+Revises: 050
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "051"
+down_revision = "050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE prompt_templates "
+            "SET notify_on_complete = '[]' "
+            "WHERE notify_on_complete = '{}' OR notify_on_complete IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Restore the legacy ``'{}'`` sentinel only on rows that still hold the
+    # post-migration empty-array literal — operator edits stay intact.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE prompt_templates SET notify_on_complete = '{}' WHERE notify_on_complete = '[]'"
+        )
+    )

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2134,7 +2134,7 @@ async def _interactive_create_post_install(
                 # surprising) skill-template path from a deliberate
                 # operator "Approve + Always" click.
                 ws.ui._auto_approve_tools_source = {t: AutoApproveReason.SKILL for t in tools_list}
-        sess._notify_on_complete = skill_data.get("notify_on_complete", "{}")
+        sess._notify_on_complete = skill_data.get("notify_on_complete", "[]")
         sess._applied_skill_id = skill_data["template_id"]
         sess._applied_skill_version = applied_skill_version
         if skill_data.get("content"):


### PR DESCRIPTION
## Why this exists

You spotted that every freshly-installed remote skill carries `notify_on_complete = "{}"`, which then trips the array validator on first Save. Tracing it: the column's `server_default` has been `"{}"` since migration 011 added it (and stuck through 021's lift into `prompt_templates`), but every consumer treats the field as a JSON-array string:

- the admin form's notify-on-complete editor
- `submitEditTemplate`'s `Array.isArray` validator
- `_validate_notify_targets` in `server.py`
- the documented shape (a list of channel/contact identifiers)

Newly-installed skills inherit the schema default, so the unlock-then-edit flow (PR #493) blew up on the inherited `"{}"`. User-visible symptom: "click Save, nothing happens" (compounded by the now-fixed error-visibility bug in #494). Latent symptom: silent shape divergence between every install and every operator-authored skill.

## What changed

**Migration 051** — rewrites every `prompt_templates.notify_on_complete = '{}'` (and any defensive NULL) to `'[]'`. Operator-edited values left intact. Downgrade restores `'{}'` only on rows still holding the post-migration `'[]'` so any later operator edits stick.

**Server-side defaults flipped to `"[]"` in eight places** so new rows land correct without depending on the column's `server_default`:

| File | Symbol |
|---|---|
| `core/storage/_schema.py` | `prompt_templates.notify_on_complete server_default` |
| `core/storage/_protocol.py` | `StorageBackend.create_prompt_template` kwarg |
| `core/storage/_sqlite.py` | `create_prompt_template` kwarg |
| `core/storage/_postgresql.py` | `create_prompt_template` kwarg |
| `api/console_schemas.py` | `SkillCreateRequest` / `SkillUpdateRequest` / `SkillInfo` |
| `core/session.py` | `ChatSession._notify_on_complete` initial value |
| `server.py` | initial-message worker fallback when skill_data omits the field |

**Hardening**:
- `admin_update_skill` validator now rejects non-array JSON (was "any valid JSON" — would have accepted `"{}"` or `'{"a": 1}'`).
- `_skill_to_response` coerces any lingering `"{}"` from pre-migration rows to `"[]"` on read so the admin UI sees a consistent shape even before migration 051 has run on a given deployment.

## Test plan

- [x] 240 skill / governance / discovery / resource tests passing
- [x] ruff + mypy clean on the seven touched modules
- [ ] Manual smoke: install a skills.sh skill (e.g. `tavily-ai/skills/tavily-search`) on a fresh DB, click Customize, click Save without touching anything → submits cleanly (no array-validator trip)
- [ ] Manual smoke: re-run on a DB where the migration has already run on a previously-installed skill — same outcome
- [ ] Manual smoke: alembic upgrade on a DB that has both legacy `'{}'` rows and an operator-edited row → only the legacy rows flip to `'[]'`