### PR TITLE
fix(judge): explicit user_decision vocabulary (no more empty strings)

### DIFF
--- a/tests/test_judge_storage.py
+++ b/tests/test_judge_storage.py
@@ -51,7 +51,11 @@ class TestIntentVerdictCRUD:
         assert v["tier"] == "heuristic"
         assert v["judge_model"] == ""
         assert v["latency_ms"] == 2
-        assert v["user_decision"] == ""
+        # ``user_decision`` defaults to ``"pending"`` (not the empty
+        # string) so an audit reader can distinguish in-flight rows
+        # from pre-convention legacy rows that carry the column's
+        # server_default of ``""``.
+        assert v["user_decision"] == "pending"
         assert "created" in v
 
     def test_get_nonexistent(self, db):

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -353,6 +353,192 @@ def test_resolve_approval_stamps_all_pending_verdicts() -> None:
 
 
 # ---------------------------------------------------------------------------
+# user_decision value space — pending / approved / denied / timeout
+# / auto-approve reasons (policy / blanket / skill / always / auto_approve_tools).
+# Guards the "user_decision is never empty for new rows" invariant.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_approval_timeout_kwarg_writes_timeout_value() -> None:
+    """``resolve_approval(False, ..., timeout=True)`` writes
+    ``user_decision="timeout"`` so the audit trail can distinguish a
+    passive timeout expiry from an active user denial — the feedback
+    string used to carry this distinction but the column alone could not."""
+    storage = MagicMock()
+    ui = _make_ui()
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
+    with _patch_get_storage(storage):
+        ui.resolve_approval(False, "expired", timeout=True)
+    storage.update_intent_verdict.assert_any_call("v1", user_decision="timeout")
+    assert ui._last_verdict_decision == "timeout"
+
+
+def test_resolve_approval_timeout_with_approved_raises() -> None:
+    """``timeout=True`` is mutually exclusive with ``approved=True`` —
+    the combination would land a row whose audit column says
+    ``"timeout"`` while the SSE event reports ``approved=True``. Fail
+    loud so the inconsistency can't ship silently."""
+    import pytest
+
+    ui = _make_ui()
+    with pytest.raises(ValueError, match="timeout"):
+        ui.resolve_approval(True, timeout=True)
+
+
+def test_record_auto_approves_populates_reason_lookup() -> None:
+    """``_record_auto_approves`` must seed
+    ``_auto_approve_reasons[call_id]`` with the per-item reason so a
+    late-arriving LLM judge verdict can recover the auto-approve
+    reason via ``on_intent_verdict``."""
+    storage = MagicMock()
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c-policy",
+            "func_name": "bash",
+            "auto_approved": True,
+            "auto_approve_reason": "policy",
+        },
+        {
+            "call_id": "c-blanket",
+            "func_name": "list_workstreams",
+            "auto_approved": True,
+            "auto_approve_reason": "blanket",
+        },
+    ]
+    with _patch_get_storage(storage):
+        ui._record_auto_approves(items)
+    assert "c-policy" in ui._auto_approve_reasons
+    assert "c-blanket" in ui._auto_approve_reasons
+    assert ui._auto_approve_reasons["c-policy"][0] == "policy"
+    assert ui._auto_approve_reasons["c-blanket"][0] == "blanket"
+
+
+def test_on_intent_verdict_consumes_auto_approve_reason() -> None:
+    """A late LLM verdict for a previously auto-approved call_id picks
+    up the reason from ``_auto_approve_reasons``, stamps it on the
+    verdict before persist, and pops the entry so re-use isn't
+    possible. Closes the misdiagnosis bug where auto-approved tools
+    landed verdict rows with ``user_decision=""``."""
+    storage = MagicMock()
+    ui = _make_ui()
+    ui._auto_approve_reasons["c-x"] = ("auto_approve_tools", 0.0)
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict({"verdict_id": "v-x", "call_id": "c-x"})
+    storage.create_intent_verdict.assert_called_once()
+    kwargs = storage.create_intent_verdict.call_args.kwargs
+    assert kwargs["user_decision"] == "auto_approve_tools"
+    # Consumed on read so the same call_id can't double-stamp later.
+    assert "c-x" not in ui._auto_approve_reasons
+    # Auto-stamped verdicts must NOT join _pending_verdicts — the
+    # row's final decision is already set; appending would let a
+    # later resolve_approval overwrite the auto-reason with the
+    # manual decision (real audit-trail clobber bug).
+    assert ui._pending_verdicts == []
+
+
+def test_on_intent_verdict_auto_reason_survives_resolve_cycle() -> None:
+    """Mixed-batch case: one tool was auto-approved (policy), another
+    needs manual approval. The LLM judge fires for the auto-approved
+    sibling DURING the manual-approval wait. The verdict must land
+    with ``user_decision="policy"`` and stay that way even after
+    ``resolve_approval`` fires for the pending sibling — the prior
+    bug was that the auto-stamped row got overwritten with
+    ``"approved"``/``"denied"`` by the resolve path."""
+    storage = MagicMock()
+    ui = _make_ui()
+    ui._auto_approve_reasons["c-auto"] = ("policy", 0.0)
+    with _patch_get_storage(storage):
+        # LLM verdict fires for the auto-approved sibling.
+        ui.on_intent_verdict({"verdict_id": "v-auto", "call_id": "c-auto"})
+        # Now the pending sibling gets a verdict + manual resolve.
+        ui.on_intent_verdict({"verdict_id": "v-pending", "call_id": "c-pending"})
+        ui.resolve_approval(True, "looks good")
+    # Only the pending verdict should be UPDATEd to "approved" — the
+    # auto-stamped one stays "policy" via its INSERT.
+    update_calls = {
+        c.args[0]: c.kwargs.get("user_decision")
+        for c in storage.update_intent_verdict.call_args_list
+    }
+    assert update_calls == {"v-pending": "approved"}
+    # The auto verdict's INSERT carried the policy reason.
+    insert_calls = {
+        c.kwargs["verdict_id"]: c.kwargs["user_decision"]
+        for c in storage.create_intent_verdict.call_args_list
+    }
+    assert insert_calls["v-auto"] == "policy"
+    assert insert_calls["v-pending"] == "pending"
+
+
+def test_persist_auto_approved_heuristic_verdicts_stamps_reason() -> None:
+    """The auto-approve early-return branches in ``approve_tools`` used
+    to drop heuristic verdicts on the floor — auditors couldn't tell
+    whether the judge ran or the call was simply silently auto-approved.
+    ``_persist_auto_approved_heuristic_verdicts`` closes that gap and
+    stamps each verdict with the item's reason."""
+    storage = MagicMock()
+    ui = _make_ui()
+    items = [
+        {
+            "call_id": "c-1",
+            "auto_approved": True,
+            "auto_approve_reason": "blanket",
+            "_heuristic_verdict": {
+                "verdict_id": "v-1",
+                "call_id": "c-1",
+                "risk_level": "low",
+                "recommendation": "review",
+            },
+        },
+        # No _heuristic_verdict — skipped (judge didn't run for this item).
+        {"call_id": "c-2", "auto_approved": True, "auto_approve_reason": "blanket"},
+        # Not auto_approved — skipped (this helper only handles auto-approved).
+        {
+            "call_id": "c-3",
+            "_heuristic_verdict": {"verdict_id": "v-3", "call_id": "c-3"},
+        },
+    ]
+    with _patch_get_storage(storage):
+        ui._persist_auto_approved_heuristic_verdicts(items)
+    storage.create_intent_verdicts_bulk.assert_called_once()
+    rows = storage.create_intent_verdicts_bulk.call_args.args[0]
+    assert len(rows) == 1
+    assert rows[0]["verdict_id"] == "v-1"
+    assert rows[0]["user_decision"] == "blanket"
+
+
+def test_auto_approve_reasons_ttl_prune_drops_stale_entries() -> None:
+    """Lazy TTL eviction at write time: entries older than
+    ``_AUTO_APPROVE_REASON_TTL`` are pruned on the next
+    ``_record_auto_approves`` call. Without this, a session with the
+    LLM judge disabled would accumulate entries that never get
+    consumed."""
+    import time as time_module
+
+    storage = MagicMock()
+    ui = _make_ui()
+    # Seed two stale entries (well past the TTL).
+    stale_ts = time_module.time() - ui._AUTO_APPROVE_REASON_TTL - 30.0
+    ui._auto_approve_reasons["c-stale-1"] = ("policy", stale_ts)
+    ui._auto_approve_reasons["c-stale-2"] = ("blanket", stale_ts)
+    items = [
+        {
+            "call_id": "c-fresh",
+            "auto_approved": True,
+            "auto_approve_reason": "skill",
+            "func_name": "bash",
+        }
+    ]
+    with _patch_get_storage(storage):
+        ui._record_auto_approves(items)
+    # Stale entries pruned; only the fresh one remains.
+    assert "c-stale-1" not in ui._auto_approve_reasons
+    assert "c-stale-2" not in ui._auto_approve_reasons
+    assert "c-fresh" in ui._auto_approve_reasons
+
+
+# ---------------------------------------------------------------------------
 # Output guard persistence
 # ---------------------------------------------------------------------------
 

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -179,6 +179,24 @@ class SessionUIBase:
         # ``/dashboard`` payload.  Capped so a long-running skill
         # workstream can't fill the live block with stale rows.
         self._recent_auto_approvals: list[dict[str, Any]] = []
+        # Maps ``call_id`` → ``(auto_approve_reason, inserted_ts)`` for
+        # verdicts that arrive AFTER ``approve_tools`` already returned.
+        # The LLM judge tier is asynchronous: ``on_intent_verdict`` can
+        # fire seconds later for a tool that ``approve_tools``
+        # short-circuited via one of the auto-approve branches.  Without
+        # this lookup the late-arriving LLM verdict lands with
+        # ``user_decision="pending"`` and stays that way forever (no
+        # ``resolve_approval`` cycle on the auto-approve path).
+        #
+        # Lifetime is bounded by ``_AUTO_APPROVE_REASON_TTL`` rather
+        # than by a count-cap or by session lifetime: a fixed cap
+        # would silently break the fix on the (N+1)th in-flight
+        # auto-approve; "evict on consume" alone would leak entries
+        # whenever the LLM judge is disabled (no ``on_intent_verdict``
+        # ever fires to drain them).  TTL means entries clear lazily
+        # on the next ``_record_auto_approves`` write whether or not
+        # the LLM judge tier is active.  Guarded by ``_ws_lock``.
+        self._auto_approve_reasons: dict[str, tuple[str, float]] = {}
         # Foreground gate — used by the CLI's WorkstreamTerminalUI to
         # block output when the workstream is in the background.
         # Starts set so non-CLI UIs can skip any explicit management.
@@ -367,6 +385,7 @@ class SessionUIBase:
         feedback: str | None = None,
         *,
         always: bool = False,
+        timeout: bool = False,
     ) -> None:
         """Unblock a pending approval with the caller's decision.
 
@@ -383,8 +402,22 @@ class SessionUIBase:
         can label their resolved-status pill correctly).  Keyword-only
         + default ``False`` so the four pre-existing callers (cancel,
         timeout, channel adapters) compile unchanged.
+
+        ``timeout`` flips the persisted ``user_decision`` from
+        ``"denied"`` to ``"timeout"`` so the audit trail can
+        distinguish an active user denial from a passive
+        approval-timeout expiry — the feedback string carries the
+        same information today but operators querying on the
+        ``user_decision`` column alone could not tell them apart.
+        Mutually exclusive with ``approved=True`` (a timeout is a
+        passive denial); the combination raises ``ValueError`` so a
+        future caller can't accidentally ship a row whose audit
+        column says ``"timeout"`` while the SSE event reports
+        ``approved=True``.
         """
-        decision_str = "approved" if approved else "denied"
+        if timeout and approved:
+            raise ValueError("resolve_approval: timeout=True is incompatible with approved=True")
+        decision_str = "timeout" if timeout else ("approved" if approved else "denied")
         # Swap-and-clear + set decision under lock to avoid racing
         # with the daemon judge thread's ``on_intent_verdict`` appends.
         with self._ws_lock:
@@ -544,8 +577,15 @@ class SessionUIBase:
                                 # the early return — the fall-through
                                 # branch never runs on this path, so without
                                 # this the policy bypass is invisible to
-                                # /dashboard + audit.
+                                # /dashboard + audit.  ``_record_auto_approves``
+                                # MUST run before ``_persist_auto_approved_*``
+                                # so the call_id → reason lookup map is
+                                # populated before the heuristic INSERTs go
+                                # in: otherwise an LLM judge verdict firing
+                                # in the gap lands with ``user_decision=
+                                # "pending"`` and stays that way.
                                 self._record_auto_approves(items)
+                                self._persist_auto_approved_heuristic_verdicts(items)
                                 self._enqueue(
                                     {
                                         "type": "tool_info",
@@ -608,7 +648,12 @@ class SessionUIBase:
                 self._ws_current_activity = f"⚙ {label}: {preview}" if label else ""
                 self._ws_activity_state = "tool" if label else ""
             self._broadcast_activity()
+            # ``_record_auto_approves`` runs FIRST so the call_id → reason
+            # lookup is populated before the heuristic INSERT can race
+            # against a concurrent LLM judge verdict — see the matching
+            # comment on the policy-deny branch above.
             self._record_auto_approves(items)
+            self._persist_auto_approved_heuristic_verdicts(items)
             self._enqueue({"type": "tool_info", "items": self._serialize_approval_items(items)})
             return True, None
 
@@ -628,19 +673,34 @@ class SessionUIBase:
         # commit instead of N (was visible as time-to-render-prompt
         # latency for fan-out turns); the per-item Prometheus call stays
         # in the loop because it's a lock+increment, not a DB round-trip.
+        #
+        # ``user_decision`` is stamped per-verdict here so the row lands
+        # with a meaningful value at insert: auto-approved items
+        # (mixed-path case: policy allowed some, others still prompt)
+        # carry their auto_approve_reason directly; items still pending
+        # operator decision carry ``"pending"`` and get updated by
+        # ``resolve_approval`` on close.  ``_pending_verdicts`` only
+        # tracks the latter — auto-approved verdicts are already final.
         heuristic_verdicts: list[dict[str, Any]] = []
+        pending_verdicts: list[dict[str, Any]] = []
         for item in items:
             hv = item.get("_heuristic_verdict")
-            if hv:
-                heuristic_verdicts.append(hv)
-                # Subclass-overridden Prometheus surface: WebUI feeds
-                # the per-node /metrics endpoint, ConsoleCoordinatorUI
-                # feeds the console's /metrics endpoint via ConsoleMetrics.
-                self._record_judge_metric(hv)
+            if not hv:
+                continue
+            if item.get("auto_approved"):
+                hv["user_decision"] = item.get("auto_approve_reason", "") or "pending"
+            else:
+                hv["user_decision"] = "pending"
+                pending_verdicts.append(hv)
+            heuristic_verdicts.append(hv)
+            # Subclass-overridden Prometheus surface: WebUI feeds
+            # the per-node /metrics endpoint, ConsoleCoordinatorUI
+            # feeds the console's /metrics endpoint via ConsoleMetrics.
+            self._record_judge_metric(hv)
         self._persist_intent_verdicts_bulk(heuristic_verdicts, default_tier="heuristic")
 
         with self._ws_lock:
-            self._pending_verdicts = heuristic_verdicts
+            self._pending_verdicts = pending_verdicts
 
         # Record any items the policy block already auto-approved
         # before falling through to the prompt — without this the
@@ -676,8 +736,14 @@ class SessionUIBase:
         if not self._approval_event.wait(timeout=self._APPROVAL_WAIT_TIMEOUT):
             # Approval timed out (e.g., user disconnected). Deny via
             # resolve_approval so verdicts and state are updated consistently.
+            # Feedback string derives from ``_APPROVAL_WAIT_TIMEOUT`` so the
+            # text follows the constant if the timeout knob moves.
             log.warning("Approval timed out for ws_id=%s", self.ws_id)
-            self.resolve_approval(False, "Approval timed out after 1 hour")
+            self.resolve_approval(
+                False,
+                f"Approval timed out after {self._APPROVAL_WAIT_TIMEOUT}s",
+                timeout=True,
+            )
         self._pending_approval = None
         approved, feedback = self._approval_result
 
@@ -714,8 +780,17 @@ class SessionUIBase:
         ``user_decision`` immediately (if the approval already
         resolved) or parks the verdict in ``_pending_verdicts`` for
         ``resolve_approval`` to stamp on close.
+
+        When the verdict arrives for a call_id that ``approve_tools``
+        already auto-approved (the LLM judge is async and can fire
+        seconds after the auto-approve path returned), stamp the
+        ``auto_approve_reason`` onto the verdict before persist so
+        the row lands with a meaningful ``user_decision`` instead of
+        the default ``"pending"`` (which would never be updated for
+        this code path).
         """
         call_id = verdict.get("call_id", "")
+        auto_reason = ""
         if call_id:
             with self._ws_lock:
                 if (
@@ -725,6 +800,14 @@ class SessionUIBase:
                     oldest_key = next(iter(self._llm_verdicts))
                     del self._llm_verdicts[oldest_key]
                 self._llm_verdicts[call_id] = verdict
+                # Pop (not get) — once consumed the entry isn't useful
+                # again; TTL pruning at the writer side keeps the
+                # never-consumed case bounded too.
+                entry = self._auto_approve_reasons.pop(call_id, None)
+                if entry is not None:
+                    auto_reason = entry[0]
+            if auto_reason:
+                verdict["user_decision"] = auto_reason
         self._enqueue({"type": "intent_verdict", **verdict})
         # Kind-specific cross-stream broadcast — ConsoleCoordinatorUI
         # overrides to push onto the cluster bus so a coord parent's
@@ -743,6 +826,17 @@ class SessionUIBase:
         # WRONG decision.  Storage UPDATE happens outside the lock
         # on the already-resolved path — no contention with other
         # ws-scoped work.
+        # If ``auto_reason`` was stamped above, the verdict already
+        # carries the final ``user_decision`` for this row.  Neither
+        # path below applies: appending to ``_pending_verdicts`` would
+        # cause ``resolve_approval`` (on the manual-approval sibling
+        # in a mixed batch) to overwrite the auto-reason with
+        # ``"approved"``/``"denied"``/``"timeout"``; the
+        # ``_persist_verdict_decisions`` immediate-stamp path would
+        # overwrite it the same way from a prior cycle's decision.
+        # Skip both so the audit trail keeps the auto-approve reason.
+        if auto_reason:
+            return
         with self._ws_lock:
             decision = self._last_verdict_decision
             if not decision:
@@ -811,6 +905,7 @@ class SessionUIBase:
                     "tier": v.get("tier", default_tier),
                     "judge_model": v.get("judge_model", ""),
                     "latency_ms": v.get("latency_ms", 0),
+                    "user_decision": v.get("user_decision", "pending"),
                 }
                 for v in verdicts
             ]
@@ -855,6 +950,7 @@ class SessionUIBase:
                 tier=verdict.get("tier", default_tier),
                 judge_model=verdict.get("judge_model", ""),
                 latency_ms=verdict.get("latency_ms", 0),
+                user_decision=verdict.get("user_decision", "pending"),
             )
         except Exception:
             log.debug("Failed to persist intent verdict", exc_info=True)
@@ -955,6 +1051,14 @@ class SessionUIBase:
     # workstreams that auto-approve dozens of tool calls per turn.
     _RECENT_AUTO_APPROVALS_MAX = 10
 
+    # TTL on the call_id → auto_approve_reason map.  Sized to comfortably
+    # cover the LLM judge's worst-case latency (cold start + a slow model
+    # + queue depth).  Pruning happens lazily at write time so the cost
+    # is paid only on the next auto-approve event; a session that goes
+    # quiet after auto-approving never pays the prune cost at all but
+    # the resident-set is also tiny.
+    _AUTO_APPROVE_REASON_TTL = 60.0
+
     @staticmethod
     def _serialize_approval_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Project each item to the wire shape the SSE event payload uses.
@@ -1026,6 +1130,38 @@ class SessionUIBase:
             else:
                 it["auto_approve_reason"] = reason
 
+    def _persist_auto_approved_heuristic_verdicts(self, items: list[dict[str, Any]]) -> None:
+        """Persist heuristic verdicts for items the auto-approve path resolved.
+
+        The manual-approval block at the bottom of ``approve_tools``
+        handles its own verdict persistence (and stamps
+        ``user_decision`` per item — auto-approved items in a
+        mixed-path batch carry their reason, pending items carry
+        ``"pending"``).  The auto-approve early-return branches
+        (policy-allow-with-deny, blanket flag, auto_approve_tools
+        match) used to drop heuristic verdicts on the floor — an
+        operator querying ``user_decision`` for the auto-approve
+        reason would find no row at all, conflating "we auto-approved
+        silently" with "the judge didn't run".  This helper closes
+        that gap: walk ``items``, persist each auto-approved verdict
+        with its reason stamped, and fan a metric row per verdict.
+        Safe to call with empty items.
+        """
+        if not items:
+            return
+        verdicts: list[dict[str, Any]] = []
+        for it in items:
+            if not it.get("auto_approved"):
+                continue
+            hv = it.get("_heuristic_verdict")
+            if not hv:
+                continue
+            hv["user_decision"] = it.get("auto_approve_reason", "") or "pending"
+            verdicts.append(hv)
+            self._record_judge_metric(hv)
+        if verdicts:
+            self._persist_intent_verdicts_bulk(verdicts, default_tier="heuristic")
+
     def _record_auto_approves(self, items: list[dict[str, Any]]) -> None:
         """Append auto-approved items to the per-ws ring buffer + audit log.
 
@@ -1062,6 +1198,32 @@ class SessionUIBase:
             overflow = len(self._recent_auto_approvals) - self._RECENT_AUTO_APPROVALS_MAX
             if overflow > 0:
                 self._recent_auto_approvals = self._recent_auto_approvals[overflow:]
+            # Mirror call_id → reason into the lookup map so a late
+            # ``on_intent_verdict`` (LLM judge tier) can stamp the
+            # right ``user_decision`` instead of leaving the verdict
+            # stuck as ``"pending"`` forever.  Prune expired entries
+            # first (lazy TTL eviction) so a session with the LLM
+            # judge disabled doesn't accumulate entries that will
+            # never be consumed.  Skip the rebuild when the map is
+            # empty or all entries are still fresh — the common case
+            # on a healthy LLM-judge-enabled session where entries
+            # drain via ``on_intent_verdict.pop`` within the TTL.
+            cutoff = ts - self._AUTO_APPROVE_REASON_TTL
+            if self._auto_approve_reasons and any(
+                ins_ts < cutoff for _, ins_ts in self._auto_approve_reasons.values()
+            ):
+                self._auto_approve_reasons = {
+                    cid: (reason, ins_ts)
+                    for cid, (reason, ins_ts) in self._auto_approve_reasons.items()
+                    if ins_ts >= cutoff
+                }
+            for entry in appended:
+                cid = entry["call_id"]
+                if cid:
+                    self._auto_approve_reasons[cid] = (
+                        entry["auto_approve_reason"],
+                        ts,
+                    )
         # Audit emission — one row per ``approve_tools`` call (not one
         # per item) keeps the audit table from blowing up on
         # tool-heavy turns while still capturing every tool name +

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -3362,6 +3362,7 @@ class PostgreSQLBackend:
         tier: str,
         judge_model: str,
         latency_ms: int,
+        user_decision: str = "pending",
     ) -> None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
@@ -3382,6 +3383,7 @@ class PostgreSQLBackend:
                     "tier": tier,
                     "judge_model": judge_model,
                     "latency_ms": latency_ms,
+                    "user_decision": user_decision,
                     "created": now,
                 },
             )
@@ -3407,6 +3409,7 @@ class PostgreSQLBackend:
                 "tier": v.get("tier", "heuristic"),
                 "judge_model": v.get("judge_model", ""),
                 "latency_ms": v.get("latency_ms", 0),
+                "user_decision": v.get("user_decision", "pending"),
                 "created": now,
             }
             for v in verdicts

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1607,8 +1607,20 @@ class StorageBackend(Protocol):
         tier: str,
         judge_model: str,
         latency_ms: int,
+        user_decision: str = "pending",
     ) -> None:
-        """Record an intent validation verdict."""
+        """Record an intent validation verdict.
+
+        ``user_decision`` defaults to ``"pending"`` rather than ``""``
+        so an audit reader can distinguish "in-flight" rows from
+        legacy pre-fix rows (which carry ``""`` from the column's
+        server_default and indicate "convention not yet established
+        when this row was written"). Resolution writers
+        (:meth:`update_intent_verdict`) later overwrite the field with
+        ``"approved"`` / ``"denied"`` / ``"timeout"`` (user-driven) or
+        ``"policy"`` / ``"blanket"`` / ``"auto_approve_tools"``
+        (auto-approve reason, mirroring :class:`AutoApproveReason`).
+        """
         ...
 
     def create_intent_verdicts_bulk(self, verdicts: list[dict[str, Any]]) -> None:
@@ -1618,10 +1630,12 @@ class StorageBackend(Protocol):
         (``verdict_id`` / ``ws_id`` / ``call_id`` / ``func_name`` /
         ``func_args`` / ``intent_summary`` / ``risk_level`` /
         ``confidence`` / ``recommendation`` / ``reasoning`` / ``evidence`` /
-        ``tier`` / ``judge_model`` / ``latency_ms``). Used by the
-        synchronous heuristic-verdict persistence loop in
-        ``approve_tools`` so a tool-heavy turn doesn't pay N×commit
-        latency before the approval prompt renders.
+        ``tier`` / ``judge_model`` / ``latency_ms`` /
+        ``user_decision``). ``user_decision`` defaults to ``"pending"``
+        when absent — see :meth:`create_intent_verdict` for the
+        vocabulary. Used by the synchronous heuristic-verdict
+        persistence loop in ``approve_tools`` so a tool-heavy turn
+        doesn't pay N×commit latency before the approval prompt renders.
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -3524,6 +3524,7 @@ class SQLiteBackend:
         tier: str,
         judge_model: str,
         latency_ms: int,
+        user_decision: str = "pending",
     ) -> None:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
@@ -3544,6 +3545,7 @@ class SQLiteBackend:
                     "tier": tier,
                     "judge_model": judge_model,
                     "latency_ms": latency_ms,
+                    "user_decision": user_decision,
                     "created": now,
                 },
             )
@@ -3569,6 +3571,7 @@ class SQLiteBackend:
                 "tier": v.get("tier", "heuristic"),
                 "judge_model": v.get("judge_model", ""),
                 "latency_ms": v.get("latency_ms", 0),
+                "user_decision": v.get("user_decision", "pending"),
                 "created": now,
             }
             for v in verdicts


### PR DESCRIPTION
## Summary

Auto-approved tool calls left `intent_verdict` rows with `user_decision=""`, indistinguishable from rows still pending manual review. A real misdiagnosis incident traced to this: a coord with `recommendation="review"` and `user_decision=""` was read as "stuck waiting for approval" when in fact the tools had been auto-approved and the child was running normally.

## New `user_decision` vocabulary

Column `server_default` stays `""` so pre-fix legacy rows are still distinguishable as legacy.

| Value | Source path |
|---|---|
| `pending` | At insert, before any resolution |
| `approved` / `denied` | Manual user resolution via `resolve_approval` |
| `timeout` | Approval-event timeout (split from `denied`) |
| `policy` / `blanket` / `skill` / `always` / `auto_approve_tools` | Auto-approve reasons (mirror `AutoApproveReason`) |

## What changed

- **Storage layer**: `create_intent_verdict` gains a `user_decision: str = "pending"` kwarg; bulk path reads it from each row dict. No migration — only the convention is new.
- **`approve_tools`**: heuristic verdicts on the two auto-approve early-return branches are now persisted with `user_decision=<reason>` (previously dropped on the floor). Mixed-path manual-approval persist stamps each item per its `auto_approved` state.
- **`on_intent_verdict`**: late LLM verdicts for already-auto-approved call_ids consume from a TTL-pruned `_auto_approve_reasons` map (lazy 60s prune at write time — no fixed count cap that could silently regress the fix on the N+1th auto-approve).
- **`resolve_approval`**: new `timeout: bool = False` kwarg writes `"timeout"` instead of `"denied"`. `timeout=True` with `approved=True` raises `ValueError` so the split-brain shape is unrepresentable.
- **Timeout caller**: feedback string now derives from `_APPROVAL_WAIT_TIMEOUT` (was hardcoded `"1 hour"`).

## Review-found bugs (all fixed in this PR)

- `on_intent_verdict` early-returns when the verdict carries an auto_reason — prevents a later `resolve_approval` on a mixed batch from overwriting the auto-stamped row with `approved`/`denied`.
- `_record_auto_approves` runs BEFORE `_persist_auto_approved_heuristic_verdicts` so the lookup map is populated before any concurrent LLM verdict can race past it.

## Test plan

- [x] `pytest tests/test_judge.py tests/test_judge_storage.py tests/test_session_ui_base.py tests/test_session.py tests/test_coord_ui_approve_tools.py tests/test_workstream_endpoints.py` — 503 pass
- [x] Full suite: 6383 passed, 10 skipped
- [x] `ruff check` + `mypy` clean
- [x] 7 new direct tests covering timeout split, auto-approve heuristic persistence, late LLM verdict reason-stamping, TTL prune, and the timeout/approved split-brain guard
- [ ] Observe a real session with mixed auto-approve + manual approval — confirm audit rows show the right `user_decision` per row

## Performance

Auto-approve workflows now pay one extra bulk-insert commit per `approve_tools` turn (heuristic verdict persistence on the early-return branches). One commit per batch, not per item; helper short-circuits when no items carry `_heuristic_verdict`.