### PR TITLE
feat(task_agent): add optional skill parameter for per-call personas

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -498,7 +498,13 @@ class TestTaskExec:
         with patch("turnstone.core.session.get_skill_by_name", return_value=skill):
             item = session._prepare_task("c1", {"prompt": "investigate X", "skill": "research"})
 
-        assert item["skill"] is skill
+        # Item carries the minimized projection — name/content/risk_level
+        # only — not the raw prompt_templates row.
+        assert item["skill"] == {
+            "name": "research",
+            "content": skill["content"],
+            "risk_level": "",
+        }
         assert item.get("needs_approval") is True
         assert "skill: research" in item["header"]
 
@@ -531,6 +537,21 @@ class TestTaskExec:
         # Default-persona literals also present (sanity check on the constant).
         assert "# Task Agent" in sys_msg
         assert "autonomous task agent with full tool access" in sys_msg
+
+    @pytest.mark.parametrize("skill_value", ["", "   ", "\t\n"])
+    def test_prepare_task_empty_or_whitespace_skill_treated_as_omitted(
+        self, tmp_db, skill_value
+    ) -> None:
+        """Documented contract: ``skill=""`` (and whitespace-only) behaves
+        identically to omitting the skill arg.  LLMs sometimes echo empty
+        strings rather than omit the field; this pins the documented
+        behavior so a future refactor of the ``(args.get("skill") or "").strip()``
+        chokepoint can't quietly diverge."""
+        session = _make_session()
+        item = session._prepare_task("c1", {"prompt": "do x", "skill": skill_value})
+        assert item.get("needs_approval") is True
+        assert item["skill"] is None
+        assert "skill:" not in item["header"]
 
     def test_prepare_task_unknown_skill_returns_error(self, tmp_db) -> None:
         """Unknown skill name → clean error item, no approval needed.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -459,6 +459,192 @@ class TestPlanExec:
 
 
 # ---------------------------------------------------------------------------
+# Tests — _exec_task (optional skill substitutes the hardcoded identity)
+# ---------------------------------------------------------------------------
+
+
+class TestTaskExec:
+    """Tests for _exec_task: optional skill= replaces the default persona,
+    but operating guidance (one-shot, tool-use over narration, no follow-ups)
+    is always preserved."""
+
+    @staticmethod
+    def _capture_exec_messages(session, item):
+        """Run _exec_task with _run_agent patched; return system message text."""
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured["messages"] = list(messages)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        return captured["messages"][0]["content"]
+
+    def test_known_skill_renders_into_system_message(self, tmp_db) -> None:
+        """Validated skill content (with template vars resolved) replaces
+        the default '# Task Agent' persona, but the operating guidance
+        (the numbered list) is preserved — those are sub-agent semantics
+        that a persona should layer on top of, not replace.
+
+        Covers the full prepare→exec round-trip so a future regression
+        in either half (skill not stored on the item, or exec ignoring it)
+        is caught."""
+        session = _make_session()
+        skill = {
+            "name": "research",
+            "content": "# Research Agent\nws={{ws_id}} model={{model}} node={{node_id}}",
+        }
+        with patch("turnstone.core.session.get_skill_by_name", return_value=skill):
+            item = session._prepare_task("c1", {"prompt": "investigate X", "skill": "research"})
+
+        assert item["skill"] is skill
+        assert item.get("needs_approval") is True
+        assert "skill: research" in item["header"]
+
+        sys_msg = self._capture_exec_messages(session, item)
+        # Skill persona rendered with template vars resolved
+        assert "# Research Agent" in sys_msg
+        assert f"ws={session._ws_id}" in sys_msg
+        assert f"model={session.model}" in sys_msg
+        # Default persona is gone — skill substitutes for it.
+        assert "# Task Agent" not in sys_msg
+        assert "autonomous task agent with full tool access" not in sys_msg
+        # Operating guidance survives regardless of skill.
+        assert ChatSession._TASK_OPERATING_GUIDANCE in sys_msg
+
+    def test_omitted_skill_uses_hardcoded_identity(self, tmp_db) -> None:
+        """Regression guard: without skill=, the default '# Task Agent'
+        persona AND the operating guidance both appear verbatim.
+
+        Pins the no-skill path so the substitution branch can't
+        accidentally swallow the default case."""
+        session = _make_session()
+        item = session._prepare_task("c1", {"prompt": "do x"})
+
+        assert item["skill"] is None
+        assert "skill:" not in item["header"]
+
+        sys_msg = self._capture_exec_messages(session, item)
+        assert ChatSession._TASK_DEFAULT_IDENTITY in sys_msg
+        assert ChatSession._TASK_OPERATING_GUIDANCE in sys_msg
+        # Default-persona literals also present (sanity check on the constant).
+        assert "# Task Agent" in sys_msg
+        assert "autonomous task agent with full tool access" in sys_msg
+
+    def test_prepare_task_unknown_skill_returns_error(self, tmp_db) -> None:
+        """Unknown skill name → clean error item, no approval needed.
+
+        Skill validation lives in _prepare_task so an LLM passing a
+        bogus name fails fast at approval time rather than at exec."""
+        session = _make_session()
+        with patch("turnstone.core.session.get_skill_by_name", return_value=None):
+            item = session._prepare_task("c1", {"prompt": "do x", "skill": "ghost"})
+        assert item.get("needs_approval") is False
+        assert "unknown skill 'ghost'" in item["error"]
+        assert "skill(action='search')" in item["error"]
+
+    def test_prepare_task_disabled_skill_returns_error(self, tmp_db) -> None:
+        """Disabled skill → distinct error, mirrors the enabled gate that
+        ``_exec_skill(action='load')`` (session.py:8404) and skill-search
+        already apply.  Distinct from the unknown-skill phrasing so the
+        LLM's recovery path can tell 'not found' from 'quarantined'."""
+        session = _make_session()
+        disabled_skill = {
+            "name": "retired",
+            "content": "# Retired",
+            "enabled": False,
+        }
+        with patch("turnstone.core.session.get_skill_by_name", return_value=disabled_skill):
+            item = session._prepare_task("c1", {"prompt": "do x", "skill": "retired"})
+        assert item.get("needs_approval") is False
+        assert "is disabled" in item["error"]
+        # Distinct wording from the unknown-skill error, so the LLM can
+        # tell them apart at recovery time.
+        assert "unknown skill" not in item["error"]
+
+    def test_prepare_task_high_risk_skill_surfaces_in_header(self, tmp_db, caplog) -> None:
+        """High/critical risk skills surface the tier in the approval header
+        and emit a structured warning, mirroring the signal ``_load_skills``
+        emits for session-level skills (session.py:1336)."""
+        import logging
+
+        session = _make_session()
+        risky_skill = {
+            "name": "danger",
+            "content": "# Danger",
+            "enabled": True,
+            "risk_level": "critical",
+        }
+        with (
+            caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
+            patch("turnstone.core.session.get_skill_by_name", return_value=risky_skill),
+        ):
+            item = session._prepare_task("c1", {"prompt": "do x", "skill": "danger"})
+        assert item.get("needs_approval") is True
+        assert "skill: danger" in item["header"]
+        assert "risk: critical" in item["header"]
+        warning_seen = any("high_risk_skill" in r.getMessage() for r in caplog.records)
+        assert warning_seen, "expected task_agent.high_risk_skill warning"
+
+    def test_prepare_task_normal_risk_skill_omits_tier_from_header(self, tmp_db) -> None:
+        """Header only surfaces high/critical — low/medium/safe skills don't
+        pollute the approval line."""
+        session = _make_session()
+        ok_skill = {
+            "name": "research",
+            "content": "# Research",
+            "enabled": True,
+            "risk_level": "low",
+        }
+        with patch("turnstone.core.session.get_skill_by_name", return_value=ok_skill):
+            item = session._prepare_task("c1", {"prompt": "do x", "skill": "research"})
+        assert "skill: research" in item["header"]
+        assert "risk:" not in item["header"]
+
+    def test_evaluate_intent_projects_skill_for_task_agent(self, tmp_db, monkeypatch) -> None:
+        """Judge projection includes the skill name so heuristic arg_patterns
+        can match on it and the audit row records which persona was chosen.
+
+        Mirrors the long-standing ``spawn_workstream`` projection at
+        session.py:4603 — without it, policy rules targeting risky
+        skills via ``task_agent`` silently no-op."""
+        session = _make_session()
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
+        fake_judge = MagicMock()
+        fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        skill = {"name": "research", "content": "# Research", "enabled": True}
+        with patch("turnstone.core.session.get_skill_by_name", return_value=skill):
+            item = session._prepare_task("c1", {"prompt": "investigate X", "skill": "research"})
+        session._evaluate_intent([item])
+
+        fa = item["func_args"]
+        assert fa["skill"] == "research"
+        assert fa["prompt"] == "investigate X"
+
+    def test_evaluate_intent_projects_empty_skill_when_omitted(self, tmp_db, monkeypatch) -> None:
+        """Symmetric regression guard: no-skill case projects skill="" so
+        the func_args shape is stable across both branches (the judge can
+        always read ``func_args["skill"]`` without a KeyError)."""
+        session = _make_session()
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
+        fake_judge = MagicMock()
+        fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        item = session._prepare_task("c1", {"prompt": "do x"})
+        session._evaluate_intent([item])
+
+        fa = item["func_args"]
+        assert fa["skill"] == ""
+        assert fa["prompt"] == "do x"
+
+
+# ---------------------------------------------------------------------------
 # Per-call model override on plan_agent / task_agent
 # ---------------------------------------------------------------------------
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6267,6 +6267,17 @@ class ChatSession:
                         "Use skill(action='search') to find available names."
                     ),
                 }
+            # ``get_skill_by_name`` returns the full prompt_templates row
+            # (~30 columns including ``scan_report``, ``installed_by``,
+            # ``source_url``, etc.).  Project to the minimal field set
+            # that ``_exec_task`` and ``_evaluate_intent`` actually read,
+            # so the approval item doesn't drag governance metadata
+            # through any future audit serializer.
+            skill_data = {
+                "name": skill_data["name"],
+                "content": skill_data["content"],
+                "risk_level": skill_data.get("risk_level", ""),
+            }
         preview_text = prompt[:300] + ("..." if len(prompt) > 300 else "")
         header = "\u2699 task_agent (autonomous agent"
         if skill_data:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4592,7 +4592,18 @@ class ChatSession:
             elif name == "notify":
                 it["func_args"] = {"message": (it.get("message") or "")[:200]}
             elif name == "task_agent":
-                it["func_args"] = {"prompt": (it.get("prompt") or "")[:200]}
+                # Pending items reach this point already shaped by
+                # ``_prepare_task``, so ``it["skill"]`` is the resolved
+                # skill_data dict (or ``None``), not the raw string the
+                # LLM passed.  Mirror the ``spawn_workstream`` projection
+                # so heuristic ``arg_pattern`` rules can match on skill
+                # name and the judge / audit row sees which persona was
+                # selected.
+                skill_dict = it.get("skill") or {}
+                it["func_args"] = {
+                    "prompt": (it.get("prompt") or "")[:200],
+                    "skill": skill_dict.get("name", "") if isinstance(skill_dict, dict) else "",
+                }
             elif name == "plan_agent":
                 it["func_args"] = {"goal": (it.get("prompt") or "")[:200]}
             # Coordinator tool args — only the ``needs_approval=True`` set
@@ -6224,17 +6235,66 @@ class ChatSession:
         model_override, err = self._validate_agent_model_override(call_id, "task_agent", args)
         if err is not None:
             return err
+        skill_arg = (args.get("skill") or "").strip()
+        skill_data: dict[str, Any] | None = None
+        if skill_arg:
+            skill_data = get_skill_by_name(skill_arg)
+            if skill_data is None:
+                return {
+                    "call_id": call_id,
+                    "func_name": "task_agent",
+                    "header": f"\u2717 task_agent: unknown skill '{skill_arg}'",
+                    "preview": "",
+                    "needs_approval": False,
+                    "error": (
+                        f"Error: unknown skill '{skill_arg}'. "
+                        "Use skill(action='search') to find available names."
+                    ),
+                }
+            # ``enabled=False`` is an admin's quarantine flag \u2014 mirror the
+            # gate that ``_exec_skill(action='load')`` and skill-search
+            # apply so task_agent can't sidestep it.  Distinct from the
+            # not-found case so the LLM's recovery path can tell them apart.
+            if not skill_data.get("enabled", True):
+                return {
+                    "call_id": call_id,
+                    "func_name": "task_agent",
+                    "header": f"\u2717 task_agent: skill '{skill_arg}' is disabled",
+                    "preview": "",
+                    "needs_approval": False,
+                    "error": (
+                        f"Error: skill '{skill_arg}' is disabled and cannot be used. "
+                        "Use skill(action='search') to find available names."
+                    ),
+                }
         preview_text = prompt[:300] + ("..." if len(prompt) > 300 else "")
+        header = "\u2699 task_agent (autonomous agent"
+        if skill_data:
+            header += f", skill: {skill_data['name']}"
+            # Surface high/critical risk at approval time so the operator
+            # sees the same signal ``_load_skills`` emits for session-level
+            # skills (session.py:1336).  Log mirrors that path's structured
+            # event for forensic continuity.
+            risk_tier = skill_data.get("risk_level", "")
+            if risk_tier in ("high", "critical"):
+                header += f", risk: {risk_tier}"
+                log.warning(
+                    "task_agent.high_risk_skill",
+                    skill=skill_data["name"],
+                    risk_level=risk_tier,
+                )
+        header += ")"
         return {
             "call_id": call_id,
             "func_name": "task_agent",
-            "header": "\u2699 task_agent (autonomous agent)",
+            "header": header,
             "preview": f"    {preview_text}",
             "needs_approval": True,
             "approval_label": "task_agent",
             "execute": self._exec_task,
             "prompt": prompt,
             "model_override": model_override,
+            "skill": skill_data,
         }
 
     def _prepare_plan(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -9420,35 +9480,68 @@ class ChatSession:
         self.ui.on_info(f"[{label} done] {len(content)} chars")
         return content
 
+    _TASK_DEFAULT_IDENTITY = (
+        "# Task Agent\n\n"
+        "You are an autonomous task agent with full tool access. "
+        "You can use bash, read_file, write_file, edit_file, search, "
+        "math, web_fetch, and web_search."
+    )
+    # Operating guidance always applies — these are sub-agent semantics
+    # (one-shot, tool-use over narration, no follow-up questions) that a
+    # persona skill should layer on top of, not replace.
+    _TASK_OPERATING_GUIDANCE = (
+        "1. **Follow through on actions:** Do not describe changes — "
+        "use the tools to make them. After read_file, call edit_file "
+        "or write_file.\n\n"
+        "2. **Tool selection:**\n"
+        "   - Use read_file before edit_file on existing files.\n"
+        "   - Use write_file for new files (not bash).\n"
+        "   - Use bash for shell commands (git, python, tests).\n"
+        "   - Use search to find code across files.\n\n"
+        "3. **Complete the task fully.** Do not ask follow-up "
+        "questions — execute the work as described in the prompt."
+    )
+
     def _exec_task(self, item: dict[str, Any]) -> tuple[str, str]:
         """Delegate to a general-purpose autonomous sub-agent."""
         call_id, prompt = item["call_id"], item["prompt"]
-        task_instruction = {
-            "role": "system",
-            "content": (
-                "# Task Agent\n\n"
-                "You are an autonomous task agent with full tool access. "
-                "You can use bash, read_file, write_file, edit_file, search, "
-                "math, web_fetch, and web_search.\n\n"
-                "1. **Follow through on actions:** Do not describe changes — "
-                "use the tools to make them. After read_file, call edit_file "
-                "or write_file.\n\n"
-                "2. **Tool selection:**\n"
-                "   - Use read_file before edit_file on existing files.\n"
-                "   - Use write_file for new files (not bash).\n"
-                "   - Use bash for shell commands (git, python, tests).\n"
-                "   - Use search to find code across files.\n\n"
-                "3. **Complete the task fully.** Do not ask follow-up "
-                "questions — execute the work as described in the prompt."
-            ),
-        }
+        skill_data = item.get("skill")
+        if skill_data:
+            # Structured forensic record naming the skill the LLM ran
+            # under.  The approval row captures the choice at consent
+            # time; this log captures it at exec time so post-incident
+            # search ("which sessions ran skill X?") doesn't have to
+            # cross-walk approval and exec tables.
+            log.info(
+                "task_agent.skill_invoked",
+                skill=skill_data["name"],
+                risk_level=skill_data.get("risk_level", ""),
+                ws_id=self._ws_id,
+            )
+            context = {
+                "model": self.model,
+                "ws_id": self._ws_id,
+                "node_id": self._node_id or "",
+            }
+            persona = _render_template(skill_data["content"], context)
+            if len(persona) > _MAX_SKILL_CONTENT:
+                log.warning(
+                    "skill_content.truncated",
+                    length=len(persona),
+                    agent="task",
+                    skill=skill_data.get("name", ""),
+                )
+                persona = persona[:_MAX_SKILL_CONTENT]
+        else:
+            persona = self._TASK_DEFAULT_IDENTITY
+        identity = persona + "\n\n" + self._TASK_OPERATING_GUIDANCE
         # Task agent gets the base system prompt (tool patterns) merged
         # with its own identity in a single system message. No conversation
         # history — it's an autonomous sub-agent. Merged to avoid
         # multi-system-message errors on models like Qwen.
         base = self._agent_system_messages[0]["content"] if self._agent_system_messages else ""
         agent_messages = [
-            {"role": "system", "content": base + "\n\n" + task_instruction["content"]},
+            {"role": "system", "content": base + "\n\n" + identity},
             {"role": "user", "content": prompt},
         ]
         try:

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -1,12 +1,16 @@
 {
   "name": "task_agent",
-  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, plan_agent, or task_agent — it cannot save memories, search conversation history, set up watches, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description.",
+  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, plan_agent, or task_agent — it cannot save memories, search conversation history, set up watches, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to run the sub-agent under a specific persona; use `skill(action='search', query='...')` to find an appropriate name first. An empty `skill` value is acceptable — the sub-agent runs as a competent general-purpose task helper.",
   "parameters": {
     "type": "object",
     "properties": {
       "prompt": {
         "type": "string",
         "description": "Complete task description for the sub-agent."
+      },
+      "skill": {
+        "type": "string",
+        "description": "Optional skill name. Sub-agent runs with this skill's content as its system identity. Use `skill(action='search', query='...')` to discover available names. An empty value is acceptable and yields a competent general-purpose task helper."
       },
       "model": {
         "type": "string",

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -1,6 +1,6 @@
 {
   "name": "task_agent",
-  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, plan_agent, or task_agent — it cannot save memories, search conversation history, set up watches, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to run the sub-agent under a specific persona; use `skill(action='search', query='...')` to find an appropriate name first. An empty `skill` value is acceptable — the sub-agent runs as a competent general-purpose task helper.",
+  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, plan_agent, or task_agent — it cannot save memories, search conversation history, set up watches, switch skills mid-task, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to run the sub-agent under a specific persona (the skill is fixed at invocation and cannot be changed mid-task); use `skill(action='search', query='...')` to find an appropriate name first. An empty `skill` value is acceptable — the sub-agent runs as a competent general-purpose task helper.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
The task_agent tool now accepts an optional `skill=<name>` argument that loads the named skill's content as the sub-agent's persona, substituting the hardcoded "# Task Agent" identity statement. The operating-guidance numbered list (one-shot, tool-use over narration, no follow-up questions) is layered on top of every persona and always applies — those are sub-agent semantics that a persona should ride on top of, not replace.

## Approval-integrity wiring

Validation lives in `_prepare_task` so the approval surface tells the operator what they're consenting to: the validated skill dict (including content) rides on the item dict from prepare to exec to defeat TOCTOU between consent and execution.

- **Unknown skill** → clean error item with a hint pointing at `skill(action='search')`.
- **Disabled skill** → distinct error so the LLM's recovery path can tell "not found" from "quarantined", mirroring the enabled gate that `_exec_skill(action='load')` and skill-search already apply.
- **High/critical risk_level** → surfaced on the approval header (`, risk: critical`) and `task_agent.high_risk_skill` warning emitted — same signal `_load_skills` emits for session-level skills.

## Forensic traceability

- `_exec_task` emits `task_agent.skill_invoked` info log on the skill branch. The approval row captures the choice at consent time; this log captures it at exec time so post-incident search doesn't have to cross-walk approval and exec tables.
- `_evaluate_intent` func_args projection now includes the skill name — without it, heuristic `arg_pattern` rules targeting a risky persona name on `task_agent` silently no-op and the audit row loses the choice. Mirrors the long-standing `spawn_workstream` projection.

## Test plan

- [x] `ruff check` + `mypy` clean
- [x] 471 tests pass across `test_session.py`, `test_load_skill.py`, `test_tools_schema.py`, `test_judge.py`, `test_coordinator_tools.py`
- [x] New `TestTaskExec` coverage: known/omitted/unknown/disabled/high-risk/normal-risk skill, plus prepare→exec round-trip and the judge-projection regression guards