### PR TITLE
fix(ui): convert remaining modal-error toggles to .is-visible class + aria-atomic

### DIFF
--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -1314,7 +1314,9 @@ function toggleScheduleNodeField() {
 function showCreateScheduleModal() {
   var overlay = document.getElementById("create-schedule-overlay");
   overlay.style.display = "flex";
-  document.getElementById("create-schedule-error").style.display = "none";
+  document
+    .getElementById("create-schedule-error")
+    .classList.remove("is-visible");
   document.getElementById("cs-name").value = "";
   document.getElementById("cs-desc").value = "";
   document.getElementById("cs-type").value = "cron";
@@ -1506,7 +1508,9 @@ function showEditScheduleModal(taskId) {
       _populateNotifyRows("es", s.notify_targets || []);
       toggleEditScheduleTypeFields();
       toggleEditScheduleNodeField();
-      document.getElementById("edit-schedule-error").style.display = "none";
+      document
+        .getElementById("edit-schedule-error")
+        .classList.remove("is-visible");
       document.getElementById("es-submit").disabled = false;
       document.getElementById("es-submit").textContent = "Save";
       var overlay = document.getElementById("edit-schedule-overlay");
@@ -1845,7 +1849,9 @@ function showCreateChannelModal() {
   }
   var overlay = document.getElementById("create-channel-overlay");
   overlay.style.display = "flex";
-  document.getElementById("create-channel-error").style.display = "none";
+  document
+    .getElementById("create-channel-error")
+    .classList.remove("is-visible");
   var ctSel = document.getElementById("cc-type");
   var uidInput = document.getElementById("cc-uid");
   ctSel.value = "discord";
@@ -1924,7 +1930,7 @@ function submitCreateChannel() {
 function showCreateUserModal() {
   var overlay = document.getElementById("create-user-overlay");
   overlay.style.display = "flex";
-  document.getElementById("create-user-error").style.display = "none";
+  document.getElementById("create-user-error").classList.remove("is-visible");
   document.getElementById("cu-username").value = "";
   document.getElementById("cu-displayname").value = "";
   document.getElementById("cu-password").value = "";
@@ -2005,7 +2011,7 @@ function showCreateTokenModal() {
   }
   var overlay = document.getElementById("create-token-overlay");
   overlay.style.display = "flex";
-  document.getElementById("create-token-error").style.display = "none";
+  document.getElementById("create-token-error").classList.remove("is-visible");
   document.getElementById("ct-name").value = "";
   document.getElementById("ct-scopes").value = "read,write,approve";
   document.getElementById("ct-expires").value = "";
@@ -3201,9 +3207,15 @@ function _resetSetting(key) {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Show an error message in a modal's [role="alert"] element. The .is-visible
+// class is the canonical toggle — see `.admin-modal [role="alert"]` in
+// style.css. Do NOT use `el.style.display = "block"` here; the CSS rule
+// `.admin-modal [role="alert"] { display: none }` is selector-equivalent and
+// will hide the element again as soon as the inline style is cleared. Hide
+// side is `el.classList.remove("is-visible")`.
 function _showModalError(el, msg) {
   el.textContent = msg;
-  el.style.display = "block";
+  el.classList.add("is-visible");
 }
 
 /* ── MCP Servers tab ─────────────────────────────────────────────────────── */
@@ -3552,7 +3564,7 @@ function showCreateMcpModal() {
   document.getElementById("mcp-oauth-client-secret").value = "";
   document.getElementById("mcp-oauth-scopes").value = "";
   document.getElementById("mcp-oauth-audience").value = "";
-  document.getElementById("mcp-create-error").style.display = "none";
+  document.getElementById("mcp-create-error").classList.remove("is-visible");
   toggleMcpTransport();
   toggleMcpAuthFields();
   _wireMcpAudienceAutofill();
@@ -3726,7 +3738,7 @@ function submitCreateMcp() {
   if (form.error) {
     var e = document.getElementById("mcp-create-error");
     e.textContent = form.error;
-    e.style.display = "";
+    e.classList.add("is-visible");
     return;
   }
   var editId = document.getElementById("mcp-edit-id").value;
@@ -3757,7 +3769,7 @@ function submitCreateMcp() {
     .catch(function (e) {
       var el = document.getElementById("mcp-create-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("mcp-create-submit").disabled = false;
@@ -3939,7 +3951,7 @@ function showImportMcpModal() {
   _mcpImportTrigger = document.activeElement;
   document.getElementById("mcp-import-overlay").style.display = "flex";
   document.getElementById("mcp-import-json").value = "";
-  document.getElementById("mcp-import-error").style.display = "none";
+  document.getElementById("mcp-import-error").classList.remove("is-visible");
   document.getElementById("mcp-import-json").focus();
   _mcpImportTrap = _installTrap("mcp-import-overlay", "mcp-import-box");
 }
@@ -3956,7 +3968,7 @@ function submitImportMcp() {
   if (!raw) {
     var e = document.getElementById("mcp-import-error");
     e.textContent = "Paste a JSON config";
-    e.style.display = "";
+    e.classList.add("is-visible");
     return;
   }
   var parsed;
@@ -3965,13 +3977,13 @@ function submitImportMcp() {
   } catch (ex) {
     var e2 = document.getElementById("mcp-import-error");
     e2.textContent = "Invalid JSON: " + ex.message;
-    e2.style.display = "";
+    e2.classList.add("is-visible");
     return;
   }
   if (!parsed.mcpServers || typeof parsed.mcpServers !== "object") {
     var e3 = document.getElementById("mcp-import-error");
     e3.textContent = 'No "mcpServers" key found in JSON';
-    e3.style.display = "";
+    e3.classList.add("is-visible");
     return;
   }
   document.getElementById("mcp-import-submit").disabled = true;
@@ -4001,7 +4013,7 @@ function submitImportMcp() {
     .catch(function (e) {
       var el = document.getElementById("mcp-import-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("mcp-import-submit").disabled = false;
@@ -4278,7 +4290,7 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
   _mcpInstallTrigger = document.activeElement;
   var ov = document.getElementById("mcp-install-overlay");
   ov.style.display = "flex";
-  document.getElementById("mcp-install-error").style.display = "none";
+  document.getElementById("mcp-install-error").classList.remove("is-visible");
 
   // Summary
   document.getElementById("mcp-install-summary").innerHTML =
@@ -4552,7 +4564,7 @@ function _doRegistryInstall(
       var errEl = document.getElementById("mcp-install-error");
       if (errEl && overlay && overlay.style.display !== "none") {
         errEl.textContent = e.message;
-        errEl.style.display = "";
+        errEl.classList.add("is-visible");
       } else {
         showToast("Install failed: " + e.message);
         // Re-render to reset card button states

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -203,7 +203,7 @@ function showCreateRoleModal() {
   document.getElementById("cr-displayname").value = "";
   document.getElementById("cr-perms-container").innerHTML =
     _buildPermCheckboxes("cr", []);
-  document.getElementById("create-role-error").style.display = "none";
+  document.getElementById("create-role-error").classList.remove("is-visible");
   document.getElementById("cr-name").focus();
   _crTrapHandler = _installTrap("create-role-overlay", "create-role-box");
 }
@@ -224,7 +224,7 @@ function submitCreateRole() {
   if (!name) {
     var e = document.getElementById("create-role-error");
     e.textContent = "Name is required";
-    e.style.display = "";
+    e.classList.add("is-visible");
     return;
   }
   if (!dname) dname = name;
@@ -253,7 +253,7 @@ function submitCreateRole() {
     .catch(function (e) {
       var el = document.getElementById("create-role-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("cr-submit").disabled = false;
@@ -277,7 +277,7 @@ function showEditRoleModal(roleId) {
   var selected = (role.permissions || "").split(",");
   document.getElementById("er-perms-container").innerHTML =
     _buildPermCheckboxes("er", selected);
-  document.getElementById("edit-role-error").style.display = "none";
+  document.getElementById("edit-role-error").classList.remove("is-visible");
   _erTrapHandler = _installTrap("edit-role-overlay", "edit-role-box");
 }
 
@@ -315,7 +315,7 @@ function submitEditRole() {
     .catch(function (e) {
       var el = document.getElementById("edit-role-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("er-submit").disabled = false;
@@ -533,7 +533,7 @@ function showCreatePolicyModal() {
   document.getElementById("cp-pattern").value = "";
   document.getElementById("cp-action").value = "ask";
   document.getElementById("cp-priority").value = "0";
-  document.getElementById("create-policy-error").style.display = "none";
+  document.getElementById("create-policy-error").classList.remove("is-visible");
   document.getElementById("cp-name").focus();
   _cpTrapHandler = _installTrap("create-policy-overlay", "create-policy-box");
 }
@@ -556,7 +556,7 @@ function submitCreatePolicy() {
   if (!name || !pattern) {
     var e = document.getElementById("create-policy-error");
     e.textContent = "Name and pattern are required";
-    e.style.display = "";
+    e.classList.add("is-visible");
     return;
   }
   document.getElementById("cp-submit").disabled = true;
@@ -585,7 +585,7 @@ function submitCreatePolicy() {
     .catch(function (e) {
       var el = document.getElementById("create-policy-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("cp-submit").disabled = false;
@@ -610,7 +610,7 @@ function showEditPolicyModal(policyId) {
   document.getElementById("ep-action").value = policy.action;
   document.getElementById("ep-priority").value = policy.priority;
   document.getElementById("ep-enabled").checked = policy.enabled;
-  document.getElementById("edit-policy-error").style.display = "none";
+  document.getElementById("edit-policy-error").classList.remove("is-visible");
   _epTrapHandler = _installTrap("edit-policy-overlay", "edit-policy-box");
 }
 
@@ -652,7 +652,7 @@ function submitEditPolicy() {
     .catch(function (e) {
       var el = document.getElementById("edit-policy-error");
       el.textContent = e.message;
-      el.style.display = "";
+      el.classList.add("is-visible");
     })
     .finally(function () {
       document.getElementById("ep-submit").disabled = false;
@@ -2727,7 +2727,7 @@ function showGitHubImportModal() {
   urlInput.value = "";
   var errEl = document.getElementById("github-import-error");
   errEl.textContent = "";
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   _giTrapHandler = _installTrap("github-import-overlay", "github-import-box");
   urlInput.focus();
 }
@@ -2746,19 +2746,19 @@ function submitGitHubImport() {
   var errEl = document.getElementById("github-import-error");
   if (!url) {
     errEl.textContent = "URL is required";
-    errEl.style.display = "";
+    errEl.classList.add("is-visible");
     return;
   }
   if (!/^https?:\/\/github\.com\//i.test(url)) {
     errEl.textContent = "Must be a GitHub URL";
-    errEl.style.display = "";
+    errEl.classList.add("is-visible");
     return;
   }
 
   var submitBtn = document.getElementById("gi-submit");
   submitBtn.disabled = true;
   submitBtn.textContent = "Installing\u2026";
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
 
   authFetch("/v1/api/admin/skills/install", {
     method: "POST",
@@ -2799,7 +2799,7 @@ function submitGitHubImport() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       submitBtn.disabled = false;
@@ -2946,7 +2946,7 @@ function showCreatePromptPolicyModal() {
   document.getElementById("cpp-gate").value = "";
   document.getElementById("cpp-content").value = "";
   document.getElementById("cpp-priority").value = "0";
-  document.getElementById("cpp-error").style.display = "none";
+  document.getElementById("cpp-error").classList.remove("is-visible");
   document.getElementById("cpp-name").focus();
   _cppTrapHandler = _installTrap(
     "create-ppolicy-overlay",
@@ -2969,10 +2969,10 @@ function submitCreatePromptPolicy() {
   var content = document.getElementById("cpp-content").value.trim();
   if (!name || !content) {
     errEl.textContent = "Name and content are required";
-    errEl.style.display = "";
+    errEl.classList.add("is-visible");
     return;
   }
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var submitBtn = document.getElementById("cpp-submit");
   submitBtn.disabled = true;
   authFetch("/v1/api/admin/prompt-policies", {
@@ -3001,7 +3001,7 @@ function submitCreatePromptPolicy() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       submitBtn.disabled = false;
@@ -3024,7 +3024,7 @@ function showEditPromptPolicyModal(policyId) {
   document.getElementById("epp-content").value = p.content || "";
   document.getElementById("epp-priority").value = p.priority || 0;
   document.getElementById("epp-enabled").checked = p.enabled;
-  document.getElementById("epp-error").style.display = "none";
+  document.getElementById("epp-error").classList.remove("is-visible");
   var ov = document.getElementById("edit-ppolicy-overlay");
   ov.style.display = "flex";
   document.getElementById("epp-name").focus();
@@ -3047,10 +3047,10 @@ function submitEditPromptPolicy() {
   var content = document.getElementById("epp-content").value.trim();
   if (!name || !content) {
     errEl.textContent = "Name and content are required";
-    errEl.style.display = "";
+    errEl.classList.add("is-visible");
     return;
   }
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var submitBtn = document.getElementById("epp-submit");
   submitBtn.disabled = true;
   authFetch("/v1/api/admin/prompt-policies/" + policyId, {
@@ -3079,7 +3079,7 @@ function submitEditPromptPolicy() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       submitBtn.disabled = false;
@@ -3603,7 +3603,7 @@ function showCreateHeuristicRuleModal() {
   document.getElementById("hr-conf").value = "0.8";
   document.getElementById("hr-intent").value = "";
   document.getElementById("hr-reason").value = "";
-  document.getElementById("create-hr-error").style.display = "none";
+  document.getElementById("create-hr-error").classList.remove("is-visible");
   document.getElementById("hr-submit").disabled = false;
   document.getElementById("hr-name").focus();
   _chrTrapHandler = _installTrap("create-hr-overlay", "create-hr-box");
@@ -3618,7 +3618,7 @@ function hideCreateHRModal() {
 
 function submitCreateHeuristicRule() {
   var errEl = document.getElementById("create-hr-error");
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var argsText = document.getElementById("hr-args").value.trim();
   var argPatterns = argsText
     ? argsText.split("\n").filter(function (l) {
@@ -3658,7 +3658,7 @@ function submitCreateHeuristicRule() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       btn.disabled = false;
@@ -3770,7 +3770,7 @@ function _populateEditHRModal(rule, isBuiltin) {
   document.getElementById("ehr-conf").value = rule.confidence;
   document.getElementById("ehr-intent").value = rule.intent_template || "";
   document.getElementById("ehr-reason").value = rule.reasoning_template || "";
-  document.getElementById("edit-hr-error").style.display = "none";
+  document.getElementById("edit-hr-error").classList.remove("is-visible");
   document.getElementById("ehr-submit").disabled = false;
 }
 
@@ -3820,7 +3820,7 @@ function hideEditHRModal() {
 
 function submitEditHeuristicRule() {
   var errEl = document.getElementById("edit-hr-error");
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var argsText = document.getElementById("ehr-args").value.trim();
   var argPatterns = argsText
     ? argsText.split("\n").filter(function (l) {
@@ -3874,7 +3874,7 @@ function submitEditHeuristicRule() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       btn.disabled = false;
@@ -4115,7 +4115,7 @@ function showCreateOutputGuardPatternModal() {
   document.getElementById("ogp-cred").checked = false;
   document.getElementById("ogp-redact").value = "";
   document.getElementById("ogp-regex-result").textContent = "";
-  document.getElementById("create-ogp-error").style.display = "none";
+  document.getElementById("create-ogp-error").classList.remove("is-visible");
   document.getElementById("ogp-submit").disabled = false;
   document.getElementById("ogp-name").focus();
   _cogpTrapHandler = _installTrap("create-ogp-overlay", "create-ogp-box");
@@ -4161,7 +4161,7 @@ function validateOGRegex() {
 
 function submitCreateOGPattern() {
   var errEl = document.getElementById("create-ogp-error");
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var payload = {
     name: document.getElementById("ogp-name").value.trim(),
     category: document.getElementById("ogp-cat").value,
@@ -4195,7 +4195,7 @@ function submitCreateOGPattern() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       btn.disabled = false;
@@ -4300,7 +4300,7 @@ function _populateEditOGPModal(pat, isBuiltin) {
   document.getElementById("eogp-cred").checked = !!pat.is_credential;
   document.getElementById("eogp-redact").value = pat.redact_label || "";
   document.getElementById("eogp-regex-result").textContent = "";
-  document.getElementById("edit-ogp-error").style.display = "none";
+  document.getElementById("edit-ogp-error").classList.remove("is-visible");
   document.getElementById("eogp-submit").disabled = false;
 }
 
@@ -4378,7 +4378,7 @@ function validateEditOGRegex() {
 
 function submitEditOGPattern() {
   var errEl = document.getElementById("edit-ogp-error");
-  errEl.style.display = "none";
+  errEl.classList.remove("is-visible");
   var patternId = document.getElementById("eogp-id").value;
   var payload = {
     name: document.getElementById("eogp-name").value.trim(),
@@ -4424,7 +4424,7 @@ function submitEditOGPattern() {
     })
     .catch(function (e) {
       errEl.textContent = e.message;
-      errEl.style.display = "";
+      errEl.classList.add("is-visible");
     })
     .finally(function () {
       btn.disabled = false;

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1010,7 +1010,7 @@
                 <div
                   id="create-hr-error"
                   role="alert"
-                  aria-live="assertive"
+                  aria-live="assertive" aria-atomic="true"
                 ></div>
                 <label for="hr-name">Name</label>
                 <input
@@ -1124,7 +1124,7 @@
                 <div
                   id="create-ogp-error"
                   role="alert"
-                  aria-live="assertive"
+                  aria-live="assertive" aria-atomic="true"
                 ></div>
                 <label for="ogp-name">Name</label>
                 <input
@@ -1245,7 +1245,7 @@
                 <div
                   id="edit-hr-error"
                   role="alert"
-                  aria-live="assertive"
+                  aria-live="assertive" aria-atomic="true"
                 ></div>
                 <input id="ehr-id" type="hidden" />
                 <input id="ehr-builtin" type="hidden" />
@@ -1349,7 +1349,7 @@
                 <div
                   id="edit-ogp-error"
                   role="alert"
-                  aria-live="assertive"
+                  aria-live="assertive" aria-atomic="true"
                 ></div>
                 <input id="eogp-id" type="hidden" />
                 <input id="eogp-builtin" type="hidden" />
@@ -2184,7 +2184,7 @@
     >
       <div id="github-import-box" class="admin-modal">
         <h2 id="github-import-title">Import from GitHub</h2>
-        <div id="github-import-error" role="alert" aria-live="assertive"></div>
+        <div id="github-import-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="gi-url">GitHub URL</label>
         <input
           id="gi-url"
@@ -2225,7 +2225,7 @@
     >
       <div id="create-user-box" class="admin-modal">
         <h2 id="create-user-title">Create User</h2>
-        <div id="create-user-error" role="alert" aria-live="assertive"></div>
+        <div id="create-user-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="cu-username">Username</label>
         <input
           id="cu-username"
@@ -2280,7 +2280,7 @@
     >
       <div id="create-token-box" class="admin-modal">
         <h2 id="create-token-title">Create API Token</h2>
-        <div id="create-token-error" role="alert" aria-live="assertive"></div>
+        <div id="create-token-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="ct-name"
           >Token name <span class="label-hint">optional</span></label
         >
@@ -2388,7 +2388,7 @@
     >
       <div id="create-channel-box" class="admin-modal">
         <h2 id="create-channel-title">Link Channel Account</h2>
-        <div id="create-channel-error" role="alert" aria-live="assertive"></div>
+        <div id="create-channel-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="cc-type">Channel type</label>
         <select id="cc-type">
           <option value="discord">Discord</option>
@@ -2427,7 +2427,7 @@
         <div
           id="create-schedule-error"
           role="alert"
-          aria-live="assertive"
+          aria-live="assertive" aria-atomic="true"
         ></div>
         <div class="modal-columns">
           <div class="modal-col">
@@ -2551,7 +2551,7 @@
     >
       <div id="edit-schedule-box" class="admin-modal admin-modal-wide">
         <h2 id="edit-schedule-title">Edit Schedule</h2>
-        <div id="edit-schedule-error" role="alert" aria-live="assertive"></div>
+        <div id="edit-schedule-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="es-id" type="hidden" />
         <div class="modal-columns">
           <div class="modal-col">
@@ -2675,7 +2675,7 @@
     >
       <div id="create-role-box" class="admin-modal admin-modal-wide">
         <h2 id="create-role-title">Create Role</h2>
-        <div id="create-role-error" role="alert" aria-live="assertive"></div>
+        <div id="create-role-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="cr-name">Name</label>
         <input
           id="cr-name"
@@ -2724,7 +2724,7 @@
     >
       <div id="edit-role-box" class="admin-modal admin-modal-wide">
         <h2 id="edit-role-title">Edit Role</h2>
-        <div id="edit-role-error" role="alert" aria-live="assertive"></div>
+        <div id="edit-role-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="er-id" type="hidden" />
         <label for="er-name">Display name</label>
         <input id="er-name" type="text" autocomplete="off" />
@@ -2761,7 +2761,7 @@
     >
       <div id="user-roles-box" class="admin-modal">
         <h2 id="user-roles-title">Assign Roles</h2>
-        <div id="user-roles-error" role="alert" aria-live="assertive"></div>
+        <div id="user-roles-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="ur-user-id" type="hidden" />
         <div id="ur-roles-container"></div>
         <div class="modal-buttons">
@@ -2783,7 +2783,7 @@
     >
       <div id="create-policy-box" class="admin-modal">
         <h2 id="create-policy-title">Create Tool Policy</h2>
-        <div id="create-policy-error" role="alert" aria-live="assertive"></div>
+        <div id="create-policy-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="cp-name">Name</label>
         <input
           id="cp-name"
@@ -2840,7 +2840,7 @@
     >
       <div id="edit-policy-box" class="admin-modal">
         <h2 id="edit-policy-title">Edit Tool Policy</h2>
-        <div id="edit-policy-error" role="alert" aria-live="assertive"></div>
+        <div id="edit-policy-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="ep-id" type="hidden" />
         <label for="ep-name">Name</label>
         <input id="ep-name" type="text" autocomplete="off" />
@@ -2887,7 +2887,7 @@
     >
       <div id="create-ppolicy-box" class="admin-modal admin-modal-wide">
         <h2 id="create-ppolicy-title">Create Prompt</h2>
-        <div id="cpp-error" role="alert" aria-live="assertive"></div>
+        <div id="cpp-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <label for="cpp-name"
           >Name <span class="label-hint">slug-style identifier</span></label
         >
@@ -2953,7 +2953,7 @@
     >
       <div id="edit-ppolicy-box" class="admin-modal admin-modal-wide">
         <h2 id="edit-ppolicy-title">Edit Prompt</h2>
-        <div id="epp-error" role="alert" aria-live="assertive"></div>
+        <div id="epp-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="epp-id" type="hidden" />
         <label for="epp-name">Name</label>
         <input id="epp-name" type="text" autocomplete="off" />
@@ -2997,7 +2997,7 @@
         <div
           id="create-template-error"
           role="alert"
-          aria-live="assertive"
+          aria-live="assertive" aria-atomic="true"
         ></div>
         <div class="skill-spec-body">
           <div class="skill-spec-col skill-spec-col-meta">
@@ -3314,7 +3314,7 @@
           class="skill-origin-badge"
           style="display: none"
         ></div>
-        <div id="edit-template-error" role="alert" aria-live="assertive"></div>
+        <div id="edit-template-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input id="etm-id" type="hidden" />
         <div class="skill-spec-body">
           <div class="skill-spec-col skill-spec-col-meta">
@@ -3635,7 +3635,7 @@
           id="mcp-create-error"
           role="alert"
           aria-live="assertive"
-          style="display: none"
+          aria-atomic="true"
         ></div>
         <input type="hidden" id="mcp-edit-id" value="" />
         <label for="mcp-name">Server Name</label>
@@ -3841,7 +3841,7 @@
           id="mcp-import-error"
           role="alert"
           aria-live="assertive"
-          style="display: none"
+          aria-atomic="true"
         ></div>
         <label for="mcp-import-json">Paste JSON</label>
         <textarea
@@ -3904,7 +3904,7 @@
           id="mcp-install-error"
           role="alert"
           aria-live="assertive"
-          style="display: none"
+          aria-atomic="true"
         ></div>
         <div id="mcp-install-summary"></div>
         <div id="mcp-install-source-select"></div>
@@ -3934,7 +3934,7 @@
     >
       <div id="model-create-box" class="admin-modal">
         <h2 id="model-create-title">Add Model</h2>
-        <div id="model-create-error" role="alert" aria-live="assertive"></div>
+        <div id="model-create-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input type="hidden" id="model-edit-id" value="" />
         <label for="model-alias">Alias</label>
         <input
@@ -4178,7 +4178,7 @@
     >
       <div id="coord-delete-box" class="ws-delete-modal-box">
         <h3 id="coord-delete-title">Delete Coordinators</h3>
-        <div id="coord-delete-error" role="alert" aria-live="assertive"></div>
+        <div id="coord-delete-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <p id="coord-delete-count"></p>
         <div id="coord-delete-list" class="ws-delete-modal-list"></div>
         <div id="coord-delete-buttons" class="ws-delete-modal-buttons">


### PR DESCRIPTION
## Summary

Follow-up sweep to PR #494, which fixed this bug class for the two skill modals. The console's CSS contract for modal errors is:

\`\`\`css
.admin-modal [role=\"alert\"]              { display: none; }
.admin-modal [role=\"alert\"].is-visible   { display: block; }
\`\`\`

…but ~30 sites across \`governance.js\` and \`admin.js\` toggled \`style.display = \"\"\` instead of the canonical class. The **show** side broke silently — clearing the inline style fell back to the CSS \`display: none\` rule, so validation errors never rendered. Net effect: clicking Save/Submit on any of these modals with bad input felt like an unresponsive button.

## What changed

**JS sweep** (commit \`10589b2\`) — mechanical conversion of every show/hide pair for these modal error elements:

- \`governance.js\` (11 modals): \`create-role-error\`, \`edit-role-error\`, \`create-policy-error\`, \`edit-policy-error\`, \`github-import-error\`, \`cpp-error\`, \`epp-error\`, \`create-hr-error\`, \`edit-hr-error\`, \`create-ogp-error\`, \`edit-ogp-error\`.
- \`admin.js\` (3 modals): \`mcp-create-error\`, \`mcp-import-error\`, \`mcp-install-error\`.
- \`_showModalError\` helper at \`admin.js:3210\` normalised: its \`style.display = \"block\"\` happened to work today (inline \`display: block\` beats the CSS rule), but moving to \`.is-visible\` keeps every modal on a single canonical path. Five modals route their show side through that helper (\`create-user\`, \`create-token\`, \`create-channel\`, \`create-schedule\`, \`edit-schedule\`); their hide sides converted in lockstep.
- Comment added on \`_showModalError\` documenting the contract so the next contributor doesn't reintroduce the bug.

**A11y uplift** (commit \`2a8a826\`) — added \`aria-atomic=\"true\"\` to all 24 modal error elements. With \`role=alert\` + \`aria-live=assertive\` alone, some AT engines only read the *diff* between old and new content when a validation error is replaced by a server error on retry. With \`aria-atomic\` the entire updated message is read each time. Same uplift across the board — no per-modal exceptions.

Also dropped stale \`style=\"display: none\"\` attributes on the three MCP error elements — the CSS rule already hides them by default, and the inline attribute would have overridden the \`.is-visible\` toggle if the class-based contract is ever changed.

## Implementation notes

- A Sonnet implementer agent did the mechanical JS conversion across both files (~30 call sites, +63/-51).
- A designer-review agent ran on the working tree before commit. Verdict: \"ship it\" with one quick win (the helper comment) — included. The optional follow-up they suggested (aria-atomic) is also included.

## Out of scope

- \`model-create-error\` — already uses the canonical class.
- \`home-coord-error\` — not inside \`.admin-modal\`, different context.
- \`edit-template-error\` / \`create-template-error\` — fixed in #494.

## Test plan

- [x] \`pytest tests/test_skills.py -k \"unlock or readonly\"\` — 11/11 passing
- [x] \`ruff check turnstone/\` — clean
- [x] Designer review: no transitions on \`.admin-modal [role=\"alert\"]\` so behaviour-equivalent visually; \`aria-live\` announcement timing improves (broken paths previously announced nothing — now both visibility and \`textContent\` mutation fire in the right order)
- [x] No \`-error.*style\\.display\` residuals in either file
- [ ] Manual smoke: trigger validation error in any of the converted modals (e.g. create role with empty name; create policy with bad regex; MCP import with bad JSON) — error renders red, fixing the input + clicking action again clears it, success closes the modal cleanly