### PR TITLE
fix(vendor): widen update-vendored-js sweep to catch shared_static/ + .py

### DIFF
--- a/scripts/update-vendored-js.sh
+++ b/scripts/update-vendored-js.sh
@@ -50,11 +50,14 @@ update_refs() {
     local old_pattern="$1"  # e.g. katex-0.16.38
     local new_pattern="$2"  # e.g. katex-0.16.39
 
-    # Find all files with version references (excludes vendored JS and worktrees)
+    # Find all files with version references. Excludes the old versioned vendor
+    # directory itself (about to be rm -rf'd anyway) so we don't bother rewriting
+    # self-references inside it — but does NOT exclude all of shared_static/,
+    # because shared_static/renderer.js loads the vendored libs and needs the bump.
     local files
-    files=$(grep -rl --include='*.toml' --include='*.html' --include='*.js' --include='*.md' \
+    files=$(grep -rl --include='*.toml' --include='*.html' --include='*.js' --include='*.md' --include='*.py' \
         -F "$old_pattern" . \
-        --exclude-dir='.claude' --exclude-dir='node_modules' --exclude-dir='shared_static' \
+        --exclude-dir='.claude' --exclude-dir='node_modules' --exclude-dir="$old_pattern" \
         2>/dev/null || true)
     for f in $files; do
         sed -i "s|${old_pattern}|${new_pattern}|g" "$f"

--- a/tests/test_web_helpers.py
+++ b/tests/test_web_helpers.py
@@ -29,7 +29,7 @@ class TestVersionHtml:
     def test_vendored_katex_skipped(self):
         from turnstone.core.web_helpers import version_html
 
-        html = '<link rel="stylesheet" href="/shared/katex-0.16.44/katex.min.css">'
+        html = '<link rel="stylesheet" href="/shared/katex-0.16.46/katex.min.css">'
         result = version_html(html)
         assert result == html  # unchanged
 
@@ -43,14 +43,14 @@ class TestVersionHtml:
     def test_vendored_mermaid_skipped(self):
         from turnstone.core.web_helpers import version_html
 
-        html = '<script src="/shared/mermaid-11.14.0/mermaid.min.js"></script>'
+        html = '<script src="/shared/mermaid-11.15.0/mermaid.min.js"></script>'
         result = version_html(html)
         assert result == html  # unchanged
 
     def test_vendored_hls_skipped(self):
         from turnstone.core.web_helpers import version_html
 
-        html = '<script src="/shared/hls-1.6.15/hls.min.js"></script>'
+        html = '<script src="/shared/hls-1.6.16/hls.min.js"></script>'
         result = version_html(html)
         assert result == html  # unchanged
 
@@ -76,7 +76,7 @@ class TestVersionHtml:
 
         html = (
             '<link rel="stylesheet" href="/shared/base.css">\n'
-            '<link rel="stylesheet" href="/shared/katex-0.16.44/katex.min.css">\n'
+            '<link rel="stylesheet" href="/shared/katex-0.16.46/katex.min.css">\n'
             '<link rel="stylesheet" href="/static/style.css">\n'
             '<script src="/shared/utils.js"></script>\n'
             '<script src="/shared/hljs-11.11.1/highlight.min.js"></script>\n'
@@ -88,7 +88,7 @@ class TestVersionHtml:
         assert f'/shared/utils.js?v={__version__}"' in result
         assert f'/static/app.js?v={__version__}"' in result
         # Vendored libs unchanged
-        assert '/shared/katex-0.16.44/katex.min.css"' in result
+        assert '/shared/katex-0.16.46/katex.min.css"' in result
         assert '/shared/hljs-11.11.1/highlight.min.js"' in result
 
     def test_version_matches_package(self):

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -869,7 +869,7 @@ function _loadMermaid(callback) {
   if (_mermaidState === "loading") return;
   _mermaidState = "loading";
   var script = document.createElement("script");
-  script.src = "/shared/mermaid-11.14.0/mermaid.min.js";
+  script.src = "/shared/mermaid-11.15.0/mermaid.min.js";
   script.onload = function () {
     _initMermaid();
     _mermaidState = "ready";


### PR DESCRIPTION
## Summary

- `scripts/update-vendored-js.sh` excluded all of `shared_static/` from its grep-and-replace pass — meant to skip self-references inside vendored libs, but it also hid first-party `shared_static/renderer.js` which *loads* those libs. As a result, `renderer.js` has pinned `mermaid-11.14.0` across every renovate bump since #426, and `tests/test_web_helpers.py` fixtures were never updated either (the include list also omitted `*.py`).
- Replace the broad `shared_static` exclude with `"$old_pattern"` (the specific old versioned vendor dir — about to be `rm -rf`'d next anyway). Add `*.py` to includes.
- Bump `renderer.js` to mermaid-11.15.0 to repair the live 404 introduced when the renovate bot deleted `mermaid-11.14.0/mermaid.min.js`.
- Refresh the test fixtures to current vendor versions so they stop drifting.

Verified the new grep query catches all three call sites:
```
$ grep -rl --include='*.toml' ... -F "mermaid-11.15.0" . --exclude-dir="mermaid-11.15.0"
pyproject.toml
tests/test_web_helpers.py
turnstone/shared_static/renderer.js
```

This wants to land on `stable/1.5` too — will cherry-pick after merge.

## Test plan

- [x] `pytest tests/test_web_helpers.py` — 13 passed
- [x] `ruff check` + `ruff format --check` on the test file
- [x] `bash -n scripts/update-vendored-js.sh`
- [ ] Manually verify the live mermaid 404 is gone after deploy