### PR TITLE
feat(reasoning): optional per-model reasoning persistence

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -281,6 +281,7 @@ Each message in the `messages` array has:
 | `role`       | string            | `"user"`, `"assistant"`, or `"tool"`          |
 | `content`    | string or null    | Text content of the message                   |
 | `tool_calls` | array or null     | Present only on assistant messages with calls  |
+| `reasoning`  | string (optional) | Concatenated reasoning / chain-of-thought text on assistant turns whose `provider_data` carried reasoning-bearing blocks (Anthropic `thinking`, OpenAI Responses `reasoning`, or synthetic `reasoning_text` from local-model servers). Present only when the active model's `surface_persisted_reasoning` flag is True. |
 
 Each entry in `tool_calls`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -634,9 +634,9 @@ LLMProvider (protocol)
 
 | Type | Fields |
 |------|--------|
-| `StreamChunk` | `content_delta`, `reasoning_delta`, `tool_call_deltas`, `info_delta`, `usage`, `finish_reason` |
-| `CompletionResult` | `content`, `tool_calls`, `finish_reason`, `usage` |
-| `ModelCapabilities` | `context_window`, `max_output_tokens`, `supports_temperature`, `token_param`, `thinking_mode`, `supports_effort`, `supports_web_search`, `supports_tool_search`, `supports_vision` |
+| `StreamChunk` | `content_delta`, `reasoning_delta`, `tool_call_deltas`, `info_delta`, `usage`, `finish_reason`, `provider_blocks` |
+| `CompletionResult` | `content`, `tool_calls`, `finish_reason`, `usage`, `provider_blocks` |
+| `ModelCapabilities` | `context_window`, `max_output_tokens`, `supports_temperature`, `token_param`, `thinking_mode`, `supports_effort`, `supports_web_search`, `supports_tool_search`, `supports_vision`, `supports_reasoning_replay` |
 | `UsageInfo` | `prompt_tokens`, `completion_tokens`, `total_tokens`, `cache_creation_tokens`, `cache_read_tokens` |
 
 **OpenAIProvider** (`_openai.py`): passes messages through unchanged (they are
@@ -723,6 +723,35 @@ and `"openai-compatible"`.
 **Per-model sampling overrides:** Each model can specify `temperature`,
 `max_tokens`, and `reasoning_effort` to override the global defaults from
 ConfigStore. When unset (`NULL`), the global default is used.
+
+**Per-model reasoning persistence:** Two booleans on `model_definitions`
+(migration 052) control how reasoning text round-trips:
+
+* `surface_persisted_reasoning` (default `True`) — gates whether stored
+  reasoning text is surfaced on `/history` payloads for UI rehydration.
+  **Storage of reasoning bytes happens regardless of this flag** — they
+  ride in `provider_data` independently. Phase-1 admin UI label "Surface
+  persisted reasoning."
+* `replay_reasoning_to_model` (default `False`) — gates whether stored
+  reasoning blocks are sent back to the provider on subsequent turns.
+  Capability-gated: `ModelCapabilities.supports_reasoning_replay` must
+  also be `True` for the wire path to actually replay (canonical OpenAI
+  gpt-5*/o-series and Anthropic Claude entries set it; unknown / local-
+  server models default to `False`).
+
+Three reasoning paths are recognised:
+
+| Path | Provider | Capture | Persist | Replay |
+|------|----------|---------|---------|--------|
+| 1 | Anthropic Messages API | `thinking_delta` | `provider_blocks` (`type="thinking"`) | Verbatim via `_provider_content` |
+| 2 | OpenAI Responses (gpt-5*, o-series) | `response.reasoning_text.delta` events | `provider_blocks` (`type="reasoning"`) — only when `include=["reasoning.encrypted_content"]` | `ResponseReasoningItemParam` input items |
+| 3 | OpenAI Chat Completions (vLLM, llama.cpp, Gemini-compat) | `delta.reasoning_content` Pydantic extras | Synthetic `{type: "reasoning_text", text, source}` block stamped at end-of-stream | None — no API surface for replay on Chat Completions |
+
+Cross-provider safety is enforced by `ANTHROPIC_VALID_BLOCK_TYPES` (a
+shape filter in `_anthropic.py:_convert_messages`): foreign blocks
+(OpenAI `reasoning`, synthetic `reasoning_text`) fall through to the
+text+tool_calls rebuild path rather than reaching Anthropic's input
+boundary as malformed content.
 
 ```toml
 [models.local]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -629,6 +629,7 @@ LLMProvider (protocol)
 | `get_capabilities()` | Per-model flags (`ModelCapabilities`) |
 | `convert_tools()` | Translate OpenAI tool schemas to provider format |
 | `retryable_error_names` | Exception class names that trigger retry |
+| `extract_reasoning_text()` | Walk stored `provider_blocks`, return concatenated reasoning text for UI rehydration (per-provider block-type knowledge: Anthropic `thinking`, OpenAI Responses `reasoning`, OpenAI Chat synthetic `reasoning_text`) |
 
 **Normalized data types:**
 

--- a/docs/diagrams/03-core-engine-classes.puml
+++ b/docs/diagrams/03-core-engine-classes.puml
@@ -69,9 +69,10 @@ class "NullUI" as NullUI {
 interface "LLMProvider" as LLMProvider <<Protocol>> {
     + provider_name: str {property}
     + get_capabilities(model) → ModelCapabilities
-    + create_streaming(client, model, messages, ...) → Iterator[StreamChunk]
-    + create_completion(client, model, messages, ...) → CompletionResult
+    + create_streaming(client, model, messages, ..., replay_reasoning_to_model) → Iterator[StreamChunk]
+    + create_completion(client, model, messages, ..., replay_reasoning_to_model) → CompletionResult
     + convert_tools(tools) → list[dict]
+    + extract_reasoning_text(provider_blocks) → str
     + retryable_error_names: frozenset[str] {property}
     --
     core/providers/_protocol.py
@@ -126,6 +127,7 @@ class "ModelCapabilities" as ModelCaps <<frozen>> {
     + supports_web_search: bool
     + supports_tool_search: bool
     + supports_vision: bool
+    + supports_reasoning_replay: bool
 }
 
 ' ChatSession

--- a/docs/diagrams/png/03-core-engine-classes.png
+++ b/docs/diagrams/png/03-core-engine-classes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25b5448bbb7da8ddafe4f65c6c5e6cbcaa9cb9f31746ca46d3a2241bc47b1956
-size 259687
+oid sha256:9857db23fe3c4316d492073aac69c7e7558b1abe3b95ad7756d4a5933bd0ece7
+size 620214

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -59,6 +59,21 @@ from ConfigStore. Model names and context windows are now configured per-model
 in the Models tab. A startup warning is logged if these keys appear in
 `config.toml`.
 
+### Reasoning persistence (per-model)
+
+Two boolean flags on `model_definitions` (migration 052) control how
+reasoning text round-trips per model:
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `surface_persisted_reasoning` | `True` | Surface stored reasoning text on `/history` payloads so a page reload re-renders the reasoning bubble. **Storage of reasoning bytes is independent of this flag** — they ride in `provider_data` regardless. |
+| `replay_reasoning_to_model` | `False` | Send stored reasoning blocks back to the provider on subsequent turns. Capability-gated: only takes effect when the model's `ModelCapabilities.supports_reasoning_replay` is also `True`. Set on canonical OpenAI gpt-5*/o-series and Anthropic Claude entries; unknown / local-server models default to `False` so an operator who flips the flag on a model whose API doesn't understand reasoning replay silently no-ops rather than 400-ing. |
+
+Edit both via the admin Models tab. See the architecture doc for the
+provider-side mechanics (Anthropic `thinking`, OpenAI Responses
+`reasoning` + `include=["reasoning.encrypted_content"]`, synthetic
+`reasoning_text` for Chat Completions / vLLM / llama.cpp / Gemini-compat).
+
 ### Plan / task agent overrides
 
 `plan_agent` and `task_agent` sub-sessions resolve independently from the

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -22,8 +22,10 @@ export interface HistoryEvent {
    * - `reminders`: metacognitive nudge bubbles (user/tool channels)
    * - `advisories`: extracted `UserInterjection` payloads on tool turns
    * - `reasoning`: concatenated reasoning text for assistant turns whose
-   *   `provider_data` carried thinking blocks (Anthropic today). Present
-   *   only when the active model's `persist_reasoning` flag is true.
+   *   `provider_data` carried reasoning-bearing blocks (Anthropic
+   *   `thinking`, OpenAI Responses `reasoning`, or synthetic
+   *   `reasoning_text` from path-3 servers). Present only when the
+   *   active model's `surface_persisted_reasoning` flag is true.
    */
   messages: Array<Record<string, unknown>>;
 }

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -13,6 +13,18 @@ export interface ConnectedEvent {
 
 export interface HistoryEvent {
   type: "history";
+  /**
+   * Per-message dicts the frontend consumes directly. Common optional keys:
+   * - `role`: "user" | "assistant" | "tool"
+   * - `content`: string or list (image/document parts)
+   * - `tool_calls`: assistant turns — list of `{id, name, arguments, verdict?, output_assessment?}`
+   * - `tool_call_id`: tool turns — id of the originating call
+   * - `reminders`: metacognitive nudge bubbles (user/tool channels)
+   * - `advisories`: extracted `UserInterjection` payloads on tool turns
+   * - `reasoning`: concatenated reasoning text for assistant turns whose
+   *   `provider_data` carried thinking blocks (Anthropic today). Present
+   *   only when the active model's `persist_reasoning` flag is true.
+   */
   messages: Array<Record<string, unknown>>;
 }
 

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -1,0 +1,45 @@
+"""Shared session-test helpers.
+
+Two reasoning-test modules (``test_session_replay_reasoning.py`` and
+``test_session_synth_reasoning_block.py``) need the same minimal
+``ChatSession`` factory + a ``SessionUIBase`` no-op subclass.  Hoisting
+keeps a future third caller from drifting on the defaults — the third
+existing ``_make_session`` (``test_model_registry.py``) deliberately
+takes a different signature (registry / model_alias / reasoning_effort
++ ``_FakeUI``) and is NOT a candidate for sharing this helper.
+
+Module is named with a leading underscore so pytest doesn't try to
+collect it as a test file — it's an importable utility, not a test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from turnstone.core.session import ChatSession
+from turnstone.core.session_ui_base import SessionUIBase
+
+
+class NullUI(SessionUIBase):
+    """Bare-bones UI satisfying the SessionUIBase contract for tests
+    that don't care about UI side effects."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+def make_session(**kwargs: Any) -> ChatSession:
+    """Build a ChatSession with minimal defaults; tests override
+    individual fields via kwargs."""
+    defaults: dict[str, Any] = {
+        "client": MagicMock(),
+        "model": "test-model",
+        "ui": NullUI(),
+        "instructions": None,
+        "temperature": 0.5,
+        "max_tokens": 4096,
+        "tool_timeout": 30,
+    }
+    defaults.update(kwargs)
+    return ChatSession(**defaults)

--- a/tests/test_build_history_reminders.py
+++ b/tests/test_build_history_reminders.py
@@ -141,3 +141,126 @@ class TestRemindersWidening:
         }
         history = _build([msg])
         assert history[0]["reminders"] == [{"type": "denial", "text": "ok"}]
+
+
+class _StubRegistry:
+    """Minimal model registry — only ``get_config`` is read by
+    ``_build_history``."""
+
+    def __init__(self, persist_reasoning: bool = True) -> None:
+        self._cfg = SimpleNamespace(persist_reasoning=persist_reasoning)
+
+    def get_config(self, alias: str) -> Any:
+        return self._cfg
+
+
+def _build_with_registry(
+    messages: list[dict[str, Any]],
+    persist_reasoning: bool = True,
+) -> list[dict[str, Any]]:
+    session = SimpleNamespace(
+        messages=messages,
+        _ws_id="ws-test",
+        _registry=_StubRegistry(persist_reasoning=persist_reasoning),
+        _model_alias="claude-opus-4-7",
+    )
+    with patch(
+        "turnstone.server._load_verdict_indexes",
+        return_value=({}, {}),
+    ):
+        return _build_history(session)
+
+
+class TestReasoningSurfacing:
+    """Phase 1 — surface stored Anthropic thinking blocks on the
+    history payload so refresh-the-page rehydrates the reasoning bubble.
+    Drives through the real ``AnthropicProvider`` extractor (no mock-of-
+    extractor) — only the model registry is stubbed.
+    """
+
+    def test_reasoning_surfaces_for_anthropic_thinking_msg(self) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "let me think", "signature": "s"},
+                {"type": "text", "text": "Final answer."},
+            ],
+        }
+        history = _build_with_registry([msg], persist_reasoning=True)
+        assert len(history) == 1
+        assert history[0]["reasoning"] == "let me think"
+
+    def test_reasoning_empty_when_persist_flag_false(self) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "hidden", "signature": "s"},
+            ],
+        }
+        history = _build_with_registry([msg], persist_reasoning=False)
+        assert "reasoning" not in history[0]
+
+    def test_provider_content_never_in_wire_entry(self) -> None:
+        # The build path does not copy ``_provider_content`` into the
+        # entry dict regardless of flag — wire payload stays tight.
+        msg = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "x", "signature": "s"},
+            ],
+        }
+        history = _build_with_registry([msg], persist_reasoning=True)
+        assert "_provider_content" not in history[0]
+
+    def test_no_reasoning_field_when_provider_content_missing(self) -> None:
+        msg = {"role": "assistant", "content": "plain answer"}
+        history = _build_with_registry([msg], persist_reasoning=True)
+        assert "reasoning" not in history[0]
+
+    def test_no_reasoning_field_for_non_assistant_messages(self) -> None:
+        # Defensive — user/tool messages with a stray _provider_content
+        # do not get the reasoning field stamped.
+        msgs: list[dict[str, Any]] = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "out",
+                "_provider_content": [{"type": "thinking", "thinking": "leak", "signature": "s"}],
+            },
+        ]
+        history = _build_with_registry(msgs, persist_reasoning=True)
+        assert "reasoning" not in history[0]
+        assert "reasoning" not in history[1]
+
+    def test_default_true_when_registry_lookup_raises(self) -> None:
+        # Conservative default — Phase 1 spec mandates rehydration on
+        # refresh.  A registry/alias mismatch must not silently kill the
+        # bubble.
+        class BrokenRegistry:
+            def get_config(self, alias: str) -> Any:
+                raise KeyError(alias)
+
+        session = SimpleNamespace(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": "x",
+                    "_provider_content": [
+                        {"type": "thinking", "thinking": "still works", "signature": "s"}
+                    ],
+                }
+            ],
+            _ws_id="ws-test",
+            _registry=BrokenRegistry(),
+            _model_alias="missing-alias",
+        )
+        with patch(
+            "turnstone.server._load_verdict_indexes",
+            return_value=({}, {}),
+        ):
+            history = _build_history(session)
+        assert history[0]["reasoning"] == "still works"

--- a/tests/test_build_history_reminders.py
+++ b/tests/test_build_history_reminders.py
@@ -147,8 +147,8 @@ class _StubRegistry:
     """Minimal model registry — only ``get_config`` is read by
     ``_build_history``."""
 
-    def __init__(self, persist_reasoning: bool = True) -> None:
-        self._cfg = SimpleNamespace(persist_reasoning=persist_reasoning)
+    def __init__(self, surface_persisted_reasoning: bool = True) -> None:
+        self._cfg = SimpleNamespace(surface_persisted_reasoning=surface_persisted_reasoning)
 
     def get_config(self, alias: str) -> Any:
         return self._cfg
@@ -156,12 +156,12 @@ class _StubRegistry:
 
 def _build_with_registry(
     messages: list[dict[str, Any]],
-    persist_reasoning: bool = True,
+    surface_persisted_reasoning: bool = True,
 ) -> list[dict[str, Any]]:
     session = SimpleNamespace(
         messages=messages,
         _ws_id="ws-test",
-        _registry=_StubRegistry(persist_reasoning=persist_reasoning),
+        _registry=_StubRegistry(surface_persisted_reasoning=surface_persisted_reasoning),
         _model_alias="claude-opus-4-7",
     )
     with patch(
@@ -187,7 +187,7 @@ class TestReasoningSurfacing:
                 {"type": "text", "text": "Final answer."},
             ],
         }
-        history = _build_with_registry([msg], persist_reasoning=True)
+        history = _build_with_registry([msg], surface_persisted_reasoning=True)
         assert len(history) == 1
         assert history[0]["reasoning"] == "let me think"
 
@@ -199,7 +199,7 @@ class TestReasoningSurfacing:
                 {"type": "thinking", "thinking": "hidden", "signature": "s"},
             ],
         }
-        history = _build_with_registry([msg], persist_reasoning=False)
+        history = _build_with_registry([msg], surface_persisted_reasoning=False)
         assert "reasoning" not in history[0]
 
     def test_provider_content_never_in_wire_entry(self) -> None:
@@ -212,12 +212,12 @@ class TestReasoningSurfacing:
                 {"type": "thinking", "thinking": "x", "signature": "s"},
             ],
         }
-        history = _build_with_registry([msg], persist_reasoning=True)
+        history = _build_with_registry([msg], surface_persisted_reasoning=True)
         assert "_provider_content" not in history[0]
 
     def test_no_reasoning_field_when_provider_content_missing(self) -> None:
         msg = {"role": "assistant", "content": "plain answer"}
-        history = _build_with_registry([msg], persist_reasoning=True)
+        history = _build_with_registry([msg], surface_persisted_reasoning=True)
         assert "reasoning" not in history[0]
 
     def test_no_reasoning_field_for_non_assistant_messages(self) -> None:
@@ -232,7 +232,7 @@ class TestReasoningSurfacing:
                 "_provider_content": [{"type": "thinking", "thinking": "leak", "signature": "s"}],
             },
         ]
-        history = _build_with_registry(msgs, persist_reasoning=True)
+        history = _build_with_registry(msgs, surface_persisted_reasoning=True)
         assert "reasoning" not in history[0]
         assert "reasoning" not in history[1]
 

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -518,12 +518,12 @@ class TestExtractReasoningForHistory:
         extract_reasoning_for_history(messages, persist_reasoning_flag=True)
         assert messages[0]["reasoning"] == "first"
 
-    def test_first_block_reasoning_dispatches_to_openai_phase3_stub(self) -> None:
-        # OpenAI Responses extractor returns "" until Phase 3 wires
-        # ``include=["reasoning.encrypted_content"]``.  The dispatcher
-        # must still route to it (not silently fall through to "").
-        # We assert the dispatcher routed by checking the strip happens
-        # AND no reasoning field is added (because the stub returns "").
+    def test_first_block_reasoning_dispatches_to_openai_responses(self) -> None:
+        # Phase 3: dispatcher routes type=="reasoning" to the
+        # OpenAI Responses extractor, which now returns the
+        # summary[*].text concatenation.  Pre-Phase-3 this asserted
+        # "" (the stub); the assertion was tightened once the wire
+        # path landed.
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [
@@ -536,7 +536,7 @@ class TestExtractReasoningForHistory:
             }
         ]
         extract_reasoning_for_history(messages, persist_reasoning_flag=True)
-        assert "reasoning" not in messages[0]
+        assert messages[0]["reasoning"] == "s"
         assert "_provider_content" not in messages[0]
 
     def test_unknown_first_block_type_no_op(self) -> None:
@@ -595,4 +595,24 @@ class TestExtractReasoningForHistory:
         ]
         extract_reasoning_for_history(messages, persist_reasoning_flag=True)
         assert "reasoning" not in messages[0]
+        assert "_provider_content" not in messages[0]
+
+    def test_first_block_reasoning_text_dispatches_to_openai_chat(self) -> None:
+        # Phase 3 path 3: synthetic ``reasoning_text`` blocks (stamped
+        # by ChatSession._maybe_synth_reasoning_block for vLLM /
+        # llama.cpp / Gemini-compat conversations) dispatch to
+        # OpenAIChatCompletionsProvider.extract_reasoning_text.
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_provider_content": [
+                    {"type": "reasoning_text", "text": "synth thought", "source": "vllm"},
+                ],
+            }
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert messages[0]["reasoning"] == "synth thought"
         assert "_provider_content" not in messages[0]

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -453,3 +453,146 @@ class TestDecorateAdvisoryExtraction:
         assert tool_msg["advisories"] == [
             {"type": "user_interjection", "text": "check the logs", "priority": "notice"}
         ]
+
+
+class TestExtractReasoningForHistory:
+    """``extract_reasoning_for_history`` — Phase 1 surfaces stored
+    Anthropic thinking blocks on assistant messages and strips
+    ``_provider_content`` from the wire payload.
+
+    Drives through the real ``AnthropicProvider.extract_reasoning_text``
+    (no mock-of-extractor) — the helper test and the provider unit
+    test (``tests/test_provider_anthropic_reasoning.py``) together
+    catch a regression at either layer distinctly.
+    """
+
+    def _anthropic_thinking_msg(self, text: str = "let me think") -> dict[str, object]:
+        return {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": text, "signature": "sig"},
+                {"type": "text", "text": "Final answer."},
+            ],
+        }
+
+    def test_extract_thinking_surfaces_reasoning_field(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [self._anthropic_thinking_msg("let me think")]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert messages[0]["reasoning"] == "let me think"
+
+    def test_strips_provider_content_after_extraction(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [self._anthropic_thinking_msg("anything")]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "_provider_content" not in messages[0]
+
+    def test_strips_provider_content_when_flag_false(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [self._anthropic_thinking_msg("anything")]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=False)
+        # Strip is unconditional; reasoning is the conditional bit.
+        assert "_provider_content" not in messages[0]
+        assert "reasoning" not in messages[0]
+
+    def test_first_block_thinking_dispatches_to_anthropic(self) -> None:
+        # Even when text and tool_use blocks follow, the first-block-type
+        # discriminator routes thinking-prefixed payloads correctly.
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": [
+                    {"type": "thinking", "thinking": "first", "signature": "s"},
+                    {"type": "text", "text": "spoken"},
+                    {"type": "tool_use", "id": "t1", "name": "f", "input": {}},
+                ],
+            }
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert messages[0]["reasoning"] == "first"
+
+    def test_first_block_reasoning_dispatches_to_openai_phase3_stub(self) -> None:
+        # OpenAI Responses extractor returns "" until Phase 3 wires
+        # ``include=["reasoning.encrypted_content"]``.  The dispatcher
+        # must still route to it (not silently fall through to "").
+        # We assert the dispatcher routed by checking the strip happens
+        # AND no reasoning field is added (because the stub returns "").
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": [
+                    {"type": "reasoning", "summary": [{"type": "summary_text", "text": "s"}]}
+                ],
+            }
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        assert "_provider_content" not in messages[0]
+
+    def test_unknown_first_block_type_no_op(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": [{"type": "text", "text": "no reasoning here"}],
+            }
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        assert "_provider_content" not in messages[0]
+
+    def test_skips_messages_without_provider_content(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [{"role": "assistant", "content": "plain"}]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        assert messages[0]["content"] == "plain"
+
+    def test_user_and_tool_messages_untouched(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages: list[dict[str, object]] = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "c1", "content": "out"},
+            self._anthropic_thinking_msg("only this one"),
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        assert "reasoning" not in messages[1]
+        assert messages[2]["reasoning"] == "only this one"
+
+    def test_empty_provider_content_no_extraction(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [{"role": "assistant", "content": "x", "_provider_content": []}]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        # Empty-list provider_content is still stripped from the wire.
+        assert "_provider_content" not in messages[0]
+
+    def test_first_block_not_a_dict_skipped(self) -> None:
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages: list[dict[str, object]] = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": ["bogus"],
+            }
+        ]
+        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        assert "reasoning" not in messages[0]
+        assert "_provider_content" not in messages[0]

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -617,6 +617,36 @@ class TestExtractReasoningForHistory:
         assert messages[0]["reasoning"] == "synth thought"
         assert "_provider_content" not in messages[0]
 
+    def test_dispatcher_scans_past_unrecognized_first_blocks(self) -> None:
+        # Regression for Copilot finding: dispatcher used to inspect
+        # only provider_content[0]['type'].  OpenAI Responses captures
+        # EVERY output_item.done event into provider_blocks (not just
+        # reasoning), so a hypothetical [message, reasoning, ...]
+        # ordering would have silently dropped the reasoning.  Now
+        # walks the list for the first recognised reasoning-bearing
+        # type and dispatches the whole list to that provider.
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_provider_content": [
+                    # First block is a non-reasoning OpenAI Responses item.
+                    {"type": "message", "role": "assistant", "content": "answer"},
+                    # Reasoning sits later in the list.
+                    {
+                        "type": "reasoning",
+                        "id": "r_1",
+                        "summary": [{"type": "summary_text", "text": "deferred"}],
+                    },
+                ],
+            }
+        ]
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
+        assert messages[0]["reasoning"] == "deferred"
+        assert "_provider_content" not in messages[0]
+
     def test_first_block_redacted_thinking_dispatches_to_anthropic(self) -> None:
         # Anthropic's extended-thinking API documents that
         # ``redacted_thinking`` blocks (sealed by the safety system)

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -480,21 +480,21 @@ class TestExtractReasoningForHistory:
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [self._anthropic_thinking_msg("let me think")]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert messages[0]["reasoning"] == "let me think"
 
     def test_strips_provider_content_after_extraction(self) -> None:
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [self._anthropic_thinking_msg("anything")]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "_provider_content" not in messages[0]
 
     def test_strips_provider_content_when_flag_false(self) -> None:
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [self._anthropic_thinking_msg("anything")]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=False)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=False)
         # Strip is unconditional; reasoning is the conditional bit.
         assert "_provider_content" not in messages[0]
         assert "reasoning" not in messages[0]
@@ -515,7 +515,7 @@ class TestExtractReasoningForHistory:
                 ],
             }
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert messages[0]["reasoning"] == "first"
 
     def test_first_block_reasoning_dispatches_to_openai_responses(self) -> None:
@@ -535,7 +535,7 @@ class TestExtractReasoningForHistory:
                 ],
             }
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert messages[0]["reasoning"] == "s"
         assert "_provider_content" not in messages[0]
 
@@ -549,7 +549,7 @@ class TestExtractReasoningForHistory:
                 "_provider_content": [{"type": "text", "text": "no reasoning here"}],
             }
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "reasoning" not in messages[0]
         assert "_provider_content" not in messages[0]
 
@@ -557,7 +557,7 @@ class TestExtractReasoningForHistory:
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [{"role": "assistant", "content": "plain"}]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "reasoning" not in messages[0]
         assert messages[0]["content"] == "plain"
 
@@ -569,7 +569,7 @@ class TestExtractReasoningForHistory:
             {"role": "tool", "tool_call_id": "c1", "content": "out"},
             self._anthropic_thinking_msg("only this one"),
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "reasoning" not in messages[0]
         assert "reasoning" not in messages[1]
         assert messages[2]["reasoning"] == "only this one"
@@ -578,7 +578,7 @@ class TestExtractReasoningForHistory:
         from turnstone.core.history_decoration import extract_reasoning_for_history
 
         messages = [{"role": "assistant", "content": "x", "_provider_content": []}]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "reasoning" not in messages[0]
         # Empty-list provider_content is still stripped from the wire.
         assert "_provider_content" not in messages[0]
@@ -593,7 +593,7 @@ class TestExtractReasoningForHistory:
                 "_provider_content": ["bogus"],
             }
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert "reasoning" not in messages[0]
         assert "_provider_content" not in messages[0]
 
@@ -613,6 +613,35 @@ class TestExtractReasoningForHistory:
                 ],
             }
         ]
-        extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert messages[0]["reasoning"] == "synth thought"
+        assert "_provider_content" not in messages[0]
+
+    def test_first_block_redacted_thinking_dispatches_to_anthropic(self) -> None:
+        # Anthropic's extended-thinking API documents that
+        # ``redacted_thinking`` blocks (sealed by the safety system)
+        # can appear before, after, or interleaved with regular
+        # ``thinking`` blocks.  When the redacted block lands first,
+        # the dispatcher must still route to AnthropicProvider so the
+        # surrounding real thinking text surfaces — without this the
+        # reasoning bubble silently disappears on history rehydration.
+        # Pinned by registering "redacted_thinking" as a second key
+        # in _BLOCK_TYPE_PROVIDER_FACTORY pointing at the Anthropic
+        # factory; Anthropic's extractor's type=="thinking" filter
+        # already correctly skips the redacted block.
+        from turnstone.core.history_decoration import extract_reasoning_for_history
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_provider_content": [
+                    {"type": "redacted_thinking", "data": "sealed-blob"},
+                    {"type": "thinking", "thinking": "real thought", "signature": "s"},
+                    {"type": "text", "text": "answer"},
+                ],
+            }
+        ]
+        extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
+        assert messages[0]["reasoning"] == "real thought"
         assert "_provider_content" not in messages[0]

--- a/tests/test_model_definition_storage.py
+++ b/tests/test_model_definition_storage.py
@@ -214,12 +214,12 @@ class TestModelDefinitionStorage:
         assert m["temperature"] is None
 
     def test_reasoning_flags_default(self, db: SQLiteBackend) -> None:
-        """persist_reasoning defaults True; replay_reasoning_to_model defaults False."""
+        """surface_persisted_reasoning defaults True; replay_reasoning_to_model defaults False."""
         did = _make_id()
         db.create_model_definition(definition_id=did, alias="reason-default", model="gpt-5")
         m = db.get_model_definition(did)
         assert m is not None
-        assert m["persist_reasoning"] is True
+        assert m["surface_persisted_reasoning"] is True
         assert m["replay_reasoning_to_model"] is False
 
     def test_create_with_explicit_reasoning_flags(self, db: SQLiteBackend) -> None:
@@ -228,27 +228,27 @@ class TestModelDefinitionStorage:
             definition_id=did,
             alias="reason-explicit",
             model="claude-opus-4-7",
-            persist_reasoning=False,
+            surface_persisted_reasoning=False,
             replay_reasoning_to_model=True,
         )
         m = db.get_model_definition(did)
         assert m is not None
-        assert m["persist_reasoning"] is False
+        assert m["surface_persisted_reasoning"] is False
         assert m["replay_reasoning_to_model"] is True
         # Same values must round-trip via the alias lookup too.
         m_alias = db.get_model_definition_by_alias("reason-explicit")
         assert m_alias is not None
-        assert m_alias["persist_reasoning"] is False
+        assert m_alias["surface_persisted_reasoning"] is False
         assert m_alias["replay_reasoning_to_model"] is True
 
-    def test_update_persist_reasoning(self, db: SQLiteBackend) -> None:
+    def test_update_surface_persisted_reasoning(self, db: SQLiteBackend) -> None:
         did = _make_id()
         db.create_model_definition(definition_id=did, alias="upd-persist", model="gpt-5")
-        ok = db.update_model_definition(did, persist_reasoning=False)
+        ok = db.update_model_definition(did, surface_persisted_reasoning=False)
         assert ok is True
         m = db.get_model_definition(did)
         assert m is not None
-        assert m["persist_reasoning"] is False
+        assert m["surface_persisted_reasoning"] is False
         assert m["replay_reasoning_to_model"] is False  # untouched
 
     def test_update_replay_reasoning_to_model(self, db: SQLiteBackend) -> None:
@@ -258,7 +258,7 @@ class TestModelDefinitionStorage:
         assert ok is True
         m = db.get_model_definition(did)
         assert m is not None
-        assert m["persist_reasoning"] is True  # untouched
+        assert m["surface_persisted_reasoning"] is True  # untouched
         assert m["replay_reasoning_to_model"] is True
 
     def test_list_returns_reasoning_flags(self, db: SQLiteBackend) -> None:
@@ -266,19 +266,19 @@ class TestModelDefinitionStorage:
             definition_id=_make_id(),
             alias="list-a",
             model="gpt-5",
-            persist_reasoning=True,
+            surface_persisted_reasoning=True,
             replay_reasoning_to_model=False,
         )
         db.create_model_definition(
             definition_id=_make_id(),
             alias="list-b",
             model="claude-opus-4-7",
-            persist_reasoning=False,
+            surface_persisted_reasoning=False,
             replay_reasoning_to_model=True,
         )
         models = db.list_model_definitions()
         by_alias = {m["alias"]: m for m in models}
-        assert by_alias["list-a"]["persist_reasoning"] is True
+        assert by_alias["list-a"]["surface_persisted_reasoning"] is True
         assert by_alias["list-a"]["replay_reasoning_to_model"] is False
-        assert by_alias["list-b"]["persist_reasoning"] is False
+        assert by_alias["list-b"]["surface_persisted_reasoning"] is False
         assert by_alias["list-b"]["replay_reasoning_to_model"] is True

--- a/tests/test_model_definition_storage.py
+++ b/tests/test_model_definition_storage.py
@@ -212,3 +212,73 @@ class TestModelDefinitionStorage:
         m = db.get_model_definition(did)
         assert m is not None
         assert m["temperature"] is None
+
+    def test_reasoning_flags_default(self, db: SQLiteBackend) -> None:
+        """persist_reasoning defaults True; replay_reasoning_to_model defaults False."""
+        did = _make_id()
+        db.create_model_definition(definition_id=did, alias="reason-default", model="gpt-5")
+        m = db.get_model_definition(did)
+        assert m is not None
+        assert m["persist_reasoning"] is True
+        assert m["replay_reasoning_to_model"] is False
+
+    def test_create_with_explicit_reasoning_flags(self, db: SQLiteBackend) -> None:
+        did = _make_id()
+        db.create_model_definition(
+            definition_id=did,
+            alias="reason-explicit",
+            model="claude-opus-4-7",
+            persist_reasoning=False,
+            replay_reasoning_to_model=True,
+        )
+        m = db.get_model_definition(did)
+        assert m is not None
+        assert m["persist_reasoning"] is False
+        assert m["replay_reasoning_to_model"] is True
+        # Same values must round-trip via the alias lookup too.
+        m_alias = db.get_model_definition_by_alias("reason-explicit")
+        assert m_alias is not None
+        assert m_alias["persist_reasoning"] is False
+        assert m_alias["replay_reasoning_to_model"] is True
+
+    def test_update_persist_reasoning(self, db: SQLiteBackend) -> None:
+        did = _make_id()
+        db.create_model_definition(definition_id=did, alias="upd-persist", model="gpt-5")
+        ok = db.update_model_definition(did, persist_reasoning=False)
+        assert ok is True
+        m = db.get_model_definition(did)
+        assert m is not None
+        assert m["persist_reasoning"] is False
+        assert m["replay_reasoning_to_model"] is False  # untouched
+
+    def test_update_replay_reasoning_to_model(self, db: SQLiteBackend) -> None:
+        did = _make_id()
+        db.create_model_definition(definition_id=did, alias="upd-replay", model="gpt-5")
+        ok = db.update_model_definition(did, replay_reasoning_to_model=True)
+        assert ok is True
+        m = db.get_model_definition(did)
+        assert m is not None
+        assert m["persist_reasoning"] is True  # untouched
+        assert m["replay_reasoning_to_model"] is True
+
+    def test_list_returns_reasoning_flags(self, db: SQLiteBackend) -> None:
+        db.create_model_definition(
+            definition_id=_make_id(),
+            alias="list-a",
+            model="gpt-5",
+            persist_reasoning=True,
+            replay_reasoning_to_model=False,
+        )
+        db.create_model_definition(
+            definition_id=_make_id(),
+            alias="list-b",
+            model="claude-opus-4-7",
+            persist_reasoning=False,
+            replay_reasoning_to_model=True,
+        )
+        models = db.list_model_definitions()
+        by_alias = {m["alias"]: m for m in models}
+        assert by_alias["list-a"]["persist_reasoning"] is True
+        assert by_alias["list-a"]["replay_reasoning_to_model"] is False
+        assert by_alias["list-b"]["persist_reasoning"] is False
+        assert by_alias["list-b"]["replay_reasoning_to_model"] is True

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -78,7 +78,7 @@ class TestModelConfig:
 
     def test_reasoning_flags_default(self) -> None:
         cfg = ModelConfig(alias="x", base_url="x", api_key="x", model="x")
-        assert cfg.persist_reasoning is True
+        assert cfg.surface_persisted_reasoning is True
         assert cfg.replay_reasoning_to_model is False
 
     def test_reasoning_flags_set(self) -> None:
@@ -87,10 +87,10 @@ class TestModelConfig:
             base_url="x",
             api_key="x",
             model="x",
-            persist_reasoning=False,
+            surface_persisted_reasoning=False,
             replay_reasoning_to_model=True,
         )
-        assert cfg.persist_reasoning is False
+        assert cfg.surface_persisted_reasoning is False
         assert cfg.replay_reasoning_to_model is True
 
 
@@ -716,7 +716,7 @@ class TestLoadModelRegistryWithDB:
                     "context_window": 200000,
                     "capabilities": "{}",
                     "enabled": True,
-                    "persist_reasoning": False,
+                    "surface_persisted_reasoning": False,
                     "replay_reasoning_to_model": True,
                 }
             ]
@@ -724,7 +724,7 @@ class TestLoadModelRegistryWithDB:
         with patch("turnstone.core.model_registry.load_config", return_value={}):
             reg = load_model_registry("http://x/v1", "x", "x", storage=storage)
         cfg = reg.get_config("anth-thinking")
-        assert cfg.persist_reasoning is False
+        assert cfg.surface_persisted_reasoning is False
         assert cfg.replay_reasoning_to_model is True
 
     def test_db_reasoning_flags_default_when_absent(self) -> None:
@@ -740,14 +740,14 @@ class TestLoadModelRegistryWithDB:
                     "context_window": 32768,
                     "capabilities": "{}",
                     "enabled": True,
-                    # persist_reasoning + replay_reasoning_to_model intentionally absent
+                    # surface_persisted_reasoning + replay_reasoning_to_model intentionally absent
                 }
             ]
         )
         with patch("turnstone.core.model_registry.load_config", return_value={}):
             reg = load_model_registry("http://x/v1", "x", "x", storage=storage)
         cfg = reg.get_config("legacy-row")
-        assert cfg.persist_reasoning is True
+        assert cfg.surface_persisted_reasoning is True
         assert cfg.replay_reasoning_to_model is False
 
     def test_db_default_alias_not_clobbered(self) -> None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -76,6 +76,23 @@ class TestModelConfig:
         assert cfg.temperature == 0.0
         assert cfg.temperature is not None
 
+    def test_reasoning_flags_default(self) -> None:
+        cfg = ModelConfig(alias="x", base_url="x", api_key="x", model="x")
+        assert cfg.persist_reasoning is True
+        assert cfg.replay_reasoning_to_model is False
+
+    def test_reasoning_flags_set(self) -> None:
+        cfg = ModelConfig(
+            alias="x",
+            base_url="x",
+            api_key="x",
+            model="x",
+            persist_reasoning=False,
+            replay_reasoning_to_model=True,
+        )
+        assert cfg.persist_reasoning is False
+        assert cfg.replay_reasoning_to_model is True
+
 
 # ---------------------------------------------------------------------------
 # ModelRegistry
@@ -685,6 +702,53 @@ class TestLoadModelRegistryWithDB:
         assert cfg.temperature is None
         assert cfg.max_tokens is None
         assert cfg.reasoning_effort is None
+
+    def test_db_reasoning_flags_loaded(self) -> None:
+        """Per-model reasoning flags from DB are carried in ModelConfig."""
+        storage = _MockStorage(
+            [
+                {
+                    "alias": "anth-thinking",
+                    "model": "claude-opus-4-7",
+                    "provider": "anthropic",
+                    "base_url": "",
+                    "api_key": "sk-anth",
+                    "context_window": 200000,
+                    "capabilities": "{}",
+                    "enabled": True,
+                    "persist_reasoning": False,
+                    "replay_reasoning_to_model": True,
+                }
+            ]
+        )
+        with patch("turnstone.core.model_registry.load_config", return_value={}):
+            reg = load_model_registry("http://x/v1", "x", "x", storage=storage)
+        cfg = reg.get_config("anth-thinking")
+        assert cfg.persist_reasoning is False
+        assert cfg.replay_reasoning_to_model is True
+
+    def test_db_reasoning_flags_default_when_absent(self) -> None:
+        """Pre-052 rows without the columns degrade to dataclass defaults."""
+        storage = _MockStorage(
+            [
+                {
+                    "alias": "legacy-row",
+                    "model": "gpt-5",
+                    "provider": "openai",
+                    "base_url": "",
+                    "api_key": "",
+                    "context_window": 32768,
+                    "capabilities": "{}",
+                    "enabled": True,
+                    # persist_reasoning + replay_reasoning_to_model intentionally absent
+                }
+            ]
+        )
+        with patch("turnstone.core.model_registry.load_config", return_value={}):
+            reg = load_model_registry("http://x/v1", "x", "x", storage=storage)
+        cfg = reg.get_config("legacy-row")
+        assert cfg.persist_reasoning is True
+        assert cfg.replay_reasoning_to_model is False
 
     def test_db_default_alias_not_clobbered(self) -> None:
         """DB model with alias='default' is not overwritten by CLI args."""

--- a/tests/test_provider_anthropic_reasoning.py
+++ b/tests/test_provider_anthropic_reasoning.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 
 import pytest
 
-from turnstone.core.providers._anthropic import (
-    _MAX_REASONING_DISPLAY_BYTES,
-    AnthropicProvider,
-)
+from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.providers._protocol import (
+    MAX_REASONING_DISPLAY_BYTES as _MAX_REASONING_DISPLAY_BYTES,
+)
 
 
 @pytest.fixture
@@ -115,9 +115,11 @@ class TestOtherProvidersDefault:
         blocks = [{"type": "thinking", "thinking": "would-be-text", "signature": "s"}]
         assert provider.extract_reasoning_text(blocks) == ""
 
-    def test_openai_responses_returns_empty_on_reasoning_shaped_blocks(self) -> None:
-        # Phase 3 stub — reasoning items exist but extractor returns ""
-        # until ``include=["reasoning.encrypted_content"]`` is wired.
+    def test_openai_responses_extracts_reasoning_summary(self) -> None:
+        # Phase 3: extractor now walks reasoning items captured via
+        # include=["reasoning.encrypted_content"] and returns the
+        # summary[*].text concatenation.  Pre-Phase-3 this returned
+        # "" — the stub was replaced once the wire path landed.
         provider = OpenAIResponsesProvider()
         blocks = [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "x"}]}]
-        assert provider.extract_reasoning_text(blocks) == ""
+        assert provider.extract_reasoning_text(blocks) == "x"

--- a/tests/test_provider_anthropic_reasoning.py
+++ b/tests/test_provider_anthropic_reasoning.py
@@ -21,7 +21,7 @@ from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
 from turnstone.core.providers._protocol import (
-    MAX_REASONING_DISPLAY_BYTES as _MAX_REASONING_DISPLAY_BYTES,
+    MAX_REASONING_DISPLAY_CHARS as _MAX_REASONING_DISPLAY_CHARS,
 )
 
 
@@ -77,13 +77,13 @@ class TestExtractReasoningText:
         assert anthropic.extract_reasoning_text(blocks) == ""
 
     def test_truncation_at_64kib_cap(self, anthropic: AnthropicProvider) -> None:
-        long_text = "x" * (_MAX_REASONING_DISPLAY_BYTES + 1024)
+        long_text = "x" * (_MAX_REASONING_DISPLAY_CHARS + 1024)
         blocks = [{"type": "thinking", "thinking": long_text, "signature": "s"}]
         result = anthropic.extract_reasoning_text(blocks)
-        assert len(result) == _MAX_REASONING_DISPLAY_BYTES
+        assert len(result) == _MAX_REASONING_DISPLAY_CHARS
 
     def test_just_under_cap_not_truncated(self, anthropic: AnthropicProvider) -> None:
-        text = "y" * (_MAX_REASONING_DISPLAY_BYTES - 1)
+        text = "y" * (_MAX_REASONING_DISPLAY_CHARS - 1)
         blocks = [{"type": "thinking", "thinking": text, "signature": "s"}]
         assert anthropic.extract_reasoning_text(blocks) == text
 

--- a/tests/test_provider_anthropic_reasoning.py
+++ b/tests/test_provider_anthropic_reasoning.py
@@ -1,0 +1,123 @@
+"""Tests for ``AnthropicProvider.extract_reasoning_text``.
+
+Phase 1 of the optional-reasoning-persistence feature: provider-side
+extractor that walks stored ``provider_blocks`` and returns the
+concatenated thinking text, capped at the operator-friendly UI display
+size.
+
+These tests drive through the real ``AnthropicProvider`` instance — no
+mocks of the extractor itself — using fixture-shaped blocks that match
+what ``_iter_anthropic_stream`` actually accumulates at
+``_anthropic.py:713-724`` (``thinking_delta`` + ``signature_delta``
+combined into ``{"type": "thinking", "thinking": <text>, "signature":
+<sig>}``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.providers._anthropic import (
+    _MAX_REASONING_DISPLAY_BYTES,
+    AnthropicProvider,
+)
+from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+
+@pytest.fixture
+def anthropic() -> AnthropicProvider:
+    return AnthropicProvider()
+
+
+class TestExtractReasoningText:
+    def test_none_input_returns_empty_string(self, anthropic: AnthropicProvider) -> None:
+        assert anthropic.extract_reasoning_text(None) == ""
+
+    def test_empty_list_returns_empty_string(self, anthropic: AnthropicProvider) -> None:
+        assert anthropic.extract_reasoning_text([]) == ""
+
+    def test_no_thinking_blocks_returns_empty(self, anthropic: AnthropicProvider) -> None:
+        blocks: list[dict[str, object]] = [
+            {"type": "text", "text": "hello"},
+            {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+        ]
+        assert anthropic.extract_reasoning_text(blocks) == ""
+
+    def test_single_thinking_block_returns_text(self, anthropic: AnthropicProvider) -> None:
+        blocks = [{"type": "thinking", "thinking": "Let me think about this.", "signature": "abc"}]
+        assert anthropic.extract_reasoning_text(blocks) == "Let me think about this."
+
+    def test_multiple_thinking_blocks_joined_with_newline(
+        self, anthropic: AnthropicProvider
+    ) -> None:
+        blocks = [
+            {"type": "thinking", "thinking": "first thought", "signature": "s1"},
+            {"type": "thinking", "thinking": "second thought", "signature": "s2"},
+        ]
+        assert anthropic.extract_reasoning_text(blocks) == "first thought\nsecond thought"
+
+    def test_mixed_blocks_extracts_only_thinking(self, anthropic: AnthropicProvider) -> None:
+        blocks = [
+            {"type": "thinking", "thinking": "reason A", "signature": "s"},
+            {"type": "text", "text": "visible answer"},
+            {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+            {"type": "thinking", "thinking": "reason B", "signature": "s"},
+        ]
+        assert anthropic.extract_reasoning_text(blocks) == "reason A\nreason B"
+
+    def test_thinking_block_without_thinking_field_skipped(
+        self, anthropic: AnthropicProvider
+    ) -> None:
+        blocks = [{"type": "thinking", "signature": "s"}]
+        assert anthropic.extract_reasoning_text(blocks) == ""
+
+    def test_thinking_block_with_empty_text_skipped(self, anthropic: AnthropicProvider) -> None:
+        blocks = [{"type": "thinking", "thinking": "", "signature": "s"}]
+        assert anthropic.extract_reasoning_text(blocks) == ""
+
+    def test_truncation_at_64kib_cap(self, anthropic: AnthropicProvider) -> None:
+        long_text = "x" * (_MAX_REASONING_DISPLAY_BYTES + 1024)
+        blocks = [{"type": "thinking", "thinking": long_text, "signature": "s"}]
+        result = anthropic.extract_reasoning_text(blocks)
+        assert len(result) == _MAX_REASONING_DISPLAY_BYTES
+
+    def test_just_under_cap_not_truncated(self, anthropic: AnthropicProvider) -> None:
+        text = "y" * (_MAX_REASONING_DISPLAY_BYTES - 1)
+        blocks = [{"type": "thinking", "thinking": text, "signature": "s"}]
+        assert anthropic.extract_reasoning_text(blocks) == text
+
+    def test_malformed_block_entry_skipped(self, anthropic: AnthropicProvider) -> None:
+        # A defensive sanity check — we should not crash if some
+        # entry isn't a dict (e.g. a corrupted JSON payload).
+        blocks = [
+            "not a dict",  # type: ignore[list-item]
+            {"type": "thinking", "thinking": "good one", "signature": "s"},
+        ]
+        assert anthropic.extract_reasoning_text(blocks) == "good one"  # type: ignore[arg-type]
+
+    def test_non_list_input_returns_empty(self, anthropic: AnthropicProvider) -> None:
+        # Defensive against a corrupted provider_data payload.
+        assert anthropic.extract_reasoning_text("not a list") == ""  # type: ignore[arg-type]
+        assert anthropic.extract_reasoning_text({"type": "thinking"}) == ""  # type: ignore[arg-type]
+
+
+class TestOtherProvidersDefault:
+    """Non-Anthropic providers return "" for the same fixture shapes."""
+
+    def test_openai_chat_returns_empty(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [{"type": "thinking", "thinking": "would-be-text", "signature": "s"}]
+        assert provider.extract_reasoning_text(blocks) == ""
+
+    def test_openai_responses_returns_empty(self) -> None:
+        provider = OpenAIResponsesProvider()
+        blocks = [{"type": "thinking", "thinking": "would-be-text", "signature": "s"}]
+        assert provider.extract_reasoning_text(blocks) == ""
+
+    def test_openai_responses_returns_empty_on_reasoning_shaped_blocks(self) -> None:
+        # Phase 3 stub — reasoning items exist but extractor returns ""
+        # until ``include=["reasoning.encrypted_content"]`` is wired.
+        provider = OpenAIResponsesProvider()
+        blocks = [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "x"}]}]
+        assert provider.extract_reasoning_text(blocks) == ""

--- a/tests/test_provider_anthropic_replay.py
+++ b/tests/test_provider_anthropic_replay.py
@@ -4,11 +4,12 @@ Phase 2 of optional reasoning persistence wraps the verbatim
 ``_provider_content`` replay path at ``_anthropic.py:_convert_messages``
 with two gates:
 
-1. ``ANTHROPIC_VALID_BLOCK_TYPES`` shape filter — foreign-shaped
-   blocks (OpenAI Responses ``type="reasoning"`` after Phase 3 lands,
-   Gemini thought parts, anything else) fall through to the
-   text+tool_calls rebuild path rather than 400-ing the API.  Closes
-   a pre-existing latent bug.
+1. ``ANTHROPIC_VALID_BLOCK_TYPES`` per-block shape filter — foreign-
+   shaped blocks (OpenAI Responses ``type="reasoning"``, Gemini thought
+   parts, the synthetic ``reasoning_text`` from path-3 capture) are
+   dropped individually; valid Anthropic blocks in the same message
+   still ride the verbatim path.  When NO valid blocks survive, the
+   converter falls through to the text+tool_calls rebuild path.
 2. ``replay_reasoning_to_model`` operator flag — when False (the
    ``model_definitions`` server_default), thinking blocks are
    stripped before the wire payload is built.  Tool_use /
@@ -277,10 +278,10 @@ class TestShapeFilterFallthrough:
         types_present = [b["type"] for b in assistant["content"]]
         assert "reasoning" not in types_present
 
-    def test_mixed_shape_one_foreign_block_falls_through(self, provider: AnthropicProvider) -> None:
-        # Even a single foreign block in a mostly-Anthropic payload
-        # forces fall-through (the shape predicate is "all blocks
-        # match", not "majority match").
+    def test_mixed_shape_drops_foreign_keeps_valid(self, provider: AnthropicProvider) -> None:
+        # Per-block filter: a single foreign block in a mostly-Anthropic
+        # payload no longer forces fall-through.  Valid Anthropic blocks
+        # ride the verbatim path; the foreign block is dropped.
         msg = {
             "role": "assistant",
             "content": "Mixed.",
@@ -292,8 +293,71 @@ class TestShapeFilterFallthrough:
         }
         _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
         assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "reasoning" not in types_present  # foreign dropped
+        assert "thinking" in types_present  # valid + replay=True kept
+        assert "text" in types_present
         for b in assistant["content"]:
             assert b.get("type") in ANTHROPIC_VALID_BLOCK_TYPES
+
+    def test_mixed_shape_preserves_web_search_encrypted_content(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # The motivating case for per-block (vs all-or-nothing) filter:
+        # cross-model resumption stamps a foreign ``reasoning`` block
+        # alongside Anthropic web-search blocks carrying encrypted
+        # citations.  An all-or-nothing filter would discard the whole
+        # message and rebuild from text+tool_calls — silently losing
+        # the encrypted_content the API needs for round-trip continuity.
+        msg = {
+            "role": "assistant",
+            "content": "From search: ...",
+            "_provider_content": [
+                {"type": "reasoning", "summary": []},  # foreign (e.g. OpenAI)
+                {
+                    "type": "server_tool_use",
+                    "id": "stu_1",
+                    "name": "web_search",
+                    "input": {"query": "x"},
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "stu_1",
+                    "content": [{"type": "web_search_result", "url": "https://e.com"}],
+                    "encrypted_content": "encrypted-blob-must-survive",
+                    "encrypted_index": "encrypted-idx-must-survive",
+                },
+                {"type": "text", "text": "From search: ..."},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "reasoning" not in types_present  # foreign dropped
+        assert "server_tool_use" in types_present
+        assert "web_search_tool_result" in types_present
+        assert "text" in types_present
+        wsr = next(b for b in assistant["content"] if b["type"] == "web_search_tool_result")
+        assert wsr["encrypted_content"] == "encrypted-blob-must-survive"
+        assert wsr["encrypted_index"] == "encrypted-idx-must-survive"
+
+    def test_all_foreign_blocks_fall_through_to_rebuild(self, provider: AnthropicProvider) -> None:
+        # When every block is foreign-shaped (no Anthropic-valid block
+        # survives the per-block filter), the converter still falls
+        # through to text+tool_calls rebuild rather than emitting an
+        # empty assistant turn.
+        msg = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "reasoning", "summary": []},
+                {"type": "reasoning_text", "text": "synthetic"},  # path-3 shape
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        # Rebuild path: msg.content lifted into a single text block.
+        assert assistant["content"] == [{"type": "text", "text": "Final answer."}]
 
     def test_empty_provider_content_falls_through(self, provider: AnthropicProvider) -> None:
         msg = {
@@ -326,6 +390,29 @@ class TestShapeFilterFallthrough:
         _, converted = provider._convert_messages([msg])
         assistant = next(m for m in converted if m["role"] == "assistant")
         assert assistant["content"] == [{"type": "text", "text": "Plain."}]
+
+    def test_non_dict_and_missing_type_blocks_are_dropped(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # Defensive branches in the per-block walk: a stray non-dict
+        # element (corrupted JSON) or a dict with no/None ``type`` key
+        # (provider drift) must be silently dropped without raising.
+        # Valid blocks in the same list still ride the verbatim path.
+        msg = {
+            "role": "assistant",
+            "content": "ok",
+            "_provider_content": [
+                {"type": "text", "text": "ok"},
+                "stray-string",  # non-dict
+                {"type": None, "text": "huh"},  # None type
+                {"no_type_key": 1},  # missing type
+                {"type": "thinking", "thinking": "t", "signature": "s"},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b.get("type") for b in assistant["content"]]
+        assert types_present == ["text", "thinking"]
 
 
 class TestLegacyAnthropicRowsNoRegression:

--- a/tests/test_provider_anthropic_replay.py
+++ b/tests/test_provider_anthropic_replay.py
@@ -1,0 +1,445 @@
+"""Tests for Phase 2 wire-build replay flag + shape filter on AnthropicProvider.
+
+Phase 2 of optional reasoning persistence wraps the verbatim
+``_provider_content`` replay path at ``_anthropic.py:_convert_messages``
+with two gates:
+
+1. ``ANTHROPIC_VALID_BLOCK_TYPES`` shape filter — foreign-shaped
+   blocks (OpenAI Responses ``type="reasoning"`` after Phase 3 lands,
+   Gemini thought parts, anything else) fall through to the
+   text+tool_calls rebuild path rather than 400-ing the API.  Closes
+   a pre-existing latent bug.
+2. ``replay_reasoning_to_model`` operator flag — when False (the
+   ``model_definitions`` server_default), thinking blocks are
+   stripped before the wire payload is built.  Tool_use /
+   server_tool_use / web_search_tool_result blocks (which carry
+   web-search ``encrypted_content``) intentionally survive — the
+   strip predicate is narrow by design.
+
+Drives through the real ``AnthropicProvider._convert_messages`` with
+fixture-shaped messages, no mocks of the converter.  Edge cases come
+from the briefing's "Edges & validation memo" sections.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.providers._anthropic import (
+    ANTHROPIC_REASONING_BLOCK_TYPES,
+    ANTHROPIC_VALID_BLOCK_TYPES,
+    AnthropicProvider,
+)
+
+
+@pytest.fixture
+def provider() -> AnthropicProvider:
+    return AnthropicProvider()
+
+
+def _assistant_with_thinking(content: str = "Final answer.") -> dict[str, object]:
+    """Build an assistant message with a thinking + text + tool_use shape
+    matching what the streaming layer captures at ``_anthropic.py:713-724``."""
+    return {
+        "role": "assistant",
+        "content": content,
+        "_provider_content": [
+            {"type": "thinking", "thinking": "let me think", "signature": "sig"},
+            {"type": "text", "text": content},
+            {
+                "type": "tool_use",
+                "id": "call_abc",
+                "name": "search",
+                "input": {"q": "x"},
+            },
+        ],
+        "tool_calls": [
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"q": "x"}'},
+            }
+        ],
+    }
+
+
+class TestReplayFlagStripsThinking:
+    """``replay_reasoning_to_model=False`` strips thinking; ``True`` preserves."""
+
+    def test_replay_true_preserves_thinking_block(self, provider: AnthropicProvider) -> None:
+        msg = _assistant_with_thinking()
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" in types_present
+        assert "text" in types_present
+        assert "tool_use" in types_present
+
+    def test_replay_false_strips_thinking_block(self, provider: AnthropicProvider) -> None:
+        msg = _assistant_with_thinking()
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" not in types_present
+        assert "text" in types_present  # final answer survives
+        assert "tool_use" in types_present  # tool dispatch survives
+
+    def test_replay_false_strips_redacted_thinking_too(self, provider: AnthropicProvider) -> None:
+        # Anthropic emits redacted_thinking blocks when the safety system
+        # rewrites a thinking block.  Phase 2 strip predicate must include
+        # both shapes.
+        msg = {
+            "role": "assistant",
+            "content": "Answer.",
+            "_provider_content": [
+                {"type": "redacted_thinking", "data": "redacted-blob"},
+                {"type": "text", "text": "Answer."},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "redacted_thinking" not in types_present
+        assert "text" in types_present
+
+    def test_default_kwarg_preserves_existing_behaviour(self, provider: AnthropicProvider) -> None:
+        """Pre-Phase-2 callers that don't pass the kwarg get the verbatim
+        replay (default True), matching the behaviour all production
+        Anthropic-with-thinking turns shipped with for months."""
+        msg = _assistant_with_thinking()
+        _, converted = provider._convert_messages([msg])  # no kwarg
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" in types_present
+
+
+class TestWebSearchBlocksSurviveStrip:
+    """Edge 14: Anthropic web-search ``encrypted_content`` rides on
+    ``server_tool_use`` / ``web_search_tool_result`` blocks (NOT
+    thinking blocks).  Strip predicate is intentionally narrow."""
+
+    def test_server_tool_use_survives(self, provider: AnthropicProvider) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "From search: ...",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "I should search", "signature": "s"},
+                {
+                    "type": "server_tool_use",
+                    "id": "stu_1",
+                    "name": "web_search",
+                    "input": {"query": "turnstone bird"},
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "stu_1",
+                    "content": [{"type": "web_search_result", "url": "https://e.com"}],
+                    "encrypted_content": "abc123encrypted",
+                    "encrypted_index": "idx456encrypted",
+                },
+                {"type": "text", "text": "From search: ..."},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" not in types_present  # stripped
+        assert "server_tool_use" in types_present  # survives
+        assert "web_search_tool_result" in types_present  # survives
+        assert "text" in types_present  # survives
+        # encrypted_content rides through intact — required for round-trip continuity
+        wsr = next(b for b in assistant["content"] if b["type"] == "web_search_tool_result")
+        assert wsr["encrypted_content"] == "abc123encrypted"
+
+    def test_tool_use_block_survives(self, provider: AnthropicProvider) -> None:
+        # Plain tool_use (not server-side) — used by client-side function
+        # tools.  Strip predicate must not touch these.
+        msg = {
+            "role": "assistant",
+            "content": "Calling tool",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "I should call tool", "signature": "s"},
+                {"type": "tool_use", "id": "tu_1", "name": "f", "input": {"a": 1}},
+            ],
+            "tool_calls": [
+                {
+                    "id": "tu_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"a": 1}'},
+                }
+            ],
+        }
+        # Provide the tool result so orphan-tool detection doesn't synthesize
+        msgs = [
+            msg,
+            {"role": "tool", "tool_call_id": "tu_1", "content": "ok"},
+        ]
+        _, converted = provider._convert_messages(msgs, replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" not in types_present
+        assert "tool_use" in types_present
+
+    def test_orphan_tool_use_synthesized_after_strip(self, provider: AnthropicProvider) -> None:
+        """Pin the post-strip orphan-tool branch at _anthropic.py:397-433.
+
+        The implementation comment specifically calls out reading
+        ``provider_content`` (not ``wire_blocks``) for the orphan-tool
+        ID walk after the strip — keeping the read on the source-of-
+        truth list so a future refactor that swapped them would still
+        get the same set of tool_use IDs.  This test exercises that
+        branch end-to-end: replay=False strips the thinking block,
+        AND the message has a tool_use whose result is missing.  The
+        converter must synthesize a 'cancelled' tool_result for the
+        orphaned tool_use ID (matching the existing pre-Phase-2
+        behaviour for the verbatim path).
+        """
+        msg = {
+            "role": "assistant",
+            "content": "Calling tool",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "let me think", "signature": "s"},
+                {"type": "tool_use", "id": "orphan_tu", "name": "f", "input": {"a": 1}},
+            ],
+            "tool_calls": [
+                {
+                    "id": "orphan_tu",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"a": 1}'},
+                }
+            ],
+        }
+        # NO tool result follows — orphan branch must synthesize one.
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        # Synthetic tool_result lands as a user-role message immediately
+        # after the assistant turn (per existing behaviour at
+        # _anthropic.py:421-430).
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        # Stripped: thinking gone, tool_use survives.
+        a_types = [b["type"] for b in assistant["content"]]
+        assert "thinking" not in a_types
+        assert "tool_use" in a_types
+        # Synthesized: cancelled tool_result for orphan_tu attached to a
+        # following user-role message.
+        user_msgs_after = [m for m in converted if m["role"] == "user"]
+        assert user_msgs_after, (
+            "Expected a synthetic user message carrying the cancelled "
+            "tool_result for the orphaned tool_use"
+        )
+        flat_results = [
+            block
+            for um in user_msgs_after
+            if isinstance(um["content"], list)
+            for block in um["content"]
+            if isinstance(block, dict) and block.get("type") == "tool_result"
+        ]
+        synth = next(
+            (b for b in flat_results if b.get("tool_use_id") == "orphan_tu"),
+            None,
+        )
+        assert synth is not None, f"Expected synthetic tool_result for orphan_tu in {flat_results}"
+        assert synth.get("is_error") is True
+        assert "cancelled" in synth.get("content", "").lower()
+
+
+class TestShapeFilterFallthrough:
+    """Foreign / empty / mixed-shape ``_provider_content`` falls through
+    to the text+tool_calls rebuild path rather than reaching the wire
+    as a malformed block."""
+
+    def test_foreign_shape_openai_reasoning_falls_through(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # OpenAI Responses style block (Phase 3 will land this shape into
+        # _provider_content via include=["reasoning.encrypted_content"]).
+        # Mid-workstream model switch from OpenAI -> Anthropic must NOT
+        # reach the API with an OpenAI-shaped block (which would 400).
+        msg = {
+            "role": "assistant",
+            "content": "Final answer from openai turn.",
+            "_provider_content": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "I reasoned..."}],
+                    "encrypted_content": "openai-encrypted",
+                }
+            ],
+            "tool_calls": [],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        # Rebuilt from text — no foreign block reached the wire.
+        for b in assistant["content"]:
+            assert b.get("type") in ANTHROPIC_VALID_BLOCK_TYPES, (
+                f"Foreign block type leaked through: {b}"
+            )
+        # And the foreign block specifically is NOT present.
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "reasoning" not in types_present
+
+    def test_mixed_shape_one_foreign_block_falls_through(self, provider: AnthropicProvider) -> None:
+        # Even a single foreign block in a mostly-Anthropic payload
+        # forces fall-through (the shape predicate is "all blocks
+        # match", not "majority match").
+        msg = {
+            "role": "assistant",
+            "content": "Mixed.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "anth shape", "signature": "s"},
+                {"type": "text", "text": "Mixed."},
+                {"type": "reasoning", "summary": []},  # foreign
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=True)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        for b in assistant["content"]:
+            assert b.get("type") in ANTHROPIC_VALID_BLOCK_TYPES
+
+    def test_empty_provider_content_falls_through(self, provider: AnthropicProvider) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "Plain text answer.",
+            "_provider_content": [],
+        }
+        _, converted = provider._convert_messages([msg])
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        # Falls through to text rebuild
+        assert assistant["content"] == [{"type": "text", "text": "Plain text answer."}]
+
+    def test_none_provider_content_falls_through(self, provider: AnthropicProvider) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "Plain text answer.",
+            "_provider_content": None,
+        }
+        _, converted = provider._convert_messages([msg])
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Plain text answer."}]
+
+    def test_provider_content_not_a_list_falls_through(self, provider: AnthropicProvider) -> None:
+        # Defensive against a corrupted provider_data deserialization.
+        msg = {
+            "role": "assistant",
+            "content": "Plain.",
+            "_provider_content": "not a list",
+        }
+        _, converted = provider._convert_messages([msg])
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Plain."}]
+
+
+class TestLegacyAnthropicRowsNoRegression:
+    """Critical property: rows persisted before Phase 2 carry valid
+    Anthropic-shape _provider_content (only Anthropic captured this lane
+    historically).  They must stay in the verbatim path and keep their
+    thinking context across the migration boundary when replay=True
+    (the legacy default).
+    """
+
+    def test_legacy_thinking_row_preserved_with_default_kwarg(
+        self, provider: AnthropicProvider
+    ) -> None:
+        """No kwarg passed (matches the pre-Phase-2 production call site)."""
+        msg = {
+            "role": "assistant",
+            "content": "Old answer from months ago.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "old reasoning", "signature": "s"},
+                {"type": "text", "text": "Old answer from months ago."},
+            ],
+        }
+        _, converted = provider._convert_messages([msg])
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        types_present = [b["type"] for b in assistant["content"]]
+        assert "thinking" in types_present  # preserved -> no regression
+        # The thinking block IS the same dict as the source (verbatim path).
+        assert assistant["content"][0]["thinking"] == "old reasoning"
+
+    def test_replay_false_only_strips_when_explicitly_requested(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # Operator flips persist+replay flags off.  Strip fires.
+        # Pinning that the strip is gated on the explicit flag value,
+        # not silently triggered by some other condition.
+        msg = {
+            "role": "assistant",
+            "content": "Answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "stripped", "signature": "s"},
+                {"type": "text", "text": "Answer."},
+            ],
+        }
+        _, converted_default = provider._convert_messages([msg])
+        _, converted_strip = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        default_types = [b["type"] for b in converted_default[0]["content"]]
+        strip_types = [b["type"] for b in converted_strip[0]["content"]]
+        assert "thinking" in default_types
+        assert "thinking" not in strip_types
+
+
+class TestStripAllBlocksFallthrough:
+    """When the message is 100% thinking (no text, no tool_use) and
+    replay=False strips everything, the message falls through to the
+    text+tool_calls rebuild path.  If both are also empty, the assistant
+    turn is silently skipped — correct: stripped reasoning has nothing
+    to replay."""
+
+    def test_only_thinking_strip_falls_to_rebuild_with_text(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # Provider_content = only thinking; msg.content has the spoken text.
+        # Strip drops thinking; rebuild path picks up the content as a
+        # text block.  No information lost.
+        msg = {
+            "role": "assistant",
+            "content": "Spoken answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "internal", "signature": "s"},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Spoken answer."}]
+
+    def test_only_thinking_strip_with_no_content_skips_message(
+        self, provider: AnthropicProvider
+    ) -> None:
+        # Edge: provider_content was 100% thinking AND msg.content is
+        # empty AND no tool_calls.  The rebuild path sees nothing to
+        # emit — assistant turn silently skipped.  Anthropic's API
+        # would reject an empty assistant content array anyway.
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "_provider_content": [
+                {"type": "thinking", "thinking": "only", "signature": "s"},
+            ],
+        }
+        _, converted = provider._convert_messages([msg], replay_reasoning_to_model=False)
+        # Assistant turn skipped — no entry for it in `converted`.
+        assert all(m["role"] != "assistant" for m in converted)
+
+
+class TestConstants:
+    """Pin the constant contents so a future edit doesn't accidentally
+    widen the strip set or narrow the valid set."""
+
+    def test_reasoning_block_types_is_narrow(self) -> None:
+        # Strip predicate MUST cover only reasoning shapes.  Adding
+        # tool_use here would break web-search round-trip.
+        assert frozenset({"thinking", "redacted_thinking"}) == ANTHROPIC_REASONING_BLOCK_TYPES
+
+    def test_valid_block_types_includes_web_search(self) -> None:
+        # Without server_tool_use / web_search_tool_result, Anthropic
+        # web-search results would fall through to the rebuild path
+        # and lose their encrypted_content.
+        assert "server_tool_use" in ANTHROPIC_VALID_BLOCK_TYPES
+        assert "web_search_tool_result" in ANTHROPIC_VALID_BLOCK_TYPES
+        assert "tool_use" in ANTHROPIC_VALID_BLOCK_TYPES
+        assert "tool_result" in ANTHROPIC_VALID_BLOCK_TYPES
+
+    def test_reasoning_subset_of_valid(self) -> None:
+        # The strip set must be a subset of the valid set — otherwise
+        # the strip predicate would never match anything (we only
+        # strip after shape validity passes).
+        assert ANTHROPIC_REASONING_BLOCK_TYPES.issubset(ANTHROPIC_VALID_BLOCK_TYPES)

--- a/tests/test_provider_openai_responses_reasoning.py
+++ b/tests/test_provider_openai_responses_reasoning.py
@@ -1,0 +1,355 @@
+"""Tests for OpenAI Responses reasoning capture + replay (Phase 3 path 2).
+
+Phase 3 wires:
+1. ``include=["reasoning.encrypted_content"]`` on the request when
+   the operator flag AND the model capability both allow.
+2. ``_convert_messages`` round-tripping stored reasoning items as
+   ``ResponseReasoningItemParam`` input items on subsequent turns.
+3. ``OpenAIResponsesProvider.extract_reasoning_text`` walking
+   reasoning items and returning concatenated summary + content text.
+
+All tests drive through the real ``OpenAIResponsesProvider`` — no
+mocks of the converter/build_kwargs themselves; only the SDK boundary
+is mocked where relevant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.providers._openai_responses import (
+    OpenAIResponsesProvider,
+    _reasoning_item_for_input,
+)
+from turnstone.core.providers._protocol import (
+    MAX_REASONING_DISPLAY_BYTES as _MAX_REASONING_DISPLAY_BYTES,
+)
+from turnstone.core.providers._protocol import ModelCapabilities
+
+
+@pytest.fixture
+def provider() -> OpenAIResponsesProvider:
+    return OpenAIResponsesProvider()
+
+
+def _capable_caps() -> ModelCapabilities:
+    """Capability fixture for a reasoning-replay-capable model."""
+    return ModelCapabilities(
+        context_window=400000,
+        max_output_tokens=128000,
+        supports_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
+        supports_reasoning_replay=True,
+    )
+
+
+def _incapable_caps() -> ModelCapabilities:
+    return ModelCapabilities(
+        context_window=128000,
+        supports_reasoning_replay=False,
+    )
+
+
+class TestExtractReasoningText:
+    def test_none_returns_empty(self, provider: OpenAIResponsesProvider) -> None:
+        assert provider.extract_reasoning_text(None) == ""
+
+    def test_empty_list_returns_empty(self, provider: OpenAIResponsesProvider) -> None:
+        assert provider.extract_reasoning_text([]) == ""
+
+    def test_no_reasoning_items_returns_empty(self, provider: OpenAIResponsesProvider) -> None:
+        blocks = [
+            {"type": "message", "role": "assistant", "content": "hi"},
+            {"type": "function_call", "call_id": "c1", "name": "x", "arguments": "{}"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == ""
+
+    def test_summary_text_extracted(self, provider: OpenAIResponsesProvider) -> None:
+        # Per ResponseReasoningItem (response_reasoning_item.py:31-62):
+        # summary is always present; content is optional.
+        blocks = [
+            {
+                "type": "reasoning",
+                "id": "r_1",
+                "summary": [
+                    {"type": "summary_text", "text": "I considered X"},
+                    {"type": "summary_text", "text": "then Y"},
+                ],
+            }
+        ]
+        assert provider.extract_reasoning_text(blocks) == "I considered X\nthen Y"
+
+    def test_content_text_extracted_alongside_summary(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        blocks = [
+            {
+                "type": "reasoning",
+                "id": "r_1",
+                "summary": [{"type": "summary_text", "text": "summary line"}],
+                "content": [{"type": "reasoning_text", "text": "raw reasoning"}],
+            }
+        ]
+        # Order: summary first, then content (matches the order the SDK
+        # surfaces them via streaming events).
+        result = provider.extract_reasoning_text(blocks)
+        assert "summary line" in result
+        assert "raw reasoning" in result
+
+    def test_truncation_at_64kib_cap(self, provider: OpenAIResponsesProvider) -> None:
+        long_text = "x" * (_MAX_REASONING_DISPLAY_BYTES + 1024)
+        blocks = [
+            {
+                "type": "reasoning",
+                "id": "r_1",
+                "summary": [{"type": "summary_text", "text": long_text}],
+            }
+        ]
+        result = provider.extract_reasoning_text(blocks)
+        assert len(result) == _MAX_REASONING_DISPLAY_BYTES
+
+    def test_malformed_summary_entry_skipped(self, provider: OpenAIResponsesProvider) -> None:
+        blocks = [
+            {
+                "type": "reasoning",
+                "id": "r_1",
+                "summary": [
+                    "not a dict",
+                    {"type": "summary_text"},  # missing text
+                    {"type": "summary_text", "text": ""},  # empty text
+                    {"type": "summary_text", "text": "good"},
+                ],
+            }
+        ]
+        assert provider.extract_reasoning_text(blocks) == "good"
+
+    def test_non_list_input_returns_empty(self, provider: OpenAIResponsesProvider) -> None:
+        assert provider.extract_reasoning_text("not a list") == ""  # type: ignore[arg-type]
+
+    def test_other_block_types_skipped_in_walk(self, provider: OpenAIResponsesProvider) -> None:
+        # Mixed payload: only the reasoning block contributes.
+        blocks = [
+            {"type": "message", "role": "assistant", "content": "hi"},
+            {
+                "type": "reasoning",
+                "id": "r_1",
+                "summary": [{"type": "summary_text", "text": "thought"}],
+            },
+            {"type": "function_call", "call_id": "c1", "name": "x", "arguments": "{}"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == "thought"
+
+
+class TestReasoningItemForInput:
+    """``_reasoning_item_for_input`` projects a stored ``ResponseReasoningItem``
+    dict into ``ResponseReasoningItemParam`` shape (drops server-only
+    ``status``)."""
+
+    def test_minimal_item_round_trip(self) -> None:
+        stored = {
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"type": "summary_text", "text": "x"}],
+            "status": "completed",
+        }
+        result = _reasoning_item_for_input(stored)
+        assert result["type"] == "reasoning"
+        assert result["id"] == "r_1"
+        assert result["summary"] == [{"type": "summary_text", "text": "x"}]
+        # status NOT round-tripped (server-only field per
+        # ResponseReasoningItemParam at response_reasoning_item_param.py).
+        assert "status" not in result
+
+    def test_encrypted_content_round_trips_when_present(self) -> None:
+        stored = {
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"type": "summary_text", "text": "x"}],
+            "encrypted_content": "opaque-blob",
+        }
+        result = _reasoning_item_for_input(stored)
+        assert result["encrypted_content"] == "opaque-blob"
+
+    def test_encrypted_content_omitted_when_absent(self) -> None:
+        stored = {
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"type": "summary_text", "text": "x"}],
+        }
+        result = _reasoning_item_for_input(stored)
+        assert "encrypted_content" not in result
+
+    def test_content_round_trips_when_present(self) -> None:
+        stored = {
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"type": "summary_text", "text": "s"}],
+            "content": [{"type": "reasoning_text", "text": "raw"}],
+        }
+        result = _reasoning_item_for_input(stored)
+        assert result["content"] == [{"type": "reasoning_text", "text": "raw"}]
+
+
+class TestBuildKwargsInclude:
+    """``_build_kwargs`` adds ``include=["reasoning.encrypted_content"]``
+    only when the operator flag AND the model capability both allow."""
+
+    def test_include_added_when_flag_and_capability_true(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        kwargs = provider._build_kwargs(
+            model="gpt-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            temperature=0.5,
+            reasoning_effort="medium",
+            deferred_names=None,
+            capabilities=_capable_caps(),
+            replay_reasoning_to_model=True,
+        )
+        assert kwargs.get("include") == ["reasoning.encrypted_content"]
+
+    def test_include_omitted_when_flag_false(self, provider: OpenAIResponsesProvider) -> None:
+        kwargs = provider._build_kwargs(
+            model="gpt-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            temperature=0.5,
+            reasoning_effort="medium",
+            deferred_names=None,
+            capabilities=_capable_caps(),
+            replay_reasoning_to_model=False,
+        )
+        assert "include" not in kwargs
+
+    def test_include_omitted_when_capability_false(self, provider: OpenAIResponsesProvider) -> None:
+        # Defends against operator flipping the flag on a non-reasoning
+        # model — the capability gate prevents the include= from being
+        # sent (silently no-op'd).
+        kwargs = provider._build_kwargs(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            temperature=0.5,
+            reasoning_effort="medium",
+            deferred_names=None,
+            capabilities=_incapable_caps(),
+            replay_reasoning_to_model=True,
+        )
+        assert "include" not in kwargs
+
+    def test_include_omitted_by_default(self, provider: OpenAIResponsesProvider) -> None:
+        # When neither flag nor capability is passed, replay defaults
+        # True (kwarg) but capability defaults False — net: no include.
+        kwargs = provider._build_kwargs(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            temperature=0.5,
+            reasoning_effort="medium",
+            deferred_names=None,
+        )
+        assert "include" not in kwargs
+
+
+class TestConvertMessagesReasoningReplay:
+    """``_convert_messages`` round-trips stored reasoning items as input."""
+
+    def test_reasoning_item_emitted_before_assistant_when_replay_true(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        messages = [
+            {"role": "user", "content": "explain"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "_provider_content": [
+                    {
+                        "type": "reasoning",
+                        "id": "r_1",
+                        "summary": [{"type": "summary_text", "text": "I thought"}],
+                        "encrypted_content": "abc",
+                    }
+                ],
+            },
+            {"role": "user", "content": "follow up"},
+        ]
+        _, items = provider._convert_messages(messages, replay_reasoning_to_model=True)
+        # Find the reasoning input item.
+        types = [it.get("type") for it in items]
+        # Expected: user, reasoning, message (assistant), user.
+        assert types == ["message", "reasoning", "message", "message"]
+        reasoning_idx = types.index("reasoning")
+        r_item = items[reasoning_idx]
+        assert r_item["id"] == "r_1"
+        assert r_item["encrypted_content"] == "abc"
+        # And the reasoning item appears immediately BEFORE the
+        # assistant message it belongs to.
+        assert items[reasoning_idx + 1]["role"] == "assistant"
+
+    def test_reasoning_item_dropped_when_replay_false(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Answer.",
+                "_provider_content": [
+                    {
+                        "type": "reasoning",
+                        "id": "r_1",
+                        "summary": [{"type": "summary_text", "text": "thought"}],
+                    }
+                ],
+            },
+        ]
+        _, items = provider._convert_messages(messages, replay_reasoning_to_model=False)
+        types = [it.get("type") for it in items]
+        assert "reasoning" not in types
+
+    def test_no_reasoning_items_when_provider_content_lacks_reasoning(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        # Anthropic-shaped _provider_content reaching OpenAI Responses
+        # (cross-provider — operator switch from Anthropic to GPT-5):
+        # no type=="reasoning" items, so nothing emitted.
+        messages = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": [
+                    {"type": "thinking", "thinking": "anth", "signature": "s"},
+                ],
+            },
+        ]
+        _, items = provider._convert_messages(messages, replay_reasoning_to_model=True)
+        types = [it.get("type") for it in items]
+        assert "reasoning" not in types
+
+    def test_default_replay_reasoning_false_omits_reasoning(
+        self, provider: OpenAIResponsesProvider
+    ) -> None:
+        # Pre-Phase-3 callers (no kwarg) get the back-compat behaviour:
+        # reasoning items are silently dropped (sanitize_messages was
+        # already stripping _provider_content anyway).
+        messages = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "_provider_content": [
+                    {
+                        "type": "reasoning",
+                        "id": "r_1",
+                        "summary": [{"type": "summary_text", "text": "x"}],
+                    }
+                ],
+            },
+        ]
+        _, items = provider._convert_messages(messages)  # no kwarg
+        types = [it.get("type") for it in items]
+        assert "reasoning" not in types

--- a/tests/test_provider_openai_responses_reasoning.py
+++ b/tests/test_provider_openai_responses_reasoning.py
@@ -22,7 +22,7 @@ from turnstone.core.providers._openai_responses import (
     _reasoning_item_for_input,
 )
 from turnstone.core.providers._protocol import (
-    MAX_REASONING_DISPLAY_BYTES as _MAX_REASONING_DISPLAY_BYTES,
+    MAX_REASONING_DISPLAY_CHARS as _MAX_REASONING_DISPLAY_CHARS,
 )
 from turnstone.core.providers._protocol import ModelCapabilities
 
@@ -98,7 +98,7 @@ class TestExtractReasoningText:
         assert "raw reasoning" in result
 
     def test_truncation_at_64kib_cap(self, provider: OpenAIResponsesProvider) -> None:
-        long_text = "x" * (_MAX_REASONING_DISPLAY_BYTES + 1024)
+        long_text = "x" * (_MAX_REASONING_DISPLAY_CHARS + 1024)
         blocks = [
             {
                 "type": "reasoning",
@@ -107,7 +107,7 @@ class TestExtractReasoningText:
             }
         ]
         result = provider.extract_reasoning_text(blocks)
-        assert len(result) == _MAX_REASONING_DISPLAY_BYTES
+        assert len(result) == _MAX_REASONING_DISPLAY_CHARS
 
     def test_malformed_summary_entry_skipped(self, provider: OpenAIResponsesProvider) -> None:
         blocks = [

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -28,11 +28,15 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+from tests._session_helpers import make_session
 from turnstone.core.history_decoration import (
     extract_reasoning_for_history,
     extract_reasoning_text_from_provider_content,
 )
 from turnstone.core.providers._anthropic import AnthropicProvider
+from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.providers._protocol import StreamChunk, UsageInfo
 from turnstone.server import _build_history
 
 _MARKER = "SECRET_REASONING_MARKER_xyz123_unlikely_collision"
@@ -151,7 +155,7 @@ class TestReasoningAuditLogDiscipline:
             p.start()
         try:
             messages = [self._thinking_msg(_MARKER)]
-            extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+            extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
             assert messages[0]["reasoning"] == _MARKER  # UI-bound is allowed
         finally:
             for p in patchers:
@@ -166,7 +170,9 @@ class TestReasoningAuditLogDiscipline:
         )
 
     def test_build_history_does_not_log_reasoning(self) -> None:
-        registry = SimpleNamespace(get_config=lambda alias: SimpleNamespace(persist_reasoning=True))
+        registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(surface_persisted_reasoning=True)
+        )
         session = SimpleNamespace(
             messages=[self._thinking_msg(_MARKER)],
             _ws_id="ws-audit",
@@ -192,3 +198,136 @@ class TestReasoningAuditLogDiscipline:
             if _payload_contains_marker(args, kwargs)
         ]
         assert offending == [], f"_build_history leaked reasoning text into INFO+ logs: {offending}"
+
+    # ------------------------------------------------------------------
+    # Phase 2 + Phase 3 surfaces — added in response to a code-review
+    # finding that the original 4-test coverage missed every code path
+    # introduced after Phase 1.  Each new test mirrors the structure
+    # above: capture every Logger.info / warning / error call across
+    # the operation, assert the marker doesn't appear in any captured
+    # payload (UI-bound returns IS allowed; logging at INFO+ is NOT).
+    # ------------------------------------------------------------------
+
+    def test_openai_responses_extractor_does_not_log_reasoning(self) -> None:
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            provider = OpenAIResponsesProvider()
+            blocks = [
+                {
+                    "type": "reasoning",
+                    "id": "r_1",
+                    "summary": [{"type": "summary_text", "text": _MARKER}],
+                }
+            ]
+            text = provider.extract_reasoning_text(blocks)
+            assert _MARKER in text  # UI-bound return is allowed
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"OpenAIResponsesProvider.extract_reasoning_text leaked reasoning "
+            f"text into INFO+ logs: {offending}"
+        )
+
+    def test_openai_chat_extractor_does_not_log_reasoning(self) -> None:
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            provider = OpenAIChatCompletionsProvider()
+            blocks = [{"type": "reasoning_text", "text": _MARKER, "source": "vllm"}]
+            text = provider.extract_reasoning_text(blocks)
+            assert text == _MARKER
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"OpenAIChatCompletionsProvider.extract_reasoning_text leaked "
+            f"reasoning text into INFO+ logs: {offending}"
+        )
+
+    def test_synth_reasoning_block_via_stream_response_does_not_log_reasoning(
+        self,
+    ) -> None:
+        """Drives ChatSession._stream_response (which calls
+        _maybe_synth_reasoning_block at end-of-stream) with a fake
+        ``reasoning_delta=_MARKER`` chunk; asserts no log call carried
+        the marker text."""
+        session = make_session()
+        chunks = [
+            StreamChunk(reasoning_delta=_MARKER, is_first=True),
+            StreamChunk(content_delta="answer"),
+            StreamChunk(
+                finish_reason="stop",
+                usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+            ),
+        ]
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            msg = session._stream_response(iter(chunks))
+            # Synth block stamped onto _provider_content with the marker.
+            assert msg["_provider_content"][0]["text"] == _MARKER
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"_stream_response + _maybe_synth_reasoning_block leaked reasoning "
+            f"text into INFO+ logs: {offending}"
+        )
+
+    def test_anthropic_convert_messages_strip_does_not_log_reasoning(self) -> None:
+        """Drives the Phase 2 strip predicate
+        (``replay_reasoning_to_model=False``) which walks thinking
+        blocks to filter them out before the wire payload is built;
+        asserts no log call carried the marker text."""
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            provider = AnthropicProvider()
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "Final answer.",
+                    "_provider_content": [
+                        {"type": "thinking", "thinking": _MARKER, "signature": "s"},
+                        {"type": "text", "text": "Final answer."},
+                    ],
+                },
+            ]
+            _, converted = provider._convert_messages(messages, replay_reasoning_to_model=False)
+            # Strip fired — thinking block dropped from wire.
+            assistant = next(m for m in converted if m["role"] == "assistant")
+            block_types = [b.get("type") for b in assistant["content"]]
+            assert "thinking" not in block_types
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"AnthropicProvider._convert_messages strip predicate leaked "
+            f"reasoning text into INFO+ logs: {offending}"
+        )

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -1,0 +1,194 @@
+"""Audit-log discipline test for reasoning text.
+
+Phase 1 of optional reasoning persistence surfaces stored thinking
+blocks on the ``/history`` payload (UI rehydration). The bytes ride
+through the helper (``extract_reasoning_for_history``), through the
+provider extractor (``AnthropicProvider.extract_reasoning_text``), and
+through the server build path (``_build_history``).
+
+This test pins the security-sensitive contract:
+
+    Reasoning text MAY land on ``msg["reasoning"]`` (UI-bound),
+    but MUST NOT appear in any ``Logger.info`` / ``warning`` /
+    ``error`` payload at any layer in the pipeline.
+
+The test mocks the standard-library ``logging.Logger`` info/warning/
+error methods, runs a thinking-bearing turn through the relevant
+extractors and history build, then asserts no captured log call's
+positional args or kwargs contain the unique marker string. Replaces
+the v4 grep-the-output approach (fragile when log strings are
+formatted) with a structural mock-and-assert (tests the actual
+contract rather than the rendered text).
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from turnstone.core.history_decoration import (
+    extract_reasoning_for_history,
+    extract_reasoning_text_from_provider_content,
+)
+from turnstone.core.providers._anthropic import AnthropicProvider
+from turnstone.server import _build_history
+
+_MARKER = "SECRET_REASONING_MARKER_xyz123_unlikely_collision"
+
+
+def _payload_contains_marker(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    """Walk a captured log call's args + kwargs for the marker string.
+
+    Logger.info-style calls accept a format string + positional substitution
+    args; the marker could appear in either the format string itself or
+    the substitution values. Format-time strings (``%`` substitution) are
+    NOT inspected because they're a stdlib formatting concern, not a
+    callable our pipeline reaches into. The structural check is "no
+    user-controlled marker appears in any arg slot we passed".
+    """
+    for a in args:
+        if isinstance(a, str) and _MARKER in a:
+            return True
+        # Defensive — a list/dict/exception arg might carry the marker too.
+        try:
+            if _MARKER in repr(a):
+                return True
+        except Exception:
+            continue
+    for v in kwargs.values():
+        if isinstance(v, str) and _MARKER in v:
+            return True
+        try:
+            if _MARKER in repr(v):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _capture_log_calls():
+    """Capture every Logger.info / warning / error call into a single list."""
+    captured: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def make_recorder(level: str):
+        def _rec(*args: Any, **kwargs: Any) -> None:
+            captured.append((level, args, kwargs))
+
+        return _rec
+
+    return captured, [
+        patch.object(logging.Logger, "info", side_effect=make_recorder("info"), autospec=True),
+        patch.object(
+            logging.Logger, "warning", side_effect=make_recorder("warning"), autospec=True
+        ),
+        patch.object(logging.Logger, "error", side_effect=make_recorder("error"), autospec=True),
+    ]
+
+
+class TestReasoningAuditLogDiscipline:
+    """Reasoning text never lands at INFO+ severity on any logger."""
+
+    def _thinking_msg(self, text: str = _MARKER) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": [
+                {"type": "thinking", "thinking": text, "signature": "sig"},
+                {"type": "text", "text": "Final answer."},
+            ],
+        }
+
+    def test_anthropic_extractor_does_not_log_reasoning(self) -> None:
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            provider = AnthropicProvider()
+            text = provider.extract_reasoning_text(
+                [{"type": "thinking", "thinking": _MARKER, "signature": "s"}]
+            )
+            assert text == _MARKER  # extractor IS allowed to return it
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"AnthropicProvider.extract_reasoning_text leaked reasoning text "
+            f"into INFO+ logs: {offending}"
+        )
+
+    def test_dispatch_helper_does_not_log_reasoning(self) -> None:
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            text = extract_reasoning_text_from_provider_content(
+                [{"type": "thinking", "thinking": _MARKER, "signature": "s"}]
+            )
+            assert text == _MARKER
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"extract_reasoning_text_from_provider_content leaked reasoning "
+            f"text into INFO+ logs: {offending}"
+        )
+
+    def test_list_helper_does_not_log_reasoning(self) -> None:
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            messages = [self._thinking_msg(_MARKER)]
+            extract_reasoning_for_history(messages, persist_reasoning_flag=True)
+            assert messages[0]["reasoning"] == _MARKER  # UI-bound is allowed
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"extract_reasoning_for_history leaked reasoning text into INFO+ logs: {offending}"
+        )
+
+    def test_build_history_does_not_log_reasoning(self) -> None:
+        registry = SimpleNamespace(get_config=lambda alias: SimpleNamespace(persist_reasoning=True))
+        session = SimpleNamespace(
+            messages=[self._thinking_msg(_MARKER)],
+            _ws_id="ws-audit",
+            _registry=registry,
+            _model_alias="claude-opus-4-7",
+        )
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            with patch(
+                "turnstone.server._load_verdict_indexes",
+                return_value=({}, {}),
+            ):
+                history = _build_history(session)
+            assert history[0]["reasoning"] == _MARKER  # UI-bound is allowed
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], f"_build_history leaked reasoning text into INFO+ logs: {offending}"

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -26,6 +26,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tests._session_helpers import make_session as _make_session
 
 
@@ -256,6 +258,7 @@ class TestSessionToWireBoundaryIntegration:
         the resolver pre-set to *replay_flag*.  Returns the kwargs
         dict that reached the (mocked) Anthropic SDK boundary.
         """
+        pytest.importorskip("anthropic")
         from turnstone.core.providers._anthropic import AnthropicProvider
 
         session = _make_session()

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -357,6 +357,181 @@ class TestSessionToWireBoundaryIntegration:
         )
 
 
+class TestSessionToOpenAIResponsesBoundaryIntegration:
+    """End-to-end integration: session._try_stream -> real
+    OpenAIResponsesProvider.create_streaming -> captured Responses
+    SDK boundary call.  Mirrors the AnthropicProvider test above
+    but for the path-2 (Responses API) replay flow.
+
+    Pins the include= request kwarg + reasoning input-item emission
+    actually fire at the wire boundary when the operator flag and
+    model capability both allow.
+    """
+
+    def _stub_responses_client(self) -> tuple[MagicMock, dict[str, object]]:
+        """Mock OpenAI Responses client.  ``client.responses.create``
+        captures kwargs and returns an empty stream iterator."""
+        captured: dict[str, object] = {}
+
+        def create(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return iter([])
+
+        client = MagicMock()
+        client.responses.create = create
+        return client, captured
+
+    def _registry_with_reasoning_capability(
+        self, replay: bool = True, supports_replay: bool = True
+    ) -> Any:
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        return SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                replay_reasoning_to_model=replay,
+                capabilities={},  # no overrides
+            ),
+            _caps=ModelCapabilities(
+                context_window=400000,
+                supports_temperature=False,
+                reasoning_effort_values=("low", "medium", "high"),
+                default_reasoning_effort="medium",
+                supports_reasoning_replay=supports_replay,
+            ),
+        )
+
+    def test_replay_true_adds_include_to_responses_request(self) -> None:
+        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=True)
+        session = _make_session()
+        session._registry = registry
+        session._model_alias = "gpt-5"
+        client, captured = self._stub_responses_client()
+        real_provider = OpenAIResponsesProvider()
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="gpt-5",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=real_provider,
+                capabilities=registry._caps,
+                model_alias="gpt-5",
+            )
+            list(stream)
+        assert captured.get("include") == ["reasoning.encrypted_content"]
+
+    def test_replay_false_omits_include(self) -> None:
+        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+        registry = self._registry_with_reasoning_capability(replay=False, supports_replay=True)
+        session = _make_session()
+        session._registry = registry
+        session._model_alias = "gpt-5"
+        client, captured = self._stub_responses_client()
+        real_provider = OpenAIResponsesProvider()
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="gpt-5",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=real_provider,
+                capabilities=registry._caps,
+                model_alias="gpt-5",
+            )
+            list(stream)
+        assert "include" not in captured
+
+    def test_capability_false_omits_include_even_when_flag_true(self) -> None:
+        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+        # Operator flips replay=True but the model has
+        # supports_reasoning_replay=False (e.g. gpt-4o via Responses).
+        # Capability gate prevents the include= from being sent.
+        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=False)
+        session = _make_session()
+        session._registry = registry
+        session._model_alias = "gpt-4o"
+        client, captured = self._stub_responses_client()
+        real_provider = OpenAIResponsesProvider()
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="gpt-4o",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=real_provider,
+                capabilities=registry._caps,
+                model_alias="gpt-4o",
+            )
+            list(stream)
+        assert "include" not in captured
+
+    def test_replay_true_emits_reasoning_input_item(self) -> None:
+        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=True)
+        session = _make_session()
+        session._registry = registry
+        session._model_alias = "gpt-5"
+        client, captured = self._stub_responses_client()
+        real_provider = OpenAIResponsesProvider()
+        # Multi-turn conversation with stored reasoning on assistant turn.
+        msgs: list[dict[str, object]] = [
+            {"role": "user", "content": "explain"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "_provider_content": [
+                    {
+                        "type": "reasoning",
+                        "id": "r_xyz",
+                        "summary": [{"type": "summary_text", "text": "I thought"}],
+                        "encrypted_content": "blob",
+                    }
+                ],
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="gpt-5",
+                msgs=msgs,
+                provider=real_provider,
+                capabilities=registry._caps,
+                model_alias="gpt-5",
+            )
+            list(stream)
+        # Walk the wire input items — one of them must be the reasoning
+        # round-trip (id matches what we stored).
+        wire_input = captured.get("input")
+        assert isinstance(wire_input, list)
+        reasoning_items = [it for it in wire_input if it.get("type") == "reasoning"]
+        assert len(reasoning_items) == 1
+        assert reasoning_items[0]["id"] == "r_xyz"
+        assert reasoning_items[0]["encrypted_content"] == "blob"
+
+
 class TestUtilityCompletionPassesFlag:
     """Non-streaming utility path (title gen, compaction, extraction) —
     same plumbing requirement as streaming."""

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -1,0 +1,388 @@
+"""Tests for session-level ``replay_reasoning_to_model`` plumbing.
+
+Phase 2 of optional reasoning persistence reads the per-model
+``ModelConfig.replay_reasoning_to_model`` flag at the wire-build call
+site and threads it through ``provider.create_streaming`` /
+``provider.create_completion``.  These tests pin:
+
+1. The resolver helper (``ChatSession._resolve_replay_reasoning_to_model``)
+   walks the registry correctly and falls back to ``False`` (the
+   conservative default matching the migration server_default) when
+   the lookup fails.
+2. The streaming wire-build call site at ``session.py:_try_stream``
+   actually passes the resolved flag down — without this, the Phase
+   2 work is dead code (the strip-when-False predicate never fires).
+3. The non-streaming wire-build call site at
+   ``session.py:_utility_completion`` does the same.
+
+Drives through the real ``ChatSession._resolve_replay_reasoning_to_model``
+with a stub registry, then captures the kwarg passed to a mock provider
+to verify the flow end-to-end.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from turnstone.core.session import ChatSession
+from turnstone.core.session_ui_base import SessionUIBase
+
+
+class _NullUI(SessionUIBase):
+    """Bare-bones UI satisfying the SessionUIBase contract for these tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+def _make_session(**kwargs: Any) -> ChatSession:
+    defaults: dict[str, Any] = {
+        "client": MagicMock(),
+        "model": "test-model",
+        "ui": _NullUI(),
+        "instructions": None,
+        "temperature": 0.5,
+        "max_tokens": 4096,
+        "tool_timeout": 30,
+    }
+    defaults.update(kwargs)
+    return ChatSession(**defaults)
+
+
+def _registry_with_flag(persist: bool = True, replay: bool = False) -> Any:
+    """Stub registry returning a ModelConfig-shaped object with the
+    flags under test."""
+    return SimpleNamespace(
+        get_config=lambda alias: SimpleNamespace(
+            persist_reasoning=persist,
+            replay_reasoning_to_model=replay,
+        )
+    )
+
+
+class TestResolveReplayReasoningToModel:
+    """Direct unit tests for the resolver."""
+
+    def test_returns_false_when_no_registry(self) -> None:
+        session = _make_session()
+        session._registry = None
+        session._model_alias = "anything"
+        assert session._resolve_replay_reasoning_to_model() is False
+
+    def test_returns_false_when_no_alias(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = ""
+        assert session._resolve_replay_reasoning_to_model() is False
+
+    def test_returns_false_default(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=False)
+        session._model_alias = "claude-opus-4-7"
+        assert session._resolve_replay_reasoning_to_model() is False
+
+    def test_returns_true_when_flag_set(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "claude-opus-4-7"
+        assert session._resolve_replay_reasoning_to_model() is True
+
+    def test_explicit_alias_arg_overrides_default(self) -> None:
+        session = _make_session()
+
+        def per_alias(alias: str) -> Any:
+            return SimpleNamespace(
+                replay_reasoning_to_model=(alias == "needs-replay"),
+            )
+
+        session._registry = SimpleNamespace(get_config=per_alias)
+        session._model_alias = "primary"
+        # Default reads session._model_alias → False.
+        assert session._resolve_replay_reasoning_to_model() is False
+        # Explicit alias arg → True for "needs-replay".
+        assert session._resolve_replay_reasoning_to_model("needs-replay") is True
+
+    def test_returns_false_on_registry_exception(self) -> None:
+        session = _make_session()
+
+        def boom(alias: str) -> Any:
+            raise KeyError(alias)
+
+        session._registry = SimpleNamespace(get_config=boom)
+        session._model_alias = "missing"
+        # Conservative fallback — losing the strip is a UX nuisance,
+        # but accepting wire-side reasoning replay against an unknown
+        # operator preference is a worse default.
+        assert session._resolve_replay_reasoning_to_model() is False
+
+
+class TestStreamingCallSitePassesFlag:
+    """Pin that ``_try_stream`` actually passes the resolved flag to
+    ``provider.create_streaming`` — without this the Phase 2 work is
+    dead code at the call site."""
+
+    def test_replay_true_propagates_to_provider(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "claude-opus-4-7"
+        # Stub provider: capture the kwargs passed to create_streaming.
+        captured: dict[str, Any] = {}
+
+        def capture_streaming(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return iter([])
+
+        mock_provider = MagicMock()
+        mock_provider.create_streaming = capture_streaming
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            session._try_stream(
+                client=MagicMock(),
+                model="claude-opus-4-7",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=mock_provider,
+                model_alias="claude-opus-4-7",
+            )
+        assert captured["replay_reasoning_to_model"] is True
+
+    def test_replay_false_propagates_to_provider(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=False)
+        session._model_alias = "claude-opus-4-7"
+        captured: dict[str, Any] = {}
+
+        def capture_streaming(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return iter([])
+
+        mock_provider = MagicMock()
+        mock_provider.create_streaming = capture_streaming
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            session._try_stream(
+                client=MagicMock(),
+                model="claude-opus-4-7",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=mock_provider,
+                model_alias="claude-opus-4-7",
+            )
+        assert captured["replay_reasoning_to_model"] is False
+
+    def test_fallback_alias_uses_its_own_flag(self) -> None:
+        # When the primary fails and we fall back to an alias with a
+        # different flag, the flag MUST track the resolved alias —
+        # not the session's primary alias.
+        session = _make_session()
+
+        def per_alias(alias: str) -> Any:
+            return SimpleNamespace(
+                replay_reasoning_to_model=(alias == "fallback-with-replay"),
+            )
+
+        session._registry = SimpleNamespace(get_config=per_alias)
+        session._model_alias = "primary"  # primary has replay=False
+        captured: dict[str, Any] = {}
+
+        def capture_streaming(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return iter([])
+
+        mock_provider = MagicMock()
+        mock_provider.create_streaming = capture_streaming
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            session._try_stream(
+                client=MagicMock(),
+                model="fallback-model",
+                msgs=[{"role": "user", "content": "hi"}],
+                provider=mock_provider,
+                model_alias="fallback-with-replay",
+            )
+        # Resolved against the FALLBACK alias, not the session's primary.
+        assert captured["replay_reasoning_to_model"] is True
+
+
+class TestSessionToWireBoundaryIntegration:
+    """End-to-end integration: session._try_stream -> real
+    AnthropicProvider.create_streaming -> captured Anthropic SDK
+    boundary call.  Verifies the strip-when-False predicate actually
+    fires at the wire payload, not just at the captured kwarg.
+
+    The bare-function-stub tests above (TestStreamingCallSitePassesFlag)
+    pin that ``_try_stream`` PASSES the flag; this test pins that the
+    real provider USES it.  Together they catch:
+      - kwarg renamed at provider boundary -> stub-tests still pass,
+        this one fails on its real-provider assertion.
+      - _convert_messages stops reading the kwarg -> stub-tests still
+        pass, this one fails because the wire payload still carries
+        the thinking block.
+      - _try_stream stops calling create_streaming -> stub-tests fail
+        on the captured kwarg, this one fails because the SDK boundary
+        was never reached.
+
+    Drives through the real ``AnthropicProvider`` with a mock client
+    whose ``client.messages.stream`` is captured — the smallest possible
+    surface that crosses the session->provider->wire boundary chain.
+
+    Negative-tested: temporarily reverting
+    ``_anthropic.py:create_streaming``'s
+    ``self._convert_messages(messages, replay_reasoning_to_model=...)``
+    call to drop the kwarg makes the wire payload carry the thinking
+    block again; ``test_replay_false_strips_thinking_at_wire`` then
+    fails with ``Strip predicate did not fire at wire boundary``.
+    Restoring the kwarg makes it pass — confirming the test gates the
+    actual wire-build invariant rather than the captured kwarg.
+    """
+
+    def _stub_anthropic_client(self) -> tuple[MagicMock, dict[str, object]]:
+        """Build a mock Anthropic client + captured-kwargs dict.
+
+        ``client.messages.stream(**kwargs)`` returns a context manager
+        whose ``__enter__`` yields an iterable of zero events — enough
+        to satisfy the ``_iter_with_cleanup`` shape without exercising
+        actual streaming protocol.
+        """
+        captured: dict[str, object] = {}
+
+        def stream(**kwargs: object) -> object:
+            captured.update(kwargs)
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=iter([]))
+            cm.__exit__ = MagicMock(return_value=False)
+            return cm
+
+        client = MagicMock()
+        client.messages.stream = stream
+        return client, captured
+
+    def _drive_session_through_anthropic(
+        self,
+        replay_flag: bool,
+        msgs: list[dict[str, object]],
+    ) -> dict[str, object]:
+        """Run session._try_stream against a real AnthropicProvider with
+        the resolver pre-set to *replay_flag*.  Returns the kwargs
+        dict that reached the (mocked) Anthropic SDK boundary.
+        """
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=replay_flag)
+        session._model_alias = "claude-opus-4-7"
+        client, captured = self._stub_anthropic_client()
+        real_provider = AnthropicProvider()
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="claude-opus-4-7",
+                msgs=msgs,
+                provider=real_provider,
+                model_alias="claude-opus-4-7",
+            )
+            # Iterate the stream to drain the (empty) generator and ensure
+            # _ensure_anthropic / convert / build_kwargs all ran.
+            list(stream)
+        return captured
+
+    def test_replay_false_strips_thinking_at_wire(self) -> None:
+        msgs: list[dict[str, object]] = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "_provider_content": [
+                    {"type": "thinking", "thinking": "secret reasoning", "signature": "s"},
+                    {"type": "text", "text": "Final answer."},
+                ],
+            },
+            {"role": "user", "content": "ack"},
+        ]
+        captured = self._drive_session_through_anthropic(False, msgs)
+        # Anthropic SDK was called.
+        wire_msgs = captured.get("messages")
+        assert isinstance(wire_msgs, list), (
+            f"Expected messages= list at SDK boundary, got {captured}"
+        )
+        # Walk the wire payload — the thinking block must NOT be present
+        # in the assistant turn's content blocks.
+        assistant = next(m for m in wire_msgs if m["role"] == "assistant")
+        block_types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+        assert "thinking" not in block_types, (
+            f"Strip predicate did not fire at wire boundary: blocks={block_types}"
+        )
+        # Defense-in-depth: the secret reasoning text must not appear
+        # anywhere in the wire payload.
+        flat = repr(captured)
+        assert "secret reasoning" not in flat, "Reasoning text leaked into the SDK boundary payload"
+
+    def test_replay_true_preserves_thinking_at_wire(self) -> None:
+        msgs: list[dict[str, object]] = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "_provider_content": [
+                    {"type": "thinking", "thinking": "kept reasoning", "signature": "s"},
+                    {"type": "text", "text": "Final answer."},
+                ],
+            },
+            {"role": "user", "content": "ack"},
+        ]
+        captured = self._drive_session_through_anthropic(True, msgs)
+        wire_msgs = captured.get("messages")
+        assert isinstance(wire_msgs, list)
+        assistant = next(m for m in wire_msgs if m["role"] == "assistant")
+        block_types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+        assert "thinking" in block_types, (
+            f"Replay-true did not preserve thinking at wire: blocks={block_types}"
+        )
+
+
+class TestUtilityCompletionPassesFlag:
+    """Non-streaming utility path (title gen, compaction, extraction) —
+    same plumbing requirement as streaming."""
+
+    def test_utility_completion_passes_resolved_flag(self) -> None:
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "claude-opus-4-7"
+        captured: dict[str, Any] = {}
+
+        def capture_completion(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SimpleNamespace(content="title", finish_reason="stop", usage=None)
+
+        mock_provider = MagicMock()
+        mock_provider.create_completion = capture_completion
+        session._provider = mock_provider
+        with (
+            patch.object(
+                session, "_get_capabilities", return_value=SimpleNamespace(max_output_tokens=0)
+            ),
+            patch.object(session, "_provider_extra_params", return_value=None),
+        ):
+            session._utility_completion(
+                messages=[{"role": "user", "content": "summarize"}],
+                max_tokens=512,
+                temperature=0.3,
+            )
+        assert captured["replay_reasoning_to_model"] is True

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -26,29 +26,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from turnstone.core.session import ChatSession
-from turnstone.core.session_ui_base import SessionUIBase
-
-
-class _NullUI(SessionUIBase):
-    """Bare-bones UI satisfying the SessionUIBase contract for these tests."""
-
-    def __init__(self) -> None:
-        super().__init__()
-
-
-def _make_session(**kwargs: Any) -> ChatSession:
-    defaults: dict[str, Any] = {
-        "client": MagicMock(),
-        "model": "test-model",
-        "ui": _NullUI(),
-        "instructions": None,
-        "temperature": 0.5,
-        "max_tokens": 4096,
-        "tool_timeout": 30,
-    }
-    defaults.update(kwargs)
-    return ChatSession(**defaults)
+from tests._session_helpers import make_session as _make_session
 
 
 def _registry_with_flag(persist: bool = True, replay: bool = False) -> Any:
@@ -56,7 +34,7 @@ def _registry_with_flag(persist: bool = True, replay: bool = False) -> Any:
     flags under test."""
     return SimpleNamespace(
         get_config=lambda alias: SimpleNamespace(
-            persist_reasoning=persist,
+            surface_persisted_reasoning=persist,
             replay_reasoning_to_model=replay,
         )
     )

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -26,34 +26,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
 
+from tests._session_helpers import make_session as _make_session
 from turnstone.core.providers._anthropic import (
     ANTHROPIC_VALID_BLOCK_TYPES,
     AnthropicProvider,
 )
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
-from turnstone.core.session import ChatSession
-from turnstone.core.session_ui_base import SessionUIBase
-
-
-class _NullUI(SessionUIBase):
-    def __init__(self) -> None:
-        super().__init__()
-
-
-def _make_session(**kwargs: Any) -> ChatSession:
-    defaults: dict[str, Any] = {
-        "client": MagicMock(),
-        "model": "test-model",
-        "ui": _NullUI(),
-        "instructions": None,
-        "temperature": 0.5,
-        "max_tokens": 4096,
-        "tool_timeout": 30,
-    }
-    defaults.update(kwargs)
-    return ChatSession(**defaults)
 
 
 class TestMaybeSynthReasoningBlock:

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -1,0 +1,332 @@
+"""Tests for ChatSession synthetic ``reasoning_text`` block stamping (Phase 3 path 3).
+
+Path 3 covers OpenAI Chat Completions endpoints — vLLM with
+``--reasoning-parser``, llama.cpp with ``reasoning_format``, Gemini's
+``/v1beta/openai/`` endpoint, and any other server that surfaces
+``delta.reasoning_content`` Pydantic extras.  These have no native
+provider_blocks shape on the wire, so ``ChatSession._stream_response``
+captures the streamed reasoning text into ``reasoning_parts`` and
+``_maybe_synth_reasoning_block`` stamps it onto ``_provider_content``
+as a synthetic ``{type: "reasoning_text"}`` block at the end of the
+turn.
+
+These tests pin:
+1. The synthesizer fires only when no native blocks were emitted AND
+   reasoning was captured (Anthropic + OpenAI Responses bypass it).
+2. ``source`` field is tagged with the active model's server_type
+   (informational; pulled from ``server_compat.server_type``).
+3. ``OpenAIChatCompletionsProvider.extract_reasoning_text`` round-trips
+   the synthetic block on history rehydration.
+4. The synthetic shape is NOT in ``ANTHROPIC_VALID_BLOCK_TYPES`` so
+   cross-model resumption (local-model → Anthropic) falls through
+   cleanly to the text+tool_calls rebuild path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from turnstone.core.providers._anthropic import (
+    ANTHROPIC_VALID_BLOCK_TYPES,
+    AnthropicProvider,
+)
+from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+from turnstone.core.session import ChatSession
+from turnstone.core.session_ui_base import SessionUIBase
+
+
+class _NullUI(SessionUIBase):
+    def __init__(self) -> None:
+        super().__init__()
+
+
+def _make_session(**kwargs: Any) -> ChatSession:
+    defaults: dict[str, Any] = {
+        "client": MagicMock(),
+        "model": "test-model",
+        "ui": _NullUI(),
+        "instructions": None,
+        "temperature": 0.5,
+        "max_tokens": 4096,
+        "tool_timeout": 30,
+    }
+    defaults.update(kwargs)
+    return ChatSession(**defaults)
+
+
+class TestMaybeSynthReasoningBlock:
+    """Direct unit tests for ``ChatSession._maybe_synth_reasoning_block``."""
+
+    def test_no_synth_when_provider_blocks_present(self) -> None:
+        # Anthropic / OpenAI Responses path — native blocks already
+        # carry the reasoning, no synth needed.
+        session = _make_session()
+        existing = [{"type": "thinking", "thinking": "x"}]
+        out = session._maybe_synth_reasoning_block(existing, ["should not be added"])
+        assert out is existing
+
+    def test_no_synth_when_reasoning_parts_empty(self) -> None:
+        session = _make_session()
+        out = session._maybe_synth_reasoning_block([], [])
+        assert out == []
+
+    def test_no_synth_when_reasoning_parts_only_whitespace(self) -> None:
+        session = _make_session()
+        out = session._maybe_synth_reasoning_block([], ["   ", "\n\t"])
+        assert out == []
+
+    def test_synth_creates_reasoning_text_block(self) -> None:
+        session = _make_session()
+        out = session._maybe_synth_reasoning_block([], ["thought ", "process"])
+        assert len(out) == 1
+        assert out[0]["type"] == "reasoning_text"
+        assert out[0]["text"] == "thought process"
+
+    def test_synth_omits_source_when_no_server_type(self) -> None:
+        session = _make_session()
+        # No registry / no server_compat → source field omitted.
+        out = session._maybe_synth_reasoning_block([], ["text"])
+        assert "source" not in out[0]
+
+    def test_synth_includes_source_when_server_type_resolvable(self) -> None:
+        session = _make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                capabilities={"server_compat": {"server_type": "vllm"}},
+            )
+        )
+        session._model_alias = "qwen3-32b"
+        out = session._maybe_synth_reasoning_block([], ["text"])
+        assert out[0]["source"] == "vllm"
+
+    def test_synth_handles_registry_exception(self) -> None:
+        # _resolve_server_type silently returns "" on any lookup error
+        # — synth still fires but omits the source field.
+        class BrokenRegistry:
+            def get_config(self, alias: str) -> Any:
+                raise KeyError(alias)
+
+        session = _make_session()
+        session._registry = BrokenRegistry()
+        session._model_alias = "missing"
+        out = session._maybe_synth_reasoning_block([], ["text"])
+        assert out[0]["text"] == "text"
+        assert "source" not in out[0]
+
+
+class TestSyntheticBlockShapeContract:
+    """The synthetic block shape MUST stay outside Anthropic's valid
+    block types so cross-model resumption falls through cleanly."""
+
+    def test_reasoning_text_not_in_anthropic_valid_types(self) -> None:
+        # If this assertion ever fails, the cross-model resumption
+        # safety story breaks: a synthetic block from a local-model
+        # session would reach Anthropic's wire as a malformed block.
+        assert "reasoning_text" not in ANTHROPIC_VALID_BLOCK_TYPES
+
+    def test_synthetic_block_falls_through_anthropic_shape_filter(self) -> None:
+        # Cross-model resumption regression: turn 1 was on a local
+        # model (synthetic block stamped), then the operator switched
+        # to Anthropic. The shape filter must reject the synthetic
+        # block and fall through to text+tool_calls rebuild.
+        provider = AnthropicProvider()
+        msg = {
+            "role": "assistant",
+            "content": "spoken answer",
+            "_provider_content": [
+                {"type": "reasoning_text", "text": "synth thought", "source": "vllm"},
+            ],
+        }
+        _, converted = provider._convert_messages([msg])
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        block_types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+        # Foreign block did NOT reach Anthropic's wire.  Rebuilt from
+        # text only.
+        assert "reasoning_text" not in block_types
+        assert assistant["content"] == [{"type": "text", "text": "spoken answer"}]
+
+
+class TestOpenAIChatExtractReasoningText:
+    """``OpenAIChatCompletionsProvider.extract_reasoning_text`` reads
+    the synthetic block back out for UI rehydration."""
+
+    def test_reads_synthetic_reasoning_text_block(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [{"type": "reasoning_text", "text": "captured thought"}]
+        assert provider.extract_reasoning_text(blocks) == "captured thought"
+
+    def test_concatenates_multiple_blocks(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [
+            {"type": "reasoning_text", "text": "first"},
+            {"type": "reasoning_text", "text": "second"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == "first\nsecond"
+
+    def test_skips_other_block_types(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [
+            {"type": "thinking", "thinking": "anth"},
+            {"type": "reasoning", "summary": [{"text": "openai"}]},
+            {"type": "reasoning_text", "text": "chat"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == "chat"
+
+    def test_handles_empty_text_field(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [
+            {"type": "reasoning_text", "text": ""},
+            {"type": "reasoning_text", "text": "kept"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == "kept"
+
+    def test_handles_missing_text_field(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [
+            {"type": "reasoning_text"},  # no text
+            {"type": "reasoning_text", "text": "kept"},
+        ]
+        assert provider.extract_reasoning_text(blocks) == "kept"
+
+    def test_returns_empty_for_no_synth_blocks(self) -> None:
+        provider = OpenAIChatCompletionsProvider()
+        blocks = [{"type": "thinking", "thinking": "x"}]
+        assert provider.extract_reasoning_text(blocks) == ""
+
+
+class TestStreamResponseSynthBlockIntegration:
+    """Integration test: drives a fake reasoning-emitting stream
+    through ``ChatSession._stream_response`` and asserts the
+    synthesizer wires up correctly.  Pins the call site at
+    ``session.py`` (where ``_maybe_synth_reasoning_block`` is invoked
+    on the assembled provider_blocks before stamping ``_provider_content``)
+    — without this, a future refactor that drops the synthesizer call
+    would silently break path-3 capture (vLLM/llama.cpp/Gemini-compat
+    reasoning would be visible live but invisible on history reload).
+    """
+
+    def _make_stream(self, content: str, reasoning: str) -> Any:
+        """Build an iterator of StreamChunks that mimic a path-3
+        capture (reasoning_delta chunks, content chunks, no
+        provider_blocks emitted).
+        """
+        from turnstone.core.providers._protocol import StreamChunk, UsageInfo
+
+        chunks = []
+        # Reasoning first (matches live SSE order).
+        if reasoning:
+            chunks.append(StreamChunk(reasoning_delta=reasoning, is_first=True))
+        # Content next.
+        if content:
+            chunks.append(
+                StreamChunk(
+                    content_delta=content,
+                    is_first=not reasoning,
+                )
+            )
+        # Final chunk with finish_reason + usage.
+        chunks.append(
+            StreamChunk(
+                finish_reason="stop",
+                usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+            )
+        )
+        return iter(chunks)
+
+    def test_stream_response_stamps_synth_block_when_path3_reasoning_captured(
+        self,
+    ) -> None:
+        """Drive a fake stream emitting reasoning_delta chunks (no
+        native provider_blocks) through ``_stream_response``; assert
+        the resulting assistant_msg carries a synthetic reasoning_text
+        block stamped onto ``_provider_content``."""
+        session = _make_session()
+        # No registry → source field omitted from synth block.
+        stream = self._make_stream(content="Final answer.", reasoning="path-3 reasoning")
+        msg = session._stream_response(stream)
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Final answer."
+        # Synthetic block should be stamped onto _provider_content.
+        provider_content = msg.get("_provider_content")
+        assert isinstance(provider_content, list)
+        assert len(provider_content) == 1
+        assert provider_content[0]["type"] == "reasoning_text"
+        assert provider_content[0]["text"] == "path-3 reasoning"
+
+    def test_stream_response_no_synth_when_no_reasoning_captured(self) -> None:
+        """Stream emits only content (no reasoning_delta).  No synth
+        block stamped — _provider_content key absent on assistant_msg."""
+        session = _make_session()
+        stream = self._make_stream(content="just content", reasoning="")
+        msg = session._stream_response(stream)
+        assert msg["content"] == "just content"
+        # No synth block (and no native blocks either) → key absent.
+        assert "_provider_content" not in msg
+
+    def test_stream_response_synth_block_carries_source_when_server_type_resolvable(
+        self,
+    ) -> None:
+        """When the active model has server_compat.server_type set,
+        the synth block carries it as the ``source`` field."""
+        session = _make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                capabilities={"server_compat": {"server_type": "vllm"}},
+            )
+        )
+        session._model_alias = "qwen3-32b"
+        stream = self._make_stream(content="answer", reasoning="reasoning text")
+        msg = session._stream_response(stream)
+        provider_content = msg.get("_provider_content")
+        assert isinstance(provider_content, list)
+        assert provider_content[0]["source"] == "vllm"
+
+
+class TestResolveServerType:
+    """Direct unit tests for the helper that pulls server_type from
+    the active model's capabilities dict."""
+
+    def test_returns_empty_when_no_registry(self) -> None:
+        session = _make_session()
+        session._registry = None
+        assert session._resolve_server_type() == ""
+
+    def test_returns_empty_when_no_alias(self) -> None:
+        session = _make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(capabilities={})
+        )
+        session._model_alias = ""
+        assert session._resolve_server_type() == ""
+
+    def test_returns_server_type_when_present(self) -> None:
+        session = _make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                capabilities={"server_compat": {"server_type": "llama.cpp"}}
+            )
+        )
+        session._model_alias = "local-model"
+        assert session._resolve_server_type() == "llama.cpp"
+
+    def test_returns_empty_when_server_compat_missing(self) -> None:
+        session = _make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                capabilities={"context_window": 32768},
+            )
+        )
+        session._model_alias = "local-model"
+        assert session._resolve_server_type() == ""
+
+    def test_returns_empty_on_exception(self) -> None:
+        class BrokenRegistry:
+            def get_config(self, alias: str) -> Any:
+                raise RuntimeError("boom")
+
+        session = _make_session()
+        session._registry = BrokenRegistry()
+        session._model_alias = "x"
+        assert session._resolve_server_type() == ""

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -94,6 +94,50 @@ class TestMaybeSynthReasoningBlock:
         assert out[0]["text"] == "text"
         assert "source" not in out[0]
 
+    def test_synth_appends_when_provider_blocks_are_non_reasoning(self) -> None:
+        # GoogleProvider attaches raw tool_call dicts as provider_blocks
+        # on the finish chunk (for thought_signature round-trip).  When
+        # the same turn streamed reasoning_delta (Gemini's reasoning_
+        # content extra), the synthesizer must APPEND the synthetic
+        # reasoning block rather than skip synthesis — otherwise the
+        # reasoning text is shown live but lost on page reload.
+        session = _make_session()
+        existing = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+                "thought_signature": "sig123",
+            }
+        ]
+        out = session._maybe_synth_reasoning_block(existing, ["I should search"])
+        assert len(out) == 2
+        assert out[0] is existing[0]  # tool_call fidelity block survives intact
+        assert out[1]["type"] == "reasoning_text"
+        assert out[1]["text"] == "I should search"
+
+    def test_no_synth_when_openai_responses_reasoning_already_present(self) -> None:
+        # OpenAI Responses native reasoning item — synth must NOT fire
+        # even though provider_blocks contains ALSO non-reasoning items
+        # (e.g. message blocks).  The reasoning-bearing block satisfies
+        # the persistence contract on its own.
+        session = _make_session()
+        existing = [
+            {"type": "reasoning", "summary": [{"text": "openai reasoning"}]},
+            {"type": "message", "role": "assistant", "content": "answer"},
+        ]
+        out = session._maybe_synth_reasoning_block(existing, ["live reasoning text"])
+        assert out is existing
+
+    def test_no_synth_when_non_reasoning_blocks_but_reasoning_parts_empty(self) -> None:
+        # Google tool_calls with no reasoning streamed — return as-is.
+        session = _make_session()
+        existing = [
+            {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+        ]
+        out = session._maybe_synth_reasoning_block(existing, [])
+        assert out is existing
+
 
 class TestSyntheticBlockShapeContract:
     """The synthetic block shape MUST stay outside Anthropic's valid

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import queue
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -1762,3 +1764,155 @@ class TestTenantCheckOnReadEndpoints:
         assert cold_check in offloaded, (
             f"tenant_check must be invoked through asyncio.to_thread; got {offloaded}"
         )
+
+
+class TestHistoryReasoningRehydration:
+    """The lifted ``GET /v1/api/workstreams/{ws_id}/history`` surfaces
+    stored Anthropic thinking blocks on assistant messages so a page
+    refresh re-renders the reasoning bubble. Drives through the real
+    ``AnthropicProvider.extract_reasoning_text`` and the storage
+    ``reconstruct_messages`` boundary that JSON-decodes
+    ``provider_data`` into ``_provider_content``.
+    """
+
+    def test_history_handler_surfaces_reasoning_for_anthropic_thinking(self, _inject_storage):
+        ws_id = "ws-reason-1"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        provider_data = json.dumps(
+            [
+                {"type": "thinking", "thinking": "let me reason", "signature": "s"},
+                {"type": "text", "text": "Final answer."},
+            ]
+        )
+        _inject_storage.save_message(
+            ws_id, "assistant", "Final answer.", provider_data=provider_data
+        )
+        # No live session — exercises the storage-only path which
+        # falls back to default persist_reasoning=True.
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        msgs = r.json()["messages"]
+        assistant = next(m for m in msgs if m.get("role") == "assistant")
+        assert assistant["reasoning"] == "let me reason"
+
+    def test_history_handler_strips_provider_content(self, _inject_storage):
+        ws_id = "ws-reason-2"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        provider_data = json.dumps([{"type": "thinking", "thinking": "x", "signature": "s"}])
+        _inject_storage.save_message(ws_id, "assistant", "Answer.", provider_data=provider_data)
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        for m in r.json()["messages"]:
+            assert "_provider_content" not in m
+
+    def test_history_handler_with_persist_flag_false_via_live_session(self, _inject_storage):
+        """Operator-flipped ``persist_reasoning=False`` on the active
+        model suppresses the reasoning field even when the data is
+        stored. ``_provider_content`` is still stripped from the wire.
+        """
+        ws_id = "ws-reason-3"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        provider_data = json.dumps([{"type": "thinking", "thinking": "hidden", "signature": "s"}])
+        _inject_storage.save_message(ws_id, "assistant", "Answer.", provider_data=provider_data)
+        live_session = SimpleNamespace(
+            id=ws_id,
+            _registry=SimpleNamespace(
+                get_config=lambda alias: SimpleNamespace(persist_reasoning=False)
+            ),
+            _model_alias="claude-opus-4-7",
+        )
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = live_session
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        for m in r.json()["messages"]:
+            if m.get("role") == "assistant":
+                assert "reasoning" not in m
+            assert "_provider_content" not in m
+
+    def test_history_handler_cold_workstream_resolves_via_workstream_config(self, _inject_storage):
+        """Cold workstream (no live session) — the handler walks
+        ``workstream_config.model_alias`` (persisted at first send by
+        the SessionManager rehydrate path) and looks up the active
+        model's ``persist_reasoning`` flag through the global registry
+        on ``app.state``. Operator flag-flip is honored uniformly
+        across live and cold workstreams.
+        """
+        ws_id = "ws-reason-cold"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        # Simulate the model alias persisted by the rehydrate path
+        # (session_manager.py:628-629 reads it back via the same key).
+        _inject_storage.save_workstream_config(ws_id, {"model_alias": "claude-opus-4-7"})
+        provider_data = json.dumps(
+            [{"type": "thinking", "thinking": "should not surface", "signature": "s"}]
+        )
+        _inject_storage.save_message(ws_id, "assistant", "Answer.", provider_data=provider_data)
+        # No live session — handler falls back to workstream_config + registry.
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+
+        # Build the app with a global registry that reports persist=False
+        # for the saved alias.
+        cfg = _interactive_endpoint_cfg(mock_mgr)
+        handler = make_history_handler(cfg)
+        app = Starlette(
+            routes=[
+                Mount(
+                    "/v1",
+                    routes=[
+                        Route(
+                            "/api/workstreams/{ws_id}/history",
+                            handler,
+                            methods=["GET"],
+                        ),
+                    ],
+                ),
+            ],
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        app.state.workstreams = mock_mgr
+        app.state.auth_storage = _inject_storage
+        app.state.registry = SimpleNamespace(
+            get_config=lambda alias: SimpleNamespace(
+                persist_reasoning=(alias != "claude-opus-4-7"),
+            )
+        )
+        client = TestClient(app)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        # Flag-flip on the saved alias is honored: reasoning suppressed.
+        for m in r.json()["messages"]:
+            if m.get("role") == "assistant":
+                assert "reasoning" not in m
+            assert "_provider_content" not in m
+
+    def test_history_handler_cold_workstream_no_alias_defaults_true(self, _inject_storage):
+        """A workstream that pre-dates the rehydrate-time alias persist
+        (or one that simply has no workstream_config row) falls through
+        to the conservative default ``True``.  Reasoning surfaces.
+        """
+        ws_id = "ws-reason-cold-no-alias"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        provider_data = json.dumps(
+            [{"type": "thinking", "thinking": "default-true wins", "signature": "s"}]
+        )
+        _inject_storage.save_message(ws_id, "assistant", "Answer.", provider_data=provider_data)
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = None
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        assistant = next(m for m in r.json()["messages"] if m.get("role") == "assistant")
+        assert assistant["reasoning"] == "default-true wins"

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1788,7 +1788,7 @@ class TestHistoryReasoningRehydration:
             ws_id, "assistant", "Final answer.", provider_data=provider_data
         )
         # No live session — exercises the storage-only path which
-        # falls back to default persist_reasoning=True.
+        # falls back to default surface_persisted_reasoning=True.
         mock_mgr = MagicMock()
         mock_mgr.get.return_value = None
         client = _build_history_app(mock_mgr, _inject_storage)
@@ -1814,7 +1814,7 @@ class TestHistoryReasoningRehydration:
             assert "_provider_content" not in m
 
     def test_history_handler_with_persist_flag_false_via_live_session(self, _inject_storage):
-        """Operator-flipped ``persist_reasoning=False`` on the active
+        """Operator-flipped ``surface_persisted_reasoning=False`` on the active
         model suppresses the reasoning field even when the data is
         stored. ``_provider_content`` is still stripped from the wire.
         """
@@ -1825,7 +1825,7 @@ class TestHistoryReasoningRehydration:
         live_session = SimpleNamespace(
             id=ws_id,
             _registry=SimpleNamespace(
-                get_config=lambda alias: SimpleNamespace(persist_reasoning=False)
+                get_config=lambda alias: SimpleNamespace(surface_persisted_reasoning=False)
             ),
             _model_alias="claude-opus-4-7",
         )
@@ -1844,7 +1844,7 @@ class TestHistoryReasoningRehydration:
         """Cold workstream (no live session) — the handler walks
         ``workstream_config.model_alias`` (persisted at first send by
         the SessionManager rehydrate path) and looks up the active
-        model's ``persist_reasoning`` flag through the global registry
+        model's ``surface_persisted_reasoning`` flag through the global registry
         on ``app.state``. Operator flag-flip is honored uniformly
         across live and cold workstreams.
         """
@@ -1884,7 +1884,7 @@ class TestHistoryReasoningRehydration:
         app.state.auth_storage = _inject_storage
         app.state.registry = SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
-                persist_reasoning=(alias != "claude-opus-4-7"),
+                surface_persisted_reasoning=(alias != "claude-opus-4-7"),
             )
         )
         client = TestClient(app)

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -908,7 +908,7 @@ class ModelDefinitionInfo(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
-    persist_reasoning: bool = True
+    surface_persisted_reasoning: bool = True
     replay_reasoning_to_model: bool = False
     source: str = ""
     created_by: str = ""
@@ -928,7 +928,7 @@ class CreateModelDefinitionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
-    persist_reasoning: bool = True
+    surface_persisted_reasoning: bool = True
     replay_reasoning_to_model: bool = False
 
 
@@ -944,7 +944,7 @@ class UpdateModelDefinitionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
-    persist_reasoning: bool | None = None
+    surface_persisted_reasoning: bool | None = None
     replay_reasoning_to_model: bool | None = None
 
 

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -908,6 +908,8 @@ class ModelDefinitionInfo(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    persist_reasoning: bool = True
+    replay_reasoning_to_model: bool = False
     source: str = ""
     created_by: str = ""
     created: str = ""
@@ -926,6 +928,8 @@ class CreateModelDefinitionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    persist_reasoning: bool = True
+    replay_reasoning_to_model: bool = False
 
 
 class UpdateModelDefinitionRequest(BaseModel):
@@ -940,6 +944,8 @@ class UpdateModelDefinitionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    persist_reasoning: bool | None = None
+    replay_reasoning_to_model: bool | None = None
 
 
 class ListModelDefinitionsResponse(BaseModel):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9904,6 +9904,9 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         if not reasoning_effort:
             reasoning_effort = None
 
+    persist_reasoning = bool(body.get("persist_reasoning", True))
+    replay_reasoning_to_model = bool(body.get("replay_reasoning_to_model", False))
+
     storage.create_model_definition(
         definition_id=definition_id,
         alias=alias,
@@ -9918,6 +9921,8 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         temperature=temperature,
         max_tokens=max_tokens,
         reasoning_effort=reasoning_effort,
+        persist_reasoning=persist_reasoning,
+        replay_reasoning_to_model=replay_reasoning_to_model,
     )
 
     record_audit(
@@ -10079,6 +10084,10 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
                 )
             else:
                 updates["reasoning_effort"] = re_val
+    if "persist_reasoning" in body:
+        updates["persist_reasoning"] = bool(body["persist_reasoning"])
+    if "replay_reasoning_to_model" in body:
+        updates["replay_reasoning_to_model"] = bool(body["replay_reasoning_to_model"])
 
     if updates:
         storage.update_model_definition(definition_id, **updates)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9904,7 +9904,7 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         if not reasoning_effort:
             reasoning_effort = None
 
-    persist_reasoning = bool(body.get("persist_reasoning", True))
+    surface_persisted_reasoning = bool(body.get("surface_persisted_reasoning", True))
     replay_reasoning_to_model = bool(body.get("replay_reasoning_to_model", False))
 
     storage.create_model_definition(
@@ -9921,7 +9921,7 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
         temperature=temperature,
         max_tokens=max_tokens,
         reasoning_effort=reasoning_effort,
-        persist_reasoning=persist_reasoning,
+        surface_persisted_reasoning=surface_persisted_reasoning,
         replay_reasoning_to_model=replay_reasoning_to_model,
     )
 
@@ -10084,8 +10084,8 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
                 )
             else:
                 updates["reasoning_effort"] = re_val
-    if "persist_reasoning" in body:
-        updates["persist_reasoning"] = bool(body["persist_reasoning"])
+    if "surface_persisted_reasoning" in body:
+        updates["surface_persisted_reasoning"] = bool(body["surface_persisted_reasoning"])
     if "replay_reasoning_to_model" in body:
         updates["replay_reasoning_to_model"] = bool(body["replay_reasoning_to_model"])
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5008,6 +5008,11 @@ function _renderModels(items) {
     if (m.max_tokens != null) overrides.push("max_tok=" + m.max_tokens);
     if (m.reasoning_effort != null)
       overrides.push("effort=" + m.reasoning_effort);
+    // Reasoning persistence flags surface only when non-default
+    // (persist=False is the operator opt-out; replay=True is the
+    // operator opt-in). Default values are silent.
+    if (m.persist_reasoning === false) overrides.push("persist=off");
+    if (m.replay_reasoning_to_model === true) overrides.push("replay=on");
     if (overrides.length) {
       var ovrSpan = document.createElement("span");
       ovrSpan.className = "model-overrides-hint";
@@ -5196,6 +5201,8 @@ function showCreateModelModal() {
     el.style.borderColor = "";
   });
   document.getElementById("model-enabled").checked = true;
+  document.getElementById("model-persist-reasoning").checked = true;
+  document.getElementById("model-replay-reasoning").checked = false;
   document.getElementById("model-detect-result").style.display = "none";
   document.getElementById("model-detect-btn").disabled = false;
   document.getElementById("model-detect-btn").textContent = "Detect";
@@ -5278,6 +5285,13 @@ function showEditModelModal(definitionId) {
       document.getElementById("model-capabilities").value =
         capsText === "{}" ? "" : capsText;
       document.getElementById("model-enabled").checked = m.enabled !== false;
+      // Reasoning persistence flags — defaults match the dataclass
+      // defaults (persist=true, replay=false) when the API returns
+      // them as undefined (legacy / pre-052 row).
+      document.getElementById("model-persist-reasoning").checked =
+        m.persist_reasoning !== false;
+      document.getElementById("model-replay-reasoning").checked =
+        m.replay_reasoning_to_model === true;
       _applyProviderDefaults();
     })
     .catch(function () {
@@ -5418,6 +5432,16 @@ function submitCreateModel() {
   } else {
     form.reasoning_effort = null;
   }
+
+  // Reasoning persistence flags — always serialize so a flip from
+  // default takes effect on PUT (the server's update path keys off
+  // "field present in body").
+  form.persist_reasoning = document.getElementById(
+    "model-persist-reasoning",
+  ).checked;
+  form.replay_reasoning_to_model = document.getElementById(
+    "model-replay-reasoning",
+  ).checked;
 
   var apiKey = document.getElementById("model-api-key").value;
   if (apiKey) form.api_key = apiKey;

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5011,7 +5011,7 @@ function _renderModels(items) {
     // Reasoning persistence flags surface only when non-default
     // (persist=False is the operator opt-out; replay=True is the
     // operator opt-in). Default values are silent.
-    if (m.persist_reasoning === false) overrides.push("persist=off");
+    if (m.surface_persisted_reasoning === false) overrides.push("surface=off");
     if (m.replay_reasoning_to_model === true) overrides.push("replay=on");
     if (overrides.length) {
       var ovrSpan = document.createElement("span");
@@ -5201,7 +5201,7 @@ function showCreateModelModal() {
     el.style.borderColor = "";
   });
   document.getElementById("model-enabled").checked = true;
-  document.getElementById("model-persist-reasoning").checked = true;
+  document.getElementById("model-surface-persisted-reasoning").checked = true;
   document.getElementById("model-replay-reasoning").checked = false;
   document.getElementById("model-detect-result").style.display = "none";
   document.getElementById("model-detect-btn").disabled = false;
@@ -5288,8 +5288,8 @@ function showEditModelModal(definitionId) {
       // Reasoning persistence flags — defaults match the dataclass
       // defaults (persist=true, replay=false) when the API returns
       // them as undefined (legacy / pre-052 row).
-      document.getElementById("model-persist-reasoning").checked =
-        m.persist_reasoning !== false;
+      document.getElementById("model-surface-persisted-reasoning").checked =
+        m.surface_persisted_reasoning !== false;
       document.getElementById("model-replay-reasoning").checked =
         m.replay_reasoning_to_model === true;
       _applyProviderDefaults();
@@ -5436,8 +5436,8 @@ function submitCreateModel() {
   // Reasoning persistence flags — always serialize so a flip from
   // default takes effect on PUT (the server's update path keys off
   // "field present in body").
-  form.persist_reasoning = document.getElementById(
-    "model-persist-reasoning",
+  form.surface_persisted_reasoning = document.getElementById(
+    "model-surface-persisted-reasoning",
   ).checked;
   form.replay_reasoning_to_model = document.getElementById(
     "model-replay-reasoning",

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -4195,6 +4195,20 @@
             appendUserMessageWithAttachments(text, [], { label: "user" });
           });
         } else if (role === "assistant") {
+          // Reasoning bubble (Phase 1 reasoning persistence) — render
+          // BEFORE the content card so the visual order matches the
+          // live SSE flow (reasoning_delta arrives before content_delta
+          // for thinking-enabled models). Mirrors the live ":1524" /
+          // snapshot ":2021" call sites — same appendMsg("reasoning")
+          // helper, just driven from history-render rather than the
+          // SSE handler. Only present when the active model's
+          // persist_reasoning flag is true and the message round-tripped
+          // a thinking lane.
+          if (typeof m.reasoning === "string" && m.reasoning.length) {
+            const rEl = appendMsg("reasoning", "", { label: "reasoning" });
+            const rBody = rEl && rEl.querySelector(".msg-body");
+            if (rBody) rBody.textContent = m.reasoning;
+          }
           // Render content BEFORE the tool batch so DOM order matches
           // chronological order (the model emits text first, then
           // dispatches tools).  Whitespace-only content (e.g. "\n\n"

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -4202,7 +4202,7 @@
           // snapshot ":2021" call sites — same appendMsg("reasoning")
           // helper, just driven from history-render rather than the
           // SSE handler. Only present when the active model's
-          // persist_reasoning flag is true and the message round-tripped
+          // surface_persisted_reasoning flag is true and the message round-tripped
           // a thinking lane.
           if (typeof m.reasoning === "string" && m.reasoning.length) {
             const rEl = appendMsg("reasoning", "", { label: "reasoning" });

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -4127,13 +4127,13 @@
           >
           <label
             style="margin: 0; font-size: 12px; color: var(--fg-dim)"
-            title="Surface stored reasoning text on /history responses (UI bubble on page reload). Storage of reasoning is independent of this flag."
+            title="Surface stored reasoning text on /history responses (UI bubble on page reload). Storage of reasoning bytes is unaffected by this flag — they ride in provider_data regardless."
             ><input
               type="checkbox"
-              id="model-persist-reasoning"
+              id="model-surface-persisted-reasoning"
               checked
               style="margin-right: 5px"
-            />Persist reasoning</label
+            />Surface persisted reasoning</label
           >
           <label
             style="margin: 0; font-size: 12px; color: var(--fg-dim)"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -4116,7 +4116,7 @@
           placeholder='{"supports_vision": true}'
           style="font-family: var(--font-mono); font-size: 11px"
         ></textarea>
-        <div style="display: flex; gap: 20px; margin-top: 14px">
+        <div style="display: flex; gap: 20px; margin-top: 14px; flex-wrap: wrap">
           <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
             ><input
               type="checkbox"
@@ -4124,6 +4124,25 @@
               checked
               style="margin-right: 5px"
             />Enabled</label
+          >
+          <label
+            style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            title="Surface stored reasoning text on /history responses (UI bubble on page reload). Storage of reasoning is independent of this flag."
+            ><input
+              type="checkbox"
+              id="model-persist-reasoning"
+              checked
+              style="margin-right: 5px"
+            />Persist reasoning</label
+          >
+          <label
+            style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            title="Replay stored reasoning blocks back to the model on subsequent provider calls. Capability-dependent; off by default for cost/spec compliance."
+            ><input
+              type="checkbox"
+              id="model-replay-reasoning"
+              style="margin-right: 5px"
+            />Replay reasoning to model</label
           >
         </div>
         <div id="model-detect-area" style="margin-top: 14px">

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -269,46 +269,67 @@ def extract_advisories_from_tool_envelope(
 
 
 if TYPE_CHECKING:
-    from turnstone.core.providers._anthropic import AnthropicProvider
-    from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+    from collections.abc import Callable
 
-_anthropic_provider_singleton: AnthropicProvider | None = None
-_openai_responses_provider_singleton: OpenAIResponsesProvider | None = None
+    from turnstone.core.providers._protocol import LLMProvider
 
 
-def _get_anthropic_provider() -> AnthropicProvider:
-    global _anthropic_provider_singleton
-    if _anthropic_provider_singleton is None:
-        from turnstone.core.providers._anthropic import AnthropicProvider as _Anthropic
+def _make_provider_factory(module_path: str, class_name: str) -> Callable[[], LLMProvider]:
+    """Build a thread-unsafe lazy-init factory for a provider singleton.
 
-        _anthropic_provider_singleton = _Anthropic()
-    return _anthropic_provider_singleton
+    Single source of truth for the dispatcher's per-provider lazy-load
+    pattern — each block-type entry in ``_BLOCK_TYPE_PROVIDER_FACTORY``
+    closes over this with its own (module_path, class_name) pair.
+    Adding a fourth provider is a single tuple in the dict, not a
+    new 9-line getter.
+    """
+    cached: dict[str, LLMProvider] = {}
+
+    def factory() -> LLMProvider:
+        if "instance" not in cached:
+            import importlib
+
+            module = importlib.import_module(module_path)
+            cached["instance"] = getattr(module, class_name)()
+        return cached["instance"]
+
+    return factory
 
 
-def _get_openai_responses_provider() -> OpenAIResponsesProvider:
-    global _openai_responses_provider_singleton
-    if _openai_responses_provider_singleton is None:
-        from turnstone.core.providers._openai_responses import (
-            OpenAIResponsesProvider as _OpenAIResp,
-        )
-
-        _openai_responses_provider_singleton = _OpenAIResp()
-    return _openai_responses_provider_singleton
+# Block-type → provider factory.  Routing is structural — block shape
+# is non-overlapping across providers by API design.  Three block
+# types are recognised today:
+#
+# * ``"thinking"`` — Anthropic native (Phase 1).  Walks the
+#   ``thinking`` field on each block.
+# * ``"reasoning"`` — OpenAI Responses native (Phase 3).  Walks
+#   ``summary[*].text`` (always present) and ``content[*].text``
+#   (present when ``include=["reasoning.encrypted_content"]`` is
+#   requested AND the response carries raw reasoning text).
+# * ``"reasoning_text"`` — synthetic, stamped by
+#   ``ChatSession._maybe_synth_reasoning_block`` for Chat Completions
+#   paths (vLLM, llama.cpp, Gemini-compat) where reasoning surfaces
+#   only as ``reasoning_delta`` chunks with no native block shape.
+_BLOCK_TYPE_PROVIDER_FACTORY: dict[str, Callable[[], LLMProvider]] = {
+    "thinking": _make_provider_factory("turnstone.core.providers._anthropic", "AnthropicProvider"),
+    "reasoning": _make_provider_factory(
+        "turnstone.core.providers._openai_responses", "OpenAIResponsesProvider"
+    ),
+    "reasoning_text": _make_provider_factory(
+        "turnstone.core.providers._openai_chat", "OpenAIChatCompletionsProvider"
+    ),
+}
 
 
 def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
     """Dispatch reasoning extraction by first-block ``type`` field.
 
-    Routing is structural — block shape is non-overlapping across
-    providers by API design (Anthropic ``thinking``, OpenAI Responses
-    ``reasoning``, Gemini ``thought``).  Phase 1 wires Anthropic
-    extraction; OpenAI Responses returns ``""`` until Phase 3 adds the
-    ``include=["reasoning.encrypted_content"]`` request flag.  Returns
-    ``""`` for empty / missing / non-list / unknown-type input.
+    Returns ``""`` for empty / missing / non-list / unknown-type input.
 
     Pure transform — safe from any thread.  Both history surfaces
     (interactive ``_build_history`` and lifted ``make_history_handler``)
-    call this directly.
+    call this directly.  See ``_BLOCK_TYPE_PROVIDER_FACTORY`` above
+    for the recognised block types and the providers that own them.
     """
     if not isinstance(provider_content, list) or not provider_content:
         return ""
@@ -318,11 +339,10 @@ def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
     block_type = first_block.get("type")
     if not isinstance(block_type, str):
         return ""
-    if block_type == "thinking":
-        return _get_anthropic_provider().extract_reasoning_text(provider_content)
-    if block_type == "reasoning":
-        return _get_openai_responses_provider().extract_reasoning_text(provider_content)
-    return ""
+    factory = _BLOCK_TYPE_PROVIDER_FACTORY.get(block_type)
+    if factory is None:
+        return ""
+    return factory().extract_reasoning_text(provider_content)
 
 
 def extract_reasoning_for_history(

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -277,31 +277,44 @@ if TYPE_CHECKING:
 def _make_provider_factory(module_path: str, class_name: str) -> Callable[[], LLMProvider]:
     """Build a thread-unsafe lazy-init factory for a provider singleton.
 
-    Single source of truth for the dispatcher's per-provider lazy-load
-    pattern — each block-type entry in ``_BLOCK_TYPE_PROVIDER_FACTORY``
-    closes over this with its own (module_path, class_name) pair.
-    Adding a fourth provider is a single tuple in the dict, not a
-    new 9-line getter.
+    Each block-type entry in ``_BLOCK_TYPE_PROVIDER_FACTORY`` closes
+    over its own (module_path, class_name) pair.  Adding a fourth
+    provider is a single tuple in the dict, not a new 9-line getter.
+
+    Uses ``nonlocal`` instead of ``functools.lru_cache`` so the cache
+    state stays inside this closure (lru_cache would attach state to
+    the inner function object, which is correct but adds a per-call
+    hash lookup on a bound key for what's effectively a single-slot
+    cache).
     """
-    cached: dict[str, LLMProvider] = {}
+    instance: LLMProvider | None = None
 
     def factory() -> LLMProvider:
-        if "instance" not in cached:
+        nonlocal instance
+        if instance is None:
             import importlib
 
             module = importlib.import_module(module_path)
-            cached["instance"] = getattr(module, class_name)()
-        return cached["instance"]
+            instance = getattr(module, class_name)()
+        return instance
 
     return factory
 
 
 # Block-type → provider factory.  Routing is structural — block shape
-# is non-overlapping across providers by API design.  Three block
-# types are recognised today:
+# is non-overlapping across providers by API design.  Recognised
+# block types today:
 #
 # * ``"thinking"`` — Anthropic native (Phase 1).  Walks the
 #   ``thinking`` field on each block.
+# * ``"redacted_thinking"`` — Anthropic native (Phase 1).  Anthropic's
+#   safety system rewrites a thinking block into a sealed
+#   ``redacted_thinking`` block; the Anthropic docs note these can
+#   appear before, after, or interleaved with regular ``thinking``
+#   blocks.  Same factory: AnthropicProvider's extractor walks the
+#   full block list and filters to ``type == "thinking"``, so the
+#   redacted blocks are correctly skipped while the surrounding
+#   real thinking text still surfaces.
 # * ``"reasoning"`` — OpenAI Responses native (Phase 3).  Walks
 #   ``summary[*].text`` (always present) and ``content[*].text``
 #   (present when ``include=["reasoning.encrypted_content"]`` is
@@ -310,8 +323,12 @@ def _make_provider_factory(module_path: str, class_name: str) -> Callable[[], LL
 #   ``ChatSession._maybe_synth_reasoning_block`` for Chat Completions
 #   paths (vLLM, llama.cpp, Gemini-compat) where reasoning surfaces
 #   only as ``reasoning_delta`` chunks with no native block shape.
+_anthropic_factory = _make_provider_factory(
+    "turnstone.core.providers._anthropic", "AnthropicProvider"
+)
 _BLOCK_TYPE_PROVIDER_FACTORY: dict[str, Callable[[], LLMProvider]] = {
-    "thinking": _make_provider_factory("turnstone.core.providers._anthropic", "AnthropicProvider"),
+    "thinking": _anthropic_factory,
+    "redacted_thinking": _anthropic_factory,
     "reasoning": _make_provider_factory(
         "turnstone.core.providers._openai_responses", "OpenAIResponsesProvider"
     ),
@@ -347,7 +364,7 @@ def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
 
 def extract_reasoning_for_history(
     messages: list[dict[str, Any]],
-    persist_reasoning_flag: bool,
+    surface_persisted_reasoning_flag: bool,
 ) -> None:
     """Surface stored reasoning text on each assistant message; strip the
     raw provider content from the wire payload.
@@ -357,7 +374,7 @@ def extract_reasoning_for_history(
     — both extraction source and stamp destination are the same dict.
     Walks *messages* in place: for every assistant message, dispatches
     via :func:`extract_reasoning_text_from_provider_content` and stamps
-    ``msg["reasoning"]`` when *persist_reasoning_flag* is True and the
+    ``msg["reasoning"]`` when *surface_persisted_reasoning_flag* is True and the
     dispatcher returned non-empty text.  Strips ``_provider_content``
     unconditionally — the field is internal and never read by either UI.
 
@@ -375,12 +392,12 @@ def extract_reasoning_for_history(
             continue
         provider_content = msg.get("_provider_content")
         # Always strip the internal lane before the wire payload leaves
-        # the helper, even when persist_reasoning_flag is False or the
+        # the helper, even when surface_persisted_reasoning_flag is False or the
         # field is empty/missing.  The strip is the contract; reasoning
         # surfacing is conditional on top of it.
         if "_provider_content" in msg:
             del msg["_provider_content"]
-        if not persist_reasoning_flag:
+        if not surface_persisted_reasoning_flag:
             continue
         text = extract_reasoning_text_from_provider_content(provider_content)
         if text:

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -19,7 +19,7 @@ either an async caller (via ``asyncio.to_thread``) or a sync hook.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from turnstone.core.log import get_logger
 from turnstone.core.tool_advisory import (
@@ -266,6 +266,105 @@ def extract_advisories_from_tool_envelope(
             advisories.append(classified)
         cursor = close_idx + len("\n</system-reminder>")
     return _entity_decode_wrapper_tags(inner), advisories
+
+
+if TYPE_CHECKING:
+    from turnstone.core.providers._anthropic import AnthropicProvider
+    from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+_anthropic_provider_singleton: AnthropicProvider | None = None
+_openai_responses_provider_singleton: OpenAIResponsesProvider | None = None
+
+
+def _get_anthropic_provider() -> AnthropicProvider:
+    global _anthropic_provider_singleton
+    if _anthropic_provider_singleton is None:
+        from turnstone.core.providers._anthropic import AnthropicProvider as _Anthropic
+
+        _anthropic_provider_singleton = _Anthropic()
+    return _anthropic_provider_singleton
+
+
+def _get_openai_responses_provider() -> OpenAIResponsesProvider:
+    global _openai_responses_provider_singleton
+    if _openai_responses_provider_singleton is None:
+        from turnstone.core.providers._openai_responses import (
+            OpenAIResponsesProvider as _OpenAIResp,
+        )
+
+        _openai_responses_provider_singleton = _OpenAIResp()
+    return _openai_responses_provider_singleton
+
+
+def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
+    """Dispatch reasoning extraction by first-block ``type`` field.
+
+    Routing is structural — block shape is non-overlapping across
+    providers by API design (Anthropic ``thinking``, OpenAI Responses
+    ``reasoning``, Gemini ``thought``).  Phase 1 wires Anthropic
+    extraction; OpenAI Responses returns ``""`` until Phase 3 adds the
+    ``include=["reasoning.encrypted_content"]`` request flag.  Returns
+    ``""`` for empty / missing / non-list / unknown-type input.
+
+    Pure transform — safe from any thread.  Both history surfaces
+    (interactive ``_build_history`` and lifted ``make_history_handler``)
+    call this directly.
+    """
+    if not isinstance(provider_content, list) or not provider_content:
+        return ""
+    first_block = provider_content[0]
+    if not isinstance(first_block, dict):
+        return ""
+    block_type = first_block.get("type")
+    if not isinstance(block_type, str):
+        return ""
+    if block_type == "thinking":
+        return _get_anthropic_provider().extract_reasoning_text(provider_content)
+    if block_type == "reasoning":
+        return _get_openai_responses_provider().extract_reasoning_text(provider_content)
+    return ""
+
+
+def extract_reasoning_for_history(
+    messages: list[dict[str, Any]],
+    persist_reasoning_flag: bool,
+) -> None:
+    """Surface stored reasoning text on each assistant message; strip the
+    raw provider content from the wire payload.
+
+    For the ``make_history_handler`` REST path where the response
+    payload IS the messages list returned from ``storage.load_messages``
+    — both extraction source and stamp destination are the same dict.
+    Walks *messages* in place: for every assistant message, dispatches
+    via :func:`extract_reasoning_text_from_provider_content` and stamps
+    ``msg["reasoning"]`` when *persist_reasoning_flag* is True and the
+    dispatcher returned non-empty text.  Strips ``_provider_content``
+    unconditionally — the field is internal and never read by either UI.
+
+    The interactive ``_build_history`` surface DOES NOT call this
+    helper; it builds new entry dicts from scratch and calls
+    :func:`extract_reasoning_text_from_provider_content` directly per
+    assistant message, stamping ``entry["reasoning"]`` inline.  The two
+    surfaces converge on the same dispatcher; only the mutation shape
+    differs.
+
+    Pure transform.  Safe to call from ``asyncio.to_thread``.
+    """
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        provider_content = msg.get("_provider_content")
+        # Always strip the internal lane before the wire payload leaves
+        # the helper, even when persist_reasoning_flag is False or the
+        # field is empty/missing.  The strip is the contract; reasoning
+        # surfacing is conditional on top of it.
+        if "_provider_content" in msg:
+            del msg["_provider_content"]
+        if not persist_reasoning_flag:
+            continue
+        text = extract_reasoning_text_from_provider_content(provider_content)
+        if text:
+            msg["reasoning"] = text
 
 
 def decorate_history_messages(

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -339,9 +339,28 @@ _BLOCK_TYPE_PROVIDER_FACTORY: dict[str, Callable[[], LLMProvider]] = {
 
 
 def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
-    """Dispatch reasoning extraction by first-block ``type`` field.
+    """Dispatch reasoning extraction by scanning for a recognised block type.
 
-    Returns ``""`` for empty / missing / non-list / unknown-type input.
+    Walks ``provider_content`` looking for the first block whose
+    ``type`` is in :data:`_BLOCK_TYPE_PROVIDER_FACTORY`, then dispatches
+    the WHOLE list to that provider's ``extract_reasoning_text``.  Each
+    provider's extractor already filters internally by its own block
+    type (Anthropic walks ``thinking``, OpenAI Responses walks
+    ``reasoning``, OpenAI Chat walks ``reasoning_text``), so passing
+    the full list is correct — interleaved foreign blocks are ignored.
+
+    Returns ``""`` for empty / missing / non-list input or when no
+    recognised reasoning-bearing block type appears anywhere in the
+    list.
+
+    Why scan instead of just inspecting ``provider_content[0]``: the
+    OpenAI Responses streaming layer captures EVERY ``output_item.done``
+    event into ``provider_blocks`` (``_openai_responses.py:415-420``),
+    not just reasoning items.  In practice the order is usually
+    ``[reasoning, message, ...]`` but the API doesn't guarantee that —
+    a hypothetical ``[message, reasoning]`` ordering would silently
+    drop the reasoning under an index-only check.  Same robustness
+    point for Anthropic's hypothetical mixed-order outputs.
 
     Pure transform — safe from any thread.  Both history surfaces
     (interactive ``_build_history`` and lifted ``make_history_handler``)
@@ -350,16 +369,16 @@ def extract_reasoning_text_from_provider_content(provider_content: Any) -> str:
     """
     if not isinstance(provider_content, list) or not provider_content:
         return ""
-    first_block = provider_content[0]
-    if not isinstance(first_block, dict):
-        return ""
-    block_type = first_block.get("type")
-    if not isinstance(block_type, str):
-        return ""
-    factory = _BLOCK_TYPE_PROVIDER_FACTORY.get(block_type)
-    if factory is None:
-        return ""
-    return factory().extract_reasoning_text(provider_content)
+    for block in provider_content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if not isinstance(block_type, str):
+            continue
+        factory = _BLOCK_TYPE_PROVIDER_FACTORY.get(block_type)
+        if factory is not None:
+            return factory().extract_reasoning_text(provider_content)
+    return ""
 
 
 def extract_reasoning_for_history(

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -40,10 +40,10 @@ class ModelConfig:
     max_tokens: int | None = None
     reasoning_effort: str | None = None
     # Per-model reasoning-persistence flags (db-backed, admin-toggleable).
-    # persist_reasoning controls UI rehydration of stored reasoning text in
+    # surface_persisted_reasoning controls UI rehydration of stored reasoning text in
     # /history responses; replay_reasoning_to_model controls whether
     # reasoning blocks ride the wire on subsequent provider calls.
-    persist_reasoning: bool = True
+    surface_persisted_reasoning: bool = True
     replay_reasoning_to_model: bool = False
     # Server compatibility settings for openai-compatible backends.
     # Populated from capabilities["server_compat"] during load.
@@ -413,7 +413,7 @@ def load_model_registry(
                 row_reasoning_effort = row.get("reasoning_effort")
                 # Per-model reasoning flags. Defaults match the dataclass so a
                 # pre-052 row missing these columns degrades gracefully.
-                row_persist_reasoning = bool(row.get("persist_reasoning", True))
+                row_surface_persisted_reasoning = bool(row.get("surface_persisted_reasoning", True))
                 row_replay_reasoning = bool(row.get("replay_reasoning_to_model", False))
                 configs[alias] = ModelConfig(
                     alias=alias,
@@ -429,7 +429,7 @@ def load_model_registry(
                     reasoning_effort=row_reasoning_effort
                     if row_reasoning_effort is not None
                     else None,
-                    persist_reasoning=row_persist_reasoning,
+                    surface_persisted_reasoning=row_surface_persisted_reasoning,
                     replay_reasoning_to_model=row_replay_reasoning,
                     server_compat=row_server_compat,
                 )

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -39,6 +39,12 @@ class ModelConfig:
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    # Per-model reasoning-persistence flags (db-backed, admin-toggleable).
+    # persist_reasoning controls UI rehydration of stored reasoning text in
+    # /history responses; replay_reasoning_to_model controls whether
+    # reasoning blocks ride the wire on subsequent provider calls.
+    persist_reasoning: bool = True
+    replay_reasoning_to_model: bool = False
     # Server compatibility settings for openai-compatible backends.
     # Populated from capabilities["server_compat"] during load.
     server_compat: dict[str, Any] = field(default_factory=dict)
@@ -405,6 +411,10 @@ def load_model_registry(
                 row_temperature = row.get("temperature")
                 row_max_tokens = row.get("max_tokens")
                 row_reasoning_effort = row.get("reasoning_effort")
+                # Per-model reasoning flags. Defaults match the dataclass so a
+                # pre-052 row missing these columns degrades gracefully.
+                row_persist_reasoning = bool(row.get("persist_reasoning", True))
+                row_replay_reasoning = bool(row.get("replay_reasoning_to_model", False))
                 configs[alias] = ModelConfig(
                     alias=alias,
                     base_url=row_base_url,
@@ -419,6 +429,8 @@ def load_model_registry(
                     reasoning_effort=row_reasoning_effort
                     if row_reasoning_effort is not None
                     else None,
+                    persist_reasoning=row_persist_reasoning,
+                    replay_reasoning_to_model=row_replay_reasoning,
                     server_compat=row_server_compat,
                 )
         except Exception:

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -159,6 +159,35 @@ def _map_reasoning_to_effort(
     return None
 
 
+# Anthropic accepts only a closed set of content-block types on the
+# input boundary.  ``_convert_messages`` gates the verbatim
+# ``_provider_content`` replay path on this set so foreign-shaped
+# blocks (OpenAI Responses ``type="reasoning"`` after Phase 3, Gemini
+# thought parts, anything else) fall through to the text+tool_calls
+# rebuild path rather than 400-ing the API.  Web-search related blocks
+# (``server_tool_use`` / ``web_search_tool_result``) intentionally
+# stay in the set — they carry ``encrypted_content`` that the API
+# requires for round-trip continuity.
+ANTHROPIC_VALID_BLOCK_TYPES = frozenset(
+    {
+        "text",
+        "image",
+        "thinking",
+        "redacted_thinking",
+        "tool_use",
+        "tool_result",
+        "server_tool_use",
+        "web_search_tool_result",
+    }
+)
+
+# Subset of valid block types whose ``content`` is reasoning text.
+# When ``replay_reasoning_to_model=False`` the strip predicate drops
+# these (and only these) before the wire payload is built — narrow by
+# design so ``tool_use`` / web-search blocks survive.
+ANTHROPIC_REASONING_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+
 # -- provider ----------------------------------------------------------------
 
 
@@ -283,10 +312,34 @@ class AnthropicProvider:
     def _convert_messages(
         self,
         messages: list[dict[str, Any]],
+        *,
+        replay_reasoning_to_model: bool = True,
     ) -> tuple[str, list[dict[str, Any]]]:
         """Convert internal (OpenAI-like) messages to Anthropic format.
 
         Returns ``(system_prompt, converted_messages)``.
+
+        ``replay_reasoning_to_model`` (Phase 2 of the reasoning-
+        persistence feature, mirroring ``ModelConfig.replay_
+        reasoning_to_model``) gates whether stored ``thinking`` blocks
+        survive the verbatim ``_provider_content`` replay path.  When
+        the caller passes ``False`` (the operator-side server_default
+        for the ``model_definitions`` row this kwarg is sourced from),
+        thinking blocks are stripped before the wire payload is built;
+        ``tool_use`` / ``server_tool_use`` / ``web_search_tool_result``
+        blocks (which carry web-search ``encrypted_content``) are
+        intentionally preserved.  The kwarg defaults to ``True`` here
+        purely for back-compat with any direct caller that hasn't been
+        updated to thread the resolver — production call sites
+        (``ChatSession._try_stream`` / ``_utility_completion``) always
+        pass the resolved flag explicitly.
+
+        Foreign-shaped ``_provider_content`` (e.g. OpenAI Responses
+        ``type="reasoning"`` blocks reaching Anthropic mid-workstream
+        once Phase 3 lands) fails the ``ANTHROPIC_VALID_BLOCK_TYPES``
+        shape check and falls through to the text+tool_calls rebuild
+        path — closes a pre-existing latent bug where the verbatim
+        replay would have 400'd the API.
         """
         system_parts: list[str] = []
         converted: list[dict[str, Any]] = []
@@ -310,12 +363,45 @@ class AnthropicProvider:
                     converted.append({"role": "user", "content": pending_orphan_results})
                     pending_orphan_results = []
                 # If raw provider content was preserved, pass it through verbatim
-                # so encrypted_content/encrypted_index from web search are retained
+                # so encrypted_content/encrypted_index from web search are retained.
+                # Phase 2: gated by ``ANTHROPIC_VALID_BLOCK_TYPES`` shape check
+                # (foreign or partially-foreign payloads fall through to the
+                # text+tool_calls rebuild path) and the ``replay_reasoning_to_model``
+                # operator flag (when False, ``thinking`` blocks are stripped).
                 provider_content = msg.get("_provider_content")
-                if provider_content:
-                    converted.append({"role": "assistant", "content": provider_content})
-                    # Check for orphaned tool_use in provider content too
-                    if isinstance(provider_content, list):
+                # Inline isinstance + non-empty + all-blocks-valid check
+                # so mypy can narrow ``provider_content`` to ``list`` for
+                # the subsequent walk; pulling these into a helper boolean
+                # would require an explicit ``cast`` to recover the type.
+                if (
+                    isinstance(provider_content, list)
+                    and provider_content
+                    and all(
+                        isinstance(b, dict) and b.get("type") in ANTHROPIC_VALID_BLOCK_TYPES
+                        for b in provider_content
+                    )
+                ):
+                    # replay=True keeps the verbatim reference (existing
+                    # behaviour — pinned by an identity assertion in
+                    # test_convert_messages_uses_provider_content).  replay=False
+                    # builds a new list with thinking blocks filtered out;
+                    # tool_use / web-search blocks survive intact so their
+                    # encrypted_content round-trips correctly.
+                    if replay_reasoning_to_model:
+                        wire_blocks: list[dict[str, Any]] = provider_content
+                    else:
+                        wire_blocks = [
+                            b
+                            for b in provider_content
+                            if b.get("type") not in ANTHROPIC_REASONING_BLOCK_TYPES
+                        ]
+                    if wire_blocks:
+                        converted.append({"role": "assistant", "content": wire_blocks})
+                        # Orphan-tool detection runs on the ORIGINAL provider_content
+                        # (not the strip-filtered ``wire_blocks``) — the strip
+                        # only drops thinking blocks, so tool_use IDs are
+                        # identical between the two lists, but we keep the
+                        # source-of-truth read explicit.
                         pc_tool_ids = [
                             b["id"]
                             for b in provider_content
@@ -348,8 +434,14 @@ class AnthropicProvider:
                                     converted.append({"role": "user", "content": synthetic_pc})
                                 else:
                                     pending_orphan_results = synthetic_pc
-                    i += 1
-                    continue
+                        i += 1
+                        continue
+                    # All blocks were stripped (message had only thinking
+                    # content + no text + no tool_calls).  Fall through to the
+                    # text+tool_calls rebuild path; if that also produces an
+                    # empty message it will be silently skipped, which is
+                    # correct: a turn with only stripped reasoning has nothing
+                    # to replay.
 
                 content_blocks: list[dict[str, Any]] = []
                 text = msg.get("content")
@@ -618,10 +710,13 @@ class AnthropicProvider:
         deferred_names: frozenset[str] | None = None,
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         _ensure_anthropic()
         caps = capabilities or self.get_capabilities(model)
-        system_prompt, converted_msgs = self._convert_messages(messages)
+        system_prompt, converted_msgs = self._convert_messages(
+            messages, replay_reasoning_to_model=replay_reasoning_to_model
+        )
         kwargs = self._build_thinking_and_kwargs(
             caps,
             reasoning_effort,
@@ -822,10 +917,13 @@ class AnthropicProvider:
         extra_params: dict[str, Any] | None = None,
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> CompletionResult:
         _ensure_anthropic()
         caps = capabilities or self.get_capabilities(model)
-        system_prompt, converted_msgs = self._convert_messages(messages)
+        system_prompt, converted_msgs = self._convert_messages(
+            messages, replay_reasoning_to_model=replay_reasoning_to_model
+        )
         kwargs = self._build_thinking_and_kwargs(
             caps,
             reasoning_effort,

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -922,6 +922,36 @@ class AnthropicProvider:
             }
         )
 
+    # -- reasoning extraction ------------------------------------------------
+
+    def extract_reasoning_text(
+        self,
+        provider_blocks: list[dict[str, Any]] | None,
+    ) -> str:
+        if not isinstance(provider_blocks, list):
+            return ""
+        parts: list[str] = []
+        for block in provider_blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "thinking":
+                continue
+            text = block.get("thinking")
+            if isinstance(text, str) and text:
+                parts.append(text)
+        if not parts:
+            return ""
+        joined = "\n".join(parts)
+        # Operator-friendly UI cap. Larger reasoning bodies are still
+        # stored verbatim in provider_data; only the rehydrated UI
+        # display payload is truncated.
+        if len(joined) > _MAX_REASONING_DISPLAY_BYTES:
+            return joined[:_MAX_REASONING_DISPLAY_BYTES]
+        return joined
+
+
+_MAX_REASONING_DISPLAY_BYTES = 64 * 1024
+
 
 def _normalize_finish_reason(reason: str) -> str:
     """Normalize Anthropic stop reasons to OpenAI-compatible strings."""

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -168,14 +168,18 @@ def _map_reasoning_to_effort(
 
 
 # Anthropic accepts only a closed set of content-block types on the
-# input boundary.  ``_convert_messages`` gates the verbatim
-# ``_provider_content`` replay path on this set so foreign-shaped
-# blocks (OpenAI Responses ``type="reasoning"`` after Phase 3, Gemini
-# thought parts, anything else) fall through to the text+tool_calls
-# rebuild path rather than 400-ing the API.  Web-search related blocks
-# (``server_tool_use`` / ``web_search_tool_result``) intentionally
-# stay in the set — they carry ``encrypted_content`` that the API
-# requires for round-trip continuity.
+# input boundary.  ``_convert_messages`` runs each block in
+# ``_provider_content`` through this set per-block: foreign-shaped
+# blocks (OpenAI Responses ``type="reasoning"``, Gemini thought parts,
+# the synthetic ``reasoning_text`` from path-3 capture) are dropped
+# individually; valid Anthropic blocks in the same message still ride
+# the verbatim path.  When no valid blocks survive, the converter falls
+# through to the text+tool_calls rebuild path.  Web-search blocks
+# (``server_tool_use`` / ``web_search_tool_result``) stay in the set
+# because they carry ``encrypted_content`` the API requires for
+# round-trip continuity — the per-block filter preserves them even when
+# they share a message with a foreign block (the prior all-or-nothing
+# filter would have silently dropped them in that case).
 ANTHROPIC_VALID_BLOCK_TYPES = frozenset(
     {
         "text",
@@ -342,12 +346,15 @@ class AnthropicProvider:
         (``ChatSession._try_stream`` / ``_utility_completion``) always
         pass the resolved flag explicitly.
 
-        Foreign-shaped ``_provider_content`` (e.g. OpenAI Responses
-        ``type="reasoning"`` blocks reaching Anthropic mid-workstream
-        once Phase 3 lands) fails the ``ANTHROPIC_VALID_BLOCK_TYPES``
-        shape check and falls through to the text+tool_calls rebuild
-        path — closes a pre-existing latent bug where the verbatim
-        replay would have 400'd the API.
+        Foreign-shaped blocks (OpenAI ``reasoning``, Gemini thought
+        parts, the synthetic ``reasoning_text`` from path-3 capture) are
+        dropped per-block; valid Anthropic blocks in the same message
+        still ride the verbatim path.  Critical for cross-model
+        resumption: an earlier all-or-nothing filter silently lost
+        web-search ``encrypted_content`` whenever a foreign block
+        shared a message with ``server_tool_use`` /
+        ``web_search_tool_result``.  If the filter leaves nothing, the
+        converter falls through to the text+tool_calls rebuild path.
         """
         system_parts: list[str] = []
         converted: list[dict[str, Any]] = []
@@ -370,86 +377,88 @@ class AnthropicProvider:
                 if pending_orphan_results:
                     converted.append({"role": "user", "content": pending_orphan_results})
                     pending_orphan_results = []
-                # If raw provider content was preserved, pass it through verbatim
-                # so encrypted_content/encrypted_index from web search are retained.
-                # Phase 2: gated by ``ANTHROPIC_VALID_BLOCK_TYPES`` shape check
-                # (foreign or partially-foreign payloads fall through to the
-                # text+tool_calls rebuild path) and the ``replay_reasoning_to_model``
-                # operator flag (when False, ``thinking`` blocks are stripped).
+                # Per-block shape filter: drop foreign blocks individually,
+                # apply the replay strip to valid ``thinking`` /
+                # ``redacted_thinking`` blocks.  See ``_convert_messages``
+                # docstring for why this is per-block, not all-or-nothing.
                 provider_content = msg.get("_provider_content")
-                # Inline isinstance + non-empty + all-blocks-valid check
-                # so mypy can narrow ``provider_content`` to ``list`` for
-                # the subsequent walk; pulling these into a helper boolean
-                # would require an explicit ``cast`` to recover the type.
-                if (
-                    isinstance(provider_content, list)
-                    and provider_content
-                    and all(
-                        isinstance(b, dict) and b.get("type") in ANTHROPIC_VALID_BLOCK_TYPES
-                        for b in provider_content
-                    )
-                ):
-                    # replay=True keeps the verbatim reference (existing
-                    # behaviour — pinned by an identity assertion in
-                    # test_convert_messages_uses_provider_content).  replay=False
-                    # builds a new list with thinking blocks filtered out;
-                    # tool_use / web-search blocks survive intact so their
-                    # encrypted_content round-trips correctly.
-                    if replay_reasoning_to_model:
-                        wire_blocks: list[dict[str, Any]] = provider_content
-                    else:
-                        wire_blocks = [
-                            b
-                            for b in provider_content
-                            if b.get("type") not in ANTHROPIC_REASONING_BLOCK_TYPES
-                        ]
-                    if wire_blocks:
-                        converted.append({"role": "assistant", "content": wire_blocks})
-                        # Orphan-tool detection runs on the ORIGINAL provider_content
-                        # (not the strip-filtered ``wire_blocks``) — the strip
-                        # only drops thinking blocks, so tool_use IDs are
-                        # identical between the two lists, but we keep the
-                        # source-of-truth read explicit.
-                        pc_tool_ids = [
-                            b["id"]
-                            for b in provider_content
-                            if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id")
-                        ]
-                        if pc_tool_ids:
-                            j = i + 1
-                            result_ids_pc: set[str] = set()
-                            while j < len(messages) and messages[j]["role"] == "tool":
-                                tc_id = messages[j].get("tool_call_id", "")
-                                if tc_id:
-                                    result_ids_pc.add(tc_id)
-                                j += 1
-                            orphaned_pc = [uid for uid in pc_tool_ids if uid not in result_ids_pc]
-                            if orphaned_pc:
-                                log.debug(
-                                    "Synthesizing %d tool_result(s) for orphaned provider_content tool_use IDs",
-                                    len(orphaned_pc),
-                                )
-                                synthetic_pc = [
-                                    {
-                                        "type": "tool_result",
-                                        "tool_use_id": uid,
-                                        "content": "Tool execution was cancelled.",
-                                        "is_error": True,
-                                    }
-                                    for uid in orphaned_pc
-                                ]
-                                if j == i + 1:
-                                    converted.append({"role": "user", "content": synthetic_pc})
-                                else:
-                                    pending_orphan_results = synthetic_pc
-                        i += 1
-                        continue
-                    # All blocks were stripped (message had only thinking
-                    # content + no text + no tool_calls).  Fall through to the
-                    # text+tool_calls rebuild path; if that also produces an
-                    # empty message it will be silently skipped, which is
-                    # correct: a turn with only stripped reasoning has nothing
-                    # to replay.
+                wire_blocks: list[dict[str, Any]] = []
+                valid_blocks: list[dict[str, Any]] = []
+                all_input_valid = True
+                if isinstance(provider_content, list) and provider_content:
+                    dropped_foreign: list[str] = []
+                    for b in provider_content:
+                        if not isinstance(b, dict):
+                            all_input_valid = False
+                            continue
+                        btype = b.get("type")
+                        if btype not in ANTHROPIC_VALID_BLOCK_TYPES:
+                            dropped_foreign.append(str(btype))
+                            all_input_valid = False
+                            continue
+                        valid_blocks.append(b)
+                        if (
+                            not replay_reasoning_to_model
+                            and btype in ANTHROPIC_REASONING_BLOCK_TYPES
+                        ):
+                            continue
+                        wire_blocks.append(b)
+                    if dropped_foreign:
+                        log.debug(
+                            "Dropped %d foreign block(s) from _provider_content "
+                            "during Anthropic conversion: %s",
+                            len(dropped_foreign),
+                            dropped_foreign,
+                        )
+                    # Identity-preserving fast path: when nothing was filtered
+                    # or stripped, reuse the source list reference rather than
+                    # the per-block-built copy.  Pinned by the ``is`` assertions
+                    # in test_providers.py (test_convert_messages_uses_provider_
+                    # content + test_thinking_block_multiturn_roundtrip).
+                    if all_input_valid and replay_reasoning_to_model:
+                        wire_blocks = provider_content
+                if valid_blocks and wire_blocks:
+                    converted.append({"role": "assistant", "content": wire_blocks})
+                    # Orphan-tool detection reads ``valid_blocks`` (unstripped
+                    # valid blocks) so a future widening of the strip predicate
+                    # can't accidentally drop tool_use IDs.
+                    pc_tool_ids = [
+                        b["id"] for b in valid_blocks if b.get("type") == "tool_use" and b.get("id")
+                    ]
+                    if pc_tool_ids:
+                        j = i + 1
+                        result_ids_pc: set[str] = set()
+                        while j < len(messages) and messages[j]["role"] == "tool":
+                            tc_id = messages[j].get("tool_call_id", "")
+                            if tc_id:
+                                result_ids_pc.add(tc_id)
+                            j += 1
+                        orphaned_pc = [uid for uid in pc_tool_ids if uid not in result_ids_pc]
+                        if orphaned_pc:
+                            log.debug(
+                                "Synthesizing %d tool_result(s) for orphaned provider_content tool_use IDs",
+                                len(orphaned_pc),
+                            )
+                            synthetic_pc = [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": uid,
+                                    "content": "Tool execution was cancelled.",
+                                    "is_error": True,
+                                }
+                                for uid in orphaned_pc
+                            ]
+                            if j == i + 1:
+                                converted.append({"role": "user", "content": synthetic_pc})
+                            else:
+                                pending_orphan_results = synthetic_pc
+                    i += 1
+                    continue
+                # Fall through to text+tool_calls rebuild when nothing
+                # survived the filter (missing/empty pc, all-foreign, or
+                # strip removed every remaining thinking block).  An empty
+                # rebuild is silently skipped — a turn with only stripped
+                # reasoning has nothing to replay.
 
                 content_blocks: list[dict[str, Any]] = []
                 text = msg.get("content")

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -12,12 +12,12 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.providers._protocol import (
-    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
     ToolCallDelta,
     UsageInfo,
+    _join_reasoning_with_cap,
     _lookup_capabilities,
 )
 
@@ -1045,12 +1045,7 @@ class AnthropicProvider:
             text = block.get("thinking")
             if isinstance(text, str) and text:
                 parts.append(text)
-        if not parts:
-            return ""
-        joined = "\n".join(parts)
-        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
-            return joined[:MAX_REASONING_DISPLAY_BYTES]
-        return joined
+        return _join_reasoning_with_cap(parts)
 
 
 def _normalize_finish_reason(reason: str) -> str:

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -12,6 +12,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.providers._protocol import (
+    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
@@ -80,6 +81,7 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
     thinking_mode="manual",
     supports_web_search=True,
     supports_vision=True,
+    supports_reasoning_replay=True,
 )
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
@@ -95,6 +97,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_vision=True,
         supports_temperature=False,
         thinking_display="summarized",
+        supports_reasoning_replay=True,
     ),
     "claude-opus-4-6": ModelCapabilities(
         context_window=1000000,
@@ -106,6 +109,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_web_search=True,
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "claude-sonnet-4-6": ModelCapabilities(
         context_window=1000000,
@@ -117,6 +121,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_web_search=True,
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "claude-haiku-4-5": ModelCapabilities(
         context_window=200000,
@@ -125,6 +130,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         thinking_mode="manual",
         supports_web_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "claude-sonnet-4-5": ModelCapabilities(
         context_window=200000,
@@ -133,6 +139,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         thinking_mode="manual",
         supports_web_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "claude-opus-4-5": ModelCapabilities(
         context_window=200000,
@@ -143,6 +150,7 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         effort_levels=("low", "medium", "high"),
         supports_web_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
 }
 
@@ -1040,15 +1048,9 @@ class AnthropicProvider:
         if not parts:
             return ""
         joined = "\n".join(parts)
-        # Operator-friendly UI cap. Larger reasoning bodies are still
-        # stored verbatim in provider_data; only the rehydrated UI
-        # display payload is truncated.
-        if len(joined) > _MAX_REASONING_DISPLAY_BYTES:
-            return joined[:_MAX_REASONING_DISPLAY_BYTES]
+        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
+            return joined[:MAX_REASONING_DISPLAY_BYTES]
         return joined
-
-
-_MAX_REASONING_DISPLAY_BYTES = 64 * 1024
 
 
 def _normalize_finish_reason(reason: str) -> str:

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -24,6 +24,7 @@ from turnstone.core.providers._openai_common import (
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
+    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
@@ -389,9 +390,32 @@ class OpenAIChatCompletionsProvider:
         self,
         provider_blocks: list[dict[str, Any]] | None,
     ) -> str:
-        # OpenAI Chat (and the local-model server flavours that route
-        # through this adapter) have no first-class reasoning shape.
-        # Chat-template ``<think>`` content is captured via the inflight
-        # buffer for live UI but not persisted to ``provider_blocks``;
-        # Phase 4 may revisit.
-        return ""
+        """Walk synthetic ``reasoning_text`` blocks (Phase 3 path-3
+        capture) and return the concatenated reasoning text.
+
+        OpenAI Chat Completions has no native reasoning shape on the
+        wire — vLLM ``--reasoning-parser``, llama.cpp
+        ``reasoning_format``, and Gemini's OpenAI-compat endpoint all
+        surface reasoning as non-canonical ``delta.reasoning_content``
+        Pydantic extras.  ``ChatSession._maybe_synth_reasoning_block``
+        captures these into a single ``{type: "reasoning_text", text,
+        source?}`` block when no native ``provider_blocks`` were
+        emitted.  This extractor unwraps those for UI rehydration.
+        """
+        if not isinstance(provider_blocks, list):
+            return ""
+        parts: list[str] = []
+        for block in provider_blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "reasoning_text":
+                continue
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+        if not parts:
+            return ""
+        joined = "\n".join(parts)
+        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
+            return joined[:MAX_REASONING_DISPLAY_BYTES]
+        return joined

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -24,11 +24,11 @@ from turnstone.core.providers._openai_common import (
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
-    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
     ToolCallDelta,
+    _join_reasoning_with_cap,
 )
 
 log = structlog.get_logger(__name__)
@@ -413,9 +413,4 @@ class OpenAIChatCompletionsProvider:
             text = block.get("text")
             if isinstance(text, str) and text:
                 parts.append(text)
-        if not parts:
-            return ""
-        joined = "\n".join(parts)
-        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
-            return joined[:MAX_REASONING_DISPLAY_BYTES]
-        return joined
+        return _join_reasoning_with_cap(parts)

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -156,6 +156,12 @@ class OpenAIChatCompletionsProvider:
 
     # -- streaming -----------------------------------------------------------
 
+    # Phase 2 of the reasoning-persistence feature plumbs an optional
+    # ``replay_reasoning_to_model`` kwarg through every provider's
+    # ``create_streaming`` / ``create_completion``.  OpenAI Chat (and
+    # the local-model server flavours that route through this adapter)
+    # have no first-class reasoning shape on the wire, so the kwarg is
+    # accepted for Protocol conformance and ignored here.
     def create_streaming(
         self,
         *,
@@ -170,6 +176,7 @@ class OpenAIChatCompletionsProvider:
         deferred_names: frozenset[str] | None = None,
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         caps = capabilities or self.get_capabilities(model)
         messages = self._prepare_messages(messages)
@@ -299,6 +306,8 @@ class OpenAIChatCompletionsProvider:
         extra_params: dict[str, Any] | None = None,
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
+        # See create_streaming above for the Phase 2 reasoning-persistence rationale.
+        replay_reasoning_to_model: bool = True,
     ) -> CompletionResult:
         caps = capabilities or self.get_capabilities(model)
         messages = self._prepare_messages(messages)

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -373,3 +373,16 @@ class OpenAIChatCompletionsProvider:
     @property
     def retryable_error_names(self) -> frozenset[str]:
         return RETRYABLE_ERROR_NAMES
+
+    # -- reasoning extraction ------------------------------------------------
+
+    def extract_reasoning_text(
+        self,
+        provider_blocks: list[dict[str, Any]] | None,
+    ) -> str:
+        # OpenAI Chat (and the local-model server flavours that route
+        # through this adapter) have no first-class reasoning shape.
+        # Chat-template ``<think>`` content is captured via the inflight
+        # buffer for live UI but not persisted to ``provider_blocks``;
+        # Phase 4 may revisit.
+        return ""

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -33,6 +33,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("minimal", "low", "medium", "high"),
         default_reasoning_effort="medium",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "gpt-5-mini": ModelCapabilities(
         context_window=400000,
@@ -41,6 +42,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("minimal", "low", "medium", "high"),
         default_reasoning_effort="medium",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "gpt-5-nano": ModelCapabilities(
         context_window=400000,
@@ -49,6 +51,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("minimal", "low", "medium", "high"),
         default_reasoning_effort="medium",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5 pro — high reasoning only, extended output
     "gpt-5-pro": ModelCapabilities(
@@ -58,6 +61,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("high",),
         default_reasoning_effort="high",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.1 — temperature OK when reasoning_effort=none (default)
     "gpt-5.1": ModelCapabilities(
@@ -66,6 +70,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("none", "low", "medium", "high"),
         default_reasoning_effort="none",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.2 — adds xhigh
     "gpt-5.2": ModelCapabilities(
@@ -74,6 +79,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         default_reasoning_effort="none",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.2 pro — always-reasoning variant
     "gpt-5.2-pro": ModelCapabilities(
@@ -83,6 +89,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("medium", "high", "xhigh"),
         default_reasoning_effort="medium",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.3 — same capabilities as 5.2 (matches gpt-5.3-chat-latest, codex)
     "gpt-5.3": ModelCapabilities(
@@ -91,6 +98,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
         default_reasoning_effort="none",
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.4 — 1M context window, native tool search
     "gpt-5.4": ModelCapabilities(
@@ -100,6 +108,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         default_reasoning_effort="none",
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.4 pro — always-reasoning, 1M context, native tool search
     "gpt-5.4-pro": ModelCapabilities(
@@ -110,6 +119,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         default_reasoning_effort="medium",
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.5 — 1M context, native tool search, stronger agentic/tool use
     "gpt-5.5": ModelCapabilities(
@@ -119,6 +129,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         default_reasoning_effort="none",
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # GPT-5.5 pro — always-reasoning, 1M context, native tool search
     "gpt-5.5-pro": ModelCapabilities(
@@ -129,6 +140,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         default_reasoning_effort="medium",
         supports_tool_search=True,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # O-series reasoning models
     "o1": ModelCapabilities(
@@ -137,6 +149,7 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_temperature=False,
         supports_streaming=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "o1-mini": ModelCapabilities(
         context_window=128000,
@@ -144,18 +157,21 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_temperature=False,
         supports_streaming=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "o3": ModelCapabilities(
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "o3-mini": ModelCapabilities(
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "o3-pro": ModelCapabilities(
         context_window=200000,
@@ -163,12 +179,14 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_temperature=False,
         supports_streaming=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     "o4-mini": ModelCapabilities(
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
         supports_vision=True,
+        supports_reasoning_replay=True,
     ),
     # Search models — always search on every request, no reasoning_effort
     "gpt-5-search-api": ModelCapabilities(

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -293,6 +293,13 @@ class OpenAIResponsesProvider:
         deferred_names: frozenset[str] | None = None,
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
+        # Phase 2 reasoning-persistence kwarg — accepted for Protocol
+        # conformance.  Phase 3 will gate ``include=
+        # ["reasoning.encrypted_content"]`` on this flag once OpenAI
+        # Responses captures replayable reasoning items.  Today the
+        # request kwargs don't carry reasoning, so the flag is unused
+        # but threaded for forward-compat.
+        replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         if extra_params:
             log.debug("openai.responses: extra_params ignored (not supported by Responses API)")
@@ -474,6 +481,8 @@ class OpenAIResponsesProvider:
         extra_params: dict[str, Any] | None = None,
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
+        # See create_streaming above for the Phase 2 reasoning-persistence rationale.
+        replay_reasoning_to_model: bool = True,
     ) -> CompletionResult:
         if extra_params:
             log.debug("openai.responses: extra_params ignored (not supported by Responses API)")

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -117,6 +117,17 @@ class OpenAIResponsesProvider:
         When *replay_reasoning_to_model* is False, reasoning items are silently
         dropped (they were stripped from the wire by ``sanitize_messages``
         anyway, but we also skip the input-item emission step).
+
+        Default ``False`` differs intentionally from
+        ``AnthropicProvider._convert_messages`` (which defaults
+        ``True``).  Anthropic's default exists for back-compat with
+        pre-Phase-2 callers who never threaded the kwarg; OpenAI
+        Responses replay is brand-new in Phase 3 and has no such
+        legacy.  Production callers (``_build_kwargs``) always pass
+        the resolved flag explicitly, so the default only matters in
+        tests.  Conservative-default-False keeps the persist-only
+        capture path live without forcing a downstream cost on every
+        unaware caller.
         """
         # Capture ``_provider_content`` reasoning items per ASSISTANT
         # ORDINAL (not raw message index) BEFORE sanitization strips

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -28,6 +28,7 @@ from turnstone.core.providers._openai_common import (
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
+    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
@@ -92,16 +93,68 @@ class OpenAIResponsesProvider:
     @staticmethod
     def _convert_messages(
         messages: list[dict[str, Any]],
+        *,
+        replay_reasoning_to_model: bool = False,
     ) -> tuple[str | None, list[dict[str, Any]]]:
         """Convert Chat Completions messages to Responses API input items.
 
         Returns ``(instructions, input_items)`` where *instructions* is the
         concatenated system/developer messages (or ``None``) and *input_items*
         is the Responses API ``input`` array.
+
+        When *replay_reasoning_to_model* is True, stored ``_provider_content``
+        reasoning items (``type=="reasoning"``, captured via
+        ``include=["reasoning.encrypted_content"]`` on a prior turn)
+        are emitted as ``ResponseReasoningItemParam`` input items
+        immediately before the assistant message they belong to.  The
+        SDK explicitly documents this round-trip pattern at
+        ``response_reasoning_item_param.py:33-37``: "Be sure to include
+        these items in your ``input`` to the Responses API for
+        subsequent turns of a conversation if you are manually managing
+        context".  Even with ``store=False``, ``encrypted_content``
+        round-trips correctly per ``response_create_params.py:70-74``.
+
+        When *replay_reasoning_to_model* is False, reasoning items are silently
+        dropped (they were stripped from the wire by ``sanitize_messages``
+        anyway, but we also skip the input-item emission step).
         """
+        # Capture ``_provider_content`` reasoning items per ASSISTANT
+        # ORDINAL (not raw message index) BEFORE sanitization strips
+        # the underscore-prefixed key.  Position-by-index would be
+        # unsafe: ``sanitize_messages`` drops orphan tool results
+        # (``_openai_common.py:489-498`` / ``:521-535``) and inserts
+        # synthesized error tool messages for orphaned tool_calls
+        # (``:510-517``).  Either operation shifts subsequent message
+        # indices, so a pre-vs-post-sanitize index match would
+        # silently miss reasoning attachments after any tool-message
+        # repair.  Assistant messages themselves are never dropped or
+        # duplicated by sanitize_messages — only tool messages — so
+        # the n-th assistant in the original list is invariably the
+        # n-th assistant in the sanitized list.  Ordinal-keyed lookup
+        # survives any tool-message length change.
+        reasoning_by_assistant_ordinal: dict[int, list[dict[str, Any]]] = {}
+        if replay_reasoning_to_model:
+            ord_pre = 0
+            for raw_msg in messages:
+                if raw_msg.get("role") != "assistant":
+                    continue
+                pc = raw_msg.get("_provider_content")
+                if isinstance(pc, list):
+                    items_to_replay = [
+                        b for b in pc if isinstance(b, dict) and b.get("type") == "reasoning"
+                    ]
+                    if items_to_replay:
+                        reasoning_by_assistant_ordinal[ord_pre] = items_to_replay
+                ord_pre += 1
+
         messages = sanitize_messages(messages)
         instructions_parts: list[str] = []
         items: list[dict[str, Any]] = []
+        # Track assistant ordinal in the SANITIZED list so the lookup
+        # into reasoning_by_assistant_ordinal stays aligned with the
+        # original-list ordinal.  See the long comment above for why
+        # ordinal is invariant under sanitization.
+        assistant_ordinal_post = 0
 
         for msg in messages:
             role = msg.get("role", "")
@@ -129,9 +182,15 @@ class OpenAIResponsesProvider:
                 items.append(item)
 
             elif role == "assistant":
-                # With store=False, provider_blocks cannot be replayed as input
-                # (output format != input format, and IDs aren't persisted).
-                # Rebuild from the normalized content/tool_calls instead.
+                # Phase 3 reasoning replay: emit stored reasoning items
+                # BEFORE the assistant message they belong to.  The SDK
+                # expects reasoning items to appear in input order
+                # alongside the assistant turn that produced them.
+                for r_item in reasoning_by_assistant_ordinal.get(assistant_ordinal_post, []):
+                    item_for_input = _reasoning_item_for_input(r_item)
+                    if item_for_input is not None:
+                        items.append(item_for_input)
+                assistant_ordinal_post += 1
 
                 # Text content → assistant message (plain string for input)
                 if content:
@@ -239,11 +298,33 @@ class OpenAIResponsesProvider:
         reasoning_effort: str,
         deferred_names: frozenset[str] | None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> dict[str, Any]:
-        """Build the kwargs dict for ``client.responses.create/stream``."""
+        """Build the kwargs dict for ``client.responses.create/stream``.
+
+        ``replay_reasoning_to_model`` (Phase 3 of the reasoning-
+        persistence feature) gates two things together:
+        1. ``include=["reasoning.encrypted_content"]`` on the request
+           (so the API surfaces ``encrypted_content`` on reasoning
+           items in ``provider_blocks``).
+        2. ``_convert_messages`` round-tripping stored reasoning items
+           from ``_provider_content`` as ``input`` items on subsequent
+           turns (the SDK's ``ResponseReasoningItemParam`` shape).
+
+        Both are also gated by ``caps.supports_reasoning_replay`` —
+        models without a reasoning lane (gpt-4o, etc.) silently skip
+        replay even if the operator flag is set.
+        """
         caps = capabilities or self.get_capabilities(model)
 
-        instructions, input_items = self._convert_messages(messages)
+        # The two replay gates collapse to a single boolean: replay is
+        # active only when both the operator flag AND the model's
+        # capability allow it.  Threaded into ``_convert_messages`` so
+        # stored reasoning items become input items on the next call.
+        replay_active = bool(replay_reasoning_to_model and caps.supports_reasoning_replay)
+        instructions, input_items = self._convert_messages(
+            messages, replay_reasoning_to_model=replay_active
+        )
         tools = apply_tool_search(caps, tools, deferred_names)
         converted_tools = self._convert_tools(tools, caps)
 
@@ -260,6 +341,13 @@ class OpenAIResponsesProvider:
             "max_output_tokens": max_tokens,
             "store": False,
         }
+
+        if replay_active:
+            # SDK doc (response_create_params.py:70-74): with
+            # ``include=["reasoning.encrypted_content"]`` the API
+            # surfaces opaque ``encrypted_content`` on reasoning
+            # items, enabling stateless replay even with ``store=False``.
+            kwargs["include"] = ["reasoning.encrypted_content"]
 
         if instructions:
             kwargs["instructions"] = instructions
@@ -293,12 +381,11 @@ class OpenAIResponsesProvider:
         deferred_names: frozenset[str] | None = None,
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
-        # Phase 2 reasoning-persistence kwarg — accepted for Protocol
-        # conformance.  Phase 3 will gate ``include=
-        # ["reasoning.encrypted_content"]`` on this flag once OpenAI
-        # Responses captures replayable reasoning items.  Today the
-        # request kwargs don't carry reasoning, so the flag is unused
-        # but threaded for forward-compat.
+        # Phase 3 reasoning-persistence kwarg — gates
+        # ``include=["reasoning.encrypted_content"]`` on the request
+        # AND ``_convert_messages`` round-tripping stored reasoning
+        # items as input.  Both are also gated by
+        # ``caps.supports_reasoning_replay`` inside ``_build_kwargs``.
         replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         if extra_params:
@@ -312,6 +399,7 @@ class OpenAIResponsesProvider:
             reasoning_effort,
             deferred_names,
             capabilities=capabilities,
+            replay_reasoning_to_model=replay_reasoning_to_model,
         )
         kwargs["stream"] = True
 
@@ -481,7 +569,7 @@ class OpenAIResponsesProvider:
         extra_params: dict[str, Any] | None = None,
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
-        # See create_streaming above for the Phase 2 reasoning-persistence rationale.
+        # See create_streaming above for the Phase 3 reasoning-persistence rationale.
         replay_reasoning_to_model: bool = True,
     ) -> CompletionResult:
         if extra_params:
@@ -495,6 +583,7 @@ class OpenAIResponsesProvider:
             reasoning_effort,
             deferred_names,
             capabilities=capabilities,
+            replay_reasoning_to_model=replay_reasoning_to_model,
         )
 
         log.debug(
@@ -592,8 +681,76 @@ class OpenAIResponsesProvider:
         self,
         provider_blocks: list[dict[str, Any]] | None,
     ) -> str:
-        # Phase 3 will wire this to walk ``type=="reasoning"`` items
-        # captured via ``include=["reasoning.encrypted_content"]``.
-        # Today the request kwargs don't pass ``include`` so reasoning
-        # items in ``provider_blocks`` carry no replayable text.
-        return ""
+        if not isinstance(provider_blocks, list):
+            return ""
+        parts: list[str] = []
+        for block in provider_blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "reasoning":
+                continue
+            # Per ``ResponseReasoningItem`` (response_reasoning_item.py:31-62):
+            # ``summary`` is the human-readable summary list (always
+            # present), ``content`` is the raw reasoning text list
+            # (optional). We surface both — summary is what the model
+            # produces by default; content is only present on certain
+            # configurations.
+            for s in block.get("summary") or []:
+                if isinstance(s, dict) and s.get("type") == "summary_text":
+                    text = s.get("text")
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+            for c in block.get("content") or []:
+                if isinstance(c, dict) and c.get("type") == "reasoning_text":
+                    text = c.get("text")
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+        if not parts:
+            return ""
+        joined = "\n".join(parts)
+        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
+            return joined[:MAX_REASONING_DISPLAY_BYTES]
+        return joined
+
+
+def _reasoning_item_for_input(stored: dict[str, Any]) -> dict[str, Any] | None:
+    """Project a stored reasoning item into ``ResponseReasoningItemParam`` shape.
+
+    The output of a Responses API call carries reasoning items shaped
+    like ``ResponseReasoningItem`` (response_reasoning_item.py:31-62);
+    we stored those verbatim into ``provider_blocks`` via
+    ``item.model_dump()`` (``_iter_stream`` line 415-420 captures all
+    output items).  To replay them as input on the next turn, the
+    Responses API expects ``ResponseReasoningItemParam``
+    (response_reasoning_item_param.py:31-62) which has the same shape
+    minus ``status`` (a server-only field).
+
+    The ``id``, ``summary``, ``content``, ``encrypted_content``, and
+    ``type`` fields all round-trip directly.  We project explicitly
+    rather than ``del stored["status"]; return stored`` so callers
+    aren't surprised by mutation of the source dict.
+
+    Returns ``None`` when ``id`` is missing or non-string — per the
+    SDK schema (``response_reasoning_item_param.py:39``) ``id`` is
+    ``Required[str]``; sending an empty string would emit a malformed
+    input item that the API may either reject (4xx) or silently
+    misroute.  Caller skips appending when None is returned.  Items
+    captured via the streaming layer always have ``id`` populated, so
+    this guard is defensive against manually-constructed or migrated
+    storage rows.
+    """
+    item_id = stored.get("id")
+    if not isinstance(item_id, str) or not item_id:
+        return None
+    out: dict[str, Any] = {
+        "type": "reasoning",
+        "id": item_id,
+        "summary": stored.get("summary") or [],
+    }
+    content = stored.get("content")
+    if content:
+        out["content"] = content
+    encrypted = stored.get("encrypted_content")
+    if encrypted:
+        out["encrypted_content"] = encrypted
+    return out

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -576,3 +576,15 @@ class OpenAIResponsesProvider:
     @property
     def retryable_error_names(self) -> frozenset[str]:
         return RETRYABLE_ERROR_NAMES
+
+    # -- reasoning extraction ------------------------------------------------
+
+    def extract_reasoning_text(
+        self,
+        provider_blocks: list[dict[str, Any]] | None,
+    ) -> str:
+        # Phase 3 will wire this to walk ``type=="reasoning"`` items
+        # captured via ``include=["reasoning.encrypted_content"]``.
+        # Today the request kwargs don't pass ``include`` so reasoning
+        # items in ``provider_blocks`` carry no replayable text.
+        return ""

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -28,11 +28,11 @@ from turnstone.core.providers._openai_common import (
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
-    MAX_REASONING_DISPLAY_BYTES,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
     ToolCallDelta,
+    _join_reasoning_with_cap,
 )
 
 log = structlog.get_logger(__name__)
@@ -705,12 +705,7 @@ class OpenAIResponsesProvider:
                     text = c.get("text")
                     if isinstance(text, str) and text:
                         parts.append(text)
-        if not parts:
-            return ""
-        joined = "\n".join(parts)
-        if len(joined) > MAX_REASONING_DISPLAY_BYTES:
-            return joined[:MAX_REASONING_DISPLAY_BYTES]
-        return joined
+        return _join_reasoning_with_cap(parts)
 
 
 def _reasoning_item_for_input(stored: dict[str, Any]) -> dict[str, Any] | None:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -133,6 +133,7 @@ class LLMProvider(Protocol):
         deferred_names: frozenset[str] | None = None,
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         """Create a streaming request, yielding normalized StreamChunks.
 
@@ -162,8 +163,17 @@ class LLMProvider(Protocol):
         extra_params: dict[str, Any] | None = None,
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
     ) -> CompletionResult:
-        """Create a non-streaming request, returning a normalized result."""
+        """Create a non-streaming request, returning a normalized result.
+
+        ``replay_reasoning_to_model`` mirrors the per-model
+        ``model_definitions`` operator flag.  Anthropic uses it to
+        gate the verbatim ``_provider_content`` replay (Phase 2);
+        other providers accept the kwarg for Protocol conformance and
+        ignore it (chat-template ``<think>`` content isn't part of
+        their wire-side replay path).
+        """
         ...
 
     def convert_tools(

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -106,8 +106,34 @@ class ModelCapabilities:
 # tuning change propagates to every provider's display path uniformly.
 # Larger reasoning bodies are still stored verbatim in
 # ``provider_data``; only the rehydrated UI display payload is
-# truncated.  64 KiB matches the briefing's recommendation.
-MAX_REASONING_DISPLAY_BYTES = 64 * 1024
+# truncated.
+#
+# Named ``_CHARS`` (not ``_BYTES``) because the cap is enforced via
+# Python ``str`` slicing, which counts code points.  Reasoning text
+# that happens to contain 4-byte UTF-8 glyphs (CJK, emoji) will
+# serialise to a larger UTF-8 payload than the constant suggests —
+# fine for the UI display path (browsers handle the encoded length),
+# but worth knowing if this is ever wired to a byte-quota system.
+MAX_REASONING_DISPLAY_CHARS = 64 * 1024
+
+
+def _join_reasoning_with_cap(parts: list[str]) -> str:
+    """Join collected reasoning text parts with newline; truncate at the
+    operator-friendly UI cap.
+
+    Shared tail of every provider's ``extract_reasoning_text`` —
+    Anthropic walks ``thinking`` blocks, OpenAI Responses walks
+    ``reasoning`` items' ``summary`` + ``content``, OpenAI Chat walks
+    synthetic ``reasoning_text`` blocks.  All three converge on the
+    same emit pattern: collect strings, drop empties, join with
+    newline, cap at :data:`MAX_REASONING_DISPLAY_CHARS`.
+    """
+    if not parts:
+        return ""
+    joined = "\n".join(parts)
+    if len(joined) > MAX_REASONING_DISPLAY_CHARS:
+        return joined[:MAX_REASONING_DISPLAY_CHARS]
+    return joined
 
 
 def _lookup_capabilities(
@@ -168,6 +194,21 @@ class LLMProvider(Protocol):
         stream object (which has a ``.close()`` method) before yielding the
         first chunk.  The caller can then close it from another thread to
         abort a blocked HTTP read immediately.
+
+        ``replay_reasoning_to_model`` defaults to ``True`` here (and on
+        every concrete provider's ``create_streaming`` /
+        ``create_completion``) for back-compat with direct callers that
+        haven't been updated to thread the resolver — eval scripts,
+        ad-hoc tests, third-party harnesses.  This is INTENTIONALLY
+        the opposite of the operator-side default
+        (``ModelConfig.replay_reasoning_to_model = False``,
+        ``model_definitions`` server_default ``0``); the resolver in
+        ``ChatSession`` reads the operator value and passes it
+        explicitly, so production call sites never rely on the
+        kwarg-omitted path.  Provider-internal helpers (e.g.
+        ``OpenAIResponsesProvider._convert_messages``) default ``False``
+        because they're called BY the public entry points — once the
+        resolver-driven value lands, it's already explicit.
         """
         ...
 

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -256,10 +256,24 @@ class LLMProvider(Protocol):
     ) -> str:
         """Return concatenated reasoning text from stored ``provider_blocks``.
 
-        Providers without a first-class reasoning shape (OpenAI Chat,
-        Google) or that haven't been wired yet (OpenAI Responses pre-
-        Phase-3) return ``""``.  AnthropicProvider walks
-        ``type=="thinking"`` blocks and returns the concatenated
-        ``thinking`` text, capped at an operator-friendly size.
+        Each provider walks the block types it owns:
+
+        * ``AnthropicProvider`` — ``thinking`` blocks (concatenated
+          ``thinking`` text).
+        * ``OpenAIResponsesProvider`` — ``reasoning`` items
+          (concatenated ``summary`` + ``content`` text).
+        * ``OpenAIChatCompletionsProvider`` — synthetic
+          ``reasoning_text`` blocks stamped by
+          ``ChatSession._maybe_synth_reasoning_block`` for vLLM /
+          llama.cpp / Gemini-OpenAI-compat reasoning capture.
+        * ``GoogleProvider`` — inherits the OpenAI Chat extractor
+          (Gemini's ``/v1beta/openai/`` reasoning surfaces as
+          synthetic ``reasoning_text`` blocks too).
+
+        All providers return the joined text capped at
+        :data:`MAX_REASONING_DISPLAY_CHARS` for UI rendering; full
+        bytes remain in ``provider_data`` for replay.  Returns ``""``
+        when the input list contains no recognised reasoning-bearing
+        blocks for the implementing provider.
         """
         ...

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -87,6 +87,27 @@ class ModelCapabilities:
     supports_tool_search: bool = False
     supports_vision: bool = False
     thinking_display: str = ""  # "summarized" for models that omit thinking by default
+    # Phase 3 reasoning-persistence: gate the per-model
+    # ``replay_reasoning_to_model`` flag.  When False, the wire-build
+    # path skips replay regardless of the operator flag (defends
+    # against operators flipping the flag on a model whose API has
+    # no reasoning-replay shape — e.g. OpenAI Chat Completions, where
+    # reasoning is purely server-side and never round-trips).  Set
+    # True for: Anthropic models with ``thinking_mode != "none"``,
+    # OpenAI Responses o-series + GPT-5+ (``include=
+    # ["reasoning.encrypted_content"]`` round-trip).  Path-3 capture
+    # (Chat Completions / vLLM / llama.cpp / Gemini-compat) is
+    # persist-only and doesn't gate on this flag.
+    supports_reasoning_replay: bool = False
+
+
+# Operator-friendly UI cap on reasoning text returned from
+# ``LLMProvider.extract_reasoning_text``.  Single source of truth so a
+# tuning change propagates to every provider's display path uniformly.
+# Larger reasoning bodies are still stored verbatim in
+# ``provider_data``; only the rehydrated UI display payload is
+# truncated.  64 KiB matches the briefing's recommendation.
+MAX_REASONING_DISPLAY_BYTES = 64 * 1024
 
 
 def _lookup_capabilities(

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -177,3 +177,17 @@ class LLMProvider(Protocol):
     def retryable_error_names(self) -> frozenset[str]:
         """Exception class names that should trigger retry."""
         ...
+
+    def extract_reasoning_text(
+        self,
+        provider_blocks: list[dict[str, Any]] | None,
+    ) -> str:
+        """Return concatenated reasoning text from stored ``provider_blocks``.
+
+        Providers without a first-class reasoning shape (OpenAI Chat,
+        Google) or that haven't been wired yet (OpenAI Responses pre-
+        Phase-3) return ``""``.  AnthropicProvider walks
+        ``type=="thinking"`` blocks and returns the concatenated
+        ``thinking`` text, capped at an operator-friendly size.
+        """
+        ...

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1096,6 +1096,73 @@ class ChatSession:
             return self._cached_capabilities
         return self._resolve_capabilities(p, m, "")
 
+    def _resolve_server_type(self, alias: str | None = None) -> str:
+        """Read ``server_compat.server_type`` for an alias from the registry.
+
+        Used by :meth:`_maybe_synth_reasoning_block` to tag synthetic
+        path-3 reasoning blocks with their origin server (vllm,
+        llama.cpp, sglang, etc.) — informational today, useful for
+        future per-server replay paths.  Returns ``""`` on any lookup
+        miss; the synthetic block then omits the ``source`` field.
+        """
+        target_alias = alias or self._model_alias or ""
+        if not self._registry or not target_alias:
+            return ""
+        try:
+            cfg: ModelConfig = self._registry.get_config(target_alias)
+            sc = (
+                cfg.capabilities.get("server_compat")
+                if isinstance(cfg.capabilities, dict)
+                else None
+            )
+            if isinstance(sc, dict):
+                return str(sc.get("server_type") or "")
+        except Exception:
+            pass
+        return ""
+
+    def _maybe_synth_reasoning_block(
+        self,
+        provider_blocks: list[dict[str, Any]],
+        reasoning_parts: list[str],
+    ) -> list[dict[str, Any]]:
+        """Stamp captured ``reasoning_parts`` as a synthetic ``reasoning_text``
+        block when no native ``provider_blocks`` were emitted.
+
+        Anthropic emits native ``thinking`` blocks; OpenAI Responses
+        emits native ``reasoning`` items via ``output_item.done``.
+        Both populate ``provider_blocks`` directly during streaming
+        and need no synthesis here.
+
+        OpenAI Chat Completions (with vLLM ``--reasoning-parser``,
+        llama.cpp ``reasoning_format``, or Gemini's ``/v1beta/openai/``
+        endpoint if it surfaces ``reasoning_content``) streams
+        reasoning as ``reasoning_delta`` chunks but never produces a
+        provider_blocks item.  Without this synthesis the captured
+        text would be dropped at the end of the stream — visible live,
+        invisible on page reload.
+
+        The synthetic block uses ``type="reasoning_text"`` (NOT
+        ``"thinking"``) so it falls through Phase 2's
+        ``ANTHROPIC_VALID_BLOCK_TYPES`` shape filter on cross-model
+        resumption — protecting against operator-switches from a
+        local-model session to Anthropic, which would otherwise hit
+        Anthropic's input boundary with an unsigned ``thinking`` block.
+        """
+        if provider_blocks:
+            return provider_blocks
+        text = "".join(reasoning_parts)
+        if not text.strip():
+            return provider_blocks
+        block: dict[str, Any] = {
+            "type": "reasoning_text",
+            "text": text,
+        }
+        server_type = self._resolve_server_type()
+        if server_type:
+            block["source"] = server_type
+        return [block]
+
     def _resolve_replay_reasoning_to_model(self, alias: str | None = None) -> bool:
         """Read ``ModelConfig.replay_reasoning_to_model`` for an alias.
 
@@ -3793,7 +3860,12 @@ class ChatSession:
             )
 
         # Store raw provider content blocks for multi-turn preservation
-        # (e.g. Anthropic web_search_tool_result with encrypted_content)
+        # (e.g. Anthropic web_search_tool_result with encrypted_content).
+        # Phase 3 path-3 capture: when no native blocks were emitted but
+        # ``reasoning_delta`` chunks accumulated text, synthesize a
+        # ``reasoning_text`` block so the captured reasoning survives
+        # past the live stream and surfaces on history reload.
+        provider_blocks = self._maybe_synth_reasoning_block(provider_blocks, reasoning_parts)
         if provider_blocks:
             msg["_provider_content"] = provider_blocks
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1156,6 +1156,14 @@ class ChatSession:
         resumption — protecting against operator-switches from a
         local-model session to Anthropic, which would otherwise hit
         Anthropic's input boundary with an unsigned ``thinking`` block.
+
+        The optional ``source`` field tags the block with the
+        originating server (``vllm``, ``llamacpp``, ``sglang``, etc.)
+        when ``ModelConfig.capabilities["server_compat"]["server_type"]``
+        is populated.  Reserved for future per-server replay paths
+        (e.g. an operator-flagged path that re-injects synthetic
+        reasoning back into a vllm round-trip) — not consumed today;
+        the field is informational metadata, not dead code.
         """
         if provider_blocks:
             return provider_blocks

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1096,6 +1096,31 @@ class ChatSession:
             return self._cached_capabilities
         return self._resolve_capabilities(p, m, "")
 
+    def _resolve_replay_reasoning_to_model(self, alias: str | None = None) -> bool:
+        """Read ``ModelConfig.replay_reasoning_to_model`` for an alias.
+
+        Used by the streaming + non-streaming wire-build paths to gate
+        Anthropic's verbatim ``_provider_content`` thinking-block
+        replay (Phase 2 of the reasoning-persistence feature).  The
+        resolver's miss-fallback is ``False``: when no registry / alias
+        is available, or the lookup raises, return ``False`` so the
+        provider-side strip path runs.  Losing the strip on operator-
+        flagged-on models would be a worse default than losing the
+        replay on operator-flagged-off models — replaying reasoning
+        text against an unknown operator preference shouldn't happen.
+        The False-on-miss matches the ``model_definitions`` server-side
+        default for the column, so cold workstreams behave the same as
+        unconfigured ones.
+        """
+        target_alias = alias or self._model_alias or ""
+        if not self._registry or not target_alias:
+            return False
+        try:
+            cfg: ModelConfig = self._registry.get_config(target_alias)
+            return bool(cfg.replay_reasoning_to_model)
+        except Exception:
+            return False
+
     def _save_config(self) -> None:
         """Persist LLM-affecting config so resumed workstreams behave identically."""
         save_workstream_config(
@@ -2464,6 +2489,7 @@ class ChatSession:
             reasoning_effort=reasoning_effort,
             extra_params=self._provider_extra_params(),
             capabilities=caps,
+            replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(),
         )
 
     # -- tool search helpers --------------------------------------------------
@@ -2665,6 +2691,7 @@ class ChatSession:
                     deferred_names=self._get_deferred_names(),
                     cancel_ref=self._cancel_ref,
                     capabilities=capabilities or self._get_capabilities(prov, model),
+                    replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(model_alias),
                 )
             except Exception as e:
                 ename = type(e).__name__
@@ -8927,6 +8954,9 @@ class ChatSession:
                         reasoning_effort=reasoning_effort or self.reasoning_effort,
                         extra_params=agent_extra,
                         capabilities=agent_caps,
+                        replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(
+                            agent_alias
+                        ),
                     )
                 except Exception as e:
                     ename = type(e).__name__

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -579,6 +579,21 @@ def _render_template(content: str, context: dict[str, str]) -> str:
     return _TEMPLATE_VAR_RE.sub(_replace, content)
 
 
+# Block types that carry reasoning content across providers.  Used by
+# ``ChatSession._maybe_synth_reasoning_block`` to decide whether
+# captured ``reasoning_parts`` need a synthetic ``reasoning_text``
+# block: if any of these types already appear in ``provider_blocks``,
+# native lane handles persistence and synthesis is a no-op.
+# - ``thinking`` / ``redacted_thinking`` — Anthropic native
+# - ``reasoning`` — OpenAI Responses native
+# - ``reasoning_text`` — synthetic (path-3 capture; included so
+#   re-running this code path against an already-synthesized list is
+#   idempotent).
+_REASONING_BEARING_BLOCK_TYPES: frozenset[str] = frozenset(
+    {"thinking", "redacted_thinking", "reasoning", "reasoning_text"}
+)
+
+
 # ---------------------------------------------------------------------------
 # SessionUI protocol — the contract every frontend must implement
 # ---------------------------------------------------------------------------
@@ -1135,20 +1150,32 @@ class ChatSession:
         reasoning_parts: list[str],
     ) -> list[dict[str, Any]]:
         """Stamp captured ``reasoning_parts`` as a synthetic ``reasoning_text``
-        block when no native ``provider_blocks`` were emitted.
+        block when no reasoning-bearing block already appears in
+        ``provider_blocks``.
 
         Anthropic emits native ``thinking`` blocks; OpenAI Responses
         emits native ``reasoning`` items via ``output_item.done``.
-        Both populate ``provider_blocks`` directly during streaming
-        and need no synthesis here.
+        Both populate ``provider_blocks`` with reasoning-bearing
+        shapes during streaming and need no synthesis here.
 
-        OpenAI Chat Completions (with vLLM ``--reasoning-parser``,
-        llama.cpp ``reasoning_format``, or Gemini's ``/v1beta/openai/``
-        endpoint if it surfaces ``reasoning_content``) streams
-        reasoning as ``reasoning_delta`` chunks but never produces a
-        provider_blocks item.  Without this synthesis the captured
-        text would be dropped at the end of the stream — visible live,
-        invisible on page reload.
+        OpenAI Chat Completions (vLLM ``--reasoning-parser``, llama.cpp
+        ``reasoning_format``, Gemini's ``/v1beta/openai/`` endpoint
+        when it surfaces ``reasoning_content``) streams reasoning as
+        ``reasoning_delta`` chunks but never emits a reasoning-bearing
+        provider block.  Without this synthesis the captured text would
+        be dropped at the end of the stream — visible live, invisible
+        on page reload.
+
+        Crucially, GoogleProvider attaches raw tool_call dicts as
+        ``provider_blocks`` on the finish chunk for ``thought_signature``
+        round-trip (``_google.py:_iter_stream``).  An earlier version
+        bailed out whenever ``provider_blocks`` was non-empty, which
+        silently lost reasoning text on Google + reasoning_delta turns.
+        The fix tests for reasoning-bearing block types specifically
+        (see ``_REASONING_BEARING_BLOCK_TYPES``) and APPENDS the
+        synthetic block to the existing list rather than replacing it
+        — preserving Google's tool-call fidelity blocks alongside the
+        new synthetic reasoning entry.
 
         The synthetic block uses ``type="reasoning_text"`` (NOT
         ``"thinking"``) so it falls through Phase 2's
@@ -1165,11 +1192,15 @@ class ChatSession:
         reasoning back into a vllm round-trip) — not consumed today;
         the field is informational metadata, not dead code.
         """
-        if provider_blocks:
-            return provider_blocks
         text = "".join(reasoning_parts)
         if not text.strip():
             return provider_blocks
+        # Native reasoning already present — Anthropic / OpenAI
+        # Responses path.  No synth needed; return reference unchanged
+        # so the existing identity contract holds.
+        for b in provider_blocks:
+            if isinstance(b, dict) and b.get("type") in _REASONING_BEARING_BLOCK_TYPES:
+                return provider_blocks
         block: dict[str, Any] = {
             "type": "reasoning_text",
             "text": text,
@@ -1177,7 +1208,9 @@ class ChatSession:
         server_type = self._resolve_server_type()
         if server_type:
             block["source"] = server_type
-        return [block]
+        # Append rather than replace so non-reasoning fidelity blocks
+        # (e.g. Google tool_calls with thought_signature) survive.
+        return [*provider_blocks, block]
 
     def _resolve_replay_reasoning_to_model(self, alias: str | None = None) -> bool:
         """Read ``ModelConfig.replay_reasoning_to_model`` for an alias.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1118,7 +1118,15 @@ class ChatSession:
             if isinstance(sc, dict):
                 return str(sc.get("server_type") or "")
         except Exception:
-            pass
+            # Best-effort lookup — synth-block source tagging is
+            # informational, never load-bearing.  Log at debug so a
+            # repeated registry-lookup failure during a session shows
+            # up under DEBUG triage but doesn't spam normal logs.
+            log.debug(
+                "_resolve_server_type lookup failed for alias=%s; defaulting to empty",
+                target_alias,
+                exc_info=True,
+            )
         return ""
 
     def _maybe_synth_reasoning_block(

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2326,7 +2326,8 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         # shares storage with the other kind. ``cfg.list_kind`` is
         # guaranteed non-None by the misconfig gate above.
         storage = getattr(request.app.state, "auth_storage", None)
-        if mgr.get(ws_id) is None:
+        live_session = mgr.get(ws_id)
+        if live_session is None:
             if storage is None:
                 return JSONResponse({"error": cfg.not_found_label}, status_code=404)
             try:
@@ -2364,6 +2365,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
             try:
                 from turnstone.core.history_decoration import (
                     decorate_history_messages,
+                    extract_reasoning_for_history,
                     load_verdict_indexes,
                 )
 
@@ -2376,6 +2378,49 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 # shared mutable state beyond the per-call message
                 # list) so the off-loop hop is free.
                 await asyncio.to_thread(decorate_history_messages, messages, indexes[0], indexes[1])
+                # Active-model ``persist_reasoning`` flag.  Three-tier
+                # resolution so the operator's flag-flip takes effect
+                # uniformly — live session, storage-rehydratable cold
+                # workstream, or unknown workstream:
+                #
+                # 1. Live session in memory → read from its registry
+                #    (already-warm path).
+                # 2. Cold workstream → ``workstream_config.model_alias``
+                #    persisted at first send (see
+                #    ``session_manager.py:628`` rehydrate path) →
+                #    resolve through the kind-appropriate registry on
+                #    ``app.state``.
+                # 3. Neither available → conservative default ``True``,
+                #    matching the migration server_default and the
+                #    rehydration default in spec.
+                persist_reasoning = True
+                resolved_alias = ""
+                resolved_registry: Any = None
+                if live_session is not None:
+                    resolved_registry = getattr(live_session, "_registry", None)
+                    resolved_alias = getattr(live_session, "_model_alias", "") or ""
+                if not resolved_alias and storage is not None:
+                    try:
+                        ws_cfg = storage.load_workstream_config(ws_id) or {}
+                    except Exception:
+                        ws_cfg = {}
+                    resolved_alias = ws_cfg.get("model_alias") or ""
+                if resolved_registry is None:
+                    # Interactive server stores the registry as
+                    # ``app.state.registry``; console stores its coord
+                    # registry as ``app.state.coord_registry``.  The
+                    # lifted handler is shared, so we try both.
+                    resolved_registry = getattr(request.app.state, "registry", None) or getattr(
+                        request.app.state, "coord_registry", None
+                    )
+                if resolved_registry is not None and resolved_alias:
+                    try:
+                        persist_reasoning = bool(
+                            resolved_registry.get_config(resolved_alias).persist_reasoning
+                        )
+                    except Exception:
+                        persist_reasoning = True
+                await asyncio.to_thread(extract_reasoning_for_history, messages, persist_reasoning)
             except Exception:
                 # Operationally interesting: a persistent decoration
                 # failure (missing migration, driver mismatch, schema

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2378,7 +2378,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 # shared mutable state beyond the per-call message
                 # list) so the off-loop hop is free.
                 await asyncio.to_thread(decorate_history_messages, messages, indexes[0], indexes[1])
-                # Active-model ``persist_reasoning`` flag.  Three-tier
+                # Active-model ``surface_persisted_reasoning`` flag.  Three-tier
                 # resolution so the operator's flag-flip takes effect
                 # uniformly — live session, storage-rehydratable cold
                 # workstream, or unknown workstream:
@@ -2393,15 +2393,22 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 # 3. Neither available → conservative default ``True``,
                 #    matching the migration server_default and the
                 #    rehydration default in spec.
-                persist_reasoning = True
+                surface_persisted_reasoning = True
                 resolved_alias = ""
                 resolved_registry: Any = None
                 if live_session is not None:
                     resolved_registry = getattr(live_session, "_registry", None)
                     resolved_alias = getattr(live_session, "_model_alias", "") or ""
                 if not resolved_alias and storage is not None:
+                    # Off-loop the sync storage call (mirrors get_workstream
+                    # / load_messages / load_verdict_indexes / decorate /
+                    # extract_reasoning_for_history above).  Preserves the
+                    # try/except so a DB failure degrades to the
+                    # conservative-default branch instead of bubbling out.
                     try:
-                        ws_cfg = storage.load_workstream_config(ws_id) or {}
+                        ws_cfg = (
+                            await asyncio.to_thread(storage.load_workstream_config, ws_id) or {}
+                        )
                     except Exception:
                         ws_cfg = {}
                     resolved_alias = ws_cfg.get("model_alias") or ""
@@ -2415,12 +2422,14 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                     )
                 if resolved_registry is not None and resolved_alias:
                     try:
-                        persist_reasoning = bool(
-                            resolved_registry.get_config(resolved_alias).persist_reasoning
+                        surface_persisted_reasoning = bool(
+                            resolved_registry.get_config(resolved_alias).surface_persisted_reasoning
                         )
                     except Exception:
-                        persist_reasoning = True
-                await asyncio.to_thread(extract_reasoning_for_history, messages, persist_reasoning)
+                        surface_persisted_reasoning = True
+                await asyncio.to_thread(
+                    extract_reasoning_for_history, messages, surface_persisted_reasoning
+                )
             except Exception:
                 # Operationally interesting: a persistent decoration
                 # failure (missing migration, driver mismatch, schema

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -4167,7 +4167,7 @@ class PostgreSQLBackend:
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
-        persist_reasoning: bool = True,
+        surface_persisted_reasoning: bool = True,
         replay_reasoning_to_model: bool = False,
     ) -> None:
         from sqlalchemy.dialects import postgresql
@@ -4189,7 +4189,7 @@ class PostgreSQLBackend:
                     temperature=temperature,
                     max_tokens=max_tokens,
                     reasoning_effort=reasoning_effort,
-                    persist_reasoning=1 if persist_reasoning else 0,
+                    surface_persisted_reasoning=1 if surface_persisted_reasoning else 0,
                     replay_reasoning_to_model=1 if replay_reasoning_to_model else 0,
                     created_by=created_by,
                     created=now,
@@ -4209,7 +4209,9 @@ class PostgreSQLBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+            return _row_to_dict(
+                row, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+            )
 
     def get_model_definition_by_alias(self, alias: str) -> dict[str, Any] | None:
 
@@ -4219,7 +4221,9 @@ class PostgreSQLBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+            return _row_to_dict(
+                row, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+            )
 
     def list_model_definitions(self, enabled_only: bool = False) -> list[dict[str, Any]]:
 
@@ -4229,7 +4233,9 @@ class PostgreSQLBackend:
                 q = q.where(model_definitions.c.enabled == 1)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+                _row_to_dict(
+                    r, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+                )
                 for r in rows
             ]
 
@@ -4239,8 +4245,10 @@ class PostgreSQLBackend:
         fields["updated"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         if "enabled" in fields:
             fields["enabled"] = 1 if fields["enabled"] else 0
-        if "persist_reasoning" in fields:
-            fields["persist_reasoning"] = 1 if fields["persist_reasoning"] else 0
+        if "surface_persisted_reasoning" in fields:
+            fields["surface_persisted_reasoning"] = (
+                1 if fields["surface_persisted_reasoning"] else 0
+            )
         if "replay_reasoning_to_model" in fields:
             fields["replay_reasoning_to_model"] = 1 if fields["replay_reasoning_to_model"] else 0
         with self._conn() as conn:

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -4167,6 +4167,8 @@ class PostgreSQLBackend:
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
+        persist_reasoning: bool = True,
+        replay_reasoning_to_model: bool = False,
     ) -> None:
         from sqlalchemy.dialects import postgresql
 
@@ -4187,6 +4189,8 @@ class PostgreSQLBackend:
                     temperature=temperature,
                     max_tokens=max_tokens,
                     reasoning_effort=reasoning_effort,
+                    persist_reasoning=1 if persist_reasoning else 0,
+                    replay_reasoning_to_model=1 if replay_reasoning_to_model else 0,
                     created_by=created_by,
                     created=now,
                     updated=now,
@@ -4205,7 +4209,7 @@ class PostgreSQLBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled")
+            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
 
     def get_model_definition_by_alias(self, alias: str) -> dict[str, Any] | None:
 
@@ -4215,7 +4219,7 @@ class PostgreSQLBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled")
+            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
 
     def list_model_definitions(self, enabled_only: bool = False) -> list[dict[str, Any]]:
 
@@ -4224,7 +4228,10 @@ class PostgreSQLBackend:
             if enabled_only:
                 q = q.where(model_definitions.c.enabled == 1)
             rows = conn.execute(q).fetchall()
-            return [_row_to_dict(r, "enabled") for r in rows]
+            return [
+                _row_to_dict(r, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+                for r in rows
+            ]
 
     def update_model_definition(self, definition_id: str, **fields: Any) -> bool:
 
@@ -4232,6 +4239,10 @@ class PostgreSQLBackend:
         fields["updated"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         if "enabled" in fields:
             fields["enabled"] = 1 if fields["enabled"] else 0
+        if "persist_reasoning" in fields:
+            fields["persist_reasoning"] = 1 if fields["persist_reasoning"] else 0
+        if "replay_reasoning_to_model" in fields:
+            fields["replay_reasoning_to_model"] = 1 if fields["replay_reasoning_to_model"] else 0
         with self._conn() as conn:
             result = conn.execute(
                 sa.update(model_definitions)

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1853,6 +1853,8 @@ class StorageBackend(Protocol):
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
+        persist_reasoning: bool = True,
+        replay_reasoning_to_model: bool = False,
     ) -> None:
         """Create a model definition. No-op if definition_id already exists."""
         ...

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1853,7 +1853,7 @@ class StorageBackend(Protocol):
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
-        persist_reasoning: bool = True,
+        surface_persisted_reasoning: bool = True,
         replay_reasoning_to_model: bool = False,
     ) -> None:
         """Create a model definition. No-op if definition_id already exists."""

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -660,6 +660,8 @@ model_definitions = sa.Table(
     sa.Column("temperature", sa.Float, nullable=True),
     sa.Column("max_tokens", sa.Integer, nullable=True),
     sa.Column("reasoning_effort", sa.Text, nullable=True),
+    sa.Column("persist_reasoning", sa.Integer, nullable=False, server_default="1"),
+    sa.Column("replay_reasoning_to_model", sa.Integer, nullable=False, server_default="0"),
     sa.Column("created_by", sa.Text, nullable=False, server_default=""),
     sa.Column("created", sa.Text, nullable=False),
     sa.Column("updated", sa.Text, nullable=False),

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -660,7 +660,7 @@ model_definitions = sa.Table(
     sa.Column("temperature", sa.Float, nullable=True),
     sa.Column("max_tokens", sa.Integer, nullable=True),
     sa.Column("reasoning_effort", sa.Text, nullable=True),
-    sa.Column("persist_reasoning", sa.Integer, nullable=False, server_default="1"),
+    sa.Column("surface_persisted_reasoning", sa.Integer, nullable=False, server_default="1"),
     sa.Column("replay_reasoning_to_model", sa.Integer, nullable=False, server_default="0"),
     sa.Column("created_by", sa.Text, nullable=False, server_default=""),
     sa.Column("created", sa.Text, nullable=False),

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -4313,7 +4313,7 @@ class SQLiteBackend:
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
-        persist_reasoning: bool = True,
+        surface_persisted_reasoning: bool = True,
         replay_reasoning_to_model: bool = False,
     ) -> None:
 
@@ -4334,7 +4334,7 @@ class SQLiteBackend:
                     "temperature": temperature,
                     "max_tokens": max_tokens,
                     "reasoning_effort": reasoning_effort,
-                    "persist_reasoning": 1 if persist_reasoning else 0,
+                    "surface_persisted_reasoning": 1 if surface_persisted_reasoning else 0,
                     "replay_reasoning_to_model": (1 if replay_reasoning_to_model else 0),
                     "created_by": created_by,
                     "created": now,
@@ -4353,7 +4353,9 @@ class SQLiteBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+            return _row_to_dict(
+                row, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+            )
 
     def get_model_definition_by_alias(self, alias: str) -> dict[str, Any] | None:
 
@@ -4363,7 +4365,9 @@ class SQLiteBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+            return _row_to_dict(
+                row, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+            )
 
     def list_model_definitions(self, enabled_only: bool = False) -> list[dict[str, Any]]:
 
@@ -4373,7 +4377,9 @@ class SQLiteBackend:
                 q = q.where(model_definitions.c.enabled == 1)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+                _row_to_dict(
+                    r, "enabled", "surface_persisted_reasoning", "replay_reasoning_to_model"
+                )
                 for r in rows
             ]
 
@@ -4383,8 +4389,10 @@ class SQLiteBackend:
         fields["updated"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         if "enabled" in fields:
             fields["enabled"] = 1 if fields["enabled"] else 0
-        if "persist_reasoning" in fields:
-            fields["persist_reasoning"] = 1 if fields["persist_reasoning"] else 0
+        if "surface_persisted_reasoning" in fields:
+            fields["surface_persisted_reasoning"] = (
+                1 if fields["surface_persisted_reasoning"] else 0
+            )
         if "replay_reasoning_to_model" in fields:
             fields["replay_reasoning_to_model"] = 1 if fields["replay_reasoning_to_model"] else 0
         with self._conn() as conn:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -4313,6 +4313,8 @@ class SQLiteBackend:
         temperature: float | None = None,
         max_tokens: int | None = None,
         reasoning_effort: str | None = None,
+        persist_reasoning: bool = True,
+        replay_reasoning_to_model: bool = False,
     ) -> None:
 
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
@@ -4332,6 +4334,8 @@ class SQLiteBackend:
                     "temperature": temperature,
                     "max_tokens": max_tokens,
                     "reasoning_effort": reasoning_effort,
+                    "persist_reasoning": 1 if persist_reasoning else 0,
+                    "replay_reasoning_to_model": (1 if replay_reasoning_to_model else 0),
                     "created_by": created_by,
                     "created": now,
                     "updated": now,
@@ -4349,7 +4353,7 @@ class SQLiteBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled")
+            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
 
     def get_model_definition_by_alias(self, alias: str) -> dict[str, Any] | None:
 
@@ -4359,7 +4363,7 @@ class SQLiteBackend:
             ).fetchone()
             if row is None:
                 return None
-            return _row_to_dict(row, "enabled")
+            return _row_to_dict(row, "enabled", "persist_reasoning", "replay_reasoning_to_model")
 
     def list_model_definitions(self, enabled_only: bool = False) -> list[dict[str, Any]]:
 
@@ -4368,7 +4372,10 @@ class SQLiteBackend:
             if enabled_only:
                 q = q.where(model_definitions.c.enabled == 1)
             rows = conn.execute(q).fetchall()
-            return [_row_to_dict(r, "enabled") for r in rows]
+            return [
+                _row_to_dict(r, "enabled", "persist_reasoning", "replay_reasoning_to_model")
+                for r in rows
+            ]
 
     def update_model_definition(self, definition_id: str, **fields: Any) -> bool:
 
@@ -4376,6 +4383,10 @@ class SQLiteBackend:
         fields["updated"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         if "enabled" in fields:
             fields["enabled"] = 1 if fields["enabled"] else 0
+        if "persist_reasoning" in fields:
+            fields["persist_reasoning"] = 1 if fields["persist_reasoning"] else 0
+        if "replay_reasoning_to_model" in fields:
+            fields["replay_reasoning_to_model"] = 1 if fields["replay_reasoning_to_model"] else 0
         with self._conn() as conn:
             result = conn.execute(
                 sa.update(model_definitions)

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -194,7 +194,7 @@ MODEL_DEFINITION_MUTABLE = frozenset(
         "temperature",
         "max_tokens",
         "reasoning_effort",
-        "persist_reasoning",
+        "surface_persisted_reasoning",
         "replay_reasoning_to_model",
     }
 )

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -194,6 +194,8 @@ MODEL_DEFINITION_MUTABLE = frozenset(
         "temperature",
         "max_tokens",
         "reasoning_effort",
+        "persist_reasoning",
+        "replay_reasoning_to_model",
     }
 )
 PROMPT_POLICY_MUTABLE = frozenset({"name", "content", "tool_gate", "priority", "enabled"})

--- a/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
+++ b/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
@@ -1,0 +1,63 @@
+"""Add per-model reasoning-persistence flags to model_definitions.
+
+Adds two boolean (integer-coded) operator knobs:
+
+* ``persist_reasoning`` (default ``1``) — when true, the history-build
+  path extracts stored reasoning text from ``provider_data`` and surfaces
+  it on each assistant message dict so a page refresh re-renders the
+  reasoning bubble. Storage of the reasoning bytes happens regardless;
+  this flag only controls the extract-and-include step in
+  ``_build_history`` / ``decorate_history_messages``.
+* ``replay_reasoning_to_model`` (default ``0``) — when true, the
+  wire-build path keeps reasoning blocks in the outgoing
+  ``_provider_content`` lane on subsequent provider calls. False is the
+  conservative default: spec compliance, lower per-turn cost, no behaviour
+  change vs. the pre-flag default. **Phase 1 stores the column but does
+  not consume it on the wire**; Phase 2 wires the strip branch in
+  ``_anthropic.py``'s ``_convert_messages``.
+
+Mirrors the ``enabled`` column pattern (``_schema.py:659``):
+``NOT NULL`` with an integer ``server_default`` so existing rows pick up
+the conservative defaults silently on upgrade. Distinct from
+``temperature`` / ``max_tokens`` / ``reasoning_effort`` (migration 036)
+which are nullable inherit-from-cluster sampling overrides — these are
+operator-toggle booleans, never NULL.
+
+Revision ID: 052
+Revises: 051
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "052"
+down_revision = "051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("model_definitions") as batch:
+        batch.add_column(
+            sa.Column(
+                "persist_reasoning",
+                sa.Integer,
+                nullable=False,
+                server_default="1",
+            )
+        )
+        batch.add_column(
+            sa.Column(
+                "replay_reasoning_to_model",
+                sa.Integer,
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("model_definitions") as batch:
+        batch.drop_column("replay_reasoning_to_model")
+        batch.drop_column("persist_reasoning")

--- a/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
+++ b/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
@@ -2,12 +2,15 @@
 
 Adds two boolean (integer-coded) operator knobs:
 
-* ``persist_reasoning`` (default ``1``) — when true, the history-build
-  path extracts stored reasoning text from ``provider_data`` and surfaces
-  it on each assistant message dict so a page refresh re-renders the
-  reasoning bubble. Storage of the reasoning bytes happens regardless;
-  this flag only controls the extract-and-include step in
-  ``_build_history`` / ``decorate_history_messages``.
+* ``surface_persisted_reasoning`` (default ``1``) — when true, the
+  history-build path extracts stored reasoning text from
+  ``provider_data`` and surfaces it on each assistant message dict so a
+  page refresh re-renders the reasoning bubble. **Storage of the
+  reasoning bytes happens regardless of this flag** — it only controls
+  the extract-and-include step in ``_build_history`` /
+  ``decorate_history_messages``.  The earlier name ``surface_persisted_reasoning``
+  was renamed because it implied a storage-control switch; this flag
+  is purely about UI rehydration.
 * ``replay_reasoning_to_model`` (default ``0``) — when true, the
   wire-build path keeps reasoning blocks in the outgoing
   ``_provider_content`` lane on subsequent provider calls. False is the
@@ -41,7 +44,7 @@ def upgrade() -> None:
     with op.batch_alter_table("model_definitions") as batch:
         batch.add_column(
             sa.Column(
-                "persist_reasoning",
+                "surface_persisted_reasoning",
                 sa.Integer,
                 nullable=False,
                 server_default="1",
@@ -60,4 +63,4 @@ def upgrade() -> None:
 def downgrade() -> None:
     with op.batch_alter_table("model_definitions") as batch:
         batch.drop_column("replay_reasoning_to_model")
-        batch.drop_column("persist_reasoning")
+        batch.drop_column("surface_persisted_reasoning")

--- a/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
+++ b/turnstone/core/storage/migrations/versions/052_model_reasoning_persistence.py
@@ -8,9 +8,10 @@ Adds two boolean (integer-coded) operator knobs:
   page refresh re-renders the reasoning bubble. **Storage of the
   reasoning bytes happens regardless of this flag** — it only controls
   the extract-and-include step in ``_build_history`` /
-  ``decorate_history_messages``.  The earlier name ``surface_persisted_reasoning``
-  was renamed because it implied a storage-control switch; this flag
-  is purely about UI rehydration.
+  ``decorate_history_messages``.  The pre-rename column was
+  ``persist_reasoning``; the rename to ``surface_persisted_reasoning``
+  happened in the review-fix wave because the original name implied a
+  storage-control switch when the flag is purely about UI rehydration.
 * ``replay_reasoning_to_model`` (default ``0``) — when true, the
   wire-build path keeps reasoning blocks in the outgoing
   ``_provider_content`` lane on subsequent provider calls. False is the

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -49,6 +49,26 @@ class ConnectedEvent(ServerEvent):
 
 @dataclass
 class HistoryEvent(ServerEvent):
+    """SSE replay payload — the per-tab message backlog on connect.
+
+    Each entry in ``messages`` is a per-message dict the frontend
+    consumes directly. Notable optional keys:
+
+    * ``role`` (``"user"`` / ``"assistant"`` / ``"tool"``)
+    * ``content`` — string for text turns, list for image / document parts
+    * ``tool_calls`` — list of ``{id, name, arguments, verdict?,
+      output_assessment?}`` (assistant turns)
+    * ``tool_call_id`` — the originating call's id (tool turns)
+    * ``reminders`` — metacognitive nudge bubbles (user / tool channels)
+    * ``advisories`` — extracted ``UserInterjection`` payloads (tool
+      turns whose envelope wrapped queued-message advisories)
+    * ``reasoning`` — concatenated reasoning text for assistant turns
+      that round-tripped a thinking-block lane (Anthropic-with-thinking
+      today; OpenAI Responses + Gemini in later phases). Present only
+      when the active model's ``persist_reasoning`` flag is true and
+      the underlying ``provider_data`` carries reasoning blocks.
+    """
+
     type: str = "history"
     messages: list[dict[str, Any]] = field(default_factory=list)
 

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -65,7 +65,7 @@ class HistoryEvent(ServerEvent):
     * ``reasoning`` — concatenated reasoning text for assistant turns
       that round-tripped a thinking-block lane (Anthropic-with-thinking
       today; OpenAI Responses + Gemini in later phases). Present only
-      when the active model's ``persist_reasoning`` flag is true and
+      when the active model's ``surface_persisted_reasoning`` flag is true and
       the underlying ``provider_data`` carries reasoning blocks.
     """
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -474,11 +474,13 @@ def _build_history(
     else:
         ws_id = getattr(session, "_ws_id", "") or ""
         verdicts_by_call_id, assessments_by_call_id = _load_verdict_indexes(ws_id)
-    # Active-model reasoning-persistence flag — defaults True so that a
-    # registry/alias lookup miss still surfaces reasoning bubbles.  The
-    # default-True semantic mirrors the migration's server_default for
-    # ``model_definitions.surface_persisted_reasoning`` and matches the conservative
-    # rehydration default (Phase 1 spec).
+    # Active-model ``surface_persisted_reasoning`` flag — single-tier
+    # resolution (live session's registry only).  This path always has
+    # a live ``ChatSession`` in hand, so the cold-workstream and
+    # app.state-registry tiers used by ``make_history_handler``
+    # (``session_routes.py:2396-2429``) are unreachable here.  Default
+    # True mirrors the migration's server_default and matches the
+    # conservative rehydration default in the Phase 1 spec.
     surface_persisted_reasoning = True
     registry = getattr(session, "_registry", None)
     model_alias = getattr(session, "_model_alias", "") or ""

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -477,19 +477,21 @@ def _build_history(
     # Active-model reasoning-persistence flag — defaults True so that a
     # registry/alias lookup miss still surfaces reasoning bubbles.  The
     # default-True semantic mirrors the migration's server_default for
-    # ``model_definitions.persist_reasoning`` and matches the conservative
+    # ``model_definitions.surface_persisted_reasoning`` and matches the conservative
     # rehydration default (Phase 1 spec).
-    persist_reasoning = True
+    surface_persisted_reasoning = True
     registry = getattr(session, "_registry", None)
     model_alias = getattr(session, "_model_alias", "") or ""
     if registry is not None and model_alias:
         try:
-            persist_reasoning = bool(registry.get_config(model_alias).persist_reasoning)
+            surface_persisted_reasoning = bool(
+                registry.get_config(model_alias).surface_persisted_reasoning
+            )
         except Exception:
             # Unknown alias / partially-built registry / dataclass drift —
             # fall back to the conservative default rather than failing
             # the entire history build.
-            persist_reasoning = True
+            surface_persisted_reasoning = True
     history = []
     for msg in session.messages:
         content = msg.get("content")
@@ -580,7 +582,7 @@ def _build_history(
         # ``_provider_content`` lane on ``session.messages`` (set
         # post-commit at ``session.py:3768-3771``).  The lane itself is
         # never copied into ``entry`` — the wire payload stays tight.
-        if msg.get("role") == "assistant" and persist_reasoning:
+        if msg.get("role") == "assistant" and surface_persisted_reasoning:
             reasoning_text = _extract_reasoning_text(msg.get("_provider_content"))
             if reasoning_text:
                 entry["reasoning"] = reasoning_text

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -59,6 +59,9 @@ from turnstone.core.history_decoration import (
     extract_advisories_from_tool_envelope,
 )
 from turnstone.core.history_decoration import (
+    extract_reasoning_text_from_provider_content as _extract_reasoning_text,
+)
+from turnstone.core.history_decoration import (
     load_verdict_indexes as _load_verdict_indexes,
 )
 from turnstone.core.log import get_logger
@@ -471,6 +474,22 @@ def _build_history(
     else:
         ws_id = getattr(session, "_ws_id", "") or ""
         verdicts_by_call_id, assessments_by_call_id = _load_verdict_indexes(ws_id)
+    # Active-model reasoning-persistence flag — defaults True so that a
+    # registry/alias lookup miss still surfaces reasoning bubbles.  The
+    # default-True semantic mirrors the migration's server_default for
+    # ``model_definitions.persist_reasoning`` and matches the conservative
+    # rehydration default (Phase 1 spec).
+    persist_reasoning = True
+    registry = getattr(session, "_registry", None)
+    model_alias = getattr(session, "_model_alias", "") or ""
+    if registry is not None and model_alias:
+        try:
+            persist_reasoning = bool(registry.get_config(model_alias).persist_reasoning)
+        except Exception:
+            # Unknown alias / partially-built registry / dataclass drift —
+            # fall back to the conservative default rather than failing
+            # the entire history build.
+            persist_reasoning = True
     history = []
     for msg in session.messages:
         content = msg.get("content")
@@ -556,6 +575,15 @@ def _build_history(
                 clean_reminders.append(clean)
             if clean_reminders:
                 entry["reminders"] = clean_reminders
+        # Surface stored reasoning text on assistant messages for UI
+        # rehydration (page-refresh path).  Sourced from the in-memory
+        # ``_provider_content`` lane on ``session.messages`` (set
+        # post-commit at ``session.py:3768-3771``).  The lane itself is
+        # never copied into ``entry`` — the wire payload stays tight.
+        if msg.get("role") == "assistant" and persist_reasoning:
+            reasoning_text = _extract_reasoning_text(msg.get("_provider_content"))
+            if reasoning_text:
+                entry["reasoning"] = reasoning_text
         if msg.get("tool_calls"):
             tc_entries: list[dict[str, Any]] = []
             for tc in msg["tool_calls"]:

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1194,6 +1194,20 @@ Pane.prototype.replayHistory = function (messages) {
       }
       lastToolBlock = null;
     } else if (msg.role === "assistant") {
+      // Reasoning bubble (Phase 1 reasoning persistence) — render
+      // BEFORE the content bubble so the visual order matches the
+      // live SSE flow (reasoning_delta arrives before content_delta
+      // for thinking-enabled models). Mirrors the live-stream
+      // construction at the "case 'reasoning':" branch above. Only
+      // surfaces when the active model's persist_reasoning flag is
+      // true and the message round-tripped a thinking lane.
+      if (msg.reasoning && msg.reasoning.length) {
+        var reasonEl = document.createElement("div");
+        reasonEl.className = "msg reasoning";
+        reasonEl.textContent = msg.reasoning;
+        self.messagesEl.appendChild(reasonEl);
+        lastToolBlock = null;
+      }
       // Render content BEFORE the tool block so the visual order
       // matches the live SSE flow (stream_text streams content first,
       // then tool_info / approve_request paints the tool block, then

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1199,7 +1199,7 @@ Pane.prototype.replayHistory = function (messages) {
       // live SSE flow (reasoning_delta arrives before content_delta
       // for thinking-enabled models). Mirrors the live-stream
       // construction at the "case 'reasoning':" branch above. Only
-      // surfaces when the active model's persist_reasoning flag is
+      // surfaces when the active model's surface_persisted_reasoning flag is
       // true and the message round-tripped a thinking lane.
       if (msg.reasoning && msg.reasoning.length) {
         var reasonEl = document.createElement("div");


### PR DESCRIPTION
## Summary

Per-model reasoning persistence with operator knobs. 4 commits stacked.

- **Phase 1** (`25f34956`) — UI rehydration. Two new boolean columns on `model_definitions` (`surface_persisted_reasoning`, `replay_reasoning_to_model`). History extractor surfaces stored reasoning text on `/history` so refreshing the page rehydrates the reasoning bubble. Wire payloads unchanged.
- **Phase 2** (`1fc68106`) — Wire-build shape filter + replay flag. Anthropic `_convert_messages` now strips thinking blocks when `replay_reasoning_to_model=False`. Foreign-shaped `_provider_content` (OpenAI Responses `type="reasoning"`, Gemini blocks) falls through cleanly via `ANTHROPIC_VALID_BLOCK_TYPES` shape filter — closes a pre-existing latent cross-provider bug.
- **Phase 3+4** (`f1892229`) — OpenAI Responses + Chat Completions paths. Path 2 (Responses API): `include=["reasoning.encrypted_content"]` + reasoning input-item round-trip via `ResponseReasoningItemParam`. Path 3 (Chat Completions / vLLM / llama.cpp / Gemini-compat): synthetic `reasoning_text` block stamped at end-of-stream so captured reasoning survives past the live SSE stream and surfaces on history reload.
- **Review fixes** (`8af27ac5`) — 9 findings from a full-stack `/review` pass: sync-storage event-loop block on cold-workstream `/history`, audit-log discipline test gap on Phase 2/3 surfaces, `persist_reasoning` rename to `surface_persisted_reasoning` (the original name implied storage control but only gates UI rehydration), redacted_thinking dispatcher gap, default-value bifurcation documentation, char-vs-byte cap rename + helper hoist, test fixture hoist, idiomatic factory pattern.

**Storage decision (load-bearing)**: reuse `provider_data` (existing `messages` column) for reasoning blocks — extract on read at history-build time. No new column on `messages`.

**Cross-provider safety**: Phase 2's shape filter rejects foreign-shape blocks at Anthropic's input boundary. Synthetic `reasoning_text` blocks (Path 3) are explicitly NOT in `ANTHROPIC_VALID_BLOCK_TYPES` so cross-model resumption (local-model → Anthropic) falls through cleanly.

**OpenAI SDK verified**: spike against `openai 2.33.0` source confirmed `include=["reasoning.encrypted_content"]` works with `store=False` (the SDK explicitly documents this case at `response_create_params.py:70-74`). The pre-existing comment claiming "with store=False, provider_blocks cannot be replayed as input" was outdated and is now removed.

## Test plan

- [x] All 6115 tests passing (`pytest -m "not live"`); +88 net new tests across the 4 commits
- [x] ruff check + ruff format clean
- [x] mypy clean across all 191 source files
- [x] Multi-stage `/review` ran on each commit AND on the full stack; all findings applied
- [x] Migration 052 server defaults match the conservative stance (`surface_persisted_reasoning=1`, `replay_reasoning_to_model=0`); existing rows backfill silently
- [ ] Manual smoke test on a thinking-bearing Anthropic conversation: live reasoning bubble + page refresh restores the bubble + admin-toggle of `surface_persisted_reasoning=False` removes the bubble on next reload
- [ ] Manual smoke test on a GPT-5 Responses turn with operator-enabled `replay_reasoning_to_model=True`: verify reasoning items round-trip across two consecutive turns (no model-side "reasoning context lost" symptoms)

## Migration

Migration 052 adds two boolean columns to `model_definitions` with conservative server_defaults. Existing rows pre-052 silently inherit defaults on upgrade; no manual backfill needed.