### PR TITLE
fix(console): allow re-auth from inside the proxy-prefixed UI

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -83,6 +83,39 @@ class TestIsPublicPath:
     def test_shared_static_public(self):
         assert is_public_path("/shared/base.css") is True
 
+    # Console proxy: a public proxied path must still be public, otherwise
+    # the login modal can never re-authenticate from inside a ``/node/{id}/``
+    # proxied page once the cookie expires.
+    def test_proxy_v1_login_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/login") is True
+
+    def test_proxy_no_v1_login_public(self):
+        assert is_public_path("/node/node-a/api/auth/login") is True
+
+    def test_proxy_v1_status_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/status") is True
+
+    def test_proxy_v1_setup_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/setup") is True
+
+    def test_proxy_v1_logout_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/logout") is True
+
+    def test_proxy_v1_oidc_authorize_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/oidc/authorize") is True
+
+    def test_proxy_v1_oidc_callback_public(self):
+        assert is_public_path("/node/node-a/v1/api/auth/oidc/callback") is True
+
+    def test_proxy_v1_workstreams_still_not_public(self):
+        """Proxy prefix must not turn protected paths into public ones."""
+        assert is_public_path("/node/node-a/v1/api/workstreams") is False
+
+    def test_proxy_v1_refresh_still_requires_auth(self):
+        """Refresh isn't in PUBLIC_PATHS — the caller must already have
+        a valid cookie. Proxy-prefix shouldn't change that."""
+        assert is_public_path("/node/node-a/v1/api/auth/refresh") is False
+
 
 # ---------------------------------------------------------------------------
 # TestRequiredRole

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from turnstone.console.collector import ClusterCollector, NodeSnapshot
+from turnstone.console.server import _PROXY_AUTH_LOCAL_HANDLERS
 
 # Shared test auth — JWT-based
 _TEST_JWT_SECRET = "test-jwt-secret-minimum-32-chars!"
@@ -1564,22 +1565,17 @@ class TestConsoleProxy:
 
     # -------------------------------------------------------------------
     # Proxied auth endpoints — handled locally by the console, not
-    # forwarded to the upstream node.  See proxy_api's docstring (and the
-    # comment above _PROXY_AUTH_LOCAL_HANDLERS) for the JWT-audience
-    # reasoning.
+    # forwarded to the upstream node.  Cases derive directly from
+    # ``_PROXY_AUTH_LOCAL_HANDLERS`` so a new dispatch entry can't be
+    # added without a matching test (or vice versa).  See proxy_api's
+    # docstring for the JWT-audience reasoning.
     # -------------------------------------------------------------------
 
     @pytest.mark.parametrize(
         ("method", "path", "handler_name"),
         [
-            ("POST", "auth/login", "auth_login"),
-            ("POST", "auth/logout", "auth_logout"),
-            ("POST", "auth/setup", "auth_setup"),
-            ("POST", "auth/refresh", "auth_refresh"),
-            ("GET", "auth/status", "auth_status"),
-            ("GET", "auth/whoami", "auth_whoami"),
-            ("GET", "auth/oidc/authorize", "oidc_authorize"),
-            ("GET", "auth/oidc/callback", "oidc_callback"),
+            (method, path, handler_name)
+            for (method, path), handler_name in sorted(_PROXY_AUTH_LOCAL_HANDLERS.items())
         ],
     )
     def test_proxy_auth_endpoint_dispatches_to_local_handler(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1562,6 +1562,147 @@ class TestConsoleProxy:
             assert sse_mock.await_count == 1
             assert sse_mock.await_args.kwargs.get("use_service_auth") is False
 
+    # -------------------------------------------------------------------
+    # Proxied auth endpoints — handled locally by the console, not
+    # forwarded to the upstream node.  See proxy_api's docstring (and the
+    # comment above _PROXY_AUTH_LOCAL_HANDLERS) for the JWT-audience
+    # reasoning.
+    # -------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("method", "path", "handler_name"),
+        [
+            ("POST", "auth/login", "auth_login"),
+            ("POST", "auth/logout", "auth_logout"),
+            ("POST", "auth/setup", "auth_setup"),
+            ("POST", "auth/refresh", "auth_refresh"),
+            ("GET", "auth/status", "auth_status"),
+            ("GET", "auth/whoami", "auth_whoami"),
+            ("GET", "auth/oidc/authorize", "oidc_authorize"),
+            ("GET", "auth/oidc/callback", "oidc_callback"),
+        ],
+    )
+    def test_proxy_auth_endpoint_dispatches_to_local_handler(
+        self, client, method, path, handler_name
+    ):
+        """Every entry in ``_PROXY_AUTH_LOCAL_HANDLERS`` must route to its
+        local console handler and never reach the upstream proxy.  The
+        lockout class of bug this dispatch was added to fix is exactly
+        what a regression here would reintroduce silently — covering all
+        eight branches keeps each path tied to its handler."""
+        from unittest.mock import AsyncMock, patch
+
+        from starlette.responses import JSONResponse
+
+        with (
+            patch(
+                f"turnstone.console.server.{handler_name}",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "ok"}),
+            ) as local_mock,
+            patch(
+                "turnstone.console.server._proxy_post",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "should-not-be-called"}),
+            ) as post_mock,
+            patch(
+                "turnstone.console.server._proxy_get",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "should-not-be-called"}),
+            ) as get_mock,
+        ):
+            resp = client.request(method, f"/node/node-a/v1/api/{path}")
+            assert resp.status_code == 200
+            assert local_mock.await_count == 1
+            assert post_mock.await_count == 0
+            assert get_mock.await_count == 0
+
+    def test_proxy_auth_login_works_without_cookie(self, mock_collector):
+        """Without this fix the AuthMiddleware 401s before any handler
+        runs — the user is locked out of the proxied UI once the cookie
+        expires.  Test bypasses _TEST_AUTH_HEADERS to reproduce."""
+        from unittest.mock import AsyncMock, patch
+
+        from starlette.responses import JSONResponse
+        from starlette.testclient import TestClient
+
+        from turnstone.console.server import _load_static, create_app
+
+        _load_static()
+        app = create_app(collector=mock_collector, jwt_secret=_TEST_JWT_SECRET)
+        unauth_client = TestClient(app, raise_server_exceptions=False)
+        try:
+            with patch(
+                "turnstone.console.server.auth_login",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "ok"}),
+            ) as local_mock:
+                resp = unauth_client.post(
+                    "/node/node-a/v1/api/auth/login",
+                    json={"username": "x", "password": "y"},
+                )
+                # AuthMiddleware must classify the proxied login path as
+                # public (is_public_path change) AND proxy_api must
+                # dispatch to the local handler (proxy_api change).
+                assert resp.status_code == 200, (
+                    f"login locked out: got {resp.status_code}, body={resp.text}"
+                )
+                assert local_mock.await_count == 1
+        finally:
+            unauth_client.close()
+
+    def test_proxy_auth_wrong_method_returns_405_not_forwarded(self, client):
+        """A non-canonical method on an auth path (e.g. PUT on auth/login)
+        must short-circuit with 405 instead of falling through to the
+        upstream proxy — falling through would forward the request
+        authenticated as the console's service token (``_proxy_auth_headers``
+        fallback)."""
+        from unittest.mock import AsyncMock, patch
+
+        from starlette.responses import JSONResponse
+
+        with (
+            patch(
+                "turnstone.console.server._proxy_post",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "should-not-be-called"}),
+            ) as post_mock,
+            patch(
+                "turnstone.console.server._proxy_get",
+                new_callable=AsyncMock,
+                return_value=JSONResponse({"status": "should-not-be-called"}),
+            ) as get_mock,
+        ):
+            # PUT on a POST-only auth path → 405
+            put_resp = client.put("/node/node-a/v1/api/auth/login")
+            assert put_resp.status_code == 405
+            # POST on a GET-only auth path → 405
+            post_resp = client.post("/node/node-a/v1/api/auth/status")
+            assert post_resp.status_code == 405
+            assert post_mock.await_count == 0
+            assert get_mock.await_count == 0
+
+    def test_proxy_non_auth_endpoint_still_forwarded(self, client, mock_collector):
+        """Sanity: only auth/* paths intercept.  Other API paths still
+        forward to the upstream node."""
+        from unittest.mock import AsyncMock, patch
+
+        from starlette.responses import JSONResponse
+
+        mock_collector.get_node_detail.return_value = {
+            "node_id": "node-a",
+            "server_url": "http://a:8080",
+            "reachable": True,
+        }
+        with patch(
+            "turnstone.console.server._proxy_get",
+            new_callable=AsyncMock,
+            return_value=JSONResponse({"ok": True}),
+        ) as proxy_mock:
+            resp = client.get("/node/node-a/v1/api/workstreams")
+            assert resp.status_code == 200
+            assert proxy_mock.await_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Proxy URL rewriting unit tests (no HTTP needed)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2636,10 +2636,77 @@ async def proxy_shared_static(request: Request) -> Response:
         return JSONResponse({"error": "Node unreachable"}, status_code=502)
 
 
+# Paths the console handles locally instead of forwarding to the upstream
+# node.  Tests parametrize against this set so a new dispatch branch
+# can't be added without a matching test.  Keep in lockstep with the
+# ``proxy_api`` dispatch chain below.
+_PROXY_AUTH_LOCAL_PATHS: frozenset[str] = frozenset(
+    {
+        "auth/login",
+        "auth/logout",
+        "auth/setup",
+        "auth/refresh",
+        "auth/status",
+        "auth/whoami",
+        "auth/oidc/authorize",
+        "auth/oidc/callback",
+    }
+)
+
+
 async def proxy_api(request: Request) -> Response:
-    """Proxy API requests to target node. Detects SSE vs regular."""
+    """Proxy API requests to target node, with two exceptions handled in-process:
+
+    1. ``auth/*`` endpoints in ``_PROXY_AUTH_LOCAL_PATHS`` are dispatched
+       to the console's own auth handlers so JWTs carry
+       ``JWT_AUD_CONSOLE`` and Set-Cookie lands on the console origin.
+       Forwarding upstream would mint ``JWT_AUD_SERVER`` tokens that the
+       console's ``AuthMiddleware`` rejects on the next proxied call,
+       locking the user out of the proxied UI — and ``_proxy_post``
+       drops Set-Cookie when forwarding anyway.  ``refresh`` and
+       ``whoami`` are intentionally NOT in ``PUBLIC_PATHS`` (caller must
+       still hold a valid cookie); local dispatch is about cookie-origin
+       and audience, not public access.
+    2. SSE endpoints (per-ws + global events) stream via ``_proxy_sse``.
+
+    Everything else is forwarded to ``server_url`` via ``_proxy_post`` /
+    ``_proxy_get``.
+    """
     node_id = request.path_params["node_id"]
     path = request.path_params["path"]
+
+    # Local auth dispatch.  Each branch reads its handler from module
+    # scope at call time, so ``patch("...auth_login")`` in tests works
+    # transparently.  Keep entries in lockstep with ``_PROXY_AUTH_LOCAL_PATHS``.
+    if request.method == "POST":
+        if path == "auth/login":
+            return await auth_login(request)
+        if path == "auth/logout":
+            return await auth_logout(request)
+        if path == "auth/setup":
+            return await auth_setup(request)
+        if path == "auth/refresh":
+            return await auth_refresh(request)
+    elif request.method == "GET":
+        if path == "auth/status":
+            return await auth_status(request)
+        if path == "auth/whoami":
+            return await auth_whoami(request)
+        if path == "auth/oidc/authorize":
+            return await oidc_authorize(request)
+        if path == "auth/oidc/callback":
+            return await oidc_callback(request)
+    # Path matches a local-dispatch auth endpoint but the method does not:
+    # short-circuit with 405 so the request can't fall through to
+    # ``_proxy_post`` / ``_proxy_get`` and reach the upstream
+    # authenticated as the console's service token
+    # (``_proxy_auth_headers`` falls back to the service identity when
+    # there's no user context).  Harmless today because every upstream
+    # auth route 405s on the wrong method too, but kept tight so a
+    # future upstream patch can't widen the surface by accident.
+    if path in _PROXY_AUTH_LOCAL_PATHS:
+        return JSONResponse({"error": "Method not allowed"}, status_code=405)
+
     server_url = _get_server_url(request, node_id)
     if not server_url:
         return JSONResponse({"error": "Node not found"}, status_code=404)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2636,29 +2636,33 @@ async def proxy_shared_static(request: Request) -> Response:
         return JSONResponse({"error": "Node unreachable"}, status_code=502)
 
 
-# Paths the console handles locally instead of forwarding to the upstream
-# node.  Tests parametrize against this set so a new dispatch branch
-# can't be added without a matching test.  Keep in lockstep with the
-# ``proxy_api`` dispatch chain below.
-_PROXY_AUTH_LOCAL_PATHS: frozenset[str] = frozenset(
-    {
-        "auth/login",
-        "auth/logout",
-        "auth/setup",
-        "auth/refresh",
-        "auth/status",
-        "auth/whoami",
-        "auth/oidc/authorize",
-        "auth/oidc/callback",
-    }
-)
+# Auth endpoints the console handles locally instead of forwarding to
+# the upstream node.  Single source of truth for the dispatch table and
+# the path set used by both the 405 short-circuit and the
+# test parametrize, so a new entry can't drift between code and tests.
+#
+# Values are handler NAMES (strings) rather than function references.
+# ``proxy_api`` resolves them via ``globals()`` at call time so test
+# ``patch("turnstone.console.server.auth_login")`` is observed; a dict
+# of refs would capture the original function at module load.
+_PROXY_AUTH_LOCAL_HANDLERS: dict[tuple[str, str], str] = {
+    ("POST", "auth/login"): "auth_login",
+    ("POST", "auth/logout"): "auth_logout",
+    ("POST", "auth/setup"): "auth_setup",
+    ("POST", "auth/refresh"): "auth_refresh",
+    ("GET", "auth/status"): "auth_status",
+    ("GET", "auth/whoami"): "auth_whoami",
+    ("GET", "auth/oidc/authorize"): "oidc_authorize",
+    ("GET", "auth/oidc/callback"): "oidc_callback",
+}
+_PROXY_AUTH_LOCAL_PATHS: frozenset[str] = frozenset(path for _, path in _PROXY_AUTH_LOCAL_HANDLERS)
 
 
 async def proxy_api(request: Request) -> Response:
     """Proxy API requests to target node, with two exceptions handled in-process:
 
-    1. ``auth/*`` endpoints in ``_PROXY_AUTH_LOCAL_PATHS`` are dispatched
-       to the console's own auth handlers so JWTs carry
+    1. ``auth/*`` endpoints in ``_PROXY_AUTH_LOCAL_HANDLERS`` are
+       dispatched to the console's own auth handlers so JWTs carry
        ``JWT_AUD_CONSOLE`` and Set-Cookie lands on the console origin.
        Forwarding upstream would mint ``JWT_AUD_SERVER`` tokens that the
        console's ``AuthMiddleware`` rejects on the next proxied call,
@@ -2675,27 +2679,13 @@ async def proxy_api(request: Request) -> Response:
     node_id = request.path_params["node_id"]
     path = request.path_params["path"]
 
-    # Local auth dispatch.  Each branch reads its handler from module
-    # scope at call time, so ``patch("...auth_login")`` in tests works
-    # transparently.  Keep entries in lockstep with ``_PROXY_AUTH_LOCAL_PATHS``.
-    if request.method == "POST":
-        if path == "auth/login":
-            return await auth_login(request)
-        if path == "auth/logout":
-            return await auth_logout(request)
-        if path == "auth/setup":
-            return await auth_setup(request)
-        if path == "auth/refresh":
-            return await auth_refresh(request)
-    elif request.method == "GET":
-        if path == "auth/status":
-            return await auth_status(request)
-        if path == "auth/whoami":
-            return await auth_whoami(request)
-        if path == "auth/oidc/authorize":
-            return await oidc_authorize(request)
-        if path == "auth/oidc/callback":
-            return await oidc_callback(request)
+    handler_name = _PROXY_AUTH_LOCAL_HANDLERS.get((request.method, path))
+    if handler_name is not None:
+        # Resolve via ``globals()`` so ``patch("...auth_login")`` in
+        # tests is observed.  A direct function-ref dict would have
+        # captured the original at module load.
+        handler = globals()[handler_name]
+        return await handler(request)  # type: ignore[no-any-return]
     # Path matches a local-dispatch auth endpoint but the method does not:
     # short-circuit with 405 so the request can't fall through to
     # ``_proxy_post`` / ``_proxy_get`` and reach the upstream

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -513,7 +513,21 @@ def is_public_path(path: str) -> bool:
     normalized = _strip_version_prefix(path)
     if normalized in PUBLIC_PATHS:
         return True
-    return any(normalized.startswith(prefix) for prefix in PUBLIC_PREFIXES)
+    if any(normalized.startswith(prefix) for prefix in PUBLIC_PREFIXES):
+        return True
+    # Console proxy: a public proxied path is still public.  Without this
+    # the login/status/setup endpoints are unreachable from inside a
+    # ``/node/{id}/...`` proxied page once the cookie expires — the
+    # AuthMiddleware 401s the login POST before any handler runs and the
+    # user is locked out of the proxied UI.
+    if normalized.startswith("/node/"):
+        proxied = _extract_proxied_path(normalized)
+        if proxied is not None:
+            if proxied in PUBLIC_PATHS:
+                return True
+            if any(proxied.startswith(prefix) for prefix in PUBLIC_PREFIXES):
+                return True
+    return False
 
 
 def required_scope(method: str, path: str) -> str:


### PR DESCRIPTION
## Summary

When the user is on a proxied node page (`/node/{id}/...`) and the JWT expires, the in-page login modal POSTs to `/v1/api/auth/login` which the proxy shim rewrites to `/node/{id}/v1/api/auth/login`. The console's `AuthMiddleware` 401's the request before any handler can run — the user is locked out of the proxied UI with no way to recover except going back to the console root and re-authenticating there.

Two latent bugs both had to be fixed:

1. **`is_public_path` didn't recognise the `/node/{id}/` prefix over a public path.** Extended via the existing `_extract_proxied_path` helper so a proxied public path stays public.
2. **Even if the path had been public, `proxy_api` would have forwarded the request to the upstream node.** The upstream mints `JWT_AUD_SERVER` tokens; the console's `AuthMiddleware` (expecting `JWT_AUD_CONSOLE`) rejects those on the next proxied call, and `_proxy_post` drops `Set-Cookie` when forwarding anyway. `proxy_api` now dispatches every entry in `_PROXY_AUTH_LOCAL_PATHS` (`login`, `logout`, `setup`, `refresh`, `status`, `whoami`, `oidc/authorize`, `oidc/callback`) to the console's own auth handlers, and short-circuits non-canonical methods on those paths with **405** instead of letting them slip through with the service-token fallback in `_proxy_auth_headers`.

`refresh` and `whoami` are intentionally NOT in `PUBLIC_PATHS` — the caller must still hold a valid cookie. Local dispatch there is about cookie-origin and JWT audience, not about granting public access.

## Test plan

- [x] Unit: 9 new `TestIsPublicPath` tests covering proxied public paths (positive) and proxied protected paths like `auth/refresh` and `/workstreams` (negative — must still require auth).
- [x] Integration: parametrized dispatch test across all 8 entries in `_PROXY_AUTH_LOCAL_PATHS` asserting each routes to its local handler and never reaches `_proxy_post` / `_proxy_get`.
- [x] Integration: reproduce the original lockout by POSTing `/node/.../v1/api/auth/login` with no auth header — must succeed once both fixes are in.
- [x] Integration: 405 regression guard — PUT on `auth/login` and POST on `auth/status` short-circuit instead of falling through to the upstream proxy.
- [x] Sanity: a non-auth path (`/v1/api/workstreams`) still forwards to the upstream.
- [x] Manual: against running console + node, browser hits the proxied URL after JWT expiry → login modal works.
- [x] ruff + mypy clean; full `tests/test_auth.py` + `tests/test_console.py` suite (371 tests) green.

## Notes

The dispatch in `proxy_api` is an if/elif chain rather than a `(method, path) -> handler` dict because the dict would capture function refs at module-load time and tests' `patch("turnstone.console.server.auth_login")` couldn't see through it. The chain is paired with a `_PROXY_AUTH_LOCAL_PATHS` frozenset that drives both the 405 short-circuit and the parametrized regression test — keeping the two in lockstep is flagged in a code comment.