### PR TITLE
fix(session): AND-gate replay_reasoning_to_model with model capability

### DIFF
--- a/tests/test_provider_openai_responses_reasoning.py
+++ b/tests/test_provider_openai_responses_reasoning.py
@@ -44,13 +44,6 @@ def _capable_caps() -> ModelCapabilities:
     )
 
 
-def _incapable_caps() -> ModelCapabilities:
-    return ModelCapabilities(
-        context_window=128000,
-        supports_reasoning_replay=False,
-    )
-
-
 class TestExtractReasoningText:
     def test_none_returns_empty(self, provider: OpenAIResponsesProvider) -> None:
         assert provider.extract_reasoning_text(None) == ""
@@ -193,11 +186,14 @@ class TestReasoningItemForInput:
 
 class TestBuildKwargsInclude:
     """``_build_kwargs`` adds ``include=["reasoning.encrypted_content"]``
-    only when the operator flag AND the model capability both allow."""
+    when the resolved operator flag is True.  The capability AND-gate
+    lives upstream in ``ChatSession._resolve_replay_reasoning_to_model``
+    (single source of truth across providers); the provider trusts the
+    bool it receives.  See
+    ``test_session_replay_reasoning.py::TestSessionToOpenAIResponsesBoundaryIntegration``
+    for the end-to-end gate test."""
 
-    def test_include_added_when_flag_and_capability_true(
-        self, provider: OpenAIResponsesProvider
-    ) -> None:
+    def test_include_added_when_flag_true(self, provider: OpenAIResponsesProvider) -> None:
         kwargs = provider._build_kwargs(
             model="gpt-5",
             messages=[{"role": "user", "content": "hi"}],
@@ -222,37 +218,6 @@ class TestBuildKwargsInclude:
             deferred_names=None,
             capabilities=_capable_caps(),
             replay_reasoning_to_model=False,
-        )
-        assert "include" not in kwargs
-
-    def test_include_omitted_when_capability_false(self, provider: OpenAIResponsesProvider) -> None:
-        # Defends against operator flipping the flag on a non-reasoning
-        # model — the capability gate prevents the include= from being
-        # sent (silently no-op'd).
-        kwargs = provider._build_kwargs(
-            model="gpt-4o",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=None,
-            max_tokens=1024,
-            temperature=0.5,
-            reasoning_effort="medium",
-            deferred_names=None,
-            capabilities=_incapable_caps(),
-            replay_reasoning_to_model=True,
-        )
-        assert "include" not in kwargs
-
-    def test_include_omitted_by_default(self, provider: OpenAIResponsesProvider) -> None:
-        # When neither flag nor capability is passed, replay defaults
-        # True (kwarg) but capability defaults False — net: no include.
-        kwargs = provider._build_kwargs(
-            model="gpt-4o",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=None,
-            max_tokens=1024,
-            temperature=0.5,
-            reasoning_effort="medium",
-            deferred_names=None,
         )
         assert "include" not in kwargs
 

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -97,6 +97,48 @@ class TestResolveReplayReasoningToModel:
         # operator preference is a worse default.
         assert session._resolve_replay_reasoning_to_model() is False
 
+    def test_caps_none_preserves_back_compat(self) -> None:
+        # When ``caps`` is omitted, the resolver returns the operator
+        # flag unchanged — matching pre-PR behaviour for any caller
+        # that hasn't been updated to thread caps yet.
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "claude-opus-4-7"
+        assert session._resolve_replay_reasoning_to_model() is True
+        assert session._resolve_replay_reasoning_to_model(caps=None) is True
+
+    def test_caps_supports_replay_true_passes_through(self) -> None:
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "claude-opus-4-7"
+        caps = ModelCapabilities(supports_reasoning_replay=True)
+        assert session._resolve_replay_reasoning_to_model(caps=caps) is True
+
+    def test_caps_supports_replay_false_blocks_replay(self) -> None:
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        # Operator flipped replay=True but the model's capability
+        # advertises supports_reasoning_replay=False — AND-gate blocks
+        # replay so the strip predicate runs at the wire build.
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)
+        session._model_alias = "hypothetical-no-replay-claude"
+        caps = ModelCapabilities(supports_reasoning_replay=False)
+        assert session._resolve_replay_reasoning_to_model(caps=caps) is False
+
+    def test_caps_supports_replay_true_does_not_force_replay(self) -> None:
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        # Capability True but operator flag False — result must be
+        # False (the AND has to be False on either side).
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=False)
+        session._model_alias = "claude-opus-4-7"
+        caps = ModelCapabilities(supports_reasoning_replay=True)
+        assert session._resolve_replay_reasoning_to_model(caps=caps) is False
+
 
 class TestStreamingCallSitePassesFlag:
     """Pin that ``_try_stream`` actually passes the resolved flag to
@@ -337,6 +379,67 @@ class TestSessionToWireBoundaryIntegration:
             f"Replay-true did not preserve thinking at wire: blocks={block_types}"
         )
 
+    def test_capability_false_strips_thinking_even_when_operator_flag_true(self) -> None:
+        # Mirror of the OpenAI Responses ``test_capability_false_omits_
+        # include_even_when_flag_true`` test below: operator flips
+        # replay=True but the model's capability advertises
+        # supports_reasoning_replay=False.  AND-gate at the resolver
+        # blocks replay, so the strip predicate fires at the wire and
+        # the thinking block does NOT reach the SDK boundary.
+        pytest.importorskip("anthropic")
+        from turnstone.core.providers._anthropic import AnthropicProvider
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        msgs: list[dict[str, object]] = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "_provider_content": [
+                    {"type": "thinking", "thinking": "secret reasoning", "signature": "s"},
+                    {"type": "text", "text": "Final answer."},
+                ],
+            },
+            {"role": "user", "content": "ack"},
+        ]
+
+        session = _make_session()
+        session._registry = _registry_with_flag(replay=True)  # operator opted in
+        session._model_alias = "hypothetical-no-replay-claude"
+        caps = ModelCapabilities(supports_reasoning_replay=False)
+        client, captured = self._stub_anthropic_client()
+        real_provider = AnthropicProvider()
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            stream = session._try_stream(
+                client=client,
+                model="hypothetical-no-replay-claude",
+                msgs=msgs,
+                provider=real_provider,
+                capabilities=caps,
+                model_alias="hypothetical-no-replay-claude",
+            )
+            list(stream)
+
+        wire_msgs = captured.get("messages")
+        assert isinstance(wire_msgs, list), (
+            f"Expected messages= list at SDK boundary, got {captured}"
+        )
+        assistant = next(m for m in wire_msgs if m["role"] == "assistant")
+        block_types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+        assert "thinking" not in block_types, (
+            "Capability gate did not block replay: thinking block reached the wire "
+            f"despite supports_reasoning_replay=False (blocks={block_types})"
+        )
+        flat = repr(captured)
+        assert "secret reasoning" not in flat, (
+            "Reasoning text leaked into the SDK boundary payload despite capability gate"
+        )
+
 
 class TestSessionToOpenAIResponsesBoundaryIntegration:
     """End-to-end integration: session._try_stream -> real
@@ -518,6 +621,8 @@ class TestUtilityCompletionPassesFlag:
     same plumbing requirement as streaming."""
 
     def test_utility_completion_passes_resolved_flag(self) -> None:
+        from turnstone.core.providers._protocol import ModelCapabilities
+
         session = _make_session()
         session._registry = _registry_with_flag(replay=True)
         session._model_alias = "claude-opus-4-7"
@@ -530,10 +635,9 @@ class TestUtilityCompletionPassesFlag:
         mock_provider = MagicMock()
         mock_provider.create_completion = capture_completion
         session._provider = mock_provider
+        caps = ModelCapabilities(max_output_tokens=0, supports_reasoning_replay=True)
         with (
-            patch.object(
-                session, "_get_capabilities", return_value=SimpleNamespace(max_output_tokens=0)
-            ),
+            patch.object(session, "_get_capabilities", return_value=caps),
             patch.object(session, "_provider_extra_params", return_value=None),
         ):
             session._utility_completion(

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -322,19 +322,16 @@ class OpenAIResponsesProvider:
            from ``_provider_content`` as ``input`` items on subsequent
            turns (the SDK's ``ResponseReasoningItemParam`` shape).
 
-        Both are also gated by ``caps.supports_reasoning_replay`` —
-        models without a reasoning lane (gpt-4o, etc.) silently skip
-        replay even if the operator flag is set.
+        The AND-gate against ``caps.supports_reasoning_replay`` lives
+        upstream in ``ChatSession._resolve_replay_reasoning_to_model``
+        (single source of truth across providers).  Production callers
+        always thread the session-resolved flag, so this method trusts
+        the bool it receives.
         """
         caps = capabilities or self.get_capabilities(model)
 
-        # The two replay gates collapse to a single boolean: replay is
-        # active only when both the operator flag AND the model's
-        # capability allow it.  Threaded into ``_convert_messages`` so
-        # stored reasoning items become input items on the next call.
-        replay_active = bool(replay_reasoning_to_model and caps.supports_reasoning_replay)
         instructions, input_items = self._convert_messages(
-            messages, replay_reasoning_to_model=replay_active
+            messages, replay_reasoning_to_model=replay_reasoning_to_model
         )
         tools = apply_tool_search(caps, tools, deferred_names)
         converted_tools = self._convert_tools(tools, caps)
@@ -353,7 +350,7 @@ class OpenAIResponsesProvider:
             "store": False,
         }
 
-        if replay_active:
+        if replay_reasoning_to_model:
             # SDK doc (response_create_params.py:70-74): with
             # ``include=["reasoning.encrypted_content"]`` the API
             # surfaces opaque ``encrypted_content`` on reasoning
@@ -395,8 +392,10 @@ class OpenAIResponsesProvider:
         # Phase 3 reasoning-persistence kwarg — gates
         # ``include=["reasoning.encrypted_content"]`` on the request
         # AND ``_convert_messages`` round-tripping stored reasoning
-        # items as input.  Both are also gated by
-        # ``caps.supports_reasoning_replay`` inside ``_build_kwargs``.
+        # items as input.  The AND-gate against
+        # ``caps.supports_reasoning_replay`` lives in
+        # ``ChatSession._resolve_replay_reasoning_to_model`` — single
+        # source of truth across providers.
         replay_reasoning_to_model: bool = True,
     ) -> Iterator[StreamChunk]:
         if extra_params:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1212,30 +1212,48 @@ class ChatSession:
         # (e.g. Google tool_calls with thought_signature) survive.
         return [*provider_blocks, block]
 
-    def _resolve_replay_reasoning_to_model(self, alias: str | None = None) -> bool:
+    def _resolve_replay_reasoning_to_model(
+        self,
+        alias: str | None = None,
+        *,
+        caps: ModelCapabilities | None = None,
+    ) -> bool:
         """Read ``ModelConfig.replay_reasoning_to_model`` for an alias.
 
         Used by the streaming + non-streaming wire-build paths to gate
-        Anthropic's verbatim ``_provider_content`` thinking-block
-        replay (Phase 2 of the reasoning-persistence feature).  The
-        resolver's miss-fallback is ``False``: when no registry / alias
-        is available, or the lookup raises, return ``False`` so the
-        provider-side strip path runs.  Losing the strip on operator-
-        flagged-on models would be a worse default than losing the
-        replay on operator-flagged-off models — replaying reasoning
-        text against an unknown operator preference shouldn't happen.
-        The False-on-miss matches the ``model_definitions`` server-side
-        default for the column, so cold workstreams behave the same as
-        unconfigured ones.
+        verbatim reasoning-block replay (Phase 2 of the reasoning-
+        persistence feature).  The resolver's miss-fallback is
+        ``False``: when no registry / alias is available, or the lookup
+        raises, return ``False`` so the provider-side strip path runs.
+        Losing the strip on operator-flagged-on models would be a
+        worse default than losing the replay on operator-flagged-off
+        models — replaying reasoning text against an unknown operator
+        preference shouldn't happen.  The False-on-miss matches the
+        ``model_definitions`` server-side default for the column, so
+        cold workstreams behave the same as unconfigured ones.
+
+        When ``caps`` is provided, the operator flag is AND-gated with
+        ``caps.supports_reasoning_replay`` so a model lacking the
+        capability silently skips replay even when the operator flag
+        is set.  Mirrors the gate in
+        ``OpenAIResponsesProvider._build_kwargs`` and protects against
+        future Claude entries (or other Anthropic-shaped surfaces)
+        shipping with ``supports_reasoning_replay=False``.  When
+        ``caps`` is omitted the resolver returns the operator flag
+        unchanged — back-compat for callers that haven't been updated
+        to thread caps yet.
         """
         target_alias = alias or self._model_alias or ""
         if not self._registry or not target_alias:
             return False
         try:
             cfg: ModelConfig = self._registry.get_config(target_alias)
-            return bool(cfg.replay_reasoning_to_model)
+            operator_on = bool(cfg.replay_reasoning_to_model)
         except Exception:
             return False
+        if caps is None:
+            return operator_on
+        return operator_on and bool(caps.supports_reasoning_replay)
 
     def _save_config(self) -> None:
         """Persist LLM-affecting config so resumed workstreams behave identically."""
@@ -2605,7 +2623,7 @@ class ChatSession:
             reasoning_effort=reasoning_effort,
             extra_params=self._provider_extra_params(),
             capabilities=caps,
-            replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(),
+            replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(caps=caps),
         )
 
     # -- tool search helpers --------------------------------------------------
@@ -2773,6 +2791,10 @@ class ChatSession:
     ) -> Iterator[StreamChunk]:
         """Attempt a streaming API call with retries on transient errors."""
         prov = provider or self._provider
+        # Resolve once outside the retry loop — caps don't change per
+        # attempt, and the resolver below threads them into the
+        # ``replay_reasoning_to_model`` AND-gate.
+        resolved_caps = capabilities or self._get_capabilities(prov, model)
         raw_url = str(getattr(client, "base_url", getattr(client, "_base_url", "?")))
         safe_url = raw_url.split("?")[0]  # strip query params (may contain keys)
         msg_count = len(msgs)
@@ -2806,8 +2828,10 @@ class ChatSession:
                     ),
                     deferred_names=self._get_deferred_names(),
                     cancel_ref=self._cancel_ref,
-                    capabilities=capabilities or self._get_capabilities(prov, model),
-                    replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(model_alias),
+                    capabilities=resolved_caps,
+                    replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(
+                        model_alias, caps=resolved_caps
+                    ),
                 )
             except Exception as e:
                 ename = type(e).__name__
@@ -9076,7 +9100,7 @@ class ChatSession:
                         extra_params=agent_extra,
                         capabilities=agent_caps,
                         replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(
-                            agent_alias
+                            agent_alias, caps=agent_caps
                         ),
                     )
                 except Exception as e:


### PR DESCRIPTION
## Summary

- The Anthropic wire-build call sites in `session.py` were passing the operator-side `replay_reasoning_to_model` flag through without checking the model's static `supports_reasoning_replay` capability. The OpenAI Responses path AND-gated both flags inside `_build_kwargs`, so the gate was provider-asymmetric — `supports_reasoning_replay` was effectively dead code on the Anthropic path.
- Move the AND-gate into `ChatSession._resolve_replay_reasoning_to_model` via a new optional `caps=` kwarg. Threaded through the three call sites (`_utility_completion`, `_try_stream`, agent `_api_call`); caps hoisted out of the streaming retry loop since they're attempt-invariant.
- With the resolver-level gate in place, drop the redundant in-provider gate in `OpenAIResponsesProvider._build_kwargs`. The provider now trusts the resolved bool it receives — single source of truth across providers, matching the AnthropicProvider shape.

## Behavior

For all current Claude entries this is a no-op (every `_ANTHROPIC_CAPABILITIES` row sets `supports_reasoning_replay=True`, so `True AND op == op`). It hardens against:
- A future Claude entry (or any Anthropic-shaped surface) shipping with `supports_reasoning_replay=False` — replay would have fired against the cap declaration before; now it's blocked at the resolver.
- Future readers reasoning about `supports_reasoning_replay` and trusting it to actually gate something per-provider.

## Test plan

- [x] 4 resolver-level tests pinning AND-gate semantics + `caps=None` back-compat
- [x] 1 wire-boundary integration test mirroring the OpenAI Responses `test_capability_false_omits_include_even_when_flag_true` — drives `session._try_stream` through the real `AnthropicProvider` with operator flag True + capability False and asserts the `thinking` block does not reach the SDK boundary
- [x] Existing tests updated: `TestUtilityCompletionPassesFlag` caps mock upgraded from `SimpleNamespace` to a real `ModelCapabilities` instance
- [x] Two provider-level OpenAI Responses tests removed (now covered end-to-end by the session-level boundary test): `test_include_omitted_when_capability_false`, `test_include_omitted_by_default`
- [x] `pytest tests/test_session_replay_reasoning.py tests/test_provider_openai_responses_reasoning.py` — 40 passed
- [x] `pytest tests/ -k "provider or session" -m "not live"` — 987 passed
- [x] `ruff check` and `mypy` clean on `session.py`, `_openai_responses.py`, both test files