### PR TITLE
feat(reasoning): Phase 5 — vLLM Chat Completions reasoning-field replay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "openai>=2.24",
+    "openai>=2.37",
     "httpx>=0.28",
     "mcp>=1.27",
     "starlette>=0.45",

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -675,3 +675,178 @@ class TestExtractReasoningForHistory:
         extract_reasoning_for_history(messages, surface_persisted_reasoning_flag=True)
         assert messages[0]["reasoning"] == "real thought"
         assert "_provider_content" not in messages[0]
+
+
+class TestAttachVllmChatReasoningField:
+    """``attach_vllm_chat_reasoning_field`` — Phase 5 surfaces persisted
+    reasoning as the vLLM-specific ``reasoning`` field on outgoing
+    assistant messages so vLLM-served reasoning models can thread CoT
+    across turns.
+
+    Drives through the real ``extract_reasoning_text_from_provider_content``
+    dispatcher — no extractor mocks — so a regression in either layer
+    surfaces distinctly.  All 3 caller-side gates (provider isinstance,
+    server_type, operator flag) are exercised by
+    ``test_session_chat_reasoning_replay.py``; this class pins the
+    helper's projection contract in isolation.
+    """
+
+    def _assistant_with(self, provider_content: list[dict[str, object]]) -> dict[str, object]:
+        return {
+            "role": "assistant",
+            "content": "Final answer.",
+            "_provider_content": provider_content,
+        }
+
+    def test_synthetic_reasoning_text_attaches_field(self) -> None:
+        # Path 3 capture (vLLM --reasoning-parser, llama.cpp
+        # reasoning_format, Gemini-compat) lands in _provider_content as
+        # a synthetic reasoning_text block; helper must round-trip it
+        # back onto the same model on the next turn.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs = [self._assistant_with([{"type": "reasoning_text", "text": "synth thought"}])]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert out[0]["reasoning"] == "synth thought"
+
+    def test_anthropic_thinking_attaches_field(self) -> None:
+        # Cross-provider switch: workstream started with Anthropic,
+        # operator flipped model to a vLLM-served reasoning model.
+        # Helper extracts the thinking text and discards the signature
+        # (vLLM doesn't validate signatures).
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs = [
+            self._assistant_with(
+                [
+                    {"type": "thinking", "thinking": "claude was here", "signature": "sig"},
+                    {"type": "text", "text": "answer"},
+                ]
+            )
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert out[0]["reasoning"] == "claude was here"
+        # Signature is dropped at extraction; ``reasoning`` field carries
+        # plain text only.
+        assert "sig" not in out[0]["reasoning"]
+
+    def test_openai_responses_reasoning_attaches_field(self) -> None:
+        # Cross-provider switch: workstream started on gpt-5, operator
+        # flipped to a vLLM-served model.  Helper extracts the
+        # summary[*].text concatenation.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs = [
+            self._assistant_with(
+                [
+                    {
+                        "type": "reasoning",
+                        "id": "r_1",
+                        "summary": [{"type": "summary_text", "text": "responses thought"}],
+                    }
+                ]
+            )
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert out[0]["reasoning"] == "responses thought"
+
+    def test_no_provider_content_returns_unchanged(self) -> None:
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs: list[dict[str, object]] = [{"role": "assistant", "content": "plain"}]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert "reasoning" not in out[0]
+        # No copy made when there's nothing to attach — same object.
+        assert out[0] is msgs[0]
+
+    def test_empty_provider_content_returns_unchanged(self) -> None:
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs: list[dict[str, object]] = [
+            {"role": "assistant", "content": "x", "_provider_content": []}
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert "reasoning" not in out[0]
+        assert out[0] is msgs[0]
+
+    def test_unknown_block_type_returns_unchanged(self) -> None:
+        # _provider_content has blocks but none are reasoning-bearing.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs: list[dict[str, object]] = [
+            self._assistant_with([{"type": "text", "text": "no reasoning here"}])
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert "reasoning" not in out[0]
+        assert out[0] is msgs[0]
+
+    def test_does_not_touch_user_tool_system_messages(self) -> None:
+        # Only assistant messages get the reasoning field.  User / tool /
+        # system messages pass through by reference.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        msgs: list[dict[str, object]] = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "c1", "content": "out"},
+            # Even an assistant-shaped non-assistant role (defensive — shouldn't happen)
+            # must not have provider_content read.
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert "reasoning" not in out[0]
+        assert "reasoning" not in out[1]
+        assert "reasoning" not in out[2]
+        # All three return by reference (no allocation when no attach).
+        for original, returned in zip(msgs, out, strict=True):
+            assert original is returned
+
+    def test_preserves_provider_content_for_downstream_sanitize(self) -> None:
+        # Helper attaches ``reasoning`` but leaves ``_provider_content``
+        # in place.  Downstream ``sanitize_messages`` (in the provider's
+        # _prepare_messages) strips the ``_``-prefixed sibling key
+        # before the wire payload leaves.  Helper isn't responsible for
+        # that strip — composition with sanitize is the contract.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        original_content = [{"type": "reasoning_text", "text": "kept"}]
+        msgs = [self._assistant_with(original_content)]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert out[0]["reasoning"] == "kept"
+        # Provider content survives on the helper's output dict.
+        assert out[0]["_provider_content"] == original_content
+
+    def test_does_not_mutate_input_messages(self) -> None:
+        # Pure transform: input list and input dicts are untouched.
+        # Callers can keep iterating the original list without surprise.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        original = self._assistant_with([{"type": "reasoning_text", "text": "x"}])
+        msgs = [original]
+        attach_vllm_chat_reasoning_field(msgs)
+        assert "reasoning" not in original
+        # Original dict untouched even though the function returned a
+        # modified copy.
+
+    def test_mixed_messages_only_attaches_to_assistants_with_reasoning(self) -> None:
+        # Realistic shape: a workstream with user, assistant-with-reasoning,
+        # tool, assistant-plain, user.  Only the first assistant gets the
+        # reasoning field; everything else passes through by reference.
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        with_reasoning = self._assistant_with([{"type": "reasoning_text", "text": "thinking"}])
+        plain_assistant: dict[str, object] = {"role": "assistant", "content": "second"}
+        msgs: list[dict[str, object]] = [
+            {"role": "user", "content": "q1"},
+            with_reasoning,
+            {"role": "tool", "tool_call_id": "c1", "content": "result"},
+            plain_assistant,
+            {"role": "user", "content": "q2"},
+        ]
+        out = attach_vllm_chat_reasoning_field(msgs)
+        assert out[0] is msgs[0]
+        assert out[1]["reasoning"] == "thinking"
+        assert out[1] is not with_reasoning  # new dict for the attached one
+        assert out[2] is msgs[2]
+        assert out[3] is plain_assistant
+        assert "reasoning" not in out[3]
+        assert out[4] is msgs[4]

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -331,3 +331,73 @@ class TestReasoningAuditLogDiscipline:
             f"AnthropicProvider._convert_messages strip predicate leaked "
             f"reasoning text into INFO+ logs: {offending}"
         )
+
+    def test_attach_vllm_chat_reasoning_field_does_not_log_reasoning(self) -> None:
+        """Phase 5 surface — ``attach_vllm_chat_reasoning_field`` extracts
+        persisted reasoning text and attaches it as a ``reasoning`` field
+        on the outgoing assistant message dict.  The attached text is
+        wire-bound (vLLM template render) and UI-bound (history rehydration
+        already covered by Phase 1 tests above), but MUST NOT appear in
+        any INFO+ log call along the way."""
+        from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
+
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            messages = [self._thinking_msg(_MARKER)]
+            out = attach_vllm_chat_reasoning_field(messages)
+            # Wire-bound attach succeeded — marker IS allowed in the
+            # returned dict's reasoning field.
+            assert out[0]["reasoning"] == _MARKER
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"attach_vllm_chat_reasoning_field leaked reasoning text into INFO+ logs: {offending}"
+        )
+
+    def test_maybe_attach_vllm_chat_reasoning_does_not_log_reasoning(self) -> None:
+        """Phase 5 gate method on ChatSession — the session-level
+        composite gate calls ``attach_vllm_chat_reasoning_field`` when
+        all 3 conditions pass.  Pin that the gate path itself doesn't
+        log reasoning text (the registry / capability lookups happen
+        adjacent to the reasoning bytes; a defensive ``log.warning``
+        showing the message dict on an error path would silently
+        violate the contract)."""
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        session = make_session()
+        session._registry = SimpleNamespace(
+            get_config=lambda _alias: SimpleNamespace(
+                replay_reasoning_to_model=True,
+                capabilities={},
+                server_compat={"server_type": "vllm"},
+            )
+        )
+        session._model_alias = "qwen3"
+        provider = OpenAIChatCompletionsProvider()
+
+        captured, patchers = _capture_log_calls()
+        for p in patchers:
+            p.start()
+        try:
+            out = session._maybe_attach_vllm_chat_reasoning([self._thinking_msg(_MARKER)], provider)
+            assert out[0]["reasoning"] == _MARKER
+        finally:
+            for p in patchers:
+                p.stop()
+        offending = [
+            (lvl, args, kwargs)
+            for lvl, args, kwargs in captured
+            if _payload_contains_marker(args, kwargs)
+        ]
+        assert offending == [], (
+            f"ChatSession._maybe_attach_vllm_chat_reasoning leaked reasoning "
+            f"text into INFO+ logs: {offending}"
+        )

--- a/tests/test_session_chat_reasoning_replay.py
+++ b/tests/test_session_chat_reasoning_replay.py
@@ -1,0 +1,424 @@
+"""Session-level integration tests for Phase 5 (Chat Completions
+``reasoning`` field replay against vLLM).
+
+Phase 5 is the only reasoning-replay path that does NOT use the static
+``supports_reasoning_replay`` capability gate.  It's a parallel path to
+Paths 1+2, gated entirely at the session level on three conditions:
+
+1. Provider is ``OpenAIChatCompletionsProvider``.
+2. ``server_compat.server_type == "vllm"``.
+3. Operator-set ``ModelConfig.replay_reasoning_to_model`` is True.
+
+These tests drive through ``ChatSession._maybe_attach_vllm_chat_reasoning``
+to pin each gate independently, then one round-trip test through the real
+OpenAI Python SDK + httpx MockTransport confirms the ``reasoning`` field
+actually reaches the wire bytes (the SDK-boundary guarantee that the
+session-level attach approach hinges on).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tests._session_helpers import make_session as _make_session
+from turnstone.core.providers._anthropic import AnthropicProvider
+from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+
+def _vllm_registry(*, replay: bool = True, alias: str = "qwen3") -> Any:
+    """Stub registry with a vLLM-typed server_compat profile and the
+    Phase 5 operator flag toggleable.
+
+    Mirrors production ModelConfig shape: ``server_compat`` lives at
+    the top-level dataclass field, NOT inside ``capabilities``.  Both
+    model_registry loader paths (DB row at line 401, config.toml at
+    line 485) ``caps.pop("server_compat", {})`` and hoist it up, so a
+    stub that populates ``capabilities["server_compat"]`` would mask
+    the same bug Phase 5 stepped on initially.
+    """
+
+    cfg = SimpleNamespace(
+        replay_reasoning_to_model=replay,
+        capabilities={},
+        server_compat={"server_type": "vllm"},
+    )
+    return SimpleNamespace(
+        get_config=lambda a: cfg if a == alias else (_ for _ in ()).throw(KeyError(a)),
+    )
+
+
+def _registry_with_server_type(server_type: str, *, replay: bool = True) -> Any:
+    cfg = SimpleNamespace(
+        replay_reasoning_to_model=replay,
+        capabilities={},
+        server_compat={"server_type": server_type},
+    )
+    return SimpleNamespace(
+        get_config=lambda _alias: cfg,
+    )
+
+
+def _assistant_msg_with_thinking(text: str = "let me think") -> dict[str, Any]:
+    """Anthropic-shape persisted reasoning — the cross-provider case
+    where workstream started on Anthropic and operator flipped to
+    vLLM-served Qwen3.  Helper must extract the text and discard the
+    Anthropic signature."""
+
+    return {
+        "role": "assistant",
+        "content": "Final answer.",
+        "_provider_content": [
+            {"type": "thinking", "thinking": text, "signature": "sig"},
+            {"type": "text", "text": "Final answer."},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gate tests via ``_maybe_attach_vllm_chat_reasoning`` directly
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeAttachVllmChatReasoningGates:
+    """The session-level method that combines all three Phase 5 gates."""
+
+    def test_all_gates_pass_attaches_reasoning(self) -> None:
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = "qwen3"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [{"role": "user", "content": "q"}, _assistant_msg_with_thinking("CoT")]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert out[1]["reasoning"] == "CoT"
+
+    def test_non_chat_completions_provider_is_no_op(self) -> None:
+        # Provider isinstance gate: Anthropic / Responses / Google all
+        # have their own reasoning-replay paths (Paths 1 / 2) — Phase 5
+        # must not double-attach.
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = "qwen3"
+        provider = AnthropicProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+        # Same reference — no copy made.
+        assert out[0] is msgs[0]
+
+    def test_openai_responses_provider_is_no_op(self) -> None:
+        # OpenAIResponsesProvider is a top-level class (not a subclass of
+        # OpenAIChatCompletionsProvider) — the isinstance gate rejects
+        # it cleanly.  This is the load-bearing distinction; an
+        # accidental inheritance refactor would break the gate.
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = "qwen3"
+        provider = OpenAIResponsesProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    @pytest.mark.parametrize("server_type", ["", "llama.cpp", "sglang", "openai", "unknown"])
+    def test_non_vllm_server_type_is_no_op(self, server_type: str) -> None:
+        # Server-type pin bounds blast radius — canonical OpenAI Chat
+        # Completions, llama.cpp, sglang, and any unrecognised server
+        # never receive the non-standard ``reasoning`` field.
+        session = _make_session()
+        session._registry = _registry_with_server_type(server_type, replay=True)
+        session._model_alias = "some-model"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    def test_operator_flag_off_is_no_op(self) -> None:
+        session = _make_session()
+        session._registry = _vllm_registry(replay=False)  # operator flag OFF
+        session._model_alias = "qwen3"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    def test_missing_registry_is_no_op(self) -> None:
+        session = _make_session()
+        session._registry = None
+        session._model_alias = "qwen3"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    def test_missing_alias_is_no_op(self) -> None:
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = ""
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    def test_registry_exception_is_no_op(self) -> None:
+        # Defensive: registry lookup raising must degrade to no-attach,
+        # not break the call.  Conservative default — operator can
+        # always re-flip the flag once the registry is healthy.
+        def boom(_alias: str) -> Any:
+            raise KeyError("missing")
+
+        session = _make_session()
+        session._registry = SimpleNamespace(get_config=boom)
+        session._model_alias = "qwen3"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out[0]
+
+    def test_explicit_alias_arg_overrides_session_default(self) -> None:
+        # When _try_stream forwards an explicit ``model_alias`` (different
+        # from the session's primary), the helper must read THAT alias'
+        # config — not the session's primary.  Mirrors the per-alias
+        # behaviour pinned for _resolve_replay_reasoning_to_model.
+        def per_alias(alias: str) -> Any:
+            return SimpleNamespace(
+                replay_reasoning_to_model=(alias == "wants-replay"),
+                capabilities={},
+                server_compat={"server_type": "vllm"},
+            )
+
+        session = _make_session()
+        session._registry = SimpleNamespace(get_config=per_alias)
+        session._model_alias = "primary"
+        provider = OpenAIChatCompletionsProvider()
+
+        msgs = [_assistant_msg_with_thinking()]
+        # Default alias → flag off → no attach.
+        out_default = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        assert "reasoning" not in out_default[0]
+        # Explicit alias arg → flag on → attached.
+        out_explicit = session._maybe_attach_vllm_chat_reasoning(msgs, provider, "wants-replay")
+        assert out_explicit[0]["reasoning"] == "let me think"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: SDK passthrough is the load-bearing assumption.  Verify it
+# with a real OpenAI client wired against an httpx MockTransport that
+# inspects the body (per feedback_mock_transport_body_inspection).
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningFieldReachesWireBytes:
+    """One round-trip test through the real OpenAI Python SDK confirms
+    the ``reasoning`` field on an assistant message dict survives the
+    sanitize_messages strip (only ``_``-prefixed keys are dropped) AND
+    the SDK's TypedDict input shape (no runtime field filtering)."""
+
+    def _capture_client(self) -> tuple[Any, list[dict[str, Any]]]:
+        from openai import OpenAI
+
+        captured: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.content.decode("utf-8") if request.content else ""
+            captured.append({"url": str(request.url), "body": body})
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-vllm-spike",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "qwen3-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            )
+
+        client = OpenAI(
+            api_key="sk-test",
+            base_url="http://mock.local/v1",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+        return client, captured
+
+    def test_reasoning_field_present_in_wire_body_when_attached(self) -> None:
+        # Send messages that have the Phase 5 ``reasoning`` field
+        # attached.  Drive a real provider call through the real OpenAI
+        # SDK + mock httpx and verify the field is in the captured POST
+        # body — the SDK passthrough assumption that the entire
+        # session-level approach hinges on.
+        client, captured = self._capture_client()
+        provider = OpenAIChatCompletionsProvider()
+
+        # Mimic the post-attach message shape that
+        # ``_maybe_attach_vllm_chat_reasoning`` produces, then sanitize.
+        # ``sanitize_messages`` runs inside provider._prepare_messages
+        # and must preserve the non-``_``-prefixed ``reasoning`` field.
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "reasoning": "vLLM-shaped CoT text",
+                "_provider_content": [{"type": "reasoning_text", "text": "vLLM-shaped CoT text"}],
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+
+        provider.create_completion(
+            client=client,
+            model="qwen3-test",
+            messages=messages,
+            max_tokens=10,
+            temperature=0.5,
+            reasoning_effort="medium",
+            extra_params=None,
+            capabilities=provider.get_capabilities("qwen3-test"),
+        )
+
+        assert captured, "no request captured"
+        body = json.loads(captured[0]["body"])
+        assistant_msg = next(m for m in body["messages"] if m["role"] == "assistant")
+        # Wire-format guarantee: field survives sanitize_messages + SDK.
+        assert assistant_msg.get("reasoning") == "vLLM-shaped CoT text"
+        # And the ``_``-prefixed sibling is stripped by sanitize_messages.
+        assert "_provider_content" not in assistant_msg
+
+    def test_reasoning_field_absent_when_not_attached(self) -> None:
+        # Negative case: when the session-level gate decided NOT to
+        # attach (any of the 3 gates failed), the SDK round-trip carries
+        # no ``reasoning`` field — the operator's opt-out / non-vLLM
+        # destination is honoured all the way to the wire.
+        client, captured = self._capture_client()
+        provider = OpenAIChatCompletionsProvider()
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                # No ``reasoning`` field — pre-attach shape, gate said no.
+                "_provider_content": [{"type": "reasoning_text", "text": "would-have-replayed"}],
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+
+        provider.create_completion(
+            client=client,
+            model="gpt-4o",  # canonical OpenAI, not vLLM
+            messages=messages,
+            max_tokens=10,
+            temperature=0.5,
+            reasoning_effort="medium",
+            extra_params=None,
+            capabilities=provider.get_capabilities("gpt-4o"),
+        )
+
+        body = json.loads(captured[0]["body"])
+        assistant_msg = next(m for m in body["messages"] if m["role"] == "assistant")
+        assert "reasoning" not in assistant_msg
+        assert "_provider_content" not in assistant_msg
+
+
+# ---------------------------------------------------------------------------
+# Call-site integration: confirm _try_stream and _utility_completion both
+# invoke the helper.  Pins that the 2 hoist points stay in sync; a missed
+# call site is exactly the kind of regression this catches.  The agent
+# _run_agent path is deliberately NOT a Phase 5 hoist — see the NOTE
+# comment inside _run_agent's nested _api_call closure (grep session.py
+# for "Phase 5 vLLM ``reasoning`` field replay is intentionally NOT
+# wired here"): agent assistant messages don't carry
+# ``_provider_content`` so the helper would no-op every turn anyway.
+# ---------------------------------------------------------------------------
+
+
+class TestCallSitesInvokeMaybeAttach:
+    """The helper does nothing unless one of the 2 call sites calls it.
+    Verify the wiring at each — without this, a refactor that drops a
+    call site would silently regress Phase 5 on that path."""
+
+    def test_try_stream_call_site_attaches(self) -> None:
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = "qwen3"
+
+        captured: dict[str, Any] = {}
+
+        def capture_streaming(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return iter([])
+
+        provider = OpenAIChatCompletionsProvider()
+        # Patch only the network-facing method so we don't actually call
+        # an LLM, but keep the real provider instance (so the isinstance
+        # gate sees the right type).
+        provider.create_streaming = capture_streaming  # type: ignore[method-assign]
+
+        with (
+            patch.object(session, "_get_active_tools", return_value=None),
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(session, "_get_deferred_names", return_value=frozenset()),
+            patch.object(session, "_check_cancelled"),
+        ):
+            session._try_stream(
+                client=MagicMock(),
+                model="qwen3",
+                msgs=[_assistant_msg_with_thinking("from try_stream")],
+                provider=provider,
+                model_alias="qwen3",
+            )
+
+        # The messages handed to the provider include the attached
+        # reasoning field — proves _try_stream invoked
+        # _maybe_attach_vllm_chat_reasoning before the call.
+        msgs_sent = captured["messages"]
+        assert msgs_sent[0]["reasoning"] == "from try_stream"
+
+    def test_utility_completion_call_site_attaches(self) -> None:
+        session = _make_session()
+        session._registry = _vllm_registry(replay=True)
+        session._model_alias = "qwen3"
+
+        captured: dict[str, Any] = {}
+
+        def capture_completion(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content="", tool_calls=[], usage=None, raw_blocks=None, provider_blocks=None
+            )
+
+        provider = OpenAIChatCompletionsProvider()
+        provider.create_completion = capture_completion  # type: ignore[method-assign]
+        session._provider = provider
+
+        with (
+            patch.object(session, "_provider_extra_params", return_value=None),
+            patch.object(
+                session, "_get_capabilities", return_value=provider.get_capabilities("qwen3")
+            ),
+        ):
+            session._utility_completion(
+                messages=[_assistant_msg_with_thinking("from utility")],
+            )
+
+        msgs_sent = captured["messages"]
+        assert msgs_sent[0]["reasoning"] == "from utility"

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -73,7 +73,8 @@ class TestMaybeSynthReasoningBlock:
         session = _make_session()
         session._registry = SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
-                capabilities={"server_compat": {"server_type": "vllm"}},
+                capabilities={},
+                server_compat={"server_type": "vllm"},
             )
         )
         session._model_alias = "qwen3-32b"
@@ -296,7 +297,8 @@ class TestStreamResponseSynthBlockIntegration:
         session = _make_session()
         session._registry = SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
-                capabilities={"server_compat": {"server_type": "vllm"}},
+                capabilities={},
+                server_compat={"server_type": "vllm"},
             )
         )
         session._model_alias = "qwen3-32b"
@@ -319,16 +321,21 @@ class TestResolveServerType:
     def test_returns_empty_when_no_alias(self) -> None:
         session = _make_session()
         session._registry = SimpleNamespace(
-            get_config=lambda alias: SimpleNamespace(capabilities={})
+            get_config=lambda alias: SimpleNamespace(capabilities={}, server_compat={})
         )
         session._model_alias = ""
         assert session._resolve_server_type() == ""
 
     def test_returns_server_type_when_present(self) -> None:
+        # Mirrors production ModelConfig shape: server_compat lives at
+        # the top-level dataclass field, NOT inside capabilities.  Both
+        # model_registry loader paths pop("server_compat") out of caps
+        # before construction (see model_registry.py:401, 485).
         session = _make_session()
         session._registry = SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
-                capabilities={"server_compat": {"server_type": "llama.cpp"}}
+                capabilities={},
+                server_compat={"server_type": "llama.cpp"},
             )
         )
         session._model_alias = "local-model"
@@ -339,6 +346,7 @@ class TestResolveServerType:
         session._registry = SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
                 capabilities={"context_window": 32768},
+                server_compat={},
             )
         )
         session._model_alias = "local-model"

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -423,6 +423,51 @@ def extract_reasoning_for_history(
             msg["reasoning"] = text
 
 
+def attach_vllm_chat_reasoning_field(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project persisted reasoning onto outgoing assistant messages as a
+    non-standard ``reasoning`` field consumed by vLLM's chat template.
+
+    vLLM's ``ChatMessage`` (``vllm/entrypoints/openai/chat_completion/
+    protocol.py``) accepts a non-standard ``reasoning`` input field that
+    propagates into the template render context as both ``reasoning``
+    and ``reasoning_content``.  Templates from reasoning-aware families
+    (Qwen3, DeepSeek-R1) inline that text on the next turn; templates
+    that don't read the field silently drop it.  Either way the field
+    name doesn't conflict with the OpenAI spec — ``sanitize_messages``
+    preserves it because it isn't ``_``-prefixed, and the OpenAI Python
+    SDK passes unknown message-level fields through to the wire
+    (TypedDict input shape, no runtime validation).
+
+    Pure transform: returns a new list with new dict copies for the
+    assistant messages that get a ``reasoning`` field attached.  Other
+    messages and assistant messages without reasoning text pass through
+    by reference.  The original messages are never mutated.
+
+    All three gates (provider isinstance, ``server_type == "vllm"``,
+    operator flag ``replay_reasoning_to_model``) MUST be checked by the
+    caller — this helper assumes the decision has already been made.
+    See ``ChatSession._maybe_attach_vllm_chat_reasoning`` for the
+    integration point.
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            out.append(msg)
+            continue
+        provider_content = msg.get("_provider_content")
+        if not provider_content:
+            out.append(msg)
+            continue
+        text = extract_reasoning_text_from_provider_content(provider_content)
+        if not text:
+            out.append(msg)
+            continue
+        out.append({**msg, "reasoning": text})
+    return out
+
+
 def decorate_history_messages(
     messages: list[dict[str, Any]],
     verdicts_by_call_id: dict[str, dict[str, Any]],

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1172,9 +1172,16 @@ class ChatSession:
 
         Used by :meth:`_maybe_synth_reasoning_block` to tag synthetic
         path-3 reasoning blocks with their origin server (vllm,
-        llama.cpp, sglang, etc.) — informational there but load-bearing
-        for :meth:`_maybe_attach_vllm_chat_reasoning` (Phase 5 gate).
-        Returns ``""`` on any lookup miss.
+        llama.cpp, sglang, etc.) — informational metadata for UI
+        rehydration.  Returns ``""`` on any lookup miss.
+
+        Phase 5 (:meth:`_maybe_attach_vllm_chat_reasoning`) does NOT
+        call this resolver — it reads ``cfg.server_compat["server_type"]``
+        directly off the single ``cfg`` it already fetched for the
+        ``replay_reasoning_to_model`` flag check, to avoid a second
+        ``registry.get_config`` round-trip.  Both readers MUST stay
+        aligned on the same field path; if you change one, change the
+        other.
 
         Reads ``cfg.server_compat`` (the dedicated dataclass field set
         by the model_registry loader) — NOT ``cfg.capabilities``.  Both
@@ -1346,8 +1353,10 @@ class ChatSession:
         edit friction (capability tables live in
         ``providers/_openai_common.py``, not the admin UI) without
         preventing the silent failure that's the actual misconfiguration
-        risk.  See ``project_reasoning_replay_capability_gate.md`` for
-        the full asymmetry rationale.
+        risk.  Paths 1+2 keep the dual-gate because their failure mode
+        is loud (Anthropic 400 on unsigned thinking, OpenAI Responses
+        400 on ResponseReasoningItemParam for non-reasoning models);
+        Path C's failure is silent so the gate doesn't help.
 
         Returns *messages* unchanged when any gate fails.
         """

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -45,7 +45,10 @@ from turnstone.core.attachments import (
 )
 from turnstone.core.config import get_tavily_key
 from turnstone.core.edit import find_occurrences, pick_nearest
-from turnstone.core.history_decoration import extract_advisories_from_tool_envelope
+from turnstone.core.history_decoration import (
+    attach_vllm_chat_reasoning_field,
+    extract_advisories_from_tool_envelope,
+)
 from turnstone.core.log import get_logger
 from turnstone.core.memory import (
     count_structured_memories,
@@ -1169,20 +1172,23 @@ class ChatSession:
 
         Used by :meth:`_maybe_synth_reasoning_block` to tag synthetic
         path-3 reasoning blocks with their origin server (vllm,
-        llama.cpp, sglang, etc.) — informational today, useful for
-        future per-server replay paths.  Returns ``""`` on any lookup
-        miss; the synthetic block then omits the ``source`` field.
+        llama.cpp, sglang, etc.) — informational there but load-bearing
+        for :meth:`_maybe_attach_vllm_chat_reasoning` (Phase 5 gate).
+        Returns ``""`` on any lookup miss.
+
+        Reads ``cfg.server_compat`` (the dedicated dataclass field set
+        by the model_registry loader) — NOT ``cfg.capabilities``.  Both
+        loader paths (DB at ``model_registry.py:401`` and config.toml at
+        ``model_registry.py:485``) ``caps.pop("server_compat", {})`` and
+        hoist the dict to the top-level field, so the capabilities dict
+        never carries server_compat in production.
         """
         target_alias = alias or self._model_alias or ""
         if not self._registry or not target_alias:
             return ""
         try:
             cfg: ModelConfig = self._registry.get_config(target_alias)
-            sc = (
-                cfg.capabilities.get("server_compat")
-                if isinstance(cfg.capabilities, dict)
-                else None
-            )
+            sc = cfg.server_compat if isinstance(cfg.server_compat, dict) else None
             if isinstance(sc, dict):
                 return str(sc.get("server_type") or "")
         except Exception:
@@ -1239,11 +1245,14 @@ class ChatSession:
 
         The optional ``source`` field tags the block with the
         originating server (``vllm``, ``llamacpp``, ``sglang``, etc.)
-        when ``ModelConfig.capabilities["server_compat"]["server_type"]``
-        is populated.  Reserved for future per-server replay paths
-        (e.g. an operator-flagged path that re-injects synthetic
-        reasoning back into a vllm round-trip) — not consumed today;
-        the field is informational metadata, not dead code.
+        resolved via :meth:`_resolve_server_type`, which reads
+        ``cfg.server_compat["server_type"]`` (the dedicated dataclass
+        field hoisted by the model_registry loader, NOT
+        ``cfg.capabilities``).  The synthetic block's ``source`` field
+        itself is informational metadata; Phase 5's vLLM replay path
+        (:meth:`_maybe_attach_vllm_chat_reasoning`) reads
+        ``cfg.server_compat`` directly rather than the synthetic
+        block's tag.
         """
         text = "".join(reasoning_parts)
         if not text.strip():
@@ -1307,6 +1316,63 @@ class ChatSession:
         if caps is None:
             return operator_on
         return operator_on and bool(caps.supports_reasoning_replay)
+
+    def _maybe_attach_vllm_chat_reasoning(
+        self,
+        messages: list[dict[str, Any]],
+        provider: LLMProvider,
+        alias: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Conditionally attach vLLM's non-standard ``reasoning`` field to
+        outgoing assistant messages so a vLLM-served reasoning model can
+        thread CoT across turns.
+
+        Phase 5 of reasoning-persistence — parallel path to Paths 1+2,
+        not a modification.  Three gates:
+
+        1. Provider is ``OpenAIChatCompletionsProvider`` (Chat Completions
+           surface, not Responses or Anthropic — those have their own
+           replay paths with loud-failure-protected dual-gates).
+        2. ``server_compat.server_type == "vllm"`` — bounds blast radius
+           to vLLM; canonical OpenAI / llama.cpp / sglang never see the
+           non-standard field.
+        3. Operator-set ``ModelConfig.replay_reasoning_to_model`` — same
+           per-model toggle PR #498 added; defaults False.
+
+        The static ``supports_reasoning_replay`` capability gate that
+        guards Paths 1+2 is intentionally NOT used here.  vLLM's chat
+        template silently drops ``reasoning`` if the loaded template
+        doesn't read ``reasoning_content`` — the gate would add code-
+        edit friction (capability tables live in
+        ``providers/_openai_common.py``, not the admin UI) without
+        preventing the silent failure that's the actual misconfiguration
+        risk.  See ``project_reasoning_replay_capability_gate.md`` for
+        the full asymmetry rationale.
+
+        Returns *messages* unchanged when any gate fails.
+        """
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        if not isinstance(provider, OpenAIChatCompletionsProvider):
+            return messages
+        target_alias = alias or self._model_alias or ""
+        if not self._registry or not target_alias:
+            return messages
+        try:
+            cfg = self._registry.get_config(target_alias)
+        except Exception:
+            return messages
+        # Read both gate fields off the single ``cfg`` we already
+        # fetched, rather than re-entering ``_resolve_server_type``
+        # (which would do a second ``get_config`` call).  Mirrors the
+        # field location ``_resolve_server_type`` reads, so the two
+        # gates stay aligned if the loader ever changes shape.
+        sc = cfg.server_compat if isinstance(cfg.server_compat, dict) else None
+        if not isinstance(sc, dict) or sc.get("server_type") != "vllm":
+            return messages
+        if not bool(cfg.replay_reasoning_to_model):
+            return messages
+        return attach_vllm_chat_reasoning_field(messages)
 
     def _save_config(self) -> None:
         """Persist LLM-affecting config so resumed workstreams behave identically."""
@@ -2772,6 +2838,7 @@ class ChatSession:
         """
         caps = self._get_capabilities()
         clamped = min(max_tokens, caps.max_output_tokens) if caps.max_output_tokens else max_tokens
+        messages = self._maybe_attach_vllm_chat_reasoning(messages, self._provider)
         return self._provider.create_completion(
             client=self.client,
             model=self.model,
@@ -2968,6 +3035,7 @@ class ChatSession:
             msg_count,
             role_counts,
         )
+        msgs = self._maybe_attach_vllm_chat_reasoning(msgs, prov, model_alias)
         last_err: Exception | None = None
         for attempt in range(self._MAX_RETRIES + 1):
             self._check_cancelled()
@@ -9375,6 +9443,13 @@ class ChatSession:
             messages: list[dict[str, Any]],
             _tools: list[dict[str, Any]] | None = tools,
         ) -> CompletionResult:
+            # NOTE: Phase 5 vLLM ``reasoning`` field replay is intentionally
+            # NOT wired here.  Agent assistant messages are built from
+            # ``CompletionResult.content + tool_calls`` only (no
+            # ``_provider_content`` carried), so the helper would no-op
+            # every turn anyway.  Plan/task agents are excluded from the
+            # persistence/replay contract — their conversation history
+            # is in-memory and rebuilt per ``_run_agent`` invocation.
             last_err: Exception | None = None
             for attempt in range(self._MAX_RETRIES + 1):
                 try:

--- a/uv.lock
+++ b/uv.lock
@@ -2815,7 +2815,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "numpy", marker = "extra == 'sandbox'", specifier = ">=2.0" },
-    { name = "openai", specifier = ">=2.24" },
+    { name = "openai", specifier = ">=2.37" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.8" },


### PR DESCRIPTION
## Summary

- New helper `attach_vllm_chat_reasoning_field` + session gate `_maybe_attach_vllm_chat_reasoning` enable multi-turn CoT replay for vLLM-served reasoning models (Qwen3, DeepSeek-R1) via the non-standard `reasoning` field on assistant messages. Closes the only known gap in PR #498's reasoning-persistence work (Chat Completions surface).
- Three-gate composite (provider isinstance + server_type=="vllm" + operator flag); deliberately drops the `supports_reasoning_replay` capability gate that protects Paths 1+2 because vLLM's failure mode is silent (template-drop), not loud. Server-type pin bounds blast radius — canonical OpenAI, llama.cpp, sglang never see the field.
- Also fixes a pre-existing `_resolve_server_type` bug that was reading the wrong field (`cfg.capabilities.get("server_compat")` vs the production `cfg.server_compat`). Pre-fix the function returned `""` for every production `ModelConfig`, silently degrading PR #498 Path 3's synth-block source tag and would have made Phase 5 dead-on-arrival. Test stubs across 3 files updated to mirror production shape.

## Design notes

- **Session-level attach** — `sanitize_messages` already preserves non-`_`-prefixed keys, so the helper attaches `reasoning` to outgoing message dicts and the OpenAI SDK passes the field through to the wire (verified via the boundary round-trip test). No provider class changes, no protocol signature changes.
- **Agent path excluded** — `_run_agent` rebuilds assistant messages per invocation from `CompletionResult.content + tool_calls`; no `_provider_content` is carried, so the helper would no-op every turn. NOTE comment inside `_api_call` documents the exclusion; test class docstring updated to reflect 2 hoist sites.
- **OpenAI SDK floor raised to >=2.37** to match the version the cross-boundary regression test (`test_reasoning_field_present_in_wire_body_when_attached`) was verified against. If a future SDK version adds runtime field filtering on `ChatCompletionMessageParam`, the test fails in CI.

## Test plan

- [x] `tests/test_history_decoration.py::TestAttachVllmChatReasoningField` — 10 unit tests for the helper's projection contract (synthetic + Anthropic + Responses block extraction, no-op cases, identity preservation, no input mutation)
- [x] `tests/test_session_chat_reasoning_replay.py` — 17 integration tests covering each gate independently, SDK boundary round-trip via httpx MockTransport, call-site wiring for both surviving hoists
- [x] `tests/test_reasoning_audit_log_discipline.py` — 2 new tests extending the PR #498 audit-log discipline contract to Phase 5 surfaces
- [x] `tests/test_session_synth_reasoning_block.py::TestResolveServerType` — 5 existing stubs updated to mirror production `ModelConfig` shape so the `_resolve_server_type` regression can't drift back
- [x] Full pytest run: 6286 passed, 14 skipped, 0 failures
- [x] Ruff + mypy clean
- [x] Two `/review` pipeline passes (initial + pre-commit); critical + minor findings addressed inline