### PR TITLE
fix(server): always emit history event on /rewind to unblock edit-and-resend

### DIFF
--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1652,11 +1652,15 @@ async def command(request: Request) -> JSONResponse:
             if history:
                 ui._enqueue({"type": "history", "messages": history})
         elif cmd_word in ("/rewind", "/retry"):
-            # Refresh frontend with truncated history
+            # Refresh frontend with truncated history. Always emit the
+            # history event even when empty: editing the first message
+            # rewinds to zero messages, and the frontend dispatches the
+            # queued edit-and-resend from the history handler — skipping
+            # the event on an empty list orphans `_pendingEditSend` and
+            # leaves the composer stuck in busy.
             ui._enqueue({"type": "clear_ui"})
             history = await asyncio.to_thread(_build_history, ws.session)
-            if history:
-                ui._enqueue({"type": "history", "messages": history})
+            ui._enqueue({"type": "history", "messages": history})
             # Audit trail
             storage = getattr(request.app.state, "auth_storage", None)
             if storage:


### PR DESCRIPTION
## Summary
- Editing the first message in a workstream rewinds to zero messages; the `/rewind` handler's `if history:` guard then suppressed the `history` event, leaving only `clear_ui`.
- The frontend dispatches the queued edit-and-resend from `case "history":` (`_pendingEditSend` in `app.js`), so an empty history orphaned the pending text and left the composer stuck in busy (matching the reported "weird state" — Stop button shown, send disabled, refresh + new message recovers).
- Fix: always emit the `history` event after `/rewind`. `replayHistory` already handles `messages.length === 0` via `showEmptyState()`, so the empty case is well-defined and the dispatch fires.

## Test plan
- [ ] Open an interactive workstream, send a message, wait for response.
- [ ] Edit the **first** user message and resend — composer should rewind, briefly show empty state, then stream the new turn.
- [ ] Edit a non-first user message and resend — preserved history renders, new turn streams (regression check).
- [ ] Plain `/rewind 1` from the command bar with no pending edit — UI renders truncated history, composer idle.
- [ ] `/retry` after a failed turn — auto-dispatched retry still streams.
- [x] `pytest tests/test_rewind_retry.py` — 26 passed.
- [x] `ruff check turnstone/server.py` — clean.
- [x] `mypy turnstone/server.py` — clean.