### PR TITLE
chore(console): admin.js innerHTML cleanup + lint expansion

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -238,21 +238,26 @@ def test_replay_renders_user_interjection_advisory_after_tool_block() -> None:
 _INDEX_HTML = Path(__file__).resolve().parent.parent / "turnstone/ui/static/index.html"
 _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style.css"
 
-# Pins the absence of unsafe DOM-write sinks. Spell the property names
-# out of literal concatenation so the tooling that flags occurrences in
-# code strings doesn't false-positive on the test source.
+# Pins the absence of unsafe DOM-write and dynamic-code sinks.  Spell
+# the property/identifier names out of literal string concatenation so
+# the tooling that flags occurrences in code strings doesn't
+# false-positive on the test source.
 #
-# The pattern catches:
-# * plain assignment — ``el.innerHTML = X``, ``el.outerHTML = X``
-# * concat-assignment — ``el.innerHTML += X``, ``el.outerHTML += X``
-#   (``\+?`` makes the ``+`` optional so a future regression that
-#   switches sinks to concat-assignment doesn't bypass the lint)
-# * doc-write — ``document.write(...)``
+# The pattern catches each of:
+#   * plain HTML-assignment   — inner/outer-HTML to a value
+#   * concat HTML-assignment  — inner/outer-HTML += value (the
+#     ``\+?`` makes the ``+`` optional so a regression switching the
+#     sink to concat-assignment doesn't bypass the lint)
+#   * legacy doc-write        — ``document.write(...)``
+#   * string-to-code helpers  — the JS ``ev`` + ``al`` builtin, the
+#     dynamic-Function constructor (``new`` + ``Function(...)``), and
+#     ``setTimeout``/``setInterval`` whose first arg is a string
+#     literal (function-first-arg forms remain unflagged)
 #
-# The trailing ``(?!=)`` negative-lookahead excludes ``===`` / ``==``
-# reads — only the assignment / call sinks are flagged.
+# The trailing ``(?!=)`` negative-lookahead on the HTML assignments
+# excludes ``===`` / ``==`` reads — only the write sinks are flagged.
 #
-# The scan in ``test_no_unsafe_dom_writes_in_static_assets`` runs the
+# The scan in ``test_no_unsafe_code_sinks_in_static_assets`` runs the
 # regex over the *entire file body* (not line-by-line) so that ``\s*``
 # can span newlines and catch multi-line sinks like
 # ``el.innerHTML\n  = X``.
@@ -260,10 +265,16 @@ _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style
 # ``insertAdjacent`` + HTML is *not* covered here because two existing
 # call sites (``app.js:1287`` and ``app.js:1538``) consume
 # ``renderVerdictBadge`` HTML output; broadening the lint would require
-# cleaning that helper first.  Tracked as a follow-up to the DOM-cleanup
-# PR.
-_UNSAFE_DOM_WRITE_RE = re.compile(
-    r"\.(?:inner|outer)" + r"HTML\s*\+?=(?!=)" + r"|document\.write\("
+# cleaning that helper first.  Tracked as a follow-up.
+_UNSAFE_CODE_SINK_RE = re.compile(
+    r"\.(?:inner|outer)"
+    + r"HTML\s*\+?=(?!=)"
+    + r"|document\.write\("
+    + r"|\b"
+    + r"eval\s*\("
+    + r"|\bnew\s+"
+    + r"Function\s*\("
+    + r"|\bset(?:Timeout|Interval)\s*\(\s*['\"`]"
 )
 
 
@@ -367,11 +378,13 @@ _DOM_WRITE_LINT_TARGETS = [
     _DOM_WRITE_LINT_TARGETS,
     ids=[label for label, _ in _DOM_WRITE_LINT_TARGETS],
 )
-def test_no_unsafe_dom_writes_in_static_assets(label: str, path: Path) -> None:
-    """Whole-file pin: no direct DOM-write sinks
-    (``inner``/``outer``-HTML assignment, legacy doc-write) in any of
-    the static JS bundles that render LLM output, tool results,
-    operator-supplied data, or user input.
+def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
+    """Whole-file pin: no direct DOM-write *or* dynamic-code sinks
+    in any of the static JS bundles that render LLM output, tool
+    results, operator-supplied data, or user input.  Covers
+    inner/outer-HTML assignment (plain and concat), legacy doc-write,
+    string-eval, dynamic-Function constructor, and string-first-arg
+    timer scheduling.
 
     Two distinct cleanup postures across the targets:
 
@@ -392,10 +405,14 @@ def test_no_unsafe_dom_writes_in_static_assets(label: str, path: Path) -> None:
     ``console/static/governance.js`` and ``console/static/app.js``
     remain pending follow-ups — same posture as admin.js once cleaned.
 
-    ``insertAdjacent`` + HTML is deliberately *not* covered yet; two
-    existing app.js sites (the verdict-badge writers at lines 1287 and
-    1538) consume the HTML-string output of ``renderVerdictBadge``, so
-    broadening the lint requires cleaning that helper first.
+    The regex covers inner/outer-HTML assignment (plain and
+    concat-assignment), legacy doc-write, and the dynamic-code
+    constructors (string-eval, dynamic-Function, string-first-arg
+    timer scheduling).  ``insertAdjacent`` + HTML is deliberately
+    *not* covered yet; two existing app.js sites (the verdict-badge
+    writers at lines 1287 and 1538) consume the HTML-string output of
+    ``renderVerdictBadge``, so broadening the lint requires cleaning
+    that helper first.
 
     Parametrized so each target is its own pytest case — a failure on
     one file is attributed precisely without masking offenders in the
@@ -408,11 +425,11 @@ def test_no_unsafe_dom_writes_in_static_assets(label: str, path: Path) -> None:
     body = path.read_text(encoding="utf-8")
     lines = body.splitlines()
     offenders: list[tuple[int, str]] = []
-    for m in _UNSAFE_DOM_WRITE_RE.finditer(body):
+    for m in _UNSAFE_CODE_SINK_RE.finditer(body):
         line_no = body.count("\n", 0, m.start()) + 1
         offenders.append((line_no, lines[line_no - 1].rstrip()))
     assert not offenders, (
-        f"Found {len(offenders)} unsafe DOM-write sink(s) in "
+        f"Found {len(offenders)} unsafe code/DOM sink(s) in "
         f"{label}:\n"
         + "\n".join(f"  line {n}: {line}" for n, line in offenders[:10])
         + "\nUse DOM construction (createElement + textContent + "
@@ -436,7 +453,7 @@ def test_shared_utils_defines_set_markdown_helper() -> None:
     )
     # The DOMParser path is what avoids the unsafe sink.  The absence
     # of the unsafe assignment inside the helper is pinned by the
-    # broader ``test_no_unsafe_dom_writes_in_interactive_assets`` scan
+    # broader ``test_no_unsafe_code_sinks_in_static_assets`` scan
     # above; pin DOMParser presence here too so a refactor that swaps
     # to e.g. ``Range.createContextualFragment`` forces an explicit
     # reviewer decision.
@@ -459,7 +476,7 @@ def test_phase8_no_unsafe_dom_write_in_settings_panel() -> None:
     # top-level keydown handler block).
     end = body.index('document.addEventListener("keydown"', start)
     section = body[start:end]
-    assert not _UNSAFE_DOM_WRITE_RE.search(section), (
+    assert not _UNSAFE_CODE_SINK_RE.search(section), (
         "Section 15 must not assign to the unsafe DOM-write property — "
         "server names and scope values flow through here and would be "
         "XSS-injectable. Use textContent / DOM APIs instead."
@@ -599,7 +616,7 @@ def test_phase8_xss_safe_render_in_build_mcp_error_embed() -> None:
     end_match = re.search(r"\n}\n", rest)
     assert end_match is not None
     fn = rest[: end_match.end()]
-    assert not _UNSAFE_DOM_WRITE_RE.search(fn), (
+    assert not _UNSAFE_CODE_SINK_RE.search(fn), (
         "buildMcpErrorEmbed must not use the unsafe-DOM-write API — "
         "server names and detail strings flow through here. An "
         "adversarial server name must render harmlessly via "

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -363,7 +363,7 @@ _COORD_JS = (
 _CONSOLE_ADMIN_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/admin.js"
 
 
-_DOM_WRITE_LINT_TARGETS = [
+_UNSAFE_CODE_SINK_LINT_TARGETS = [
     ("turnstone/ui/static/app.js", _APP_JS),
     ("turnstone/shared_static/utils.js", _UTILS_JS),
     ("turnstone/shared_static/auth.js", _AUTH_JS),
@@ -375,8 +375,8 @@ _DOM_WRITE_LINT_TARGETS = [
 
 @pytest.mark.parametrize(
     "label,path",
-    _DOM_WRITE_LINT_TARGETS,
-    ids=[label for label, _ in _DOM_WRITE_LINT_TARGETS],
+    _UNSAFE_CODE_SINK_LINT_TARGETS,
+    ids=[label for label, _ in _UNSAFE_CODE_SINK_LINT_TARGETS],
 )
 def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
     """Whole-file pin: no direct DOM-write *or* dynamic-code sinks

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
 
 
@@ -347,55 +349,76 @@ _KB_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/kb.js
 _COORD_JS = (
     Path(__file__).resolve().parent.parent / "turnstone/console/static/coordinator/coordinator.js"
 )
+_CONSOLE_ADMIN_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/admin.js"
 
 
-def test_no_unsafe_dom_writes_in_interactive_assets() -> None:
+_DOM_WRITE_LINT_TARGETS = [
+    ("turnstone/ui/static/app.js", _APP_JS),
+    ("turnstone/shared_static/utils.js", _UTILS_JS),
+    ("turnstone/shared_static/auth.js", _AUTH_JS),
+    ("turnstone/shared_static/kb.js", _KB_JS),
+    ("turnstone/console/static/coordinator/coordinator.js", _COORD_JS),
+    ("turnstone/console/static/admin.js", _CONSOLE_ADMIN_JS),
+]
+
+
+@pytest.mark.parametrize(
+    "label,path",
+    _DOM_WRITE_LINT_TARGETS,
+    ids=[label for label, _ in _DOM_WRITE_LINT_TARGETS],
+)
+def test_no_unsafe_dom_writes_in_static_assets(label: str, path: Path) -> None:
     """Whole-file pin: no direct DOM-write sinks
-    (``inner``/``outer``-HTML assignment, legacy doc-write) in the
-    interactive surface or the shared modules it loads.  Renderer
-    output routes through the ``setMarkdown`` helper in utils.js (or
-    ``setSafeHtml`` for pre-baked HTML strings), both of which parse
-    via ``DOMParser`` + ``replaceChildren``; every other site uses DOM
-    construction (``createElement`` + ``textContent`` + ``append`` /
-    ``replaceChildren``).
+    (``inner``/``outer``-HTML assignment, legacy doc-write) in any of
+    the static JS bundles that render LLM output, tool results,
+    operator-supplied data, or user input.
 
-    Coverage now spans the interactive entry point, the shared
-    helpers (utils / auth / kb), and the coord chat entry — the
-    surfaces that render LLM output, tool results, or user input.
-    The console admin / governance JS bundles remain outside this
-    scan (different threat model, admin-only behind auth gate);
-    cleaning them is a separate effort.
+    Two distinct cleanup postures across the targets:
+
+    1. **Strict DOM-construction** (``app.js``, ``utils.js``,
+       ``auth.js``, ``kb.js``, ``coordinator.js`` chat entry):
+       renderer output routes through ``setMarkdown`` (or
+       ``setSafeHtml`` for pre-baked HTML strings); every other site
+       uses ``createElement`` + ``textContent`` + ``append`` /
+       ``replaceChildren``.  Missing escapes are structurally
+       impossible — no HTML string is ever interpolated.
+    2. **Sink-free string-concat** (``admin.js``): operator-facing
+       admin pages still build HTML via ``escapeHtml`` + string concat,
+       but the unsafe sink is off the call site (everything routes
+       through ``setSafeHtml``).  XSS defence still depends on every
+       interpolated value going through escapeHtml; the lint catches
+       the sink but cannot catch a missing escape.
+
+    ``console/static/governance.js`` and ``console/static/app.js``
+    remain pending follow-ups — same posture as admin.js once cleaned.
 
     ``insertAdjacent`` + HTML is deliberately *not* covered yet; two
     existing app.js sites (the verdict-badge writers at lines 1287 and
     1538) consume the HTML-string output of ``renderVerdictBadge``, so
-    broadening the lint requires cleaning that helper first."""
-    targets = [
-        ("turnstone/ui/static/app.js", _APP_JS),
-        ("turnstone/shared_static/utils.js", _UTILS_JS),
-        ("turnstone/shared_static/auth.js", _AUTH_JS),
-        ("turnstone/shared_static/kb.js", _KB_JS),
-        ("turnstone/console/static/coordinator/coordinator.js", _COORD_JS),
-    ]
-    for label, path in targets:
-        body = path.read_text(encoding="utf-8")
-        # Scan whole-file (not line-by-line) so the regex's ``\s*``
-        # spans newlines and catches multi-line sinks like
-        # ``el.innerHTML\n  = X``.  Map match positions back to line
-        # numbers for the failure message.
-        lines = body.splitlines()
-        offenders: list[tuple[int, str]] = []
-        for m in _UNSAFE_DOM_WRITE_RE.finditer(body):
-            line_no = body.count("\n", 0, m.start()) + 1
-            offenders.append((line_no, lines[line_no - 1].rstrip()))
-        assert not offenders, (
-            f"Found {len(offenders)} unsafe DOM-write sink(s) in "
-            f"{label}:\n"
-            + "\n".join(f"  line {n}: {line}" for n, line in offenders[:10])
-            + "\nUse DOM construction (createElement + textContent + "
-            "append/replaceChildren) or route renderer output through "
-            "setMarkdown() in shared/utils.js."
-        )
+    broadening the lint requires cleaning that helper first.
+
+    Parametrized so each target is its own pytest case — a failure on
+    one file is attributed precisely without masking offenders in the
+    others.
+
+    Scans the whole file body (not line-by-line) so the regex's
+    ``\\s*`` can span newlines and catch multi-line sinks like
+    ``el.innerHTML\\n  = X``.  Match positions map back to line
+    numbers for the failure message."""
+    body = path.read_text(encoding="utf-8")
+    lines = body.splitlines()
+    offenders: list[tuple[int, str]] = []
+    for m in _UNSAFE_DOM_WRITE_RE.finditer(body):
+        line_no = body.count("\n", 0, m.start()) + 1
+        offenders.append((line_no, lines[line_no - 1].rstrip()))
+    assert not offenders, (
+        f"Found {len(offenders)} unsafe DOM-write sink(s) in "
+        f"{label}:\n"
+        + "\n".join(f"  line {n}: {line}" for n, line in offenders[:10])
+        + "\nUse DOM construction (createElement + textContent + "
+        "append/replaceChildren) or route renderer output through "
+        "setMarkdown() / setSafeHtml() in shared/utils.js."
+    )
 
 
 def test_shared_utils_defines_set_markdown_helper() -> None:

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -3110,9 +3110,10 @@ function _toggleSettingsSection(headerEl) {
 
 function _onSettingChange(inp) {
   // ``inp`` is the input element the listener fired on — passed in by
-  // the delegated handler so we avoid a document-wide selector per
-  // keystroke.  Save button + restart badge for this key live inside
-  // the same ``.settings-row`` (which carries the unique ``data-row-key``).
+  // the per-input event-listener callback so we avoid a document-wide
+  // selector per keystroke.  Save button + restart badge for this key
+  // live inside the same ``.settings-row`` (which carries the unique
+  // ``data-row-key``).
   var row = inp.closest(".settings-row");
   if (!row) return;
   var saveBtn = row.querySelector("[data-save-key]");

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -328,16 +328,20 @@ function loadAdminUsers() {
       _populateTokenUserSelect();
     })
     .catch(function () {
-      document.getElementById("admin-users-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load users</div>';
+      setSafeHtml(
+        document.getElementById("admin-users-table"),
+        '<div class="dashboard-empty">Failed to load users</div>',
+      );
     });
 }
 
 function _renderUsers(users) {
   var container = document.getElementById("admin-users-table");
   if (!users.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No users yet. Create one to get started.</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No users yet. Create one to get started.</div>',
+    );
     return;
   }
   var html = "";
@@ -371,7 +375,7 @@ function _renderUsers(users) {
       "</span>" +
       "</div>";
   }
-  container.innerHTML = html;
+  setSafeHtml(container, html);
   // Bind roles buttons
   var roleBtns = container.querySelectorAll("[data-user-roles]");
   for (var rj = 0; rj < roleBtns.length; rj++) {
@@ -482,11 +486,13 @@ function _toggleOidcPanel(userId, username, rowEl) {
   var panel = document.createElement("div");
   panel.className = "oidc-detail-panel";
   panel.setAttribute("role", "none");
-  panel.innerHTML =
+  setSafeHtml(
+    panel,
     '<div class="oidc-detail-inner">' +
-    '<div class="oidc-detail-header">OIDC Identities</div>' +
-    '<div class="oidc-detail-body"><span class="oidc-detail-empty">Loading\u2026</span></div>' +
-    "</div>";
+      '<div class="oidc-detail-header">OIDC Identities</div>' +
+      '<div class="oidc-detail-body"><span class="oidc-detail-empty">Loading\u2026</span></div>' +
+      "</div>",
+  );
   rowEl.after(panel);
   // Animate open
   requestAnimationFrame(function () {
@@ -506,8 +512,10 @@ function _toggleOidcPanel(userId, username, rowEl) {
     .catch(function () {
       var body = panel.querySelector(".oidc-detail-body");
       if (body)
-        body.innerHTML =
-          '<span class="oidc-detail-empty">Failed to load</span>';
+        setSafeHtml(
+          body,
+          '<span class="oidc-detail-empty">Failed to load</span>',
+        );
     });
 }
 
@@ -558,8 +566,10 @@ function _renderOidcDetail(panel, identities, userId, username) {
   var body = panel.querySelector(".oidc-detail-body");
   if (!body) return;
   if (!identities.length) {
-    body.innerHTML =
-      '<span class="oidc-detail-empty">No OIDC identities linked</span>';
+    setSafeHtml(
+      body,
+      '<span class="oidc-detail-empty">No OIDC identities linked</span>',
+    );
     panel.style.maxHeight = panel.scrollHeight + "px";
     return;
   }
@@ -567,7 +577,7 @@ function _renderOidcDetail(panel, identities, userId, username) {
   for (var i = 0; i < identities.length; i++) {
     html += _buildOidcRow(identities[i], userId, username);
   }
-  body.innerHTML = html;
+  setSafeHtml(body, html);
   // Update panel height for animation
   panel.style.maxHeight = panel.scrollHeight + "px";
   // Bind unlink buttons
@@ -625,8 +635,10 @@ function _confirmUnlinkOidc(issuer, subject, username, userId) {
             if (panel && panel.classList.contains("oidc-detail-panel")) {
               var body = panel.querySelector(".oidc-detail-body");
               if (body)
-                body.innerHTML =
-                  '<span class="oidc-detail-empty">Loading\u2026</span>';
+                setSafeHtml(
+                  body,
+                  '<span class="oidc-detail-empty">Loading\u2026</span>',
+                );
               authFetch(
                 "/v1/api/admin/users/" +
                   encodeURIComponent(userId) +
@@ -646,8 +658,10 @@ function _confirmUnlinkOidc(issuer, subject, username, userId) {
                 })
                 .catch(function () {
                   if (body)
-                    body.innerHTML =
-                      '<span class="oidc-detail-empty">Failed to load</span>';
+                    setSafeHtml(
+                      body,
+                      '<span class="oidc-detail-empty">Failed to load</span>',
+                    );
                 });
             }
           }
@@ -697,7 +711,7 @@ function _relativeTime(isoStr) {
 function _populateTokenUserSelect() {
   var sel = document.getElementById("admin-token-user");
   var current = sel.value;
-  sel.innerHTML = '<option value="">Select user...</option>';
+  setSafeHtml(sel, '<option value="">Select user...</option>');
   for (var i = 0; i < _adminUsers.length; i++) {
     var u = _adminUsers[i];
     var opt = document.createElement("option");
@@ -712,8 +726,10 @@ function loadAdminTokens() {
   var userId = document.getElementById("admin-token-user").value;
   _adminTokenUserId = userId;
   if (!userId) {
-    document.getElementById("admin-tokens-table").innerHTML =
-      '<div class="dashboard-empty">Select a user to view tokens</div>';
+    setSafeHtml(
+      document.getElementById("admin-tokens-table"),
+      '<div class="dashboard-empty">Select a user to view tokens</div>',
+    );
     return;
   }
   authFetch("/v1/api/admin/users/" + encodeURIComponent(userId) + "/tokens")
@@ -725,16 +741,20 @@ function loadAdminTokens() {
       _renderTokens(data.tokens || []);
     })
     .catch(function () {
-      document.getElementById("admin-tokens-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load tokens</div>';
+      setSafeHtml(
+        document.getElementById("admin-tokens-table"),
+        '<div class="dashboard-empty">Failed to load tokens</div>',
+      );
     });
 }
 
 function _renderTokens(tokens) {
   var container = document.getElementById("admin-tokens-table");
   if (!tokens.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No tokens for this user</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No tokens for this user</div>',
+    );
     return;
   }
   var html = "";
@@ -765,7 +785,7 @@ function _renderTokens(tokens) {
       "</span>" +
       "</div>";
   }
-  container.innerHTML = html;
+  setSafeHtml(container, html);
   // Bind revoke buttons via delegation (avoids inline JS injection)
   var rbtns = container.querySelectorAll("[data-revoke-token]");
   for (var j = 0; j < rbtns.length; j++) {
@@ -818,7 +838,7 @@ function confirmRevokeToken(tokenId) {
 function _populateChannelUserSelect() {
   var sel = document.getElementById("admin-channel-user");
   var current = sel.value;
-  sel.innerHTML = '<option value="">Select user...</option>';
+  setSafeHtml(sel, '<option value="">Select user...</option>');
   for (var i = 0; i < _adminUsers.length; i++) {
     var u = _adminUsers[i];
     var opt = document.createElement("option");
@@ -833,12 +853,16 @@ function loadAdminChannels() {
   var userId = document.getElementById("admin-channel-user").value;
   _adminChannelUserId = userId;
   if (!userId) {
-    document.getElementById("admin-channels-table").innerHTML =
-      '<div class="dashboard-empty">Select a user to view channel links</div>';
+    setSafeHtml(
+      document.getElementById("admin-channels-table"),
+      '<div class="dashboard-empty">Select a user to view channel links</div>',
+    );
     return;
   }
-  document.getElementById("admin-channels-table").innerHTML =
-    '<div class="dashboard-empty">Loading channel links...</div>';
+  setSafeHtml(
+    document.getElementById("admin-channels-table"),
+    '<div class="dashboard-empty">Loading channel links...</div>',
+  );
   authFetch("/v1/api/admin/users/" + encodeURIComponent(userId) + "/channels")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load channels");
@@ -848,16 +872,20 @@ function loadAdminChannels() {
       _renderChannels(data.channels || []);
     })
     .catch(function () {
-      document.getElementById("admin-channels-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load channel links</div>';
+      setSafeHtml(
+        document.getElementById("admin-channels-table"),
+        '<div class="dashboard-empty">Failed to load channel links</div>',
+      );
     });
 }
 
 function _renderChannels(channels) {
   var container = document.getElementById("admin-channels-table");
   if (!channels.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No channel links for this user</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No channel links for this user</div>',
+    );
     return;
   }
   var html = "";
@@ -894,7 +922,7 @@ function _renderChannels(channels) {
       "</span>" +
       "</div>";
   }
-  container.innerHTML = html;
+  setSafeHtml(container, html);
   var btns = container.querySelectorAll("[data-unlink-type]");
   for (var j = 0; j < btns.length; j++) {
     btns[j].addEventListener("click", function () {
@@ -955,16 +983,20 @@ function loadAdminSchedules() {
       _renderSchedules(data.schedules || []);
     })
     .catch(function () {
-      document.getElementById("admin-schedules-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load schedules</div>';
+      setSafeHtml(
+        document.getElementById("admin-schedules-table"),
+        '<div class="dashboard-empty">Failed to load schedules</div>',
+      );
     });
 }
 
 function _renderSchedules(schedules) {
   var container = document.getElementById("admin-schedules-table");
   if (!schedules.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No scheduled tasks. Create one to get started.</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No scheduled tasks. Create one to get started.</div>',
+    );
     return;
   }
   var html = "";
@@ -1037,7 +1069,7 @@ function _renderSchedules(schedules) {
       '" title="Delete">delete</button>' +
       "</span></div>";
   }
-  container.innerHTML = html;
+  setSafeHtml(container, html);
   // Bind buttons
   var editBtns = container.querySelectorAll("[data-edit-sched]");
   for (var j = 0; j < editBtns.length; j++) {
@@ -1663,7 +1695,10 @@ function showScheduleRuns(taskId) {
       var runs = data.runs || [];
       var container = document.getElementById("schedule-runs-table");
       if (!runs.length) {
-        container.innerHTML = '<div class="dashboard-empty">No runs yet</div>';
+        setSafeHtml(
+          container,
+          '<div class="dashboard-empty">No runs yet</div>',
+        );
       } else {
         var html =
           '<div class="admin-colheaders sched-runs-grid" aria-hidden="true">' +
@@ -1698,7 +1733,7 @@ function showScheduleRuns(taskId) {
             escapeHtml(r.error || "\u2014") +
             "</span></div>";
         }
-        container.innerHTML = html;
+        setSafeHtml(container, html);
       }
       var overlay = document.getElementById("schedule-runs-overlay");
       overlay.style.display = "flex";
@@ -1729,7 +1764,7 @@ function _populateWatchNodeSelect() {
   var sel = document.getElementById("admin-watch-node");
   var current = sel.value;
   var seen = {};
-  sel.innerHTML = '<option value="">All nodes</option>';
+  setSafeHtml(sel, '<option value="">All nodes</option>');
   for (var i = 0; i < _adminWatches.length; i++) {
     var nid = _adminWatches[i].node_id || "";
     if (nid && !seen[nid]) {
@@ -1762,8 +1797,10 @@ function loadAdminWatches() {
       _renderWatches(filtered);
     })
     .catch(function () {
-      document.getElementById("admin-watches-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load watches</div>';
+      setSafeHtml(
+        document.getElementById("admin-watches-table"),
+        '<div class="dashboard-empty">Failed to load watches</div>',
+      );
     });
 }
 
@@ -1777,8 +1814,10 @@ function _formatInterval(secs) {
 function _renderWatches(watches) {
   var container = document.getElementById("admin-watches-table");
   if (!watches.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No active watches. Watches are created when workstreams use the watch tool.</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No active watches. Watches are created when workstreams use the watch tool.</div>',
+    );
     return;
   }
   var html = "";
@@ -1842,7 +1881,7 @@ function _renderWatches(watches) {
       cancelBtn +
       "</span></div>";
   }
-  container.innerHTML = html;
+  setSafeHtml(container, html);
   // Bind cancel buttons
   var btns = container.querySelectorAll("[data-cancel-watch]");
   for (var j = 0; j < btns.length; j++) {
@@ -2745,10 +2784,12 @@ function loadSettings() {
     })
     .catch(function (err) {
       // NOTE: escapeHtml sanitises err.message before insertion.
-      el.innerHTML =
+      setSafeHtml(
+        el,
         '<div class="dashboard-empty">Failed to load settings: ' +
-        escapeHtml(err.message || String(err)) +
-        "</div>";
+          escapeHtml(err.message || String(err)) +
+          "</div>",
+      );
     });
 }
 
@@ -2806,7 +2847,7 @@ function _renderSettings(container, grouped) {
     }
   }
 
-  container.innerHTML = html;
+  setSafeHtml(container, html);
 
   // Store original values for dirty detection
   var inputs = container.querySelectorAll("[data-setting-key]");
@@ -3291,16 +3332,20 @@ function loadAdminMcp() {
       _renderMcpServers(_mcpServers);
     })
     .catch(function () {
-      document.getElementById("admin-mcp-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load MCP servers</div>';
+      setSafeHtml(
+        document.getElementById("admin-mcp-table"),
+        '<div class="dashboard-empty">Failed to load MCP servers</div>',
+      );
     });
 }
 
 function _renderMcpServers(items) {
   var el = document.getElementById("admin-mcp-table");
   if (!items.length) {
-    el.innerHTML =
-      '<div class="dashboard-empty">No MCP servers configured</div>';
+    setSafeHtml(
+      el,
+      '<div class="dashboard-empty">No MCP servers configured</div>',
+    );
     return;
   }
   var html = "";
@@ -3501,7 +3546,7 @@ function _renderMcpServers(items) {
       actions +
       "</span></div>";
   }
-  el.innerHTML = html;
+  setSafeHtml(el, html);
 
   // Bind event handlers
   el.querySelectorAll("[data-mcp-detail]").forEach(function (a) {
@@ -4083,7 +4128,7 @@ function _openMcpDetail(s) {
   html += "</div></div></div>";
 
   document.getElementById("mcp-detail-title").textContent = s.name;
-  document.getElementById("mcp-detail-content").innerHTML = html;
+  setSafeHtml(document.getElementById("mcp-detail-content"), html);
   document.getElementById("mcp-detail-overlay").style.display = "flex";
   _mcpDetailTrap = _installTrap("mcp-detail-overlay", "mcp-detail-box");
 }
@@ -4209,7 +4254,7 @@ function searchMcpRegistry(append) {
 
   var resultsEl = document.getElementById("mcp-registry-results");
   if (!append) {
-    resultsEl.innerHTML = '<div class="dashboard-empty">Searching…</div>';
+    setSafeHtml(resultsEl, '<div class="dashboard-empty">Searching…</div>');
   }
   var searchBtn = document.getElementById("mcp-registry-search-btn");
   var moreBtn = document.getElementById("mcp-registry-more");
@@ -4233,8 +4278,10 @@ function searchMcpRegistry(append) {
     })
     .catch(function (e) {
       if (!append) {
-        resultsEl.innerHTML =
-          '<div class="dashboard-empty">' + escapeHtml(e.message) + "</div>";
+        setSafeHtml(
+          resultsEl,
+          '<div class="dashboard-empty">' + escapeHtml(e.message) + "</div>",
+        );
       }
     })
     .finally(function () {
@@ -4254,7 +4301,7 @@ function _applyRegistryFilter() {
 function _renderRegistryResults() {
   var el = document.getElementById("mcp-registry-results");
   if (!_registryResults.length) {
-    el.innerHTML = '<div class="dashboard-empty">No servers found</div>';
+    setSafeHtml(el, '<div class="dashboard-empty">No servers found</div>');
     document.getElementById("mcp-registry-pagination").style.display = "none";
     return;
   }
@@ -4351,10 +4398,12 @@ function _renderRegistryResults() {
   }
 
   if (!visibleCount && _registryResults.length) {
-    el.innerHTML =
-      '<div class="dashboard-empty">No servers match the selected filter</div>';
+    setSafeHtml(
+      el,
+      '<div class="dashboard-empty">No servers match the selected filter</div>',
+    );
   } else {
-    el.innerHTML = html;
+    setSafeHtml(el, html);
   }
 
   // Pagination
@@ -4441,15 +4490,17 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
   document.getElementById("mcp-install-error").classList.remove("is-visible");
 
   // Summary
-  document.getElementById("mcp-install-summary").innerHTML =
+  setSafeHtml(
+    document.getElementById("mcp-install-summary"),
     '<div class="mcp-install-summary-name">' +
-    escapeHtml(srv.title || srv.name) +
-    "</div>" +
-    (srv.description
-      ? '<div class="mcp-install-summary-desc">' +
-        escapeHtml(srv.description) +
-        "</div>"
-      : "");
+      escapeHtml(srv.title || srv.name) +
+      "</div>" +
+      (srv.description
+        ? '<div class="mcp-install-summary-desc">' +
+          escapeHtml(srv.description) +
+          "</div>"
+        : ""),
+  );
 
   // Source selector (only if both remote AND package)
   var srcEl = document.getElementById("mcp-install-source-select");
@@ -4474,9 +4525,9 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
         "</span></label>";
     }
     srcHtml += "</div>";
-    srcEl.innerHTML = srcHtml;
+    setSafeHtml(srcEl, srcHtml);
   } else {
-    srcEl.innerHTML = "";
+    srcEl.replaceChildren();
   }
 
   _updateInstallFields();
@@ -4623,7 +4674,7 @@ function _updateInstallFields() {
       '<p style="font-size:12px;color:var(--fg-dim);margin:8px 0">' +
       "No configuration required — click Install to proceed.</p>";
   }
-  fieldsEl.innerHTML = html;
+  setSafeHtml(fieldsEl, html);
   fieldsEl.setAttribute("data-source", source);
   fieldsEl.setAttribute("data-pkg-index", String(pkgIndex));
 }
@@ -6026,7 +6077,7 @@ var _nodeMetaCache = {};
 function loadAdminNodeMetadata() {
   var container = document.getElementById("admin-node-metadata-content");
   if (!container) return;
-  container.innerHTML = '<div class="dashboard-empty">Loading\u2026</div>';
+  setSafeHtml(container, '<div class="dashboard-empty">Loading\u2026</div>');
 
   // Single bulk fetch for all node metadata
   authFetch("/v1/api/admin/node-metadata")
@@ -6039,8 +6090,10 @@ function loadAdminNodeMetadata() {
       _renderNodeMetadata();
     })
     .catch(function () {
-      container.innerHTML =
-        '<div class="dashboard-empty">Failed to load node metadata</div>';
+      setSafeHtml(
+        container,
+        '<div class="dashboard-empty">Failed to load node metadata</div>',
+      );
     });
 }
 
@@ -6049,8 +6102,10 @@ function _renderNodeMetadata() {
   if (!container) return;
   var nodeIds = Object.keys(_nodeMetaCache).sort();
   if (!nodeIds.length) {
-    container.innerHTML =
-      '<div class="dashboard-empty">No nodes registered</div>';
+    setSafeHtml(
+      container,
+      '<div class="dashboard-empty">No nodes registered</div>',
+    );
     return;
   }
 
@@ -6147,7 +6202,7 @@ function _renderNodeMetadata() {
 
     html += "</div></div>";
   });
-  container.innerHTML = html;
+  setSafeHtml(container, html);
 
   // Bind button handlers (data-* attrs carry node/key context)
   var delBtns = container.querySelectorAll(".nm-del-btn");

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2806,7 +2806,7 @@ function _renderSettings(container, grouped) {
       sec +
       '" data-collapsed>';
     html +=
-      '<div class="settings-section-header" onclick="_toggleSettingsSection(this)" onkeydown="_onSettingsHeaderKey(event,this)" role="button" tabindex="0" aria-expanded="false" aria-controls="settings-body-' +
+      '<div class="settings-section-header" role="button" tabindex="0" aria-expanded="false" aria-controls="settings-body-' +
       sec +
       '">';
     html += "<span>" + _settingsSectionLabel(sec) + "</span>";
@@ -2831,7 +2831,7 @@ function _renderSettings(container, grouped) {
         allSections[s] +
         '" data-collapsed>';
       html +=
-        '<div class="settings-section-header" onclick="_toggleSettingsSection(this)" onkeydown="_onSettingsHeaderKey(event,this)" role="button" tabindex="0" aria-expanded="false" aria-controls="settings-body-' +
+        '<div class="settings-section-header" role="button" tabindex="0" aria-expanded="false" aria-controls="settings-body-' +
         allSections[s] +
         '">';
       html += "<span>" + _settingsSectionLabel(allSections[s]) + "</span>";
@@ -2849,7 +2849,27 @@ function _renderSettings(container, grouped) {
 
   setSafeHtml(container, html);
 
-  // Store original values for dirty detection
+  // Bind handlers via data-* attributes — a key with an apostrophe
+  // would otherwise break out of the JS string when the HTML parser
+  // decodes &#39; before JS evaluation.
+  var sectionHeaders = container.querySelectorAll(".settings-section-header");
+  for (var sh = 0; sh < sectionHeaders.length; sh++) {
+    sectionHeaders[sh].addEventListener("click", function () {
+      _toggleSettingsSection(this);
+    });
+    sectionHeaders[sh].addEventListener("keydown", function (e) {
+      _onSettingsHeaderKey(e, this);
+    });
+  }
+  var helpBtns = container.querySelectorAll(".settings-help-btn");
+  for (var hb = 0; hb < helpBtns.length; hb++) {
+    helpBtns[hb].addEventListener("click", function (e) {
+      _toggleSettingsHelp(e, this);
+    });
+  }
+
+  // Store original values for dirty detection + wire per-key change
+  // handlers off data-setting-key (no key interpolation into JS).
   var inputs = container.querySelectorAll("[data-setting-key]");
   for (var n = 0; n < inputs.length; n++) {
     var inp = inputs[n];
@@ -2859,6 +2879,23 @@ function _renderSettings(container, grouped) {
     } else {
       _settingsOriginal[key] = inp.value;
     }
+    var evtName =
+      inp.type === "checkbox" || inp.tagName === "SELECT" ? "change" : "input";
+    inp.addEventListener(evtName, function () {
+      _onSettingChange(this);
+    });
+  }
+  var saveBtns = container.querySelectorAll("[data-save-key]");
+  for (var sb = 0; sb < saveBtns.length; sb++) {
+    saveBtns[sb].addEventListener("click", function () {
+      _saveSettingValue(this.getAttribute("data-save-key"));
+    });
+  }
+  var resetBtns = container.querySelectorAll("[data-reset-key]");
+  for (var rb = 0; rb < resetBtns.length; rb++) {
+    resetBtns[rb].addEventListener("click", function () {
+      _resetSetting(this.getAttribute("data-reset-key"));
+    });
   }
 }
 
@@ -2879,7 +2916,7 @@ function _renderSettingRow(item) {
   html += escapeHtml(shortKey);
   if (item.help) {
     html +=
-      ' <button class="settings-help-btn" onclick="_toggleSettingsHelp(event, this)" ' +
+      ' <button class="settings-help-btn" ' +
       'aria-label="Help for ' +
       escapedShort +
       '" aria-expanded="false" title="More info">?</button>';
@@ -2912,9 +2949,7 @@ function _renderSettingRow(item) {
       escapedShort +
       '" autocomplete="off" value="" placeholder="' +
       (item.source === "storage" ? "***" : "not set") +
-      '" oninput="_onSettingChange(\'' +
-      escapedKey +
-      "')\">";
+      '">';
   } else if (item.type === "bool") {
     var checked =
       item.value === true || item.value === "true" ? " checked" : "";
@@ -2925,18 +2960,14 @@ function _renderSettingRow(item) {
       escapedShort +
       '"' +
       checked +
-      " onchange=\"_onSettingChange('" +
-      escapedKey +
-      '\')"><span class="settings-toggle-slider"></span></label>';
+      '><span class="settings-toggle-slider"></span></label>';
   } else if (item.choices && item.choices.length > 0) {
     html +=
       '<select data-setting-key="' +
       escapedKey +
       '" aria-label="' +
       escapedShort +
-      '" onchange="_onSettingChange(\'' +
-      escapedKey +
-      "')\">";
+      '">';
     for (var c = 0; c < item.choices.length; c++) {
       var sel = item.choices[c] === String(item.value) ? " selected" : "";
       var label;
@@ -2981,9 +3012,7 @@ function _renderSettingRow(item) {
       '"' +
       minAttr +
       maxAttr +
-      " oninput=\"_onSettingChange('" +
-      escapedKey +
-      "')\">";
+      ">";
   } else {
     // str
     html +=
@@ -2993,9 +3022,7 @@ function _renderSettingRow(item) {
       escapedShort +
       '" value="' +
       escapeHtml(String(item.value != null ? item.value : "")) +
-      '" oninput="_onSettingChange(\'' +
-      escapedKey +
-      "')\">";
+      '">';
   }
   html += "</div>";
 
@@ -3021,18 +3048,14 @@ function _renderSettingRow(item) {
   html +=
     '<button class="settings-save-btn" data-save-key="' +
     escapedKey +
-    '" onclick="_saveSettingValue(\'' +
-    escapedKey +
-    "')\">save</button>";
+    '">save</button>';
 
   // Reset link (when stored — including secrets, to clear legacy overrides)
   if (item.source === "storage") {
     html +=
       '<button class="settings-reset-btn" data-reset-key="' +
       escapedKey +
-      '" onclick="_resetSetting(\'' +
-      escapedKey +
-      "')\">reset</button>";
+      '">reset</button>';
   }
 
   html += "</div>";
@@ -3085,10 +3108,16 @@ function _toggleSettingsSection(headerEl) {
   }
 }
 
-function _onSettingChange(key) {
-  var inp = document.querySelector('[data-setting-key="' + key + '"]');
-  var saveBtn = document.querySelector('[data-save-key="' + key + '"]');
-  if (!inp || !saveBtn) return;
+function _onSettingChange(inp) {
+  // ``inp`` is the input element the listener fired on — passed in by
+  // the delegated handler so we avoid a document-wide selector per
+  // keystroke.  Save button + restart badge for this key live inside
+  // the same ``.settings-row`` (which carries the unique ``data-row-key``).
+  var row = inp.closest(".settings-row");
+  if (!row) return;
+  var saveBtn = row.querySelector("[data-save-key]");
+  if (!saveBtn) return;
+  var key = inp.getAttribute("data-setting-key");
 
   var current;
   if (inp.type === "checkbox") {
@@ -3117,7 +3146,7 @@ function _onSettingChange(key) {
   }
 
   // Show/hide restart badge alongside dirty state (but keep it if already saved)
-  var restartBadge = document.querySelector('[data-restart-key="' + key + '"]');
+  var restartBadge = row.querySelector("[data-restart-key]");
   if (restartBadge && !restartBadge.classList.contains("saved")) {
     restartBadge.classList.toggle("visible", dirty);
   }
@@ -4508,8 +4537,7 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
     var srcHtml = '<div class="mcp-install-source-group">';
     srcHtml +=
       '<label class="mcp-install-source-label">' +
-      '<input type="radio" name="mcp-install-src" value="remote" checked ' +
-      'onchange="_updateInstallFields()"> ' +
+      '<input type="radio" name="mcp-install-src" value="remote" checked> ' +
       'Remote <span class="mcp-install-source-type">streamable-http</span>' +
       "</label>";
     for (var pi = 0; pi < srv.packages.length; pi++) {
@@ -4517,7 +4545,7 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
         '<label class="mcp-install-source-label">' +
         '<input type="radio" name="mcp-install-src" value="package-' +
         pi +
-        '" onchange="_updateInstallFields()"> ' +
+        '"> ' +
         'Package <span class="mcp-install-source-type">' +
         escapeHtml(srv.packages[pi].registry_type) +
         " / " +
@@ -4526,6 +4554,10 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
     }
     srcHtml += "</div>";
     setSafeHtml(srcEl, srcHtml);
+    var srcRadios = srcEl.querySelectorAll('input[name="mcp-install-src"]');
+    for (var sr = 0; sr < srcRadios.length; sr++) {
+      srcRadios[sr].addEventListener("change", _updateInstallFields);
+    }
   } else {
     srcEl.replaceChildren();
   }
@@ -6117,9 +6149,7 @@ function _renderNodeMetadata() {
       escapeHtml(nid) +
       '" data-collapsed>';
     html +=
-      '<div class="settings-section-header" onclick="_toggleSettingsSection(this)" ';
-    html += 'onkeydown="_onSettingsHeaderKey(event,this)" ';
-    html += 'role="button" tabindex="0" aria-expanded="false" ';
+      '<div class="settings-section-header" role="button" tabindex="0" aria-expanded="false" ';
     html += 'aria-controls="nm-body-' + escapeHtml(nid) + '">';
     html +=
       "<span>" +
@@ -6203,6 +6233,19 @@ function _renderNodeMetadata() {
     html += "</div></div>";
   });
   setSafeHtml(container, html);
+
+  // Bind section-header click/keydown (no inline handlers — keys come
+  // from operator-controlled node IDs and would be a footgun in a
+  // ``onclick="..._('NID')"`` attribute).
+  var nmHeaders = container.querySelectorAll(".settings-section-header");
+  for (var nh = 0; nh < nmHeaders.length; nh++) {
+    nmHeaders[nh].addEventListener("click", function () {
+      _toggleSettingsSection(this);
+    });
+    nmHeaders[nh].addEventListener("keydown", function (e) {
+      _onSettingsHeaderKey(e, this);
+    });
+  }
 
   // Bind button handlers (data-* attrs carry node/key context)
   var delBtns = container.querySelectorAll(".nm-del-btn");


### PR DESCRIPTION
## Summary

Follow-up to #532 (interactive cleanup, merged).  Removes the 48 direct `.innerHTML =` sites from `turnstone/console/static/admin.js` and replaces the 14 inline event-handler attributes that interpolated setting keys into JS-strings-inside-HTML-attributes.  Extends the CI lint to cover admin.js and broadens the regex to also flag dynamic-code sinks (`eval`, `new Function`, string-first-arg `setTimeout`/`setInterval`).

## Commits

1. **`refactor(console): route admin.js innerHTML sinks through setSafeHtml`** — 48 sites swapped via the shared helper added in #532.  Mechanical AST-light transform + prettier; `node --check` clean.  HTML strings are still built via `escapeHtml` + concat — same defence as before, just no `innerHTML` sink at the call site.  One empty-string clear became `replaceChildren()` for clarity.
2. **`test(ci): extend zero-DOM-write lint to admin.js, parametrize per file`** — adds admin.js to the lint target list and parametrizes the test so each file is its own pytest case (clean failure attribution instead of masking offenders behind the first failure).
3. **`refactor(console): replace inline event handlers with delegated bindings`** — removes 14 inline `onclick`/`onkeydown`/`oninput`/`onchange` attributes that previously embedded setting keys as JS-strings inside HTML attributes.  The footgun: `escapeHtml` turns `'` into `&#39;`, but the HTML parser decodes that **before** the JS parser runs, so a key with an apostrophe would break out of the JS string.  Today the keys come from a static registry without apostrophes, so no live vuln — but the pattern is brittle.  Handlers now read context off `data-*` attributes via `this.getAttribute("...")`.  Also: `_onSettingChange` now receives the input element instead of a key string, so the 3 document-wide `querySelector` calls per keystroke collapse to 1 ancestor walk + 2 scoped queries.
4. **`test(ci): broaden DOM-write lint to dynamic-code sinks`** — extends `_UNSAFE_CODE_SINK_RE` (renamed from `_UNSAFE_DOM_WRITE_RE`) to catch `eval(`, `new Function(`, `setTimeout(string, ...)`, `setInterval(string, ...)`.  Function-first-arg timer forms remain unflagged.  Zero existing offenders across the 6 scanned files.

## Posture difference vs interactive PR

- **Interactive (#532)**: full DOM-construction — `escapeHtml` drops out, missing-escape becomes structurally impossible.
- **Admin (this PR)**: sink-free string-concat — `escapeHtml` stays as the defence; the lint catches the sink but cannot catch a missing escape.  Full DOM rewrite would be ~10× the work (136 `escapeHtml` call sites, thousands of lines of builder code).  Captured honestly in the test docstring.

## Out of scope (separate follow-ups)

- `console/static/governance.js` (46 sites) — same admin-page posture once cleaned.
- `console/static/app.js` (12 sites) — same.
- `insertAdjacentHTML` lint coverage — blocked on cleaning `renderVerdictBadge` (2 sites in `ui/static/app.js`) first.
- Optional delegation refactor in `_renderSettings` (~160 listener attachments → 1-2 delegated) — cold-path, profiling would tell whether it's worth doing.

## Verification

- 307 tests pass (`test_app_js.py`, `test_admin*.py`, `test_console*.py`)
- `node --check` clean on admin.js
- `ruff check` clean
- Multi-stage `/review` pipeline ran twice (initial admin cleanup + the two follow-up commits); all minor findings applied via autosquash before this PR opened

## Test plan

- [ ] CI: lint + typecheck + test + security all green
- [ ] Manual: open console admin panel, verify Users / API Tokens / Channels / Schedules / Watches / Roles / Policies / Skills / MCP / Memories tabs render and their action buttons work
- [ ] Manual: open Settings tab, verify section headers expand/collapse, help popovers toggle, dirty-state shows save buttons, save + reset work, keyboard Enter/Space on section headers works
- [ ] Manual: MCP install flow, verify source-selector radios toggle correctly between remote and package