### PR TITLE
feat(console-ui): home composer placeholders, toggle component, admin polish

### DIFF
--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -23,6 +23,7 @@ placeholder stays correct as the precedence rules evolve.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -78,8 +79,6 @@ def _make_client(
     if registry_default is not None:
         # Mimic the live console's ``coord_registry`` shape — the handler
         # only reads ``.default``, so a SimpleNamespace is enough.
-        from types import SimpleNamespace
-
         app.state.coord_registry = SimpleNamespace(default=registry_default)
     client = TestClient(app)
     client.headers.update({"X-Test-User": "admin", "X-Test-Perms": ""})

--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -67,6 +67,7 @@ def _make_client(
     storage: SQLiteBackend,
     *,
     settings: dict[str, str] | None = None,
+    registry_default: str | None = None,
 ) -> TestClient:
     app = Starlette(
         routes=[Route("/v1/api/models", list_available_models)],
@@ -74,6 +75,12 @@ def _make_client(
     )
     app.state.auth_storage = storage
     app.state.config_store = _FakeConfigStore(dict(settings or {}))
+    if registry_default is not None:
+        # Mimic the live console's ``coord_registry`` shape — the handler
+        # only reads ``.default``, so a SimpleNamespace is enough.
+        from types import SimpleNamespace
+
+        app.state.coord_registry = SimpleNamespace(default=registry_default)
     client = TestClient(app)
     client.headers.update({"X-Test-User": "admin", "X-Test-Perms": ""})
     return client
@@ -163,6 +170,34 @@ def test_coordinator_set_to_unknown_alias_falls_back_to_default(
         )
     )
     assert body["coordinator_default_alias"] == "primary"
+
+
+def test_coordinator_falls_back_to_registry_default_when_config_store_empty(
+    storage: SQLiteBackend,
+) -> None:
+    """Match ``console/session_factory.py:109-110``: when both
+    ``coordinator.model_alias`` and ``model.default_alias`` are unset, new
+    coordinator sessions run on ``registry.default`` (loaded from
+    config.toml ``[model].default``).  The placeholder must report the
+    same alias rather than going blank — otherwise the home composer
+    advertises "Default model" while sessions actually launch on a
+    concrete alias."""
+    _seed_model(storage, definition_id="m1", alias="primary")
+    body = _get_models(_make_client(storage, registry_default="primary"))
+    assert body["default_alias"] == ""
+    assert body["coordinator_default_alias"] == "primary"
+    assert body["judge_default_alias"] == "primary"
+
+
+def test_coordinator_skips_registry_default_when_alias_disabled(
+    storage: SQLiteBackend,
+) -> None:
+    """Registry default points at an alias that's been disabled in the DB
+    — the placeholder stays blank rather than advertising a model that
+    workstream creation would refuse to use."""
+    _seed_model(storage, definition_id="m1", alias="legacy", enabled=False)
+    body = _get_models(_make_client(storage, registry_default="legacy"))
+    assert body["coordinator_default_alias"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -1,0 +1,273 @@
+"""``GET /v1/api/models`` resolution-chain coverage.
+
+The console handler resolves four defaults from settings + the enabled
+model list:
+
+* ``default_alias`` ← ``model.default_alias``
+* ``channel_default_alias`` ← ``channels.default_model_alias``
+* ``coordinator_default_alias`` ← ``coordinator.model_alias``, falling
+  back to ``default_alias`` when empty *or* pointing at a disabled /
+  removed alias (mirrors :mod:`turnstone.console.session_factory`).
+* ``judge_default_alias`` ← ``judge.model``, falling back to the
+  resolved coordinator alias when empty *or* pointing at a value that
+  isn't an enabled alias.  ``judge.model`` is alias-only — same
+  contract as the other model roles — and
+  :class:`turnstone.core.judge.IntentJudge` silently inherits the
+  session model when an unknown value is configured, so the API
+  surfaces the resolved coordinator alias rather than echoing the
+  misconfigured string.
+
+These tests pin each branch so the home composer's resolved-alias
+placeholder stays correct as the precedence rules evolve.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tests._coord_test_helpers import _AuthMiddleware, _FakeConfigStore
+from turnstone.console.server import list_available_models
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+@pytest.fixture
+def storage(tmp_path: Any) -> SQLiteBackend:
+    return SQLiteBackend(str(tmp_path / "available_models.db"))
+
+
+def _seed_model(
+    storage: SQLiteBackend,
+    *,
+    definition_id: str,
+    alias: str,
+    model: str = "model-x",
+    enabled: bool = True,
+) -> None:
+    storage.create_model_definition(
+        definition_id=definition_id,
+        alias=alias,
+        model=model,
+        provider="openai-compatible",
+        base_url="http://localhost:8000/v1",
+        api_key="sk-test",
+        context_window=8192,
+        capabilities="{}",
+        enabled=enabled,
+        created_by="admin",
+    )
+
+
+def _make_client(
+    storage: SQLiteBackend,
+    *,
+    settings: dict[str, str] | None = None,
+) -> TestClient:
+    app = Starlette(
+        routes=[Route("/v1/api/models", list_available_models)],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.auth_storage = storage
+    app.state.config_store = _FakeConfigStore(dict(settings or {}))
+    client = TestClient(app)
+    client.headers.update({"X-Test-User": "admin", "X-Test-Perms": ""})
+    return client
+
+
+def _get_models(client: TestClient) -> dict[str, Any]:
+    resp = client.get("/v1/api/models")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Coordinator resolution
+# ---------------------------------------------------------------------------
+
+
+def test_no_settings_leaves_all_defaults_blank(storage: SQLiteBackend) -> None:
+    """No model.default_alias, no per-role overrides → every default
+    field is empty and ``models`` is an empty list."""
+    body = _get_models(_make_client(storage))
+    assert body == {
+        "models": [],
+        "default_alias": "",
+        "channel_default_alias": "",
+        "coordinator_default_alias": "",
+        "judge_default_alias": "",
+    }
+
+
+def test_coordinator_inherits_default_alias_when_unset(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary")
+    body = _get_models(_make_client(storage, settings={"model.default_alias": "primary"}))
+    assert body["default_alias"] == "primary"
+    assert body["coordinator_default_alias"] == "primary"
+
+
+def test_coordinator_explicit_enabled_alias_passes_through(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary")
+    _seed_model(storage, definition_id="m2", alias="fast")
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "coordinator.model_alias": "fast",
+            },
+        )
+    )
+    assert body["coordinator_default_alias"] == "fast"
+
+
+def test_coordinator_set_to_disabled_alias_falls_back_to_default(
+    storage: SQLiteBackend,
+) -> None:
+    """Operator disabled the alias the coordinator was pinned to —
+    fall back to the registry default rather than advertising a model
+    that workstream creation would refuse to use."""
+    _seed_model(storage, definition_id="m1", alias="primary")
+    _seed_model(storage, definition_id="m2", alias="legacy", enabled=False)
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "coordinator.model_alias": "legacy",
+            },
+        )
+    )
+    assert body["coordinator_default_alias"] == "primary"
+
+
+def test_coordinator_set_to_unknown_alias_falls_back_to_default(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary")
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "coordinator.model_alias": "ghost",
+            },
+        )
+    )
+    assert body["coordinator_default_alias"] == "primary"
+
+
+# ---------------------------------------------------------------------------
+# Judge resolution
+# ---------------------------------------------------------------------------
+
+
+def test_judge_empty_inherits_resolved_coordinator_alias(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary")
+    _seed_model(storage, definition_id="m2", alias="fast")
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "coordinator.model_alias": "fast",
+            },
+        )
+    )
+    assert body["coordinator_default_alias"] == "fast"
+    assert body["judge_default_alias"] == "fast"
+
+
+def test_judge_explicit_enabled_alias_passes_through(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary")
+    _seed_model(storage, definition_id="m2", alias="judge-fast")
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "judge.model": "judge-fast",
+            },
+        )
+    )
+    assert body["judge_default_alias"] == "judge-fast"
+
+
+def test_judge_set_to_unknown_value_inherits_coordinator(
+    storage: SQLiteBackend,
+) -> None:
+    """``judge.model`` is alias-only — same contract as the other model
+    roles.  An unknown value silently inherits the session model in
+    :class:`IntentJudge`, so the API surfaces the resolved coordinator
+    alias rather than echoing the misconfigured string."""
+    _seed_model(storage, definition_id="m1", alias="primary")
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "judge.model": "anthropic/claude-haiku-4-5",  # raw, not an alias
+            },
+        )
+    )
+    assert body["coordinator_default_alias"] == "primary"
+    assert body["judge_default_alias"] == "primary"
+
+
+def test_judge_set_to_disabled_alias_inherits_coordinator(
+    storage: SQLiteBackend,
+) -> None:
+    """Disabled-alias case is handled identically to the unknown-value
+    case — both trip the alias-not-resolved path."""
+    _seed_model(storage, definition_id="m1", alias="primary")
+    _seed_model(storage, definition_id="m2", alias="judge-old", enabled=False)
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={
+                "model.default_alias": "primary",
+                "judge.model": "judge-old",
+            },
+        )
+    )
+    assert body["judge_default_alias"] == "primary"
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing fields stay correct under the new resolution code
+# ---------------------------------------------------------------------------
+
+
+def test_channel_default_alias_blanked_when_disabled(
+    storage: SQLiteBackend,
+) -> None:
+    _seed_model(storage, definition_id="m1", alias="primary", enabled=False)
+    body = _get_models(
+        _make_client(
+            storage,
+            settings={"channels.default_model_alias": "primary"},
+        )
+    )
+    assert body["channel_default_alias"] == ""
+
+
+def test_models_payload_strips_secret_fields(storage: SQLiteBackend) -> None:
+    """Regression guard: only alias/model/provider land in the response,
+    never api_key / base_url / context_window / capabilities."""
+    _seed_model(storage, definition_id="m1", alias="primary")
+    body = _get_models(_make_client(storage))
+    assert body["models"] == [
+        {"alias": "primary", "model": "model-x", "provider": "openai-compatible"}
+    ]

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -777,6 +777,58 @@ class TestModelAliasResolution:
         assert judge._client_factory_args["api_key"] == "alias-key"
         assert judge._client_factory_args["provider_name"] == "openai"
 
+    def test_unknown_alias_inherits_session_model(self):
+        """``judge.model`` is alias-only.  A value that doesn't resolve
+        through the registry inherits the session model (same path as
+        an empty config.model) rather than getting pinned onto the
+        session provider as a raw model id — that legacy behavior
+        silently broke whenever the session provider didn't speak the
+        configured model id (Anthropic session, ``judge.model =
+        "gpt-5-mini"`` → every verdict came back as ``llm_fallback``)."""
+        session_provider = _make_mock_provider()
+        session_provider.provider_name = "anthropic"
+        session_client = MagicMock()
+        session_client.base_url = "https://session.example/v1"
+        session_client.api_key = "session-key"
+
+        registry = MagicMock()
+        registry.has_alias.return_value = False  # judge.model isn't an alias
+
+        config = JudgeConfig(enabled=True, model="gpt-5-mini")
+        judge = IntentJudge(
+            config=config,
+            session_provider=session_provider,
+            session_client=session_client,
+            session_model="session-default-model",
+            context_window=100_000,
+            model_registry=registry,
+        )
+
+        assert judge._provider is session_provider
+        assert judge._model == "session-default-model"
+        # Context window mirrors the session, not the (uncalled) caps lookup.
+        assert judge._judge_context_window == 100_000
+
+    def test_empty_model_inherits_session_model(self):
+        """Empty ``config.model`` is the documented self-consistency path."""
+        session_provider = _make_mock_provider()
+        session_provider.provider_name = "openai"
+        session_client = MagicMock()
+        session_client.base_url = "https://session.example/v1"
+        session_client.api_key = "session-key"
+
+        config = JudgeConfig(enabled=True, model="")
+        judge = IntentJudge(
+            config=config,
+            session_provider=session_provider,
+            session_client=session_client,
+            session_model="session-default-model",
+            context_window=100_000,
+        )
+
+        assert judge._provider is session_provider
+        assert judge._model == "session-default-model"
+
     def test_coordinator_tool_call_returns_llm_verdict_not_fallback(self):
         """Happy-path regression for coordinator tool calls: with a properly
         resolved provider, the verdict tier must be ``llm`` — the

--- a/tests/test_models_changed_event.py
+++ b/tests/test_models_changed_event.py
@@ -197,6 +197,7 @@ _EXPECTED_AFFECTING_KEYS = frozenset(
         "coordinator.model_alias",
         "coordinator.reasoning_effort",
         "judge.model",
+        "channels.default_model_alias",
     }
 )
 

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -996,6 +996,8 @@ class ListAvailableModelsResponse(BaseModel):
     models: list[AvailableModelInfo] = Field(default_factory=list)
     default_alias: str = ""
     channel_default_alias: str = ""
+    coordinator_default_alias: str = ""
+    judge_default_alias: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1684,15 +1684,25 @@ async def list_available_models(request: Request) -> JSONResponse:
         default_alias = ""
     if channel_default_alias and channel_default_alias not in enabled_aliases:
         channel_default_alias = ""
-    # Coordinator falls back to model.default_alias when its setting is
-    # empty or points at a disabled/removed alias (matches
-    # console/session_factory.py).  Judge falls back to the resolved
-    # coordinator alias when judge.model is empty *or* not a registered
-    # alias — judge.model is alias-only (matches IntentJudge.__init__),
-    # so an unknown value is operator misconfiguration that the judge
-    # itself silently inherits the session model on.
+    # Coordinator fallback chain mirrors console/session_factory.py:109-110:
+    # explicit ``coordinator.model_alias`` → ``model.default_alias``
+    # (admin-managed) → ``registry.default`` (the config.toml default that
+    # session_factory falls through to via ``registry.default`` when both
+    # ConfigStore keys are unset).  Without the registry tier the
+    # placeholder lies whenever an operator never set ``model.default_alias``
+    # in the admin UI — new coordinator sessions will still run on
+    # ``registry.default``.  Judge falls back to the resolved coordinator
+    # alias when ``judge.model`` is empty *or* not a registered alias —
+    # judge.model is alias-only (matches IntentJudge.__init__), so an
+    # unknown value is operator misconfiguration that the judge itself
+    # silently inherits the session model on.
     if not coordinator_default_alias or coordinator_default_alias not in enabled_aliases:
         coordinator_default_alias = default_alias
+    if not coordinator_default_alias:
+        coord_registry = getattr(request.app.state, "coord_registry", None)
+        registry_default = getattr(coord_registry, "default", "") if coord_registry else ""
+        if registry_default and registry_default in enabled_aliases:
+            coordinator_default_alias = registry_default
     if not judge_default_alias or judge_default_alias not in enabled_aliases:
         judge_default_alias = coordinator_default_alias
     return JSONResponse(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1684,18 +1684,30 @@ async def list_available_models(request: Request) -> JSONResponse:
         default_alias = ""
     if channel_default_alias and channel_default_alias not in enabled_aliases:
         channel_default_alias = ""
-    # Coordinator fallback chain mirrors console/session_factory.py:109-110:
-    # explicit ``coordinator.model_alias`` → ``model.default_alias``
-    # (admin-managed) → ``registry.default`` (the config.toml default that
-    # session_factory falls through to via ``registry.default`` when both
-    # ConfigStore keys are unset).  Without the registry tier the
-    # placeholder lies whenever an operator never set ``model.default_alias``
-    # in the admin UI — new coordinator sessions will still run on
-    # ``registry.default``.  Judge falls back to the resolved coordinator
-    # alias when ``judge.model`` is empty *or* not a registered alias —
-    # judge.model is alias-only (matches IntentJudge.__init__), so an
-    # unknown value is operator misconfiguration that the judge itself
-    # silently inherits the session model on.
+    # Coordinator fallback chain — three tiers, in priority order:
+    #   1. explicit ``coordinator.model_alias``
+    #   2. ``model.default_alias`` (admin-managed default in the Models tab)
+    #   3. ``registry.default`` (config.toml ``[model].default``)
+    #
+    # Tier 3 mirrors what console/session_factory.py:109-110 does when
+    # ``coordinator.model_alias`` is unset (``effective_alias =
+    # explicit_alias or registry.default``).  Without it the placeholder
+    # went blank whenever operators left both ConfigStore keys unset, even
+    # though new coordinator sessions still launch on ``registry.default``.
+    #
+    # Note: this chain extends session_factory's by inserting tier 2 as a
+    # courtesy — admins who set ``model.default_alias`` in the UI expect
+    # the home composer to advertise it.  session_factory itself does NOT
+    # consult ``model.default_alias`` today, so a configuration where
+    # ``model.default_alias`` ≠ ``registry.default`` will still drift
+    # between placeholder ("X") and runtime ("Y").  Aligning that is a
+    # session_factory change, tracked separately.
+    #
+    # Judge falls back to the resolved coordinator alias when
+    # ``judge.model`` is empty *or* not a registered alias — judge.model
+    # is alias-only (matches IntentJudge.__init__), so an unknown value is
+    # operator misconfiguration that the judge itself silently inherits
+    # the session model on.
     if not coordinator_default_alias or coordinator_default_alias not in enabled_aliases:
         coordinator_default_alias = default_alias
     if not coordinator_default_alias:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1671,20 +1671,37 @@ async def list_available_models(request: Request) -> JSONResponse:
     # Include effective defaults for clients (web UI, channel gateway).
     default_alias = ""
     channel_default_alias = ""
+    coordinator_default_alias = ""
+    judge_default_alias = ""
     cs = getattr(request.app.state, "config_store", None)
     if cs is not None:
         default_alias = cs.get("model.default_alias") or ""
         channel_default_alias = cs.get("channels.default_model_alias") or ""
+        coordinator_default_alias = (cs.get("coordinator.model_alias") or "").strip()
+        judge_default_alias = (cs.get("judge.model") or "").strip()
     enabled_aliases = {r["alias"] for r in rows}
     if default_alias and default_alias not in enabled_aliases:
         default_alias = ""
     if channel_default_alias and channel_default_alias not in enabled_aliases:
         channel_default_alias = ""
+    # Coordinator falls back to model.default_alias when its setting is
+    # empty or points at a disabled/removed alias (matches
+    # console/session_factory.py).  Judge falls back to the resolved
+    # coordinator alias when judge.model is empty *or* not a registered
+    # alias — judge.model is alias-only (matches IntentJudge.__init__),
+    # so an unknown value is operator misconfiguration that the judge
+    # itself silently inherits the session model on.
+    if not coordinator_default_alias or coordinator_default_alias not in enabled_aliases:
+        coordinator_default_alias = default_alias
+    if not judge_default_alias or judge_default_alias not in enabled_aliases:
+        judge_default_alias = coordinator_default_alias
     return JSONResponse(
         {
             "models": models,
             "default_alias": default_alias,
             "channel_default_alias": channel_default_alias,
+            "coordinator_default_alias": coordinator_default_alias,
+            "judge_default_alias": judge_default_alias,
         }
     )
 
@@ -7884,6 +7901,7 @@ _MODEL_AFFECTING_SETTING_KEYS: frozenset[str] = frozenset(
         "coordinator.model_alias",
         "coordinator.reasoning_effort",
         "judge.model",
+        "channels.default_model_alias",
     }
 )
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -1142,10 +1142,52 @@ function _populateScheduleSelect(selectId, url, labelKey, valueKey, opts) {
         sel.appendChild(opt);
       });
       if (opts && opts.selected) sel.value = opts.selected;
+      // Caller hook for placeholder annotation / other post-load tweaks.
+      // Used by the schedule modals to rewrite the bare "Default model"
+      // placeholder with the resolved alias so the label matches the
+      // home composer (see app.js _populateHomeModelDropdowns).
+      if (opts && typeof opts.afterPopulate === "function") {
+        try {
+          opts.afterPopulate(sel, data, items);
+        } catch (_e) {
+          /* hook errors must not break the dropdown */
+        }
+      }
     })
     .catch(function () {
       /* dropdown stays with placeholder or temporary option */
     });
+}
+
+// Update the schedule-model placeholder option (first <option>) to
+// "Default — alias (model)" using /v1/api/models's resolved
+// default_alias, mirroring the home composer.  Schedules don't carry
+// a coordinator/judge split, so they consume the workstream-creation
+// default rather than coordinator_default_alias / judge_default_alias.
+// Em-dash separator (rather than nested parens) keeps the alias's
+// "(model)" suffix legible.
+function _decorateScheduleModelPlaceholder(sel, data) {
+  if (!sel || sel.options.length === 0) return;
+  var alias = (data && data.default_alias) || "";
+  if (!alias) return;
+  var match = null;
+  var models = (data && data.models) || [];
+  for (var i = 0; i < models.length; i++) {
+    if (models[i].alias === alias) {
+      match = models[i];
+      break;
+    }
+  }
+  var label;
+  if (match) {
+    label =
+      match.alias === match.model
+        ? match.alias
+        : match.alias + " (" + match.model + ")";
+  } else {
+    label = alias;
+  }
+  sel.options[0].textContent = "Default — " + label;
 }
 
 // Channel platforms shown in admin notify-target rows.  Mirror server-side
@@ -1333,6 +1375,7 @@ function showCreateScheduleModal() {
     display: function (m) {
       return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
     },
+    afterPopulate: _decorateScheduleModelPlaceholder,
   });
   // Populate skill dropdown
   _populateScheduleSelect(
@@ -1487,6 +1530,7 @@ function showEditScheduleModal(taskId) {
         display: function (m) {
           return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
         },
+        afterPopulate: _decorateScheduleModelPlaceholder,
       });
       // Populate skill dropdown with current value pre-selected
       _populateScheduleSelect(
@@ -2637,7 +2681,7 @@ function loadSettings() {
 
       // Merge values + schema.  Skip role-assignment settings owned by
       // the Models → Roles sub-tab (judge.* settings still live on the
-      // Judge tab; the four model-tab roles render only there).
+      // Judge tab; the model-tab roles render only there).
       var merged = {};
       var roleKeys = {
         "coordinator.model_alias": 1,
@@ -2646,6 +2690,7 @@ function loadSettings() {
         "model.plan_effort": 1,
         "model.task_alias": 1,
         "model.task_effort": 1,
+        "channels.default_model_alias": 1,
       };
       for (var j = 0; j < valuesArr.length; j++) {
         var v = valuesArr[j];
@@ -4639,6 +4684,14 @@ var _modelCreateTrigger = null;
 // setting render a second selector inline.  Adding a new role (e.g.
 // ``perception.audio.model``) is purely additive: drop a row here once
 // the SettingDef lands in turnstone/core/settings_registry.py.
+// ``fallbackKind`` controls how the empty/blank option in the alias
+// dropdown is labelled.  Coordinator and Judge fall back to a single
+// well-defined alias (model.default_alias / coordinator alias) so we
+// surface that concrete model in the placeholder.  Plan/Task agents
+// cascade through ``[model].plan_model → [model].agent_model →
+// session model`` per turnstone/core/settings_registry.py — there's
+// no single "default" to advertise, so the blank reads "(inherit)"
+// to match the vocabulary of the reasoning-effort dropdowns.
 var MODEL_ROLES = [
   {
     label: "Coordinator",
@@ -4646,12 +4699,14 @@ var MODEL_ROLES = [
       "Console-hosted coordinator sessions that drive child workstreams.",
     aliasKey: "coordinator.model_alias",
     effortKey: "coordinator.reasoning_effort",
+    fallbackKind: "default",
   },
   {
     label: "Judge",
     description:
       "Intent-validation judge that scores tool calls before approval.",
     aliasKey: "judge.model",
+    fallbackKind: "default",
   },
   {
     label: "Plan agent",
@@ -4659,6 +4714,7 @@ var MODEL_ROLES = [
       "plan_agent sub-agent — produces high-level plans before task dispatch.",
     aliasKey: "model.plan_alias",
     effortKey: "model.plan_effort",
+    fallbackKind: "inherit",
   },
   {
     label: "Task agent",
@@ -4666,6 +4722,14 @@ var MODEL_ROLES = [
       "task_agent sub-agent — runs autonomous subtasks dispatched by the parent.",
     aliasKey: "model.task_alias",
     effortKey: "model.task_effort",
+    fallbackKind: "inherit",
+  },
+  {
+    label: "Channel adapter",
+    description:
+      "Workstreams created by channel adapters (Discord, Slack) when no model is specified at creation time.",
+    aliasKey: "channels.default_model_alias",
+    fallbackKind: "default",
   },
 ];
 
@@ -4848,11 +4912,40 @@ function _renderModelRoles(container, values, schema) {
       "aria-label",
       role.label + " model (empty = default)",
     );
+    // Format the blank/inherit option in the same "alias (model)" shape
+    // as the other rows so the dropdown reads consistently — without
+    // this the empty row was bare "(default — flatspark)" while every
+    // other row carried a "(/models/...)" suffix.  Plan/Task agent
+    // fall back through a multi-step chain (config.toml → agent_model
+    // → session) that has no single concrete "default", so they get
+    // a plain "(inherit)" instead of the misleading
+    // "(default — <coordinator-alias>)".
     var blank = document.createElement("option");
     blank.value = "";
-    blank.textContent = _modelDefaultAlias
-      ? "(default — " + _modelDefaultAlias + ")"
-      : "(default)";
+    if (role.fallbackKind === "inherit") {
+      blank.textContent = "(inherit)";
+    } else {
+      var defaultDef = null;
+      if (_modelDefaultAlias) {
+        for (var dm = 0; dm < enabledAliases.length; dm++) {
+          if (enabledAliases[dm].alias === _modelDefaultAlias) {
+            defaultDef = enabledAliases[dm];
+            break;
+          }
+        }
+      }
+      if (defaultDef) {
+        var defLabel =
+          defaultDef.alias === defaultDef.model
+            ? defaultDef.alias
+            : defaultDef.alias + " (" + defaultDef.model + ")";
+        blank.textContent = "(default — " + defLabel + ")";
+      } else if (_modelDefaultAlias) {
+        blank.textContent = "(default — " + _modelDefaultAlias + ")";
+      } else {
+        blank.textContent = "(default)";
+      }
+    }
     aliasSel.appendChild(blank);
     var currentAlias = aliasInfo.value || "";
     var matched = false;

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1813,7 +1813,7 @@ function _resolveModelLabel(alias, models) {
       return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
     }
   }
-  return alias;
+  return "";
 }
 
 // Populate Model + Judge Model dropdowns from /v1/api/models — same

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1761,11 +1761,11 @@ function _mountHomeCoordComposer() {
           id: "judge_model",
           label: "Judge Model",
           type: "select",
-          // Neutral label — the actual default is ConfigStore
-          // ``judge.model`` when set, IntentJudge's agent-model
-          // fallback when not.  "Default judge model" doesn't
-          // mislead either way.
-          choices: [{ value: "", text: "Default judge model" }],
+          // Initial placeholder; _populateHomeModelDropdowns rewrites this
+          // to "Default model (<alias>)" once /v1/api/models reports the
+          // resolved judge alias (judge.model when set, otherwise the
+          // session model — see IntentJudge.__init__).
+          choices: [{ value: "", text: "Default model" }],
         },
       ],
     },
@@ -1801,6 +1801,21 @@ function _populateHomeSkillDropdown() {
     });
 }
 
+// Format a resolved alias with its model suffix the same way as the
+// dropdown rows ("alias (model)", or just "alias" when they coincide).
+// Returns "" when alias is empty or unknown so callers can fall back
+// to a neutral placeholder.
+function _resolveModelLabel(alias, models) {
+  if (!alias) return "";
+  for (var i = 0; i < (models || []).length; i++) {
+    var m = models[i];
+    if (m.alias === alias) {
+      return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
+    }
+  }
+  return alias;
+}
+
 // Populate Model + Judge Model dropdowns from /v1/api/models — same
 // list the interactive new-ws modal uses.  Empty/default option stays
 // at the top so submitting without a choice falls back to the
@@ -1819,6 +1834,30 @@ function _populateHomeModelDropdowns() {
       });
       _homeCoordComposer.setOptionChoices("model", choices);
       _homeCoordComposer.setOptionChoices("judge_model", choices);
+      // Both placeholders use the same "Default — alias (model)"
+      // template — the field-row labels (MODEL / JUDGE MODEL) already
+      // carry the role context, so an asymmetric "Default judge model"
+      // reads awkwardly alongside the plain "Default model" line above
+      // it.  Em-dash separator (rather than nested parens) keeps the
+      // alias's "(model)" suffix legible and matches the
+      // ``(default — alias (model))`` pattern used in the admin Roles
+      // tab.
+      var coordDefault = _resolveModelLabel(
+        data.coordinator_default_alias || "",
+        data.models || [],
+      );
+      var judgeDefault = _resolveModelLabel(
+        data.judge_default_alias || "",
+        data.models || [],
+      );
+      _homeCoordComposer.setOptionPlaceholder(
+        "model",
+        coordDefault ? "Default — " + coordDefault : "Default model",
+      );
+      _homeCoordComposer.setOptionPlaceholder(
+        "judge_model",
+        judgeDefault ? "Default — " + judgeDefault : "Default model",
+      );
     })
     .catch(function () {
       /* defaults still work even without the dropdown populated */

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -143,46 +143,91 @@ function _renderGovRoles(items) {
   }
 }
 
-// All permission names for the checkbox UI
-var _ALL_PERMISSIONS = [
-  "read",
-  "write",
-  "approve",
-  "admin.users",
-  "admin.roles",
-  "admin.orgs",
-  "admin.policies",
-  "admin.skills",
-  "admin.audit",
-  "admin.usage",
-  "admin.schedules",
-  "admin.watches",
-  "admin.judge",
-  "admin.memories",
-  "admin.settings",
-  "admin.mcp",
-  "tools.approve",
-  "workstreams.create",
-  "workstreams.close",
+// Permission inventory grouped by namespace so the role modal can
+// render each section under its own heading.  Sectioning prevents the
+// row-flow grid from slicing a namespace mid-column (e.g. half of
+// ``admin.*`` ending up in column 1, the rest in column 2) and lets
+// readers who don't yet know the permission taxonomy scan by
+// concept.  Each section's permissions render as a 2-column grid;
+// the ``Scopes`` and ``Workstreams & Tools`` sections are short
+// enough to fit one row, ``Admin`` carries the bulk.
+var _PERMISSION_SECTIONS = [
+  {
+    label: "Scopes",
+    permissions: ["read", "write", "approve"],
+  },
+  {
+    label: "Admin",
+    permissions: [
+      "admin.users",
+      "admin.roles",
+      "admin.orgs",
+      "admin.policies",
+      "admin.skills",
+      "admin.audit",
+      "admin.usage",
+      "admin.schedules",
+      "admin.watches",
+      "admin.judge",
+      "admin.memories",
+      "admin.settings",
+      "admin.mcp",
+    ],
+  },
+  {
+    label: "Workstreams & Tools",
+    permissions: ["workstreams.create", "workstreams.close", "tools.approve"],
+  },
 ];
 
-function _buildPermCheckboxes(prefix, selected) {
-  var html = '<div class="perm-grid">';
-  for (var i = 0; i < _ALL_PERMISSIONS.length; i++) {
-    var p = _ALL_PERMISSIONS[i];
-    var checked = selected && selected.indexOf(p) >= 0 ? " checked" : "";
-    html +=
-      '<label class="perm-checkbox"><input type="checkbox" value="' +
-      p +
-      '" name="' +
-      prefix +
-      '-perm"' +
-      checked +
-      "> " +
-      escapeHtml(p) +
-      "</label>";
+// Flat list — kept for any caller that wants the full permission
+// inventory without caring about sectioning.
+var _ALL_PERMISSIONS = (function () {
+  var flat = [];
+  for (var i = 0; i < _PERMISSION_SECTIONS.length; i++) {
+    flat = flat.concat(_PERMISSION_SECTIONS[i].permissions);
   }
-  html += "</div>";
+  return flat;
+})();
+
+function _buildPermCheckboxes(prefix, selected) {
+  // Emits the toggle-switch component used elsewhere in the admin
+  // modals so each permission reads as a deliberate on/off rather
+  // than a generic checkbox.  Sections are wrapped in a
+  // ``.perm-section`` block with a caps-styled heading so the
+  // typographic system inside the role modal stays consistent (the
+  // surrounding label cadence is also caps + 0.08em letter-spacing).
+  // The underlying ``<input type="checkbox" name="{prefix}-perm">``
+  // shape is preserved so ``_collectPermCheckboxes`` still picks
+  // them up regardless of section.
+  var html = "";
+  for (var s = 0; s < _PERMISSION_SECTIONS.length; s++) {
+    var section = _PERMISSION_SECTIONS[s];
+    html +=
+      '<div class="perm-section">' +
+      '<div class="perm-section-label">' +
+      escapeHtml(section.label) +
+      "</div>" +
+      '<div class="perm-grid">';
+    for (var i = 0; i < section.permissions.length; i++) {
+      var p = section.permissions[i];
+      var checked = selected && selected.indexOf(p) >= 0 ? " checked" : "";
+      html +=
+        '<label class="toggle-switch perm-toggle">' +
+        '<input type="checkbox" value="' +
+        p +
+        '" name="' +
+        prefix +
+        '-perm"' +
+        checked +
+        ">" +
+        '<span class="toggle-track" aria-hidden="true"></span>' +
+        '<span class="toggle-label">' +
+        escapeHtml(p) +
+        "</span></label>";
+    }
+    html += "</div></div>";
+  }
   return html;
 }
 
@@ -346,20 +391,27 @@ function showUserRolesModal(userId) {
       var assigned = {};
       for (var i = 0; i < userRoles.length; i++)
         assigned[userRoles[i].role_id] = true;
-      var html = "";
+      // Role-assignment rows reuse the toggle-switch component for
+      // consistency with the rest of the admin UX.  Role display names
+      // are human-readable text, so no monospace override is needed.
+      var html = '<div class="user-roles-list">';
       for (var j = 0; j < allRoles.length; j++) {
         var r = allRoles[j];
         var checked = assigned[r.role_id] ? " checked" : "";
         html +=
-          '<label class="perm-checkbox"><input type="checkbox" value="' +
+          '<label class="toggle-switch user-role-toggle">' +
+          '<input type="checkbox" value="' +
           escapeHtml(r.role_id) +
           '" name="ur-role"' +
           checked +
-          "> " +
+          ">" +
+          '<span class="toggle-track" aria-hidden="true"></span>' +
+          '<span class="toggle-label">' +
           escapeHtml(r.display_name) +
-          "</label>";
+          "</span></label>";
       }
-      container.innerHTML = html;
+      html += "</div>";
+      container.innerHTML = html; // values escaped via escapeHtml above
     })
     .catch(function () {
       container.innerHTML =
@@ -3199,18 +3251,27 @@ function renderJudgeSettings() {
     var isDefault = s.source === "default";
 
     if (s.type === "bool") {
+      // Toggle switch — same component used by the admin modals.
+      // ``onchange`` reads the box's new ``.checked`` and writes via
+      // saveJudgeSetting.  The ``.toggle-label`` is a static "Enabled"
+      // because the slider position is the truth — flipping the
+      // caption text on save round-tripped through reload, so the
+      // slider moved instantly while the caption lagged 50-300ms and
+      // looked broken.  ``aria-label`` carries the setting name so
+      // screen readers get the row context inline.
       inputHtml =
-        '<label class="toggle-label" style="display:flex;align-items:center;gap:8px;cursor:pointer">' +
+        '<label class="toggle-switch toggle--flush">' +
         '<input type="checkbox" data-key="' +
         s.key +
+        '" aria-label="' +
+        escapeHtml(shortKey) +
         '" ' +
         (currentVal ? "checked" : "") +
         " onchange=\"saveJudgeSetting('" +
         s.key +
-        '\',this.checked)" style="width:16px;height:16px">' +
-        '<span style="font-size:12px">' +
-        (currentVal ? "Enabled" : "Disabled") +
-        "</span></label>";
+        "',this.checked)\">" +
+        '<span class="toggle-track" aria-hidden="true"></span>' +
+        '<span class="toggle-label">Enabled</span></label>';
     } else if (s.type === "float") {
       inputHtml =
         '<div style="display:flex;gap:8px;align-items:center">' +

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -2507,10 +2507,11 @@
               rows="3"
               placeholder="What should the workstream do?"
             ></textarea>
-            <label class="admin-checkbox"
-              ><input id="cs-autoapprove" type="checkbox" /> Auto-approve tool
-              calls</label
-            >
+            <label class="toggle-switch">
+              <input id="cs-autoapprove" type="checkbox" />
+              <span class="toggle-track" aria-hidden="true"></span>
+              <span class="toggle-label">Auto-approve tool calls</span>
+            </label>
             <label
               >Notify on completion
               <span class="label-hint">optional</span></label
@@ -2609,13 +2610,16 @@
             </select>
             <label for="es-message">Initial message</label>
             <textarea id="es-message" rows="3"></textarea>
-            <label class="admin-checkbox"
-              ><input id="es-autoapprove" type="checkbox" /> Auto-approve tool
-              calls</label
-            >
-            <label class="admin-checkbox"
-              ><input id="es-enabled" type="checkbox" /> Enabled</label
-            >
+            <label class="toggle-switch">
+              <input id="es-autoapprove" type="checkbox" />
+              <span class="toggle-track" aria-hidden="true"></span>
+              <span class="toggle-label">Auto-approve tool calls</span>
+            </label>
+            <label class="toggle-switch">
+              <input id="es-enabled" type="checkbox" />
+              <span class="toggle-track" aria-hidden="true"></span>
+              <span class="toggle-label">Enabled</span>
+            </label>
             <label
               >Notify on completion
               <span class="label-hint">optional</span></label
@@ -2859,9 +2863,11 @@
         </select>
         <label for="ep-priority">Priority</label>
         <input id="ep-priority" type="number" value="0" min="0" max="9999" />
-        <label class="admin-checkbox"
-          ><input id="ep-enabled" type="checkbox" checked /> Enabled</label
-        >
+        <label class="toggle-switch">
+          <input id="ep-enabled" type="checkbox" checked />
+          <span class="toggle-track" aria-hidden="true"></span>
+          <span class="toggle-label">Enabled</span>
+        </label>
         <div class="modal-buttons">
           <button class="modal-cancel" onclick="hideEditPolicyModal()">
             Cancel
@@ -2963,9 +2969,11 @@
         <textarea id="epp-content" rows="10" spellcheck="false"></textarea>
         <label for="epp-priority">Priority</label>
         <input id="epp-priority" type="number" value="0" min="0" max="9999" />
-        <label class="admin-checkbox"
-          ><input id="epp-enabled" type="checkbox" checked /> Enabled</label
-        >
+        <label class="toggle-switch">
+          <input id="epp-enabled" type="checkbox" checked />
+          <span class="toggle-track" aria-hidden="true"></span>
+          <span class="toggle-label">Enabled</span>
+        </label>
         <div class="modal-buttons">
           <button class="modal-cancel" onclick="hideEditPromptPolicyModal()">
             Cancel
@@ -3083,10 +3091,11 @@
                 </option>
                 <option value="search">Search — BM25 discoverable</option>
               </select>
-              <label class="admin-checkbox"
-                ><input id="ctm-default" type="checkbox" /> Apply to new
-                workstreams by default</label
-              >
+              <label class="toggle-switch">
+                <input id="ctm-default" type="checkbox" />
+                <span class="toggle-track" aria-hidden="true"></span>
+                <span class="toggle-label">Apply to new workstreams by default</span>
+              </label>
             </div>
           </div>
           <div class="skill-spec-col skill-spec-col-content">
@@ -3189,10 +3198,11 @@
               />
             </div>
           </div>
-          <label class="admin-checkbox"
-            ><input id="csk-auto-approve" type="checkbox" /> Auto-approve all
-            tools</label
-          >
+          <label class="toggle-switch">
+            <input id="csk-auto-approve" type="checkbox" />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Auto-approve all tools</span>
+          </label>
           <label for="csk-allowed-tools"
             >Allowed Tools
             <span class="label-hint"
@@ -3222,9 +3232,11 @@
             style="display: block; margin-top: 3px"
             >JSON array. Each: channel_type + channel_id or user_id</span
           >
-          <label class="admin-checkbox"
-            ><input id="csk-enabled" type="checkbox" checked /> Enabled</label
-          >
+          <label class="toggle-switch">
+            <input id="csk-enabled" type="checkbox" checked />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Enabled</span>
+          </label>
         </details>
         <details class="admin-details">
           <summary>
@@ -3395,10 +3407,11 @@
                 </option>
                 <option value="search">Search — BM25 discoverable</option>
               </select>
-              <label class="admin-checkbox"
-                ><input id="etm-default" type="checkbox" /> Apply to new
-                workstreams by default</label
-              >
+              <label class="toggle-switch">
+                <input id="etm-default" type="checkbox" />
+                <span class="toggle-track" aria-hidden="true"></span>
+                <span class="toggle-label">Apply to new workstreams by default</span>
+              </label>
             </div>
           </div>
           <div class="skill-spec-col skill-spec-col-content">
@@ -3480,10 +3493,11 @@
               />
             </div>
           </div>
-          <label class="admin-checkbox"
-            ><input id="esk-auto-approve" type="checkbox" /> Auto-approve all
-            tools</label
-          >
+          <label class="toggle-switch">
+            <input id="esk-auto-approve" type="checkbox" />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Auto-approve all tools</span>
+          </label>
           <label for="esk-allowed-tools"
             >Allowed Tools
             <span class="label-hint"
@@ -3513,9 +3527,11 @@
             style="display: block; margin-top: 3px"
             >JSON array. Each: channel_type + channel_id or user_id</span
           >
-          <label class="admin-checkbox"
-            ><input id="esk-enabled" type="checkbox" checked /> Enabled</label
-          >
+          <label class="toggle-switch">
+            <input id="esk-enabled" type="checkbox" checked />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Enabled</span>
+          </label>
         </details>
         <div id="etm-scan-section" style="display: none" class="admin-field">
           <span class="admin-field-heading" id="etm-scan-heading"
@@ -3699,43 +3715,48 @@
           <legend style="font-size: 12px; padding: 0 6px">
             Multitenant Authorization
           </legend>
-          <label
-            style="display: block; margin: 4px 0; font-weight: 400; font-size: 13px"
-          >
-            <input
-              type="radio"
-              name="mcp-auth-type"
-              id="mcp-auth-none"
-              value="none"
-              onchange="toggleMcpAuthFields()"
-              style="margin-right: 6px"
-            />No authorization
-          </label>
-          <label
-            style="display: block; margin: 4px 0; font-weight: 400; font-size: 13px"
-          >
-            <input
-              type="radio"
-              name="mcp-auth-type"
-              id="mcp-auth-static"
-              value="static"
-              onchange="toggleMcpAuthFields()"
-              checked
-              style="margin-right: 6px"
-            />Static headers (single shared identity)
-          </label>
-          <label
-            style="display: block; margin: 4px 0; font-weight: 400; font-size: 13px"
-          >
-            <input
-              type="radio"
-              name="mcp-auth-type"
-              id="mcp-auth-oauth"
-              value="oauth_user"
-              onchange="toggleMcpAuthFields()"
-              style="margin-right: 6px"
-            />Per-user OAuth 2.1 (recommended)
-          </label>
+          <div class="segmented-control" role="radiogroup" aria-label="Multitenant Authorization">
+            <label class="segmented-option">
+              <input
+                type="radio"
+                name="mcp-auth-type"
+                id="mcp-auth-none"
+                value="none"
+                onchange="toggleMcpAuthFields()"
+              />
+              <span class="segmented-indicator" aria-hidden="true"></span>
+              <span class="segmented-text">No authorization</span>
+            </label>
+            <label class="segmented-option">
+              <input
+                type="radio"
+                name="mcp-auth-type"
+                id="mcp-auth-static"
+                value="static"
+                onchange="toggleMcpAuthFields()"
+                checked
+              />
+              <span class="segmented-indicator" aria-hidden="true"></span>
+              <span class="segmented-text"
+                >Static headers
+                <span class="segmented-hint">single shared identity</span></span
+              >
+            </label>
+            <label class="segmented-option">
+              <input
+                type="radio"
+                name="mcp-auth-type"
+                id="mcp-auth-oauth"
+                value="oauth_user"
+                onchange="toggleMcpAuthFields()"
+              />
+              <span class="segmented-indicator" aria-hidden="true"></span>
+              <span class="segmented-text"
+                >Per-user OAuth 2.1
+                <span class="segmented-hint">recommended</span></span
+              >
+            </label>
+          </div>
           <div id="mcp-oauth-fields" style="display: none; margin-top: 8px">
             <label for="mcp-oauth-as-url"
               >Authorization Server URL
@@ -3796,22 +3817,17 @@
             />
           </div>
         </fieldset>
-        <div style="display: flex; gap: 20px; margin-top: 14px">
-          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
-            ><input
-              type="checkbox"
-              id="mcp-auto-approve"
-              style="margin-right: 5px"
-            />Auto-approve tools</label
-          >
-          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
-            ><input
-              type="checkbox"
-              id="mcp-enabled"
-              checked
-              style="margin-right: 5px"
-            />Enabled</label
-          >
+        <div class="toggle-stack">
+          <label class="toggle-switch">
+            <input type="checkbox" id="mcp-auto-approve" />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Auto-approve tools</span>
+          </label>
+          <label class="toggle-switch">
+            <input type="checkbox" id="mcp-enabled" checked />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Enabled</span>
+          </label>
         </div>
         <div class="modal-buttons">
           <button class="modal-cancel" onclick="hideCreateMcpModal()">
@@ -3936,6 +3952,14 @@
         <h2 id="model-create-title">Add Model</h2>
         <div id="model-create-error" role="alert" aria-live="assertive" aria-atomic="true"></div>
         <input type="hidden" id="model-edit-id" value="" />
+        <label
+          class="toggle-switch toggle--flush"
+          title="Disable to hide this alias from every model dropdown (workstreams, schedules, channel adapters, role assignments) without removing the definition."
+        >
+          <input type="checkbox" id="model-enabled" checked />
+          <span class="toggle-track" aria-hidden="true"></span>
+          <span class="toggle-label">Active</span>
+        </label>
         <label for="model-alias">Alias</label>
         <input
           type="text"
@@ -4116,34 +4140,27 @@
           placeholder='{"supports_vision": true}'
           style="font-family: var(--font-mono); font-size: 11px"
         ></textarea>
-        <div style="display: flex; gap: 20px; margin-top: 14px; flex-wrap: wrap">
-          <label style="margin: 0; font-size: 12px; color: var(--fg-dim)"
-            ><input
-              type="checkbox"
-              id="model-enabled"
-              checked
-              style="margin-right: 5px"
-            />Enabled</label
-          >
+        <div class="toggle-stack">
           <label
-            style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            class="toggle-switch"
             title="Surface stored reasoning text on /history responses (UI bubble on page reload). Storage of reasoning bytes is unaffected by this flag — they ride in provider_data regardless."
-            ><input
+          >
+            <input
               type="checkbox"
               id="model-surface-persisted-reasoning"
               checked
-              style="margin-right: 5px"
-            />Surface persisted reasoning</label
-          >
+            />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Surface persisted reasoning</span>
+          </label>
           <label
-            style="margin: 0; font-size: 12px; color: var(--fg-dim)"
+            class="toggle-switch"
             title="Replay stored reasoning blocks back to the model on subsequent provider calls. Capability-dependent; off by default for cost/spec compliance."
-            ><input
-              type="checkbox"
-              id="model-replay-reasoning"
-              style="margin-right: 5px"
-            />Replay reasoning to model</label
           >
+            <input type="checkbox" id="model-replay-reasoning" />
+            <span class="toggle-track" aria-hidden="true"></span>
+            <span class="toggle-label">Replay reasoning to model</span>
+          </label>
         </div>
         <div id="model-detect-area" style="margin-top: 14px">
           <button

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -1572,23 +1572,284 @@
   padding-left: 12px;
 }
 
-/* Checkbox labels inside admin modals */
-.admin-modal label.admin-checkbox {
+/* Toggle switch — modern replacement for boolean checkboxes inside
+ * admin modals.  The native <input type="checkbox"> stays in the
+ * markup (visually hidden but keyboard-focusable) so existing JS
+ * that reads `.checked` keeps working; the .toggle-track + ::before
+ * pseudo render the slider, .toggle-label carries the caption.
+ *
+ * Usage:
+ *   <label class="toggle-switch">
+ *     <input type="checkbox" id="..." />
+ *     <span class="toggle-track" aria-hidden="true"></span>
+ *     <span class="toggle-label">Enabled</span>
+ *   </label>
+ */
+/* Selector is doubled with .admin-modal so we win the specificity
+ * battle against ``.admin-modal label`` (0,1,1) — without that, the
+ * parent rule's display:block + text-transform:uppercase + margins
+ * cascade and we lose the inline-flex layout.
+ *
+ * Default margin-top: 14px matches the .admin-modal label cadence
+ * for toggles that sit directly between regular labelled rows
+ * (schedule/policy/skill modals).  When a toggle is inside an
+ * explicit ``.toggle-stack`` flex container, the stack resets the
+ * margin so the parent's gap controls spacing on its own. */
+.admin-modal label.toggle-switch,
+label.toggle-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+  margin: 14px 0 0 0;
+  padding: 0;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg);
+}
+.admin-modal .toggle-stack > label.toggle-switch,
+.toggle-stack > label.toggle-switch {
+  margin: 0;
+}
+/* Modifier for toggles that should sit flush against the surrounding
+ * rhythm rather than carry the default 14px top margin — used when a
+ * toggle is the first row of a modal (under the h2) or when it lives
+ * in a dynamically-rendered row that already supplies its own
+ * spacing (e.g. judge bool settings). */
+.admin-modal label.toggle-switch.toggle--flush,
+label.toggle-switch.toggle--flush {
+  margin-top: 0;
+}
+.admin-modal .toggle-stack,
+.toggle-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+}
+/* Hidden-input + track rules also need the .admin-modal prefix to
+ * outrank ``.admin-modal input:not([type="hidden"])`` (same
+ * specificity 0,2,1; that one comes later in source so without the
+ * bump it wins and forces width:100% on the hidden input, popping it
+ * back into the layout). */
+.admin-modal .toggle-switch input[type="checkbox"],
+.toggle-switch input[type="checkbox"] {
+  /* Visually hidden but still focusable + click-targetable via the
+   * <label> wrap.  Avoids display:none, which would strip the input
+   * from the keyboard tab order. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+.admin-modal .toggle-switch .toggle-track,
+.toggle-switch .toggle-track {
+  position: relative;
+  flex: 0 0 auto;
+  /* 40×22 meets WCAG 2.5.5 (Level AAA) target size when combined with
+   * the label's hit area, and reads as a deliberate switch on touch
+   * targets without dominating the form rhythm. */
+  width: 40px;
+  height: 22px;
+  /* Off state: depressed inset on the modal background so the track
+   * silhouette stays visible at 1.5+ contrast ratio.  The earlier
+   * ``var(--border-strong)`` solid fill was ~1.18:1 against the modal
+   * surface — visible to most readers, invisible to anyone on a
+   * glare-y screen or at ``prefers-contrast: more``. */
+  background: var(--bg);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+  border-radius: 11px;
+  transition:
+    background 0.18s ease,
+    box-shadow 0.18s ease;
+}
+.admin-modal .toggle-switch .toggle-track::before,
+.toggle-switch .toggle-track::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  background: var(--fg);
+  border-radius: 50%;
+  transition: transform 0.18s ease;
+}
+.admin-modal .toggle-switch input:checked + .toggle-track,
+.toggle-switch input:checked + .toggle-track {
+  background: var(--accent);
+  box-shadow: none;
+}
+.admin-modal .toggle-switch input:checked + .toggle-track::before,
+.toggle-switch input:checked + .toggle-track::before {
+  transform: translateX(18px);
+  background: var(--bg);
+}
+.admin-modal .toggle-switch input:focus-visible + .toggle-track,
+.toggle-switch input:focus-visible + .toggle-track {
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+.admin-modal .toggle-switch input:disabled + .toggle-track,
+.toggle-switch input:disabled + .toggle-track {
+  opacity: 0.4;
+}
+.toggle-switch:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+.toggle-switch .toggle-label {
+  display: inline-block;
+  /* The label text rides at the modal's normal label cadence — caps
+   * + letter-spacing so it sits next to the surrounding form rows
+   * without shifting the visual rhythm. */
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-dim);
+}
+
+/* Hair divider for separating conceptually-grouped toggles inside a
+ * stack — used between the lone "Enabled" toggle and the paired
+ * Reasoning toggles in the Add Model modal so the grouping reads
+ * without needing a subheading or indent.  Margin: 0 because the
+ * .toggle-stack flex container already supplies a 10px gap on each
+ * side; adding a margin on top would visually separate the divider
+ * twice. */
+.admin-modal hr.toggle-group-divider,
+hr.toggle-group-divider {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 0;
+  width: 100%;
+}
+
+/* Segmented option list — vertical card group for radio choices that
+ * benefit from a strong selected-state highlight.  The native
+ * ``<input type="radio">`` is visually hidden but stays focusable;
+ * the ``.segmented-indicator`` pseudo-circle and the row's
+ * background carry the selected state.
+ *
+ * Usage:
+ *   <div class="segmented-control" role="radiogroup">
+ *     <label class="segmented-option">
+ *       <input type="radio" name="..." value="..." />
+ *       <span class="segmented-indicator" aria-hidden="true"></span>
+ *       <span class="segmented-text">Label
+ *         <span class="segmented-hint">(hint)</span>
+ *       </span>
+ *     </label>
+ *     ...
+ *   </div>
+ */
+.admin-modal .segmented-control,
+.segmented-control {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg);
+  margin-top: 8px;
+}
+.admin-modal .segmented-option,
+.segmented-option {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 12px;
+  gap: 10px;
+  padding: 11px 14px;
+  cursor: pointer;
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
   font-weight: 500;
   text-transform: none;
   letter-spacing: 0;
-  color: var(--fg);
-  cursor: pointer;
-  margin-top: 14px;
+  color: var(--fg-dim);
+  border-top: 1px solid var(--border);
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
-.admin-modal label.admin-checkbox input[type="checkbox"],
-.admin-modal label.admin-checkbox input[type="radio"] {
-  width: auto;
-  margin: 0;
+.segmented-option:first-of-type {
+  border-top: none;
+}
+.segmented-option input[type="radio"] {
+  /* Visually hidden but focusable + click-targetable via the label
+   * wrap.  Keyboard arrows still cycle within the radiogroup. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+.segmented-option .segmented-indicator {
+  position: relative;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.segmented-option .segmented-indicator::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background 0.15s ease;
+}
+.segmented-option:hover {
+  background: var(--bg-highlight);
+  color: var(--fg);
+}
+.segmented-option:has(input:checked) {
+  background: var(--accent-dim);
+  color: var(--fg);
+}
+.segmented-option:has(input:checked) .segmented-indicator {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+.segmented-option:has(input:checked) .segmented-indicator::after {
+  background: var(--accent);
+}
+.segmented-option:has(input:focus-visible) {
+  /* Bright accent (not --accent-dim) so the ring stays visible even
+   * on the currently-selected row, which already paints --accent-dim
+   * as its background. */
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+.segmented-option .segmented-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.segmented-option .segmented-hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--fg-dim);
+  margin-left: 4px;
+}
+.segmented-option:has(input:checked) .segmented-hint {
+  color: var(--accent);
 }
 
 /* Admin modals */
@@ -1691,9 +1952,6 @@
   background: var(--bg-highlight);
   border-color: var(--border);
   color: var(--fg-dim);
-}
-.admin-modal label.admin-checkbox input:disabled {
-  opacity: 0.4;
 }
 .admin-modal input::placeholder,
 .admin-modal textarea::placeholder {
@@ -2755,28 +3013,64 @@ textarea.skill-content-area {
   padding: 0;
   margin-bottom: 4px;
 }
+/* Permission section grouping — keeps each namespace contiguous so
+ * the row-flow grid below doesn't slice ``admin.*`` mid-column.  The
+ * caps-styled ``.perm-section-label`` re-anchors the toggles to the
+ * modal's typographic system (matches ``.admin-modal label``: 10px
+ * caps, 0.08em letter-spacing, fg-dim). */
+.perm-section {
+  margin-top: 12px;
+}
+.perm-section:first-of-type {
+  margin-top: 0;
+}
+.perm-section-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-dim);
+  margin-bottom: 4px;
+}
 .perm-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4px 16px;
-  padding: 8px 0;
+  gap: 8px 16px;
+  padding: 4px 0 0;
 }
-.perm-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
+/* Permission rows inherit the toggle-switch component but render the
+ * permission name in monospace + lower case (it's an identifier, not
+ * a heading) — overrides the .toggle-label's caps/letter-spacing
+ * cadence used elsewhere in admin modals. */
+.admin-modal .perm-grid label.toggle-switch.perm-toggle,
+.perm-grid label.toggle-switch.perm-toggle {
+  margin: 0;
+}
+.perm-grid .toggle-switch.perm-toggle .toggle-label {
   font-family: var(--font-mono);
-  color: var(--fg);
-  padding: 3px 0;
-  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
   text-transform: none;
   letter-spacing: normal;
+  color: var(--fg);
 }
-.perm-checkbox input[type="checkbox"] {
-  width: auto;
+
+/* User-role assignment list (Users tab → Manage roles modal).  Same
+ * toggle-switch component as elsewhere, but the labels are
+ * human-readable role display names so we keep ui-font + caps-on so
+ * the stack reads like a settings list.  Only override the layout
+ * margin (the modal already provides outer padding). */
+.admin-modal .user-roles-list,
+.user-roles-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+.admin-modal .user-roles-list label.toggle-switch.user-role-toggle,
+.user-roles-list label.toggle-switch.user-role-toggle {
   margin: 0;
-  accent-color: var(--accent);
 }
 
 /* ==========================================================================

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -910,7 +910,17 @@ class IntentJudge:
         self._context_window = context_window
         self._rule_registry = rule_registry
 
-        # Resolve judge model via ModelRegistry alias, falling back to session
+        # Resolve judge model via ModelRegistry alias, otherwise self-
+        # consistency on the session model.  ``judge.model`` is alias-only
+        # — same contract as ``coordinator.model_alias`` /
+        # ``model.plan_alias`` / ``model.task_alias``.  A non-alias value
+        # used to be accepted as a raw model id pinned onto the session
+        # provider, but that path silently broke whenever the session
+        # provider didn't speak that model id (e.g. coordinator on
+        # Anthropic, ``judge.model = "gpt-5-mini"`` → every judge call
+        # returned ``llm_fallback``).  Operators register an alias
+        # instead; an unknown value here logs a warning and inherits the
+        # session model.
         resolved = False
         if config.model and model_registry is not None:
             try:
@@ -928,18 +938,15 @@ class IntentJudge:
             except Exception:
                 log.debug("Model alias resolution failed for %r, falling back", config.model)
 
-        if not resolved and config.model:
-            # Model name override with session provider
-            self._provider = session_provider
-            self._client_factory_args = self._extract_client_config(
-                session_client,
-                session_provider.provider_name,
-            )
-            self._model = config.model
-            caps = self._provider.get_capabilities(self._model)
-            self._judge_context_window = caps.context_window
-        elif not resolved:
-            # Self-consistency: same model as session
+        if not resolved:
+            if config.model:
+                log.warning(
+                    "judge.model=%r is not a registered alias — falling back to "
+                    "session model %r.  Register the model in the Models tab and "
+                    "set judge.model to its alias.",
+                    config.model,
+                    session_model,
+                )
             self._provider = session_provider
             self._client_factory_args = self._extract_client_config(
                 session_client,

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -419,11 +419,13 @@ def _build_registry() -> dict[str, SettingDef]:
             "judge.model",
             "str",
             "",
-            "Model for LLM judge (empty = same as session)",
+            "Model alias for LLM judge (empty = same as session)",
             "judge",
-            help="The judge can use a different AI model than the main conversation. Leave empty "
-            "to use the same model (self-consistency), or specify a different model for "
-            "cross-model evaluation.",
+            help="The judge can use a different AI model than the main conversation. "
+            "Specify a registered alias from the Models tab, or leave empty to use the "
+            "same model as the session (self-consistency). Values that aren’t "
+            "registered aliases inherit the session model and log a warning — "
+            "register the model in the Models tab and reference it by alias.",
         ),
         SettingDef(
             "judge.confidence_threshold",
@@ -634,13 +636,15 @@ def _build_registry() -> dict[str, SettingDef]:
             "coordinator.reasoning_effort",
             "str",
             "medium",
-            "Reasoning effort for coordinator sessions",
+            "Reasoning effort for coordinator sessions (empty = inherit from model.reasoning_effort)",
             "coordinator",
-            choices=["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+            choices=["", "none", "minimal", "low", "medium", "high", "xhigh", "max"],
             help="Reasoning effort for coordinator sessions. Coordinators benefit from "
             "medium-or-higher effort when juggling multiple child workstreams. Use "
             "'low' only when your coordinator handles simple, one-off dispatch "
-            "workflows.",
+            "workflows. (Empty here means “inherit” — the per-model "
+            "override on the alias wins, otherwise model.reasoning_effort. Use "
+            "‘none’ to actually disable reasoning.)",
         ),
         SettingDef(
             "coordinator.max_active",

--- a/turnstone/shared_static/composer.js
+++ b/turnstone/shared_static/composer.js
@@ -690,6 +690,18 @@
     this._refreshOptionsSummary();
   };
 
+  // Update just the placeholder (first) option's text without disturbing
+  // the rest of the choice list.  Callers that resolve the effective
+  // default asynchronously use this to annotate the empty option with the
+  // concrete alias — e.g. "Default model" → "Default model (gpt-5)".
+  Composer.prototype.setOptionPlaceholder = function (id, text) {
+    var ctrl = this._optionFields && this._optionFields[id];
+    if (!ctrl || ctrl.tagName !== "SELECT") return;
+    if (ctrl.options.length === 0) return;
+    ctrl.options[0].textContent = text == null ? "" : String(text);
+    this._refreshOptionsSummary();
+  };
+
   Composer.prototype._refreshOptionsSummary = function () {
     if (!this.optionsSummaryEl) return;
     var summaryFn = this._opts.options && this._opts.options.summary;


### PR DESCRIPTION
## Summary

Two-commit polish PR on the console admin UX, prompted by clicking around and finding rough edges:

1. **`refactor(judge)`** — `judge.model` is now alias-only, matching the other model roles. The previous "raw model id pinned onto the session provider" fallback was a documented footgun that silently broke verdicts whenever the session provider didn't recognise the configured model id. Unknown values now log a warning and inherit the session model.
2. **`feat(console-ui)`** — home composer placeholder shows the resolved alias (`Default — alias (model)`); admin Roles tab gains the missing Channel adapter row, drops the misleading `(default — alias)` for Plan/Task agent in favour of `(inherit)`, and accepts an empty value on `coordinator.reasoning_effort`. Every admin-modal boolean is now a `.toggle-switch` component (40×22, WCAG 2.5.5 AAA, inset off-state ring for contrast). MCP authorization replaces three radios with a vertical `.segmented-control` (filled indicator + accent-dim background on the selected row). The Role permissions modal sections by namespace under caps-styled headings so `admin.*` no longer splits mid-column. The Add Model "Enabled" → "Active" + moved flush to the top of the form.

Two designer review rounds were applied — most fixes (focus ring, hit target, em-dash placeholders, optimistic caption flip, perm grid sectioning, `.toggle--flush` modifier) live inline in the polish commit.

## Test plan

- [x] `pytest -k "not live"` — full suite green (525 pass on the affected slices including `test_judge`, `test_console_available_models`, `test_settings_registry`, `test_models_changed_event`, `test_session`, `test_admin_model_registry_refresh`, `test_console`)
- [x] `ruff check` + `mypy` clean on touched Python files
- [x] `scripts/css_specificity_audit.py` reports no conflicts on `.toggle-switch`, `.segmented-control`, `.perm-toggle`, `.toggle--flush`, `.user-role-toggle`
- [ ] Click through the admin tabs locally to spot-check the toggle conversions across Schedule / Policy / Skill / MCP / Model modals and the Role permissions grid
- [ ] Verify keyboard navigation: Tab through MCP segmented control + arrow keys cycle between options
- [ ] Confirm the home composer placeholders update via SSE when role assignments change