### PR TITLE
refactor(ui): migrate Pane from prototype constructor to ES6 class

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -117,8 +117,8 @@ def test_replay_history_renders_content_before_tool_block() -> None:
     The test pins the order via the offsets of the ``msg.content`` and
     ``msg.tool_calls`` branch headers inside the function body."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("Pane.prototype.replayHistory = function")
-    end = body.index("Pane.prototype._attachRetryToLastAssistant", start)
+    start = body.index("\n  replayHistory(")
+    end = body.index("\n  _attachRetryToLastAssistant(", start)
     fn = body[start:end]
     # Locate the assistant branch and bound the search to its body —
     # the function also handles user / tool roles which would otherwise
@@ -154,8 +154,8 @@ def test_replay_history_renders_persisted_verdict_badge() -> None:
     call. This test pins the call site so a refactor that drops the
     decoration regresses the audit surface."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("Pane.prototype.replayHistory = function")
-    end = body.index("Pane.prototype._attachRetryToLastAssistant", start)
+    start = body.index("\n  replayHistory(")
+    end = body.index("\n  _attachRetryToLastAssistant(", start)
     fn = body[start:end]
     # Match a `renderVerdictBadge(<something>.verdict, ...)` call inside
     # the replay loop.  Loose on whitespace + identifier so a future
@@ -210,8 +210,8 @@ def test_replay_renders_user_interjection_advisory_after_tool_block() -> None:
     invocation regresses the queued-during-batch replay shape
     silently."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("Pane.prototype.replayHistory = function")
-    end = body.index("Pane.prototype._attachRetryToLastAssistant", start)
+    start = body.index("\n  replayHistory(")
+    end = body.index("\n  _attachRetryToLastAssistant(", start)
     fn = body[start:end]
     # The replay loop must invoke the shared helper, passing
     # ``msg.advisories`` and a renderer that routes through

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -337,8 +337,8 @@ def test_phase8_appendtooloutput_dispatches_mcp_error_before_renderer() -> None:
     interactive consent card replace the JSON dump; reverse the calls
     and the user sees the raw error envelope as text again."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("Pane.prototype.appendToolOutput = function")
-    end = body.index("Pane.prototype.", start + 10)
+    start = body.index("\n  appendToolOutput(")
+    end = body.index("\n  sendMessage(", start)
     fn = body[start:end]
     parse_idx = fn.find("tryParseMcpError(")
     render_idx = fn.find("renderToolOutput(")

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -17,6 +17,22 @@ import pytest
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
 
 
+def _pane_method_offset(body: str, name: str) -> int:
+    """Return the start offset of class method ``name`` in ``body``.
+
+    Indent-agnostic — matches the method header at any leading-whitespace
+    depth (2 spaces for the current class, 4 if the class is ever
+    wrapped in an IIFE or module, etc.) so slice tests survive deferred
+    modernization without silent ``ValueError`` failures.  Asserts on
+    miss so a refactor that renames the method fails loudly at the
+    pinning slice instead of further downstream.
+    """
+    pattern = re.compile(r"^\s{2,}" + re.escape(name) + r"\(", re.MULTILINE)
+    m = pattern.search(body)
+    assert m is not None, f"class method {name!r} not found in app.js"
+    return m.start()
+
+
 def test_switch_tab_bootstraps_pane_when_none_exists() -> None:
     """``switchTab`` must create a pane when none exists. A fresh-
     loaded interactive UI with no workstreams shows the dashboard
@@ -117,8 +133,8 @@ def test_replay_history_renders_content_before_tool_block() -> None:
     The test pins the order via the offsets of the ``msg.content`` and
     ``msg.tool_calls`` branch headers inside the function body."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("\n  replayHistory(")
-    end = body.index("\n  _attachRetryToLastAssistant(", start)
+    start = _pane_method_offset(body, "replayHistory")
+    end = _pane_method_offset(body, "_attachRetryToLastAssistant")
     fn = body[start:end]
     # Locate the assistant branch and bound the search to its body —
     # the function also handles user / tool roles which would otherwise
@@ -154,8 +170,8 @@ def test_replay_history_renders_persisted_verdict_badge() -> None:
     call. This test pins the call site so a refactor that drops the
     decoration regresses the audit surface."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("\n  replayHistory(")
-    end = body.index("\n  _attachRetryToLastAssistant(", start)
+    start = _pane_method_offset(body, "replayHistory")
+    end = _pane_method_offset(body, "_attachRetryToLastAssistant")
     fn = body[start:end]
     # Match a `renderVerdictBadge(<something>.verdict, ...)` call inside
     # the replay loop.  Loose on whitespace + identifier so a future
@@ -210,8 +226,8 @@ def test_replay_renders_user_interjection_advisory_after_tool_block() -> None:
     invocation regresses the queued-during-batch replay shape
     silently."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("\n  replayHistory(")
-    end = body.index("\n  _attachRetryToLastAssistant(", start)
+    start = _pane_method_offset(body, "replayHistory")
+    end = _pane_method_offset(body, "_attachRetryToLastAssistant")
     fn = body[start:end]
     # The replay loop must invoke the shared helper, passing
     # ``msg.advisories`` and a renderer that routes through
@@ -263,9 +279,9 @@ _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style
 # ``el.innerHTML\n  = X``.
 #
 # ``insertAdjacent`` + HTML is *not* covered here because two existing
-# call sites (``ui/static/app.js:1287`` and ``ui/static/app.js:1538``)
-# consume ``renderVerdictBadge`` HTML output; broadening the lint
-# would require cleaning that helper first.  Tracked as a follow-up.
+# call sites in ``ui/static/app.js`` consume ``renderVerdictBadge``
+# HTML output; broadening the lint would require cleaning that
+# helper first.  Tracked as a follow-up.
 _UNSAFE_CODE_SINK_RE = re.compile(
     r"\.(?:inner|outer)"
     + r"HTML\s*\+?=(?!=)"
@@ -337,8 +353,8 @@ def test_phase8_appendtooloutput_dispatches_mcp_error_before_renderer() -> None:
     interactive consent card replace the JSON dump; reverse the calls
     and the user sees the raw error envelope as text again."""
     body = _APP_JS.read_text(encoding="utf-8")
-    start = body.index("\n  appendToolOutput(")
-    end = body.index("\n  sendMessage(", start)
+    start = _pane_method_offset(body, "appendToolOutput")
+    end = _pane_method_offset(body, "sendMessage")
     fn = body[start:end]
     parse_idx = fn.find("tryParseMcpError(")
     render_idx = fn.find("renderToolOutput(")
@@ -416,10 +432,10 @@ def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
     concat-assignment), legacy doc-write, and the dynamic-code
     constructors (string-eval, dynamic-Function, string-first-arg
     timer scheduling).  ``insertAdjacent`` + HTML is deliberately
-    *not* covered yet; two existing ``ui/static/app.js`` sites (the
-    verdict-badge writers at lines 1287 and 1538) consume the
-    HTML-string output of ``renderVerdictBadge``, so broadening the
-    lint requires cleaning that helper first.
+    *not* covered yet; two existing ``ui/static/app.js`` sites — the
+    verdict-badge writers — consume the HTML-string output of
+    ``renderVerdictBadge``, so broadening the lint requires cleaning
+    that helper first.
 
     Parametrized so each target is its own pytest case — a failure on
     one file is attributed precisely without masking offenders in the

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -336,10 +336,10 @@
   }
 
   // User-message bubble with attachment-pill cluster appended below
-  // the text.  Mirrors Pane.prototype.addUserMessage in the
-  // interactive UI so live-send and history-replay both render the
-  // same chip strip the composer staged on submit.  Attachments is a
-  // list of {kind, filename}; falsy/empty falls through to plain text.
+  // the text.  Mirrors Pane.addUserMessage in the interactive UI so
+  // live-send and history-replay both render the same chip strip the
+  // composer staged on submit.  Attachments is a list of
+  // {kind, filename}; falsy/empty falls through to plain text.
   function appendUserMessageWithAttachments(text, attachments, opts) {
     const el = appendText("user", text, opts);
     if (!Array.isArray(attachments) || attachments.length === 0) return el;
@@ -436,7 +436,7 @@
 
   // Metacognitive reminder bubble (user-channel correction / denial /
   // resume / start / completion AND tool-channel tool_error / repeat).
-  // Mirrors Pane.prototype.addUserReminder / addToolReminder in the
+  // Mirrors Pane.addUserReminder / addToolReminder in the
   // interactive UI — yellow themed bubble slotted directly below the
   // message it advises.  ``watch_triggered`` reminders branch off into
   // the structured ``.msg.watch-result`` card.  ``anchor`` is the DOM
@@ -563,7 +563,7 @@
     } else if (argsRaw) {
       // Malformed JSON or non-object args — show the raw payload
       // truncated.  Matches the interactive replay's substring(0, 100)
-      // fallback at ui/static/app.js Pane.prototype.replayHistory.
+      // fallback at ui/static/app.js Pane.replayHistory.
       header = name;
       preview = argsRaw.length > 200 ? argsRaw.slice(0, 200) + "…" : argsRaw;
     }

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -477,6 +477,829 @@ class Pane {
       this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
     }
   }
+
+  _createDOM() {
+    this.el = document.createElement("div");
+    this.el.className = "pane";
+    this.el.dataset.paneId = this.id;
+
+    // Focus on mousedown (before child clicks)
+    this.el.addEventListener("mousedown", () => {
+      setFocusedPane(this.id);
+    });
+    // Also track keyboard focus moving into this pane (e.g. Tab into textarea)
+    this.el.addEventListener(
+      "focusin",
+      () => {
+        setFocusedPane(this.id);
+      },
+      true,
+    );
+
+    // Right-click context menu for split/close actions — skip interactive
+    // elements (textareas, links, buttons) so native copy/paste works
+    this.el.addEventListener("contextmenu", (e) => {
+      var tag = e.target.tagName;
+      if (
+        tag === "TEXTAREA" ||
+        tag === "INPUT" ||
+        tag === "A" ||
+        tag === "BUTTON" ||
+        e.target.isContentEditable
+      )
+        return;
+      var sel = window.getSelection();
+      if (sel && sel.toString().length > 0) return;
+      e.preventDefault();
+      setFocusedPane(this.id);
+      showPaneContextMenu(e.clientX, e.clientY, this.id);
+    });
+
+    // Pane header (visible only in multi-pane mode)
+    this.headerEl = document.createElement("div");
+    this.headerEl.className = "pane-header";
+
+    var wsName = document.createElement("span");
+    wsName.className = "pane-ws-name";
+    wsName.textContent = this.wsId
+      ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
+        this.wsId.substring(0, 8)
+      : "";
+    this.headerEl.appendChild(wsName);
+
+    var actions = document.createElement("div");
+    actions.className = "pane-actions";
+
+    var splitRightBtn = document.createElement("button");
+    splitRightBtn.className = "pane-action-btn";
+    splitRightBtn.title = "Split right";
+    splitRightBtn.setAttribute("aria-label", "Split right");
+    splitRightBtn.textContent = "\u2502";
+    splitRightBtn.onclick = (e) => {
+      e.stopPropagation();
+      splitPane(this.id, "horizontal");
+    };
+    actions.appendChild(splitRightBtn);
+
+    var splitDownBtn = document.createElement("button");
+    splitDownBtn.className = "pane-action-btn";
+    splitDownBtn.title = "Split down";
+    splitDownBtn.setAttribute("aria-label", "Split down");
+    splitDownBtn.textContent = "\u2500";
+    splitDownBtn.onclick = (e) => {
+      e.stopPropagation();
+      splitPane(this.id, "vertical");
+    };
+    actions.appendChild(splitDownBtn);
+
+    var closeBtn = document.createElement("button");
+    closeBtn.className = "pane-action-btn pane-close-btn";
+    closeBtn.title = "Close pane";
+    closeBtn.setAttribute("aria-label", "Close pane");
+    closeBtn.textContent = "\u00d7";
+    closeBtn.onclick = (e) => {
+      e.stopPropagation();
+      if (countLeaves(splitRoot) > 1) closePane(this.id);
+    };
+    actions.appendChild(closeBtn);
+
+    this.headerEl.appendChild(actions);
+    this.el.appendChild(this.headerEl);
+
+    // Messages area
+    this.messagesEl = document.createElement("div");
+    this.messagesEl.className = "pane-messages";
+    this.messagesEl.setAttribute("role", "log");
+    this.messagesEl.setAttribute("aria-live", "polite");
+    this.messagesEl.setAttribute("aria-label", "Chat messages");
+    this.el.appendChild(this.messagesEl);
+
+    // Per-workstream status bar (above input)
+    this.statusBarEl = document.createElement("div");
+    this.statusBarEl.className = "ws-status-bar";
+    this.statusBarEl.setAttribute("role", "status");
+    this.statusBarEl.setAttribute("aria-live", "polite");
+    this.statusBarEl.setAttribute("aria-atomic", "true");
+    this.statusBarEl.setAttribute("aria-label", "Workstream status");
+
+    this._sbModel = document.createElement("span");
+    this._sbModel.className = "ws-sb-model";
+    this._sbModel.textContent = "\u2014";
+    this._sbModel.setAttribute("aria-label", "Model");
+    this._sbTokens = document.createElement("span");
+    this._sbTokens.className = "ws-sb-tokens";
+    this._sbTokens.textContent = "0 / \u2014";
+    this._sbTokens.setAttribute("aria-label", "Token usage");
+    this._sbTools = document.createElement("span");
+    this._sbTools.className = "ws-sb-tools";
+    this._sbTools.textContent = "0 tools";
+    this._sbTools.setAttribute("aria-label", "Tool calls this turn");
+    this._sbTurns = document.createElement("span");
+    this._sbTurns.className = "ws-sb-turns";
+    this._sbTurns.textContent = "turn 0";
+    this._sbTurns.setAttribute("aria-label", "Conversation turn");
+
+    this.statusBarEl.appendChild(this._sbModel);
+    this.statusBarEl.appendChild(this._sbTokens);
+    this.statusBarEl.appendChild(this._sbTools);
+    this.statusBarEl.appendChild(this._sbTurns);
+    this.el.appendChild(this.statusBarEl);
+
+    // Input area — DOM + behavior comes from shared/composer.js.  The
+    // pane keeps the attachment-upload pipeline (because attachments are
+    // pane-specific state) and routes file events through the composer's
+    // attach/paste/drop callbacks.
+    this.composer = new Composer(this.el, {
+      attachments: {
+        onAttach: (file) => {
+          this.attachments.upload(file);
+        },
+      },
+      stopBtn: true,
+      queueWhileBusy: true,
+      busyPlaceholder: "Queue a message\u2026 (!!! for urgent)",
+      onSend: () => {
+        this.sendMessage();
+      },
+      onStop: () => {
+        this.cancelGeneration();
+      },
+      dragDrop: { targetEl: this.el, dropClass: "pane-drop-target" },
+    });
+    this.inputEl = this.composer.inputEl;
+    this.sendBtn = this.composer.sendBtn;
+    this.stopBtn = this.composer.stopBtn;
+    // Lazy wsId read \u2014 a tab swap (Pane re-bound to a new workstream)
+    // changes the closure target without re-instantiating the controllers.
+    this.attachments = createAttachmentController({
+      chipsEl: this.composer.chipsEl,
+      getWsId: () => {
+        return this.wsId;
+      },
+      onError: (msg) => {
+        showToast(msg);
+      },
+    });
+    this.queue = createQueueController({
+      messagesEl: this.messagesEl,
+      getWsId: () => {
+        return this.wsId;
+      },
+      onAfterDequeue: () => {
+        this.attachments.rehydrate();
+      },
+      // Idle-edge cleanup of the cancel/force-stop timers — without
+      // this they fire on the *next* busy turn, relabel Stop to "Force
+      // Stop", and surface a misleading "Cancel didn't complete in
+      // time" toast about a turn the user already moved past.
+      onIdle: () => {
+        if (this._cancelTimeout) {
+          clearTimeout(this._cancelTimeout);
+          this._cancelTimeout = null;
+        }
+        if (this._forceTimeout) {
+          clearTimeout(this._forceTimeout);
+          this._forceTimeout = null;
+        }
+      },
+    });
+  }
+
+  connectSSE(wsId) {
+    this.disconnectSSE();
+    var wsChanged = this.wsId !== wsId;
+    this.wsId = wsId;
+    if (wsChanged) {
+      this.attachments.clearChips();
+      this.attachments.rehydrate();
+    }
+
+    this.evtSource = new EventSource(
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events",
+    );
+
+    this.evtSource.onopen = () => {
+      this.retryDelay = 1000;
+      this.statusBarEl.classList.remove("ws-sb-disconnected");
+      if (this._lastStatusEvt) this.updateStatus(this._lastStatusEvt);
+    };
+
+    this.evtSource.onmessage = (e) => {
+      var data = JSON.parse(e.data);
+      this.handleEvent(data);
+    };
+
+    this.evtSource.onerror = () => {
+      this.evtSource.close();
+      this.evtSource = null;
+      var loginOverlay = document.getElementById("login-overlay");
+      if (loginOverlay && loginOverlay.style.display !== "none") return;
+      this.statusBarEl.classList.add("ws-sb-disconnected");
+      this._sbTokens.textContent = "Reconnecting\u2026";
+      // Only the focused pane refreshes the global workstream list to avoid
+      // race conditions when multiple panes disconnect simultaneously.
+      if (this.id === focusedPaneId) {
+        fetch("/v1/api/workstreams")
+          .then((r) => {
+            if (r.status === 401) {
+              showLogin();
+              return;
+            }
+            return r.json().then((data) => {
+              workstreams = {};
+              (data.workstreams || []).forEach((ws) => {
+                workstreams[ws.ws_id] = { name: ws.name, state: ws.state };
+              });
+              renderTabBar();
+              // Reconnect all disconnected panes, reassigning stale ws_ids.
+              // Two passes: (1) reassign stale panes, (2) reconnect all.
+              // Track assigned ws_ids to avoid multiple panes on the same ws.
+              var remaining = Object.keys(workstreams);
+              if (!remaining.length) {
+                showDashboard();
+                return;
+              }
+              var usedWsIds = {};
+              for (var pid in panes) {
+                if (panes[pid].wsId && workstreams[panes[pid].wsId])
+                  usedWsIds[panes[pid].wsId] = true;
+              }
+              for (var pid2 in panes) {
+                var p2 = panes[pid2];
+                if (p2.wsId && !workstreams[p2.wsId]) {
+                  var newWsId = null;
+                  for (var ri = 0; ri < remaining.length; ri++) {
+                    if (!usedWsIds[remaining[ri]]) {
+                      newWsId = remaining[ri];
+                      break;
+                    }
+                  }
+                  if (newWsId) {
+                    p2.disconnectSSE();
+                    p2.wsId = newWsId;
+                    usedWsIds[newWsId] = true;
+                    while (p2.messagesEl.firstChild)
+                      p2.messagesEl.removeChild(p2.messagesEl.firstChild);
+                    p2.showEmptyState();
+                    p2.updateWsName();
+                  }
+                  // else: more panes than workstreams — leave pane stale,
+                  // connectSSE below will pick it up or it stays disconnected.
+                }
+              }
+              // Pass 2: reconnect all panes and sync focused pane
+              for (var pid3 in panes) {
+                var p3 = panes[pid3];
+                if (pid3 === focusedPaneId) currentWsId = p3.wsId;
+                if (!p3.evtSource && p3.wsId && workstreams[p3.wsId]) {
+                  setTimeout(
+                    ((pp) => {
+                      return () => {
+                        pp.connectSSE(pp.wsId);
+                      };
+                    })(p3),
+                    this.retryDelay,
+                  );
+                }
+              }
+              this.retryDelay = Math.min(this.retryDelay * 2, 30000);
+            });
+          })
+          .catch(() => {
+            setTimeout(() => {
+              this.connectSSE(this.wsId);
+            }, this.retryDelay);
+            this.retryDelay = Math.min(this.retryDelay * 2, 30000);
+          });
+      } else {
+        // Non-focused pane: just retry own connection after delay
+        setTimeout(() => {
+          this.connectSSE(this.wsId);
+        }, this.retryDelay);
+        this.retryDelay = Math.min(this.retryDelay * 2, 30000);
+      }
+    };
+  }
+
+  handleEvent(evt) {
+    // Guard: drop events that belong to a different workstream.
+    // This prevents cross-contamination during tab switches and reconnects.
+    if (evt.ws_id && evt.ws_id !== this.wsId) return;
+    switch (evt.type) {
+      case "thinking_start":
+        this.isThinking = true;
+        this.setBusy(true);
+        this.removeEmptyState();
+        this.addThinkingIndicator();
+        break;
+
+      case "thinking_stop":
+        this.isThinking = false;
+        this.removeThinkingIndicator();
+        break;
+
+      case "reasoning":
+        this.removeThinkingIndicator();
+        if (!this.currentReasoningEl) {
+          this.currentReasoningEl = document.createElement("div");
+          this.currentReasoningEl.className = "msg reasoning";
+          this.messagesEl.appendChild(this.currentReasoningEl);
+        }
+        this.currentReasoningEl.textContent += evt.text;
+        this.scrollToBottom();
+        break;
+
+      case "content":
+        this.removeThinkingIndicator();
+        if (this.currentReasoningEl) {
+          this.currentReasoningEl = null;
+        }
+        if (!this.currentAssistantEl) {
+          this.currentAssistantEl = document.createElement("div");
+          this.currentAssistantEl.className = "msg assistant";
+          this.currentAssistantBodyEl = document.createElement("div");
+          this.currentAssistantBodyEl.className = "msg-body";
+          this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
+          this.messagesEl.appendChild(this.currentAssistantEl);
+        }
+        this.contentBuffer += evt.text;
+        streamingRender(this.currentAssistantBodyEl, this.contentBuffer);
+        this.scrollToBottom();
+        break;
+
+      case "stream_end":
+        if (this._cancelTimeout) {
+          clearTimeout(this._cancelTimeout);
+          this._cancelTimeout = null;
+        }
+        if (this._forceTimeout) {
+          clearTimeout(this._forceTimeout);
+          this._forceTimeout = null;
+        }
+        // Finalize the current streaming segment's markdown.  This fires
+        // per-segment (between tool calls), NOT per-turn.  Busy state is
+        // managed by state_change events instead.
+        if (this.currentAssistantBodyEl && this.contentBuffer) {
+          streamingRenderFinalize(
+            this.currentAssistantBodyEl,
+            this.contentBuffer,
+          );
+        }
+        this.currentAssistantBodyEl = null;
+        this.currentAssistantEl = null;
+        this.currentReasoningEl = null;
+        this.contentBuffer = "";
+        this.scrollToBottom(true);
+        break;
+
+      case "in_progress_snapshot":
+        // One-shot replay of the in-progress turn's reasoning + content
+        // when this client connects mid-stream (page refresh while the
+        // model is generating).  Both fields may be empty; render only
+        // the non-empty halves.  Idempotent on EventSource auto-reconnect:
+        // skip overwrite when the current buffer is already at-or-past
+        // the snapshot length, so a stale replay can't reset the live-
+        // streamed view back to a shorter prefix.
+        this.removeThinkingIndicator();
+        if (evt.reasoning) {
+          if (!this.currentReasoningEl) {
+            this.currentReasoningEl = document.createElement("div");
+            this.currentReasoningEl.className = "msg reasoning";
+            this.messagesEl.appendChild(this.currentReasoningEl);
+          }
+          var curReason = this.currentReasoningEl.textContent || "";
+          if (curReason.length < evt.reasoning.length) {
+            this.currentReasoningEl.textContent = evt.reasoning;
+          }
+        }
+        if (evt.content) {
+          // Content snapshot supersedes any reasoning bubble — matches
+          // the "case content" invariant of clearing currentReasoningEl
+          // when content begins.
+          if (this.currentReasoningEl) {
+            this.currentReasoningEl = null;
+          }
+          if (!this.currentAssistantEl) {
+            this.currentAssistantEl = document.createElement("div");
+            this.currentAssistantEl.className = "msg assistant";
+            this.currentAssistantBodyEl = document.createElement("div");
+            this.currentAssistantBodyEl.className = "msg-body";
+            this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
+            this.messagesEl.appendChild(this.currentAssistantEl);
+          }
+          if (this.contentBuffer.length < evt.content.length) {
+            this.contentBuffer = evt.content;
+            streamingRender(this.currentAssistantBodyEl, this.contentBuffer);
+          }
+        }
+        this.scrollToBottom();
+        break;
+
+      case "state_change":
+        if (evt.state === "idle" || evt.state === "error") {
+          this.setBusy(false);
+          this._attachRetryToLastAssistant();
+          // Only steal focus if this is the active pane and no approval pending.
+          if (this.id === focusedPaneId && !this.pendingApproval) {
+            this.inputEl.focus();
+          }
+        } else if (
+          evt.state === "thinking" ||
+          evt.state === "running" ||
+          evt.state === "attention"
+        ) {
+          this.setBusy(true);
+        }
+        break;
+
+      case "tool_info":
+        this.showInlineToolBlock(evt.items, true);
+        break;
+
+      case "approve_request":
+        this.showInlineToolBlock(evt.items, false, evt.judge_pending);
+        break;
+
+      case "intent_verdict":
+        this.updateVerdictBadge(evt);
+        break;
+
+      case "output_warning":
+        this.showOutputWarning(evt);
+        break;
+
+      case "approval_resolved":
+        this.resolveApproval(evt.approved, false, evt.feedback, true);
+        break;
+
+      case "tool_output_chunk":
+        this.appendToolOutputChunk(evt.call_id || "", evt.chunk);
+        break;
+
+      case "tool_result":
+        this.appendToolOutput(
+          evt.call_id || "",
+          evt.name,
+          evt.output,
+          evt.is_error,
+        );
+        break;
+
+      case "status":
+        this.updateStatus(evt);
+        break;
+
+      case "plan_review":
+        showPlanDialog(evt.content);
+        break;
+
+      case "plan_resolved":
+        // Plan was resolved on another client (or by server-initiated cancel).
+        // Only act if our modal is for this pane's workstream.
+        if (_planWsId === this.wsId) {
+          dismissPlanDialog(evt.feedback);
+        }
+        break;
+
+      case "info":
+        this.addInfoMessage(evt.message);
+        break;
+
+      case "error":
+        // Show the error but don't change busy state — state_change
+        // handles idle/error transitions.  on_error fires for non-terminal
+        // errors (tool parse failures, truncation) mid-turn too.
+        this.addErrorMessage(evt.message);
+        break;
+
+      case "user_reminder":
+        // Metacognitive nudges — render as their own bubble below the
+        // user message they advise (semantically: a hint to the model
+        // right before its turn).  The originating tab's optimistic
+        // addUserMessage already ran when the user clicked send, so by
+        // the time this SSE event arrives the just-sent user bubble is
+        // at the bottom of messagesEl and addUserReminder's "anchor to
+        // most recent .msg.user" lookup finds it correctly; the
+        // insertAdjacentElement('afterend', el) call drops the bubble
+        // immediately below.
+        //
+        // Wake-driven reminders (``evt.source === "system_nudge"``)
+        // render the thin .msg.user.system-nudge marker first and
+        // anchor below it, so non-originating tabs see the same shape
+        // the originating tab does.
+        //
+        // Multi-tab caveat (non-wake): the server emits no user_message
+        // SSE event for real user input today, so a non-originating tab
+        // sees the reminder without a paired user-message render — the
+        // anchor falls on a stale prior user bubble, mis-positioning
+        // the reminder.  The next /history reload corrects it.
+        // Acceptable cost for stage 1; closing the gap is a follow-up
+        // that adds a user_message SSE event.
+        if (Array.isArray(evt.reminders) && evt.reminders.length) {
+          this.addUserReminder(evt.reminders, evt.source || "");
+        }
+        break;
+
+      case "tool_reminder":
+        // Metacognitive tool-channel nudge (tool_error / repeat) —
+        // render as the same yellow themed bubble used for user-channel
+        // reminders, anchored below the .ts-approval block whose tool
+        // result triggered the batch's reminder.  evt.tool_call_id
+        // identifies the specific tool element; addToolReminder walks
+        // up to its parent approval block and inserts the bubble
+        // immediately after.
+        if (Array.isArray(evt.reminders) && evt.reminders.length) {
+          this.addToolReminder(evt.reminders, evt.tool_call_id || "");
+        }
+        break;
+
+      case "message_queued":
+        // Confirmation from server that a queued message was accepted.
+        // The UI already showed the message optimistically in addQueuedMessage.
+        break;
+
+      case "busy_error":
+        // Server is still busy — don't transition to send mode.
+        // Re-enable the stop button so the user can try cancelling.
+        this.addErrorMessage(evt.message);
+        this.stopBtn.textContent = "\u25a0 Stop";
+        this.stopBtn.setAttribute("aria-label", "Stop generation");
+        delete this.stopBtn.dataset.forceCancel;
+        this.stopBtn.disabled = false;
+        break;
+
+      case "cancelled":
+        // Cancel requested but worker thread may still be finishing.
+        // Show "Cancelling..." state; state_change will transition to ready.
+        // If state_change already arrived (busy is false), the cancel is
+        // already handled — don't re-enter the cancelling state.
+        if (!this.busy) break;
+        // Clear any prior timeouts first (duplicate cancelled events).
+        clearTimeout(this._cancelTimeout);
+        clearTimeout(this._forceTimeout);
+        this.currentAssistantEl = null;
+        this.currentReasoningEl = null;
+        this.contentBuffer = "";
+        this.stopBtn.disabled = true;
+        this.stopBtn.textContent = "Cancelling\u2026";
+        this.stopBtn.setAttribute("aria-label", "Cancelling generation");
+        this.scrollToBottom(true);
+        // After 2s, offer "Force Stop" for a harder cancel that abandons
+        // the stuck worker thread.  Safety timeout at 10s auto-recovers
+        // if state_change never arrives (connection drop).
+        this._cancelTimeout = setTimeout(() => {
+          if (this.busy) {
+            this.stopBtn.disabled = false;
+            this.stopBtn.textContent = "\u26a0 Force Stop";
+            this.stopBtn.setAttribute("aria-label", "Force stop generation");
+            this.stopBtn.dataset.forceCancel = "true";
+          }
+        }, 2000);
+        this._forceTimeout = setTimeout(() => {
+          if (this.busy) {
+            this.addInfoMessage(
+              "Cancel didn\u2019t complete in time. You may need to resend your last message.",
+            );
+            this.setBusy(false);
+          }
+        }, 10000);
+        break;
+
+      case "connected":
+        this.model = evt.model || "";
+        this.modelAlias = evt.model_alias || evt.model || "";
+        this._sbModel.textContent = this.modelAlias || this.model || "—";
+        this._sbModel.title = this.model || "";
+        if (evt.skip_permissions) {
+          var existing = document.querySelector(".skip-permissions-warning");
+          if (!existing) {
+            var warn = document.createElement("div");
+            warn.className = "skip-permissions-warning";
+            warn.textContent =
+              "\u26a0 Running with --skip-permissions: all tool calls are auto-approved";
+            document.getElementById("ui-header").appendChild(warn);
+          }
+        }
+        break;
+
+      case "history":
+        this.replayHistory(evt.messages);
+        // Dispatch pending edit-and-resend after rewind history arrives
+        if (this._pendingEditSend) {
+          var editText = this._pendingEditSend;
+          this._pendingEditSend = null;
+          this.setBusy(true);
+          this.addUserMessage(editText);
+          authFetch(
+            "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/send",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ message: editText }),
+            },
+          ).catch((err) => {
+            this.addErrorMessage("Connection error: " + err.message);
+            this.setBusy(false);
+          });
+        }
+        break;
+
+      case "clear_ui":
+        this.messagesEl.replaceChildren();
+        break;
+    }
+  }
+
+  _addUserMsgActions(el, text) {
+    var bar = document.createElement("div");
+    bar.className = "msg-actions";
+    bar.setAttribute("role", "toolbar");
+    bar.setAttribute("aria-label", "Message actions");
+    // Edit button
+    var editBtn = document.createElement("button");
+    editBtn.className = "msg-action-btn";
+    editBtn.title = "Edit & resend";
+    editBtn.setAttribute("aria-label", "Edit and resend this message");
+    var editIcon = document.createElement("span");
+    editIcon.className = "icon-edit";
+    editIcon.setAttribute("aria-hidden", "true");
+    editBtn.appendChild(editIcon);
+    editBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this._startEdit(el, text);
+    });
+    bar.appendChild(editBtn);
+    // Rewind-to-here button
+    var rewindBtn = document.createElement("button");
+    rewindBtn.className = "msg-action-btn";
+    rewindBtn.title = "Rewind to before this message";
+    rewindBtn.setAttribute(
+      "aria-label",
+      "Rewind conversation to before this message",
+    );
+    var rewindIcon = document.createElement("span");
+    rewindIcon.className = "icon-rewind";
+    rewindIcon.setAttribute("aria-hidden", "true");
+    rewindBtn.appendChild(rewindIcon);
+    rewindBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this._rewindToMessage(el);
+    });
+    bar.appendChild(rewindBtn);
+    el.appendChild(bar);
+  }
+
+  _addRetryAction(el) {
+    var bar = el.querySelector(".msg-actions");
+    if (!bar) {
+      bar = document.createElement("div");
+      bar.className = "msg-actions";
+      bar.setAttribute("role", "toolbar");
+      bar.setAttribute("aria-label", "Message actions");
+      el.appendChild(bar);
+    }
+    var btn = document.createElement("button");
+    btn.className = "msg-action-btn";
+    btn.title = "Retry (regenerate response)";
+    btn.setAttribute("aria-label", "Retry last response");
+    var icon = document.createElement("span");
+    icon.className = "icon-retry";
+    icon.setAttribute("aria-hidden", "true");
+    btn.appendChild(icon);
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this._retryLast();
+    });
+    bar.insertBefore(btn, bar.firstChild);
+  }
+
+  _retryLast() {
+    if (this.busy) return;
+    authFetch("/v1/api/command", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: "/retry", ws_id: this.wsId }),
+    }).catch((err) => {
+      this.addErrorMessage("Retry failed: " + err.message);
+    });
+  }
+
+  _rewindToMessage(msgEl) {
+    if (this.busy) return;
+    // Count how many user messages come at or after this one
+    var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
+    var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
+    if (idx < 0) return;
+    var turnsToRewind = userMsgs.length - idx;
+    if (turnsToRewind < 1) return;
+    authFetch("/v1/api/command", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        command: "/rewind " + turnsToRewind,
+        ws_id: this.wsId,
+      }),
+    }).catch((err) => {
+      this.addErrorMessage("Rewind failed: " + err.message);
+    });
+  }
+
+  _startEdit(msgEl, originalText) {
+    if (this.busy) return;
+    // Save current child nodes for cancel restoration
+    var savedNodes = [];
+    while (msgEl.firstChild) {
+      savedNodes.push(msgEl.removeChild(msgEl.firstChild));
+    }
+    msgEl.classList.add("msg-editing");
+
+    var form = document.createElement("div");
+    form.className = "msg-edit-form";
+
+    var textarea = document.createElement("textarea");
+    textarea.className = "msg-edit-textarea";
+    textarea.setAttribute("aria-label", "Edit message text");
+    textarea.value = originalText;
+    textarea.rows = Math.min(originalText.split("\n").length + 1, 8);
+    form.appendChild(textarea);
+
+    var actions = document.createElement("div");
+    actions.className = "msg-edit-actions";
+
+    var cancelBtn = document.createElement("button");
+    cancelBtn.className = "msg-edit-btn";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.addEventListener("click", () => {
+      // Restore original nodes
+      while (msgEl.firstChild) msgEl.removeChild(msgEl.firstChild);
+      savedNodes.forEach((n) => {
+        msgEl.appendChild(n);
+      });
+      msgEl.classList.remove("msg-editing");
+    });
+    actions.appendChild(cancelBtn);
+
+    var sendBtn = document.createElement("button");
+    sendBtn.className = "msg-edit-btn msg-edit-btn-send";
+    sendBtn.textContent = "Send";
+    sendBtn.addEventListener("click", () => {
+      var newText = textarea.value.trim();
+      if (!newText) return;
+      this._editAndResend(msgEl, newText);
+    });
+    actions.appendChild(sendBtn);
+
+    // Ctrl+Enter to send, Escape to cancel
+    textarea.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        sendBtn.click();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancelBtn.click();
+      }
+    });
+
+    form.appendChild(actions);
+    msgEl.appendChild(form);
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+  }
+
+  _editAndResend(msgEl, newText) {
+    if (this.busy) return;
+    // Count turns to rewind (from this message onward)
+    var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
+    var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
+    if (idx < 0) return;
+    var turnsToRewind = userMsgs.length - idx;
+
+    this.setBusy(true);
+    // Store pending send — dispatched when the rewind history event arrives
+    this._pendingEditSend = newText;
+    authFetch("/v1/api/command", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        command: "/rewind " + turnsToRewind,
+        ws_id: this.wsId,
+      }),
+    })
+      .then((r) => {
+        if (r && !r.ok) {
+          this._pendingEditSend = null;
+          this.setBusy(false);
+          this.addErrorMessage(
+            "Rewind failed (HTTP " + r.status + " " + r.statusText + ")",
+          );
+        }
+      })
+      .catch((err) => {
+        this._pendingEditSend = null;
+        this.addErrorMessage("Rewind failed: " + err.message);
+        this.setBusy(false);
+      });
+  }
 }
 
 // Build a structured ``.msg.watch-result`` card for a
@@ -536,840 +1359,6 @@ function _buildDefaultReminderBubble(r) {
   el.appendChild(body);
   return el;
 }
-
-Pane.prototype._createDOM = function () {
-  var self = this;
-
-  this.el = document.createElement("div");
-  this.el.className = "pane";
-  this.el.dataset.paneId = this.id;
-
-  // Focus on mousedown (before child clicks)
-  this.el.addEventListener("mousedown", function () {
-    setFocusedPane(self.id);
-  });
-  // Also track keyboard focus moving into this pane (e.g. Tab into textarea)
-  this.el.addEventListener(
-    "focusin",
-    function () {
-      setFocusedPane(self.id);
-    },
-    true,
-  );
-
-  // Right-click context menu for split/close actions — skip interactive
-  // elements (textareas, links, buttons) so native copy/paste works
-  this.el.addEventListener("contextmenu", function (e) {
-    var tag = e.target.tagName;
-    if (
-      tag === "TEXTAREA" ||
-      tag === "INPUT" ||
-      tag === "A" ||
-      tag === "BUTTON" ||
-      e.target.isContentEditable
-    )
-      return;
-    var sel = window.getSelection();
-    if (sel && sel.toString().length > 0) return;
-    e.preventDefault();
-    setFocusedPane(self.id);
-    showPaneContextMenu(e.clientX, e.clientY, self.id);
-  });
-
-  // Pane header (visible only in multi-pane mode)
-  this.headerEl = document.createElement("div");
-  this.headerEl.className = "pane-header";
-
-  var wsName = document.createElement("span");
-  wsName.className = "pane-ws-name";
-  wsName.textContent = this.wsId
-    ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
-      this.wsId.substring(0, 8)
-    : "";
-  this.headerEl.appendChild(wsName);
-
-  var actions = document.createElement("div");
-  actions.className = "pane-actions";
-
-  var splitRightBtn = document.createElement("button");
-  splitRightBtn.className = "pane-action-btn";
-  splitRightBtn.title = "Split right";
-  splitRightBtn.setAttribute("aria-label", "Split right");
-  splitRightBtn.textContent = "\u2502";
-  splitRightBtn.onclick = function (e) {
-    e.stopPropagation();
-    splitPane(self.id, "horizontal");
-  };
-  actions.appendChild(splitRightBtn);
-
-  var splitDownBtn = document.createElement("button");
-  splitDownBtn.className = "pane-action-btn";
-  splitDownBtn.title = "Split down";
-  splitDownBtn.setAttribute("aria-label", "Split down");
-  splitDownBtn.textContent = "\u2500";
-  splitDownBtn.onclick = function (e) {
-    e.stopPropagation();
-    splitPane(self.id, "vertical");
-  };
-  actions.appendChild(splitDownBtn);
-
-  var closeBtn = document.createElement("button");
-  closeBtn.className = "pane-action-btn pane-close-btn";
-  closeBtn.title = "Close pane";
-  closeBtn.setAttribute("aria-label", "Close pane");
-  closeBtn.textContent = "\u00d7";
-  closeBtn.onclick = function (e) {
-    e.stopPropagation();
-    if (countLeaves(splitRoot) > 1) closePane(self.id);
-  };
-  actions.appendChild(closeBtn);
-
-  this.headerEl.appendChild(actions);
-  this.el.appendChild(this.headerEl);
-
-  // Messages area
-  this.messagesEl = document.createElement("div");
-  this.messagesEl.className = "pane-messages";
-  this.messagesEl.setAttribute("role", "log");
-  this.messagesEl.setAttribute("aria-live", "polite");
-  this.messagesEl.setAttribute("aria-label", "Chat messages");
-  this.el.appendChild(this.messagesEl);
-
-  // Per-workstream status bar (above input)
-  this.statusBarEl = document.createElement("div");
-  this.statusBarEl.className = "ws-status-bar";
-  this.statusBarEl.setAttribute("role", "status");
-  this.statusBarEl.setAttribute("aria-live", "polite");
-  this.statusBarEl.setAttribute("aria-atomic", "true");
-  this.statusBarEl.setAttribute("aria-label", "Workstream status");
-
-  this._sbModel = document.createElement("span");
-  this._sbModel.className = "ws-sb-model";
-  this._sbModel.textContent = "\u2014";
-  this._sbModel.setAttribute("aria-label", "Model");
-  this._sbTokens = document.createElement("span");
-  this._sbTokens.className = "ws-sb-tokens";
-  this._sbTokens.textContent = "0 / \u2014";
-  this._sbTokens.setAttribute("aria-label", "Token usage");
-  this._sbTools = document.createElement("span");
-  this._sbTools.className = "ws-sb-tools";
-  this._sbTools.textContent = "0 tools";
-  this._sbTools.setAttribute("aria-label", "Tool calls this turn");
-  this._sbTurns = document.createElement("span");
-  this._sbTurns.className = "ws-sb-turns";
-  this._sbTurns.textContent = "turn 0";
-  this._sbTurns.setAttribute("aria-label", "Conversation turn");
-
-  this.statusBarEl.appendChild(this._sbModel);
-  this.statusBarEl.appendChild(this._sbTokens);
-  this.statusBarEl.appendChild(this._sbTools);
-  this.statusBarEl.appendChild(this._sbTurns);
-  this.el.appendChild(this.statusBarEl);
-
-  // Input area — DOM + behavior comes from shared/composer.js.  The
-  // pane keeps the attachment-upload pipeline (because attachments are
-  // pane-specific state) and routes file events through the composer's
-  // attach/paste/drop callbacks.
-  this.composer = new Composer(this.el, {
-    attachments: {
-      onAttach: function (file) {
-        self.attachments.upload(file);
-      },
-    },
-    stopBtn: true,
-    queueWhileBusy: true,
-    busyPlaceholder: "Queue a message\u2026 (!!! for urgent)",
-    onSend: function () {
-      self.sendMessage();
-    },
-    onStop: function () {
-      self.cancelGeneration();
-    },
-    dragDrop: { targetEl: this.el, dropClass: "pane-drop-target" },
-  });
-  this.inputEl = this.composer.inputEl;
-  this.sendBtn = this.composer.sendBtn;
-  this.stopBtn = this.composer.stopBtn;
-  // Lazy wsId read \u2014 a tab swap (Pane re-bound to a new workstream)
-  // changes the closure target without re-instantiating the controllers.
-  this.attachments = createAttachmentController({
-    chipsEl: this.composer.chipsEl,
-    getWsId: function () {
-      return self.wsId;
-    },
-    onError: function (msg) {
-      showToast(msg);
-    },
-  });
-  this.queue = createQueueController({
-    messagesEl: this.messagesEl,
-    getWsId: function () {
-      return self.wsId;
-    },
-    onAfterDequeue: function () {
-      self.attachments.rehydrate();
-    },
-    // Idle-edge cleanup of the cancel/force-stop timers — without
-    // this they fire on the *next* busy turn, relabel Stop to "Force
-    // Stop", and surface a misleading "Cancel didn't complete in
-    // time" toast about a turn the user already moved past.
-    onIdle: function () {
-      if (self._cancelTimeout) {
-        clearTimeout(self._cancelTimeout);
-        self._cancelTimeout = null;
-      }
-      if (self._forceTimeout) {
-        clearTimeout(self._forceTimeout);
-        self._forceTimeout = null;
-      }
-    },
-  });
-};
-
-Pane.prototype.connectSSE = function (wsId) {
-  var self = this;
-  this.disconnectSSE();
-  var wsChanged = this.wsId !== wsId;
-  this.wsId = wsId;
-  if (wsChanged) {
-    this.attachments.clearChips();
-    this.attachments.rehydrate();
-  }
-
-  this.evtSource = new EventSource(
-    "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events",
-  );
-
-  this.evtSource.onopen = function () {
-    self.retryDelay = 1000;
-    self.statusBarEl.classList.remove("ws-sb-disconnected");
-    if (self._lastStatusEvt) self.updateStatus(self._lastStatusEvt);
-  };
-
-  this.evtSource.onmessage = function (e) {
-    var data = JSON.parse(e.data);
-    self.handleEvent(data);
-  };
-
-  this.evtSource.onerror = function () {
-    self.evtSource.close();
-    self.evtSource = null;
-    var loginOverlay = document.getElementById("login-overlay");
-    if (loginOverlay && loginOverlay.style.display !== "none") return;
-    self.statusBarEl.classList.add("ws-sb-disconnected");
-    self._sbTokens.textContent = "Reconnecting\u2026";
-    // Only the focused pane refreshes the global workstream list to avoid
-    // race conditions when multiple panes disconnect simultaneously.
-    if (self.id === focusedPaneId) {
-      fetch("/v1/api/workstreams")
-        .then(function (r) {
-          if (r.status === 401) {
-            showLogin();
-            return;
-          }
-          return r.json().then(function (data) {
-            workstreams = {};
-            (data.workstreams || []).forEach(function (ws) {
-              workstreams[ws.ws_id] = { name: ws.name, state: ws.state };
-            });
-            renderTabBar();
-            // Reconnect all disconnected panes, reassigning stale ws_ids.
-            // Two passes: (1) reassign stale panes, (2) reconnect all.
-            // Track assigned ws_ids to avoid multiple panes on the same ws.
-            var remaining = Object.keys(workstreams);
-            if (!remaining.length) {
-              showDashboard();
-              return;
-            }
-            var usedWsIds = {};
-            for (var pid in panes) {
-              if (panes[pid].wsId && workstreams[panes[pid].wsId])
-                usedWsIds[panes[pid].wsId] = true;
-            }
-            for (var pid2 in panes) {
-              var p2 = panes[pid2];
-              if (p2.wsId && !workstreams[p2.wsId]) {
-                var newWsId = null;
-                for (var ri = 0; ri < remaining.length; ri++) {
-                  if (!usedWsIds[remaining[ri]]) {
-                    newWsId = remaining[ri];
-                    break;
-                  }
-                }
-                if (newWsId) {
-                  p2.disconnectSSE();
-                  p2.wsId = newWsId;
-                  usedWsIds[newWsId] = true;
-                  while (p2.messagesEl.firstChild)
-                    p2.messagesEl.removeChild(p2.messagesEl.firstChild);
-                  p2.showEmptyState();
-                  p2.updateWsName();
-                }
-                // else: more panes than workstreams — leave pane stale,
-                // connectSSE below will pick it up or it stays disconnected.
-              }
-            }
-            // Pass 2: reconnect all panes and sync focused pane
-            for (var pid3 in panes) {
-              var p3 = panes[pid3];
-              if (pid3 === focusedPaneId) currentWsId = p3.wsId;
-              if (!p3.evtSource && p3.wsId && workstreams[p3.wsId]) {
-                setTimeout(
-                  (function (pp) {
-                    return function () {
-                      pp.connectSSE(pp.wsId);
-                    };
-                  })(p3),
-                  self.retryDelay,
-                );
-              }
-            }
-            self.retryDelay = Math.min(self.retryDelay * 2, 30000);
-          });
-        })
-        .catch(function () {
-          setTimeout(function () {
-            self.connectSSE(self.wsId);
-          }, self.retryDelay);
-          self.retryDelay = Math.min(self.retryDelay * 2, 30000);
-        });
-    } else {
-      // Non-focused pane: just retry own connection after delay
-      setTimeout(function () {
-        self.connectSSE(self.wsId);
-      }, self.retryDelay);
-      self.retryDelay = Math.min(self.retryDelay * 2, 30000);
-    }
-  };
-};
-
-Pane.prototype.handleEvent = function (evt) {
-  // Guard: drop events that belong to a different workstream.
-  // This prevents cross-contamination during tab switches and reconnects.
-  if (evt.ws_id && evt.ws_id !== this.wsId) return;
-  var self = this;
-  switch (evt.type) {
-    case "thinking_start":
-      this.isThinking = true;
-      this.setBusy(true);
-      this.removeEmptyState();
-      this.addThinkingIndicator();
-      break;
-
-    case "thinking_stop":
-      this.isThinking = false;
-      this.removeThinkingIndicator();
-      break;
-
-    case "reasoning":
-      this.removeThinkingIndicator();
-      if (!this.currentReasoningEl) {
-        this.currentReasoningEl = document.createElement("div");
-        this.currentReasoningEl.className = "msg reasoning";
-        this.messagesEl.appendChild(this.currentReasoningEl);
-      }
-      this.currentReasoningEl.textContent += evt.text;
-      this.scrollToBottom();
-      break;
-
-    case "content":
-      this.removeThinkingIndicator();
-      if (this.currentReasoningEl) {
-        this.currentReasoningEl = null;
-      }
-      if (!this.currentAssistantEl) {
-        this.currentAssistantEl = document.createElement("div");
-        this.currentAssistantEl.className = "msg assistant";
-        this.currentAssistantBodyEl = document.createElement("div");
-        this.currentAssistantBodyEl.className = "msg-body";
-        this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
-        this.messagesEl.appendChild(this.currentAssistantEl);
-      }
-      this.contentBuffer += evt.text;
-      streamingRender(this.currentAssistantBodyEl, this.contentBuffer);
-      this.scrollToBottom();
-      break;
-
-    case "stream_end":
-      if (this._cancelTimeout) {
-        clearTimeout(this._cancelTimeout);
-        this._cancelTimeout = null;
-      }
-      if (this._forceTimeout) {
-        clearTimeout(this._forceTimeout);
-        this._forceTimeout = null;
-      }
-      // Finalize the current streaming segment's markdown.  This fires
-      // per-segment (between tool calls), NOT per-turn.  Busy state is
-      // managed by state_change events instead.
-      if (this.currentAssistantBodyEl && this.contentBuffer) {
-        streamingRenderFinalize(
-          this.currentAssistantBodyEl,
-          this.contentBuffer,
-        );
-      }
-      this.currentAssistantBodyEl = null;
-      this.currentAssistantEl = null;
-      this.currentReasoningEl = null;
-      this.contentBuffer = "";
-      this.scrollToBottom(true);
-      break;
-
-    case "in_progress_snapshot":
-      // One-shot replay of the in-progress turn's reasoning + content
-      // when this client connects mid-stream (page refresh while the
-      // model is generating).  Both fields may be empty; render only
-      // the non-empty halves.  Idempotent on EventSource auto-reconnect:
-      // skip overwrite when the current buffer is already at-or-past
-      // the snapshot length, so a stale replay can't reset the live-
-      // streamed view back to a shorter prefix.
-      this.removeThinkingIndicator();
-      if (evt.reasoning) {
-        if (!this.currentReasoningEl) {
-          this.currentReasoningEl = document.createElement("div");
-          this.currentReasoningEl.className = "msg reasoning";
-          this.messagesEl.appendChild(this.currentReasoningEl);
-        }
-        var curReason = this.currentReasoningEl.textContent || "";
-        if (curReason.length < evt.reasoning.length) {
-          this.currentReasoningEl.textContent = evt.reasoning;
-        }
-      }
-      if (evt.content) {
-        // Content snapshot supersedes any reasoning bubble — matches
-        // the "case content" invariant of clearing currentReasoningEl
-        // when content begins.
-        if (this.currentReasoningEl) {
-          this.currentReasoningEl = null;
-        }
-        if (!this.currentAssistantEl) {
-          this.currentAssistantEl = document.createElement("div");
-          this.currentAssistantEl.className = "msg assistant";
-          this.currentAssistantBodyEl = document.createElement("div");
-          this.currentAssistantBodyEl.className = "msg-body";
-          this.currentAssistantEl.appendChild(this.currentAssistantBodyEl);
-          this.messagesEl.appendChild(this.currentAssistantEl);
-        }
-        if (this.contentBuffer.length < evt.content.length) {
-          this.contentBuffer = evt.content;
-          streamingRender(this.currentAssistantBodyEl, this.contentBuffer);
-        }
-      }
-      this.scrollToBottom();
-      break;
-
-    case "state_change":
-      if (evt.state === "idle" || evt.state === "error") {
-        this.setBusy(false);
-        this._attachRetryToLastAssistant();
-        // Only steal focus if this is the active pane and no approval pending.
-        if (this.id === focusedPaneId && !this.pendingApproval) {
-          this.inputEl.focus();
-        }
-      } else if (
-        evt.state === "thinking" ||
-        evt.state === "running" ||
-        evt.state === "attention"
-      ) {
-        this.setBusy(true);
-      }
-      break;
-
-    case "tool_info":
-      this.showInlineToolBlock(evt.items, true);
-      break;
-
-    case "approve_request":
-      this.showInlineToolBlock(evt.items, false, evt.judge_pending);
-      break;
-
-    case "intent_verdict":
-      this.updateVerdictBadge(evt);
-      break;
-
-    case "output_warning":
-      this.showOutputWarning(evt);
-      break;
-
-    case "approval_resolved":
-      this.resolveApproval(evt.approved, false, evt.feedback, true);
-      break;
-
-    case "tool_output_chunk":
-      this.appendToolOutputChunk(evt.call_id || "", evt.chunk);
-      break;
-
-    case "tool_result":
-      this.appendToolOutput(
-        evt.call_id || "",
-        evt.name,
-        evt.output,
-        evt.is_error,
-      );
-      break;
-
-    case "status":
-      this.updateStatus(evt);
-      break;
-
-    case "plan_review":
-      showPlanDialog(evt.content);
-      break;
-
-    case "plan_resolved":
-      // Plan was resolved on another client (or by server-initiated cancel).
-      // Only act if our modal is for this pane's workstream.
-      if (_planWsId === this.wsId) {
-        dismissPlanDialog(evt.feedback);
-      }
-      break;
-
-    case "info":
-      this.addInfoMessage(evt.message);
-      break;
-
-    case "error":
-      // Show the error but don't change busy state — state_change
-      // handles idle/error transitions.  on_error fires for non-terminal
-      // errors (tool parse failures, truncation) mid-turn too.
-      this.addErrorMessage(evt.message);
-      break;
-
-    case "user_reminder":
-      // Metacognitive nudges — render as their own bubble below the
-      // user message they advise (semantically: a hint to the model
-      // right before its turn).  The originating tab's optimistic
-      // addUserMessage already ran when the user clicked send, so by
-      // the time this SSE event arrives the just-sent user bubble is
-      // at the bottom of messagesEl and addUserReminder's "anchor to
-      // most recent .msg.user" lookup finds it correctly; the
-      // insertAdjacentElement('afterend', el) call drops the bubble
-      // immediately below.
-      //
-      // Wake-driven reminders (``evt.source === "system_nudge"``)
-      // render the thin .msg.user.system-nudge marker first and
-      // anchor below it, so non-originating tabs see the same shape
-      // the originating tab does.
-      //
-      // Multi-tab caveat (non-wake): the server emits no user_message
-      // SSE event for real user input today, so a non-originating tab
-      // sees the reminder without a paired user-message render — the
-      // anchor falls on a stale prior user bubble, mis-positioning
-      // the reminder.  The next /history reload corrects it.
-      // Acceptable cost for stage 1; closing the gap is a follow-up
-      // that adds a user_message SSE event.
-      if (Array.isArray(evt.reminders) && evt.reminders.length) {
-        this.addUserReminder(evt.reminders, evt.source || "");
-      }
-      break;
-
-    case "tool_reminder":
-      // Metacognitive tool-channel nudge (tool_error / repeat) —
-      // render as the same yellow themed bubble used for user-channel
-      // reminders, anchored below the .ts-approval block whose tool
-      // result triggered the batch's reminder.  evt.tool_call_id
-      // identifies the specific tool element; addToolReminder walks
-      // up to its parent approval block and inserts the bubble
-      // immediately after.
-      if (Array.isArray(evt.reminders) && evt.reminders.length) {
-        this.addToolReminder(evt.reminders, evt.tool_call_id || "");
-      }
-      break;
-
-    case "message_queued":
-      // Confirmation from server that a queued message was accepted.
-      // The UI already showed the message optimistically in addQueuedMessage.
-      break;
-
-    case "busy_error":
-      // Server is still busy — don't transition to send mode.
-      // Re-enable the stop button so the user can try cancelling.
-      this.addErrorMessage(evt.message);
-      this.stopBtn.textContent = "\u25a0 Stop";
-      this.stopBtn.setAttribute("aria-label", "Stop generation");
-      delete this.stopBtn.dataset.forceCancel;
-      this.stopBtn.disabled = false;
-      break;
-
-    case "cancelled":
-      // Cancel requested but worker thread may still be finishing.
-      // Show "Cancelling..." state; state_change will transition to ready.
-      // If state_change already arrived (busy is false), the cancel is
-      // already handled — don't re-enter the cancelling state.
-      if (!this.busy) break;
-      // Clear any prior timeouts first (duplicate cancelled events).
-      clearTimeout(this._cancelTimeout);
-      clearTimeout(this._forceTimeout);
-      this.currentAssistantEl = null;
-      this.currentReasoningEl = null;
-      this.contentBuffer = "";
-      this.stopBtn.disabled = true;
-      this.stopBtn.textContent = "Cancelling\u2026";
-      this.stopBtn.setAttribute("aria-label", "Cancelling generation");
-      this.scrollToBottom(true);
-      // After 2s, offer "Force Stop" for a harder cancel that abandons
-      // the stuck worker thread.  Safety timeout at 10s auto-recovers
-      // if state_change never arrives (connection drop).
-      var self = this;
-      this._cancelTimeout = setTimeout(function () {
-        if (self.busy) {
-          self.stopBtn.disabled = false;
-          self.stopBtn.textContent = "\u26a0 Force Stop";
-          self.stopBtn.setAttribute("aria-label", "Force stop generation");
-          self.stopBtn.dataset.forceCancel = "true";
-        }
-      }, 2000);
-      this._forceTimeout = setTimeout(function () {
-        if (self.busy) {
-          self.addInfoMessage(
-            "Cancel didn\u2019t complete in time. You may need to resend your last message.",
-          );
-          self.setBusy(false);
-        }
-      }, 10000);
-      break;
-
-    case "connected":
-      this.model = evt.model || "";
-      this.modelAlias = evt.model_alias || evt.model || "";
-      this._sbModel.textContent = this.modelAlias || this.model || "—";
-      this._sbModel.title = this.model || "";
-      if (evt.skip_permissions) {
-        var existing = document.querySelector(".skip-permissions-warning");
-        if (!existing) {
-          var warn = document.createElement("div");
-          warn.className = "skip-permissions-warning";
-          warn.textContent =
-            "\u26a0 Running with --skip-permissions: all tool calls are auto-approved";
-          document.getElementById("ui-header").appendChild(warn);
-        }
-      }
-      break;
-
-    case "history":
-      this.replayHistory(evt.messages);
-      // Dispatch pending edit-and-resend after rewind history arrives
-      if (this._pendingEditSend) {
-        var editText = this._pendingEditSend;
-        this._pendingEditSend = null;
-        this.setBusy(true);
-        this.addUserMessage(editText);
-        authFetch(
-          "/v1/api/workstreams/" + encodeURIComponent(self.wsId) + "/send",
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message: editText }),
-          },
-        ).catch(function (err) {
-          self.addErrorMessage("Connection error: " + err.message);
-          self.setBusy(false);
-        });
-      }
-      break;
-
-    case "clear_ui":
-      this.messagesEl.replaceChildren();
-      break;
-  }
-};
-
-Pane.prototype._addUserMsgActions = function (el, text) {
-  var self = this;
-  var bar = document.createElement("div");
-  bar.className = "msg-actions";
-  bar.setAttribute("role", "toolbar");
-  bar.setAttribute("aria-label", "Message actions");
-  // Edit button
-  var editBtn = document.createElement("button");
-  editBtn.className = "msg-action-btn";
-  editBtn.title = "Edit & resend";
-  editBtn.setAttribute("aria-label", "Edit and resend this message");
-  var editIcon = document.createElement("span");
-  editIcon.className = "icon-edit";
-  editIcon.setAttribute("aria-hidden", "true");
-  editBtn.appendChild(editIcon);
-  editBtn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    self._startEdit(el, text);
-  });
-  bar.appendChild(editBtn);
-  // Rewind-to-here button
-  var rewindBtn = document.createElement("button");
-  rewindBtn.className = "msg-action-btn";
-  rewindBtn.title = "Rewind to before this message";
-  rewindBtn.setAttribute(
-    "aria-label",
-    "Rewind conversation to before this message",
-  );
-  var rewindIcon = document.createElement("span");
-  rewindIcon.className = "icon-rewind";
-  rewindIcon.setAttribute("aria-hidden", "true");
-  rewindBtn.appendChild(rewindIcon);
-  rewindBtn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    self._rewindToMessage(el);
-  });
-  bar.appendChild(rewindBtn);
-  el.appendChild(bar);
-};
-
-Pane.prototype._addRetryAction = function (el) {
-  var self = this;
-  var bar = el.querySelector(".msg-actions");
-  if (!bar) {
-    bar = document.createElement("div");
-    bar.className = "msg-actions";
-    bar.setAttribute("role", "toolbar");
-    bar.setAttribute("aria-label", "Message actions");
-    el.appendChild(bar);
-  }
-  var btn = document.createElement("button");
-  btn.className = "msg-action-btn";
-  btn.title = "Retry (regenerate response)";
-  btn.setAttribute("aria-label", "Retry last response");
-  var icon = document.createElement("span");
-  icon.className = "icon-retry";
-  icon.setAttribute("aria-hidden", "true");
-  btn.appendChild(icon);
-  btn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    self._retryLast();
-  });
-  bar.insertBefore(btn, bar.firstChild);
-};
-
-Pane.prototype._retryLast = function () {
-  if (this.busy) return;
-  var self = this;
-  authFetch("/v1/api/command", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ command: "/retry", ws_id: this.wsId }),
-  }).catch(function (err) {
-    self.addErrorMessage("Retry failed: " + err.message);
-  });
-};
-
-Pane.prototype._rewindToMessage = function (msgEl) {
-  if (this.busy) return;
-  var self = this;
-  // Count how many user messages come at or after this one
-  var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
-  var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
-  if (idx < 0) return;
-  var turnsToRewind = userMsgs.length - idx;
-  if (turnsToRewind < 1) return;
-  authFetch("/v1/api/command", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      command: "/rewind " + turnsToRewind,
-      ws_id: this.wsId,
-    }),
-  }).catch(function (err) {
-    self.addErrorMessage("Rewind failed: " + err.message);
-  });
-};
-
-Pane.prototype._startEdit = function (msgEl, originalText) {
-  if (this.busy) return;
-  var self = this;
-  // Save current child nodes for cancel restoration
-  var savedNodes = [];
-  while (msgEl.firstChild) {
-    savedNodes.push(msgEl.removeChild(msgEl.firstChild));
-  }
-  msgEl.classList.add("msg-editing");
-
-  var form = document.createElement("div");
-  form.className = "msg-edit-form";
-
-  var textarea = document.createElement("textarea");
-  textarea.className = "msg-edit-textarea";
-  textarea.setAttribute("aria-label", "Edit message text");
-  textarea.value = originalText;
-  textarea.rows = Math.min(originalText.split("\n").length + 1, 8);
-  form.appendChild(textarea);
-
-  var actions = document.createElement("div");
-  actions.className = "msg-edit-actions";
-
-  var cancelBtn = document.createElement("button");
-  cancelBtn.className = "msg-edit-btn";
-  cancelBtn.textContent = "Cancel";
-  cancelBtn.addEventListener("click", function () {
-    // Restore original nodes
-    while (msgEl.firstChild) msgEl.removeChild(msgEl.firstChild);
-    savedNodes.forEach(function (n) {
-      msgEl.appendChild(n);
-    });
-    msgEl.classList.remove("msg-editing");
-  });
-  actions.appendChild(cancelBtn);
-
-  var sendBtn = document.createElement("button");
-  sendBtn.className = "msg-edit-btn msg-edit-btn-send";
-  sendBtn.textContent = "Send";
-  sendBtn.addEventListener("click", function () {
-    var newText = textarea.value.trim();
-    if (!newText) return;
-    self._editAndResend(msgEl, newText);
-  });
-  actions.appendChild(sendBtn);
-
-  // Ctrl+Enter to send, Escape to cancel
-  textarea.addEventListener("keydown", function (e) {
-    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-      e.preventDefault();
-      sendBtn.click();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      cancelBtn.click();
-    }
-  });
-
-  form.appendChild(actions);
-  msgEl.appendChild(form);
-  textarea.focus();
-  textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-};
-
-Pane.prototype._editAndResend = function (msgEl, newText) {
-  if (this.busy) return;
-  var self = this;
-  // Count turns to rewind (from this message onward)
-  var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
-  var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
-  if (idx < 0) return;
-  var turnsToRewind = userMsgs.length - idx;
-
-  this.setBusy(true);
-  // Store pending send — dispatched when the rewind history event arrives
-  this._pendingEditSend = newText;
-  authFetch("/v1/api/command", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      command: "/rewind " + turnsToRewind,
-      ws_id: self.wsId,
-    }),
-  })
-    .then(function (r) {
-      if (r && !r.ok) {
-        self._pendingEditSend = null;
-        self.setBusy(false);
-        self.addErrorMessage(
-          "Rewind failed (HTTP " + r.status + " " + r.statusText + ")",
-        );
-      }
-    })
-    .catch(function (err) {
-      self._pendingEditSend = null;
-      self.addErrorMessage("Rewind failed: " + err.message);
-      self.setBusy(false);
-    });
-};
 
 Pane.prototype.replayHistory = function (messages) {
   var self = this;

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -9,31 +9,532 @@
 
 var _paneCounter = 0;
 
-function Pane(wsId) {
-  this.id = "p" + ++_paneCounter;
-  this.wsId = wsId || null;
-  this.evtSource = null;
-  this.el = null;
-  this.headerEl = null;
-  this.messagesEl = null;
-  this.inputEl = null;
-  this.sendBtn = null;
-  this.stopBtn = null;
-  this.currentAssistantEl = null;
-  this.currentReasoningEl = null;
-  this.contentBuffer = "";
-  this.busy = false;
-  this.isThinking = false;
-  this.pendingApproval = false;
-  this.approvalBlockEl = null;
-  this.retryDelay = 1000;
-  this.model = "";
-  this.modelAlias = "";
-  this._lastStatusEvt = null;
-  this._cancelTimeout = null;
-  this._forceTimeout = null;
-  this._pendingEditSend = null;
-  this._createDOM();
+class Pane {
+  constructor(wsId) {
+    this.id = "p" + ++_paneCounter;
+    this.wsId = wsId || null;
+    this.evtSource = null;
+    this.el = null;
+    this.headerEl = null;
+    this.messagesEl = null;
+    this.inputEl = null;
+    this.sendBtn = null;
+    this.stopBtn = null;
+    this.currentAssistantEl = null;
+    this.currentReasoningEl = null;
+    this.contentBuffer = "";
+    this.busy = false;
+    this.isThinking = false;
+    this.pendingApproval = false;
+    this.approvalBlockEl = null;
+    this.retryDelay = 1000;
+    this.model = "";
+    this.modelAlias = "";
+    this._lastStatusEvt = null;
+    this._cancelTimeout = null;
+    this._forceTimeout = null;
+    this._pendingEditSend = null;
+    this._createDOM();
+  }
+
+  reset() {
+    this.currentAssistantEl = null;
+    this.currentReasoningEl = null;
+    this.contentBuffer = "";
+    this.setBusy(false);
+    this.pendingApproval = false;
+    this.approvalBlockEl = null;
+    this._pendingEditSend = null;
+    this.inputEl.disabled = false;
+    this.attachments.clearChips();
+  }
+
+  updateWsName() {
+    var nameEl = this.headerEl.querySelector(".pane-ws-name");
+    if (nameEl) {
+      nameEl.textContent = this.wsId
+        ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
+          this.wsId.substring(0, 8)
+        : "";
+    }
+  }
+
+  disconnectSSE() {
+    if (this._cancelTimeout) {
+      clearTimeout(this._cancelTimeout);
+      this._cancelTimeout = null;
+    }
+    if (this._forceTimeout) {
+      clearTimeout(this._forceTimeout);
+      this._forceTimeout = null;
+    }
+    if (this.evtSource) {
+      this.evtSource.close();
+      this.evtSource = null;
+    }
+  }
+
+  // composer.setBusy runs unconditionally so the Stop button label /
+  // dataset.forceCancel / placeholder stay canonical even on a redundant
+  // call (Pane.reset() and any future caller relies on that idempotent
+  // reset). queue.onIdleEdge runs only on the actual edge — it carries
+  // the heavier work (querySelectorAll-driven promote sweep + cancel-
+  // timer cleanup wired via the queue's onIdle hook).
+  setBusy(b) {
+    var next = !!b;
+    this.composer.setBusy(next);
+    this.messagesEl.dataset.busy = next ? "true" : "false";
+    var edge = next !== this.busy;
+    this.busy = next;
+    if (edge && !next) this.queue.onIdleEdge();
+  }
+
+  showEmptyState() {
+    if (!this.messagesEl.querySelector(".empty-state")) {
+      var el = document.createElement("div");
+      el.className = "empty-state";
+      el.textContent = "Type a message to start";
+      this.messagesEl.appendChild(el);
+    }
+  }
+
+  removeEmptyState() {
+    var el = this.messagesEl.querySelector(".empty-state");
+    if (el) el.remove();
+  }
+
+  addThinkingIndicator() {
+    if (this.messagesEl.querySelector(".thinking-indicator")) return;
+    var el = document.createElement("div");
+    el.className = "thinking-indicator";
+    el.textContent = "Thinking";
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  removeThinkingIndicator() {
+    var el = this.messagesEl.querySelector(".thinking-indicator");
+    if (el) el.remove();
+  }
+
+  addSystemNudgeMarker() {
+    // Thin .msg.user.system-nudge marker rendered as the anchor for
+    // wake-driven reminder bubbles.  Replaces the previously-invisible
+    // synthetic empty user turn with a visible-but-subtle DOM element so
+    // the bubble below it lands in the right place even when the wake
+    // fires long after the user's last real message.
+    this.removeEmptyState();
+    var el = document.createElement("div");
+    el.className = "msg user system-nudge";
+    el.setAttribute("data-source", "system_nudge");
+    el.setAttribute("aria-label", "system nudge");
+    el.textContent = "system nudge";
+    this.messagesEl.appendChild(el);
+    return el;
+  }
+
+  addUserReminder(reminders, source) {
+    // Render each metacognitive reminder as its own bubble immediately
+    // BELOW the user message it advises — semantically the reminder is
+    // a hint to the model right before the assistant turn.  Always
+    // called AFTER the corresponding addUserMessage (live: optimistic
+    // local render ran before the SSE event arrived; replay:
+    // replayHistory renders the user message first), so "most recent
+    // .msg.user" is always THIS turn's bubble — insertAdjacentElement
+    // afterend drops the reminder directly below it.  When no .msg.user
+    // exists at all (e.g. a non-originating tab receiving a reminder
+    // before any user turn has rendered) we append; the next /history
+    // reload corrects any anchor anomaly.
+    //
+    // ``source === "system_nudge"`` is the wake-driven case: render
+    // a thin .msg.user.system-nudge marker first and anchor below it.
+    // ``watch_triggered`` reminders branch off into a structured
+    // .msg.watch-result card.
+    this.removeEmptyState();
+    var anchor;
+    if (source === "system_nudge") {
+      anchor = this.addSystemNudgeMarker();
+    } else {
+      var userBubbles = this.messagesEl.querySelectorAll(
+        ".msg.user:not(.system-nudge)",
+      );
+      anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
+    }
+    for (var i = 0; i < reminders.length; i++) {
+      var r = reminders[i] || {};
+      var el =
+        r.type === "watch_triggered"
+          ? _buildWatchResultBubble(r)
+          : _buildDefaultReminderBubble(r);
+      if (anchor) {
+        anchor.insertAdjacentElement("afterend", el);
+        // Anchor advances so multiple reminders stack below the user
+        // message in queued order (rather than each landing
+        // immediately-after the user msg, which would reverse them).
+        anchor = el;
+      } else {
+        this.messagesEl.appendChild(el);
+      }
+    }
+    this.scrollToBottom(true);
+  }
+
+  addToolReminder(reminders, toolCallId) {
+    // Render each metacognitive tool-channel reminder (tool_error /
+    // repeat) as the same yellow themed bubble used for user-channel
+    // reminders, anchored below the .ts-approval block that produced
+    // the tool result.  toolCallId is the live-path anchor (SSE event
+    // carries it); during replay it's an empty string and we fall back
+    // to "last .ts-approval block in messagesEl", which is correct
+    // because messages render in order — the assistant block carrying
+    // the tool batch is always the most recent approval block by the
+    // time we hit the tool message that owns the reminder.  Tool-channel
+    // reminders also branch on r.type so a watch_triggered drained at
+    // the tool seam (channel="any") renders the structured card.
+    this.removeEmptyState();
+    var anchor = null;
+    if (toolCallId) {
+      var escapedId = CSS.escape(toolCallId);
+      var toolEl = this.messagesEl.querySelector(
+        '.ts-approval-tool[data-call-id="' + escapedId + '"]',
+      );
+      if (toolEl) {
+        anchor = toolEl.closest(".ts-approval");
+      }
+    }
+    if (!anchor) {
+      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+      if (blocks.length) anchor = blocks[blocks.length - 1];
+    }
+    for (var i = 0; i < reminders.length; i++) {
+      var r = reminders[i] || {};
+      var el =
+        r.type === "watch_triggered"
+          ? _buildWatchResultBubble(r)
+          : _buildDefaultReminderBubble(r);
+      if (anchor) {
+        anchor.insertAdjacentElement("afterend", el);
+        anchor = el;
+      } else {
+        this.messagesEl.appendChild(el);
+      }
+    }
+    this.scrollToBottom(true);
+  }
+
+  addUserMessage(text, attachments) {
+    this.removeEmptyState();
+    var el = document.createElement("div");
+    el.className = "msg user";
+    var textEl = document.createElement("div");
+    textEl.className = "msg-user-text";
+    textEl.textContent = text;
+    el.appendChild(textEl);
+    if (Array.isArray(attachments) && attachments.length > 0) {
+      var pills = document.createElement("div");
+      pills.className = "msg-user-attach";
+      attachments.forEach(function (a) {
+        var pill = document.createElement("span");
+        pill.className =
+          "msg-user-attach-pill msg-user-attach-pill-" + (a.kind || "other");
+        var icon = document.createElement("span");
+        icon.className = "msg-user-attach-icon";
+        icon.setAttribute("aria-hidden", "true");
+        icon.textContent = a.kind === "image" ? "\ud83d\uddbc" : "\ud83d\udcc4";
+        pill.appendChild(icon);
+        var nameEl = document.createElement("span");
+        nameEl.className = "msg-user-attach-name";
+        nameEl.textContent =
+          a.filename || (a.kind === "image" ? "image" : "document");
+        pill.appendChild(nameEl);
+        pills.appendChild(pill);
+      });
+      el.appendChild(pills);
+    }
+    this._addUserMsgActions(el, text);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom(true);
+  }
+
+  getFeedback() {
+    if (!this.approvalBlockEl) return null;
+    var inp = this.approvalBlockEl.querySelector(".ts-approval-feedback");
+    return inp && inp.value.trim() ? inp.value.trim() : null;
+  }
+
+  appendToolOutputChunk(callId, chunk) {
+    if (!chunk) return;
+    var stripped = stripAnsi(chunk);
+    if (!stripped) return;
+
+    var escapedId = callId ? CSS.escape(callId) : "";
+    var el = escapedId
+      ? this.messagesEl.querySelector(
+          '.tool-output-stream[data-call-id="' + escapedId + '"]',
+        )
+      : null;
+    if (!el) {
+      var target = escapedId
+        ? this.messagesEl.querySelector(
+            '.ts-approval-tool[data-call-id="' + escapedId + '"]',
+          )
+        : null;
+      if (!target) {
+        var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+        if (!blocks.length) return;
+        var block = blocks[blocks.length - 1];
+        var tools = block.querySelectorAll(
+          '.ts-approval-tool[data-func-name="bash"]',
+        );
+        target = tools.length ? tools[tools.length - 1] : null;
+        if (!target) {
+          var allTools = block.querySelectorAll(".ts-approval-tool");
+          target = allTools.length ? allTools[allTools.length - 1] : null;
+        }
+      }
+      if (!target) return;
+
+      el = document.createElement("pre");
+      el.className = "tool-output tool-output-stream";
+      el.dataset.callId = callId;
+      el.setAttribute("aria-label", "Streaming command output");
+      el.setAttribute("aria-live", "off");
+      el.textContent = "";
+      target.after(el);
+    }
+
+    el.appendChild(document.createTextNode(stripped));
+    el.scrollTop = el.scrollHeight;
+    this.scrollToBottom();
+  }
+
+  showOutputWarning(evt) {
+    if (!evt.call_id || evt.risk_level === "none") return;
+    var escapedId = CSS.escape(evt.call_id);
+    var toolDiv = this.messagesEl.querySelector(
+      '.ts-approval-tool[data-call-id="' + escapedId + '"]',
+    );
+    if (!toolDiv) return;
+    // Shared DOM-builder with replayHistory \u2014 single source of truth for
+    // role / class / escape semantics.  Argument shape mirrors the
+    // server-side output_assessment dict (risk_level / flags / redacted).
+    var warning = _buildOutputWarningEl({
+      risk_level: evt.risk_level,
+      flags: evt.flags,
+      redacted: evt.redacted,
+    });
+    var nextEl = toolDiv.nextElementSibling;
+    if (nextEl && nextEl.classList.contains("tool-output")) {
+      nextEl.insertAdjacentElement("afterend", warning);
+    } else {
+      toolDiv.insertAdjacentElement("afterend", warning);
+    }
+  }
+
+  updateVerdictBadge(verdict) {
+    if (!verdict || !verdict.call_id) return;
+    var escapedId = CSS.escape(verdict.call_id);
+    var badge = this.messagesEl.querySelector(
+      '.verdict-badge[data-call-id="' + escapedId + '"]',
+    );
+    if (!badge) {
+      // Badge no longer in DOM (tool block replaced by output) — show
+      // a toast so the user still sees the late-arriving verdict.
+      var conf = Math.round((verdict.confidence || 0) * 100);
+      var rec = verdict.recommendation || "review";
+      var func = verdict.func_name || "";
+      showToast(
+        "Judge verdict for " + func + ": " + rec + " (" + conf + "%)",
+        rec === "approve" ? "success" : rec === "deny" ? "error" : "warning",
+      );
+      return;
+    }
+
+    var risk = verdict.risk_level || "medium";
+    badge.className = "verdict-badge verdict-" + risk + " ts-verdict-badge";
+    badge.setAttribute("data-risk", risk);
+
+    var riskEl = badge.querySelector(".verdict-risk");
+    var recEl = badge.querySelector(".verdict-rec");
+    var confEl = badge.querySelector(".verdict-conf");
+    if (riskEl) riskEl.textContent = risk.toUpperCase();
+    if (recEl) recEl.textContent = verdict.recommendation || "review";
+    if (confEl)
+      confEl.textContent = Math.round((verdict.confidence || 0) * 100) + "%";
+
+    var spinner = badge.querySelector(".verdict-judge-spinner");
+    if (spinner) spinner.remove();
+
+    var detail = badge.nextElementSibling;
+    if (detail && detail.classList.contains("verdict-detail")) {
+      var summaryEl = detail.querySelector(".verdict-summary");
+      var reasonEl = detail.querySelector(".verdict-reasoning");
+      var tierEl = detail.querySelector(".verdict-tier");
+      if (summaryEl) summaryEl.textContent = verdict.intent_summary || "";
+      if (reasonEl) reasonEl.textContent = verdict.reasoning || "";
+      if (tierEl)
+        tierEl.textContent =
+          (verdict.tier || "llm") +
+          " tier" +
+          (verdict.judge_model ? " | " + verdict.judge_model : "");
+      var evidenceEl = detail.querySelector(".verdict-evidence");
+      if (verdict.evidence && verdict.evidence.length) {
+        if (!evidenceEl) {
+          evidenceEl = document.createElement("div");
+          evidenceEl.className = "verdict-evidence";
+          var tierDiv = detail.querySelector(".verdict-tier");
+          if (tierDiv) detail.insertBefore(evidenceEl, tierDiv);
+          else detail.appendChild(evidenceEl);
+        }
+        evidenceEl.replaceChildren(
+          ...verdict.evidence.map(function (e) {
+            var div = document.createElement("div");
+            div.textContent = "\u2022 " + e;
+            return div;
+          }),
+        );
+      } else if (evidenceEl) {
+        evidenceEl.remove();
+      }
+    }
+
+    this.updateVerdictGlow(verdict.recommendation);
+  }
+
+  updateVerdictGlow(recommendation) {
+    if (!this.approvalBlockEl) return;
+    var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
+    if (!prompt) return;
+
+    // Collect all verdict badges currently visible in this approval block
+    var badges = this.approvalBlockEl.querySelectorAll(".verdict-badge");
+    var worst = recommendation;
+    for (var i = 0; i < badges.length; i++) {
+      var recEl = badges[i].querySelector(".verdict-rec");
+      if (recEl) {
+        var r = recEl.textContent;
+        if (r === "deny") {
+          worst = "deny";
+          break;
+        }
+        if (r === "review" && worst !== "deny") worst = "review";
+      }
+    }
+
+    prompt.classList.remove(
+      "ts-verdict-glow--approve",
+      "ts-verdict-glow--deny",
+      "ts-verdict-glow--review",
+    );
+    if (worst === "approve") prompt.classList.add("ts-verdict-glow--approve");
+    else if (worst === "deny") prompt.classList.add("ts-verdict-glow--deny");
+    else prompt.classList.add("ts-verdict-glow--review");
+  }
+
+  addInfoMessage(text) {
+    var el = document.createElement("div");
+    el.className = "msg info";
+    el.textContent = stripAnsi(text);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  addErrorMessage(text) {
+    var el = document.createElement("div");
+    el.className = "msg error";
+    el.setAttribute("role", "alert");
+    el.textContent = stripAnsi(text);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  updateStatus(evt) {
+    StatusBar.paint(
+      {
+        rootEl: this.statusBarEl,
+        modelEl: this._sbModel,
+        tokensEl: this._sbTokens,
+        toolsEl: this._sbTools,
+        turnsEl: this._sbTurns,
+      },
+      evt,
+      { alias: this.modelAlias, model: this.model },
+    );
+    this._lastStatusEvt = evt;
+  }
+
+  isNearBottom() {
+    return (
+      this.messagesEl.scrollHeight -
+        this.messagesEl.scrollTop -
+        this.messagesEl.clientHeight <
+      80
+    );
+  }
+
+  scrollToBottom(force) {
+    if (force || this.isNearBottom()) {
+      this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    }
+  }
+}
+
+// Build a structured ``.msg.watch-result`` card for a
+// ``watch_triggered`` reminder — full-width treatment with command
+// preview header + shell output body + poll counter footer.  Mirrors
+// the coordinator pane's buildWatchResultBubble; first-pass functional
+// rendering only.  All text goes through textContent so shell output
+// containing angle brackets / scripts / steering bytes renders inertly.
+function _buildWatchResultBubble(r) {
+  var el = document.createElement("div");
+  el.className = "msg watch-result";
+  el.setAttribute("role", "article");
+  el.setAttribute("data-ts-role", "watch");
+  el.setAttribute("aria-label", "watch");
+  var header = document.createElement("div");
+  header.className = "msg-watch-header";
+  header.textContent =
+    "watch" + (r.watch_name ? " · " + String(r.watch_name) : "");
+  el.appendChild(header);
+  if (r.command) {
+    var cmd = document.createElement("div");
+    cmd.className = "msg-watch-cmd";
+    cmd.textContent = "$ " + String(r.command);
+    el.appendChild(cmd);
+  }
+  var body = document.createElement("pre");
+  body.className = "msg-watch-body";
+  body.textContent = r.text || "";
+  el.appendChild(body);
+  if (r.poll_count != null && r.max_polls != null) {
+    var footer = document.createElement("div");
+    footer.className = "msg-watch-footer";
+    var finalSuffix = r.is_final ? " · final" : "";
+    footer.textContent =
+      "poll " + String(r.poll_count) + "/" + String(r.max_polls) + finalSuffix;
+    el.appendChild(footer);
+  }
+  return el;
+}
+
+// Default ``.msg.user-reminder`` bubble — yellow themed advisory used
+// for every metacog nudge other than ``watch_triggered``.
+function _buildDefaultReminderBubble(r) {
+  var el = document.createElement("div");
+  el.className = "msg user-reminder";
+  var body = document.createElement("div");
+  body.className = "msg-body";
+  var labelEl = document.createElement("span");
+  labelEl.className = "msg-user-reminder-label";
+  labelEl.textContent =
+    "metacognition" + (r.type ? " · " + String(r.type) : "");
+  var textEl = document.createElement("span");
+  textEl.className = "msg-user-reminder-text";
+  textEl.textContent = r.text || "";
+  body.appendChild(labelEl);
+  body.appendChild(textEl);
+  el.appendChild(body);
+  return el;
 }
 
 Pane.prototype._createDOM = function () {
@@ -223,72 +724,6 @@ Pane.prototype._createDOM = function () {
       }
     },
   });
-};
-
-Pane.prototype.reset = function () {
-  this.currentAssistantEl = null;
-  this.currentReasoningEl = null;
-  this.contentBuffer = "";
-  this.setBusy(false);
-  this.pendingApproval = false;
-  this.approvalBlockEl = null;
-  this._pendingEditSend = null;
-  this.inputEl.disabled = false;
-  this.attachments.clearChips();
-};
-
-Pane.prototype.updateWsName = function () {
-  var nameEl = this.headerEl.querySelector(".pane-ws-name");
-  if (nameEl) {
-    nameEl.textContent = this.wsId
-      ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
-        this.wsId.substring(0, 8)
-      : "";
-  }
-};
-
-Pane.prototype.disconnectSSE = function () {
-  if (this._cancelTimeout) {
-    clearTimeout(this._cancelTimeout);
-    this._cancelTimeout = null;
-  }
-  if (this._forceTimeout) {
-    clearTimeout(this._forceTimeout);
-    this._forceTimeout = null;
-  }
-  if (this.evtSource) {
-    this.evtSource.close();
-    this.evtSource = null;
-  }
-};
-
-// composer.setBusy runs unconditionally so the Stop button label /
-// dataset.forceCancel / placeholder stay canonical even on a redundant
-// call (Pane.reset() and any future caller relies on that idempotent
-// reset). queue.onIdleEdge runs only on the actual edge — it carries
-// the heavier work (querySelectorAll-driven promote sweep + cancel-
-// timer cleanup wired via the queue's onIdle hook).
-Pane.prototype.setBusy = function (b) {
-  var next = !!b;
-  this.composer.setBusy(next);
-  this.messagesEl.dataset.busy = next ? "true" : "false";
-  var edge = next !== this.busy;
-  this.busy = next;
-  if (edge && !next) this.queue.onIdleEdge();
-};
-
-Pane.prototype.showEmptyState = function () {
-  if (!this.messagesEl.querySelector(".empty-state")) {
-    var el = document.createElement("div");
-    el.className = "empty-state";
-    el.textContent = "Type a message to start";
-    this.messagesEl.appendChild(el);
-  }
-};
-
-Pane.prototype.removeEmptyState = function () {
-  var el = this.messagesEl.querySelector(".empty-state");
-  if (el) el.remove();
 };
 
 Pane.prototype.connectSSE = function (wsId) {
@@ -737,217 +1172,6 @@ Pane.prototype.handleEvent = function (evt) {
       this.messagesEl.replaceChildren();
       break;
   }
-};
-
-Pane.prototype.addThinkingIndicator = function () {
-  if (this.messagesEl.querySelector(".thinking-indicator")) return;
-  var el = document.createElement("div");
-  el.className = "thinking-indicator";
-  el.textContent = "Thinking";
-  this.messagesEl.appendChild(el);
-  this.scrollToBottom();
-};
-
-Pane.prototype.removeThinkingIndicator = function () {
-  var el = this.messagesEl.querySelector(".thinking-indicator");
-  if (el) el.remove();
-};
-
-// Build a structured ``.msg.watch-result`` card for a
-// ``watch_triggered`` reminder — full-width treatment with command
-// preview header + shell output body + poll counter footer.  Mirrors
-// the coordinator pane's buildWatchResultBubble; first-pass functional
-// rendering only.  All text goes through textContent so shell output
-// containing angle brackets / scripts / steering bytes renders inertly.
-function _buildWatchResultBubble(r) {
-  var el = document.createElement("div");
-  el.className = "msg watch-result";
-  el.setAttribute("role", "article");
-  el.setAttribute("data-ts-role", "watch");
-  el.setAttribute("aria-label", "watch");
-  var header = document.createElement("div");
-  header.className = "msg-watch-header";
-  header.textContent =
-    "watch" + (r.watch_name ? " · " + String(r.watch_name) : "");
-  el.appendChild(header);
-  if (r.command) {
-    var cmd = document.createElement("div");
-    cmd.className = "msg-watch-cmd";
-    cmd.textContent = "$ " + String(r.command);
-    el.appendChild(cmd);
-  }
-  var body = document.createElement("pre");
-  body.className = "msg-watch-body";
-  body.textContent = r.text || "";
-  el.appendChild(body);
-  if (r.poll_count != null && r.max_polls != null) {
-    var footer = document.createElement("div");
-    footer.className = "msg-watch-footer";
-    var finalSuffix = r.is_final ? " · final" : "";
-    footer.textContent =
-      "poll " + String(r.poll_count) + "/" + String(r.max_polls) + finalSuffix;
-    el.appendChild(footer);
-  }
-  return el;
-}
-
-// Default ``.msg.user-reminder`` bubble — yellow themed advisory used
-// for every metacog nudge other than ``watch_triggered``.
-function _buildDefaultReminderBubble(r) {
-  var el = document.createElement("div");
-  el.className = "msg user-reminder";
-  var body = document.createElement("div");
-  body.className = "msg-body";
-  var labelEl = document.createElement("span");
-  labelEl.className = "msg-user-reminder-label";
-  labelEl.textContent =
-    "metacognition" + (r.type ? " · " + String(r.type) : "");
-  var textEl = document.createElement("span");
-  textEl.className = "msg-user-reminder-text";
-  textEl.textContent = r.text || "";
-  body.appendChild(labelEl);
-  body.appendChild(textEl);
-  el.appendChild(body);
-  return el;
-}
-
-Pane.prototype.addSystemNudgeMarker = function () {
-  // Thin .msg.user.system-nudge marker rendered as the anchor for
-  // wake-driven reminder bubbles.  Replaces the previously-invisible
-  // synthetic empty user turn with a visible-but-subtle DOM element so
-  // the bubble below it lands in the right place even when the wake
-  // fires long after the user's last real message.
-  this.removeEmptyState();
-  var el = document.createElement("div");
-  el.className = "msg user system-nudge";
-  el.setAttribute("data-source", "system_nudge");
-  el.setAttribute("aria-label", "system nudge");
-  el.textContent = "system nudge";
-  this.messagesEl.appendChild(el);
-  return el;
-};
-
-Pane.prototype.addUserReminder = function (reminders, source) {
-  // Render each metacognitive reminder as its own bubble immediately
-  // BELOW the user message it advises — semantically the reminder is
-  // a hint to the model right before the assistant turn.  Always
-  // called AFTER the corresponding addUserMessage (live: optimistic
-  // local render ran before the SSE event arrived; replay:
-  // replayHistory renders the user message first), so "most recent
-  // .msg.user" is always THIS turn's bubble — insertAdjacentElement
-  // afterend drops the reminder directly below it.  When no .msg.user
-  // exists at all (e.g. a non-originating tab receiving a reminder
-  // before any user turn has rendered) we append; the next /history
-  // reload corrects any anchor anomaly.
-  //
-  // ``source === "system_nudge"`` is the wake-driven case: render
-  // a thin .msg.user.system-nudge marker first and anchor below it.
-  // ``watch_triggered`` reminders branch off into a structured
-  // .msg.watch-result card.
-  this.removeEmptyState();
-  var anchor;
-  if (source === "system_nudge") {
-    anchor = this.addSystemNudgeMarker();
-  } else {
-    var userBubbles = this.messagesEl.querySelectorAll(
-      ".msg.user:not(.system-nudge)",
-    );
-    anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
-  }
-  for (var i = 0; i < reminders.length; i++) {
-    var r = reminders[i] || {};
-    var el =
-      r.type === "watch_triggered"
-        ? _buildWatchResultBubble(r)
-        : _buildDefaultReminderBubble(r);
-    if (anchor) {
-      anchor.insertAdjacentElement("afterend", el);
-      // Anchor advances so multiple reminders stack below the user
-      // message in queued order (rather than each landing
-      // immediately-after the user msg, which would reverse them).
-      anchor = el;
-    } else {
-      this.messagesEl.appendChild(el);
-    }
-  }
-  this.scrollToBottom(true);
-};
-
-Pane.prototype.addToolReminder = function (reminders, toolCallId) {
-  // Render each metacognitive tool-channel reminder (tool_error /
-  // repeat) as the same yellow themed bubble used for user-channel
-  // reminders, anchored below the .ts-approval block that produced
-  // the tool result.  toolCallId is the live-path anchor (SSE event
-  // carries it); during replay it's an empty string and we fall back
-  // to "last .ts-approval block in messagesEl", which is correct
-  // because messages render in order — the assistant block carrying
-  // the tool batch is always the most recent approval block by the
-  // time we hit the tool message that owns the reminder.  Tool-channel
-  // reminders also branch on r.type so a watch_triggered drained at
-  // the tool seam (channel="any") renders the structured card.
-  this.removeEmptyState();
-  var anchor = null;
-  if (toolCallId) {
-    var escapedId = CSS.escape(toolCallId);
-    var toolEl = this.messagesEl.querySelector(
-      '.ts-approval-tool[data-call-id="' + escapedId + '"]',
-    );
-    if (toolEl) {
-      anchor = toolEl.closest(".ts-approval");
-    }
-  }
-  if (!anchor) {
-    var blocks = this.messagesEl.querySelectorAll(".ts-approval");
-    if (blocks.length) anchor = blocks[blocks.length - 1];
-  }
-  for (var i = 0; i < reminders.length; i++) {
-    var r = reminders[i] || {};
-    var el =
-      r.type === "watch_triggered"
-        ? _buildWatchResultBubble(r)
-        : _buildDefaultReminderBubble(r);
-    if (anchor) {
-      anchor.insertAdjacentElement("afterend", el);
-      anchor = el;
-    } else {
-      this.messagesEl.appendChild(el);
-    }
-  }
-  this.scrollToBottom(true);
-};
-
-Pane.prototype.addUserMessage = function (text, attachments) {
-  this.removeEmptyState();
-  var el = document.createElement("div");
-  el.className = "msg user";
-  var textEl = document.createElement("div");
-  textEl.className = "msg-user-text";
-  textEl.textContent = text;
-  el.appendChild(textEl);
-  if (Array.isArray(attachments) && attachments.length > 0) {
-    var pills = document.createElement("div");
-    pills.className = "msg-user-attach";
-    attachments.forEach(function (a) {
-      var pill = document.createElement("span");
-      pill.className =
-        "msg-user-attach-pill msg-user-attach-pill-" + (a.kind || "other");
-      var icon = document.createElement("span");
-      icon.className = "msg-user-attach-icon";
-      icon.setAttribute("aria-hidden", "true");
-      icon.textContent = a.kind === "image" ? "\ud83d\uddbc" : "\ud83d\udcc4";
-      pill.appendChild(icon);
-      var nameEl = document.createElement("span");
-      nameEl.className = "msg-user-attach-name";
-      nameEl.textContent =
-        a.filename || (a.kind === "image" ? "image" : "document");
-      pill.appendChild(nameEl);
-      pills.appendChild(pill);
-    });
-    el.appendChild(pills);
-  }
-  this._addUserMsgActions(el, text);
-  this.messagesEl.appendChild(el);
-  this.scrollToBottom(true);
 };
 
 Pane.prototype._addUserMsgActions = function (el, text) {
@@ -1702,58 +1926,6 @@ Pane.prototype.resolveApproval = function (
   this.scrollToBottom();
 };
 
-Pane.prototype.getFeedback = function () {
-  if (!this.approvalBlockEl) return null;
-  var inp = this.approvalBlockEl.querySelector(".ts-approval-feedback");
-  return inp && inp.value.trim() ? inp.value.trim() : null;
-};
-
-Pane.prototype.appendToolOutputChunk = function (callId, chunk) {
-  if (!chunk) return;
-  var stripped = stripAnsi(chunk);
-  if (!stripped) return;
-
-  var escapedId = callId ? CSS.escape(callId) : "";
-  var el = escapedId
-    ? this.messagesEl.querySelector(
-        '.tool-output-stream[data-call-id="' + escapedId + '"]',
-      )
-    : null;
-  if (!el) {
-    var target = escapedId
-      ? this.messagesEl.querySelector(
-          '.ts-approval-tool[data-call-id="' + escapedId + '"]',
-        )
-      : null;
-    if (!target) {
-      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
-      if (!blocks.length) return;
-      var block = blocks[blocks.length - 1];
-      var tools = block.querySelectorAll(
-        '.ts-approval-tool[data-func-name="bash"]',
-      );
-      target = tools.length ? tools[tools.length - 1] : null;
-      if (!target) {
-        var allTools = block.querySelectorAll(".ts-approval-tool");
-        target = allTools.length ? allTools[allTools.length - 1] : null;
-      }
-    }
-    if (!target) return;
-
-    el = document.createElement("pre");
-    el.className = "tool-output tool-output-stream";
-    el.dataset.callId = callId;
-    el.setAttribute("aria-label", "Streaming command output");
-    el.setAttribute("aria-live", "off");
-    el.textContent = "";
-    target.after(el);
-  }
-
-  el.appendChild(document.createTextNode(stripped));
-  el.scrollTop = el.scrollHeight;
-  this.scrollToBottom();
-};
-
 Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
   var escapedId = callId ? CSS.escape(callId) : "";
   var target = escapedId
@@ -1847,176 +2019,6 @@ Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
 
   target.after(out);
   this.scrollToBottom();
-};
-
-Pane.prototype.showOutputWarning = function (evt) {
-  if (!evt.call_id || evt.risk_level === "none") return;
-  var escapedId = CSS.escape(evt.call_id);
-  var toolDiv = this.messagesEl.querySelector(
-    '.ts-approval-tool[data-call-id="' + escapedId + '"]',
-  );
-  if (!toolDiv) return;
-  // Shared DOM-builder with replayHistory \u2014 single source of truth for
-  // role / class / escape semantics.  Argument shape mirrors the
-  // server-side output_assessment dict (risk_level / flags / redacted).
-  var warning = _buildOutputWarningEl({
-    risk_level: evt.risk_level,
-    flags: evt.flags,
-    redacted: evt.redacted,
-  });
-  var nextEl = toolDiv.nextElementSibling;
-  if (nextEl && nextEl.classList.contains("tool-output")) {
-    nextEl.insertAdjacentElement("afterend", warning);
-  } else {
-    toolDiv.insertAdjacentElement("afterend", warning);
-  }
-};
-
-Pane.prototype.updateVerdictBadge = function (verdict) {
-  if (!verdict || !verdict.call_id) return;
-  var escapedId = CSS.escape(verdict.call_id);
-  var badge = this.messagesEl.querySelector(
-    '.verdict-badge[data-call-id="' + escapedId + '"]',
-  );
-  if (!badge) {
-    // Badge no longer in DOM (tool block replaced by output) — show
-    // a toast so the user still sees the late-arriving verdict.
-    var conf = Math.round((verdict.confidence || 0) * 100);
-    var rec = verdict.recommendation || "review";
-    var func = verdict.func_name || "";
-    showToast(
-      "Judge verdict for " + func + ": " + rec + " (" + conf + "%)",
-      rec === "approve" ? "success" : rec === "deny" ? "error" : "warning",
-    );
-    return;
-  }
-
-  var risk = verdict.risk_level || "medium";
-  badge.className = "verdict-badge verdict-" + risk + " ts-verdict-badge";
-  badge.setAttribute("data-risk", risk);
-
-  var riskEl = badge.querySelector(".verdict-risk");
-  var recEl = badge.querySelector(".verdict-rec");
-  var confEl = badge.querySelector(".verdict-conf");
-  if (riskEl) riskEl.textContent = risk.toUpperCase();
-  if (recEl) recEl.textContent = verdict.recommendation || "review";
-  if (confEl)
-    confEl.textContent = Math.round((verdict.confidence || 0) * 100) + "%";
-
-  var spinner = badge.querySelector(".verdict-judge-spinner");
-  if (spinner) spinner.remove();
-
-  var detail = badge.nextElementSibling;
-  if (detail && detail.classList.contains("verdict-detail")) {
-    var summaryEl = detail.querySelector(".verdict-summary");
-    var reasonEl = detail.querySelector(".verdict-reasoning");
-    var tierEl = detail.querySelector(".verdict-tier");
-    if (summaryEl) summaryEl.textContent = verdict.intent_summary || "";
-    if (reasonEl) reasonEl.textContent = verdict.reasoning || "";
-    if (tierEl)
-      tierEl.textContent =
-        (verdict.tier || "llm") +
-        " tier" +
-        (verdict.judge_model ? " | " + verdict.judge_model : "");
-    var evidenceEl = detail.querySelector(".verdict-evidence");
-    if (verdict.evidence && verdict.evidence.length) {
-      if (!evidenceEl) {
-        evidenceEl = document.createElement("div");
-        evidenceEl.className = "verdict-evidence";
-        var tierDiv = detail.querySelector(".verdict-tier");
-        if (tierDiv) detail.insertBefore(evidenceEl, tierDiv);
-        else detail.appendChild(evidenceEl);
-      }
-      evidenceEl.replaceChildren(
-        ...verdict.evidence.map(function (e) {
-          var div = document.createElement("div");
-          div.textContent = "\u2022 " + e;
-          return div;
-        }),
-      );
-    } else if (evidenceEl) {
-      evidenceEl.remove();
-    }
-  }
-
-  this.updateVerdictGlow(verdict.recommendation);
-};
-
-Pane.prototype.updateVerdictGlow = function (recommendation) {
-  if (!this.approvalBlockEl) return;
-  var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
-  if (!prompt) return;
-
-  // Collect all verdict badges currently visible in this approval block
-  var badges = this.approvalBlockEl.querySelectorAll(".verdict-badge");
-  var worst = recommendation;
-  for (var i = 0; i < badges.length; i++) {
-    var recEl = badges[i].querySelector(".verdict-rec");
-    if (recEl) {
-      var r = recEl.textContent;
-      if (r === "deny") {
-        worst = "deny";
-        break;
-      }
-      if (r === "review" && worst !== "deny") worst = "review";
-    }
-  }
-
-  prompt.classList.remove(
-    "ts-verdict-glow--approve",
-    "ts-verdict-glow--deny",
-    "ts-verdict-glow--review",
-  );
-  if (worst === "approve") prompt.classList.add("ts-verdict-glow--approve");
-  else if (worst === "deny") prompt.classList.add("ts-verdict-glow--deny");
-  else prompt.classList.add("ts-verdict-glow--review");
-};
-
-Pane.prototype.addInfoMessage = function (text) {
-  var el = document.createElement("div");
-  el.className = "msg info";
-  el.textContent = stripAnsi(text);
-  this.messagesEl.appendChild(el);
-  this.scrollToBottom();
-};
-
-Pane.prototype.addErrorMessage = function (text) {
-  var el = document.createElement("div");
-  el.className = "msg error";
-  el.setAttribute("role", "alert");
-  el.textContent = stripAnsi(text);
-  this.messagesEl.appendChild(el);
-  this.scrollToBottom();
-};
-
-Pane.prototype.updateStatus = function (evt) {
-  StatusBar.paint(
-    {
-      rootEl: this.statusBarEl,
-      modelEl: this._sbModel,
-      tokensEl: this._sbTokens,
-      toolsEl: this._sbTools,
-      turnsEl: this._sbTurns,
-    },
-    evt,
-    { alias: this.modelAlias, model: this.model },
-  );
-  this._lastStatusEvt = evt;
-};
-
-Pane.prototype.isNearBottom = function () {
-  return (
-    this.messagesEl.scrollHeight -
-      this.messagesEl.scrollTop -
-      this.messagesEl.clientHeight <
-    80
-  );
-};
-
-Pane.prototype.scrollToBottom = function (force) {
-  if (force || this.isNearBottom()) {
-    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
-  }
 };
 
 Pane.prototype.sendMessage = function () {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1631,6 +1631,414 @@ class Pane {
       this._addRetryAction(assistants[assistants.length - 1]);
     }
   }
+
+  showInlineToolBlock(items, autoApproved, judgePending) {
+    var block = document.createElement("div");
+    block.className =
+      "msg ts-approval ts-approval--inline" + (autoApproved ? " approved" : "");
+    if (!autoApproved) {
+      block.setAttribute("role", "alertdialog");
+      block.setAttribute("aria-label", "Tool approval required");
+    }
+
+    // Track the highest-priority recommendation for glow
+    var glowRec = null;
+
+    items.forEach((item) => {
+      block.appendChild(buildToolDiv(item));
+      // Render verdict badge if present.  Server emits the heuristic
+      // verdict under ``heuristic_verdict`` (matches the api/server_schemas
+      // PendingApprovalItem shape).  Falls back to the legacy ``verdict``
+      // key in case a stale SSE payload arrives mid-deploy.
+      var heuristic = item.heuristic_verdict || item.verdict;
+      if (heuristic) {
+        block.insertAdjacentHTML(
+          "beforeend",
+          renderVerdictBadge(heuristic, judgePending),
+        );
+        var rec = heuristic.recommendation || "review";
+        if (
+          !glowRec ||
+          rec === "deny" ||
+          (rec === "review" && glowRec === "approve")
+        ) {
+          glowRec = rec;
+        }
+      }
+    });
+
+    if (autoApproved) {
+      var badge = document.createElement("div");
+      badge.setAttribute("role", "status");
+      badge.className = "ts-approval-badge ts-approval-badge--approved";
+      badge.textContent = "\u2713 auto-approved";
+      block.appendChild(badge);
+    } else {
+      var prompt = document.createElement("div");
+      prompt.className = "ts-approval-body";
+
+      // Apply verdict glow on initial heuristic verdict
+      if (glowRec) {
+        if (glowRec === "approve")
+          prompt.classList.add("ts-verdict-glow--approve");
+        else if (glowRec === "deny")
+          prompt.classList.add("ts-verdict-glow--deny");
+        else prompt.classList.add("ts-verdict-glow--review");
+      }
+
+      var alwaysNames = items
+        .filter((it) => {
+          return (
+            it.needs_approval &&
+            it.func_name &&
+            it.func_name !== "__budget_override__" &&
+            !it.error
+          );
+        })
+        .map((it) => {
+          return it.approval_label || it.func_name;
+        });
+      block.dataset.alwaysNames = JSON.stringify(alwaysNames);
+      var alwaysTitle = alwaysNames.length
+        ? "Always approve " + alwaysNames.join(", ")
+        : "Always approve this tool type";
+
+      var actionsDiv = document.createElement("div");
+      actionsDiv.className = "ts-approval-actions";
+
+      var approveBtn = document.createElement("button");
+      approveBtn.className = "ts-approval-btn ts-approval-btn--approve";
+      approveBtn.append(makeKeyLabel("y", "Approve"));
+      approveBtn.onclick = () => {
+        this.resolveApproval(true, false, this.getFeedback());
+      };
+      actionsDiv.appendChild(approveBtn);
+
+      var denyBtn = document.createElement("button");
+      denyBtn.className = "ts-approval-btn ts-approval-btn--deny";
+      denyBtn.append(makeKeyLabel("n", "Deny"));
+      denyBtn.onclick = () => {
+        this.resolveApproval(false, false, this.getFeedback());
+      };
+      actionsDiv.appendChild(denyBtn);
+
+      if (alwaysNames.length) {
+        var alwaysBtn = document.createElement("button");
+        alwaysBtn.className = "ts-approval-btn ts-approval-btn--always";
+        alwaysBtn.title = alwaysTitle;
+        alwaysBtn.setAttribute("aria-label", alwaysTitle);
+        alwaysBtn.append(makeKeyLabel("a", "Always"));
+        alwaysBtn.onclick = () => {
+          this.resolveApproval(true, true, this.getFeedback());
+        };
+        actionsDiv.appendChild(alwaysBtn);
+      }
+
+      prompt.appendChild(actionsDiv);
+
+      var fbInput = document.createElement("input");
+      fbInput.type = "text";
+      fbInput.className = "ts-approval-feedback";
+      fbInput.placeholder = "feedback (optional)";
+      prompt.appendChild(fbInput);
+
+      block.appendChild(prompt);
+      this.pendingApproval = true;
+      this.approvalBlockEl = block;
+      this.inputEl.disabled = true;
+      this.sendBtn.disabled = true;
+      requestAnimationFrame(() => {
+        fbInput.focus();
+      });
+    }
+
+    this.messagesEl.appendChild(block);
+    this.scrollToBottom();
+  }
+
+  resolveApproval(approved, always, feedback, skipPost) {
+    if (!this.approvalBlockEl) return;
+    this.pendingApproval = false;
+
+    // Remove prompt
+    var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
+    if (prompt) prompt.remove();
+
+    // Add badge
+    var badge = document.createElement("div");
+    badge.setAttribute("role", "status");
+    if (approved) {
+      badge.className = "ts-approval-badge ts-approval-badge--approved";
+      var label = "\u2713 approved";
+      if (always) {
+        var raw = this.approvalBlockEl.dataset.alwaysNames;
+        var names = raw ? JSON.parse(raw) : [];
+        label = names.length
+          ? "\u2713 always approve " + names.join(", ")
+          : "\u2713 always approve";
+      }
+      badge.textContent = feedback ? label + ": " + feedback : label;
+      this.approvalBlockEl.classList.add("approved");
+    } else {
+      badge.className = "ts-approval-badge ts-approval-badge--denied";
+      badge.textContent = "\u2717 denied" + (feedback ? ": " + feedback : "");
+      this.approvalBlockEl.classList.add("denied");
+    }
+    this.approvalBlockEl.appendChild(badge);
+    this.approvalBlockEl = null;
+
+    // Re-enable input
+    this.inputEl.disabled = false;
+    this.sendBtn.disabled = this.busy;
+    this.inputEl.focus();
+
+    // POST to server (skip when server already resolved, e.g. timeout)
+    if (!skipPost) {
+      authFetch(
+        "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/approve",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            approved: approved,
+            feedback: feedback || null,
+            always: !!always,
+          }),
+        },
+      ).catch((err) => {
+        this.addErrorMessage("Connection error: " + err.message);
+      });
+    }
+
+    this.scrollToBottom();
+  }
+
+  appendToolOutput(callId, name, output, isError) {
+    var escapedId = callId ? CSS.escape(callId) : "";
+    var target = escapedId
+      ? this.messagesEl.querySelector(
+          '.ts-approval-tool[data-call-id="' + escapedId + '"]',
+        )
+      : null;
+    if (!target) {
+      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+      if (!blocks.length) return;
+      var block = blocks[blocks.length - 1];
+      var tools = block.querySelectorAll(".ts-approval-tool");
+      for (var i = tools.length - 1; i >= 0; i--) {
+        if (tools[i].dataset.funcName === name) {
+          target = tools[i];
+          break;
+        }
+      }
+      if (!target && tools.length) target = tools[tools.length - 1];
+    }
+    if (!target) return;
+
+    // Remove the streaming output element for this tool
+    var streamEl = null;
+    if (escapedId) {
+      streamEl = this.messagesEl.querySelector(
+        '.tool-output-stream[data-call-id="' + escapedId + '"]',
+      );
+    } else {
+      var next = target.nextElementSibling;
+      if (next && next.classList.contains("tool-output-stream")) {
+        streamEl = next;
+      }
+    }
+    if (streamEl) streamEl.remove();
+
+    var stripped = stripAnsi(output || "").trim();
+    if (!stripped) return;
+
+    // Skip rendering for denied/blocked tool results — the ✗ denied
+    // badge from resolveApproval already shows the denial reason; the
+    // SSE tool_result event would otherwise duplicate the text.  Mirror
+    // the guard in the history-replay path (the live path used to be
+    // safe because no tool_result event was ever emitted for denied
+    // items, but we now emit one so _tool_error_flags gets set).
+    var parentBlock = target.closest(".ts-approval");
+    var isDenied =
+      (parentBlock && parentBlock.classList.contains("denied")) ||
+      /^Denied by user/.test(stripped) ||
+      /^Blocked/.test(stripped);
+    if (isDenied) return;
+
+    // Detect structured media output and render interactive embed
+    if (!isError) {
+      var media = tryParseMedia(stripped);
+      if (media) {
+        var embed = buildMediaEmbed(media, stripped);
+        target.after(embed);
+        this.scrollToBottom();
+        return;
+      }
+    }
+
+    // Detect structured MCP error envelope and render an interactive
+    // consent / re-consent / forbidden / operator card.  The existing
+    // ✗ error badge from appendToolErrorBadge still fires below.
+    if (isError) {
+      var mcpErr = tryParseMcpError(stripped);
+      if (mcpErr) {
+        if (parentBlock && !parentBlock.classList.contains("denied")) {
+          parentBlock.classList.add("error");
+          appendToolErrorBadge(parentBlock);
+        }
+        target.after(buildMcpErrorEmbed(mcpErr, stripped));
+        this.scrollToBottom();
+        return;
+      }
+    }
+
+    var out = renderToolOutput(stripped, isError);
+
+    // Mark the parent approval block as errored
+    if (isError && parentBlock && !parentBlock.classList.contains("denied")) {
+      parentBlock.classList.add("error");
+      appendToolErrorBadge(parentBlock);
+    }
+
+    if (out.textContent.split("\n").length > 10) {
+      makeCollapsible(out);
+    }
+
+    target.after(out);
+    this.scrollToBottom();
+  }
+
+  sendMessage() {
+    var text = this.inputEl.value.trim();
+    if (!text) return;
+
+    if (text.startsWith("/")) {
+      if (this.busy) return; // commands not allowed while busy
+      authFetch("/v1/api/command", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: text, ws_id: this.wsId }),
+      });
+      this.addUserMessage(text);
+      this.composer.clear();
+      return;
+    }
+
+    var isBusy = this.busy;
+    var queuedEl = null;
+    var snap = this.attachments.snapshot();
+
+    if (isBusy) {
+      // Server re-parses the !!! prefix to set queue priority — the
+      // optimistic bubble strips it for display.
+      var displayText = text;
+      var priority = "notice";
+      if (text.startsWith("!!!")) {
+        displayText = text.slice(3).trimStart();
+        priority = "important";
+      }
+      this.removeEmptyState();
+      queuedEl = this.queue.addQueuedMessage(displayText, priority);
+    } else {
+      this.setBusy(true);
+      this.addUserMessage(text, snap.attachments);
+    }
+    this.composer.clear();
+
+    authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/send",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          attachment_ids: snap.attachment_ids,
+        }),
+      },
+    )
+      .then((r) => {
+        return r.json();
+      })
+      .then((data) => {
+        if (data.status === "queued" && data.msg_id) {
+          // queuedEl-present path: bind() handles the three known races
+          // (pre-bind dismiss, promote sweep raced ahead, normal accept).
+          // queuedEl-absent path: client thought it was idle but the
+          // server saw a live worker (SSE state_change hadn't arrived
+          // yet). Flip busy so subsequent sends queue correctly; the
+          // optimistic user bubble is already in the log and the server
+          // still delivers the message on worker drain — accept the
+          // small UX gap (no in-UI dismiss for THIS message).
+          if (queuedEl) this.queue.bind(queuedEl, data.msg_id);
+          else this.setBusy(true);
+          this.attachments.consume(
+            data.attached_ids,
+            data.dropped_attachment_ids,
+          );
+        } else if (data.status === "busy") {
+          if (queuedEl) this.queue.remove(queuedEl);
+          this.addErrorMessage("Server is busy. Please wait.");
+          if (!isBusy) this.setBusy(false);
+        } else if (data.status === "queue_full") {
+          if (queuedEl) this.queue.remove(queuedEl);
+          this.addErrorMessage("Message queue full. Please wait.");
+        } else if (data.status === "attachments_busy") {
+          // Attachments can't ride a queued user turn — server held the
+          // chips' reservations long enough to bounce the request and
+          // released them. Surface to the user; chips stay in the
+          // composer so they can retry once the assistant finishes.
+          if (queuedEl) this.queue.remove(queuedEl);
+          this.addErrorMessage(
+            "Attachments can't be sent while the assistant is working. " +
+              "Send a text-only message now, or wait and resend with attachments.",
+          );
+        } else {
+          this.attachments.consume(
+            data.attached_ids,
+            data.dropped_attachment_ids,
+          );
+        }
+      })
+      .catch((err) => {
+        if (queuedEl) this.queue.remove(queuedEl);
+        this.addErrorMessage("Connection error: " + err.message);
+        if (!isBusy) this.setBusy(false);
+      });
+  }
+
+  cancelGeneration() {
+    if (!this.busy || !this.wsId || this.stopBtn.disabled) return;
+    var isForce = this.stopBtn.dataset.forceCancel === "true";
+    this.stopBtn.disabled = true;
+    authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/cancel",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ force: isForce }),
+      },
+    )
+      .then(() => {
+        if (isForce) {
+          // Force cancel abandons the worker — transition immediately.
+          // Clear timeouts to prevent stale timers firing on next send.
+          if (this._cancelTimeout) {
+            clearTimeout(this._cancelTimeout);
+            this._cancelTimeout = null;
+          }
+          if (this._forceTimeout) {
+            clearTimeout(this._forceTimeout);
+            this._forceTimeout = null;
+          }
+          this.addInfoMessage("Force stopped. Previous generation abandoned.");
+          this.setBusy(false);
+        }
+      })
+      .catch((err) => {
+        this.addErrorMessage("Cancel error: " + err.message);
+        this.stopBtn.disabled = false;
+      });
+  }
 }
 
 // Build a structured ``.msg.watch-result`` card for a
@@ -1720,424 +2128,6 @@ function _buildOutputWarningEl(assessment) {
   }
   return warning;
 }
-
-Pane.prototype.showInlineToolBlock = function (
-  items,
-  autoApproved,
-  judgePending,
-) {
-  var self = this;
-  var block = document.createElement("div");
-  block.className =
-    "msg ts-approval ts-approval--inline" + (autoApproved ? " approved" : "");
-  if (!autoApproved) {
-    block.setAttribute("role", "alertdialog");
-    block.setAttribute("aria-label", "Tool approval required");
-  }
-
-  // Track the highest-priority recommendation for glow
-  var glowRec = null;
-
-  items.forEach(function (item) {
-    block.appendChild(buildToolDiv(item));
-    // Render verdict badge if present.  Server emits the heuristic
-    // verdict under ``heuristic_verdict`` (matches the api/server_schemas
-    // PendingApprovalItem shape).  Falls back to the legacy ``verdict``
-    // key in case a stale SSE payload arrives mid-deploy.
-    var heuristic = item.heuristic_verdict || item.verdict;
-    if (heuristic) {
-      block.insertAdjacentHTML(
-        "beforeend",
-        renderVerdictBadge(heuristic, judgePending),
-      );
-      var rec = heuristic.recommendation || "review";
-      if (
-        !glowRec ||
-        rec === "deny" ||
-        (rec === "review" && glowRec === "approve")
-      ) {
-        glowRec = rec;
-      }
-    }
-  });
-
-  if (autoApproved) {
-    var badge = document.createElement("div");
-    badge.setAttribute("role", "status");
-    badge.className = "ts-approval-badge ts-approval-badge--approved";
-    badge.textContent = "\u2713 auto-approved";
-    block.appendChild(badge);
-  } else {
-    var prompt = document.createElement("div");
-    prompt.className = "ts-approval-body";
-
-    // Apply verdict glow on initial heuristic verdict
-    if (glowRec) {
-      if (glowRec === "approve")
-        prompt.classList.add("ts-verdict-glow--approve");
-      else if (glowRec === "deny")
-        prompt.classList.add("ts-verdict-glow--deny");
-      else prompt.classList.add("ts-verdict-glow--review");
-    }
-
-    var alwaysNames = items
-      .filter(function (it) {
-        return (
-          it.needs_approval &&
-          it.func_name &&
-          it.func_name !== "__budget_override__" &&
-          !it.error
-        );
-      })
-      .map(function (it) {
-        return it.approval_label || it.func_name;
-      });
-    block.dataset.alwaysNames = JSON.stringify(alwaysNames);
-    var alwaysTitle = alwaysNames.length
-      ? "Always approve " + alwaysNames.join(", ")
-      : "Always approve this tool type";
-
-    var actionsDiv = document.createElement("div");
-    actionsDiv.className = "ts-approval-actions";
-
-    var approveBtn = document.createElement("button");
-    approveBtn.className = "ts-approval-btn ts-approval-btn--approve";
-    approveBtn.append(makeKeyLabel("y", "Approve"));
-    approveBtn.onclick = function () {
-      self.resolveApproval(true, false, self.getFeedback());
-    };
-    actionsDiv.appendChild(approveBtn);
-
-    var denyBtn = document.createElement("button");
-    denyBtn.className = "ts-approval-btn ts-approval-btn--deny";
-    denyBtn.append(makeKeyLabel("n", "Deny"));
-    denyBtn.onclick = function () {
-      self.resolveApproval(false, false, self.getFeedback());
-    };
-    actionsDiv.appendChild(denyBtn);
-
-    if (alwaysNames.length) {
-      var alwaysBtn = document.createElement("button");
-      alwaysBtn.className = "ts-approval-btn ts-approval-btn--always";
-      alwaysBtn.title = alwaysTitle;
-      alwaysBtn.setAttribute("aria-label", alwaysTitle);
-      alwaysBtn.append(makeKeyLabel("a", "Always"));
-      alwaysBtn.onclick = function () {
-        self.resolveApproval(true, true, self.getFeedback());
-      };
-      actionsDiv.appendChild(alwaysBtn);
-    }
-
-    prompt.appendChild(actionsDiv);
-
-    var fbInput = document.createElement("input");
-    fbInput.type = "text";
-    fbInput.className = "ts-approval-feedback";
-    fbInput.placeholder = "feedback (optional)";
-    prompt.appendChild(fbInput);
-
-    block.appendChild(prompt);
-    this.pendingApproval = true;
-    this.approvalBlockEl = block;
-    this.inputEl.disabled = true;
-    this.sendBtn.disabled = true;
-    requestAnimationFrame(function () {
-      fbInput.focus();
-    });
-  }
-
-  this.messagesEl.appendChild(block);
-  this.scrollToBottom();
-};
-
-Pane.prototype.resolveApproval = function (
-  approved,
-  always,
-  feedback,
-  skipPost,
-) {
-  if (!this.approvalBlockEl) return;
-  this.pendingApproval = false;
-
-  // Remove prompt
-  var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
-  if (prompt) prompt.remove();
-
-  // Add badge
-  var badge = document.createElement("div");
-  badge.setAttribute("role", "status");
-  if (approved) {
-    badge.className = "ts-approval-badge ts-approval-badge--approved";
-    var label = "\u2713 approved";
-    if (always) {
-      var raw = this.approvalBlockEl.dataset.alwaysNames;
-      var names = raw ? JSON.parse(raw) : [];
-      label = names.length
-        ? "\u2713 always approve " + names.join(", ")
-        : "\u2713 always approve";
-    }
-    badge.textContent = feedback ? label + ": " + feedback : label;
-    this.approvalBlockEl.classList.add("approved");
-  } else {
-    badge.className = "ts-approval-badge ts-approval-badge--denied";
-    badge.textContent = "\u2717 denied" + (feedback ? ": " + feedback : "");
-    this.approvalBlockEl.classList.add("denied");
-  }
-  this.approvalBlockEl.appendChild(badge);
-  this.approvalBlockEl = null;
-
-  // Re-enable input
-  this.inputEl.disabled = false;
-  this.sendBtn.disabled = this.busy;
-  this.inputEl.focus();
-
-  // POST to server (skip when server already resolved, e.g. timeout)
-  if (!skipPost) {
-    var self = this;
-    authFetch(
-      "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/approve",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          approved: approved,
-          feedback: feedback || null,
-          always: !!always,
-        }),
-      },
-    ).catch(function (err) {
-      self.addErrorMessage("Connection error: " + err.message);
-    });
-  }
-
-  this.scrollToBottom();
-};
-
-Pane.prototype.appendToolOutput = function (callId, name, output, isError) {
-  var escapedId = callId ? CSS.escape(callId) : "";
-  var target = escapedId
-    ? this.messagesEl.querySelector(
-        '.ts-approval-tool[data-call-id="' + escapedId + '"]',
-      )
-    : null;
-  if (!target) {
-    var blocks = this.messagesEl.querySelectorAll(".ts-approval");
-    if (!blocks.length) return;
-    var block = blocks[blocks.length - 1];
-    var tools = block.querySelectorAll(".ts-approval-tool");
-    for (var i = tools.length - 1; i >= 0; i--) {
-      if (tools[i].dataset.funcName === name) {
-        target = tools[i];
-        break;
-      }
-    }
-    if (!target && tools.length) target = tools[tools.length - 1];
-  }
-  if (!target) return;
-
-  // Remove the streaming output element for this tool
-  var streamEl = null;
-  if (escapedId) {
-    streamEl = this.messagesEl.querySelector(
-      '.tool-output-stream[data-call-id="' + escapedId + '"]',
-    );
-  } else {
-    var next = target.nextElementSibling;
-    if (next && next.classList.contains("tool-output-stream")) {
-      streamEl = next;
-    }
-  }
-  if (streamEl) streamEl.remove();
-
-  var stripped = stripAnsi(output || "").trim();
-  if (!stripped) return;
-
-  // Skip rendering for denied/blocked tool results — the ✗ denied
-  // badge from resolveApproval already shows the denial reason; the
-  // SSE tool_result event would otherwise duplicate the text.  Mirror
-  // the guard in the history-replay path (the live path used to be
-  // safe because no tool_result event was ever emitted for denied
-  // items, but we now emit one so _tool_error_flags gets set).
-  var parentBlock = target.closest(".ts-approval");
-  var isDenied =
-    (parentBlock && parentBlock.classList.contains("denied")) ||
-    /^Denied by user/.test(stripped) ||
-    /^Blocked/.test(stripped);
-  if (isDenied) return;
-
-  // Detect structured media output and render interactive embed
-  if (!isError) {
-    var media = tryParseMedia(stripped);
-    if (media) {
-      var embed = buildMediaEmbed(media, stripped);
-      target.after(embed);
-      this.scrollToBottom();
-      return;
-    }
-  }
-
-  // Detect structured MCP error envelope and render an interactive
-  // consent / re-consent / forbidden / operator card.  The existing
-  // ✗ error badge from appendToolErrorBadge still fires below.
-  if (isError) {
-    var mcpErr = tryParseMcpError(stripped);
-    if (mcpErr) {
-      if (parentBlock && !parentBlock.classList.contains("denied")) {
-        parentBlock.classList.add("error");
-        appendToolErrorBadge(parentBlock);
-      }
-      target.after(buildMcpErrorEmbed(mcpErr, stripped));
-      this.scrollToBottom();
-      return;
-    }
-  }
-
-  var out = renderToolOutput(stripped, isError);
-
-  // Mark the parent approval block as errored
-  if (isError && parentBlock && !parentBlock.classList.contains("denied")) {
-    parentBlock.classList.add("error");
-    appendToolErrorBadge(parentBlock);
-  }
-
-  if (out.textContent.split("\n").length > 10) {
-    makeCollapsible(out);
-  }
-
-  target.after(out);
-  this.scrollToBottom();
-};
-
-Pane.prototype.sendMessage = function () {
-  var text = this.inputEl.value.trim();
-  if (!text) return;
-
-  if (text.startsWith("/")) {
-    if (this.busy) return; // commands not allowed while busy
-    authFetch("/v1/api/command", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ command: text, ws_id: this.wsId }),
-    });
-    this.addUserMessage(text);
-    this.composer.clear();
-    return;
-  }
-
-  var self = this;
-  var isBusy = this.busy;
-  var queuedEl = null;
-  var snap = this.attachments.snapshot();
-
-  if (isBusy) {
-    // Server re-parses the !!! prefix to set queue priority — the
-    // optimistic bubble strips it for display.
-    var displayText = text;
-    var priority = "notice";
-    if (text.startsWith("!!!")) {
-      displayText = text.slice(3).trimStart();
-      priority = "important";
-    }
-    this.removeEmptyState();
-    queuedEl = this.queue.addQueuedMessage(displayText, priority);
-  } else {
-    this.setBusy(true);
-    this.addUserMessage(text, snap.attachments);
-  }
-  this.composer.clear();
-
-  authFetch("/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/send", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      message: text,
-      attachment_ids: snap.attachment_ids,
-    }),
-  })
-    .then(function (r) {
-      return r.json();
-    })
-    .then(function (data) {
-      if (data.status === "queued" && data.msg_id) {
-        // queuedEl-present path: bind() handles the three known races
-        // (pre-bind dismiss, promote sweep raced ahead, normal accept).
-        // queuedEl-absent path: client thought it was idle but the
-        // server saw a live worker (SSE state_change hadn't arrived
-        // yet). Flip busy so subsequent sends queue correctly; the
-        // optimistic user bubble is already in the log and the server
-        // still delivers the message on worker drain — accept the
-        // small UX gap (no in-UI dismiss for THIS message).
-        if (queuedEl) self.queue.bind(queuedEl, data.msg_id);
-        else self.setBusy(true);
-        self.attachments.consume(
-          data.attached_ids,
-          data.dropped_attachment_ids,
-        );
-      } else if (data.status === "busy") {
-        if (queuedEl) self.queue.remove(queuedEl);
-        self.addErrorMessage("Server is busy. Please wait.");
-        if (!isBusy) self.setBusy(false);
-      } else if (data.status === "queue_full") {
-        if (queuedEl) self.queue.remove(queuedEl);
-        self.addErrorMessage("Message queue full. Please wait.");
-      } else if (data.status === "attachments_busy") {
-        // Attachments can't ride a queued user turn — server held the
-        // chips' reservations long enough to bounce the request and
-        // released them. Surface to the user; chips stay in the
-        // composer so they can retry once the assistant finishes.
-        if (queuedEl) self.queue.remove(queuedEl);
-        self.addErrorMessage(
-          "Attachments can't be sent while the assistant is working. " +
-            "Send a text-only message now, or wait and resend with attachments.",
-        );
-      } else {
-        self.attachments.consume(
-          data.attached_ids,
-          data.dropped_attachment_ids,
-        );
-      }
-    })
-    .catch(function (err) {
-      if (queuedEl) self.queue.remove(queuedEl);
-      self.addErrorMessage("Connection error: " + err.message);
-      if (!isBusy) self.setBusy(false);
-    });
-};
-
-Pane.prototype.cancelGeneration = function () {
-  if (!this.busy || !this.wsId || this.stopBtn.disabled) return;
-  var self = this;
-  var isForce = this.stopBtn.dataset.forceCancel === "true";
-  this.stopBtn.disabled = true;
-  authFetch(
-    "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/cancel",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ force: isForce }),
-    },
-  )
-    .then(function () {
-      if (isForce) {
-        // Force cancel abandons the worker — transition immediately.
-        // Clear timeouts to prevent stale timers firing on next send.
-        if (self._cancelTimeout) {
-          clearTimeout(self._cancelTimeout);
-          self._cancelTimeout = null;
-        }
-        if (self._forceTimeout) {
-          clearTimeout(self._forceTimeout);
-          self._forceTimeout = null;
-        }
-        self.addInfoMessage("Force stopped. Previous generation abandoned.");
-        self.setBusy(false);
-      }
-    })
-    .catch(function (err) {
-      self.addErrorMessage("Cancel error: " + err.message);
-      self.stopBtn.disabled = false;
-    });
-};
 
 // ===========================================================================
 //  2. Layout tree + rendering

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1300,6 +1300,337 @@ class Pane {
         this.setBusy(false);
       });
   }
+
+  replayHistory(messages) {
+    this.messagesEl.replaceChildren();
+    if (!messages.length) {
+      this.showEmptyState();
+      return;
+    }
+    // Suppress the polite live region while we batch-build the replay
+    // — messagesEl is aria-live="polite" so a fresh replay would otherwise
+    // queue an announcement for every approved/denied/verdict pill we
+    // insert.  Restored after the loop so live SSE updates announce
+    // normally.  WCAG 4.1.3 — historical content should not behave like
+    // real-time updates.
+    this.messagesEl.setAttribute("aria-busy", "true");
+    // pendingAssessments[call_id] = output_assessment dict.  Populated
+    // from the assistant branch, consumed by the role==="tool" branch
+    // (or after the loop, for legacy rows missing tool_call_id).
+    // Replaces a JSON.stringify→dataset→JSON.parse round-trip with an
+    // in-memory map keyed by call_id.
+    var pendingAssessments = {};
+    var lastToolBlock = null;
+    for (var i = 0; i < messages.length; i++) {
+      var msg = messages[i];
+      if (msg.role === "user") {
+        if (msg.source === "system_nudge") {
+          // Wake-driven empty user turn: render the thin marker
+          // (replaces the previously-skipped synthetic empty bubble)
+          // and anchor reminder bubbles below it.
+          this.addUserReminder(
+            Array.isArray(msg.reminders) ? msg.reminders : [],
+            "system_nudge",
+          );
+          lastToolBlock = null;
+          continue;
+        }
+        // addUserMessage first so addUserReminder's "anchor to most
+        // recent .msg.user" lookup finds THIS message's bubble (not the
+        // previous user message's, which would associate the reminder
+        // with the wrong turn).  addUserReminder then drops the bubble
+        // immediately below the just-rendered user message via
+        // insertAdjacentElement('afterend', el).
+        this.addUserMessage(msg.content || "", msg.attachments || null);
+        if (Array.isArray(msg.reminders) && msg.reminders.length) {
+          this.addUserReminder(msg.reminders);
+        }
+        lastToolBlock = null;
+      } else if (msg.role === "assistant") {
+        // Reasoning bubble (Phase 1 reasoning persistence) — render
+        // BEFORE the content bubble so the visual order matches the
+        // live SSE flow (reasoning_delta arrives before content_delta
+        // for thinking-enabled models). Mirrors the live-stream
+        // construction at the "case 'reasoning':" branch above. Only
+        // surfaces when the active model's surface_persisted_reasoning flag is
+        // true and the message round-tripped a thinking lane.
+        if (msg.reasoning && msg.reasoning.length) {
+          var reasonEl = document.createElement("div");
+          reasonEl.className = "msg reasoning";
+          reasonEl.textContent = msg.reasoning;
+          this.messagesEl.appendChild(reasonEl);
+          lastToolBlock = null;
+        }
+        // Render content BEFORE the tool block so the visual order
+        // matches the live SSE flow (stream_text streams content first,
+        // then tool_info / approve_request paints the tool block, then
+        // tool_result fills it in).  Order also matters structurally:
+        // the tool-result message in the NEXT iteration anchors via
+        // lastToolBlock, which the tool-block branch sets last — so
+        // content must run first to avoid clobbering that anchor.
+        //
+        // Whitespace-only content (e.g. "\n\n" from a reasoning-parser
+        // model that strips <think>…</think> and leaves only trailing
+        // newlines before the tool call) is treated as empty — the
+        // live stream never accumulated a visible bubble for it, so
+        // surfacing one on replay would be a phantom card that diverges
+        // from what the originating tab saw.
+        if (msg.content && msg.content.trim()) {
+          var el = document.createElement("div");
+          el.className = "msg assistant";
+          var bodyEl = document.createElement("div");
+          bodyEl.className = "msg-body";
+          el.appendChild(bodyEl);
+          setMarkdown(bodyEl, msg.content);
+          this.messagesEl.appendChild(el);
+          lastToolBlock = null;
+        }
+        if (msg.tool_calls && msg.tool_calls.length) {
+          if (msg.pending) {
+            lastToolBlock = null;
+          } else {
+            var wasDenied = !!msg.denied;
+            var block = document.createElement("div");
+            block.className =
+              "msg ts-approval ts-approval--inline " +
+              (wasDenied ? "denied" : "approved");
+            msg.tool_calls.forEach((tc) => {
+              var div = document.createElement("div");
+              div.className = "ts-approval-tool";
+              div.dataset.funcName = tc.name;
+              div.dataset.callId = tc.id || "";
+              var nameEl = document.createElement("div");
+              nameEl.className = "tool-name";
+              nameEl.textContent = tc.name;
+              div.appendChild(nameEl);
+              var cmd = document.createElement("div");
+              cmd.className = "tool-cmd";
+              try {
+                var args = JSON.parse(tc.arguments);
+                if (tc.name === "bash") {
+                  var preview = Object.values(args)[0] || "";
+                  var dollar = document.createElement("span");
+                  dollar.className = "dollar";
+                  dollar.textContent = "$ ";
+                  cmd.append(dollar, String(preview));
+                } else {
+                  var parts = [];
+                  var keys = Object.keys(args);
+                  for (var k = 0; k < keys.length; k++) {
+                    var val = args[keys[k]];
+                    var valStr =
+                      val === null || val === undefined ? "null" : String(val);
+                    if (valStr.length > 80)
+                      valStr = valStr.substring(0, 77) + "...";
+                    parts.push(keys[k] + ": " + valStr);
+                  }
+                  cmd.textContent = parts.join("\n");
+                }
+              } catch (e) {
+                cmd.textContent = tc.arguments.substring(0, 100);
+              }
+              div.appendChild(cmd);
+              // Verdict badge — anchor to THIS tool's row (div) rather
+              // than the whole block, so a multi-tool batch with one
+              // flagged call doesn't drift the badge above unrelated
+              // calls.  Same renderVerdictBadge helper as live; pass
+              // judgePending=false because any verdict on replay is
+              // final — no spinner.
+              if (tc.verdict) {
+                div.insertAdjacentHTML(
+                  "beforeend",
+                  renderVerdictBadge(tc.verdict, false),
+                );
+              }
+              block.appendChild(div);
+              // Output-guard finding — defer insertion until the tool
+              // result lands so the warning anchors under the output
+              // (mirrors live showOutputWarning placement).  Stash in
+              // a function-local map keyed by call_id so the
+              // role==="tool" branch below can pick it up; legacy rows
+              // missing tool_call_id are flushed at end-of-replay.
+              if (
+                tc.output_assessment &&
+                tc.output_assessment.risk_level &&
+                tc.output_assessment.risk_level !== "none"
+              ) {
+                pendingAssessments[tc.id || ""] = {
+                  assessment: tc.output_assessment,
+                  toolDiv: div,
+                };
+              }
+            });
+            var badge = document.createElement("div");
+            badge.setAttribute("role", "status");
+            if (wasDenied) {
+              badge.className = "ts-approval-badge ts-approval-badge--denied";
+              badge.textContent = "\u2717 denied";
+            } else {
+              badge.className = "ts-approval-badge ts-approval-badge--approved";
+              badge.textContent = "\u2713 approved";
+            }
+            block.appendChild(badge);
+            this.messagesEl.appendChild(block);
+            lastToolBlock = block;
+          }
+        }
+      } else if (msg.role === "tool") {
+        if (lastToolBlock) {
+          var stripped = stripAnsi(msg.content || "").trim();
+          var isDenied =
+            msg.denied ||
+            /^Denied by user/.test(stripped) ||
+            /^Blocked/.test(stripped);
+          var isToolError = !!msg.is_error;
+          // Anchor the rendered output to the specific .ts-approval-tool
+          // element matching this result's tool_call_id — mirrors the
+          // live appendToolOutput path so multi-tool batches show
+          // [hdr A][out A][hdr B][out B] rather than [A][B][out A][out B].
+          // Falls back to "before badge" when tool_call_id is absent
+          // (legacy rows pre-dating the wire-format addition).
+          var resultTarget = null;
+          if (msg.tool_call_id) {
+            resultTarget = lastToolBlock.querySelector(
+              '.ts-approval-tool[data-call-id="' +
+                CSS.escape(msg.tool_call_id) +
+                '"]',
+            );
+          }
+          // Cursor-style append: cursor advances after each insert so
+          // the next sibling lands AFTER the previous one.  Fixes the
+          // bug where calling resultTarget.after(node) twice put the
+          // second node BETWEEN resultTarget and the first (the second
+          // .after call was always relative to the same anchor).
+          // Resulting order with all present:
+          //   [tool div][output][output-warning]
+          var insertCursor = resultTarget;
+          var insertChained = (node) => {
+            if (insertCursor) {
+              insertCursor.after(node);
+              insertCursor = node;
+            } else {
+              var bdg = lastToolBlock.querySelector(".ts-approval-badge");
+              if (bdg) lastToolBlock.insertBefore(node, bdg);
+              else lastToolBlock.appendChild(node);
+            }
+          };
+          if (stripped && !isDenied) {
+            var media = !isToolError ? tryParseMedia(stripped) : null;
+            if (media) {
+              insertChained(buildMediaEmbed(media, stripped));
+            } else {
+              var out = renderToolOutput(stripped, isToolError);
+              if (out.textContent.split("\n").length > 10) {
+                makeCollapsible(out);
+              }
+              insertChained(out);
+            }
+          }
+          if (isToolError && !lastToolBlock.classList.contains("denied")) {
+            lastToolBlock.classList.add("error");
+            appendToolErrorBadge(lastToolBlock);
+          }
+          // Output-guard warning — pull the assessment out of the
+          // function-local pendingAssessments map (populated in the
+          // assistant branch).  Skip when the tool result was denied —
+          // the ✗ denied badge already signals the deny path.
+          if (!isDenied && msg.tool_call_id) {
+            var pending = pendingAssessments[msg.tool_call_id];
+            if (pending) {
+              insertChained(_buildOutputWarningEl(pending.assessment));
+              delete pendingAssessments[msg.tool_call_id];
+            }
+          }
+        }
+        // Tool-channel metacog reminders (tool_error / repeat) attach
+        // to the LAST tool message in a batch; on replay we render the
+        // bubble immediately below the .ts-approval block that owns
+        // the tool result.  addToolReminder's empty-toolCallId fallback
+        // resolves to "last .ts-approval block" — which is exactly
+        // lastToolBlock here.
+        if (Array.isArray(msg.reminders) && msg.reminders.length) {
+          this.addToolReminder(msg.reminders, "");
+        }
+        // Queued user messages spliced into the last tool-result envelope
+        // (Seam 1) replay as proper user bubbles after the tool block.
+        // ``decorate_history_messages`` extracts the user_interjection
+        // advisory from the persisted envelope and the wire layer projects
+        // it onto ``msg.advisories``; rendering through ``addUserMessage``
+        // matches the live shape a Seam 2/3 message would produce.  The
+        // walk/filter is shared via ``replayAdvisoriesAfterTool`` in
+        // ``shared/utils.js`` so coord and interactive can never drift on
+        // advisory-shape filtering.
+        replayAdvisoriesAfterTool(msg.advisories, (text) => {
+          this.addUserMessage(text, null);
+          lastToolBlock = null;
+        });
+      }
+    }
+    // Flush any output_assessments left in the map — these correspond
+    // to assistant tool_calls whose tool result row didn't carry a
+    // tool_call_id (legacy / migrated rows pre-dating the wire-format
+    // addition).  Render the warning under the tool div itself rather
+    // than dropping the safety information silently.
+    var leftoverIds = Object.keys(pendingAssessments);
+    for (var p = 0; p < leftoverIds.length; p++) {
+      var leftover = pendingAssessments[leftoverIds[p]];
+      if (!leftover) continue;
+      leftover.toolDiv.insertAdjacentElement(
+        "afterend",
+        _buildOutputWarningEl(leftover.assessment),
+      );
+    }
+    this._attachRetryToLastAssistant();
+    this.scrollToBottom();
+    // Focus the input so keyboard users land on the next-action target
+    // after replay finishes — but only when this is the focused pane,
+    // there's no pending approval competing for focus, and an input
+    // element actually exists.  Skipping when not the focused pane
+    // avoids stealing focus from another tab the user is interacting
+    // with while a background replay completes.
+    if (
+      this.id === focusedPaneId &&
+      !this.pendingApproval &&
+      this.inputEl &&
+      !this.busy
+    ) {
+      try {
+        this.inputEl.focus({ preventScroll: true });
+      } catch (_) {
+        this.inputEl.focus();
+      }
+    }
+    // Restore live-region semantics now that the batch build is done.
+    this.messagesEl.removeAttribute("aria-busy");
+  }
+
+  _attachRetryToLastAssistant() {
+    // Remove any previous retry buttons
+    var old = this.messagesEl.querySelectorAll(".msg.assistant .msg-actions");
+    for (var i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
+    // Find the last assistant message with content and add retry.
+    // Reasoning blocks emit as .msg.reasoning (distinct modifier) so the
+    // .msg.assistant selector already excludes them — no extra guard needed.
+    //
+    // Skip retry attachment when the most recent semantic turn is
+    // tool-only — last DOM child is a .ts-approval block.  Walk back
+    // past .user-reminder bubbles (added via addToolReminder /
+    // addUserReminder AFTER the .ts-approval block they advise) so the
+    // guard fires correctly even when the tool turn carried a metacog
+    // reminder.  Without this skip, retry lands on a stale prior
+    // assistant content bubble belonging to an earlier turn.
+    var lastChild = this.messagesEl.lastElementChild;
+    while (lastChild && lastChild.classList.contains("user-reminder")) {
+      lastChild = lastChild.previousElementSibling;
+    }
+    if (lastChild && lastChild.classList.contains("ts-approval")) {
+      return;
+    }
+    var assistants = this.messagesEl.querySelectorAll(".msg.assistant");
+    if (assistants.length) {
+      this._addRetryAction(assistants[assistants.length - 1]);
+    }
+  }
 }
 
 // Build a structured ``.msg.watch-result`` card for a
@@ -1360,311 +1691,6 @@ function _buildDefaultReminderBubble(r) {
   return el;
 }
 
-Pane.prototype.replayHistory = function (messages) {
-  var self = this;
-  this.messagesEl.replaceChildren();
-  if (!messages.length) {
-    this.showEmptyState();
-    return;
-  }
-  // Suppress the polite live region while we batch-build the replay
-  // — messagesEl is aria-live="polite" so a fresh replay would otherwise
-  // queue an announcement for every approved/denied/verdict pill we
-  // insert.  Restored after the loop so live SSE updates announce
-  // normally.  WCAG 4.1.3 — historical content should not behave like
-  // real-time updates.
-  this.messagesEl.setAttribute("aria-busy", "true");
-  // pendingAssessments[call_id] = output_assessment dict.  Populated
-  // from the assistant branch, consumed by the role==="tool" branch
-  // (or after the loop, for legacy rows missing tool_call_id).
-  // Replaces a JSON.stringify→dataset→JSON.parse round-trip with an
-  // in-memory map keyed by call_id.
-  var pendingAssessments = {};
-  var lastToolBlock = null;
-  for (var i = 0; i < messages.length; i++) {
-    var msg = messages[i];
-    if (msg.role === "user") {
-      if (msg.source === "system_nudge") {
-        // Wake-driven empty user turn: render the thin marker
-        // (replaces the previously-skipped synthetic empty bubble)
-        // and anchor reminder bubbles below it.
-        this.addUserReminder(
-          Array.isArray(msg.reminders) ? msg.reminders : [],
-          "system_nudge",
-        );
-        lastToolBlock = null;
-        continue;
-      }
-      // addUserMessage first so addUserReminder's "anchor to most
-      // recent .msg.user" lookup finds THIS message's bubble (not the
-      // previous user message's, which would associate the reminder
-      // with the wrong turn).  addUserReminder then drops the bubble
-      // immediately below the just-rendered user message via
-      // insertAdjacentElement('afterend', el).
-      this.addUserMessage(msg.content || "", msg.attachments || null);
-      if (Array.isArray(msg.reminders) && msg.reminders.length) {
-        this.addUserReminder(msg.reminders);
-      }
-      lastToolBlock = null;
-    } else if (msg.role === "assistant") {
-      // Reasoning bubble (Phase 1 reasoning persistence) — render
-      // BEFORE the content bubble so the visual order matches the
-      // live SSE flow (reasoning_delta arrives before content_delta
-      // for thinking-enabled models). Mirrors the live-stream
-      // construction at the "case 'reasoning':" branch above. Only
-      // surfaces when the active model's surface_persisted_reasoning flag is
-      // true and the message round-tripped a thinking lane.
-      if (msg.reasoning && msg.reasoning.length) {
-        var reasonEl = document.createElement("div");
-        reasonEl.className = "msg reasoning";
-        reasonEl.textContent = msg.reasoning;
-        self.messagesEl.appendChild(reasonEl);
-        lastToolBlock = null;
-      }
-      // Render content BEFORE the tool block so the visual order
-      // matches the live SSE flow (stream_text streams content first,
-      // then tool_info / approve_request paints the tool block, then
-      // tool_result fills it in).  Order also matters structurally:
-      // the tool-result message in the NEXT iteration anchors via
-      // lastToolBlock, which the tool-block branch sets last — so
-      // content must run first to avoid clobbering that anchor.
-      //
-      // Whitespace-only content (e.g. "\n\n" from a reasoning-parser
-      // model that strips <think>…</think> and leaves only trailing
-      // newlines before the tool call) is treated as empty — the
-      // live stream never accumulated a visible bubble for it, so
-      // surfacing one on replay would be a phantom card that diverges
-      // from what the originating tab saw.
-      if (msg.content && msg.content.trim()) {
-        var el = document.createElement("div");
-        el.className = "msg assistant";
-        var bodyEl = document.createElement("div");
-        bodyEl.className = "msg-body";
-        el.appendChild(bodyEl);
-        setMarkdown(bodyEl, msg.content);
-        self.messagesEl.appendChild(el);
-        lastToolBlock = null;
-      }
-      if (msg.tool_calls && msg.tool_calls.length) {
-        if (msg.pending) {
-          lastToolBlock = null;
-        } else {
-          var wasDenied = !!msg.denied;
-          var block = document.createElement("div");
-          block.className =
-            "msg ts-approval ts-approval--inline " +
-            (wasDenied ? "denied" : "approved");
-          msg.tool_calls.forEach(function (tc) {
-            var div = document.createElement("div");
-            div.className = "ts-approval-tool";
-            div.dataset.funcName = tc.name;
-            div.dataset.callId = tc.id || "";
-            var nameEl = document.createElement("div");
-            nameEl.className = "tool-name";
-            nameEl.textContent = tc.name;
-            div.appendChild(nameEl);
-            var cmd = document.createElement("div");
-            cmd.className = "tool-cmd";
-            try {
-              var args = JSON.parse(tc.arguments);
-              if (tc.name === "bash") {
-                var preview = Object.values(args)[0] || "";
-                var dollar = document.createElement("span");
-                dollar.className = "dollar";
-                dollar.textContent = "$ ";
-                cmd.append(dollar, String(preview));
-              } else {
-                var parts = [];
-                var keys = Object.keys(args);
-                for (var k = 0; k < keys.length; k++) {
-                  var val = args[keys[k]];
-                  var valStr =
-                    val === null || val === undefined ? "null" : String(val);
-                  if (valStr.length > 80)
-                    valStr = valStr.substring(0, 77) + "...";
-                  parts.push(keys[k] + ": " + valStr);
-                }
-                cmd.textContent = parts.join("\n");
-              }
-            } catch (e) {
-              cmd.textContent = tc.arguments.substring(0, 100);
-            }
-            div.appendChild(cmd);
-            // Verdict badge — anchor to THIS tool's row (div) rather
-            // than the whole block, so a multi-tool batch with one
-            // flagged call doesn't drift the badge above unrelated
-            // calls.  Same renderVerdictBadge helper as live; pass
-            // judgePending=false because any verdict on replay is
-            // final — no spinner.
-            if (tc.verdict) {
-              div.insertAdjacentHTML(
-                "beforeend",
-                renderVerdictBadge(tc.verdict, false),
-              );
-            }
-            block.appendChild(div);
-            // Output-guard finding — defer insertion until the tool
-            // result lands so the warning anchors under the output
-            // (mirrors live showOutputWarning placement).  Stash in
-            // a function-local map keyed by call_id so the
-            // role==="tool" branch below can pick it up; legacy rows
-            // missing tool_call_id are flushed at end-of-replay.
-            if (
-              tc.output_assessment &&
-              tc.output_assessment.risk_level &&
-              tc.output_assessment.risk_level !== "none"
-            ) {
-              pendingAssessments[tc.id || ""] = {
-                assessment: tc.output_assessment,
-                toolDiv: div,
-              };
-            }
-          });
-          var badge = document.createElement("div");
-          badge.setAttribute("role", "status");
-          if (wasDenied) {
-            badge.className = "ts-approval-badge ts-approval-badge--denied";
-            badge.textContent = "\u2717 denied";
-          } else {
-            badge.className = "ts-approval-badge ts-approval-badge--approved";
-            badge.textContent = "\u2713 approved";
-          }
-          block.appendChild(badge);
-          self.messagesEl.appendChild(block);
-          lastToolBlock = block;
-        }
-      }
-    } else if (msg.role === "tool") {
-      if (lastToolBlock) {
-        var stripped = stripAnsi(msg.content || "").trim();
-        var isDenied =
-          msg.denied ||
-          /^Denied by user/.test(stripped) ||
-          /^Blocked/.test(stripped);
-        var isToolError = !!msg.is_error;
-        // Anchor the rendered output to the specific .ts-approval-tool
-        // element matching this result's tool_call_id — mirrors the
-        // live appendToolOutput path so multi-tool batches show
-        // [hdr A][out A][hdr B][out B] rather than [A][B][out A][out B].
-        // Falls back to "before badge" when tool_call_id is absent
-        // (legacy rows pre-dating the wire-format addition).
-        var resultTarget = null;
-        if (msg.tool_call_id) {
-          resultTarget = lastToolBlock.querySelector(
-            '.ts-approval-tool[data-call-id="' +
-              CSS.escape(msg.tool_call_id) +
-              '"]',
-          );
-        }
-        // Cursor-style append: cursor advances after each insert so
-        // the next sibling lands AFTER the previous one.  Fixes the
-        // bug where calling resultTarget.after(node) twice put the
-        // second node BETWEEN resultTarget and the first (the second
-        // .after call was always relative to the same anchor).
-        // Resulting order with all present:
-        //   [tool div][output][output-warning]
-        var insertCursor = resultTarget;
-        var insertChained = function (node) {
-          if (insertCursor) {
-            insertCursor.after(node);
-            insertCursor = node;
-          } else {
-            var bdg = lastToolBlock.querySelector(".ts-approval-badge");
-            if (bdg) lastToolBlock.insertBefore(node, bdg);
-            else lastToolBlock.appendChild(node);
-          }
-        };
-        if (stripped && !isDenied) {
-          var media = !isToolError ? tryParseMedia(stripped) : null;
-          if (media) {
-            insertChained(buildMediaEmbed(media, stripped));
-          } else {
-            var out = renderToolOutput(stripped, isToolError);
-            if (out.textContent.split("\n").length > 10) {
-              makeCollapsible(out);
-            }
-            insertChained(out);
-          }
-        }
-        if (isToolError && !lastToolBlock.classList.contains("denied")) {
-          lastToolBlock.classList.add("error");
-          appendToolErrorBadge(lastToolBlock);
-        }
-        // Output-guard warning — pull the assessment out of the
-        // function-local pendingAssessments map (populated in the
-        // assistant branch).  Skip when the tool result was denied —
-        // the ✗ denied badge already signals the deny path.
-        if (!isDenied && msg.tool_call_id) {
-          var pending = pendingAssessments[msg.tool_call_id];
-          if (pending) {
-            insertChained(_buildOutputWarningEl(pending.assessment));
-            delete pendingAssessments[msg.tool_call_id];
-          }
-        }
-      }
-      // Tool-channel metacog reminders (tool_error / repeat) attach
-      // to the LAST tool message in a batch; on replay we render the
-      // bubble immediately below the .ts-approval block that owns
-      // the tool result.  addToolReminder's empty-toolCallId fallback
-      // resolves to "last .ts-approval block" — which is exactly
-      // lastToolBlock here.
-      if (Array.isArray(msg.reminders) && msg.reminders.length) {
-        this.addToolReminder(msg.reminders, "");
-      }
-      // Queued user messages spliced into the last tool-result envelope
-      // (Seam 1) replay as proper user bubbles after the tool block.
-      // ``decorate_history_messages`` extracts the user_interjection
-      // advisory from the persisted envelope and the wire layer projects
-      // it onto ``msg.advisories``; rendering through ``addUserMessage``
-      // matches the live shape a Seam 2/3 message would produce.  The
-      // walk/filter is shared via ``replayAdvisoriesAfterTool`` in
-      // ``shared/utils.js`` so coord and interactive can never drift on
-      // advisory-shape filtering.
-      var self = this;
-      replayAdvisoriesAfterTool(msg.advisories, function (text) {
-        self.addUserMessage(text, null);
-        lastToolBlock = null;
-      });
-    }
-  }
-  // Flush any output_assessments left in the map — these correspond
-  // to assistant tool_calls whose tool result row didn't carry a
-  // tool_call_id (legacy / migrated rows pre-dating the wire-format
-  // addition).  Render the warning under the tool div itself rather
-  // than dropping the safety information silently.
-  var leftoverIds = Object.keys(pendingAssessments);
-  for (var p = 0; p < leftoverIds.length; p++) {
-    var leftover = pendingAssessments[leftoverIds[p]];
-    if (!leftover) continue;
-    leftover.toolDiv.insertAdjacentElement(
-      "afterend",
-      _buildOutputWarningEl(leftover.assessment),
-    );
-  }
-  this._attachRetryToLastAssistant();
-  this.scrollToBottom();
-  // Focus the input so keyboard users land on the next-action target
-  // after replay finishes — but only when this is the focused pane,
-  // there's no pending approval competing for focus, and an input
-  // element actually exists.  Skipping when not the focused pane
-  // avoids stealing focus from another tab the user is interacting
-  // with while a background replay completes.
-  if (
-    this.id === focusedPaneId &&
-    !this.pendingApproval &&
-    this.inputEl &&
-    !this.busy
-  ) {
-    try {
-      this.inputEl.focus({ preventScroll: true });
-    } catch (_) {
-      this.inputEl.focus();
-    }
-  }
-  // Restore live-region semantics now that the batch build is done.
-  this.messagesEl.removeAttribute("aria-busy");
-};
-
 // Shared output-warning DOM builder — used by both replayHistory
 // (saved-workstream rendering) and the live appendToolOutput path
 // via showOutputWarning.  Single source of truth keeps the two
@@ -1694,34 +1720,6 @@ function _buildOutputWarningEl(assessment) {
   }
   return warning;
 }
-
-Pane.prototype._attachRetryToLastAssistant = function () {
-  // Remove any previous retry buttons
-  var old = this.messagesEl.querySelectorAll(".msg.assistant .msg-actions");
-  for (var i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
-  // Find the last assistant message with content and add retry.
-  // Reasoning blocks emit as .msg.reasoning (distinct modifier) so the
-  // .msg.assistant selector already excludes them — no extra guard needed.
-  //
-  // Skip retry attachment when the most recent semantic turn is
-  // tool-only — last DOM child is a .ts-approval block.  Walk back
-  // past .user-reminder bubbles (added via addToolReminder /
-  // addUserReminder AFTER the .ts-approval block they advise) so the
-  // guard fires correctly even when the tool turn carried a metacog
-  // reminder.  Without this skip, retry lands on a stale prior
-  // assistant content bubble belonging to an earlier turn.
-  var lastChild = this.messagesEl.lastElementChild;
-  while (lastChild && lastChild.classList.contains("user-reminder")) {
-    lastChild = lastChild.previousElementSibling;
-  }
-  if (lastChild && lastChild.classList.contains("ts-approval")) {
-    return;
-  }
-  var assistants = this.messagesEl.querySelectorAll(".msg.assistant");
-  if (assistants.length) {
-    this._addRetryAction(assistants[assistants.length - 1]);
-  }
-};
 
 Pane.prototype.showInlineToolBlock = function (
   items,


### PR DESCRIPTION
## Summary

Modernises `Pane` in `turnstone/ui/static/app.js` from a prototype-function-constructor (`function Pane()` + 38 `Pane.prototype.X = function`) into a single `class Pane { ... }` block. Goal: close the ES6+ idiom gap between `app.js` (was essentially pre-2015 JS) and `coordinator.js` (already ES6). Pure refactor — no behaviour change, no algorithm change.

**Scorecard** (before → after, in `app.js`):

| | before | after |
|---|---:|---:|
| `class Pane` | 0 | **1** |
| `Pane.prototype.X = function` | 38 | **0** |
| `var self = this` | 16 | **0** |
| Arrow callbacks (`=>`) | 0 | **55** |

The 38 prototype methods consolidate into one class block (lines 12 → ~1634). 16 `var self = this` workarounds dissolve into arrow-function lexical-`this` — all 16 sites were Type 1 per the boundary spike (outer-`this` capture only; zero event-target-`this`, zero delayed semantic capture). Three module-level helpers (`_buildWatchResultBubble`, `_buildDefaultReminderBubble`, `_buildOutputWarningEl`) that were nested between prototype assignments relocate to live just after the class block — function declarations hoist, so the move is semantically free.

## Commit shape

Five commits, each ends CI-green:

1. **`e97da317`** — Scaffold `class Pane { constructor + 22 leaf methods }` + relocate 2 stranded helpers. The 22 callback-free methods migrate first because they have no var-self-this surface.
2. **`dddc795b`** — Migrate 9 callback-heavy methods (`_createDOM`, `connectSSE`, `handleEvent`, `_addUserMsgActions`, `_addRetryAction`, `_retryLast`, `_rewindToMessage`, `_startEdit`, `_editAndResend`). Dissolves 12 of the 16 var-self-this sites via arrow-function conversion in the same diff.
3. **`2bc64936`** — Migrate `replayHistory` (304-line, the largest single method) + `_attachRetryToLastAssistant`, relocate the third helper to join the cluster, and update the three pytest assertions anchored on the prototype-shape literal.
4. **`ee01c961`** — Migrate the last 5 methods (`showInlineToolBlock`, `resolveApproval`, `appendToolOutput`, `sendMessage`, `cancelGeneration`), update the fourth anchored test. After this commit zero `Pane.prototype.X` declarations remain.
5. **`321f2417`** — Post-`/review` hygiene: drop stale `app.js:1287/1538` line-number comments from `test_app_js.py`, drop `.prototype` from three coord cross-reference comments, and introduce a `_pane_method_offset(body, name)` helper so the four `body.index("\n  X(")` slice points become indent-agnostic (survives a future class-in-IIFE wrap without silent ValueError).

## Spike-verified guardrails (from `~/pane-class-refactor.md` §2.10)

- **Hoisting**: only `new Pane()` site is `createPane` at line 2152; class block ends at 1634. Class declaration strictly precedes the call site.
- **Strict mode**: zero `with`, `arguments.caller`, `arguments.callee`. Implicit-strict class body is a no-op.
- **Method enumerability**: 14 `for (var pid in panes)` sites all iterate the module-level `panes` ID-map, not method names on a pane instance. Non-enumerable class methods are irrelevant.
- **`this`-as-event-target**: spike sampled all 16 `var self = this` sites; all are Type 1 (no Type 2 / Type 3). Mechanical conversion is safe.
- **HTML/template coupling**: zero hits for `\bPane\b` in HTML or templates — refactor is self-contained to `app.js` + `tests/test_app_js.py` + 3 coord-comment cleanups.

## Out of scope (follow-ups tracked in `~/pane-class-refactor.md` §8)

- Whole-file `var` → `const`/`let` sweep in `app.js` (PR B).
- Same sweep across `console/static/{admin,governance,app}.js` + `shared_static/*.js` (PRs C-F).
- Template literal conversion, `for (var i = ...)` → `for...of` rewrites.
- ES modules + bundler (architectural; needs design).
- Promoting any method to `static` (none are eligible today — all 38 reference `this`).

## Test plan

- [x] `pytest tests/test_app_js.py` — 27/27 green (4 anchored slices migrated to class-method form)
- [x] `pytest tests/test_app_js.py tests/test_renderer_js.py tests/test_console.py tests/test_console_router.py` — 258/258 green
- [x] `node --check turnstone/ui/static/app.js` — syntax valid
- [x] `npx prettier --check turnstone/ui/static/app.js` — formatted
- [x] `ruff check tests/test_app_js.py` + `mypy tests/test_app_js.py` — clean
- [x] Multi-stage `/review` pipeline — 0 bug / 0 security / 0 perf findings; 3 quality findings (1 minor, 2 nit) all addressed in commit 5
- [x] Manual browser smoke — saved-workstream replay, approval flow, split pane

## Diff size

3 files, 1,983 insertions / 1,988 deletions (net −5). The bulk of the line count is +2-space body re-indents (class-method depth); the actual semantic delta is the header rewrites (38 ×) + var-self-this dissolutions (16 ×) + 3 helper relocations + 4 test anchor migrations.