### PR TITLE
chore(console): full DOM-construction for cluster dashboard renderer

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -263,9 +263,9 @@ _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style
 # ``el.innerHTML\n  = X``.
 #
 # ``insertAdjacent`` + HTML is *not* covered here because two existing
-# call sites (``app.js:1287`` and ``app.js:1538``) consume
-# ``renderVerdictBadge`` HTML output; broadening the lint would require
-# cleaning that helper first.  Tracked as a follow-up.
+# call sites (``ui/static/app.js:1287`` and ``ui/static/app.js:1538``)
+# consume ``renderVerdictBadge`` HTML output; broadening the lint
+# would require cleaning that helper first.  Tracked as a follow-up.
 _UNSAFE_CODE_SINK_RE = re.compile(
     r"\.(?:inner|outer)"
     + r"HTML\s*\+?=(?!=)"
@@ -364,6 +364,7 @@ _CONSOLE_ADMIN_JS = Path(__file__).resolve().parent.parent / "turnstone/console/
 _CONSOLE_GOVERNANCE_JS = (
     Path(__file__).resolve().parent.parent / "turnstone/console/static/governance.js"
 )
+_CONSOLE_APP_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/app.js"
 
 
 _UNSAFE_CODE_SINK_LINT_TARGETS = [
@@ -374,6 +375,7 @@ _UNSAFE_CODE_SINK_LINT_TARGETS = [
     ("turnstone/console/static/coordinator/coordinator.js", _COORD_JS),
     ("turnstone/console/static/admin.js", _CONSOLE_ADMIN_JS),
     ("turnstone/console/static/governance.js", _CONSOLE_GOVERNANCE_JS),
+    ("turnstone/console/static/app.js", _CONSOLE_APP_JS),
 ]
 
 
@@ -392,33 +394,32 @@ def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
 
     Two distinct cleanup postures across the targets:
 
-    1. **Strict DOM-construction** (``app.js``, ``utils.js``,
-       ``auth.js``, ``kb.js``, ``coordinator.js`` chat entry):
-       renderer output routes through ``setMarkdown`` (or
-       ``setSafeHtml`` for pre-baked HTML strings); every other site
-       uses ``createElement`` + ``textContent`` + ``append`` /
-       ``replaceChildren``.  Missing escapes are structurally
-       impossible — no HTML string is ever interpolated.
-    2. **Sink-free string-concat** (``admin.js``, ``governance.js``):
-       operator-facing admin / governance pages still build HTML via
-       ``escapeHtml`` + string concat, but the unsafe sink is off the
-       call site (everything routes through ``setSafeHtml``).  XSS
-       defence still depends on every interpolated value going through
-       escapeHtml; the lint catches the sink but cannot catch a missing
-       escape.
+    1. **Strict DOM-construction** (``ui/static/app.js``,
+       ``shared_static/utils.js``, ``shared_static/auth.js``,
+       ``shared_static/kb.js``, ``coordinator.js`` chat entry,
+       ``console/static/app.js``): renderer output routes through
+       ``setMarkdown`` (or ``setSafeHtml`` for pre-baked HTML strings);
+       every other site uses ``createElement`` + ``textContent`` +
+       ``append`` / ``replaceChildren``.  Missing escapes are
+       structurally impossible — no HTML string is ever interpolated.
+    2. **Sink-free string-concat** (``console/static/admin.js``,
+       ``console/static/governance.js``): operator-facing admin /
+       governance pages still build HTML via ``escapeHtml`` + string
+       concat, but the unsafe sink is off the call site (everything
+       routes through ``setSafeHtml``).  XSS defence still depends on
+       every interpolated value going through escapeHtml; the lint
+       catches the sink but cannot catch a missing escape.
 
-    ``console/static/app.js`` (the cluster dashboard / node table
-    surface) is the last admin-side bundle still pending — same posture
-    as admin.js once cleaned.
+    All admin-side bundles are now covered.
 
     The regex covers inner/outer-HTML assignment (plain and
     concat-assignment), legacy doc-write, and the dynamic-code
     constructors (string-eval, dynamic-Function, string-first-arg
     timer scheduling).  ``insertAdjacent`` + HTML is deliberately
-    *not* covered yet; two existing app.js sites (the verdict-badge
-    writers at lines 1287 and 1538) consume the HTML-string output of
-    ``renderVerdictBadge``, so broadening the lint requires cleaning
-    that helper first.
+    *not* covered yet; two existing ``ui/static/app.js`` sites (the
+    verdict-badge writers at lines 1287 and 1538) consume the
+    HTML-string output of ``renderVerdictBadge``, so broadening the
+    lint requires cleaning that helper first.
 
     Parametrized so each target is its own pytest case — a failure on
     one file is attributed precisely without masking offenders in the

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -487,8 +487,9 @@ function loadOverview() {
       applySnapshot(data);
     })
     .catch(function () {
-      document.getElementById("node-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load</div>';
+      document
+        .getElementById("node-table")
+        .replaceChildren(makeEmptyState("Failed to load"));
     });
 }
 
@@ -507,7 +508,7 @@ function renderStatusBar(overview) {
   var agg = overview.aggregate || {};
 
   var statesContainer = document.getElementById("csb-states");
-  statesContainer.innerHTML = "";
+  statesContainer.replaceChildren();
   STATE_ORDER.forEach(function (state) {
     var count = states[state] || 0;
     var sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
@@ -517,18 +518,17 @@ function renderStatusBar(overview) {
       pill.classList.add("active");
     }
     pill.setAttribute("aria-label", sd.label + ": " + count + " workstreams");
-    pill.innerHTML =
-      '<span class="csb-state-dot" data-state="' +
-      escapeHtml(state) +
-      '" aria-hidden="true"></span>' +
-      '<span class="csb-state-count' +
-      (count === 0 ? " zero" : "") +
-      '">' +
-      formatCount(count) +
-      "</span>" +
-      '<span class="csb-state-label">' +
-      sd.label +
-      "</span>";
+    var stateDot = document.createElement("span");
+    stateDot.className = "csb-state-dot";
+    stateDot.setAttribute("data-state", state);
+    stateDot.setAttribute("aria-hidden", "true");
+    var stateCount = document.createElement("span");
+    stateCount.className = "csb-state-count" + (count === 0 ? " zero" : "");
+    stateCount.textContent = formatCount(count);
+    var stateLabel = document.createElement("span");
+    stateLabel.className = "csb-state-label";
+    stateLabel.textContent = sd.label;
+    pill.append(stateDot, stateCount, stateLabel);
     pill.onclick = function () {
       drillDownByState(state);
     };
@@ -536,7 +536,7 @@ function renderStatusBar(overview) {
   });
 
   var metricsContainer = document.getElementById("csb-metrics");
-  metricsContainer.innerHTML = "";
+  metricsContainer.replaceChildren();
   var metrics = [
     { value: overview.nodes || 0, label: "nodes", format: formatCount },
     { value: overview.workstreams || 0, label: "ws", format: formatCount },
@@ -691,6 +691,58 @@ function groupNodes(nodes) {
   return groups;
 }
 
+// 7-span node-table column header — used at the top of the table and
+// inside each multi-node group body.  Returns a DocumentFragment built
+// via createElement so the static label list is constructed once with
+// no HTML parsing / string interpolation per render.
+var _NODE_COLHEADER_LABELS = [
+  ["ncol ncol-node", "NODE"],
+  ["ncol ncol-ws", "WS"],
+  ["ncol ncol-run", "RUN"],
+  ["ncol ncol-attn", "ATTN"],
+  ["ncol ncol-tokens", "TOKENS"],
+  ["ncol ncol-version", "VER"],
+  ["ncol ncol-health", "LOAD"],
+];
+
+function buildColHeaders() {
+  var frag = document.createDocumentFragment();
+  for (var i = 0; i < _NODE_COLHEADER_LABELS.length; i++) {
+    var span = document.createElement("span");
+    span.className = _NODE_COLHEADER_LABELS[i][0];
+    span.textContent = _NODE_COLHEADER_LABELS[i][1];
+    frag.appendChild(span);
+  }
+  return frag;
+}
+
+// Build a numeric cell for the node table.  ``highlighted`` adds
+// ``has-value`` so non-zero counts get the CSS treatment.
+function _buildNodeNumCell(value, highlighted, cellClass) {
+  var cell = document.createElement("span");
+  cell.className = cellClass + (highlighted ? " has-value" : "");
+  cell.textContent = String(value);
+  return cell;
+}
+
+// Build the health-bar trailing cell ("[bar] [pct]%") for either a
+// node row or a group header — the structure is identical, only the
+// outer cell class differs.
+function _buildHealthCell(cellClass, healthPct, healthFillClass) {
+  var cell = document.createElement("span");
+  cell.className = cellClass;
+  var bar = document.createElement("span");
+  bar.className = "health-bar";
+  if (healthPct > 0) {
+    var fill = document.createElement("span");
+    fill.className = "health-bar-fill " + healthFillClass;
+    fill.style.width = healthPct + "%";
+    bar.appendChild(fill);
+  }
+  cell.append(bar, " " + healthPct + "%");
+  return cell;
+}
+
 function buildNodeRow(node) {
   var row = document.createElement("div");
   row.className = "node-row";
@@ -727,62 +779,70 @@ function buildNodeRow(node) {
     maxWs > 0 ? Math.min(Math.round((node.ws_total / maxWs) * 100), 100) : 0;
   var healthFillClass =
     healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
-  var healthFillHtml =
-    healthPct > 0
-      ? '<span class="health-bar-fill ' +
-        healthFillClass +
-        '" style="width:' +
-        healthPct +
-        '%"></span>'
-      : "";
 
   var healthTitle = "";
   if (node.health && node.health.backend) {
     healthTitle = "backend: " + node.health.backend.status;
   }
-  var degradedBadge = isDegraded
-    ? '<span class="node-degraded-badge" title="' +
-      escapeHtml(healthTitle) +
-      '" aria-label="' +
-      escapeHtml(healthTitle) +
-      '">degraded</span>'
-    : "";
 
-  row.innerHTML =
-    '<span class="node-cell node-cell-name"' +
-    (healthTitle ? ' title="' + escapeHtml(healthTitle) + '"' : "") +
-    '><span class="' +
-    dotClass +
-    '"></span>' +
-    escapeHtml(node.node_id) +
-    degradedBadge +
-    "</span>" +
-    '<span class="node-cell node-cell-num' +
-    (node.ws_total > 0 ? " has-value" : "") +
-    '">' +
-    node.ws_total +
-    "</span>" +
-    '<span class="node-cell node-cell-num' +
-    (node.ws_running > 0 ? " has-value" : "") +
-    '">' +
-    node.ws_running +
-    "</span>" +
-    '<span class="node-cell node-cell-num' +
-    (node.ws_attention > 0 ? " has-value" : "") +
-    '">' +
-    node.ws_attention +
-    "</span>" +
-    '<span class="node-cell node-cell-num">' +
-    formatTokens(displayTokens) +
-    "</span>" +
-    '<span class="node-cell node-cell-version">' +
-    escapeHtml(node.version || "") +
-    "</span>" +
-    '<span class="node-cell node-cell-health"><span class="health-bar">' +
-    healthFillHtml +
-    "</span> " +
-    healthPct +
-    "%</span>";
+  // Name cell — dot, node id, optional degraded badge.
+  var nameCell = document.createElement("span");
+  nameCell.className = "node-cell node-cell-name";
+  if (healthTitle) nameCell.setAttribute("title", healthTitle);
+  var dot = document.createElement("span");
+  dot.className = dotClass;
+  nameCell.append(dot, node.node_id);
+  if (isDegraded) {
+    var degradedEl = document.createElement("span");
+    degradedEl.className = "node-degraded-badge";
+    // Only attach the descriptive title / aria-label when there's a
+    // backend-status string to surface.  An empty aria-label would
+    // suppress the badge's textContent ("degraded") for screen
+    // readers — strictly worse than leaving the attribute off.
+    if (healthTitle) {
+      degradedEl.setAttribute("title", healthTitle);
+      degradedEl.setAttribute("aria-label", healthTitle);
+    }
+    degradedEl.textContent = "degraded";
+    nameCell.appendChild(degradedEl);
+  }
+  row.appendChild(nameCell);
+
+  row.appendChild(
+    _buildNodeNumCell(
+      node.ws_total,
+      node.ws_total > 0,
+      "node-cell node-cell-num",
+    ),
+  );
+  row.appendChild(
+    _buildNodeNumCell(
+      node.ws_running,
+      node.ws_running > 0,
+      "node-cell node-cell-num",
+    ),
+  );
+  row.appendChild(
+    _buildNodeNumCell(
+      node.ws_attention,
+      node.ws_attention > 0,
+      "node-cell node-cell-num",
+    ),
+  );
+
+  var tokensCell = document.createElement("span");
+  tokensCell.className = "node-cell node-cell-num";
+  tokensCell.textContent = formatTokens(displayTokens);
+  row.appendChild(tokensCell);
+
+  var versionCell = document.createElement("span");
+  versionCell.className = "node-cell node-cell-version";
+  versionCell.textContent = node.version || "";
+  row.appendChild(versionCell);
+
+  row.appendChild(
+    _buildHealthCell("node-cell node-cell-health", healthPct, healthFillClass),
+  );
 
   var nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
   row.onclick = function () {
@@ -823,23 +883,16 @@ function renderNodeGroups(nodes, total) {
   _lastNodesJson = json;
 
   var table = document.getElementById("node-table");
-  table.innerHTML = "";
+  table.replaceChildren();
   if (!nodes.length) {
-    table.innerHTML = '<div class="dashboard-empty">No nodes discovered</div>';
+    table.appendChild(makeEmptyState("No nodes discovered"));
     return;
   }
 
   var topHeaders = document.createElement("div");
   topHeaders.className = "node-colheaders";
   topHeaders.setAttribute("aria-hidden", "true");
-  topHeaders.innerHTML =
-    '<span class="ncol ncol-node">NODE</span>' +
-    '<span class="ncol ncol-ws">WS</span>' +
-    '<span class="ncol ncol-run">RUN</span>' +
-    '<span class="ncol ncol-attn">ATTN</span>' +
-    '<span class="ncol ncol-tokens">TOKENS</span>' +
-    '<span class="ncol ncol-version">VER</span>' +
-    '<span class="ncol ncol-health">LOAD</span>';
+  topHeaders.appendChild(buildColHeaders());
   table.appendChild(topHeaders);
 
   var groups = groupNodes(nodes);
@@ -897,18 +950,6 @@ function renderNodeGroups(nodes, total) {
         : 0;
     var healthFillClass =
       healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
-    var healthFillHtml =
-      healthPct > 0
-        ? '<span class="health-bar-fill ' +
-          healthFillClass +
-          '" style="width:' +
-          healthPct +
-          '%"></span>'
-        : "";
-
-    var groupDegradedBadge = group.any_degraded
-      ? '<span class="node-degraded-badge">degraded</span>'
-      : "";
     var groupVersionText = "";
     var groupVersionDrift = false;
     if (group.versions.size === 1) {
@@ -917,50 +958,72 @@ function renderNodeGroups(nodes, total) {
       groupVersionText = "mixed";
       groupVersionDrift = true;
     }
-    var versionDriftBadge = groupVersionDrift
-      ? '<span class="node-version-drift-badge">drift</span>'
-      : "";
 
-    header.innerHTML =
-      '<span class="node-group-name">' +
-      '<span class="' +
-      chevronClass +
-      '" aria-hidden="true">&#x25b8;</span>' +
-      escapeHtml(group.prefix) +
-      '<span class="node-group-badge">' +
-      group.nodes.length +
-      " nodes</span>" +
-      groupDegradedBadge +
-      "</span>" +
-      '<span class="node-group-cell num' +
-      (group.ws_total > 0 ? " has-value" : "") +
-      '">' +
-      group.ws_total +
-      "</span>" +
-      '<span class="node-group-cell num' +
-      (group.ws_running > 0 ? " has-value" : "") +
-      '">' +
-      group.ws_running +
-      "</span>" +
-      '<span class="node-group-cell num' +
-      (group.ws_attention > 0 ? " has-value" : "") +
-      '">' +
-      group.ws_attention +
-      "</span>" +
-      '<span class="node-group-cell num">' +
-      formatTokens(group.total_tokens) +
-      "</span>" +
-      '<span class="node-group-cell node-cell-version' +
-      (groupVersionDrift ? " drift" : "") +
-      '">' +
-      escapeHtml(groupVersionText) +
-      versionDriftBadge +
-      "</span>" +
-      '<span class="node-group-cell node-cell-health"><span class="health-bar">' +
-      healthFillHtml +
-      "</span> " +
-      healthPct +
-      "%</span>";
+    // Group-name cell: chevron + prefix + node count + optional degraded badge.
+    var nameCell = document.createElement("span");
+    nameCell.className = "node-group-name";
+    var chevron = document.createElement("span");
+    chevron.className = chevronClass;
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "▸";
+    var badge = document.createElement("span");
+    badge.className = "node-group-badge";
+    badge.textContent = group.nodes.length + " nodes";
+    nameCell.append(chevron, group.prefix, badge);
+    if (group.any_degraded) {
+      var degradedEl = document.createElement("span");
+      degradedEl.className = "node-degraded-badge";
+      degradedEl.textContent = "degraded";
+      nameCell.appendChild(degradedEl);
+    }
+    header.appendChild(nameCell);
+
+    header.appendChild(
+      _buildNodeNumCell(
+        group.ws_total,
+        group.ws_total > 0,
+        "node-group-cell num",
+      ),
+    );
+    header.appendChild(
+      _buildNodeNumCell(
+        group.ws_running,
+        group.ws_running > 0,
+        "node-group-cell num",
+      ),
+    );
+    header.appendChild(
+      _buildNodeNumCell(
+        group.ws_attention,
+        group.ws_attention > 0,
+        "node-group-cell num",
+      ),
+    );
+
+    var groupTokensCell = document.createElement("span");
+    groupTokensCell.className = "node-group-cell num";
+    groupTokensCell.textContent = formatTokens(group.total_tokens);
+    header.appendChild(groupTokensCell);
+
+    var groupVersionCell = document.createElement("span");
+    groupVersionCell.className =
+      "node-group-cell node-cell-version" + (groupVersionDrift ? " drift" : "");
+    groupVersionCell.textContent = groupVersionText;
+    if (groupVersionDrift) {
+      var driftBadge = document.createElement("span");
+      driftBadge.className = "node-version-drift-badge";
+      driftBadge.textContent = "drift";
+      groupVersionCell.appendChild(driftBadge);
+    }
+    header.appendChild(groupVersionCell);
+
+    header.appendChild(
+      _buildHealthCell(
+        "node-group-cell node-cell-health",
+        healthPct,
+        healthFillClass,
+      ),
+    );
 
     var prefix = group.prefix;
     header.onclick = function () {
@@ -982,14 +1045,7 @@ function renderNodeGroups(nodes, total) {
     var colHeaders = document.createElement("div");
     colHeaders.className = "node-colheaders";
     colHeaders.setAttribute("aria-hidden", "true");
-    colHeaders.innerHTML =
-      '<span class="ncol ncol-node">NODE</span>' +
-      '<span class="ncol ncol-ws">WS</span>' +
-      '<span class="ncol ncol-run">RUN</span>' +
-      '<span class="ncol ncol-attn">ATTN</span>' +
-      '<span class="ncol ncol-tokens">TOKENS</span>' +
-      '<span class="ncol ncol-version">VER</span>' +
-      '<span class="ncol ncol-health">LOAD</span>';
+    colHeaders.appendChild(buildColHeaders());
     body.appendChild(colHeaders);
 
     group.nodes.forEach(function (node) {
@@ -1059,13 +1115,14 @@ function loadFilteredWorkstreams() {
       applySnapshot(data);
     })
     .catch(function () {
-      document.getElementById("filtered-ws-table").innerHTML =
-        '<div class="dashboard-empty">Failed to load</div>';
+      document
+        .getElementById("filtered-ws-table")
+        .replaceChildren(makeEmptyState("Failed to load"));
     });
 }
 
 function renderPagination(container, page, pages) {
-  container.innerHTML = "";
+  container.replaceChildren();
   if (pages <= 1) return;
   var prev = document.createElement("button");
   prev.textContent = "\u25c4 Prev";


### PR DESCRIPTION
**Stacked on #534** (governance.js cleanup) — will rebase onto main after #534 merges.

## Summary

Last PR in the admin-side DOM cleanup arc.  12 ``innerHTML =`` sites in ``turnstone/console/static/app.js`` (cluster dashboard / node table / metrics surface) cleaned up.

The /review pipeline found that the initial mechanical sweep (8 ``setSafeHtml`` + 4 ``replaceChildren()`` for empty-string clears) put DOMParser on the node-table hot path: ``buildNodeRow`` would parse ~100 small HTML fragments per render at the project's 100-node design ceiling, and the static colHeaders literal was re-parsed for every render and again per multi-node group.  Rather than ship that and call it done, this PR lifts the entire renderer to **true DOM construction** — matching the strict-posture lane used by ``ui/static/app.js`` rather than the sink-free string-concat posture admin/governance use.

**Net result: zero ``innerHTML`` and zero ``setSafeHtml`` in ``console/static/app.js``.**

## What changed

Three new module-local helpers carry the heavy structural fragments:

- ``buildColHeaders()`` — DocumentFragment with the 7-span column-header layout.  Used at the top of the table and inside each multi-node group body.  Built once via createElement so the static literal isn't re-parsed every render (and the duplication between top-table and per-group sites collapses into one helper).
- ``_buildNodeNumCell(value, highlighted, cellClass)`` — the ``<span class="X num [has-value]">N</span>`` shape used 8× across ``buildNodeRow`` and the group header.
- ``_buildHealthCell(cellClass, healthPct, healthFillClass)`` — the health-bar trailing cell used both per-row and per-group.

Sites converted (all now ``createElement`` + ``textContent`` + ``append`` / ``replaceChildren``):

1. ``renderStatusBar`` state pill builder (in ``STATE_ORDER.forEach``) — was setSafeHtml; now createElement on the 3 inner spans.
2. ``buildNodeRow`` — 7 cells (name with dot + optional degraded badge, 3 numeric, tokens, version, health).
3. Group-header in ``renderNodeGroups`` — chevron + prefix + count badge + optional degraded badge + 4 numeric cells + version cell with optional drift badge + health cell.
4. Top-table ``topHeaders`` and per-group ``colHeaders`` — both now ``appendChild(buildColHeaders())``.
5. Two ``catch`` error placeholders (node-table, filtered-ws-table) — ``replaceChildren(makeEmptyState("Failed to load"))``.
6. "No nodes discovered" empty state — ``appendChild(makeEmptyState(...))``.

## Lint extension

``test_no_unsafe_code_sinks_in_static_assets`` now covers 8 bundles.  ``console/static/app.js`` joins the **strict DOM-construction** posture group (alongside ``ui/static/app.js``, ``shared_static/{utils,auth,kb}.js``, and the ``coordinator.js`` chat entry).  Docstring qualifies all bundle paths to disambiguate the two ``app.js`` files.

## Out of scope (separate follow-up)

- ``insertAdjacentHTML`` lint coverage — blocked on cleaning ``renderVerdictBadge`` (2 sites in ``ui/static/app.js``).  Different shape from the mechanical / DOM-construction work; will tackle separately.

## Verification

- 309 tests pass (test_app_js.py 27 cases including new console/static/app.js parametrized lint case + all test_admin*.py + all test_console*.py)
- ``node --check turnstone/console/static/app.js`` clean
- prettier reports already-formatted
- ruff clean
- Multi-stage ``/review`` pipeline ran; both findings (perf-1+perf-2 minor, q-1+q-2 nit) addressed pre-PR

## Test plan

- [ ] CI: lint + typecheck + test + security all green
- [ ] Manual: open console cluster dashboard — confirm node table renders with correct headers, node rows show the dot + node_id + degraded badge (if applicable), numeric cells highlight when non-zero, version cell renders, health bar fills correctly
- [ ] Manual: multi-node group — verify group header renders with chevron + prefix + count badge + version drift indicator (if applicable), expand/collapse works, inner col-headers render
- [ ] Manual: empty state — when no nodes discovered, the "No nodes discovered" placeholder shows
- [ ] Manual: error states — disconnect to force the ``.catch`` paths and confirm "Failed to load" placeholder appears
- [ ] Manual: state pill clicks — clicking a state pill in the status bar should drill down to filtered workstreams