### PR TITLE
refactor: drop `var` across 7 legacy JS bundles + add lint guards

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -719,6 +719,11 @@ def test_phase8_consent_url_prefix_check_in_click_handler() -> None:
 import subprocess  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+# Bundles that completed the var → const/let sweep.  Add a new JS file
+# here only after it has itself been swept — the var-free + const-reassign
+# guards below will otherwise fail loudly on any pre-sweep `var` it
+# contains.  coordinator.js is intentionally excluded (already modern;
+# 3 surviving `var` are by design per the sweep briefing).
 _SWEPT_BUNDLES = [
     _REPO_ROOT / "turnstone/ui/static/app.js",
     _REPO_ROOT / "turnstone/console/static/admin.js",
@@ -839,9 +844,7 @@ def _is_regex_context_at(text: str, slash_pos: int) -> bool:
                 k -= 1
             ident = text[k + 1 : i + 1]
             return ident in _REGEX_OK_KEYWORDS
-        if ch in ")]":
-            return False
-        return True
+        return ch not in ")]"
     return True
 
 
@@ -932,9 +935,8 @@ def _build_brace_map(
                     continue
         if ch == "{":
             stack.append(i)
-        elif ch == "}":
-            if stack:
-                open_to_close[stack.pop()] = i
+        elif ch == "}" and stack:
+            open_to_close[stack.pop()] = i
         i += 1
     return open_to_close, line_starts
 
@@ -971,18 +973,21 @@ def _enclosing_block(
 @pytest.mark.parametrize("bundle", _SWEPT_BUNDLES, ids=lambda p: p.name)
 def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
     """For each ``const X = …`` declaration, fail if X is reassigned
-    *within the same block scope* (``X = …``, ``X +=``, ``X++`` etc., with
-    lookbehind to skip ``obj.X = …`` property writes).  Block scope is
-    found by brace-tracking with regex/string/comment awareness, so a
-    same-named ``let X`` in an unrelated function doesn't false-positive
-    against a ``const X`` in this one.  Caught the original
-    ``_redactApiKeys`` shipped bug — ``TypeError`` was invisible to
-    ``node --check`` and to whole-file keyword scans."""
+    *within the same block scope* (``X = …``, ``X +=``, ``X++``, ``++X``,
+    etc., with lookbehind to skip ``obj.X = …`` property writes).  Block
+    scope is found by brace-tracking with regex/string/comment awareness,
+    so a same-named ``let X`` in an unrelated function doesn't
+    false-positive against a ``const X`` in this one.  Caught the
+    original ``_redactApiKeys`` shipped bug (postfix ``redacted = …``)
+    and a sibling ``++_paneCounter`` prefix-increment that the first
+    iteration of this guard missed — both were ``TypeError`` at
+    call-time, invisible to ``node --check`` and to whole-file
+    keyword scans."""
     body = bundle.read_text(encoding="utf-8")
     lines = body.splitlines()
     open_to_close, line_starts = _build_brace_map(body)
     const_decl = re.compile(r"^(\s*)const\s+(\w+)\b")
-    bugs: list[tuple[int, str, int]] = []
+    bugs: list[tuple[int, str, int, str, str]] = []
     for idx, line in enumerate(lines):
         m = const_decl.match(line)
         if not m:
@@ -990,12 +995,21 @@ def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
         name = m.group(2)
         decl_offset = line_starts[idx] + len(m.group(1))
         start_line, end_line = _enclosing_block(decl_offset, open_to_close, line_starts, len(lines))
+        # Reassignment forms: postfix `X++`/`X--`, prefix `++X`/`--X`,
+        # compound `X +=`/`X -=`/.../`X ??=`, plain `X =` (not ==/===).
+        # Negative lookbehind skips property writes (`obj.X = …`).
         pat = re.compile(
+            r"(?:"
+            r"(?<![A-Za-z0-9_$])(?:\+\+|--)"  # prefix `++X` / `--X`
+            + re.escape(name)
+            + r"(?![A-Za-z0-9_$])"
+            + r"|"
             r"(?<![A-Za-z0-9_$.])"
             + re.escape(name)
-            + r"\s*(?:\+\+|--|"
-            + r"(?:\+|-|\*\*?|/|%|&&?|\|\|?|\^|<<|>>>?|\?\?)=|"
-            + r"=(?!=))"
+            + r"\s*(?:\+\+|--|"  # postfix `X++` / `X--`
+            + r"(?:\+|-|\*\*?|/|%|&&?|\|\|?|\^|<<|>>>?|\?\?)=|"  # compound
+            + r"=(?!=))"  # plain `X =`
+            + r")"
         )
         decl_other = re.compile(
             r"(?:^\s*(?:let|const|var)\s+|\bfor\s*\(\s*(?:let|const|var)\s+)"
@@ -1015,13 +1029,19 @@ def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
                 cleaned = param.sub("(", stripped)
                 if not pat.search(cleaned):
                     continue
-            bugs.append((idx + 1, name, j + 1))
+            bugs.append((idx + 1, name, j + 1, lines[idx].strip(), lines[j].strip()))
             break
-    assert not bugs, (
-        f"{bundle.name}: ``const`` declaration reassigned within its block "
-        f"scope — {bugs[:3]}{' …' if len(bugs) > 3 else ''}.  Change to "
-        f"``let`` or eliminate the reassignment."
-    )
+    if bugs:
+        detail = "\n".join(
+            f"  {bundle.name}:{decl_ln} const {name} reassigned at "
+            f"{bundle.name}:{reass_ln}\n    decl:   {decl_text}\n    reass:  {reass_text}"
+            for decl_ln, name, reass_ln, decl_text, reass_text in bugs[:3]
+        )
+        suffix = f"\n  ... and {len(bugs) - 3} more" if len(bugs) > 3 else ""
+        raise AssertionError(
+            f"const declaration(s) reassigned within block scope.  "
+            f"Change to `let` or eliminate the reassignment:\n{detail}{suffix}"
+        )
 
 
 def test_redact_api_keys_runtime_smoke() -> None:
@@ -1057,7 +1077,6 @@ def test_redact_api_keys_runtime_smoke() -> None:
         )
     except FileNotFoundError:
         pytest.skip("node binary not available on PATH")
-    assert proc.returncode == 0, "_redactApiKeys runtime smoke failed.  stdout=%r stderr=%r" % (
-        proc.stdout,
-        proc.stderr,
+    assert proc.returncode == 0, (
+        f"_redactApiKeys runtime smoke failed.  stdout={proc.stdout!r} stderr={proc.stderr!r}"
     )

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -693,3 +693,371 @@ def test_phase8_consent_url_prefix_check_in_click_handler() -> None:
         '"javascript:" injection) would be passed straight to '
         "window.open."
     )
+
+
+# ---------------------------------------------------------------------------
+# Post-var-sweep invariants — added by chore/interactive-var-sweep
+# ---------------------------------------------------------------------------
+#
+# After the whole-file var → const/let sweep across these 7 bundles, three
+# guards keep the post-sweep state honest:
+#   1. ``node --check`` per bundle catches parse-level regressions on any
+#      future edit (mis-balanced braces, stray tokens) before they reach
+#      the browser.
+#   2. A var-free static assertion pins the keyword sweep — any future
+#      ``var`` declaration in these bundles fails CI loudly.
+#   3. A static const-reassign guard catches the specific bug class that
+#      shipped through the original sweep (``const X = …; … X = …``
+#      throws ``TypeError`` only at call-time, which ``node --check``
+#      does not surface).  This is the same paren/string/regex-aware
+#      reassignment check the sweep walker uses.
+#
+# A fourth guard runs ``_redactApiKeys`` via ``node -e`` as a runtime
+# smoke; the function is pure (no DOM dependency) so it transplants
+# cleanly into a standalone node invocation.
+
+import subprocess  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SWEPT_BUNDLES = [
+    _REPO_ROOT / "turnstone/ui/static/app.js",
+    _REPO_ROOT / "turnstone/console/static/admin.js",
+    _REPO_ROOT / "turnstone/console/static/governance.js",
+    _REPO_ROOT / "turnstone/console/static/app.js",
+    _REPO_ROOT / "turnstone/shared_static/auth.js",
+    _REPO_ROOT / "turnstone/shared_static/kb.js",
+    _REPO_ROOT / "turnstone/shared_static/utils.js",
+]
+
+
+@pytest.mark.parametrize("bundle", _SWEPT_BUNDLES, ids=lambda p: p.name)
+def test_swept_bundle_parses(bundle: Path) -> None:
+    """``node --check`` each swept bundle.  Catches syntax-level
+    regressions (a future edit that drops a brace, mis-balances a
+    string, etc.) before they reach the browser.  Skipped silently if
+    ``node`` is not on PATH so local dev without Node still passes."""
+    node = "node"
+    try:
+        proc = subprocess.run(
+            [node, "--check", str(bundle)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    assert proc.returncode == 0, f"node --check failed for {bundle.name}:\n{proc.stderr}"
+
+
+@pytest.mark.parametrize("bundle", _SWEPT_BUNDLES, ids=lambda p: p.name)
+def test_swept_bundle_has_no_var_decl(bundle: Path) -> None:
+    """Pin the var-free post-sweep state across all 7 bundles.  A
+    future ``var`` declaration here fails CI loudly so the sweep
+    doesn't regress in patches."""
+    body = bundle.read_text(encoding="utf-8")
+    # Line-start ``var`` declarations.
+    line_start = re.findall(r"^\s*var\s+\w", body, re.MULTILINE)
+    # ``for (var i …)`` counters anywhere on a line.
+    for_init = re.findall(r"\bfor\s*\(\s*var\s+", body)
+    stray = line_start + for_init
+    assert not stray, (
+        f"{bundle.name}: {len(stray)} stray ``var`` declarations found "
+        f"after the var-sweep — the post-sweep invariant is broken.  "
+        f"Convert to ``const``/``let``."
+    )
+
+
+def _strip_strings_and_line_comments(line: str) -> str:
+    """Return ``line`` with string-literal contents and ``// …`` tails
+    removed, so simple regex-based scanning can't be tricked by an
+    identifier embedded in a CSS class name or HTML attribute.
+    Mirrors the sweep walker's helper of the same purpose."""
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    in_str: str | None = None
+    while i < n:
+        ch = line[i]
+        if in_str:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = ch
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and line[i + 1] == "/":
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+_REGEX_OK_KEYWORDS = frozenset(
+    {
+        "return",
+        "throw",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "do",
+        "yield",
+        "await",
+        "case",
+        "else",
+    }
+)
+
+
+def _is_regex_context_at(text: str, slash_pos: int) -> bool:
+    """``text[slash_pos]`` is ``/``.  Return ``True`` if it starts a regex
+    literal vs the division operator, by inspecting the previous significant
+    char (skipping whitespace and ``/* */`` block comments going backward)."""
+    i = slash_pos - 1
+    while i >= 0:
+        ch = text[i]
+        if ch.isspace():
+            i -= 1
+            continue
+        if ch == "/" and i >= 1 and text[i - 1] == "*":
+            open_i = text.rfind("/*", 0, i - 1)
+            if open_i == -1:
+                return True
+            i = open_i - 1
+            continue
+        if ch.isalnum() or ch in "_$":
+            k = i
+            while k >= 0 and (text[k].isalnum() or text[k] in "_$"):
+                k -= 1
+            ident = text[k + 1 : i + 1]
+            return ident in _REGEX_OK_KEYWORDS
+        if ch in ")]":
+            return False
+        return True
+    return True
+
+
+def _consume_regex_at(text: str, start: int) -> tuple[int, bool]:
+    """Consume regex literal starting at ``text[start] == '/'``.  Returns
+    ``(end_pos, ok)``.  Handles backslash escapes and ``[...]`` char classes
+    (a ``/`` inside a class doesn't end the regex)."""
+    n = len(text)
+    i = start + 1
+    in_class = False
+    while i < n:
+        ch = text[i]
+        if ch == "\n":
+            return start, False
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if ch == "[":
+            in_class = True
+        elif ch == "]":
+            in_class = False
+        elif ch == "/" and not in_class:
+            i += 1
+            while i < n and text[i] in "gimsuyd":
+                i += 1
+            return i, True
+        i += 1
+    return start, False
+
+
+def _build_brace_map(
+    text: str,
+) -> tuple[dict[int, int], list[int]]:
+    """Walk ``text`` once.  Returns ``(open_to_close, line_starts)`` where
+    ``open_to_close[open_off] = close_off`` for matched braces, and
+    ``line_starts[i]`` is the char offset where line index ``i`` (0-based)
+    begins.  Robust to JS regex literals, strings, ``//`` and ``/* */``
+    comments."""
+    n = len(text)
+    line_starts = [0]
+    for i, ch in enumerate(text):
+        if ch == "\n":
+            line_starts.append(i + 1)
+    stack: list[int] = []
+    open_to_close: dict[int, int] = {}
+    in_str: str | None = None
+    in_comment: str | None = None
+    i = 0
+    while i < n:
+        ch = text[i]
+        if in_comment == "//":
+            if ch == "\n":
+                in_comment = None
+            i += 1
+            continue
+        if in_comment == "/*":
+            if ch == "*" and i + 1 < n and text[i + 1] == "/":
+                in_comment = None
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_str:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = ch
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n:
+            if text[i + 1] == "/":
+                in_comment = "//"
+                i += 2
+                continue
+            if text[i + 1] == "*":
+                in_comment = "/*"
+                i += 2
+                continue
+            if _is_regex_context_at(text, i):
+                end, ok = _consume_regex_at(text, i)
+                if ok:
+                    i = end
+                    continue
+        if ch == "{":
+            stack.append(i)
+        elif ch == "}":
+            if stack:
+                open_to_close[stack.pop()] = i
+        i += 1
+    return open_to_close, line_starts
+
+
+def _offset_to_line(line_starts: list[int], off: int) -> int:
+    lo, hi = 0, len(line_starts)
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if line_starts[mid] <= off:
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
+def _enclosing_block(
+    decl_offset: int,
+    open_to_close: dict[int, int],
+    line_starts: list[int],
+    total_lines: int,
+) -> tuple[int, int]:
+    """Innermost block containing ``decl_offset``.  ``(start_line, end_line)``
+    inclusive.  Returns ``(0, total_lines - 1)`` when at top-level."""
+    candidates = [(op, cl) for op, cl in open_to_close.items() if op < decl_offset < cl]
+    if not candidates:
+        return 0, total_lines - 1
+    op, cl = max(candidates, key=lambda x: x[0])
+    return (
+        _offset_to_line(line_starts, op),
+        _offset_to_line(line_starts, cl),
+    )
+
+
+@pytest.mark.parametrize("bundle", _SWEPT_BUNDLES, ids=lambda p: p.name)
+def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
+    """For each ``const X = …`` declaration, fail if X is reassigned
+    *within the same block scope* (``X = …``, ``X +=``, ``X++`` etc., with
+    lookbehind to skip ``obj.X = …`` property writes).  Block scope is
+    found by brace-tracking with regex/string/comment awareness, so a
+    same-named ``let X`` in an unrelated function doesn't false-positive
+    against a ``const X`` in this one.  Caught the original
+    ``_redactApiKeys`` shipped bug — ``TypeError`` was invisible to
+    ``node --check`` and to whole-file keyword scans."""
+    body = bundle.read_text(encoding="utf-8")
+    lines = body.splitlines()
+    open_to_close, line_starts = _build_brace_map(body)
+    const_decl = re.compile(r"^(\s*)const\s+(\w+)\b")
+    bugs: list[tuple[int, str, int]] = []
+    for idx, line in enumerate(lines):
+        m = const_decl.match(line)
+        if not m:
+            continue
+        name = m.group(2)
+        decl_offset = line_starts[idx] + len(m.group(1))
+        start_line, end_line = _enclosing_block(decl_offset, open_to_close, line_starts, len(lines))
+        pat = re.compile(
+            r"(?<![A-Za-z0-9_$.])"
+            + re.escape(name)
+            + r"\s*(?:\+\+|--|"
+            + r"(?:\+|-|\*\*?|/|%|&&?|\|\|?|\^|<<|>>>?|\?\?)=|"
+            + r"=(?!=))"
+        )
+        decl_other = re.compile(
+            r"(?:^\s*(?:let|const|var)\s+|\bfor\s*\(\s*(?:let|const|var)\s+)"
+            + re.escape(name)
+            + r"\b"
+        )
+        param = re.compile(r"\((?:[^()]*?,\s*)?" + re.escape(name) + r"\s*[,)]")
+        for j in range(start_line, end_line + 1):
+            if j == idx:
+                continue
+            stripped = _strip_strings_and_line_comments(lines[j])
+            if not pat.search(stripped):
+                continue
+            if decl_other.search(stripped):
+                continue
+            if param.search(stripped):
+                cleaned = param.sub("(", stripped)
+                if not pat.search(cleaned):
+                    continue
+            bugs.append((idx + 1, name, j + 1))
+            break
+    assert not bugs, (
+        f"{bundle.name}: ``const`` declaration reassigned within its block "
+        f"scope — {bugs[:3]}{' …' if len(bugs) > 3 else ''}.  Change to "
+        f"``let`` or eliminate the reassignment."
+    )
+
+
+def test_redact_api_keys_runtime_smoke() -> None:
+    """Runtime smoke for ``_redactApiKeys``.  The function is pure — no
+    DOM dependency — so it transplants cleanly into a standalone
+    ``node -e`` invocation.  This is the bit that would have caught
+    the original ``const redacted`` bug (which ``node --check`` and a
+    pure-static keyword scan both miss; the ``TypeError`` only fires
+    at call-time)."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    m = re.search(
+        r"function _redactApiKeys\(text\) \{.*?\n\}\n",
+        body,
+        re.DOTALL,
+    )
+    assert m is not None, "_redactApiKeys not found in app.js"
+    fn = m.group(0)
+    script = (
+        fn
+        + "\nconst q = _redactApiKeys('https://x?api_key=abc&u=foo');\n"
+        + 'if (q !== "https://x?api_key=***&u=foo") '
+        + "throw new Error('query-string redact failed: ' + q);\n"
+        + 'const j = _redactApiKeys(\'{"api_key":"abc"}\');\n'
+        + 'if (j !== \'{"api_key":"***"}\') '
+        + "throw new Error('json-style redact failed: ' + j);\n"
+    )
+    try:
+        proc = subprocess.run(
+            ["node", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    assert proc.returncode == 0, "_redactApiKeys runtime smoke failed.  stdout=%r stderr=%r" % (
+        proc.stdout,
+        proc.stderr,
+    )

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -116,7 +116,7 @@ function showAdmin() {
     const closeHeader = document.createElement("div");
     closeHeader.id = "admin-sidebar-close";
     closeHeader.className = "admin-sidebar-close";
-    let label = document.createElement("span");
+    const label = document.createElement("span");
     label.textContent = "Navigation";
     const closeBtn = document.createElement("button");
     closeBtn.setAttribute("aria-label", "Close navigation");
@@ -290,7 +290,7 @@ function switchAdminTab(tab) {
 
   // Update breadcrumb with active tab label
   const activeNav = document.querySelector('.admin-nav[data-tab="' + tab + '"]');
-  let label = activeNav ? activeNav.textContent : tab;
+  const label = activeNav ? activeNav.textContent : tab;
   const bcLabel = document.getElementById("breadcrumb-label");
   if (bcLabel) bcLabel.textContent = "Admin / " + label;
 
@@ -398,8 +398,8 @@ function _renderUsers(users) {
   for (let k = 0; k < rows.length; k++) {
     (function (row) {
       const _expand = function () {
-        let uid = row.getAttribute("data-user-id");
-        let uname = row.getAttribute("data-username");
+        const uid = row.getAttribute("data-user-id");
+        const uname = row.getAttribute("data-username");
         _toggleOidcPanel(uid, uname, row);
       };
       row.addEventListener("click", function (e) {
@@ -710,7 +710,7 @@ function _relativeTime(isoStr) {
 
 function _populateTokenUserSelect() {
   const sel = document.getElementById("admin-token-user");
-  let current = sel.value;
+  const current = sel.value;
   setSafeHtml(sel, '<option value="">Select user...</option>');
   for (let i = 0; i < _adminUsers.length; i++) {
     const u = _adminUsers[i];
@@ -837,7 +837,7 @@ function confirmRevokeToken(tokenId) {
 
 function _populateChannelUserSelect() {
   const sel = document.getElementById("admin-channel-user");
-  let current = sel.value;
+  const current = sel.value;
   setSafeHtml(sel, '<option value="">Select user...</option>');
   for (let i = 0; i < _adminUsers.length; i++) {
     const u = _adminUsers[i];
@@ -1708,7 +1708,7 @@ function showScheduleRuns(taskId) {
           '<span class="admin-col">ERROR</span></div>';
         for (let i = 0; i < runs.length; i++) {
           const r = runs[i];
-          let statusCls =
+          const statusCls =
             r.status === "dispatched"
               ? "sched-active"
               : r.status === "failed"
@@ -1762,7 +1762,7 @@ function hideScheduleRunsModal() {
 
 function _populateWatchNodeSelect() {
   const sel = document.getElementById("admin-watch-node");
-  let current = sel.value;
+  const current = sel.value;
   const seen = {};
   setSafeHtml(sel, '<option value="">All nodes</option>');
   for (let i = 0; i < _adminWatches.length; i++) {
@@ -1833,9 +1833,9 @@ function _renderWatches(watches) {
     const cond = w.stop_on || "on change";
     const condTrunc = cond.length > 30 ? cond.slice(0, 30) + "\u2026" : cond;
     const active = w.active;
-    let statusCls = active ? "watch-active" : "watch-completed";
-    let statusLabel = active ? "active" : "done";
-    let statusDot = active ? "\u25cf " : "\u25cb ";
+    const statusCls = active ? "watch-active" : "watch-completed";
+    const statusLabel = active ? "active" : "done";
+    const statusDot = active ? "\u25cf " : "\u25cb ";
     const cancelBtn = active
       ? '<button class="admin-btn-danger" data-cancel-watch="' +
         escapeHtml(w.watch_id) +
@@ -2542,7 +2542,7 @@ function loadTlsCerts() {
       while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
 
       if (!data.enabled) {
-        let msg = document.createElement("div");
+        const msg = document.createElement("div");
         msg.className = "dashboard-empty";
         msg.textContent =
           "TLS is not enabled. Set tls.enabled = true in Settings.";
@@ -2563,7 +2563,7 @@ function loadTlsCerts() {
 
       const certs = certData.certs || [];
       if (certs.length === 0) {
-        let empty = document.createElement("div");
+        const empty = document.createElement("div");
         empty.className = "dashboard-empty";
         empty.textContent = "No certificates issued yet.";
         listEl.appendChild(empty);
@@ -3641,7 +3641,7 @@ function _renderMcpServers(items) {
       const name = this.getAttribute("data-mcp-oauth-connect");
       // Open the OAuth /start endpoint in a new window so the redirect
       // chain (AS → callback → return_url) doesn't displace the admin UI.
-      let url =
+      const url =
         "/v1/api/mcp/oauth/start?server=" +
         encodeURIComponent(name) +
         "&return_url=" +
@@ -3966,7 +3966,7 @@ function submitCreateMcp() {
   }
   const editId = document.getElementById("mcp-edit-id").value;
   const method = editId ? "PUT" : "POST";
-  let url = editId
+  const url = editId
     ? "/v1/api/admin/mcp-servers/" + editId
     : "/v1/api/admin/mcp-servers";
 
@@ -4461,7 +4461,7 @@ function _renderRegistryResults() {
   // Bind install buttons
   el.querySelectorAll("[data-reg-install]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      let idx = parseInt(this.getAttribute("data-reg-install"), 10);
+      const idx = parseInt(this.getAttribute("data-reg-install"), 10);
       _initiateRegistryInstall(_registryResults[idx]);
     });
   });
@@ -4498,7 +4498,7 @@ function _initiateRegistryInstall(srv) {
     // Disable the clicked Install button for loading feedback
     const cardBtns = document.querySelectorAll("[data-reg-install]");
     for (let bi = 0; bi < cardBtns.length; bi++) {
-      let idx = parseInt(cardBtns[bi].getAttribute("data-reg-install"), 10);
+      const idx = parseInt(cardBtns[bi].getAttribute("data-reg-install"), 10);
       if (_registryResults[idx] && _registryResults[idx].name === srv.name) {
         cardBtns[bi].disabled = true;
         cardBtns[bi].textContent = "Installing\u2026";
@@ -4725,8 +4725,8 @@ function submitInstallMcp() {
   const srv = _mcpInstallServer;
   if (!srv) return;
   const fieldsEl = document.getElementById("mcp-install-fields");
-  let source = fieldsEl.getAttribute("data-source") || "remote";
-  let pkgIndex = parseInt(fieldsEl.getAttribute("data-pkg-index") || "0", 10);
+  const source = fieldsEl.getAttribute("data-source") || "remote";
+  const pkgIndex = parseInt(fieldsEl.getAttribute("data-pkg-index") || "0", 10);
   const index = source === "remote" ? 0 : pkgIndex;
 
   const variables = {};
@@ -4998,7 +4998,7 @@ function switchModelsSection(section) {
     const secs = [];
     for (let i = 0; i < btns.length; i++)
       secs.push(btns[i].getAttribute("data-section"));
-    let current = switcher.querySelector(".admin-subtab-btn.active");
+    const current = switcher.querySelector(".admin-subtab-btn.active");
     let idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
     if (e.key === "ArrowRight") idx = (idx + 1) % secs.length;
     else idx = (idx - 1 + secs.length) % secs.length;
@@ -5224,7 +5224,7 @@ function _renderModels(items) {
   // Clear previous content
   el.textContent = "";
   if (!items.length) {
-    let empty = document.createElement("div");
+    const empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No model definitions configured";
     el.appendChild(empty);
@@ -5235,11 +5235,11 @@ function _renderModels(items) {
     const isConfig = m.source === "config";
 
     // Status
-    let dotClass = m.enabled
+    const dotClass = m.enabled
       ? "model-status-dot enabled"
       : "model-status-dot disabled";
-    let rowClass = m.enabled ? "model-row-enabled" : "model-row-disabled";
-    let statusText = m.enabled ? "enabled" : "disabled";
+    const rowClass = m.enabled ? "model-row-enabled" : "model-row-disabled";
+    const statusText = m.enabled ? "enabled" : "disabled";
 
     // Context window formatting (0 = auto-detect)
     const ctxText = m.context_window
@@ -5728,7 +5728,7 @@ function submitCreateModel() {
 
   const editId = document.getElementById("model-edit-id").value;
   const method = editId ? "PUT" : "POST";
-  let url = editId
+  const url = editId
     ? "/v1/api/admin/model-definitions/" + encodeURIComponent(editId)
     : "/v1/api/admin/model-definitions";
 
@@ -5974,7 +5974,7 @@ function _onModelFieldChange() {
         }
         const capsInput = document.getElementById("model-capabilities");
         if (!capsInput.value.trim()) {
-          let caps = Object.assign({}, d.capabilities);
+          const caps = Object.assign({}, d.capabilities);
           delete caps.context_window;
           delete caps.max_output_tokens;
           delete caps.token_param;

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -1,23 +1,23 @@
 /* Admin panel — user & token management for turnstone console */
 
-var _adminTab = "users";
-var _adminUsers = [];
-var _adminTokenUserId = "";
-var _adminChannelUserId = "";
-var _lastCreatedToken = "";
-var _cuTrapHandler = null;
-var _ctTrapHandler = null;
-var _tcTrapHandler = null;
-var _ccTrapHandler = null;
-var _cfTrapHandler = null;
-var _adminWatches = [];
-var _confirmCallbackFn = null;
-var _confirmTriggerEl = null;
-var _mobileSidebarOpen = false;
+let _adminTab = "users";
+let _adminUsers = [];
+let _adminTokenUserId = "";
+let _adminChannelUserId = "";
+let _lastCreatedToken = "";
+let _cuTrapHandler = null;
+let _ctTrapHandler = null;
+let _tcTrapHandler = null;
+let _ccTrapHandler = null;
+let _cfTrapHandler = null;
+let _adminWatches = [];
+let _confirmCallbackFn = null;
+let _confirmTriggerEl = null;
+let _mobileSidebarOpen = false;
 
 // Settings whose choices are populated dynamically from the live model
 // alias list, and whose empty-string option renders as "(server default)".
-var ALIAS_SETTING_KEYS = [
+const ALIAS_SETTING_KEYS = [
   "model.default_alias",
   "model.plan_alias",
   "model.task_alias",
@@ -28,7 +28,7 @@ var ALIAS_SETTING_KEYS = [
 // opposed to "no value" — distinct from the literal "none" choice (e.g.
 // reasoning_effort="none" actually disables reasoning, very different
 // from leaving it unset).
-var INHERIT_EMPTY_LABEL_KEYS = ["model.plan_effort", "model.task_effort"];
+const INHERIT_EMPTY_LABEL_KEYS = ["model.plan_effort", "model.task_effort"];
 
 // ---------------------------------------------------------------------------
 // View switching (called from app.js showHome/drillDown pattern)
@@ -38,7 +38,7 @@ function showAdmin() {
   /* global currentView, showHome */
   // Toggle: if already in admin view, go back to the home landing
   if (currentView === "admin") {
-    var adminBtn = document.getElementById("admin-btn");
+    const adminBtn = document.getElementById("admin-btn");
     if (adminBtn) {
       adminBtn.classList.remove("active");
       adminBtn.setAttribute("aria-expanded", "false");
@@ -48,7 +48,7 @@ function showAdmin() {
   }
 
   currentView = "admin";
-  var homeView = document.getElementById("view-home");
+  const homeView = document.getElementById("view-home");
   if (homeView) homeView.style.display = "none";
   document.getElementById("view-filtered").style.display = "none";
   document.getElementById("view-admin").style.display = "";
@@ -57,7 +57,7 @@ function showAdmin() {
   document.getElementById("main").scrollTop = 0;
 
   // Highlight admin button as active
-  var adminBtn = document.getElementById("admin-btn");
+  const adminBtn = document.getElementById("admin-btn");
   if (adminBtn) {
     adminBtn.classList.add("active");
     adminBtn.setAttribute("aria-expanded", "true");
@@ -65,8 +65,8 @@ function showAdmin() {
   history.pushState({ view: "admin" }, "");
 
   // Permission gating: hide nav items the user cannot access
-  var perms = sessionStorage.getItem("turnstone_permissions") || "";
-  var tabPerms = {
+  const perms = sessionStorage.getItem("turnstone_permissions") || "";
+  const tabPerms = {
     users: "admin.users",
     tokens: "admin.users",
     channels: "admin.users",
@@ -86,11 +86,11 @@ function showAdmin() {
     models: "admin.models",
   };
   if (perms) {
-    var permSet = perms.split(",");
-    var navItems = document.querySelectorAll(".admin-nav");
-    for (var i = 0; i < navItems.length; i++) {
-      var tabName = navItems[i].getAttribute("data-tab");
-      var needed = tabPerms[tabName];
+    const permSet = perms.split(",");
+    const navItems = document.querySelectorAll(".admin-nav");
+    for (let i = 0; i < navItems.length; i++) {
+      const tabName = navItems[i].getAttribute("data-tab");
+      const needed = tabPerms[tabName];
       if (needed && permSet.indexOf(needed) < 0) {
         navItems[i].style.display = "none";
       } else {
@@ -100,31 +100,31 @@ function showAdmin() {
   }
 
   // Hide groups where all children are permission-hidden
-  var groups = document.querySelectorAll(".admin-sidebar-group");
-  for (var g = 0; g < groups.length; g++) {
-    var visibleInGroup = groups[g].querySelectorAll(
+  const groups = document.querySelectorAll(".admin-sidebar-group");
+  for (let g = 0; g < groups.length; g++) {
+    const visibleInGroup = groups[g].querySelectorAll(
       '.admin-nav:not([style*="display: none"])',
     );
     groups[g].style.display = visibleInGroup.length > 0 ? "" : "none";
   }
 
   // Mobile: ensure sidebar starts hidden + inert; desktop: ensure it's accessible
-  var sidebar = document.getElementById("admin-sidebar");
+  const sidebar = document.getElementById("admin-sidebar");
 
   // Inject close header for mobile drawer (once)
   if (!document.getElementById("admin-sidebar-close")) {
-    var closeHeader = document.createElement("div");
+    const closeHeader = document.createElement("div");
     closeHeader.id = "admin-sidebar-close";
     closeHeader.className = "admin-sidebar-close";
-    var label = document.createElement("span");
+    let label = document.createElement("span");
     label.textContent = "Navigation";
-    var closeBtn = document.createElement("button");
+    const closeBtn = document.createElement("button");
     closeBtn.setAttribute("aria-label", "Close navigation");
     closeBtn.textContent = "\u00d7";
     closeBtn.addEventListener("click", function () {
       if (_mobileSidebarOpen) {
         _toggleMobileSidebar();
-        var mt = document.getElementById("admin-mobile-toggle");
+        const mt = document.getElementById("admin-mobile-toggle");
         if (mt) mt.focus();
       }
     });
@@ -145,12 +145,12 @@ function showAdmin() {
   }
 
   // Mobile backdrop listener (idempotent)
-  var backdrop = document.getElementById("admin-sidebar-backdrop");
+  const backdrop = document.getElementById("admin-sidebar-backdrop");
   if (backdrop && !backdrop._listenerAttached) {
     backdrop.addEventListener("click", function () {
       if (_mobileSidebarOpen) {
         _toggleMobileSidebar();
-        var mt = document.getElementById("admin-mobile-toggle");
+        const mt = document.getElementById("admin-mobile-toggle");
         if (mt) mt.focus();
       }
     });
@@ -158,16 +158,16 @@ function showAdmin() {
   }
 
   // Switch to the first visible nav item
-  var visibleNavs = document.querySelectorAll(
+  const visibleNavs = document.querySelectorAll(
     '.admin-nav:not([style*="display: none"])',
   );
   if (visibleNavs.length > 0) {
     switchAdminTab(visibleNavs[0].getAttribute("data-tab"));
   } else {
     // No tabs visible — show empty state
-    var panels = document.querySelectorAll(".admin-panel");
-    for (var j = 0; j < panels.length; j++) panels[j].style.display = "none";
-    var empty = document.getElementById("admin-no-permissions");
+    const panels = document.querySelectorAll(".admin-panel");
+    for (let j = 0; j < panels.length; j++) panels[j].style.display = "none";
+    let empty = document.getElementById("admin-no-permissions");
     if (!empty) {
       empty = document.createElement("div");
       empty.id = "admin-no-permissions";
@@ -180,7 +180,7 @@ function showAdmin() {
 }
 
 function _injectMobileToggle(tab) {
-  var toggle = document.getElementById("admin-mobile-toggle");
+  let toggle = document.getElementById("admin-mobile-toggle");
   if (!toggle) {
     toggle = document.createElement("button");
     toggle.id = "admin-mobile-toggle";
@@ -191,9 +191,9 @@ function _injectMobileToggle(tab) {
       _toggleMobileSidebar();
     };
   }
-  var panel = document.getElementById("admin-" + tab);
+  const panel = document.getElementById("admin-" + tab);
   if (!panel) return;
-  var toolbar = panel.querySelector(".admin-toolbar");
+  const toolbar = panel.querySelector(".admin-toolbar");
   if (toolbar) {
     if (!toolbar.contains(toggle))
       toolbar.insertBefore(toggle, toolbar.firstChild);
@@ -205,16 +205,16 @@ function _injectMobileToggle(tab) {
 
 function _toggleMobileSidebar() {
   _mobileSidebarOpen = !_mobileSidebarOpen;
-  var sidebar = document.getElementById("admin-sidebar");
+  const sidebar = document.getElementById("admin-sidebar");
   sidebar.classList.toggle("open", _mobileSidebarOpen);
   sidebar.classList.toggle("collapsed", !_mobileSidebarOpen);
   sidebar.setAttribute("aria-hidden", _mobileSidebarOpen ? "false" : "true");
   if (_mobileSidebarOpen) sidebar.removeAttribute("inert");
   else sidebar.setAttribute("inert", "");
-  var backdrop = document.getElementById("admin-sidebar-backdrop");
+  const backdrop = document.getElementById("admin-sidebar-backdrop");
   if (backdrop) backdrop.classList.toggle("visible", _mobileSidebarOpen);
   // Update hamburger aria-label to reflect current state
-  var mt = document.getElementById("admin-mobile-toggle");
+  const mt = document.getElementById("admin-mobile-toggle");
   if (mt) {
     mt.setAttribute(
       "aria-label",
@@ -224,7 +224,7 @@ function _toggleMobileSidebar() {
   }
   // Move focus into drawer on open; callers handle focus-return on close
   if (_mobileSidebarOpen) {
-    var closeBtn = sidebar.querySelector(".admin-sidebar-close button");
+    const closeBtn = sidebar.querySelector(".admin-sidebar-close button");
     if (closeBtn) closeBtn.focus();
   }
 }
@@ -232,16 +232,16 @@ function _toggleMobileSidebar() {
 function switchAdminTab(tab) {
   _adminTab = tab;
   // Hide no-permissions empty state if it was showing
-  var noPerms = document.getElementById("admin-no-permissions");
+  const noPerms = document.getElementById("admin-no-permissions");
   if (noPerms) noPerms.style.display = "none";
-  var navItems = document.querySelectorAll(".admin-nav");
-  for (var i = 0; i < navItems.length; i++) {
-    var isActive = navItems[i].getAttribute("data-tab") === tab;
+  const navItems = document.querySelectorAll(".admin-nav");
+  for (let i = 0; i < navItems.length; i++) {
+    const isActive = navItems[i].getAttribute("data-tab") === tab;
     navItems[i].classList.toggle("active", isActive);
     navItems[i].setAttribute("aria-selected", isActive ? "true" : "false");
     navItems[i].setAttribute("tabindex", isActive ? "0" : "-1");
   }
-  var panels = [
+  const panels = [
     "users",
     "tokens",
     "channels",
@@ -261,8 +261,8 @@ function switchAdminTab(tab) {
     "prompt-policies",
     "judge",
   ];
-  for (var p = 0; p < panels.length; p++) {
-    var el = document.getElementById("admin-" + panels[p]);
+  for (let p = 0; p < panels.length; p++) {
+    const el = document.getElementById("admin-" + panels[p]);
     if (el) el.style.display = panels[p] === tab ? "" : "none";
   }
 
@@ -289,9 +289,9 @@ function switchAdminTab(tab) {
   if (tab === "judge") loadJudgeTab();
 
   // Update breadcrumb with active tab label
-  var activeNav = document.querySelector('.admin-nav[data-tab="' + tab + '"]');
-  var label = activeNav ? activeNav.textContent : tab;
-  var bcLabel = document.getElementById("breadcrumb-label");
+  const activeNav = document.querySelector('.admin-nav[data-tab="' + tab + '"]');
+  let label = activeNav ? activeNav.textContent : tab;
+  const bcLabel = document.getElementById("breadcrumb-label");
   if (bcLabel) bcLabel.textContent = "Admin / " + label;
 
   // Inject mobile hamburger toggle into active panel's toolbar
@@ -301,8 +301,8 @@ function switchAdminTab(tab) {
   if (window.innerWidth <= 700 && _mobileSidebarOpen) {
     _toggleMobileSidebar();
     // Move focus to the newly active panel instead of leaving it in the inert sidebar
-    var panel = document.getElementById("admin-" + tab);
-    var focusTarget =
+    const panel = document.getElementById("admin-" + tab);
+    const focusTarget =
       panel &&
       panel.querySelector("h2, .section-header, button:not([disabled])");
     if (focusTarget) {
@@ -336,7 +336,7 @@ function loadAdminUsers() {
 }
 
 function _renderUsers(users) {
-  var container = document.getElementById("admin-users-table");
+  const container = document.getElementById("admin-users-table");
   if (!users.length) {
     setSafeHtml(
       container,
@@ -344,9 +344,9 @@ function _renderUsers(users) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < users.length; i++) {
-    var u = users[i];
+  let html = "";
+  for (let i = 0; i < users.length; i++) {
+    const u = users[i];
     html +=
       '<div class="admin-row" role="listitem" data-expandable data-user-id="' +
       escapeHtml(u.user_id) +
@@ -377,15 +377,15 @@ function _renderUsers(users) {
   }
   setSafeHtml(container, html);
   // Bind roles buttons
-  var roleBtns = container.querySelectorAll("[data-user-roles]");
-  for (var rj = 0; rj < roleBtns.length; rj++) {
+  const roleBtns = container.querySelectorAll("[data-user-roles]");
+  for (let rj = 0; rj < roleBtns.length; rj++) {
     roleBtns[rj].addEventListener("click", function () {
       showUserRolesModal(this.getAttribute("data-user-roles"));
     });
   }
   // Bind delete buttons via delegation (avoids inline JS injection)
-  var btns = container.querySelectorAll("[data-delete-user]");
-  for (var j = 0; j < btns.length; j++) {
+  const btns = container.querySelectorAll("[data-delete-user]");
+  for (let j = 0; j < btns.length; j++) {
     btns[j].addEventListener("click", function () {
       confirmDeleteUser(
         this.getAttribute("data-delete-user"),
@@ -394,12 +394,12 @@ function _renderUsers(users) {
     });
   }
   // Bind expandable row click + keyboard handlers for OIDC detail panel
-  var rows = container.querySelectorAll(".admin-row[data-expandable]");
-  for (var k = 0; k < rows.length; k++) {
+  const rows = container.querySelectorAll(".admin-row[data-expandable]");
+  for (let k = 0; k < rows.length; k++) {
     (function (row) {
-      var _expand = function () {
-        var uid = row.getAttribute("data-user-id");
-        var uname = row.getAttribute("data-username");
+      const _expand = function () {
+        let uid = row.getAttribute("data-user-id");
+        let uname = row.getAttribute("data-username");
         _toggleOidcPanel(uid, uname, row);
       };
       row.addEventListener("click", function (e) {
@@ -448,11 +448,11 @@ function confirmDeleteUser(userId, username) {
 // ---------------------------------------------------------------------------
 
 function _toggleOidcPanel(userId, username, rowEl) {
-  var existing = rowEl.nextElementSibling;
+  const existing = rowEl.nextElementSibling;
   if (existing && existing.classList.contains("oidc-detail-panel")) {
     // Collapse
     existing.style.maxHeight = "0";
-    var indicator = rowEl.querySelector(".admin-expand-indicator");
+    const indicator = rowEl.querySelector(".admin-expand-indicator");
     if (indicator) indicator.classList.remove("expanded");
     rowEl.setAttribute("aria-expanded", "false");
     setTimeout(function () {
@@ -461,14 +461,14 @@ function _toggleOidcPanel(userId, username, rowEl) {
     return;
   }
   // Collapse any other open panel first
-  var openPanels = document.querySelectorAll(
+  const openPanels = document.querySelectorAll(
     "#admin-users-table .oidc-detail-panel",
   );
-  for (var i = 0; i < openPanels.length; i++) {
+  for (let i = 0; i < openPanels.length; i++) {
     openPanels[i].style.maxHeight = "0";
-    var prevRow = openPanels[i].previousElementSibling;
+    const prevRow = openPanels[i].previousElementSibling;
     if (prevRow) {
-      var ind = prevRow.querySelector(".admin-expand-indicator");
+      const ind = prevRow.querySelector(".admin-expand-indicator");
       if (ind) ind.classList.remove("expanded");
       prevRow.setAttribute("aria-expanded", "false");
     }
@@ -479,11 +479,11 @@ function _toggleOidcPanel(userId, username, rowEl) {
     })(openPanels[i]);
   }
   // Mark expanded
-  var indicator = rowEl.querySelector(".admin-expand-indicator");
+  const indicator = rowEl.querySelector(".admin-expand-indicator");
   if (indicator) indicator.classList.add("expanded");
   rowEl.setAttribute("aria-expanded", "true");
   // Create panel (role="none" so it doesn't break the parent role="list")
-  var panel = document.createElement("div");
+  const panel = document.createElement("div");
   panel.className = "oidc-detail-panel";
   panel.setAttribute("role", "none");
   setSafeHtml(
@@ -510,7 +510,7 @@ function _toggleOidcPanel(userId, username, rowEl) {
       _renderOidcDetail(panel, data.oidc_identities || [], userId, username);
     })
     .catch(function () {
-      var body = panel.querySelector(".oidc-detail-body");
+      const body = panel.querySelector(".oidc-detail-body");
       if (body)
         setSafeHtml(
           body,
@@ -520,12 +520,12 @@ function _toggleOidcPanel(userId, username, rowEl) {
 }
 
 function _buildOidcRow(oid, userId, username) {
-  var shortIssuer = _issuerShortName(oid.issuer || "");
-  var shortSubject =
+  const shortIssuer = _issuerShortName(oid.issuer || "");
+  const shortSubject =
     (oid.subject || "").length > 12
       ? (oid.subject || "").slice(0, 12) + "\u2026"
       : oid.subject || "";
-  var lastLogin = oid.last_login ? _relativeTime(oid.last_login) : "never";
+  const lastLogin = oid.last_login ? _relativeTime(oid.last_login) : "never";
   return (
     '<div class="oidc-identity-row">' +
     '<span class="oidc-identity-issuer"><span class="scope-badge">' +
@@ -563,7 +563,7 @@ function _buildOidcRow(oid, userId, username) {
 }
 
 function _renderOidcDetail(panel, identities, userId, username) {
-  var body = panel.querySelector(".oidc-detail-body");
+  const body = panel.querySelector(".oidc-detail-body");
   if (!body) return;
   if (!identities.length) {
     setSafeHtml(
@@ -573,30 +573,30 @@ function _renderOidcDetail(panel, identities, userId, username) {
     panel.style.maxHeight = panel.scrollHeight + "px";
     return;
   }
-  var html = "";
-  for (var i = 0; i < identities.length; i++) {
+  let html = "";
+  for (let i = 0; i < identities.length; i++) {
     html += _buildOidcRow(identities[i], userId, username);
   }
   setSafeHtml(body, html);
   // Update panel height for animation
   panel.style.maxHeight = panel.scrollHeight + "px";
   // Bind unlink buttons
-  var btns = body.querySelectorAll("[data-oidc-issuer]");
-  for (var j = 0; j < btns.length; j++) {
+  const btns = body.querySelectorAll("[data-oidc-issuer]");
+  for (let j = 0; j < btns.length; j++) {
     btns[j].addEventListener("click", function (e) {
       e.stopPropagation();
-      var issuer = this.getAttribute("data-oidc-issuer");
-      var subject = this.getAttribute("data-oidc-subject");
-      var uname = this.getAttribute("data-oidc-username");
-      var uid = this.getAttribute("data-oidc-user-id");
+      const issuer = this.getAttribute("data-oidc-issuer");
+      const subject = this.getAttribute("data-oidc-subject");
+      const uname = this.getAttribute("data-oidc-username");
+      const uid = this.getAttribute("data-oidc-user-id");
       _confirmUnlinkOidc(issuer, subject, uname, uid);
     });
   }
 }
 
 function _confirmUnlinkOidc(issuer, subject, username, userId) {
-  var shortIssuer = _issuerShortName(issuer);
-  var shortSubject =
+  const shortIssuer = _issuerShortName(issuer);
+  const shortSubject =
     subject.length > 16 ? subject.slice(0, 16) + "\u2026" : subject;
   showConfirmModal(
     "Unlink OIDC Identity",
@@ -620,20 +620,20 @@ function _confirmUnlinkOidc(issuer, subject, username, userId) {
           if (!r.ok) throw new Error("Unlink failed");
           showToast("OIDC identity unlinked");
           // Refresh the panel content in place (no close/reopen flicker)
-          var allRows = document.querySelectorAll(
+          const allRows = document.querySelectorAll(
             "#admin-users-table .admin-row[data-expandable]",
           );
-          var targetRow = null;
-          for (var ri = 0; ri < allRows.length; ri++) {
+          let targetRow = null;
+          for (let ri = 0; ri < allRows.length; ri++) {
             if (allRows[ri].getAttribute("data-user-id") === userId) {
               targetRow = allRows[ri];
               break;
             }
           }
           if (targetRow) {
-            var panel = targetRow.nextElementSibling;
+            const panel = targetRow.nextElementSibling;
             if (panel && panel.classList.contains("oidc-detail-panel")) {
-              var body = panel.querySelector(".oidc-detail-body");
+              const body = panel.querySelector(".oidc-detail-body");
               if (body)
                 setSafeHtml(
                   body,
@@ -675,7 +675,7 @@ function _confirmUnlinkOidc(issuer, subject, username, userId) {
 
 function _issuerShortName(issuer) {
   try {
-    var host = new URL(issuer).hostname;
+    const host = new URL(issuer).hostname;
     if (host.includes("google")) return "google";
     if (host.includes("microsoftonline") || host.includes("azure"))
       return "azure";
@@ -690,10 +690,10 @@ function _issuerShortName(issuer) {
 
 function _relativeTime(isoStr) {
   try {
-    var then = new Date(
+    const then = new Date(
       isoStr + (isoStr.includes("Z") || isoStr.includes("+") ? "" : "Z"),
     );
-    var diff = (Date.now() - then.getTime()) / 1000;
+    const diff = (Date.now() - then.getTime()) / 1000;
     if (diff < 60) return "just now";
     if (diff < 3600) return Math.floor(diff / 60) + "m ago";
     if (diff < 86400) return Math.floor(diff / 3600) + "h ago";
@@ -709,12 +709,12 @@ function _relativeTime(isoStr) {
 // ---------------------------------------------------------------------------
 
 function _populateTokenUserSelect() {
-  var sel = document.getElementById("admin-token-user");
-  var current = sel.value;
+  const sel = document.getElementById("admin-token-user");
+  let current = sel.value;
   setSafeHtml(sel, '<option value="">Select user...</option>');
-  for (var i = 0; i < _adminUsers.length; i++) {
-    var u = _adminUsers[i];
-    var opt = document.createElement("option");
+  for (let i = 0; i < _adminUsers.length; i++) {
+    const u = _adminUsers[i];
+    const opt = document.createElement("option");
     opt.value = u.user_id;
     opt.textContent = u.username + " (" + u.display_name + ")";
     sel.appendChild(opt);
@@ -723,7 +723,7 @@ function _populateTokenUserSelect() {
 }
 
 function loadAdminTokens() {
-  var userId = document.getElementById("admin-token-user").value;
+  const userId = document.getElementById("admin-token-user").value;
   _adminTokenUserId = userId;
   if (!userId) {
     setSafeHtml(
@@ -749,7 +749,7 @@ function loadAdminTokens() {
 }
 
 function _renderTokens(tokens) {
-  var container = document.getElementById("admin-tokens-table");
+  const container = document.getElementById("admin-tokens-table");
   if (!tokens.length) {
     setSafeHtml(
       container,
@@ -757,10 +757,10 @@ function _renderTokens(tokens) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < tokens.length; i++) {
-    var t = tokens[i];
-    var expires = t.expires ? escapeHtml(t.expires).slice(0, 10) : "\u2014";
+  let html = "";
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const expires = t.expires ? escapeHtml(t.expires).slice(0, 10) : "\u2014";
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col admin-col-prefix"><code>' +
@@ -787,8 +787,8 @@ function _renderTokens(tokens) {
   }
   setSafeHtml(container, html);
   // Bind revoke buttons via delegation (avoids inline JS injection)
-  var rbtns = container.querySelectorAll("[data-revoke-token]");
-  for (var j = 0; j < rbtns.length; j++) {
+  const rbtns = container.querySelectorAll("[data-revoke-token]");
+  for (let j = 0; j < rbtns.length; j++) {
     rbtns[j].addEventListener("click", function () {
       confirmRevokeToken(this.getAttribute("data-revoke-token"));
     });
@@ -797,12 +797,12 @@ function _renderTokens(tokens) {
 
 function _renderScopeBadges(scopes) {
   if (!scopes) return "";
-  var parts = scopes.split(",");
-  var html = "";
-  for (var i = 0; i < parts.length; i++) {
-    var s = parts[i].trim();
+  const parts = scopes.split(",");
+  let html = "";
+  for (let i = 0; i < parts.length; i++) {
+    const s = parts[i].trim();
     if (!s) continue;
-    var cls = "scope-badge";
+    let cls = "scope-badge";
     if (s === "approve") cls += " scope-approve";
     else if (s === "write") cls += " scope-write";
     html += '<span class="' + cls + '">' + escapeHtml(s) + "</span>";
@@ -836,12 +836,12 @@ function confirmRevokeToken(tokenId) {
 // ---------------------------------------------------------------------------
 
 function _populateChannelUserSelect() {
-  var sel = document.getElementById("admin-channel-user");
-  var current = sel.value;
+  const sel = document.getElementById("admin-channel-user");
+  let current = sel.value;
   setSafeHtml(sel, '<option value="">Select user...</option>');
-  for (var i = 0; i < _adminUsers.length; i++) {
-    var u = _adminUsers[i];
-    var opt = document.createElement("option");
+  for (let i = 0; i < _adminUsers.length; i++) {
+    const u = _adminUsers[i];
+    const opt = document.createElement("option");
     opt.value = u.user_id;
     opt.textContent = u.username + " (" + u.display_name + ")";
     sel.appendChild(opt);
@@ -850,7 +850,7 @@ function _populateChannelUserSelect() {
 }
 
 function loadAdminChannels() {
-  var userId = document.getElementById("admin-channel-user").value;
+  const userId = document.getElementById("admin-channel-user").value;
   _adminChannelUserId = userId;
   if (!userId) {
     setSafeHtml(
@@ -880,7 +880,7 @@ function loadAdminChannels() {
 }
 
 function _renderChannels(channels) {
-  var container = document.getElementById("admin-channels-table");
+  const container = document.getElementById("admin-channels-table");
   if (!channels.length) {
     setSafeHtml(
       container,
@@ -888,15 +888,15 @@ function _renderChannels(channels) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < channels.length; i++) {
-    var c = channels[i];
+  let html = "";
+  for (let i = 0; i < channels.length; i++) {
+    const c = channels[i];
     // Per-platform badge class (scope-discord / scope-slack) so different
     // adapters render with their own color.  Falls back to the generic
     // scope-channel for unknown platforms; the per-platform class wins
     // by being the only class set, not by source order.
-    var ctSlug = (c.channel_type || "").toLowerCase().replace(/[^a-z0-9]/g, "");
-    var ctClass =
+    const ctSlug = (c.channel_type || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+    const ctClass =
       ctSlug && (ctSlug === "discord" || ctSlug === "slack")
         ? "scope-badge scope-" + ctSlug
         : "scope-badge scope-channel";
@@ -923,8 +923,8 @@ function _renderChannels(channels) {
       "</div>";
   }
   setSafeHtml(container, html);
-  var btns = container.querySelectorAll("[data-unlink-type]");
-  for (var j = 0; j < btns.length; j++) {
+  const btns = container.querySelectorAll("[data-unlink-type]");
+  for (let j = 0; j < btns.length; j++) {
     btns[j].addEventListener("click", function () {
       confirmUnlinkChannel(
         this.getAttribute("data-unlink-type"),
@@ -967,11 +967,11 @@ function confirmUnlinkChannel(channelType, channelUserId) {
 // Schedules
 // ---------------------------------------------------------------------------
 
-var _csTrapHandler = null;
-var _esTrapHandler = null;
-var _srTrapHandler = null;
-var _editScheduleTriggerEl = null;
-var _runsScheduleTriggerEl = null;
+let _csTrapHandler = null;
+let _esTrapHandler = null;
+let _srTrapHandler = null;
+let _editScheduleTriggerEl = null;
+let _runsScheduleTriggerEl = null;
 
 function loadAdminSchedules() {
   authFetch("/v1/api/admin/schedules")
@@ -991,7 +991,7 @@ function loadAdminSchedules() {
 }
 
 function _renderSchedules(schedules) {
-  var container = document.getElementById("admin-schedules-table");
+  const container = document.getElementById("admin-schedules-table");
   if (!schedules.length) {
     setSafeHtml(
       container,
@@ -999,23 +999,23 @@ function _renderSchedules(schedules) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < schedules.length; i++) {
-    var s = schedules[i];
-    var typeLabel = s.schedule_type === "cron" ? "cron" : "at";
-    var typeCls = s.schedule_type === "cron" ? "scope-write" : "scope-approve";
-    var schedule =
+  let html = "";
+  for (let i = 0; i < schedules.length; i++) {
+    const s = schedules[i];
+    const typeLabel = s.schedule_type === "cron" ? "cron" : "at";
+    const typeCls = s.schedule_type === "cron" ? "scope-write" : "scope-approve";
+    const schedule =
       s.schedule_type === "cron"
         ? s.cron_expr
         : _utcToLocalDatetime(s.at_time).replace("T", " ");
-    var target = s.target_mode;
-    var nextRun = s.next_run
+    const target = s.target_mode;
+    const nextRun = s.next_run
       ? _utcToLocalDatetime(s.next_run).replace("T", " ")
       : "\u2014";
-    var enabled = s.enabled;
-    var statusCls = enabled ? "sched-active" : "sched-disabled";
-    var statusLabel = enabled ? "active" : "disabled";
-    var statusDot = enabled ? "\u25cf " : "\u25cb ";
+    const enabled = s.enabled;
+    let statusCls = enabled ? "sched-active" : "sched-disabled";
+    let statusLabel = enabled ? "active" : "disabled";
+    let statusDot = enabled ? "\u25cf " : "\u25cb ";
     if (s.schedule_type === "at" && !enabled && s.last_run) {
       statusCls = "sched-expired";
       statusLabel = "completed";
@@ -1071,20 +1071,20 @@ function _renderSchedules(schedules) {
   }
   setSafeHtml(container, html);
   // Bind buttons
-  var editBtns = container.querySelectorAll("[data-edit-sched]");
-  for (var j = 0; j < editBtns.length; j++) {
+  const editBtns = container.querySelectorAll("[data-edit-sched]");
+  for (let j = 0; j < editBtns.length; j++) {
     editBtns[j].addEventListener("click", function () {
       showEditScheduleModal(this.getAttribute("data-edit-sched"));
     });
   }
-  var runsBtns = container.querySelectorAll("[data-runs-sched]");
-  for (var k = 0; k < runsBtns.length; k++) {
+  const runsBtns = container.querySelectorAll("[data-runs-sched]");
+  for (let k = 0; k < runsBtns.length; k++) {
     runsBtns[k].addEventListener("click", function () {
       showScheduleRuns(this.getAttribute("data-runs-sched"));
     });
   }
-  var toggleBtns = container.querySelectorAll("[data-toggle-sched]");
-  for (var m = 0; m < toggleBtns.length; m++) {
+  const toggleBtns = container.querySelectorAll("[data-toggle-sched]");
+  for (let m = 0; m < toggleBtns.length; m++) {
     toggleBtns[m].addEventListener("click", function () {
       toggleSchedule(
         this.getAttribute("data-toggle-sched"),
@@ -1092,8 +1092,8 @@ function _renderSchedules(schedules) {
       );
     });
   }
-  var delBtns = container.querySelectorAll("[data-delete-sched]");
-  for (var n = 0; n < delBtns.length; n++) {
+  const delBtns = container.querySelectorAll("[data-delete-sched]");
+  for (let n = 0; n < delBtns.length; n++) {
     delBtns[n].addEventListener("click", function () {
       confirmDeleteSchedule(
         this.getAttribute("data-delete-sched"),
@@ -1145,12 +1145,12 @@ function confirmDeleteSchedule(taskId, name) {
 // --- Schedule helpers: dropdowns, notify rows, timezone ---
 
 function _populateScheduleSelect(selectId, url, labelKey, valueKey, opts) {
-  var sel = document.getElementById(selectId);
+  const sel = document.getElementById(selectId);
   // Keep the first option (placeholder) and remove the rest
   while (sel.options.length > 1) sel.remove(1);
   // Add temporary option for pre-selected value so form is correct before fetch completes
   if (opts && opts.selected) {
-    var tmp = document.createElement("option");
+    const tmp = document.createElement("option");
     tmp.value = opts.selected;
     tmp.textContent = opts.selected;
     tmp.dataset.temporary = "1";
@@ -1162,12 +1162,12 @@ function _populateScheduleSelect(selectId, url, labelKey, valueKey, opts) {
       return r.json();
     })
     .then(function (data) {
-      var temp = sel.querySelector("[data-temporary]");
+      const temp = sel.querySelector("[data-temporary]");
       if (temp) temp.remove();
-      var items = opts && opts.listKey ? data[opts.listKey] : data;
+      const items = opts && opts.listKey ? data[opts.listKey] : data;
       if (!Array.isArray(items)) return;
       items.forEach(function (item) {
-        var opt = document.createElement("option");
+        const opt = document.createElement("option");
         opt.value = item[valueKey];
         opt.textContent =
           opts && opts.display ? opts.display(item) : item[labelKey];
@@ -1200,17 +1200,17 @@ function _populateScheduleSelect(selectId, url, labelKey, valueKey, opts) {
 // "(model)" suffix legible.
 function _decorateScheduleModelPlaceholder(sel, data) {
   if (!sel || sel.options.length === 0) return;
-  var alias = (data && data.default_alias) || "";
+  const alias = (data && data.default_alias) || "";
   if (!alias) return;
-  var match = null;
-  var models = (data && data.models) || [];
-  for (var i = 0; i < models.length; i++) {
+  let match = null;
+  const models = (data && data.models) || [];
+  for (let i = 0; i < models.length; i++) {
     if (models[i].alias === alias) {
       match = models[i];
       break;
     }
   }
-  var label;
+  let label;
   if (match) {
     label =
       match.alias === match.model
@@ -1225,7 +1225,7 @@ function _decorateScheduleModelPlaceholder(sel, data) {
 // Channel platforms shown in admin notify-target rows.  Mirror server-side
 // channel adapters; expand here when a new adapter ships (Discord / Slack
 // today, MS Teams / etc. later).
-var _NOTIFY_CHANNEL_TYPES = [
+const _NOTIFY_CHANNEL_TYPES = [
   {
     value: "discord",
     label: "Discord",
@@ -1239,7 +1239,7 @@ var _NOTIFY_CHANNEL_TYPES = [
 ];
 
 function _notifyIdPlaceholder(channelType) {
-  for (var i = 0; i < _NOTIFY_CHANNEL_TYPES.length; i++) {
+  for (let i = 0; i < _NOTIFY_CHANNEL_TYPES.length; i++) {
     if (_NOTIFY_CHANNEL_TYPES[i].value === channelType) {
       return _NOTIFY_CHANNEL_TYPES[i].id_hint;
     }
@@ -1248,35 +1248,35 @@ function _notifyIdPlaceholder(channelType) {
 }
 
 function _addNotifyRow(prefix, targetType, targetId, channelType) {
-  var container = document.getElementById(prefix + "-notify-rows");
-  var row = document.createElement("div");
+  const container = document.getElementById(prefix + "-notify-rows");
+  const row = document.createElement("div");
   row.className = "notify-row";
 
-  var ctSel = document.createElement("select");
+  const ctSel = document.createElement("select");
   ctSel.setAttribute("aria-label", "Channel platform");
   ctSel.className = "notify-row-ct";
-  for (var i = 0; i < _NOTIFY_CHANNEL_TYPES.length; i++) {
-    var ctOpt = document.createElement("option");
+  for (let i = 0; i < _NOTIFY_CHANNEL_TYPES.length; i++) {
+    const ctOpt = document.createElement("option");
     ctOpt.value = _NOTIFY_CHANNEL_TYPES[i].value;
     ctOpt.textContent = _NOTIFY_CHANNEL_TYPES[i].label;
     ctSel.appendChild(ctOpt);
   }
   ctSel.value = channelType || "discord";
 
-  var typeSel = document.createElement("select");
+  const typeSel = document.createElement("select");
   typeSel.setAttribute("aria-label", "Target type");
   typeSel.className = "notify-row-target";
-  var optCh = document.createElement("option");
+  const optCh = document.createElement("option");
   optCh.value = "channel_id";
   optCh.textContent = "Channel";
-  var optUsr = document.createElement("option");
+  const optUsr = document.createElement("option");
   optUsr.value = "user_id";
   optUsr.textContent = "User DM";
   typeSel.appendChild(optCh);
   typeSel.appendChild(optUsr);
   if (targetType) typeSel.value = targetType;
 
-  var idInput = document.createElement("input");
+  const idInput = document.createElement("input");
   idInput.type = "text";
   idInput.className = "notify-row-id";
   idInput.placeholder = _notifyIdPlaceholder(ctSel.value);
@@ -1290,7 +1290,7 @@ function _addNotifyRow(prefix, targetType, targetId, channelType) {
     idInput.placeholder = _notifyIdPlaceholder(ctSel.value);
   });
 
-  var removeBtn = document.createElement("button");
+  const removeBtn = document.createElement("button");
   removeBtn.type = "button";
   removeBtn.className = "notify-row-remove";
   removeBtn.setAttribute("aria-label", "Remove target");
@@ -1308,18 +1308,18 @@ function _addNotifyRow(prefix, targetType, targetId, channelType) {
 }
 
 function _collectNotifyTargets(prefix) {
-  var rows = document
+  const rows = document
     .getElementById(prefix + "-notify-rows")
     .querySelectorAll(".notify-row");
-  var targets = [];
-  for (var i = 0; i < rows.length; i++) {
-    var ct = (rows[i].querySelector(".notify-row-ct") || {}).value || "discord";
-    var type =
+  const targets = [];
+  for (let i = 0; i < rows.length; i++) {
+    const ct = (rows[i].querySelector(".notify-row-ct") || {}).value || "discord";
+    const type =
       (rows[i].querySelector(".notify-row-target") || {}).value || "channel_id";
-    var idEl = rows[i].querySelector(".notify-row-id");
-    var id = ((idEl && idEl.value) || "").trim();
+    const idEl = rows[i].querySelector(".notify-row-id");
+    const id = ((idEl && idEl.value) || "").trim();
     if (!id) continue;
-    var t = { channel_type: ct };
+    const t = { channel_type: ct };
     t[type] = id;
     targets.push(t);
   }
@@ -1327,12 +1327,12 @@ function _collectNotifyTargets(prefix) {
 }
 
 function _populateNotifyRows(prefix, targets) {
-  var container = document.getElementById(prefix + "-notify-rows");
+  const container = document.getElementById(prefix + "-notify-rows");
   while (container.firstChild) container.removeChild(container.firstChild);
   if (!Array.isArray(targets)) return;
   targets.forEach(function (t) {
-    var targetType = "channel_id" in t ? "channel_id" : "user_id";
-    var targetId = t[targetType] || "";
+    const targetType = "channel_id" in t ? "channel_id" : "user_id";
+    const targetId = t[targetType] || "";
     _addNotifyRow(prefix, targetType, targetId, t.channel_type || "discord");
   });
 }
@@ -1340,7 +1340,7 @@ function _populateNotifyRows(prefix, targets) {
 function _localToUtcIso(localDatetimeStr) {
   // datetime-local gives "YYYY-MM-DDTHH:MM" in browser local time
   // Convert to UTC ISO string for the server
-  var d = new Date(localDatetimeStr);
+  const d = new Date(localDatetimeStr);
   if (isNaN(d.getTime())) return "";
   return d.toISOString().replace(/\.\d{3}Z$/, "+00:00");
 }
@@ -1348,9 +1348,9 @@ function _localToUtcIso(localDatetimeStr) {
 function _utcToLocalDatetime(utcStr) {
   // Convert UTC ISO string to datetime-local format in browser local time
   if (!utcStr) return "";
-  var d = new Date(utcStr);
+  const d = new Date(utcStr);
   if (isNaN(d.getTime())) return utcStr.slice(0, 16);
-  var pad = function (n) {
+  const pad = function (n) {
     return n < 10 ? "0" + n : "" + n;
   };
   return (
@@ -1369,7 +1369,7 @@ function _utcToLocalDatetime(utcStr) {
 // --- Create Schedule Modal ---
 
 function toggleScheduleTypeFields() {
-  var t = document.getElementById("cs-type").value;
+  const t = document.getElementById("cs-type").value;
   document.getElementById("cs-cron-group").style.display =
     t === "cron" ? "" : "none";
   document.getElementById("cs-at-group").style.display =
@@ -1379,14 +1379,14 @@ function toggleScheduleTypeFields() {
 }
 
 function toggleScheduleNodeField() {
-  var v = document.getElementById("cs-target").value;
+  const v = document.getElementById("cs-target").value;
   document.getElementById("cs-node-group").style.display =
     v === "node" ? "" : "none";
   if (v === "node") document.getElementById("cs-node").focus();
 }
 
 function showCreateScheduleModal() {
-  var overlay = document.getElementById("create-schedule-overlay");
+  const overlay = document.getElementById("create-schedule-overlay");
   overlay.style.display = "flex";
   document
     .getElementById("create-schedule-error")
@@ -1438,24 +1438,24 @@ function showCreateScheduleModal() {
 function hideCreateScheduleModal() {
   document.getElementById("create-schedule-overlay").style.display = "none";
   _csTrapHandler = _removeTrap(_csTrapHandler);
-  var trigger = document.querySelector("#admin-schedules .admin-action-btn");
+  const trigger = document.querySelector("#admin-schedules .admin-action-btn");
   if (trigger) trigger.focus();
 }
 
 function submitCreateSchedule() {
-  var name = (document.getElementById("cs-name").value || "").trim();
-  var desc = (document.getElementById("cs-desc").value || "").trim();
-  var schedType = document.getElementById("cs-type").value;
-  var cronExpr = (document.getElementById("cs-cron").value || "").trim();
-  var atTime = document.getElementById("cs-at").value || "";
-  var targetMode = document.getElementById("cs-target").value;
-  var nodeId = (document.getElementById("cs-node").value || "").trim();
-  var model = (document.getElementById("cs-model").value || "").trim();
-  var message = (document.getElementById("cs-message").value || "").trim();
-  var skill = (document.getElementById("cs-template").value || "").trim();
-  var autoApprove = document.getElementById("cs-autoapprove").checked;
-  var notifyTargets = _collectNotifyTargets("cs");
-  var errEl = document.getElementById("create-schedule-error");
+  const name = (document.getElementById("cs-name").value || "").trim();
+  const desc = (document.getElementById("cs-desc").value || "").trim();
+  const schedType = document.getElementById("cs-type").value;
+  const cronExpr = (document.getElementById("cs-cron").value || "").trim();
+  let atTime = document.getElementById("cs-at").value || "";
+  let targetMode = document.getElementById("cs-target").value;
+  const nodeId = (document.getElementById("cs-node").value || "").trim();
+  const model = (document.getElementById("cs-model").value || "").trim();
+  const message = (document.getElementById("cs-message").value || "").trim();
+  const skill = (document.getElementById("cs-template").value || "").trim();
+  const autoApprove = document.getElementById("cs-autoapprove").checked;
+  const notifyTargets = _collectNotifyTargets("cs");
+  const errEl = document.getElementById("create-schedule-error");
 
   if (!name) return _showModalError(errEl, "Name is required");
   if (!message) return _showModalError(errEl, "Initial message is required");
@@ -1471,7 +1471,7 @@ function submitCreateSchedule() {
 
   if (targetMode === "node") targetMode = nodeId;
 
-  var btn = document.getElementById("cs-submit");
+  const btn = document.getElementById("cs-submit");
   btn.disabled = true;
   btn.textContent = "Creating\u2026";
 
@@ -1514,7 +1514,7 @@ function submitCreateSchedule() {
 // --- Edit Schedule Modal ---
 
 function toggleEditScheduleTypeFields() {
-  var t = document.getElementById("es-type").value;
+  const t = document.getElementById("es-type").value;
   document.getElementById("es-cron-group").style.display =
     t === "cron" ? "" : "none";
   document.getElementById("es-at-group").style.display =
@@ -1524,7 +1524,7 @@ function toggleEditScheduleTypeFields() {
 }
 
 function toggleEditScheduleNodeField() {
-  var v = document.getElementById("es-target").value;
+  const v = document.getElementById("es-target").value;
   document.getElementById("es-node-group").style.display =
     v === "node" ? "" : "none";
   if (v === "node") document.getElementById("es-node").focus();
@@ -1544,7 +1544,7 @@ function showEditScheduleModal(taskId) {
       document.getElementById("es-type").value = s.schedule_type;
       document.getElementById("es-cron").value = s.cron_expr || "";
       document.getElementById("es-at").value = _utcToLocalDatetime(s.at_time);
-      var isSpecificNode =
+      const isSpecificNode =
         s.target_mode &&
         s.target_mode !== "auto" &&
         s.target_mode !== "pool" &&
@@ -1589,7 +1589,7 @@ function showEditScheduleModal(taskId) {
         .classList.remove("is-visible");
       document.getElementById("es-submit").disabled = false;
       document.getElementById("es-submit").textContent = "Save";
-      var overlay = document.getElementById("edit-schedule-overlay");
+      const overlay = document.getElementById("edit-schedule-overlay");
       overlay.style.display = "flex";
       _esTrapHandler = _installTrap(
         "edit-schedule-overlay",
@@ -1614,18 +1614,18 @@ function hideEditScheduleModal() {
 }
 
 function submitEditSchedule() {
-  var taskId = document.getElementById("es-id").value;
-  var name = (document.getElementById("es-name").value || "").trim();
-  var message = (document.getElementById("es-message").value || "").trim();
-  var schedType = document.getElementById("es-type").value;
-  var cronExpr = (document.getElementById("es-cron").value || "").trim();
-  var targetMode = document.getElementById("es-target").value;
+  const taskId = document.getElementById("es-id").value;
+  const name = (document.getElementById("es-name").value || "").trim();
+  const message = (document.getElementById("es-message").value || "").trim();
+  const schedType = document.getElementById("es-type").value;
+  const cronExpr = (document.getElementById("es-cron").value || "").trim();
+  let targetMode = document.getElementById("es-target").value;
   if (targetMode === "node")
     targetMode = (document.getElementById("es-node").value || "").trim();
-  var atTime = document.getElementById("es-at").value || "";
+  let atTime = document.getElementById("es-at").value || "";
 
-  var editNotifyTargets = _collectNotifyTargets("es");
-  var errEl = document.getElementById("edit-schedule-error");
+  const editNotifyTargets = _collectNotifyTargets("es");
+  const errEl = document.getElementById("edit-schedule-error");
 
   if (!name) return _showModalError(errEl, "Name is required");
   if (!message) return _showModalError(errEl, "Initial message is required");
@@ -1639,7 +1639,7 @@ function submitEditSchedule() {
     atTime = _localToUtcIso(atTime);
   }
 
-  var btn = document.getElementById("es-submit");
+  const btn = document.getElementById("es-submit");
   btn.disabled = true;
   btn.textContent = "Saving\u2026";
 
@@ -1692,23 +1692,23 @@ function showScheduleRuns(taskId) {
       return r.json();
     })
     .then(function (data) {
-      var runs = data.runs || [];
-      var container = document.getElementById("schedule-runs-table");
+      const runs = data.runs || [];
+      const container = document.getElementById("schedule-runs-table");
       if (!runs.length) {
         setSafeHtml(
           container,
           '<div class="dashboard-empty">No runs yet</div>',
         );
       } else {
-        var html =
+        let html =
           '<div class="admin-colheaders sched-runs-grid" aria-hidden="true">' +
           '<span class="admin-col">STARTED</span>' +
           '<span class="admin-col">NODE</span>' +
           '<span class="admin-col">STATUS</span>' +
           '<span class="admin-col">ERROR</span></div>';
-        for (var i = 0; i < runs.length; i++) {
-          var r = runs[i];
-          var statusCls =
+        for (let i = 0; i < runs.length; i++) {
+          const r = runs[i];
+          let statusCls =
             r.status === "dispatched"
               ? "sched-active"
               : r.status === "failed"
@@ -1735,7 +1735,7 @@ function showScheduleRuns(taskId) {
         }
         setSafeHtml(container, html);
       }
-      var overlay = document.getElementById("schedule-runs-overlay");
+      const overlay = document.getElementById("schedule-runs-overlay");
       overlay.style.display = "flex";
       _srTrapHandler = _installTrap(
         "schedule-runs-overlay",
@@ -1761,15 +1761,15 @@ function hideScheduleRunsModal() {
 // ---------------------------------------------------------------------------
 
 function _populateWatchNodeSelect() {
-  var sel = document.getElementById("admin-watch-node");
-  var current = sel.value;
-  var seen = {};
+  const sel = document.getElementById("admin-watch-node");
+  let current = sel.value;
+  const seen = {};
   setSafeHtml(sel, '<option value="">All nodes</option>');
-  for (var i = 0; i < _adminWatches.length; i++) {
-    var nid = _adminWatches[i].node_id || "";
+  for (let i = 0; i < _adminWatches.length; i++) {
+    const nid = _adminWatches[i].node_id || "";
     if (nid && !seen[nid]) {
       seen[nid] = true;
-      var opt = document.createElement("option");
+      const opt = document.createElement("option");
       opt.value = nid;
       opt.textContent = nid;
       sel.appendChild(opt);
@@ -1787,8 +1787,8 @@ function loadAdminWatches() {
     .then(function (data) {
       _adminWatches = data.watches || [];
       _populateWatchNodeSelect();
-      var nodeFilter = document.getElementById("admin-watch-node").value;
-      var filtered = _adminWatches;
+      const nodeFilter = document.getElementById("admin-watch-node").value;
+      let filtered = _adminWatches;
       if (nodeFilter) {
         filtered = _adminWatches.filter(function (w) {
           return w.node_id === nodeFilter;
@@ -1812,7 +1812,7 @@ function _formatInterval(secs) {
 }
 
 function _renderWatches(watches) {
-  var container = document.getElementById("admin-watches-table");
+  const container = document.getElementById("admin-watches-table");
   if (!watches.length) {
     setSafeHtml(
       container,
@@ -1820,23 +1820,23 @@ function _renderWatches(watches) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < watches.length; i++) {
-    var w = watches[i];
-    var name = w.name || w.watch_id || "\u2014";
-    var nodeShort = (w.node_id || "").slice(0, 8);
-    var cmd = w.command || "";
-    var cmdTrunc = cmd.length > 40 ? cmd.slice(0, 40) + "\u2026" : cmd;
-    var interval = _formatInterval(w.interval_secs);
-    var pollMax = w.max_polls ? w.max_polls : "\u221e";
-    var pollLabel = (w.poll_count || 0) + "/" + pollMax;
-    var cond = w.stop_on || "on change";
-    var condTrunc = cond.length > 30 ? cond.slice(0, 30) + "\u2026" : cond;
-    var active = w.active;
-    var statusCls = active ? "watch-active" : "watch-completed";
-    var statusLabel = active ? "active" : "done";
-    var statusDot = active ? "\u25cf " : "\u25cb ";
-    var cancelBtn = active
+  let html = "";
+  for (let i = 0; i < watches.length; i++) {
+    const w = watches[i];
+    const name = w.name || w.watch_id || "\u2014";
+    const nodeShort = (w.node_id || "").slice(0, 8);
+    const cmd = w.command || "";
+    const cmdTrunc = cmd.length > 40 ? cmd.slice(0, 40) + "\u2026" : cmd;
+    const interval = _formatInterval(w.interval_secs);
+    const pollMax = w.max_polls ? w.max_polls : "\u221e";
+    const pollLabel = (w.poll_count || 0) + "/" + pollMax;
+    const cond = w.stop_on || "on change";
+    const condTrunc = cond.length > 30 ? cond.slice(0, 30) + "\u2026" : cond;
+    const active = w.active;
+    let statusCls = active ? "watch-active" : "watch-completed";
+    let statusLabel = active ? "active" : "done";
+    let statusDot = active ? "\u25cf " : "\u25cb ";
+    const cancelBtn = active
       ? '<button class="admin-btn-danger" data-cancel-watch="' +
         escapeHtml(w.watch_id) +
         '" data-watch-node="' +
@@ -1883,8 +1883,8 @@ function _renderWatches(watches) {
   }
   setSafeHtml(container, html);
   // Bind cancel buttons
-  var btns = container.querySelectorAll("[data-cancel-watch]");
-  for (var j = 0; j < btns.length; j++) {
+  const btns = container.querySelectorAll("[data-cancel-watch]");
+  for (let j = 0; j < btns.length; j++) {
     btns[j].addEventListener("click", function () {
       _cancelWatch(
         this.getAttribute("data-cancel-watch"),
@@ -1930,13 +1930,13 @@ function showCreateChannelModal() {
     showToast("Select a user first");
     return;
   }
-  var overlay = document.getElementById("create-channel-overlay");
+  const overlay = document.getElementById("create-channel-overlay");
   overlay.style.display = "flex";
   document
     .getElementById("create-channel-error")
     .classList.remove("is-visible");
-  var ctSel = document.getElementById("cc-type");
-  var uidInput = document.getElementById("cc-uid");
+  const ctSel = document.getElementById("cc-type");
+  const uidInput = document.getElementById("cc-uid");
   ctSel.value = "discord";
   uidInput.value = "";
   uidInput.placeholder = _notifyIdPlaceholder(ctSel.value);
@@ -1954,19 +1954,19 @@ function showCreateChannelModal() {
 function hideCreateChannelModal() {
   document.getElementById("create-channel-overlay").style.display = "none";
   _ccTrapHandler = _removeTrap(_ccTrapHandler);
-  var trigger = document.querySelector("#admin-channels .admin-action-btn");
+  const trigger = document.querySelector("#admin-channels .admin-action-btn");
   if (trigger) trigger.focus();
 }
 
 function submitCreateChannel() {
-  var channelType = document.getElementById("cc-type").value;
-  var channelUserId = (document.getElementById("cc-uid").value || "").trim();
-  var errEl = document.getElementById("create-channel-error");
+  const channelType = document.getElementById("cc-type").value;
+  const channelUserId = (document.getElementById("cc-uid").value || "").trim();
+  const errEl = document.getElementById("create-channel-error");
 
   if (!channelUserId)
     return _showModalError(errEl, "External user ID is required");
 
-  var btn = document.getElementById("cc-submit");
+  const btn = document.getElementById("cc-submit");
   btn.disabled = true;
   btn.textContent = "Linking\u2026";
 
@@ -2011,7 +2011,7 @@ function submitCreateChannel() {
 // ---------------------------------------------------------------------------
 
 function showCreateUserModal() {
-  var overlay = document.getElementById("create-user-overlay");
+  const overlay = document.getElementById("create-user-overlay");
   overlay.style.display = "flex";
   document.getElementById("create-user-error").classList.remove("is-visible");
   document.getElementById("cu-username").value = "";
@@ -2029,18 +2029,18 @@ function showCreateUserModal() {
 function hideCreateUserModal() {
   document.getElementById("create-user-overlay").style.display = "none";
   _cuTrapHandler = _removeTrap(_cuTrapHandler);
-  var trigger = document.querySelector("#admin-users .admin-action-btn");
+  const trigger = document.querySelector("#admin-users .admin-action-btn");
   if (trigger) trigger.focus();
 }
 
 function submitCreateUser() {
-  var username = (document.getElementById("cu-username").value || "").trim();
-  var displayName = (
+  const username = (document.getElementById("cu-username").value || "").trim();
+  const displayName = (
     document.getElementById("cu-displayname").value || ""
   ).trim();
-  var password = document.getElementById("cu-password").value || "";
-  var confirm = document.getElementById("cu-confirm").value || "";
-  var errEl = document.getElementById("create-user-error");
+  const password = document.getElementById("cu-password").value || "";
+  const confirm = document.getElementById("cu-confirm").value || "";
+  const errEl = document.getElementById("create-user-error");
 
   if (!username) return _showModalError(errEl, "Username is required");
   if (!displayName) return _showModalError(errEl, "Display name is required");
@@ -2050,7 +2050,7 @@ function submitCreateUser() {
   if (password !== confirm)
     return _showModalError(errEl, "Passwords do not match");
 
-  var btn = document.getElementById("cu-submit");
+  const btn = document.getElementById("cu-submit");
   btn.disabled = true;
   btn.textContent = "Creating\u2026";
 
@@ -2092,7 +2092,7 @@ function showCreateTokenModal() {
     showToast("Select a user first");
     return;
   }
-  var overlay = document.getElementById("create-token-overlay");
+  const overlay = document.getElementById("create-token-overlay");
   overlay.style.display = "flex";
   document.getElementById("create-token-error").classList.remove("is-visible");
   document.getElementById("ct-name").value = "";
@@ -2109,21 +2109,21 @@ function showCreateTokenModal() {
 function hideCreateTokenModal() {
   document.getElementById("create-token-overlay").style.display = "none";
   _ctTrapHandler = _removeTrap(_ctTrapHandler);
-  var trigger = document.querySelector("#admin-tokens .admin-action-btn");
+  const trigger = document.querySelector("#admin-tokens .admin-action-btn");
   if (trigger) trigger.focus();
 }
 
 function submitCreateToken() {
-  var name = (document.getElementById("ct-name").value || "").trim();
-  var scopes = document.getElementById("ct-scopes").value;
-  var expiresDays = document.getElementById("ct-expires").value;
-  var errEl = document.getElementById("create-token-error");
+  const name = (document.getElementById("ct-name").value || "").trim();
+  const scopes = document.getElementById("ct-scopes").value;
+  const expiresDays = document.getElementById("ct-expires").value;
+  const errEl = document.getElementById("create-token-error");
 
-  var btn = document.getElementById("ct-submit");
+  const btn = document.getElementById("ct-submit");
   btn.disabled = true;
   btn.textContent = "Creating\u2026";
 
-  var body = { name: name, scopes: scopes };
+  const body = { name: name, scopes: scopes };
   if (expiresDays) body.expires_days = parseInt(expiresDays, 10);
 
   authFetch(
@@ -2168,7 +2168,7 @@ function hideTokenCreatedModal() {
   document.getElementById("token-created-overlay").style.display = "none";
   _tcTrapHandler = _removeTrap(_tcTrapHandler);
   _lastCreatedToken = "";
-  var trigger = document.querySelector("#admin-tokens .admin-action-btn");
+  const trigger = document.querySelector("#admin-tokens .admin-action-btn");
   if (trigger) trigger.focus();
 }
 
@@ -2180,10 +2180,10 @@ function copyCreatedToken() {
     });
   } else {
     // Fallback: select the text
-    var el = document.getElementById("token-created-value");
-    var range = document.createRange();
+    const el = document.getElementById("token-created-value");
+    const range = document.createRange();
     range.selectNodeContents(el);
-    var sel = window.getSelection();
+    const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);
     showToast("Select and copy the token");
@@ -2197,18 +2197,18 @@ function copyCreatedToken() {
 function _modalFocusTrap(boxId) {
   return function (e) {
     if (e.key === "Tab") {
-      var box = document.getElementById(boxId);
+      const box = document.getElementById(boxId);
       if (!box) return;
-      var focusable = box.querySelectorAll(
+      const focusable = box.querySelectorAll(
         "input:not([disabled]):not([type='hidden']), select:not([disabled]), textarea:not([disabled]), button:not([disabled])",
       );
-      var visible = [];
-      for (var i = 0; i < focusable.length; i++) {
+      const visible = [];
+      for (let i = 0; i < focusable.length; i++) {
         if (focusable[i].offsetParent !== null) visible.push(focusable[i]);
       }
       if (visible.length === 0) return;
-      var first = visible[0];
-      var last = visible[visible.length - 1];
+      const first = visible[0];
+      const last = visible[visible.length - 1];
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault();
@@ -2225,7 +2225,7 @@ function _modalFocusTrap(boxId) {
 }
 
 function _installTrap(overlayId, boxId, trapRef) {
-  var overlay = document.getElementById(overlayId);
+  const overlay = document.getElementById(overlayId);
   if (overlay) {
     overlay.onclick = function (e) {
       if (e.target === overlay) {
@@ -2266,7 +2266,7 @@ function _installTrap(overlayId, boxId, trapRef) {
     };
   }
   document.body.style.overflow = "hidden";
-  var handler = _modalFocusTrap(boxId);
+  const handler = _modalFocusTrap(boxId);
   document.addEventListener("keydown", handler);
   return handler;
 }
@@ -2281,62 +2281,62 @@ function _removeTrap(handler) {
 document.addEventListener("keydown", function (e) {
   if (e.key !== "Escape") return;
   // Close any open settings help popover first
-  var openHelp = document.querySelector('.settings-help-popover[style=""]');
+  const openHelp = document.querySelector('.settings-help-popover[style=""]');
   if (openHelp) {
     e.preventDefault();
     _closeAllSettingsHelp();
     return;
   }
-  var cu = document.getElementById("create-user-overlay");
+  const cu = document.getElementById("create-user-overlay");
   if (cu && cu.style.display !== "none") {
     e.preventDefault();
     hideCreateUserModal();
     return;
   }
-  var ct = document.getElementById("create-token-overlay");
+  const ct = document.getElementById("create-token-overlay");
   if (ct && ct.style.display !== "none") {
     e.preventDefault();
     hideCreateTokenModal();
     return;
   }
-  var tc = document.getElementById("token-created-overlay");
+  const tc = document.getElementById("token-created-overlay");
   if (tc && tc.style.display !== "none") {
     e.preventDefault();
     hideTokenCreatedModal();
     return;
   }
-  var cc = document.getElementById("create-channel-overlay");
+  const cc = document.getElementById("create-channel-overlay");
   if (cc && cc.style.display !== "none") {
     e.preventDefault();
     hideCreateChannelModal();
     return;
   }
-  var cso = document.getElementById("create-schedule-overlay");
+  const cso = document.getElementById("create-schedule-overlay");
   if (cso && cso.style.display !== "none") {
     e.preventDefault();
     hideCreateScheduleModal();
     return;
   }
-  var eso = document.getElementById("edit-schedule-overlay");
+  const eso = document.getElementById("edit-schedule-overlay");
   if (eso && eso.style.display !== "none") {
     e.preventDefault();
     hideEditScheduleModal();
     return;
   }
-  var sro = document.getElementById("schedule-runs-overlay");
+  const sro = document.getElementById("schedule-runs-overlay");
   if (sro && sro.style.display !== "none") {
     e.preventDefault();
     hideScheduleRunsModal();
     return;
   }
-  var cf = document.getElementById("confirm-overlay");
+  const cf = document.getElementById("confirm-overlay");
   if (cf && cf.style.display !== "none") {
     e.preventDefault();
     hideConfirmModal();
     return;
   }
   // Governance modals
-  var govOverlays = [
+  const govOverlays = [
     ["create-role-overlay", hideCreateRoleModal],
     ["edit-role-overlay", hideEditRoleModal],
     ["user-roles-overlay", hideUserRolesModal],
@@ -2358,8 +2358,8 @@ document.addEventListener("keydown", function (e) {
     ["create-ogp-overlay", hideCreateOGPModal],
     ["edit-ogp-overlay", hideEditOGPModal],
   ];
-  for (var gi = 0; gi < govOverlays.length; gi++) {
-    var govEl = document.getElementById(govOverlays[gi][0]);
+  for (let gi = 0; gi < govOverlays.length; gi++) {
+    const govEl = document.getElementById(govOverlays[gi][0]);
     if (govEl && govEl.style.display !== "none") {
       e.preventDefault();
       govOverlays[gi][1]();
@@ -2370,7 +2370,7 @@ document.addEventListener("keydown", function (e) {
   if (_mobileSidebarOpen && window.innerWidth <= 700) {
     e.preventDefault();
     _toggleMobileSidebar();
-    var mt = document.getElementById("admin-mobile-toggle");
+    const mt = document.getElementById("admin-mobile-toggle");
     if (mt) mt.focus();
     return;
   }
@@ -2378,24 +2378,24 @@ document.addEventListener("keydown", function (e) {
 
 // Sidebar arrow key navigation (vertical)
 (function () {
-  var sidebar = document.getElementById("admin-sidebar");
+  const sidebar = document.getElementById("admin-sidebar");
   if (!sidebar) return;
   sidebar.addEventListener("keydown", function (e) {
     if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
     e.preventDefault();
-    var allNavs = document.querySelectorAll(
+    const allNavs = document.querySelectorAll(
       '.admin-nav:not([style*="display: none"])',
     );
-    var navOrder = [];
-    for (var ni = 0; ni < allNavs.length; ni++) {
+    const navOrder = [];
+    for (let ni = 0; ni < allNavs.length; ni++) {
       navOrder.push(allNavs[ni].getAttribute("data-tab"));
     }
     if (navOrder.length === 0) return;
-    var idx = navOrder.indexOf(_adminTab);
+    let idx = navOrder.indexOf(_adminTab);
     if (e.key === "ArrowDown") idx = (idx + 1) % navOrder.length;
     else idx = (idx - 1 + navOrder.length) % navOrder.length;
     switchAdminTab(navOrder[idx]);
-    var btn = document.querySelector(
+    const btn = document.querySelector(
       '.admin-nav[data-tab="' + navOrder[idx] + '"]',
     );
     if (btn) btn.focus();
@@ -2404,15 +2404,15 @@ document.addEventListener("keydown", function (e) {
 
 // Sync sidebar aria-hidden/inert when crossing mobile/desktop breakpoint
 (function () {
-  var resizeTimer;
+  let resizeTimer;
   window.addEventListener("resize", function () {
     clearTimeout(resizeTimer);
     resizeTimer = setTimeout(function () {
       if (typeof currentView === "undefined" || currentView !== "admin") return;
-      var sidebar = document.getElementById("admin-sidebar");
+      const sidebar = document.getElementById("admin-sidebar");
       if (!sidebar) return;
-      var isMobile = window.innerWidth <= 700;
-      var backdrop = document.getElementById("admin-sidebar-backdrop");
+      const isMobile = window.innerWidth <= 700;
+      const backdrop = document.getElementById("admin-sidebar-backdrop");
       if (!isMobile) {
         // Crossed into desktop: close drawer cleanly if it was open
         if (_mobileSidebarOpen) _toggleMobileSidebar();
@@ -2441,10 +2441,10 @@ function showConfirmModal(title, message, actionLabel, callback) {
   _confirmTriggerEl = document.activeElement;
   document.getElementById("confirm-title").textContent = title;
   document.getElementById("confirm-message").textContent = message;
-  var btn = document.getElementById("confirm-submit");
+  const btn = document.getElementById("confirm-submit");
   btn.textContent = actionLabel;
   btn.disabled = false;
-  var overlay = document.getElementById("confirm-overlay");
+  const overlay = document.getElementById("confirm-overlay");
   overlay.style.display = "flex";
   _cfTrapHandler = _installTrap("confirm-overlay", "confirm-box");
   setTimeout(function () {
@@ -2467,9 +2467,9 @@ function hideConfirmModal() {
 }
 
 function _confirmCallback() {
-  var fn = _confirmCallbackFn;
+  const fn = _confirmCallbackFn;
   _confirmCallbackFn = null;
-  var btn = document.getElementById("confirm-submit");
+  const btn = document.getElementById("confirm-submit");
   if (btn) btn.disabled = true;
   if (fn) fn();
   hideConfirmModal();
@@ -2479,10 +2479,10 @@ function _confirmCallback() {
 // Settings — form-based editor grouped by section
 // ---------------------------------------------------------------------------
 
-var _settingsOriginal = {}; // original values for dirty detection
+let _settingsOriginal = {}; // original values for dirty detection
 
 // Section display order
-var _settingsSectionOrder = [
+const _settingsSectionOrder = [
   "model",
   "session",
   "tools",
@@ -2498,7 +2498,7 @@ var _settingsSectionOrder = [
 ];
 
 function _settingsSectionLabel(section) {
-  var labels = {
+  const labels = {
     model: "Model",
     session: "Session",
     tools: "Tools",
@@ -2520,8 +2520,8 @@ function _settingsSectionLabel(section) {
 // ---------------------------------------------------------------------------
 
 function loadTlsCerts() {
-  var statusEl = document.getElementById("tls-ca-status");
-  var listEl = document.getElementById("tls-cert-list");
+  const statusEl = document.getElementById("tls-ca-status");
+  const listEl = document.getElementById("tls-cert-list");
   if (!statusEl || !listEl) return;
 
   // Fetch CA status and cert list in parallel
@@ -2536,13 +2536,13 @@ function loadTlsCerts() {
     }),
   ])
     .then(function (results) {
-      var data = results[0];
-      var certData = results[1];
+      const data = results[0];
+      const certData = results[1];
       while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
       while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
 
       if (!data.enabled) {
-        var msg = document.createElement("div");
+        let msg = document.createElement("div");
         msg.className = "dashboard-empty";
         msg.textContent =
           "TLS is not enabled. Set tls.enabled = true in Settings.";
@@ -2551,19 +2551,19 @@ function loadTlsCerts() {
       }
 
       // CA status bar
-      var bar = document.createElement("div");
+      const bar = document.createElement("div");
       bar.className = "tls-ca-bar";
-      var caLabel = document.createElement("span");
+      const caLabel = document.createElement("span");
       caLabel.textContent = "CA: " + data.ca_cn;
-      var countLabel = document.createElement("span");
+      const countLabel = document.createElement("span");
       countLabel.textContent = "Certificates: " + data.cert_count;
       bar.appendChild(caLabel);
       bar.appendChild(countLabel);
       statusEl.appendChild(bar);
 
-      var certs = certData.certs || [];
+      const certs = certData.certs || [];
       if (certs.length === 0) {
-        var empty = document.createElement("div");
+        let empty = document.createElement("div");
         empty.className = "dashboard-empty";
         empty.textContent = "No certificates issued yet.";
         listEl.appendChild(empty);
@@ -2572,36 +2572,36 @@ function loadTlsCerts() {
 
       // Cert rows
       certs.forEach(function (c) {
-        var row = document.createElement("div");
+        const row = document.createElement("div");
         row.className = "admin-row";
         row.setAttribute("role", "listitem");
 
-        var colDomain = document.createElement("span");
+        const colDomain = document.createElement("span");
         colDomain.className = "admin-col";
         colDomain.textContent = c.domain;
 
-        var colSans = document.createElement("span");
+        const colSans = document.createElement("span");
         colSans.className = "admin-col";
         colSans.textContent = (c.domains || [c.domain]).join(", ");
 
-        var colIssued = document.createElement("span");
+        const colIssued = document.createElement("span");
         colIssued.className = "admin-col";
         colIssued.textContent = (c.issued_at || "")
           .slice(0, 16)
           .replace("T", " ");
 
-        var colExpires = document.createElement("span");
+        const colExpires = document.createElement("span");
         colExpires.className = "admin-col";
-        var expires = new Date(c.expires_at);
-        var isExpired = expires < new Date();
+        const expires = new Date(c.expires_at);
+        const isExpired = expires < new Date();
         colExpires.textContent =
           (isExpired ? "EXPIRED " : "") +
           (c.expires_at || "").slice(0, 16).replace("T", " ");
         if (isExpired) colExpires.style.color = "var(--red)";
 
-        var colActions = document.createElement("span");
+        const colActions = document.createElement("span");
         colActions.className = "admin-col admin-col-actions";
-        var renewBtn = document.createElement("button");
+        const renewBtn = document.createElement("button");
         renewBtn.className = "admin-btn-action";
         renewBtn.textContent = "Renew";
         renewBtn.setAttribute(
@@ -2611,7 +2611,7 @@ function loadTlsCerts() {
         renewBtn.onclick = function () {
           tlsRenewCert(c.domain);
         };
-        var deleteBtn = document.createElement("button");
+        const deleteBtn = document.createElement("button");
         deleteBtn.className = "admin-btn-danger";
         deleteBtn.textContent = "Delete";
         deleteBtn.setAttribute(
@@ -2635,7 +2635,7 @@ function loadTlsCerts() {
     .catch(function () {
       while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
       while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
-      var errMsg = document.createElement("div");
+      const errMsg = document.createElement("div");
       errMsg.className = "dashboard-empty";
       errMsg.textContent = "Failed to load TLS status";
       statusEl.appendChild(errMsg);
@@ -2690,7 +2690,7 @@ function tlsDeleteCert(domain) {
 // ---------------------------------------------------------------------------
 
 function loadSettings() {
-  var el = document.getElementById("admin-settings-content");
+  const el = document.getElementById("admin-settings-content");
   if (!el) return;
 
   Promise.all([
@@ -2708,21 +2708,21 @@ function loadSettings() {
     }),
   ])
     .then(function (results) {
-      var valuesArr = results[0].settings || [];
-      var schemaArr = results[1].schema || [];
-      var modelDefs = results[2].models || [];
+      const valuesArr = results[0].settings || [];
+      const schemaArr = results[1].schema || [];
+      const modelDefs = results[2].models || [];
 
       // Build schema lookup
-      var schemaMap = {};
-      for (var i = 0; i < schemaArr.length; i++) {
+      const schemaMap = {};
+      for (let i = 0; i < schemaArr.length; i++) {
         schemaMap[schemaArr[i].key] = schemaArr[i];
       }
 
       // Merge values + schema.  Skip role-assignment settings owned by
       // the Models → Roles sub-tab (judge.* settings still live on the
       // Judge tab; the model-tab roles render only there).
-      var merged = {};
-      var roleKeys = {
+      const merged = {};
+      const roleKeys = {
         "coordinator.model_alias": 1,
         "coordinator.reasoning_effort": 1,
         "model.plan_alias": 1,
@@ -2731,11 +2731,11 @@ function loadSettings() {
         "model.task_effort": 1,
         "channels.default_model_alias": 1,
       };
-      for (var j = 0; j < valuesArr.length; j++) {
-        var v = valuesArr[j];
+      for (let j = 0; j < valuesArr.length; j++) {
+        const v = valuesArr[j];
         if (v.key.startsWith("judge.")) continue;
         if (roleKeys[v.key]) continue;
-        var s = schemaMap[v.key] || {};
+        const s = schemaMap[v.key] || {};
         merged[v.key] = {
           key: v.key,
           value: v.value,
@@ -2757,13 +2757,13 @@ function loadSettings() {
       }
 
       // Inject dynamic choices for model alias settings from model definitions.
-      var enabledAliases = [""];
-      for (var m = 0; m < modelDefs.length; m++) {
+      const enabledAliases = [""];
+      for (let m = 0; m < modelDefs.length; m++) {
         if (modelDefs[m].enabled) enabledAliases.push(modelDefs[m].alias);
       }
       if (enabledAliases.length > 1) {
-        for (var ak = 0; ak < ALIAS_SETTING_KEYS.length; ak++) {
-          var aliasKey = ALIAS_SETTING_KEYS[ak];
+        for (let ak = 0; ak < ALIAS_SETTING_KEYS.length; ak++) {
+          const aliasKey = ALIAS_SETTING_KEYS[ak];
           if (merged[aliasKey]) merged[aliasKey].choices = enabledAliases;
         }
       }
@@ -2771,11 +2771,11 @@ function loadSettings() {
       _settingsOriginal = {};
 
       // Group by section
-      var grouped = {};
-      var keys = Object.keys(merged);
-      for (var k = 0; k < keys.length; k++) {
-        var item = merged[keys[k]];
-        var sec = item.section || "other";
+      const grouped = {};
+      const keys = Object.keys(merged);
+      for (let k = 0; k < keys.length; k++) {
+        const item = merged[keys[k]];
+        const sec = item.section || "other";
         if (!grouped[sec]) grouped[sec] = [];
         grouped[sec].push(item);
       }
@@ -2794,11 +2794,11 @@ function loadSettings() {
 }
 
 function _renderSettings(container, grouped) {
-  var html = "";
+  let html = "";
 
-  for (var i = 0; i < _settingsSectionOrder.length; i++) {
-    var sec = _settingsSectionOrder[i];
-    var items = grouped[sec];
+  for (let i = 0; i < _settingsSectionOrder.length; i++) {
+    const sec = _settingsSectionOrder[i];
+    const items = grouped[sec];
     if (!items || items.length === 0) continue;
 
     html +=
@@ -2814,7 +2814,7 @@ function _renderSettings(container, grouped) {
     html +=
       '<div class="settings-section-body" id="settings-body-' + sec + '">';
 
-    for (var j = 0; j < items.length; j++) {
+    for (let j = 0; j < items.length; j++) {
       html += _renderSettingRow(items[j]);
     }
 
@@ -2822,10 +2822,10 @@ function _renderSettings(container, grouped) {
   }
 
   // Render any sections not in the explicit order
-  var allSections = Object.keys(grouped);
-  for (var s = 0; s < allSections.length; s++) {
+  const allSections = Object.keys(grouped);
+  for (let s = 0; s < allSections.length; s++) {
     if (_settingsSectionOrder.indexOf(allSections[s]) === -1) {
-      var extra = grouped[allSections[s]];
+      const extra = grouped[allSections[s]];
       html +=
         '<div class="settings-section" data-section="' +
         allSections[s] +
@@ -2840,7 +2840,7 @@ function _renderSettings(container, grouped) {
         '<div class="settings-section-body" id="settings-body-' +
         allSections[s] +
         '">';
-      for (var x = 0; x < extra.length; x++) {
+      for (let x = 0; x < extra.length; x++) {
         html += _renderSettingRow(extra[x]);
       }
       html += "</div></div>";
@@ -2852,8 +2852,8 @@ function _renderSettings(container, grouped) {
   // Bind handlers via data-* attributes — a key with an apostrophe
   // would otherwise break out of the JS string when the HTML parser
   // decodes &#39; before JS evaluation.
-  var sectionHeaders = container.querySelectorAll(".settings-section-header");
-  for (var sh = 0; sh < sectionHeaders.length; sh++) {
+  const sectionHeaders = container.querySelectorAll(".settings-section-header");
+  for (let sh = 0; sh < sectionHeaders.length; sh++) {
     sectionHeaders[sh].addEventListener("click", function () {
       _toggleSettingsSection(this);
     });
@@ -2861,8 +2861,8 @@ function _renderSettings(container, grouped) {
       _onSettingsHeaderKey(e, this);
     });
   }
-  var helpBtns = container.querySelectorAll(".settings-help-btn");
-  for (var hb = 0; hb < helpBtns.length; hb++) {
+  const helpBtns = container.querySelectorAll(".settings-help-btn");
+  for (let hb = 0; hb < helpBtns.length; hb++) {
     helpBtns[hb].addEventListener("click", function (e) {
       _toggleSettingsHelp(e, this);
     });
@@ -2870,29 +2870,29 @@ function _renderSettings(container, grouped) {
 
   // Store original values for dirty detection + wire per-key change
   // handlers off data-setting-key (no key interpolation into JS).
-  var inputs = container.querySelectorAll("[data-setting-key]");
-  for (var n = 0; n < inputs.length; n++) {
-    var inp = inputs[n];
-    var key = inp.getAttribute("data-setting-key");
+  const inputs = container.querySelectorAll("[data-setting-key]");
+  for (let n = 0; n < inputs.length; n++) {
+    const inp = inputs[n];
+    const key = inp.getAttribute("data-setting-key");
     if (inp.type === "checkbox") {
       _settingsOriginal[key] = inp.checked;
     } else {
       _settingsOriginal[key] = inp.value;
     }
-    var evtName =
+    const evtName =
       inp.type === "checkbox" || inp.tagName === "SELECT" ? "change" : "input";
     inp.addEventListener(evtName, function () {
       _onSettingChange(this);
     });
   }
-  var saveBtns = container.querySelectorAll("[data-save-key]");
-  for (var sb = 0; sb < saveBtns.length; sb++) {
+  const saveBtns = container.querySelectorAll("[data-save-key]");
+  for (let sb = 0; sb < saveBtns.length; sb++) {
     saveBtns[sb].addEventListener("click", function () {
       _saveSettingValue(this.getAttribute("data-save-key"));
     });
   }
-  var resetBtns = container.querySelectorAll("[data-reset-key]");
-  for (var rb = 0; rb < resetBtns.length; rb++) {
+  const resetBtns = container.querySelectorAll("[data-reset-key]");
+  for (let rb = 0; rb < resetBtns.length; rb++) {
     resetBtns[rb].addEventListener("click", function () {
       _resetSetting(this.getAttribute("data-reset-key"));
     });
@@ -2900,15 +2900,15 @@ function _renderSettings(container, grouped) {
 }
 
 function _renderSettingRow(item) {
-  var shortKey =
+  const shortKey =
     item.key.indexOf(".") !== -1
       ? item.key.substring(item.key.indexOf(".") + 1)
       : item.key;
-  var escapedKey = escapeHtml(item.key);
-  var escapedShort = escapeHtml(shortKey);
-  var escapedDesc = escapeHtml(item.description);
+  const escapedKey = escapeHtml(item.key);
+  const escapedShort = escapeHtml(shortKey);
+  const escapedDesc = escapeHtml(item.description);
 
-  var html = '<div class="settings-row" data-row-key="' + escapedKey + '">';
+  let html = '<div class="settings-row" data-row-key="' + escapedKey + '">';
 
   // Label column
   html += '<div class="settings-label-col">';
@@ -2951,7 +2951,7 @@ function _renderSettingRow(item) {
       (item.source === "storage" ? "***" : "not set") +
       '">';
   } else if (item.type === "bool") {
-    var checked =
+    const checked =
       item.value === true || item.value === "true" ? " checked" : "";
     html +=
       '<label class="settings-toggle"><input type="checkbox" data-setting-key="' +
@@ -2968,9 +2968,9 @@ function _renderSettingRow(item) {
       '" aria-label="' +
       escapedShort +
       '">';
-    for (var c = 0; c < item.choices.length; c++) {
-      var sel = item.choices[c] === String(item.value) ? " selected" : "";
-      var label;
+    for (let c = 0; c < item.choices.length; c++) {
+      const sel = item.choices[c] === String(item.value) ? " selected" : "";
+      let label;
       if (item.choices[c] !== "") {
         label = escapeHtml(item.choices[c]);
       } else if (ALIAS_SETTING_KEYS.indexOf(item.key) !== -1) {
@@ -2991,12 +2991,12 @@ function _renderSettingRow(item) {
     }
     html += "</select>";
   } else if (item.type === "int" || item.type === "float") {
-    var step = item.type === "float" ? "0.01" : "1";
-    var minAttr =
+    const step = item.type === "float" ? "0.01" : "1";
+    const minAttr =
       item.min_value !== null && item.min_value !== undefined
         ? ' min="' + item.min_value + '"'
         : "";
-    var maxAttr =
+    const maxAttr =
       item.max_value !== null && item.max_value !== undefined
         ? ' max="' + item.max_value + '"'
         : "";
@@ -3065,11 +3065,11 @@ function _renderSettingRow(item) {
 
 function _toggleSettingsHelp(e, btn) {
   e.stopPropagation();
-  var popover = btn
+  const popover = btn
     .closest(".settings-label-col")
     .querySelector(".settings-help-popover");
   if (!popover) return;
-  var isVisible = popover.style.display !== "none";
+  const isVisible = popover.style.display !== "none";
   // Close any other open popovers and reset their buttons
   _closeAllSettingsHelp(popover);
   popover.style.display = isVisible ? "none" : "";
@@ -3077,13 +3077,13 @@ function _toggleSettingsHelp(e, btn) {
 }
 
 function _closeAllSettingsHelp(except) {
-  var allOpen = document.querySelectorAll('.settings-help-popover[style=""]');
-  for (var i = 0; i < allOpen.length; i++) {
+  const allOpen = document.querySelectorAll('.settings-help-popover[style=""]');
+  for (let i = 0; i < allOpen.length; i++) {
     if (allOpen[i] !== except) {
       allOpen[i].style.display = "none";
-      var col = allOpen[i].closest(".settings-label-col");
+      const col = allOpen[i].closest(".settings-label-col");
       if (col) {
-        var helpBtn = col.querySelector(".settings-help-btn");
+        const helpBtn = col.querySelector(".settings-help-btn");
         if (helpBtn) helpBtn.setAttribute("aria-expanded", "false");
       }
     }
@@ -3098,7 +3098,7 @@ function _onSettingsHeaderKey(e, el) {
 }
 
 function _toggleSettingsSection(headerEl) {
-  var section = headerEl.parentElement;
+  const section = headerEl.parentElement;
   if (section.hasAttribute("data-collapsed")) {
     section.removeAttribute("data-collapsed");
     headerEl.setAttribute("aria-expanded", "true");
@@ -3114,21 +3114,21 @@ function _onSettingChange(inp) {
   // selector per keystroke.  Save button + restart badge for this key
   // live inside the same ``.settings-row`` (which carries the unique
   // ``data-row-key``).
-  var row = inp.closest(".settings-row");
+  const row = inp.closest(".settings-row");
   if (!row) return;
-  var saveBtn = row.querySelector("[data-save-key]");
+  const saveBtn = row.querySelector("[data-save-key]");
   if (!saveBtn) return;
-  var key = inp.getAttribute("data-setting-key");
+  const key = inp.getAttribute("data-setting-key");
 
-  var current;
+  let current;
   if (inp.type === "checkbox") {
     current = inp.checked;
   } else {
     current = inp.value;
   }
 
-  var orig = _settingsOriginal[key];
-  var dirty;
+  const orig = _settingsOriginal[key];
+  let dirty;
   if (inp.type === "checkbox") {
     dirty = current !== orig;
   } else if (inp.type === "number" && current !== "" && orig !== "") {
@@ -3139,7 +3139,7 @@ function _onSettingChange(inp) {
   }
 
   // Disable save for empty number fields (server will reject)
-  var emptyNumber = inp.type === "number" && current === "";
+  const emptyNumber = inp.type === "number" && current === "";
   if (dirty && !emptyNumber) {
     saveBtn.classList.add("visible");
   } else {
@@ -3147,18 +3147,18 @@ function _onSettingChange(inp) {
   }
 
   // Show/hide restart badge alongside dirty state (but keep it if already saved)
-  var restartBadge = row.querySelector("[data-restart-key]");
+  const restartBadge = row.querySelector("[data-restart-key]");
   if (restartBadge && !restartBadge.classList.contains("saved")) {
     restartBadge.classList.toggle("visible", dirty);
   }
 }
 
 function _saveSettingValue(key) {
-  var inp = document.querySelector('[data-setting-key="' + key + '"]');
-  var saveBtn = document.querySelector('[data-save-key="' + key + '"]');
+  const inp = document.querySelector('[data-setting-key="' + key + '"]');
+  const saveBtn = document.querySelector('[data-save-key="' + key + '"]');
   if (!inp) return;
 
-  var value;
+  let value;
   if (inp.type === "checkbox") {
     value = inp.checked;
   } else if (inp.type === "number") {
@@ -3214,18 +3214,18 @@ function _saveSettingValue(key) {
       }
 
       // Update source badge to "storage"
-      var row = document.querySelector('[data-row-key="' + key + '"]');
+      const row = document.querySelector('[data-row-key="' + key + '"]');
       if (row) {
-        var badge = row.querySelector(".scope-badge");
+        const badge = row.querySelector(".scope-badge");
         if (badge) {
           badge.className = "scope-badge scope-write";
           badge.textContent = "storage";
         }
         // Add reset button if not present
         if (!row.querySelector('[data-reset-key="' + key + '"]')) {
-          var actions = row.querySelector(".settings-actions");
+          const actions = row.querySelector(".settings-actions");
           if (actions) {
-            var resetBtn = document.createElement("button");
+            const resetBtn = document.createElement("button");
             resetBtn.className = "settings-reset-btn";
             resetBtn.setAttribute("data-reset-key", key);
             resetBtn.textContent = "reset";
@@ -3238,7 +3238,7 @@ function _saveSettingValue(key) {
       }
 
       // Show restart badge post-save (stays until page reload = restart)
-      var restartBadge = document.querySelector(
+      const restartBadge = document.querySelector(
         '[data-restart-key="' + key + '"]',
       );
       if (restartBadge) {
@@ -3265,13 +3265,13 @@ function _saveSettingValue(key) {
       // onThemeChange — it would fire a redundant PUT since the settings
       // save above already persisted the value.
       if (key === "interface.theme") {
-        var isLight = value === "light";
+        const isLight = value === "light";
         document.documentElement.dataset.theme = isLight ? "light" : "";
         localStorage.setItem(
           "turnstone_interface.theme",
           isLight ? "light" : "dark",
         );
-        var themeBtn = document.getElementById("theme-toggle");
+        const themeBtn = document.getElementById("theme-toggle");
         if (themeBtn) {
           themeBtn.textContent = isLight ? "\u2600" : "\u263E";
           themeBtn.title = isLight
@@ -3336,20 +3336,20 @@ function _showModalError(el, msg) {
 
 /* ── MCP Servers tab ─────────────────────────────────────────────────────── */
 
-var _mcpServers = [];
-var _mcpCreateTrap = null;
-var _mcpCreateTrigger = null;
-var _mcpImportTrap = null;
-var _mcpImportTrigger = null;
-var _mcpDetailTrap = null;
-var _mcpDetailTrigger = null;
-var _mcpInstallTrap = null;
-var _mcpInstallTrigger = null;
-var _mcpInstallServer = null;
-var _mcpCurrentView = "servers";
-var _registryResults = [];
-var _registryCursor = null;
-var _registryQuery = "";
+let _mcpServers = [];
+let _mcpCreateTrap = null;
+let _mcpCreateTrigger = null;
+let _mcpImportTrap = null;
+let _mcpImportTrigger = null;
+let _mcpDetailTrap = null;
+let _mcpDetailTrigger = null;
+let _mcpInstallTrap = null;
+let _mcpInstallTrigger = null;
+let _mcpInstallServer = null;
+let _mcpCurrentView = "servers";
+let _registryResults = [];
+let _registryCursor = null;
+let _registryQuery = "";
 
 function loadAdminMcp() {
   authFetch("/v1/api/admin/mcp-servers")
@@ -3370,7 +3370,7 @@ function loadAdminMcp() {
 }
 
 function _renderMcpServers(items) {
-  var el = document.getElementById("admin-mcp-table");
+  const el = document.getElementById("admin-mcp-table");
   if (!items.length) {
     setSafeHtml(
       el,
@@ -3378,24 +3378,24 @@ function _renderMcpServers(items) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < items.length; i++) {
-    var s = items[i];
-    var statusEntries = s.status || {};
-    var nodeIds = Object.keys(statusEntries);
-    var anyConnected = false;
-    var anyError = false;
-    var firstError = "";
-    var totalTools = 0,
+  let html = "";
+  for (let i = 0; i < items.length; i++) {
+    const s = items[i];
+    const statusEntries = s.status || {};
+    const nodeIds = Object.keys(statusEntries);
+    let anyConnected = false;
+    let anyError = false;
+    let firstError = "";
+    let totalTools = 0,
       totalRes = 0,
       totalPrompts = 0;
     // Phase 9: aggregate the most-recent refresh entry across nodes
     // so the admin pill reflects "the freshest known state" rather
     // than picking an arbitrary node.
-    var newestRefreshAt = null;
-    var newestRefreshOutcome = null;
-    for (var j = 0; j < nodeIds.length; j++) {
-      var ns = statusEntries[nodeIds[j]];
+    let newestRefreshAt = null;
+    let newestRefreshOutcome = null;
+    for (let j = 0; j < nodeIds.length; j++) {
+      const ns = statusEntries[nodeIds[j]];
       if (ns.connected) {
         anyConnected = true;
         totalTools += ns.tools || 0;
@@ -3415,9 +3415,9 @@ function _renderMcpServers(items) {
       }
     }
 
-    var dotClass = "mcp-status-dot disabled";
-    var rowClass = "mcp-row-disabled";
-    var statusText = "disabled";
+    let dotClass = "mcp-status-dot disabled";
+    let rowClass = "mcp-row-disabled";
+    let statusText = "disabled";
     if (!s.enabled) {
       statusText = "disabled";
     } else if (anyConnected) {
@@ -3443,22 +3443,22 @@ function _renderMcpServers(items) {
     // in the tooltip.  Pill is omitted (and the cell stays unchanged from
     // its pre-Phase-9 shape) when no node has yet recorded a refresh
     // outcome for this server.
-    var refreshPill = "";
+    let refreshPill = "";
     if (newestRefreshAt !== null) {
-      var ageSeconds = Math.max(
+      const ageSeconds = Math.max(
         0,
         Math.floor(Date.now() / 1000 - newestRefreshAt),
       );
-      var ageShort;
+      let ageShort;
       if (ageSeconds < 60) ageShort = ageSeconds + "s";
       else if (ageSeconds < 3600) ageShort = Math.floor(ageSeconds / 60) + "m";
       else if (ageSeconds < 86400)
         ageShort = Math.floor(ageSeconds / 3600) + "h";
       else ageShort = Math.floor(ageSeconds / 86400) + "d";
-      var outcomeText = newestRefreshOutcome || "unknown";
-      var pillCls =
+      const outcomeText = newestRefreshOutcome || "unknown";
+      const pillCls =
         outcomeText === "ok" ? "mcp-refresh-pill-ok" : "mcp-refresh-pill-err";
-      var pillTitle =
+      const pillTitle =
         "Last refresh " +
         new Date(newestRefreshAt * 1000).toISOString() +
         " (" +
@@ -3474,29 +3474,29 @@ function _renderMcpServers(items) {
         "</span>";
     }
 
-    var transportCls =
+    const transportCls =
       s.transport === "stdio" ? "mcp-transport-stdio" : "mcp-transport-http";
-    var toolsVal = anyConnected
+    const toolsVal = anyConnected
       ? totalTools
       : '<span class="mcp-count-dim">--</span>';
-    var resVal = anyConnected
+    const resVal = anyConnected
       ? totalRes
       : '<span class="mcp-count-dim">--</span>';
-    var promptsVal = anyConnected
+    const promptsVal = anyConnected
       ? totalPrompts
       : '<span class="mcp-count-dim">--</span>';
 
-    var isConfig = s.source === "config";
-    var isRegistry = !!s.registry_name;
-    var nameBadge = isConfig
+    const isConfig = s.source === "config";
+    const isRegistry = !!s.registry_name;
+    const nameBadge = isConfig
       ? ' <span class="scope-badge scope-config">config</span>'
       : isRegistry
         ? ' <span class="scope-badge scope-registry">registry</span>'
         : ' <span class="scope-badge scope-manual">manual</span>';
-    var detailAttr = isConfig
+    const detailAttr = isConfig
       ? 'data-mcp-detail-name="' + escapeHtml(s.name) + '"'
       : 'data-mcp-detail="' + escapeHtml(s.server_id) + '"';
-    var actionBtns =
+    let actionBtns =
       '<button class="admin-btn-action" data-mcp-refresh="' +
       escapeHtml(s.name) +
       '">refresh</button>' +
@@ -3510,7 +3510,7 @@ function _renderMcpServers(items) {
         '">connect</button>';
       // Phase 9: surface the consented-users count + bulk-revoke
       // affordance only when at least one user has consented.
-      var consentCount =
+      const consentCount =
         typeof s.consented_users_count === "number"
           ? s.consented_users_count
           : 0;
@@ -3527,7 +3527,7 @@ function _renderMcpServers(items) {
           ")</button>";
       }
     }
-    var actions = isConfig
+    const actions = isConfig
       ? actionBtns
       : actionBtns +
         '<button class="admin-btn-action" data-mcp-edit="' +
@@ -3598,7 +3598,7 @@ function _renderMcpServers(items) {
   });
   el.querySelectorAll("[data-mcp-refresh]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var name = this.getAttribute("data-mcp-refresh");
+      const name = this.getAttribute("data-mcp-refresh");
       authFetch(
         "/v1/api/admin/mcp-servers/" + encodeURIComponent(name) + "/refresh",
         { method: "POST" },
@@ -3618,7 +3618,7 @@ function _renderMcpServers(items) {
   });
   el.querySelectorAll("[data-mcp-reconnect]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var name = this.getAttribute("data-mcp-reconnect");
+      const name = this.getAttribute("data-mcp-reconnect");
       authFetch(
         "/v1/api/admin/mcp-servers/" + encodeURIComponent(name) + "/reconnect",
         { method: "POST" },
@@ -3638,10 +3638,10 @@ function _renderMcpServers(items) {
   });
   el.querySelectorAll("[data-mcp-oauth-connect]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var name = this.getAttribute("data-mcp-oauth-connect");
+      const name = this.getAttribute("data-mcp-oauth-connect");
       // Open the OAuth /start endpoint in a new window so the redirect
       // chain (AS → callback → return_url) doesn't displace the admin UI.
-      var url =
+      let url =
         "/v1/api/mcp/oauth/start?server=" +
         encodeURIComponent(name) +
         "&return_url=" +
@@ -3651,8 +3651,8 @@ function _renderMcpServers(items) {
   });
   el.querySelectorAll("[data-mcp-bulk-revoke]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var name = this.getAttribute("data-mcp-bulk-revoke");
-      var count = this.getAttribute("data-mcp-consent-count") || "?";
+      const name = this.getAttribute("data-mcp-bulk-revoke");
+      const count = this.getAttribute("data-mcp-consent-count") || "?";
       showConfirmModal(
         "Bulk-revoke MCP consents",
         "Drop all " +
@@ -3687,8 +3687,8 @@ function _renderMcpServers(items) {
   });
   el.querySelectorAll("[data-mcp-delete]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var sid = this.getAttribute("data-mcp-delete");
-      var sname = this.getAttribute("data-mcp-name");
+      const sid = this.getAttribute("data-mcp-delete");
+      const sname = this.getAttribute("data-mcp-name");
       showConfirmModal(
         "Delete MCP Server",
         'Delete server "' + sname + '"?',
@@ -3714,7 +3714,7 @@ function _renderMcpServers(items) {
 }
 
 function toggleMcpTransport() {
-  var v = document.getElementById("mcp-transport").value;
+  const v = document.getElementById("mcp-transport").value;
   document.getElementById("mcp-stdio-fields").style.display =
     v === "stdio" ? "" : "none";
   document.getElementById("mcp-http-fields").style.display =
@@ -3725,26 +3725,26 @@ function toggleMcpTransport() {
 }
 
 function _selectedMcpAuthType() {
-  var radios = document.getElementsByName("mcp-auth-type");
-  for (var i = 0; i < radios.length; i++) {
+  const radios = document.getElementsByName("mcp-auth-type");
+  for (let i = 0; i < radios.length; i++) {
     if (radios[i].checked) return radios[i].value;
   }
   return "static";
 }
 
 function toggleMcpAuthFields() {
-  var authType = _selectedMcpAuthType();
-  var oauthDiv = document.getElementById("mcp-oauth-fields");
+  const authType = _selectedMcpAuthType();
+  const oauthDiv = document.getElementById("mcp-oauth-fields");
   if (oauthDiv) {
     oauthDiv.style.display = authType === "oauth_user" ? "" : "none";
   }
   // The "Headers" textarea (inside mcp-http-fields) is only meaningful
   // for static auth; hide it for 'none' / 'oauth_user' so operators
   // don't accidentally configure stale credentials.
-  var headersInput = document.getElementById("mcp-headers");
+  const headersInput = document.getElementById("mcp-headers");
   if (headersInput) {
-    var headersLabel = document.querySelector('label[for="mcp-headers"]');
-    var show = authType === "static";
+    const headersLabel = document.querySelector('label[for="mcp-headers"]');
+    const show = authType === "static";
     headersInput.style.display = show ? "" : "none";
     if (headersLabel) headersLabel.style.display = show ? "" : "none";
   }
@@ -3752,18 +3752,18 @@ function toggleMcpAuthFields() {
 
 function _wireMcpAudienceAutofill() {
   // Idempotent — only attach the listener once per page lifetime.
-  var urlInput = document.getElementById("mcp-url");
+  const urlInput = document.getElementById("mcp-url");
   if (!urlInput || urlInput.dataset.audAutofill === "1") return;
   urlInput.dataset.audAutofill = "1";
   urlInput.addEventListener("blur", function () {
-    var aud = document.getElementById("mcp-oauth-audience");
+    const aud = document.getElementById("mcp-oauth-audience");
     if (aud && !aud.value.trim()) aud.value = urlInput.value.trim();
   });
 }
 
 function showCreateMcpModal() {
   _mcpCreateTrigger = document.activeElement;
-  var ov = document.getElementById("mcp-create-overlay");
+  const ov = document.getElementById("mcp-create-overlay");
   ov.style.display = "flex";
   document.getElementById("mcp-edit-id").value = "";
   document.getElementById("mcp-create-title").textContent = "Add MCP Server";
@@ -3812,13 +3812,13 @@ function showEditMcpModal(serverId) {
       document.getElementById("mcp-transport").value = s.transport;
       document.getElementById("mcp-command").value = s.command || "";
       try {
-        var argsList = JSON.parse(s.args || "[]");
+        const argsList = JSON.parse(s.args || "[]");
         document.getElementById("mcp-args").value = argsList.join("\n");
       } catch (e) {
         document.getElementById("mcp-args").value = "";
       }
       try {
-        var envObj = JSON.parse(s.env || "{}");
+        const envObj = JSON.parse(s.env || "{}");
         document.getElementById("mcp-env").value = Object.keys(envObj)
           .map(function (k) {
             return k + "=" + envObj[k];
@@ -3829,7 +3829,7 @@ function showEditMcpModal(serverId) {
       }
       document.getElementById("mcp-url").value = s.url || "";
       try {
-        var hdrObj = JSON.parse(s.headers || "{}");
+        const hdrObj = JSON.parse(s.headers || "{}");
         document.getElementById("mcp-headers").value = Object.keys(hdrObj)
           .map(function (k) {
             return k + ": " + hdrObj[k];
@@ -3841,7 +3841,7 @@ function showEditMcpModal(serverId) {
       document.getElementById("mcp-auto-approve").checked =
         s.auto_approve || false;
       document.getElementById("mcp-enabled").checked = s.enabled !== false;
-      var authType = s.auth_type || "static";
+      const authType = s.auth_type || "static";
       document.getElementById("mcp-auth-none").checked = authType === "none";
       document.getElementById("mcp-auth-static").checked =
         authType === "static";
@@ -3874,15 +3874,15 @@ function hideCreateMcpModal() {
 }
 
 function _parseMcpForm() {
-  var name = document.getElementById("mcp-name").value.trim();
-  var transport = document.getElementById("mcp-transport").value;
+  const name = document.getElementById("mcp-name").value.trim();
+  const transport = document.getElementById("mcp-transport").value;
   if (!name) return { error: "Name is required" };
   if (!/^[a-zA-Z0-9._-]+$/.test(name))
     return { error: "Name must match [a-zA-Z0-9._-]+" };
   if (name.indexOf("__") >= 0) return { error: "Name must not contain '__'" };
 
-  var authType = _selectedMcpAuthType();
-  var payload = {
+  const authType = _selectedMcpAuthType();
+  const payload = {
     name: name,
     transport: transport,
     auto_approve: document.getElementById("mcp-auto-approve").checked,
@@ -3892,7 +3892,7 @@ function _parseMcpForm() {
 
   if (transport === "stdio") {
     payload.command = document.getElementById("mcp-command").value.trim();
-    var argsText = document.getElementById("mcp-args").value.trim();
+    const argsText = document.getElementById("mcp-args").value.trim();
     payload.args = argsText
       ? argsText
           .split("\n")
@@ -3901,11 +3901,11 @@ function _parseMcpForm() {
           })
           .filter(Boolean)
       : [];
-    var envText = document.getElementById("mcp-env").value.trim();
-    var envObj = {};
+    const envText = document.getElementById("mcp-env").value.trim();
+    const envObj = {};
     if (envText) {
       envText.split("\n").forEach(function (line) {
-        var eq = line.indexOf("=");
+        const eq = line.indexOf("=");
         if (eq > 0)
           envObj[line.substring(0, eq).trim()] = line.substring(eq + 1).trim();
       });
@@ -3914,11 +3914,11 @@ function _parseMcpForm() {
   } else {
     payload.url = document.getElementById("mcp-url").value.trim();
     if (authType === "static") {
-      var hdrText = document.getElementById("mcp-headers").value.trim();
-      var hdrObj = {};
+      const hdrText = document.getElementById("mcp-headers").value.trim();
+      const hdrObj = {};
       if (hdrText) {
         hdrText.split("\n").forEach(function (line) {
-          var colon = line.indexOf(":");
+          const colon = line.indexOf(":");
           if (colon > 0)
             hdrObj[line.substring(0, colon).trim()] = line
               .substring(colon + 1)
@@ -3948,7 +3948,7 @@ function _parseMcpForm() {
     payload.oauth_audience = document
       .getElementById("mcp-oauth-audience")
       .value.trim();
-    var secret = document.getElementById("mcp-oauth-client-secret").value;
+    const secret = document.getElementById("mcp-oauth-client-secret").value;
     // Submit only when the operator typed a value; redacted in audit log.
     if (secret) payload.oauth_client_secret = secret;
   }
@@ -3957,16 +3957,16 @@ function _parseMcpForm() {
 }
 
 function submitCreateMcp() {
-  var form = _parseMcpForm();
+  const form = _parseMcpForm();
   if (form.error) {
-    var e = document.getElementById("mcp-create-error");
+    const e = document.getElementById("mcp-create-error");
     e.textContent = form.error;
     e.classList.add("is-visible");
     return;
   }
-  var editId = document.getElementById("mcp-edit-id").value;
-  var method = editId ? "PUT" : "POST";
-  var url = editId
+  const editId = document.getElementById("mcp-edit-id").value;
+  const method = editId ? "PUT" : "POST";
+  let url = editId
     ? "/v1/api/admin/mcp-servers/" + editId
     : "/v1/api/admin/mcp-servers";
 
@@ -3990,7 +3990,7 @@ function submitCreateMcp() {
       loadAdminMcp();
     })
     .catch(function (e) {
-      var el = document.getElementById("mcp-create-error");
+      const el = document.getElementById("mcp-create-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -4000,12 +4000,12 @@ function submitCreateMcp() {
 }
 
 function _flagMcpSyncPending() {
-  var btn = document.getElementById("mcp-sync-btn");
+  const btn = document.getElementById("mcp-sync-btn");
   if (btn) btn.classList.add("mcp-sync-pending");
 }
 
 function _clearMcpSyncPending() {
-  var btn = document.getElementById("mcp-sync-btn");
+  const btn = document.getElementById("mcp-sync-btn");
   if (btn) btn.classList.remove("mcp-sync-pending");
 }
 
@@ -4016,16 +4016,16 @@ function reloadMcpNodes() {
       return r.json();
     })
     .then(function (data) {
-      var results = data.results || {};
-      var nodeIds = Object.keys(results);
-      var totalAdded = 0,
+      const results = data.results || {};
+      const nodeIds = Object.keys(results);
+      let totalAdded = 0,
         totalRemoved = 0;
-      for (var i = 0; i < nodeIds.length; i++) {
-        var nr = results[nodeIds[i]];
+      for (let i = 0; i < nodeIds.length; i++) {
+        const nr = results[nodeIds[i]];
         totalAdded += (nr.added || []).length;
         totalRemoved += (nr.removed || []).length;
       }
-      var msg = "Reload sent to " + nodeIds.length + " node(s)";
+      let msg = "Reload sent to " + nodeIds.length + " node(s)";
       if (totalAdded) msg += ", +" + totalAdded + " added";
       if (totalRemoved) msg += ", -" + totalRemoved + " removed";
       showToast(msg);
@@ -4038,7 +4038,7 @@ function reloadMcpNodes() {
 }
 
 function showMcpDetailByName(name) {
-  for (var i = 0; i < _mcpServers.length; i++) {
+  for (let i = 0; i < _mcpServers.length; i++) {
     if (_mcpServers[i].name === name) {
       return _openMcpDetail(_mcpServers[i]);
     }
@@ -4046,7 +4046,7 @@ function showMcpDetailByName(name) {
 }
 
 function showMcpDetailModal(serverId) {
-  for (var i = 0; i < _mcpServers.length; i++) {
+  for (let i = 0; i < _mcpServers.length; i++) {
     if (_mcpServers[i].server_id === serverId) {
       return _openMcpDetail(_mcpServers[i]);
     }
@@ -4057,7 +4057,7 @@ function _openMcpDetail(s) {
   if (!s) return;
   _mcpDetailTrigger = document.activeElement;
 
-  var html = '<div class="modal-columns">';
+  let html = '<div class="modal-columns">';
   html += '<div class="modal-col">';
   html += '<div class="mcp-detail-section"><h3>Configuration</h3>';
   html +=
@@ -4072,7 +4072,7 @@ function _openMcpDetail(s) {
       escapeHtml(s.command || "") +
       "</code></p>";
     try {
-      var a = JSON.parse(s.args || "[]");
+      const a = JSON.parse(s.args || "[]");
       if (a.length)
         html +=
           '<p style="font-size:12px;color:var(--fg-dim)">Args: <code>' +
@@ -4099,7 +4099,7 @@ function _openMcpDetail(s) {
         "</code></p>";
     }
     try {
-      var meta =
+      const meta =
         typeof s.registry_meta === "string"
           ? JSON.parse(s.registry_meta)
           : s.registry_meta || {};
@@ -4123,20 +4123,20 @@ function _openMcpDetail(s) {
   html += "</div>";
 
   html += '<div class="modal-col">';
-  var statusEntries = s.status || {};
-  var nodeIds = Object.keys(statusEntries);
+  const statusEntries = s.status || {};
+  const nodeIds = Object.keys(statusEntries);
   html += '<div class="mcp-detail-section"><h3>Node Status</h3>';
   if (nodeIds.length === 0) {
     html +=
       '<p style="font-size:12px;color:var(--fg-dim)">Not connected on any node</p>';
   } else {
     html += '<ul class="mcp-detail-list">';
-    for (var j = 0; j < nodeIds.length; j++) {
-      var ns = statusEntries[nodeIds[j]];
-      var dot = ns.connected
+    for (let j = 0; j < nodeIds.length; j++) {
+      const ns = statusEntries[nodeIds[j]];
+      const dot = ns.connected
         ? '<span class="mcp-status-dot connected"></span>'
         : '<span class="mcp-status-dot error"></span>';
-      var nodeInfo =
+      let nodeInfo =
         escapeHtml(nodeIds[j]) +
         " — " +
         (ns.tools || 0) +
@@ -4187,24 +4187,24 @@ function hideImportMcpModal() {
 }
 
 function submitImportMcp() {
-  var raw = document.getElementById("mcp-import-json").value.trim();
+  const raw = document.getElementById("mcp-import-json").value.trim();
   if (!raw) {
-    var e = document.getElementById("mcp-import-error");
+    const e = document.getElementById("mcp-import-error");
     e.textContent = "Paste a JSON config";
     e.classList.add("is-visible");
     return;
   }
-  var parsed;
+  let parsed;
   try {
     parsed = JSON.parse(raw);
   } catch (ex) {
-    var e2 = document.getElementById("mcp-import-error");
+    const e2 = document.getElementById("mcp-import-error");
     e2.textContent = "Invalid JSON: " + ex.message;
     e2.classList.add("is-visible");
     return;
   }
   if (!parsed.mcpServers || typeof parsed.mcpServers !== "object") {
-    var e3 = document.getElementById("mcp-import-error");
+    const e3 = document.getElementById("mcp-import-error");
     e3.textContent = 'No "mcpServers" key found in JSON';
     e3.classList.add("is-visible");
     return;
@@ -4224,7 +4224,7 @@ function submitImportMcp() {
     })
     .then(function (data) {
       hideImportMcpModal();
-      var msg = "Imported " + (data.imported || []).length;
+      let msg = "Imported " + (data.imported || []).length;
       if ((data.skipped || []).length)
         msg += ", skipped " + data.skipped.length;
       if ((data.errors || []).length)
@@ -4234,7 +4234,7 @@ function submitImportMcp() {
       loadAdminMcp();
     })
     .catch(function (e) {
-      var el = document.getElementById("mcp-import-error");
+      const el = document.getElementById("mcp-import-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -4247,9 +4247,9 @@ function submitImportMcp() {
 
 function switchMcpView(view) {
   _mcpCurrentView = view;
-  var btns = document.querySelectorAll("#admin-mcp .mcp-view-btn");
-  for (var i = 0; i < btns.length; i++) {
-    var isActive = btns[i].getAttribute("data-mcp-view") === view;
+  const btns = document.querySelectorAll("#admin-mcp .mcp-view-btn");
+  for (let i = 0; i < btns.length; i++) {
+    const isActive = btns[i].getAttribute("data-mcp-view") === view;
     btns[i].classList.toggle("active", isActive);
     btns[i].setAttribute("aria-selected", isActive ? "true" : "false");
     btns[i].setAttribute("tabindex", isActive ? "0" : "-1");
@@ -4262,32 +4262,32 @@ function switchMcpView(view) {
     view === "servers" ? "" : "none";
   if (view === "servers") loadAdminMcp();
   if (view === "registry") {
-    var q = document.getElementById("mcp-registry-q");
+    const q = document.getElementById("mcp-registry-q");
     if (q) q.focus();
     if (!_registryResults.length) searchMcpRegistry();
   }
 }
 
 function searchMcpRegistry(append) {
-  var q = document.getElementById("mcp-registry-q").value.trim();
+  const q = document.getElementById("mcp-registry-q").value.trim();
   if (!append) {
     _registryResults = [];
     _registryCursor = null;
     _registryQuery = q;
-    var filterEl = document.getElementById("mcp-registry-filter");
+    const filterEl = document.getElementById("mcp-registry-filter");
     if (filterEl) filterEl.value = "";
   }
-  var url = "/v1/api/admin/mcp-registry/search?limit=20";
+  let url = "/v1/api/admin/mcp-registry/search?limit=20";
   if (_registryQuery) url += "&search=" + encodeURIComponent(_registryQuery);
   if (append && _registryCursor)
     url += "&cursor=" + encodeURIComponent(_registryCursor);
 
-  var resultsEl = document.getElementById("mcp-registry-results");
+  const resultsEl = document.getElementById("mcp-registry-results");
   if (!append) {
     setSafeHtml(resultsEl, '<div class="dashboard-empty">Searching…</div>');
   }
-  var searchBtn = document.getElementById("mcp-registry-search-btn");
-  var moreBtn = document.getElementById("mcp-registry-more");
+  const searchBtn = document.getElementById("mcp-registry-search-btn");
+  const moreBtn = document.getElementById("mcp-registry-more");
   if (searchBtn) searchBtn.disabled = true;
   if (moreBtn) moreBtn.disabled = true;
 
@@ -4329,7 +4329,7 @@ function _applyRegistryFilter() {
 }
 
 function _renderRegistryResults() {
-  var el = document.getElementById("mcp-registry-results");
+  const el = document.getElementById("mcp-registry-results");
   if (!_registryResults.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No servers found</div>');
     document.getElementById("mcp-registry-pagination").style.display = "none";
@@ -4337,15 +4337,15 @@ function _renderRegistryResults() {
   }
 
   // Client-side type filter
-  var filterEl = document.getElementById("mcp-registry-filter");
-  var typeFilter = filterEl ? filterEl.value : "";
+  const filterEl = document.getElementById("mcp-registry-filter");
+  const typeFilter = filterEl ? filterEl.value : "";
 
-  var html = "";
-  var visibleCount = 0;
-  for (var i = 0; i < _registryResults.length; i++) {
-    var srv = _registryResults[i];
-    var hasRemote = srv.remotes && srv.remotes.length > 0;
-    var pkgTypes = (srv.packages || []).map(function (p) {
+  let html = "";
+  let visibleCount = 0;
+  for (let i = 0; i < _registryResults.length; i++) {
+    const srv = _registryResults[i];
+    const hasRemote = srv.remotes && srv.remotes.length > 0;
+    const pkgTypes = (srv.packages || []).map(function (p) {
       return p.registry_type;
     });
 
@@ -4356,8 +4356,8 @@ function _renderRegistryResults() {
     visibleCount++;
 
     // Action button
-    var srvLabel = escapeHtml(srv.title || srv.name);
-    var actionHtml = "";
+    const srvLabel = escapeHtml(srv.title || srv.name);
+    let actionHtml = "";
     if (srv.installed && srv.update_available) {
       actionHtml =
         '<button class="mcp-install-btn mcp-update-btn" data-reg-install="' +
@@ -4377,12 +4377,12 @@ function _renderRegistryResults() {
     }
 
     // Source type badges
-    var sourceBadges = "";
+    let sourceBadges = "";
     if (hasRemote) {
       sourceBadges +=
         '<span class="scope-badge mcp-transport-http">remote</span>';
     }
-    for (var p = 0; p < (srv.packages || []).length; p++) {
+    for (let p = 0; p < (srv.packages || []).length; p++) {
       sourceBadges +=
         '<span class="scope-badge mcp-transport-stdio">' +
         escapeHtml(srv.packages[p].registry_type) +
@@ -4390,8 +4390,8 @@ function _renderRegistryResults() {
     }
 
     // Repo link for trust signal
-    var repoLink = "";
-    var repoUrl = (srv.repository || {}).url || "";
+    let repoLink = "";
+    const repoUrl = (srv.repository || {}).url || "";
     if (repoUrl && /^https?:\/\//i.test(repoUrl)) {
       repoLink =
         ' <a href="' +
@@ -4437,10 +4437,10 @@ function _renderRegistryResults() {
   }
 
   // Pagination
-  var pagEl = document.getElementById("mcp-registry-pagination");
-  var moreBtn = document.getElementById("mcp-registry-more");
-  var countEl = document.getElementById("mcp-registry-count");
-  var isFiltered = typeFilter && visibleCount < _registryResults.length;
+  const pagEl = document.getElementById("mcp-registry-pagination");
+  const moreBtn = document.getElementById("mcp-registry-more");
+  const countEl = document.getElementById("mcp-registry-count");
+  const isFiltered = typeFilter && visibleCount < _registryResults.length;
   if (_registryCursor) {
     pagEl.style.display = "";
     moreBtn.style.display = "";
@@ -4461,7 +4461,7 @@ function _renderRegistryResults() {
   // Bind install buttons
   el.querySelectorAll("[data-reg-install]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var idx = parseInt(this.getAttribute("data-reg-install"), 10);
+      let idx = parseInt(this.getAttribute("data-reg-install"), 10);
       _initiateRegistryInstall(_registryResults[idx]);
     });
   });
@@ -4471,21 +4471,21 @@ function _renderRegistryResults() {
 
 function _initiateRegistryInstall(srv) {
   _mcpInstallServer = srv;
-  var hasRemote = srv.remotes && srv.remotes.length > 0;
-  var hasPackage = srv.packages && srv.packages.length > 0;
+  const hasRemote = srv.remotes && srv.remotes.length > 0;
+  const hasPackage = srv.packages && srv.packages.length > 0;
 
   // Check if remote needs configuration
-  var remoteNeedsConfig = false;
+  let remoteNeedsConfig = false;
   if (hasRemote) {
-    var remote = srv.remotes[0];
-    for (var hi = 0; hi < (remote.headers || []).length; hi++) {
+    const remote = srv.remotes[0];
+    for (let hi = 0; hi < (remote.headers || []).length; hi++) {
       if (remote.headers[hi].is_required) {
         remoteNeedsConfig = true;
         break;
       }
     }
-    var varKeys = Object.keys(remote.variables || {});
-    for (var vi = 0; vi < varKeys.length; vi++) {
+    const varKeys = Object.keys(remote.variables || {});
+    for (let vi = 0; vi < varKeys.length; vi++) {
       if (remote.variables[varKeys[vi]].is_required) {
         remoteNeedsConfig = true;
         break;
@@ -4496,9 +4496,9 @@ function _initiateRegistryInstall(srv) {
   // One-click: remote with no config needed and no package alternative
   if (hasRemote && !remoteNeedsConfig && !hasPackage) {
     // Disable the clicked Install button for loading feedback
-    var cardBtns = document.querySelectorAll("[data-reg-install]");
-    for (var bi = 0; bi < cardBtns.length; bi++) {
-      var idx = parseInt(cardBtns[bi].getAttribute("data-reg-install"), 10);
+    const cardBtns = document.querySelectorAll("[data-reg-install]");
+    for (let bi = 0; bi < cardBtns.length; bi++) {
+      let idx = parseInt(cardBtns[bi].getAttribute("data-reg-install"), 10);
       if (_registryResults[idx] && _registryResults[idx].name === srv.name) {
         cardBtns[bi].disabled = true;
         cardBtns[bi].textContent = "Installing\u2026";
@@ -4515,7 +4515,7 @@ function _initiateRegistryInstall(srv) {
 
 function _showInstallMcpModal(srv, hasRemote, hasPackage) {
   _mcpInstallTrigger = document.activeElement;
-  var ov = document.getElementById("mcp-install-overlay");
+  const ov = document.getElementById("mcp-install-overlay");
   ov.style.display = "flex";
   document.getElementById("mcp-install-error").classList.remove("is-visible");
 
@@ -4533,15 +4533,15 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
   );
 
   // Source selector (only if both remote AND package)
-  var srcEl = document.getElementById("mcp-install-source-select");
+  const srcEl = document.getElementById("mcp-install-source-select");
   if (hasRemote && hasPackage) {
-    var srcHtml = '<div class="mcp-install-source-group">';
+    let srcHtml = '<div class="mcp-install-source-group">';
     srcHtml +=
       '<label class="mcp-install-source-label">' +
       '<input type="radio" name="mcp-install-src" value="remote" checked> ' +
       'Remote <span class="mcp-install-source-type">streamable-http</span>' +
       "</label>";
-    for (var pi = 0; pi < srv.packages.length; pi++) {
+    for (let pi = 0; pi < srv.packages.length; pi++) {
       srcHtml +=
         '<label class="mcp-install-source-label">' +
         '<input type="radio" name="mcp-install-src" value="package-' +
@@ -4555,8 +4555,8 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
     }
     srcHtml += "</div>";
     setSafeHtml(srcEl, srcHtml);
-    var srcRadios = srcEl.querySelectorAll('input[name="mcp-install-src"]');
-    for (var sr = 0; sr < srcRadios.length; sr++) {
+    const srcRadios = srcEl.querySelectorAll('input[name="mcp-install-src"]');
+    for (let sr = 0; sr < srcRadios.length; sr++) {
       srcRadios[sr].addEventListener("change", _updateInstallFields);
     }
   } else {
@@ -4568,16 +4568,16 @@ function _showInstallMcpModal(srv, hasRemote, hasPackage) {
 }
 
 function _updateInstallFields() {
-  var srv = _mcpInstallServer;
+  const srv = _mcpInstallServer;
   if (!srv) return;
-  var fieldsEl = document.getElementById("mcp-install-fields");
-  var srcRadio = document.querySelector(
+  const fieldsEl = document.getElementById("mcp-install-fields");
+  const srcRadio = document.querySelector(
     'input[name="mcp-install-src"]:checked',
   );
-  var srcVal = srcRadio ? srcRadio.value : "";
+  const srcVal = srcRadio ? srcRadio.value : "";
 
-  var source = "remote";
-  var pkgIndex = 0;
+  let source = "remote";
+  let pkgIndex = 0;
   if (srcVal.startsWith("package-")) {
     source = "package";
     pkgIndex = parseInt(srcVal.replace("package-", ""), 10);
@@ -4585,12 +4585,12 @@ function _updateInstallFields() {
     source = "package";
   }
 
-  var html = "";
+  let html = "";
   if (source === "package") {
-    var pkg = srv.packages && srv.packages[pkgIndex];
-    var pkgId = pkg ? pkg.identifier : "";
-    var pkgType = pkg ? pkg.registry_type : "";
-    var runner =
+    const pkg = srv.packages && srv.packages[pkgIndex];
+    const pkgId = pkg ? pkg.identifier : "";
+    const pkgType = pkg ? pkg.registry_type : "";
+    const runner =
       pkgType === "npm" ? "npx" : pkgType === "pypi" ? "uvx" : pkgType;
     html +=
       '<div class="mcp-registry-notice" role="alert" style="margin-bottom:14px">' +
@@ -4603,11 +4603,11 @@ function _updateInstallFields() {
       "Verify the package source before proceeding.</div>";
   }
   if (source === "remote" && srv.remotes && srv.remotes.length > 0) {
-    var remote = srv.remotes[0];
+    const remote = srv.remotes[0];
     // URL variables
-    var varKeys = Object.keys(remote.variables || {});
-    for (var vi = 0; vi < varKeys.length; vi++) {
-      var v = remote.variables[varKeys[vi]];
+    const varKeys = Object.keys(remote.variables || {});
+    for (let vi = 0; vi < varKeys.length; vi++) {
+      const v = remote.variables[varKeys[vi]];
       html +=
         '<label for="mcp-inst-var-' +
         vi +
@@ -4625,8 +4625,8 @@ function _updateInstallFields() {
           escapeHtml(varKeys[vi]) +
           '">';
         if (!v.is_required) html += '<option value="">--</option>';
-        for (var ci = 0; ci < v.choices.length; ci++) {
-          var sel = v.choices[ci] === (v["default"] || "") ? " selected" : "";
+        for (let ci = 0; ci < v.choices.length; ci++) {
+          const sel = v.choices[ci] === (v["default"] || "") ? " selected" : "";
           html +=
             '<option value="' +
             escapeHtml(v.choices[ci]) +
@@ -4651,8 +4651,8 @@ function _updateInstallFields() {
       }
     }
     // Required headers
-    for (var hi = 0; hi < (remote.headers || []).length; hi++) {
-      var h = remote.headers[hi];
+    for (let hi = 0; hi < (remote.headers || []).length; hi++) {
+      const h = remote.headers[hi];
       html +=
         '<label for="mcp-inst-hdr-' +
         hi +
@@ -4674,10 +4674,10 @@ function _updateInstallFields() {
         '">';
     }
   } else if (source === "package" && srv.packages && srv.packages[pkgIndex]) {
-    var pkg = srv.packages[pkgIndex];
-    var evs = pkg.environment_variables || [];
-    for (var ei = 0; ei < evs.length; ei++) {
-      var ev = evs[ei];
+    const pkg = srv.packages[pkgIndex];
+    const evs = pkg.environment_variables || [];
+    for (let ei = 0; ei < evs.length; ei++) {
+      const ev = evs[ei];
       html +=
         '<label for="mcp-inst-env-' +
         ei +
@@ -4722,22 +4722,22 @@ function hideInstallMcpModal() {
 }
 
 function submitInstallMcp() {
-  var srv = _mcpInstallServer;
+  const srv = _mcpInstallServer;
   if (!srv) return;
-  var fieldsEl = document.getElementById("mcp-install-fields");
-  var source = fieldsEl.getAttribute("data-source") || "remote";
-  var pkgIndex = parseInt(fieldsEl.getAttribute("data-pkg-index") || "0", 10);
-  var index = source === "remote" ? 0 : pkgIndex;
+  const fieldsEl = document.getElementById("mcp-install-fields");
+  let source = fieldsEl.getAttribute("data-source") || "remote";
+  let pkgIndex = parseInt(fieldsEl.getAttribute("data-pkg-index") || "0", 10);
+  const index = source === "remote" ? 0 : pkgIndex;
 
-  var variables = {};
+  const variables = {};
   fieldsEl.querySelectorAll("[data-var-name]").forEach(function (el) {
     variables[el.getAttribute("data-var-name")] = el.value;
   });
-  var headers = {};
+  const headers = {};
   fieldsEl.querySelectorAll("[data-hdr-name]").forEach(function (el) {
     if (el.value) headers[el.getAttribute("data-hdr-name")] = el.value;
   });
-  var env = {};
+  const env = {};
   fieldsEl.querySelectorAll("[data-env-name]").forEach(function (el) {
     if (el.value) env[el.getAttribute("data-env-name")] = el.value;
   });
@@ -4753,7 +4753,7 @@ function _doRegistryInstall(
   env,
   headers,
 ) {
-  var submitBtn = document.getElementById("mcp-install-submit");
+  const submitBtn = document.getElementById("mcp-install-submit");
   if (submitBtn) submitBtn.disabled = true;
 
   authFetch("/v1/api/admin/mcp-registry/install", {
@@ -4776,11 +4776,11 @@ function _doRegistryInstall(
       return r.json();
     })
     .then(function (data) {
-      var overlay = document.getElementById("mcp-install-overlay");
+      const overlay = document.getElementById("mcp-install-overlay");
       if (overlay && overlay.style.display !== "none") {
         hideInstallMcpModal();
       }
-      var serverName = data.name || registryName;
+      const serverName = data.name || registryName;
       showToast("Installed " + serverName + " — connecting to nodes\u2026");
       // Re-search to update installed status
       if (_mcpCurrentView === "registry" && _registryResults.length) {
@@ -4792,8 +4792,8 @@ function _doRegistryInstall(
       }
     })
     .catch(function (e) {
-      var overlay = document.getElementById("mcp-install-overlay");
-      var errEl = document.getElementById("mcp-install-error");
+      const overlay = document.getElementById("mcp-install-overlay");
+      const errEl = document.getElementById("mcp-install-error");
       if (errEl && overlay && overlay.style.display !== "none") {
         errEl.textContent = e.message;
         errEl.classList.add("is-visible");
@@ -4817,24 +4817,24 @@ function _pollInstallStatus(serverId, serverName, attempt) {
       })
       .then(function (data) {
         if (!data) return;
-        var status = data.status || {};
-        var nodeIds = Object.keys(status);
-        var anyConnected = false;
-        var errors = [];
-        for (var i = 0; i < nodeIds.length; i++) {
-          var ns = status[nodeIds[i]];
+        const status = data.status || {};
+        const nodeIds = Object.keys(status);
+        let anyConnected = false;
+        const errors = [];
+        for (let i = 0; i < nodeIds.length; i++) {
+          const ns = status[nodeIds[i]];
           if (ns.connected) anyConnected = true;
           if (ns.error) errors.push(ns.error);
         }
         if (anyConnected) {
-          var tools = 0;
-          for (var j = 0; j < nodeIds.length; j++) {
+          let tools = 0;
+          for (let j = 0; j < nodeIds.length; j++) {
             if (status[nodeIds[j]].connected) {
               tools = status[nodeIds[j]].tools || 0;
               break;
             }
           }
-          var msg = serverName + " connected";
+          let msg = serverName + " connected";
           if (tools)
             msg += " (" + tools + " tool" + (tools !== 1 ? "s" : "") + ")";
           if (errors.length)
@@ -4860,10 +4860,10 @@ function _pollInstallStatus(serverId, serverName, attempt) {
 // Models tab
 // ---------------------------------------------------------------------------
 
-var _modelDefs = [];
-var _modelDefaultAlias = "";
-var _modelCreateTrap = null;
-var _modelCreateTrigger = null;
+let _modelDefs = [];
+let _modelDefaultAlias = "";
+let _modelCreateTrap = null;
+let _modelCreateTrigger = null;
 
 // Roles surfaced in the Models → Roles sub-tab.  Each entry maps a
 // settings-registry key onto a UX label.  ``effortKey`` is optional —
@@ -4879,7 +4879,7 @@ var _modelCreateTrigger = null;
 // session model`` per turnstone/core/settings_registry.py — there's
 // no single "default" to advertise, so the blank reads "(inherit)"
 // to match the vocabulary of the reasoning-effort dropdowns.
-var MODEL_ROLES = [
+const MODEL_ROLES = [
   {
     label: "Coordinator",
     description:
@@ -4926,12 +4926,12 @@ var MODEL_ROLES = [
 // access but not Settings, hide the sub-tab button + force the
 // Definitions panel visible so they don't see a perpetual 403 loader.
 function _modelRolesAccessible() {
-  var perms = sessionStorage.getItem("turnstone_permissions") || "";
+  const perms = sessionStorage.getItem("turnstone_permissions") || "";
   return perms.split(",").indexOf("admin.settings") !== -1;
 }
 
 function _applyModelRolesPermission() {
-  var btn = document.getElementById("models-tab-roles");
+  const btn = document.getElementById("models-tab-roles");
   if (!btn) return;
   if (_modelRolesAccessible()) {
     btn.style.display = "";
@@ -4964,9 +4964,9 @@ function loadAdminModels() {
       }
     })
     .catch(function () {
-      var el = document.getElementById("admin-models-table");
+      const el = document.getElementById("admin-models-table");
       el.textContent = "";
-      var d = document.createElement("div");
+      const d = document.createElement("div");
       d.className = "dashboard-empty";
       d.textContent = "Failed to load models";
       el.appendChild(d);
@@ -4974,32 +4974,32 @@ function loadAdminModels() {
 }
 
 function switchModelsSection(section) {
-  var sections = document.querySelectorAll("#admin-models .models-section");
-  for (var i = 0; i < sections.length; i++) sections[i].style.display = "none";
-  var switcher = document.querySelector("#admin-models .admin-subtab-switcher");
-  var btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
-  for (var k = 0; k < btns.length; k++) {
-    var isActive = btns[k].getAttribute("data-section") === section;
+  const sections = document.querySelectorAll("#admin-models .models-section");
+  for (let i = 0; i < sections.length; i++) sections[i].style.display = "none";
+  const switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  const btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
+  for (let k = 0; k < btns.length; k++) {
+    const isActive = btns[k].getAttribute("data-section") === section;
     btns[k].classList.toggle("active", isActive);
     btns[k].setAttribute("aria-selected", isActive ? "true" : "false");
     btns[k].setAttribute("tabindex", isActive ? "0" : "-1");
   }
-  var target = document.getElementById(section + "-section");
+  const target = document.getElementById(section + "-section");
   if (target) target.style.display = "";
 }
 
 // Arrow key navigation for Models sub-tabs (matches the Judge tab).
 (function () {
-  var switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  const switcher = document.querySelector("#admin-models .admin-subtab-switcher");
   if (!switcher) return;
   switcher.addEventListener("keydown", function (e) {
     if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-    var btns = switcher.querySelectorAll(".admin-subtab-btn");
-    var secs = [];
-    for (var i = 0; i < btns.length; i++)
+    const btns = switcher.querySelectorAll(".admin-subtab-btn");
+    const secs = [];
+    for (let i = 0; i < btns.length; i++)
       secs.push(btns[i].getAttribute("data-section"));
-    var current = switcher.querySelector(".admin-subtab-btn.active");
-    var idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
+    let current = switcher.querySelector(".admin-subtab-btn.active");
+    let idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
     if (e.key === "ArrowRight") idx = (idx + 1) % secs.length;
     else idx = (idx - 1 + secs.length) % secs.length;
     e.preventDefault();
@@ -5010,14 +5010,14 @@ function switchModelsSection(section) {
 
 function _modelRolesError(container, msg) {
   while (container.firstChild) container.removeChild(container.firstChild);
-  var d = document.createElement("div");
+  const d = document.createElement("div");
   d.className = "dashboard-empty";
   d.textContent = msg;
   container.appendChild(d);
 }
 
 function loadAdminModelRoles() {
-  var c = document.getElementById("admin-models-roles-container");
+  const c = document.getElementById("admin-models-roles-container");
   if (!c) return;
   // Reads ``_modelDefs`` / ``_modelDefaultAlias`` populated by the most
   // recent ``loadAdminModels`` — both entry points into the Models tab
@@ -5036,12 +5036,12 @@ function loadAdminModelRoles() {
     }),
   ])
     .then(function (results) {
-      var values = {};
-      var arr = results[0].settings || [];
-      for (var i = 0; i < arr.length; i++) values[arr[i].key] = arr[i];
-      var schema = {};
-      var sa = results[1].schema || [];
-      for (var j = 0; j < sa.length; j++) schema[sa[j].key] = sa[j];
+      const values = {};
+      const arr = results[0].settings || [];
+      for (let i = 0; i < arr.length; i++) values[arr[i].key] = arr[i];
+      const schema = {};
+      const sa = results[1].schema || [];
+      for (let j = 0; j < sa.length; j++) schema[sa[j].key] = sa[j];
       _renderModelRoles(c, values, schema);
     })
     .catch(function () {
@@ -5050,17 +5050,17 @@ function loadAdminModelRoles() {
 }
 
 function _renderModelRoles(container, values, schema) {
-  var enabledAliases = [];
-  for (var i = 0; i < _modelDefs.length; i++) {
+  const enabledAliases = [];
+  for (let i = 0; i < _modelDefs.length; i++) {
     if (_modelDefs[i].enabled) enabledAliases.push(_modelDefs[i]);
   }
   container.textContent = "";
-  for (var r = 0; r < MODEL_ROLES.length; r++) {
-    var role = MODEL_ROLES[r];
-    var aliasInfo = values[role.aliasKey];
+  for (let r = 0; r < MODEL_ROLES.length; r++) {
+    const role = MODEL_ROLES[r];
+    const aliasInfo = values[role.aliasKey];
     if (!aliasInfo) continue; // setting not registered (e.g. older server)
 
-    var row = document.createElement("div");
+    const row = document.createElement("div");
     row.className = "model-role-row";
 
     // The dropdown's selected-option text is the single source of
@@ -5068,32 +5068,32 @@ function _renderModelRoles(container, values, schema) {
     // "(default — <alias>)", otherwise it shows the chosen alias.  No
     // separate badge: redundant with the select, and prone to
     // confusing color contrasts on freshly-rendered rows.
-    var head = document.createElement("div");
+    const head = document.createElement("div");
     head.className = "model-role-head";
-    var nameEl = document.createElement("span");
+    const nameEl = document.createElement("span");
     nameEl.className = "model-role-label";
     nameEl.textContent = role.label;
     head.appendChild(nameEl);
     row.appendChild(head);
 
     if (role.description) {
-      var desc = document.createElement("div");
+      const desc = document.createElement("div");
       desc.className = "model-role-desc";
       desc.textContent = role.description;
       row.appendChild(desc);
     }
 
-    var controls = document.createElement("div");
+    const controls = document.createElement("div");
     controls.className = "model-role-controls";
 
     // Alias dropdown
-    var aliasWrap = document.createElement("label");
+    const aliasWrap = document.createElement("label");
     aliasWrap.className = "model-role-control";
-    var aliasLabel = document.createElement("span");
+    const aliasLabel = document.createElement("span");
     aliasLabel.className = "model-role-control-label";
     aliasLabel.textContent = "Model";
     aliasWrap.appendChild(aliasLabel);
-    var aliasSel = document.createElement("select");
+    const aliasSel = document.createElement("select");
     aliasSel.setAttribute("data-role-key", role.aliasKey);
     aliasSel.setAttribute(
       "aria-label",
@@ -5107,14 +5107,14 @@ function _renderModelRoles(container, values, schema) {
     // → session) that has no single concrete "default", so they get
     // a plain "(inherit)" instead of the misleading
     // "(default — <coordinator-alias>)".
-    var blank = document.createElement("option");
+    const blank = document.createElement("option");
     blank.value = "";
     if (role.fallbackKind === "inherit") {
       blank.textContent = "(inherit)";
     } else {
-      var defaultDef = null;
+      let defaultDef = null;
       if (_modelDefaultAlias) {
-        for (var dm = 0; dm < enabledAliases.length; dm++) {
+        for (let dm = 0; dm < enabledAliases.length; dm++) {
           if (enabledAliases[dm].alias === _modelDefaultAlias) {
             defaultDef = enabledAliases[dm];
             break;
@@ -5122,7 +5122,7 @@ function _renderModelRoles(container, values, schema) {
         }
       }
       if (defaultDef) {
-        var defLabel =
+        const defLabel =
           defaultDef.alias === defaultDef.model
             ? defaultDef.alias
             : defaultDef.alias + " (" + defaultDef.model + ")";
@@ -5134,11 +5134,11 @@ function _renderModelRoles(container, values, schema) {
       }
     }
     aliasSel.appendChild(blank);
-    var currentAlias = aliasInfo.value || "";
-    var matched = false;
-    for (var m = 0; m < enabledAliases.length; m++) {
-      var md = enabledAliases[m];
-      var opt = document.createElement("option");
+    const currentAlias = aliasInfo.value || "";
+    let matched = false;
+    for (let m = 0; m < enabledAliases.length; m++) {
+      const md = enabledAliases[m];
+      const opt = document.createElement("option");
       opt.value = md.alias;
       opt.textContent =
         md.alias === md.model ? md.alias : md.alias + " (" + md.model + ")";
@@ -5149,7 +5149,7 @@ function _renderModelRoles(container, values, schema) {
       aliasSel.appendChild(opt);
     }
     if (currentAlias && !matched) {
-      var manual = document.createElement("option");
+      const manual = document.createElement("option");
       manual.value = currentAlias;
       manual.textContent = currentAlias + " (manual)";
       manual.selected = true;
@@ -5163,19 +5163,19 @@ function _renderModelRoles(container, values, schema) {
 
     // Optional reasoning effort dropdown
     if (role.effortKey && values[role.effortKey] && schema[role.effortKey]) {
-      var effortWrap = document.createElement("label");
+      const effortWrap = document.createElement("label");
       effortWrap.className = "model-role-control";
-      var effortLabel = document.createElement("span");
+      const effortLabel = document.createElement("span");
       effortLabel.className = "model-role-control-label";
       effortLabel.textContent = "Reasoning effort";
       effortWrap.appendChild(effortLabel);
-      var effortSel = document.createElement("select");
+      const effortSel = document.createElement("select");
       effortSel.setAttribute("data-role-key", role.effortKey);
       effortSel.setAttribute("aria-label", role.label + " reasoning effort");
-      var choices = schema[role.effortKey].choices || [];
-      var currentEffort = values[role.effortKey].value;
-      for (var c2 = 0; c2 < choices.length; c2++) {
-        var eo = document.createElement("option");
+      const choices = schema[role.effortKey].choices || [];
+      const currentEffort = values[role.effortKey].value;
+      for (let c2 = 0; c2 < choices.length; c2++) {
+        const eo = document.createElement("option");
         eo.value = choices[c2];
         eo.textContent = choices[c2] === "" ? "(inherit)" : choices[c2];
         if (currentEffort === choices[c2]) eo.selected = true;
@@ -5220,36 +5220,36 @@ function _saveModelRole(key, value) {
 }
 
 function _renderModels(items) {
-  var el = document.getElementById("admin-models-table");
+  const el = document.getElementById("admin-models-table");
   // Clear previous content
   el.textContent = "";
   if (!items.length) {
-    var empty = document.createElement("div");
+    let empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No model definitions configured";
     el.appendChild(empty);
     return;
   }
-  for (var i = 0; i < items.length; i++) {
-    var m = items[i];
-    var isConfig = m.source === "config";
+  for (let i = 0; i < items.length; i++) {
+    const m = items[i];
+    const isConfig = m.source === "config";
 
     // Status
-    var dotClass = m.enabled
+    let dotClass = m.enabled
       ? "model-status-dot enabled"
       : "model-status-dot disabled";
-    var rowClass = m.enabled ? "model-row-enabled" : "model-row-disabled";
-    var statusText = m.enabled ? "enabled" : "disabled";
+    let rowClass = m.enabled ? "model-row-enabled" : "model-row-disabled";
+    let statusText = m.enabled ? "enabled" : "disabled";
 
     // Context window formatting (0 = auto-detect)
-    var ctxText = m.context_window
+    const ctxText = m.context_window
       ? m.context_window >= 1000
         ? Math.round(m.context_window / 1000) + "k"
         : String(m.context_window)
       : "auto";
 
     // Provider badge class
-    var providerCls =
+    const providerCls =
       m.provider === "anthropic"
         ? "model-provider-anthropic"
         : m.provider === "google"
@@ -5259,16 +5259,16 @@ function _renderModels(items) {
             : "model-provider-openai";
 
     // Build row via DOM
-    var row = document.createElement("div");
+    const row = document.createElement("div");
     row.className = "admin-row models-grid " + rowClass;
     row.setAttribute("role", "listitem");
 
     // Alias + source badge + default badge
-    var isDefault = m.alias === _modelDefaultAlias;
-    var colAlias = document.createElement("span");
+    const isDefault = m.alias === _modelDefaultAlias;
+    const colAlias = document.createElement("span");
     colAlias.className = "admin-col";
     colAlias.textContent = m.alias;
-    var badge = document.createElement("span");
+    const badge = document.createElement("span");
     badge.className = isConfig
       ? "scope-badge scope-config"
       : "scope-badge scope-db";
@@ -5276,14 +5276,14 @@ function _renderModels(items) {
     colAlias.appendChild(document.createTextNode(" "));
     colAlias.appendChild(badge);
     if (isDefault) {
-      var defBadge = document.createElement("span");
+      const defBadge = document.createElement("span");
       defBadge.className = "scope-badge scope-default";
       defBadge.textContent = "default";
       colAlias.appendChild(document.createTextNode(" "));
       colAlias.appendChild(defBadge);
     }
     // Per-model sampling override indicators
-    var overrides = [];
+    const overrides = [];
     if (m.temperature != null) overrides.push("temp=" + m.temperature);
     if (m.max_tokens != null) overrides.push("max_tok=" + m.max_tokens);
     if (m.reasoning_effort != null)
@@ -5294,7 +5294,7 @@ function _renderModels(items) {
     if (m.surface_persisted_reasoning === false) overrides.push("surface=off");
     if (m.replay_reasoning_to_model === true) overrides.push("replay=on");
     if (overrides.length) {
-      var ovrSpan = document.createElement("span");
+      const ovrSpan = document.createElement("span");
       ovrSpan.className = "model-overrides-hint";
       ovrSpan.textContent = overrides.join(", ");
       ovrSpan.title = "Per-model overrides (override global defaults)";
@@ -5308,32 +5308,32 @@ function _renderModels(items) {
     row.appendChild(colAlias);
 
     // Model ID
-    var colModel = document.createElement("span");
+    const colModel = document.createElement("span");
     colModel.className = "admin-col";
-    var code = document.createElement("code");
+    const code = document.createElement("code");
     code.textContent = m.model;
     colModel.appendChild(code);
     row.appendChild(colModel);
 
     // Provider
-    var colProvider = document.createElement("span");
+    const colProvider = document.createElement("span");
     colProvider.className = "admin-col";
-    var provBadge = document.createElement("span");
+    const provBadge = document.createElement("span");
     provBadge.className = "model-provider-badge " + providerCls;
     provBadge.textContent = m.provider;
     colProvider.appendChild(provBadge);
     row.appendChild(colProvider);
 
     // Context window
-    var colCtx = document.createElement("span");
+    const colCtx = document.createElement("span");
     colCtx.className = "admin-col";
     colCtx.textContent = ctxText;
     row.appendChild(colCtx);
 
     // Status
-    var colStatus = document.createElement("span");
+    const colStatus = document.createElement("span");
     colStatus.className = "admin-col";
-    var dot = document.createElement("span");
+    const dot = document.createElement("span");
     dot.className = dotClass;
     dot.setAttribute("aria-hidden", "true");
     colStatus.appendChild(dot);
@@ -5341,10 +5341,10 @@ function _renderModels(items) {
     row.appendChild(colStatus);
 
     // Actions
-    var colActions = document.createElement("span");
+    const colActions = document.createElement("span");
     colActions.className = "admin-col";
     if (!isDefault && m.enabled) {
-      var defBtn = document.createElement("button");
+      const defBtn = document.createElement("button");
       defBtn.className = "admin-btn-action";
       defBtn.textContent = "set default";
       defBtn.setAttribute("data-model-set-default", m.alias);
@@ -5353,14 +5353,14 @@ function _renderModels(items) {
       colActions.appendChild(defBtn);
     }
     if (!isConfig) {
-      var editBtn = document.createElement("button");
+      const editBtn = document.createElement("button");
       editBtn.className = "admin-btn-action";
       editBtn.textContent = "edit";
       editBtn.setAttribute("data-model-edit", m.definition_id);
       editBtn.setAttribute("title", "Edit " + m.alias);
       colActions.appendChild(editBtn);
 
-      var delBtn = document.createElement("button");
+      const delBtn = document.createElement("button");
       delBtn.className = "admin-btn-danger";
       delBtn.textContent = "del";
       delBtn.setAttribute("data-model-delete", m.definition_id);
@@ -5376,8 +5376,8 @@ function _renderModels(items) {
   // Bind event handlers
   el.querySelectorAll("[data-model-set-default]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var alias = this.getAttribute("data-model-set-default");
-      var self = this;
+      const alias = this.getAttribute("data-model-set-default");
+      const self = this;
       self.disabled = true;
       self.textContent = "setting\u2026";
       authFetch("/v1/api/admin/settings/model.default_alias", {
@@ -5405,8 +5405,8 @@ function _renderModels(items) {
   });
   el.querySelectorAll("[data-model-delete]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var did = this.getAttribute("data-model-delete");
-      var dalias = this.getAttribute("data-model-alias");
+      const did = this.getAttribute("data-model-delete");
+      const dalias = this.getAttribute("data-model-alias");
       showConfirmModal(
         "Delete Model",
         'Delete model "' + dalias + '"?',
@@ -5441,17 +5441,17 @@ function _isPlainObject(v) {
 }
 
 function _toggleThinkingParam() {
-  var mode = document.getElementById("model-thinking-mode").value;
-  var row = document.getElementById("model-thinking-param-row");
+  const mode = document.getElementById("model-thinking-mode").value;
+  const row = document.getElementById("model-thinking-param-row");
   row.style.display = mode ? "" : "none";
   // Set default when first enabling
-  var paramEl = document.getElementById("model-thinking-param");
+  const paramEl = document.getElementById("model-thinking-param");
   if (mode && !paramEl.value) paramEl.value = "enable_thinking";
 }
 
 function showCreateModelModal() {
   _modelCreateTrigger = document.activeElement;
-  var ov = document.getElementById("model-create-overlay");
+  const ov = document.getElementById("model-create-overlay");
   ov.style.display = "flex";
   document.getElementById("model-edit-id").value = "";
   document.getElementById("model-create-title").textContent = "Add Model";
@@ -5476,7 +5476,7 @@ function showCreateModelModal() {
   document.getElementById("model-capabilities").value = "";
   // Clear validation error styling from prior submit attempts
   ["model-extra-body", "model-capabilities"].forEach(function (id) {
-    var el = document.getElementById(id);
+    const el = document.getElementById(id);
     el.removeAttribute("aria-invalid");
     el.style.borderColor = "";
   });
@@ -5521,7 +5521,7 @@ function showEditModelModal(definitionId) {
       document.getElementById("model-reasoning-effort").value =
         m.reasoning_effort != null ? m.reasoning_effort : "";
       // Parse capabilities JSON and extract server_compat for structured fields
-      var capsObj = {};
+      let capsObj = {};
       try {
         capsObj = JSON.parse(m.capabilities || "{}");
       } catch (e) {
@@ -5529,15 +5529,15 @@ function showEditModelModal(definitionId) {
       }
       // Defend against null/array/primitive values in the DB
       if (!_isPlainObject(capsObj)) capsObj = {};
-      var sc = _isPlainObject(capsObj.server_compat)
+      const sc = _isPlainObject(capsObj.server_compat)
         ? capsObj.server_compat
         : {};
       // Only extract thinking_mode into the dropdown when the UI can
       // represent it ("manual" or "").  Values like "adaptive" (Anthropic-
       // only) stay in the raw capabilities JSON so they aren't silently
       // lost on save.
-      var tmVal = capsObj.thinking_mode || "";
-      var tmRepresentable = tmVal === "" || tmVal === "manual";
+      const tmVal = capsObj.thinking_mode || "";
+      const tmRepresentable = tmVal === "" || tmVal === "manual";
       if (tmRepresentable) {
         document.getElementById("model-thinking-mode").value = tmVal;
         document.getElementById("model-thinking-param").value =
@@ -5550,8 +5550,8 @@ function showEditModelModal(definitionId) {
       // Server compat: server_type, api_surface, and extra_body workarounds
       document.getElementById("model-server-type").value = sc.server_type || "";
       document.getElementById("model-api-surface").value = sc.api_surface || "";
-      var eb = sc.extra_body || {};
-      var ebText = JSON.stringify(eb, null, 2);
+      const eb = sc.extra_body || {};
+      const ebText = JSON.stringify(eb, null, 2);
       document.getElementById("model-extra-body").value =
         ebText === "{}" ? "" : ebText;
       // Remove structured fields from capabilities display — only delete
@@ -5561,7 +5561,7 @@ function showEditModelModal(definitionId) {
         delete capsObj.thinking_mode;
         delete capsObj.thinking_param;
       }
-      var capsText = JSON.stringify(capsObj, null, 2);
+      const capsText = JSON.stringify(capsObj, null, 2);
       document.getElementById("model-capabilities").value =
         capsText === "{}" ? "" : capsText;
       document.getElementById("model-enabled").checked = m.enabled !== false;
@@ -5588,8 +5588,8 @@ function hideCreateModelModal() {
 }
 
 function submitCreateModel() {
-  var alias = document.getElementById("model-alias").value.trim();
-  var modelName = document.getElementById("model-name").value.trim();
+  const alias = document.getElementById("model-alias").value.trim();
+  const modelName = document.getElementById("model-name").value.trim();
   if (!alias) {
     _showModelError("Alias is required");
     return;
@@ -5603,9 +5603,9 @@ function submitCreateModel() {
     return;
   }
 
-  var capsEl = document.getElementById("model-capabilities");
-  var capsText = capsEl.value.trim();
-  var caps = {};
+  const capsEl = document.getElementById("model-capabilities");
+  const capsText = capsEl.value.trim();
+  let caps = {};
   capsEl.removeAttribute("aria-invalid");
   capsEl.style.borderColor = "";
   if (capsText) {
@@ -5629,12 +5629,12 @@ function submitCreateModel() {
 
   // Thinking mode → capabilities (provider uses this to inject
   // the correct chat_template_kwargs param automatically).
-  var thinkingMode = document.getElementById("model-thinking-mode").value;
+  const thinkingMode = document.getElementById("model-thinking-mode").value;
   if (thinkingMode) {
     caps.thinking_mode = thinkingMode;
     // Preserve thinking_param so Granite/DeepSeek "thinking" key
     // isn't silently reverted to the default "enable_thinking".
-    var savedParam = document.getElementById("model-thinking-param").value;
+    const savedParam = document.getElementById("model-thinking-param").value;
     if (savedParam) caps.thinking_param = savedParam;
   }
 
@@ -5642,20 +5642,20 @@ function submitCreateModel() {
   // openai-compatible aliases — for other providers the section is hidden
   // but the form values can linger after a provider switch, so gate the
   // whole block on the active provider to keep persisted state honest.
-  var serverCompat = {};
-  var providerVal = document.getElementById("model-provider").value;
-  var ebEl = document.getElementById("model-extra-body");
+  const serverCompat = {};
+  const providerVal = document.getElementById("model-provider").value;
+  const ebEl = document.getElementById("model-extra-body");
   ebEl.removeAttribute("aria-invalid");
   ebEl.style.borderColor = "";
   if (providerVal === "openai-compatible") {
-    var serverType = document.getElementById("model-server-type").value;
+    const serverType = document.getElementById("model-server-type").value;
     if (serverType) serverCompat.server_type = serverType;
-    var apiSurface = document.getElementById("model-api-surface").value;
+    const apiSurface = document.getElementById("model-api-surface").value;
     if (apiSurface) serverCompat.api_surface = apiSurface;
-    var ebText = ebEl.value.trim();
+    const ebText = ebEl.value.trim();
     if (ebText) {
       try {
-        var ebParsed = JSON.parse(ebText);
+        const ebParsed = JSON.parse(ebText);
         if (!_isPlainObject(ebParsed)) {
           throw new Error("not an object");
         }
@@ -5672,7 +5672,7 @@ function submitCreateModel() {
     caps.server_compat = serverCompat;
   }
 
-  var form = {
+  const form = {
     alias: alias,
     model: modelName,
     provider: document.getElementById("model-provider").value,
@@ -5684,9 +5684,9 @@ function submitCreateModel() {
   };
 
   // Per-model sampling overrides — null when empty (use global default)
-  var tempVal = document.getElementById("model-temperature").value.trim();
+  const tempVal = document.getElementById("model-temperature").value.trim();
   if (tempVal !== "") {
-    var t = parseFloat(tempVal);
+    const t = parseFloat(tempVal);
     if (isNaN(t) || t < 0 || t > 2) {
       _showModelError("Temperature must be between 0 and 2");
       return;
@@ -5695,9 +5695,9 @@ function submitCreateModel() {
   } else {
     form.temperature = null;
   }
-  var mtVal = document.getElementById("model-max-tokens").value.trim();
+  const mtVal = document.getElementById("model-max-tokens").value.trim();
   if (mtVal !== "") {
-    var mt = parseInt(mtVal, 10);
+    const mt = parseInt(mtVal, 10);
     if (isNaN(mt) || mt < 1) {
       _showModelError("Max tokens must be at least 1");
       return;
@@ -5706,7 +5706,7 @@ function submitCreateModel() {
   } else {
     form.max_tokens = null;
   }
-  var reVal = document.getElementById("model-reasoning-effort").value;
+  const reVal = document.getElementById("model-reasoning-effort").value;
   if (reVal !== "") {
     form.reasoning_effort = reVal;
   } else {
@@ -5723,12 +5723,12 @@ function submitCreateModel() {
     "model-replay-reasoning",
   ).checked;
 
-  var apiKey = document.getElementById("model-api-key").value;
+  const apiKey = document.getElementById("model-api-key").value;
   if (apiKey) form.api_key = apiKey;
 
-  var editId = document.getElementById("model-edit-id").value;
-  var method = editId ? "PUT" : "POST";
-  var url = editId
+  const editId = document.getElementById("model-edit-id").value;
+  const method = editId ? "PUT" : "POST";
+  let url = editId
     ? "/v1/api/admin/model-definitions/" + encodeURIComponent(editId)
     : "/v1/api/admin/model-definitions";
 
@@ -5760,13 +5760,13 @@ function submitCreateModel() {
 }
 
 function _showModelError(msg) {
-  var e = document.getElementById("model-create-error");
+  const e = document.getElementById("model-create-error");
   e.textContent = msg;
   e.classList.add("is-visible");
 }
 
 function _detectResultLine(text, color) {
-  var div = document.createElement("div");
+  const div = document.createElement("div");
   div.style.marginTop = "3px";
   if (color) div.style.color = "var(--" + color + ")";
   div.textContent = text;
@@ -5774,7 +5774,7 @@ function _detectResultLine(text, color) {
 }
 
 function _clearDetectResult() {
-  var rd = document.getElementById("model-detect-result");
+  const rd = document.getElementById("model-detect-result");
   if (rd) {
     rd.style.display = "none";
     rd.textContent = "";
@@ -5783,22 +5783,22 @@ function _clearDetectResult() {
 }
 
 function detectModel() {
-  var btn = document.getElementById("model-detect-btn");
-  var resultDiv = document.getElementById("model-detect-result");
+  const btn = document.getElementById("model-detect-btn");
+  const resultDiv = document.getElementById("model-detect-result");
   btn.disabled = true;
   btn.setAttribute("aria-busy", "true");
   btn.textContent = "Detecting\u2026";
   resultDiv.style.display = "none";
   resultDiv.textContent = "";
 
-  var form = {
+  const form = {
     provider: document.getElementById("model-provider").value,
     base_url: document.getElementById("model-base-url").value.trim(),
     model: document.getElementById("model-name").value.trim(),
   };
-  var apiKey = document.getElementById("model-api-key").value;
+  const apiKey = document.getElementById("model-api-key").value;
   if (apiKey) form.api_key = apiKey;
-  var editId = document.getElementById("model-edit-id").value;
+  const editId = document.getElementById("model-edit-id").value;
   if (editId) form.definition_id = editId;
 
   authFetch("/v1/api/admin/model-definitions/detect", {
@@ -5823,22 +5823,22 @@ function detectModel() {
         resultDiv.style.borderColor = "var(--red)";
         return;
       }
-      var line1 = "\u2713 Connected";
+      let line1 = "\u2713 Connected";
       if (d.available_models && d.available_models.length) {
         line1 += " \u2014 " + d.available_models.length + " model(s) available";
       }
       resultDiv.appendChild(_detectResultLine(line1, "green"));
 
       if (d.model_found === false) {
-        var models = d.available_models || [];
-        var msg =
+        const models = d.available_models || [];
+        let msg =
           '\u26A0 Model "' +
           form.model +
           '" not found in ' +
           models.length +
           " available model(s)";
         if (models.length > 0) {
-          var shown = models.slice(0, 8);
+          const shown = models.slice(0, 8);
           msg += ": " + shown.join(", ");
           if (models.length > 8)
             msg += ", \u2026 +" + (models.length - 8) + " more";
@@ -5847,11 +5847,11 @@ function detectModel() {
       }
 
       if (d.available_models && d.available_models.length > 0) {
-        var dl = document.getElementById("model-name-suggestions");
+        const dl = document.getElementById("model-name-suggestions");
         if (dl) {
           dl.textContent = "";
           d.available_models.forEach(function (m) {
-            var opt = document.createElement("option");
+            const opt = document.createElement("option");
             opt.value = m;
             dl.appendChild(opt);
           });
@@ -5863,7 +5863,7 @@ function detectModel() {
             "Context window: " + d.context_window.toLocaleString() + " tokens",
           ),
         );
-        var ctxInput = document.getElementById("model-ctx-window");
+        const ctxInput = document.getElementById("model-ctx-window");
         if (parseInt(ctxInput.value, 10) === 0) {
           ctxInput.value = d.context_window;
         }
@@ -5873,8 +5873,8 @@ function detectModel() {
           _detectResultLine("Server type: " + d.server_type),
         );
         // Auto-fill server type if not already set and value is a known option
-        var stEl = document.getElementById("model-server-type");
-        var stOpts = Array.from(stEl.options).map(function (o) {
+        const stEl = document.getElementById("model-server-type");
+        const stOpts = Array.from(stEl.options).map(function (o) {
           return o.value;
         });
         if (!stEl.value && stOpts.indexOf(d.server_type) !== -1)
@@ -5882,22 +5882,22 @@ function detectModel() {
       }
       // Auto-fill capabilities from suggested profile
       if (d.suggested_capabilities) {
-        var sc2 = d.suggested_capabilities;
-        var tmEl = document.getElementById("model-thinking-mode");
+        const sc2 = d.suggested_capabilities;
+        const tmEl = document.getElementById("model-thinking-mode");
         if (!tmEl.value && sc2.thinking_mode) {
           tmEl.value = sc2.thinking_mode;
         }
         if (sc2.thinking_param) {
-          var tpEl = document.getElementById("model-thinking-param");
+          const tpEl = document.getElementById("model-thinking-param");
           if (!tpEl.value) tpEl.value = sc2.thinking_param;
         }
         _toggleThinkingParam();
       }
       // Auto-fill server compat from suggested profile
       if (d.suggested_server_compat) {
-        var ssc = d.suggested_server_compat;
-        var stEl2 = document.getElementById("model-server-type");
-        var stOpts2 = Array.from(stEl2.options).map(function (o) {
+        const ssc = d.suggested_server_compat;
+        const stEl2 = document.getElementById("model-server-type");
+        const stOpts2 = Array.from(stEl2.options).map(function (o) {
           return o.value;
         });
         if (
@@ -5908,15 +5908,15 @@ function detectModel() {
           stEl2.value = ssc.server_type;
         // Restrict to the known set so a hostile detect response can't
         // smuggle a non-listed value into the form.
-        var _SURFACE_SUGGESTABLE = { chat: 1, responses: 1 };
+        const _SURFACE_SUGGESTABLE = { chat: 1, responses: 1 };
         if (ssc.api_surface && _SURFACE_SUGGESTABLE[ssc.api_surface]) {
-          var asEl = document.getElementById("model-api-surface");
+          const asEl = document.getElementById("model-api-surface");
           if (!asEl.value) asEl.value = ssc.api_surface;
         }
         if (ssc.extra_body) {
-          var ebEl2 = document.getElementById("model-extra-body");
+          const ebEl2 = document.getElementById("model-extra-body");
           if (!ebEl2.value.trim()) {
-            var ebJson = JSON.stringify(ssc.extra_body, null, 2);
+            const ebJson = JSON.stringify(ssc.extra_body, null, 2);
             if (ebJson !== "{}") ebEl2.value = ebJson;
           }
         }
@@ -5945,14 +5945,14 @@ function detectModel() {
 /* Capability auto-fill: when the user types a known model name or
    changes the provider, look up static capabilities and pre-fill
    context_window and the capabilities textarea. */
-var _capsTimer = null;
+let _capsTimer = null;
 function _onModelFieldChange() {
   clearTimeout(_capsTimer);
   _capsTimer = setTimeout(function () {
-    var overlay = document.getElementById("model-create-overlay");
+    const overlay = document.getElementById("model-create-overlay");
     if (!overlay || overlay.style.display === "none") return;
-    var provider = document.getElementById("model-provider").value;
-    var modelName = document.getElementById("model-name").value.trim();
+    const provider = document.getElementById("model-provider").value;
+    const modelName = document.getElementById("model-name").value.trim();
     if (!modelName) return;
     authFetch(
       "/v1/api/admin/model-capabilities?provider=" +
@@ -5965,22 +5965,22 @@ function _onModelFieldChange() {
       })
       .then(function (d) {
         if (!d.known || !d.capabilities) return;
-        var ctxInput = document.getElementById("model-ctx-window");
+        const ctxInput = document.getElementById("model-ctx-window");
         if (
           parseInt(ctxInput.value, 10) === 0 &&
           d.capabilities.context_window
         ) {
           ctxInput.value = d.capabilities.context_window;
         }
-        var capsInput = document.getElementById("model-capabilities");
+        const capsInput = document.getElementById("model-capabilities");
         if (!capsInput.value.trim()) {
-          var caps = Object.assign({}, d.capabilities);
+          let caps = Object.assign({}, d.capabilities);
           delete caps.context_window;
           delete caps.max_output_tokens;
           delete caps.token_param;
           delete caps.supports_streaming;
           delete caps.supports_tools;
-          var text = JSON.stringify(caps, null, 2);
+          const text = JSON.stringify(caps, null, 2);
           if (text !== "{}") capsInput.value = text;
         }
       })
@@ -5992,7 +5992,7 @@ function _onModelFieldChange() {
 /* Provider-specific placeholder hints for base_url and model ID fields.
    Keep URLs in sync with _PROVIDER_DEFAULT_URLS in console/server.py
    and GOOGLE_DEFAULT_BASE_URL in core/providers/_google.py. */
-var _providerDefaults = {
+const _providerDefaults = {
   openai: {
     urlPlaceholder: "https://api.openai.com/v1",
     modelPlaceholder: "gpt-5",
@@ -6013,13 +6013,13 @@ var _providerDefaults = {
 
 /* Update placeholders when provider changes. */
 function _applyProviderDefaults() {
-  var provider = document.getElementById("model-provider").value;
-  var def = _providerDefaults[provider];
+  const provider = document.getElementById("model-provider").value;
+  const def = _providerDefaults[provider];
   if (!def) return;
   document.getElementById("model-base-url").placeholder = def.urlPlaceholder;
   document.getElementById("model-name").placeholder = def.modelPlaceholder;
   // Server compat section only applies to local model servers
-  var scSection = document.getElementById("model-server-compat-section");
+  const scSection = document.getElementById("model-server-compat-section");
   if (scSection) {
     scSection.style.display = provider === "openai-compatible" ? "" : "none";
   }
@@ -6028,9 +6028,9 @@ function _applyProviderDefaults() {
 /* Populate the model name datalist with known model prefixes for the
    selected provider.  Called on page load and provider change. */
 function _refreshModelSuggestions() {
-  var dl = document.getElementById("model-name-suggestions");
+  const dl = document.getElementById("model-name-suggestions");
   if (!dl) return;
-  var provider = document.getElementById("model-provider").value;
+  const provider = document.getElementById("model-provider").value;
   authFetch(
     "/v1/api/admin/model-capabilities/known?provider=" +
       encodeURIComponent(provider),
@@ -6041,7 +6041,7 @@ function _refreshModelSuggestions() {
     .then(function (d) {
       dl.textContent = "";
       (d.models || []).forEach(function (m) {
-        var opt = document.createElement("option");
+        const opt = document.createElement("option");
         opt.value = m;
         dl.appendChild(opt);
       });
@@ -6053,8 +6053,8 @@ function _refreshModelSuggestions() {
 
 /* Register listeners once at page load */
 (function () {
-  var nameEl = document.getElementById("model-name");
-  var provEl = document.getElementById("model-provider");
+  const nameEl = document.getElementById("model-name");
+  const provEl = document.getElementById("model-provider");
   if (nameEl) nameEl.addEventListener("input", _onModelFieldChange);
   if (provEl) {
     provEl.addEventListener("change", _onModelFieldChange);
@@ -6064,22 +6064,22 @@ function _refreshModelSuggestions() {
   }
   /* Clear stale detect results when probe-relevant inputs change */
   ["model-base-url", "model-api-key"].forEach(function (id) {
-    var el = document.getElementById(id);
+    const el = document.getElementById(id);
     if (el) el.addEventListener("input", _clearDetectResult);
   });
 })();
 
 function _flagModelSyncPending() {
-  var btn = document.getElementById("model-sync-btn");
+  const btn = document.getElementById("model-sync-btn");
   if (btn) btn.classList.add("model-sync-pending");
 }
 function _clearModelSyncPending() {
-  var btn = document.getElementById("model-sync-btn");
+  const btn = document.getElementById("model-sync-btn");
   if (btn) btn.classList.remove("model-sync-pending");
 }
 
 function reloadModelNodes() {
-  var btn = document.getElementById("model-sync-btn");
+  const btn = document.getElementById("model-sync-btn");
   btn.disabled = true;
   btn.textContent = "Syncing...";
   authFetch("/v1/api/admin/model-definitions/reload", { method: "POST" })
@@ -6105,10 +6105,10 @@ function reloadModelNodes() {
 // Node Metadata tab
 // ---------------------------------------------------------------------------
 
-var _nodeMetaCache = {};
+let _nodeMetaCache = {};
 
 function loadAdminNodeMetadata() {
-  var container = document.getElementById("admin-node-metadata-content");
+  const container = document.getElementById("admin-node-metadata-content");
   if (!container) return;
   setSafeHtml(container, '<div class="dashboard-empty">Loading\u2026</div>');
 
@@ -6131,9 +6131,9 @@ function loadAdminNodeMetadata() {
 }
 
 function _renderNodeMetadata() {
-  var container = document.getElementById("admin-node-metadata-content");
+  const container = document.getElementById("admin-node-metadata-content");
   if (!container) return;
-  var nodeIds = Object.keys(_nodeMetaCache).sort();
+  const nodeIds = Object.keys(_nodeMetaCache).sort();
   if (!nodeIds.length) {
     setSafeHtml(
       container,
@@ -6142,9 +6142,9 @@ function _renderNodeMetadata() {
     return;
   }
 
-  var html = "";
+  let html = "";
   nodeIds.forEach(function (nid) {
-    var meta = _nodeMetaCache[nid] || [];
+    const meta = _nodeMetaCache[nid] || [];
     html +=
       '<div class="settings-section" data-section="nm-' +
       escapeHtml(nid) +
@@ -6177,11 +6177,11 @@ function _renderNodeMetadata() {
       html +=
         '<th scope="col"><span class="sr-only">Actions</span></th></tr></thead><tbody>';
       meta.forEach(function (m) {
-        var valStr =
+        const valStr =
           typeof m.value === "object"
             ? JSON.stringify(m.value)
             : String(m.value);
-        var isAuto = m.source === "auto";
+        const isAuto = m.source === "auto";
         html += "<tr>";
         html += '<td class="nm-key">' + escapeHtml(m.key) + "</td>";
         html +=
@@ -6238,8 +6238,8 @@ function _renderNodeMetadata() {
   // Bind section-header click/keydown (no inline handlers — keys come
   // from operator-controlled node IDs and would be a footgun in a
   // ``onclick="..._('NID')"`` attribute).
-  var nmHeaders = container.querySelectorAll(".settings-section-header");
-  for (var nh = 0; nh < nmHeaders.length; nh++) {
+  const nmHeaders = container.querySelectorAll(".settings-section-header");
+  for (let nh = 0; nh < nmHeaders.length; nh++) {
     nmHeaders[nh].addEventListener("click", function () {
       _toggleSettingsSection(this);
     });
@@ -6249,8 +6249,8 @@ function _renderNodeMetadata() {
   }
 
   // Bind button handlers (data-* attrs carry node/key context)
-  var delBtns = container.querySelectorAll(".nm-del-btn");
-  for (var d = 0; d < delBtns.length; d++) {
+  const delBtns = container.querySelectorAll(".nm-del-btn");
+  for (let d = 0; d < delBtns.length; d++) {
     delBtns[d].addEventListener("click", function () {
       _deleteNodeMeta(
         this.getAttribute("data-node"),
@@ -6258,8 +6258,8 @@ function _renderNodeMetadata() {
       );
     });
   }
-  var addBtns = container.querySelectorAll(".nm-add-btn");
-  for (var a = 0; a < addBtns.length; a++) {
+  const addBtns = container.querySelectorAll(".nm-add-btn");
+  for (let a = 0; a < addBtns.length; a++) {
     addBtns[a].addEventListener("click", function () {
       _addNodeMeta(this.getAttribute("data-node"));
     });
@@ -6267,17 +6267,17 @@ function _renderNodeMetadata() {
 }
 
 function _addNodeMeta(nodeId) {
-  var keyEl = document.getElementById("nm-key-" + nodeId);
-  var valEl = document.getElementById("nm-val-" + nodeId);
+  const keyEl = document.getElementById("nm-key-" + nodeId);
+  const valEl = document.getElementById("nm-val-" + nodeId);
   if (!keyEl || !valEl) return;
-  var key = keyEl.value.trim();
-  var rawVal = valEl.value.trim();
+  const key = keyEl.value.trim();
+  const rawVal = valEl.value.trim();
   if (!key) {
     showToast("Key is required", "error");
     return;
   }
 
-  var value;
+  let value;
   try {
     value = JSON.parse(rawVal);
   } catch (e) {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -223,7 +223,7 @@ function recomputeOverview() {
       totalWs++;
       nodeWsTokens += ws.tokens || 0;
     });
-    let aggTokens = (node.aggregate || {}).total_tokens || 0;
+    const aggTokens = (node.aggregate || {}).total_tokens || 0;
     totalTokens += aggTokens || nodeWsTokens;
     totalToolCalls += (node.aggregate || {}).total_tool_calls || 0;
     if (node.version) versions[node.version] = true;
@@ -865,10 +865,10 @@ function toggleGroup(prefix) {
       '"]',
   );
   if (!body) return;
-  let isExpanded = expandedGroups[prefix];
+  const isExpanded = expandedGroups[prefix];
   if (isExpanded) body.classList.remove("collapsed");
   else body.classList.add("collapsed");
-  let groupEl = body.parentElement;
+  const groupEl = body.parentElement;
   if (groupEl) groupEl.setAttribute("aria-expanded", String(isExpanded));
   const chevron = groupEl ? groupEl.querySelector(".node-group-chevron") : null;
   if (chevron) {
@@ -1885,7 +1885,7 @@ function _populateHomeModelDropdowns() {
     })
     .then(function (data) {
       const choices = (data.models || []).map(function (m) {
-        let label =
+        const label =
           m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
         return { value: m.alias, text: label };
       });
@@ -1938,7 +1938,7 @@ function submitHomeCoord(textFromComposer) {
   // read from the composer.
   const task =
     textFromComposer != null ? textFromComposer : _homeCoordComposer.value;
-  let opts = _homeCoordComposer.getOptionValues();
+  const opts = _homeCoordComposer.getOptionValues();
   // Snapshot at submit time so a chip remove mid-request can't race
   // the multipart payload (the actual reset only fires on the success
   // branch, after the response lands).

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -30,9 +30,9 @@ window.onLogout = function () {
   }
 };
 window.onThemeChange = function (next) {
-  var btn = document.getElementById("theme-toggle");
+  const btn = document.getElementById("theme-toggle");
   if (btn) {
-    var isLight = next === "light";
+    const isLight = next === "light";
     btn.textContent = isLight ? "\u2600" : "\u263E";
     btn.title = isLight ? "Switch to dark theme" : "Switch to light theme";
     btn.setAttribute(
@@ -41,7 +41,7 @@ window.onThemeChange = function (next) {
     );
   }
   // Persist to server so admin settings and node UIs see the change
-  var themeValue = next === "light" ? "light" : "dark";
+  const themeValue = next === "light" ? "light" : "dark";
   authFetch("/v1/api/admin/settings/interface.theme", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -50,9 +50,9 @@ window.onThemeChange = function (next) {
 };
 // Set initial theme button text and aria
 (function () {
-  var btn = document.getElementById("theme-toggle");
+  const btn = document.getElementById("theme-toggle");
   if (btn) {
-    var isLight = document.documentElement.dataset.theme === "light";
+    const isLight = document.documentElement.dataset.theme === "light";
     btn.textContent = isLight ? "\u2600" : "\u263E";
     btn.title = isLight ? "Switch to dark theme" : "Switch to light theme";
     btn.setAttribute(
@@ -63,25 +63,25 @@ window.onThemeChange = function (next) {
 })();
 
 // --- State ---
-var currentView = "home"; // "home" | "overview" | "filtered" | "admin"
-var currentFilter = { state: null, node: null, page: 1, per_page: 50 };
-var expandedGroups = {};
-var _lastOverviewJson = "";
-var _lastNodesJson = "";
-var evtSource = null;
-var retryDelay = 1000;
-var clusterState = null;
-var _navigatingFromPopstate = false;
+let currentView = "home"; // "home" | "overview" | "filtered" | "admin"
+let currentFilter = { state: null, node: null, page: 1, per_page: 50 };
+const expandedGroups = {};
+let _lastOverviewJson = "";
+let _lastNodesJson = "";
+let evtSource = null;
+let retryDelay = 1000;
+let clusterState = null;
+let _navigatingFromPopstate = false;
 
 // --- Constants ---
-var STATE_DISPLAY = {
+const STATE_DISPLAY = {
   running: { symbol: "\u25b8", label: "run" },
   thinking: { symbol: "\u25cc", label: "think" },
   attention: { symbol: "\u25c6", label: "attn" },
   idle: { symbol: "\u00b7", label: "idle" },
   error: { symbol: "\u2716", label: "err" },
 };
-var STATE_ORDER = ["running", "thinking", "attention", "error", "idle"];
+const STATE_ORDER = ["running", "thinking", "attention", "error", "idle"];
 
 // --- Cluster State Model ---
 function applySnapshot(data) {
@@ -98,9 +98,9 @@ function applySnapshot(data) {
 
 function patchClusterState(data) {
   if (!clusterState) return;
-  var t = data.type;
+  const t = data.type;
   if (t === "cluster_state") {
-    var node = clusterState.nodes[data.node_id];
+    const node = clusterState.nodes[data.node_id];
     if (node) {
       (node.workstreams || []).forEach(function (ws) {
         if (ws.id === data.ws_id) {
@@ -113,7 +113,7 @@ function patchClusterState(data) {
       });
     }
   } else if (t === "ws_created") {
-    var targetNode = clusterState.nodes[data.node_id];
+    const targetNode = clusterState.nodes[data.node_id];
     if (targetNode) {
       targetNode.workstreams = targetNode.workstreams || [];
       targetNode.workstreams.push({
@@ -145,7 +145,7 @@ function patchClusterState(data) {
     // they're already typed in clusterState from the matching ws_created
     // event.  Skipping interactive closes avoids per-close fan-out into
     // /v1/api/workstreams/saved on busy clusters.
-    var wasCoordinator = false;
+    let wasCoordinator = false;
     Object.keys(clusterState.nodes).forEach(function (nid) {
       (clusterState.nodes[nid].workstreams || []).forEach(function (ws) {
         if (ws.id === data.ws_id && ws.kind === "coordinator") {
@@ -154,7 +154,7 @@ function patchClusterState(data) {
       });
     });
     Object.keys(clusterState.nodes).forEach(function (nid) {
-      var n = clusterState.nodes[nid];
+      const n = clusterState.nodes[nid];
       n.workstreams = (n.workstreams || []).filter(function (ws) {
         return ws.id !== data.ws_id;
       });
@@ -189,7 +189,7 @@ function patchClusterState(data) {
   scheduleRender();
 }
 
-var _renderTimer = null;
+let _renderTimer = null;
 function scheduleRender() {
   if (_renderTimer) return;
   _renderTimer = requestAnimationFrame(function () {
@@ -201,42 +201,42 @@ function scheduleRender() {
 
 function recomputeOverview() {
   if (!clusterState) return;
-  var states = { running: 0, thinking: 0, attention: 0, idle: 0, error: 0 };
-  var totalTokens = 0,
+  const states = { running: 0, thinking: 0, attention: 0, idle: 0, error: 0 };
+  let totalTokens = 0,
     totalToolCalls = 0,
     totalWs = 0;
-  var mcpServers = 0,
+  let mcpServers = 0,
     mcpResources = 0,
     mcpPrompts = 0;
-  var versions = {};
+  const versions = {};
   Object.keys(clusterState.nodes).forEach(function (nid) {
     // Skip the "console" pseudo-node — coordinators aren't compute-
     // node workstreams, and counting them here would inflate the
     // cluster totals.  The active-coordinators list surfaces them
     // separately.
     if (nid === "console") return;
-    var node = clusterState.nodes[nid];
-    var nodeWsTokens = 0;
+    const node = clusterState.nodes[nid];
+    let nodeWsTokens = 0;
     (node.workstreams || []).forEach(function (ws) {
-      var s = ws.state || "idle";
+      const s = ws.state || "idle";
       states[s] = (states[s] || 0) + 1;
       totalWs++;
       nodeWsTokens += ws.tokens || 0;
     });
-    var aggTokens = (node.aggregate || {}).total_tokens || 0;
+    let aggTokens = (node.aggregate || {}).total_tokens || 0;
     totalTokens += aggTokens || nodeWsTokens;
     totalToolCalls += (node.aggregate || {}).total_tool_calls || 0;
     if (node.version) versions[node.version] = true;
-    var mcp = (node.health || {}).mcp || {};
+    const mcp = (node.health || {}).mcp || {};
     mcpServers += mcp.servers || 0;
     mcpResources += mcp.resources || 0;
     mcpPrompts += mcp.prompts || 0;
   });
-  var versionList = Object.keys(versions).sort();
+  const versionList = Object.keys(versions).sort();
   // Count only real compute nodes for the cluster summary — the
   // "console" pseudo-node hosts coordinators, which are surfaced
   // separately by the active-coordinators list.
-  var realNodeCount = Object.keys(clusterState.nodes).filter(function (nid) {
+  const realNodeCount = Object.keys(clusterState.nodes).filter(function (nid) {
     return nid !== "console";
   }).length;
   clusterState.overview = {
@@ -258,13 +258,13 @@ function recomputeOverview() {
 }
 
 function buildNodeInfoFromSnapshot(node) {
-  var states = { running: 0, thinking: 0, attention: 0, idle: 0, error: 0 };
-  var ws = node.workstreams || [];
+  const states = { running: 0, thinking: 0, attention: 0, idle: 0, error: 0 };
+  const ws = node.workstreams || [];
   ws.forEach(function (w) {
-    var s = w.state || "idle";
+    const s = w.state || "idle";
     states[s] = (states[s] || 0) + 1;
   });
-  var aggTokens = (node.aggregate || {}).total_tokens || 0;
+  let aggTokens = (node.aggregate || {}).total_tokens || 0;
   if (!aggTokens) {
     ws.forEach(function (w) {
       aggTokens += w.tokens || 0;
@@ -297,7 +297,7 @@ function renderFromState() {
     _renderHomeView();
     // Home view also hosts the inline node-list (cluster details);
     // render it so the next SSE tick doesn't leave it stale.
-    var nodesList = Object.keys(clusterState.nodes)
+    const nodesList = Object.keys(clusterState.nodes)
       .filter(function (nid) {
         // Exclude the "console" pseudo-node from the nodes list — it's
         // a synthetic carrier for coordinators, not a compute node.
@@ -307,12 +307,12 @@ function renderFromState() {
         return buildNodeInfoFromSnapshot(clusterState.nodes[nid]);
       });
     nodesList.sort(function (a, b) {
-      var d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
+      const d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
       return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
     });
     renderNodeGroups(nodesList, nodesList.length);
   } else if (currentView === "filtered") {
-    var allWs = [];
+    let allWs = [];
     Object.keys(clusterState.nodes).forEach(function (nid) {
       (clusterState.nodes[nid].workstreams || []).forEach(function (ws) {
         allWs.push(ws);
@@ -328,7 +328,7 @@ function renderFromState() {
         return ws.node === currentFilter.node;
       });
     }
-    var stateOrder = {
+    const stateOrder = {
       running: 0,
       thinking: 1,
       attention: 2,
@@ -338,12 +338,12 @@ function renderFromState() {
     allWs.sort(function (a, b) {
       return (stateOrder[a.state] || 9) - (stateOrder[b.state] || 9);
     });
-    var total = allWs.length;
-    var perPage = currentFilter.per_page || 50;
-    var pages = Math.max(1, Math.ceil(total / perPage));
-    var page = Math.min(currentFilter.page || 1, pages);
-    var start = (page - 1) * perPage;
-    var pageWs = allWs.slice(start, start + perPage);
+    const total = allWs.length;
+    const perPage = currentFilter.per_page || 50;
+    const pages = Math.max(1, Math.ceil(total / perPage));
+    const page = Math.min(currentFilter.page || 1, pages);
+    const start = (page - 1) * perPage;
+    const pageWs = allWs.slice(start, start + perPage);
     document.getElementById("filtered-summary").textContent =
       "Page " + page + " of " + pages + " (" + total + " total)";
     renderWsTable(document.getElementById("filtered-ws-table"), pageWs);
@@ -362,17 +362,17 @@ function connectSSE() {
     evtSource = null;
   }
   evtSource = new EventSource("/v1/api/cluster/events");
-  var statusBar = document.getElementById("status-bar");
+  const statusBar = document.getElementById("status-bar");
   evtSource.onopen = function () {
     retryDelay = 1000;
     statusBar.classList.remove("disconnected");
     statusBar.textContent = "";
-    var csb = document.getElementById("cluster-status-bar");
+    const csb = document.getElementById("cluster-status-bar");
     if (csb) csb.classList.remove("stale");
   };
   evtSource.onmessage = function (e) {
     try {
-      var data = JSON.parse(e.data);
+      const data = JSON.parse(e.data);
       handleClusterEvent(data);
     } catch (err) {
       /* ignore malformed SSE */
@@ -382,11 +382,11 @@ function connectSSE() {
     evtSource.close();
     evtSource = null;
     // Don't show reconnecting state if login overlay is visible
-    var loginOverlay = document.getElementById("login-overlay");
+    const loginOverlay = document.getElementById("login-overlay");
     if (loginOverlay && loginOverlay.style.display !== "none") return;
     statusBar.textContent = "Reconnecting\u2026";
     statusBar.classList.add("disconnected");
-    var csb = document.getElementById("cluster-status-bar");
+    const csb = document.getElementById("cluster-status-bar");
     if (csb) csb.classList.add("stale");
     // Raw fetch (not authFetch) — need to inspect status before throwing
     fetch("/v1/api/cluster/overview")
@@ -451,9 +451,9 @@ function showHome() {
   currentView = "home";
   currentFilter = { state: null, node: null, page: 1, per_page: 50 };
   _setLandingView("home");
-  var adminView = document.getElementById("view-admin");
+  const adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
-  var adminBtn = document.getElementById("admin-btn");
+  const adminBtn = document.getElementById("admin-btn");
   if (adminBtn) {
     adminBtn.classList.remove("active");
     adminBtn.setAttribute("aria-expanded", "false");
@@ -470,9 +470,9 @@ function _setLandingView(which) {
   // Toggle the two top-level landing panes.  The node list lives inside
   // #view-home as a sibling section, and clicking a node navigates
   // straight to /node/<id>/ rather than swapping in a detail pane.
-  var views = ["home", "filtered"];
+  const views = ["home", "filtered"];
   views.forEach(function (name) {
-    var el = document.getElementById("view-" + name);
+    const el = document.getElementById("view-" + name);
     if (!el) return;
     el.style.display = name === which ? "" : "none";
   });
@@ -495,7 +495,7 @@ function loadOverview() {
 
 // --- Status Bar ---
 function renderStatusBar(overview) {
-  var cacheKey =
+  const cacheKey =
     JSON.stringify(overview) +
     "|" +
     currentView +
@@ -504,28 +504,28 @@ function renderStatusBar(overview) {
   if (cacheKey === _lastOverviewJson) return;
   _lastOverviewJson = cacheKey;
 
-  var states = overview.states || {};
-  var agg = overview.aggregate || {};
+  const states = overview.states || {};
+  const agg = overview.aggregate || {};
 
-  var statesContainer = document.getElementById("csb-states");
+  const statesContainer = document.getElementById("csb-states");
   statesContainer.replaceChildren();
   STATE_ORDER.forEach(function (state) {
-    var count = states[state] || 0;
-    var sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
-    var pill = document.createElement("button");
+    const count = states[state] || 0;
+    const sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
+    const pill = document.createElement("button");
     pill.className = "csb-state";
     if (currentView === "filtered" && currentFilter.state === state) {
       pill.classList.add("active");
     }
     pill.setAttribute("aria-label", sd.label + ": " + count + " workstreams");
-    var stateDot = document.createElement("span");
+    const stateDot = document.createElement("span");
     stateDot.className = "csb-state-dot";
     stateDot.setAttribute("data-state", state);
     stateDot.setAttribute("aria-hidden", "true");
-    var stateCount = document.createElement("span");
+    const stateCount = document.createElement("span");
     stateCount.className = "csb-state-count" + (count === 0 ? " zero" : "");
     stateCount.textContent = formatCount(count);
-    var stateLabel = document.createElement("span");
+    const stateLabel = document.createElement("span");
     stateLabel.className = "csb-state-label";
     stateLabel.textContent = sd.label;
     pill.append(stateDot, stateCount, stateLabel);
@@ -535,9 +535,9 @@ function renderStatusBar(overview) {
     statesContainer.appendChild(pill);
   });
 
-  var metricsContainer = document.getElementById("csb-metrics");
+  const metricsContainer = document.getElementById("csb-metrics");
   metricsContainer.replaceChildren();
-  var metrics = [
+  const metrics = [
     { value: overview.nodes || 0, label: "nodes", format: formatCount },
     { value: overview.workstreams || 0, label: "ws", format: formatCount },
     { value: agg.total_tokens || 0, label: "tokens", format: formatTokens },
@@ -545,12 +545,12 @@ function renderStatusBar(overview) {
   ];
   metrics.forEach(function (m) {
     if (m.value === 0 && m.label !== "nodes" && m.label !== "ws") return;
-    var el = document.createElement("span");
+    const el = document.createElement("span");
     el.className = "csb-metric";
-    var valSpan = document.createElement("span");
+    const valSpan = document.createElement("span");
     valSpan.className = "csb-metric-value";
     valSpan.textContent = m.format(m.value);
-    var labelSpan = document.createElement("span");
+    const labelSpan = document.createElement("span");
     labelSpan.className = "csb-metric-label";
     labelSpan.textContent = m.label;
     el.appendChild(valSpan);
@@ -562,25 +562,25 @@ function renderStatusBar(overview) {
     overview.versions &&
     overview.versions.length > 1
   ) {
-    var driftEl = document.createElement("span");
+    const driftEl = document.createElement("span");
     driftEl.className = "csb-metric csb-version-drift";
     driftEl.title = "Versions detected: " + overview.versions.join(", ");
-    var warnSpan = document.createElement("span");
+    const warnSpan = document.createElement("span");
     warnSpan.className = "csb-metric-value drift-warn";
     warnSpan.textContent = "DRIFT";
-    var verLabel = document.createElement("span");
+    const verLabel = document.createElement("span");
     verLabel.className = "csb-metric-label";
     verLabel.textContent = overview.versions.join(" / ");
     driftEl.appendChild(warnSpan);
     driftEl.appendChild(verLabel);
     metricsContainer.appendChild(driftEl);
   } else if (overview.versions && overview.versions.length === 1) {
-    var verEl = document.createElement("span");
+    const verEl = document.createElement("span");
     verEl.className = "csb-metric";
-    var valSpan = document.createElement("span");
+    const valSpan = document.createElement("span");
     valSpan.className = "csb-metric-value";
     valSpan.textContent = overview.versions[0];
-    var verLbl = document.createElement("span");
+    const verLbl = document.createElement("span");
     verLbl.className = "csb-metric-label";
     verLbl.textContent = "ver";
     verEl.appendChild(valSpan);
@@ -589,34 +589,34 @@ function renderStatusBar(overview) {
   }
   // MCP aggregate metrics
   if (overview.mcp_servers && overview.mcp_servers > 0) {
-    var mcpDivider = document.createElement("span");
+    const mcpDivider = document.createElement("span");
     mcpDivider.className = "csb-divider";
     mcpDivider.setAttribute("aria-hidden", "true");
     metricsContainer.appendChild(mcpDivider);
-    var mcpTitles = {
+    const mcpTitles = {
       mcp: "MCP servers",
       rsrc: "MCP resources",
       pmpt: "MCP prompts",
     };
-    var mcpMetrics = [
+    const mcpMetrics = [
       { value: overview.mcp_servers, label: "mcp" },
       { value: overview.mcp_resources, label: "rsrc" },
       { value: overview.mcp_prompts, label: "pmpt" },
     ];
     mcpMetrics.forEach(function (m) {
-      var el = document.createElement("span");
+      const el = document.createElement("span");
       el.className = "csb-metric";
       el.title = mcpTitles[m.label] || "";
       if (m.label === "mcp") {
-        var dot = document.createElement("span");
+        const dot = document.createElement("span");
         dot.className = "csb-mcp-dot";
         dot.setAttribute("aria-hidden", "true");
         el.appendChild(dot);
       }
-      var valSpan = document.createElement("span");
+      const valSpan = document.createElement("span");
       valSpan.className = "csb-metric-value";
       valSpan.textContent = formatCount(m.value);
-      var labelSpan = document.createElement("span");
+      const labelSpan = document.createElement("span");
       labelSpan.className = "csb-metric-label";
       labelSpan.textContent = m.label;
       el.appendChild(valSpan);
@@ -628,7 +628,7 @@ function renderStatusBar(overview) {
 
 // --- Node Grouping ---
 function extractNodePrefix(nodeId) {
-  var stripped = nodeId.replace(/[-_][a-z0-9]*\d[a-z0-9]*$/i, "");
+  let stripped = nodeId.replace(/[-_][a-z0-9]*\d[a-z0-9]*$/i, "");
   if (!stripped || stripped === nodeId) {
     stripped = nodeId.replace(/[-_]?\d+$/, "");
   }
@@ -638,10 +638,10 @@ function extractNodePrefix(nodeId) {
 }
 
 function groupNodes(nodes) {
-  var groupMap = {};
-  var groupOrder = [];
+  const groupMap = {};
+  const groupOrder = [];
   nodes.forEach(function (node) {
-    var prefix = extractNodePrefix(node.node_id);
+    const prefix = extractNodePrefix(node.node_id);
     if (!groupMap[prefix]) {
       groupMap[prefix] = {
         prefix: prefix,
@@ -659,7 +659,7 @@ function groupNodes(nodes) {
       };
       groupOrder.push(prefix);
     }
-    var g = groupMap[prefix];
+    const g = groupMap[prefix];
     g.nodes.push(node);
     g.ws_total += node.ws_total || 0;
     g.ws_running += node.ws_running || 0;
@@ -670,21 +670,21 @@ function groupNodes(nodes) {
     g.total_tokens += node.total_tokens || 0;
     if (!node.reachable) g.all_reachable = false;
     if (node.health && node.health.status === "degraded") g.any_degraded = true;
-    var nodeVer = node.version || "";
+    const nodeVer = node.version || "";
     if (nodeVer) g.versions.add(nodeVer);
   });
   groupOrder.forEach(function (prefix) {
     groupMap[prefix].nodes.sort(function (a, b) {
-      var d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
+      const d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
       return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
     });
   });
-  var groups = groupOrder.map(function (p) {
+  const groups = groupOrder.map(function (p) {
     return groupMap[p];
   });
   groups.sort(function (a, b) {
-    var aAct = a.ws_running + a.ws_attention;
-    var bAct = b.ws_running + b.ws_attention;
+    const aAct = a.ws_running + a.ws_attention;
+    const bAct = b.ws_running + b.ws_attention;
     if (bAct !== aAct) return bAct - aAct;
     return a.prefix.localeCompare(b.prefix);
   });
@@ -695,7 +695,7 @@ function groupNodes(nodes) {
 // inside each multi-node group body.  Returns a DocumentFragment built
 // via createElement so the static label list is constructed once with
 // no HTML parsing / string interpolation per render.
-var _NODE_COLHEADER_LABELS = [
+const _NODE_COLHEADER_LABELS = [
   ["ncol ncol-node", "NODE"],
   ["ncol ncol-ws", "WS"],
   ["ncol ncol-run", "RUN"],
@@ -706,9 +706,9 @@ var _NODE_COLHEADER_LABELS = [
 ];
 
 function buildColHeaders() {
-  var frag = document.createDocumentFragment();
-  for (var i = 0; i < _NODE_COLHEADER_LABELS.length; i++) {
-    var span = document.createElement("span");
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < _NODE_COLHEADER_LABELS.length; i++) {
+    const span = document.createElement("span");
     span.className = _NODE_COLHEADER_LABELS[i][0];
     span.textContent = _NODE_COLHEADER_LABELS[i][1];
     frag.appendChild(span);
@@ -719,7 +719,7 @@ function buildColHeaders() {
 // Build a numeric cell for the node table.  ``highlighted`` adds
 // ``has-value`` so non-zero counts get the CSS treatment.
 function _buildNodeNumCell(value, highlighted, cellClass) {
-  var cell = document.createElement("span");
+  const cell = document.createElement("span");
   cell.className = cellClass + (highlighted ? " has-value" : "");
   cell.textContent = String(value);
   return cell;
@@ -729,12 +729,12 @@ function _buildNodeNumCell(value, highlighted, cellClass) {
 // node row or a group header — the structure is identical, only the
 // outer cell class differs.
 function _buildHealthCell(cellClass, healthPct, healthFillClass) {
-  var cell = document.createElement("span");
+  const cell = document.createElement("span");
   cell.className = cellClass;
-  var bar = document.createElement("span");
+  const bar = document.createElement("span");
   bar.className = "health-bar";
   if (healthPct > 0) {
-    var fill = document.createElement("span");
+    const fill = document.createElement("span");
     fill.className = "health-bar-fill " + healthFillClass;
     fill.style.width = healthPct + "%";
     bar.appendChild(fill);
@@ -744,7 +744,7 @@ function _buildHealthCell(cellClass, healthPct, healthFillClass) {
 }
 
 function buildNodeRow(node) {
-  var row = document.createElement("div");
+  const row = document.createElement("div");
   row.className = "node-row";
   if (node.ws_attention > 0) row.classList.add("has-attention");
   else if (node.ws_running > 0) row.classList.add("has-running");
@@ -767,33 +767,33 @@ function buildNodeRow(node) {
       (node.version ? ", version " + node.version : ""),
   );
 
-  var isDegraded = node.health && node.health.status === "degraded";
-  var dotClass = node.reachable
+  const isDegraded = node.health && node.health.status === "degraded";
+  const dotClass = node.reachable
     ? isDegraded
       ? "node-dot degraded"
       : "node-dot"
     : "node-dot unreachable";
-  var displayTokens = node.total_tokens || node.ws_tokens || 0;
-  var maxWs = node.max_ws || 10;
-  var healthPct =
+  const displayTokens = node.total_tokens || node.ws_tokens || 0;
+  const maxWs = node.max_ws || 10;
+  const healthPct =
     maxWs > 0 ? Math.min(Math.round((node.ws_total / maxWs) * 100), 100) : 0;
-  var healthFillClass =
+  const healthFillClass =
     healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
 
-  var healthTitle = "";
+  let healthTitle = "";
   if (node.health && node.health.backend) {
     healthTitle = "backend: " + node.health.backend.status;
   }
 
   // Name cell — dot, node id, optional degraded badge.
-  var nameCell = document.createElement("span");
+  const nameCell = document.createElement("span");
   nameCell.className = "node-cell node-cell-name";
   if (healthTitle) nameCell.setAttribute("title", healthTitle);
-  var dot = document.createElement("span");
+  const dot = document.createElement("span");
   dot.className = dotClass;
   nameCell.append(dot, node.node_id);
   if (isDegraded) {
-    var degradedEl = document.createElement("span");
+    const degradedEl = document.createElement("span");
     degradedEl.className = "node-degraded-badge";
     // Only attach the descriptive title / aria-label when there's a
     // backend-status string to surface.  An empty aria-label would
@@ -830,12 +830,12 @@ function buildNodeRow(node) {
     ),
   );
 
-  var tokensCell = document.createElement("span");
+  const tokensCell = document.createElement("span");
   tokensCell.className = "node-cell node-cell-num";
   tokensCell.textContent = formatTokens(displayTokens);
   row.appendChild(tokensCell);
 
-  var versionCell = document.createElement("span");
+  const versionCell = document.createElement("span");
   versionCell.className = "node-cell node-cell-version";
   versionCell.textContent = node.version || "";
   row.appendChild(versionCell);
@@ -844,7 +844,7 @@ function buildNodeRow(node) {
     _buildHealthCell("node-cell node-cell-health", healthPct, healthFillClass),
   );
 
-  var nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
+  const nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
   row.onclick = function () {
     window.location.href = nodeUrl;
   };
@@ -859,18 +859,18 @@ function buildNodeRow(node) {
 
 function toggleGroup(prefix) {
   expandedGroups[prefix] = !expandedGroups[prefix];
-  var body = document.querySelector(
+  const body = document.querySelector(
     '.node-group-body[data-prefix="' +
       prefix.replace(/\\/g, "\\\\").replace(/"/g, '\\"') +
       '"]',
   );
   if (!body) return;
-  var isExpanded = expandedGroups[prefix];
+  let isExpanded = expandedGroups[prefix];
   if (isExpanded) body.classList.remove("collapsed");
   else body.classList.add("collapsed");
-  var groupEl = body.parentElement;
+  let groupEl = body.parentElement;
   if (groupEl) groupEl.setAttribute("aria-expanded", String(isExpanded));
-  var chevron = groupEl ? groupEl.querySelector(".node-group-chevron") : null;
+  const chevron = groupEl ? groupEl.querySelector(".node-group-chevron") : null;
   if (chevron) {
     if (isExpanded) chevron.classList.add("expanded");
     else chevron.classList.remove("expanded");
@@ -878,43 +878,43 @@ function toggleGroup(prefix) {
 }
 
 function renderNodeGroups(nodes, total) {
-  var json = JSON.stringify(nodes);
+  const json = JSON.stringify(nodes);
   if (json === _lastNodesJson) return;
   _lastNodesJson = json;
 
-  var table = document.getElementById("node-table");
+  const table = document.getElementById("node-table");
   table.replaceChildren();
   if (!nodes.length) {
     table.appendChild(makeEmptyState("No nodes discovered"));
     return;
   }
 
-  var topHeaders = document.createElement("div");
+  const topHeaders = document.createElement("div");
   topHeaders.className = "node-colheaders";
   topHeaders.setAttribute("aria-hidden", "true");
   topHeaders.appendChild(buildColHeaders());
   table.appendChild(topHeaders);
 
-  var groups = groupNodes(nodes);
+  const groups = groupNodes(nodes);
 
   groups.forEach(function (group) {
     // Single-node group — render as plain row
     if (group.nodes.length === 1) {
-      var wrapper = document.createElement("div");
+      const wrapper = document.createElement("div");
       wrapper.className = "node-group node-group-single";
       wrapper.appendChild(buildNodeRow(group.nodes[0]));
       table.appendChild(wrapper);
       return;
     }
 
-    var groupEl = document.createElement("div");
+    const groupEl = document.createElement("div");
     groupEl.className = "node-group";
-    var isExpanded = !!expandedGroups[group.prefix];
+    const isExpanded = !!expandedGroups[group.prefix];
     groupEl.setAttribute("role", "listitem");
     groupEl.setAttribute("aria-expanded", String(isExpanded));
 
     // Group header
-    var header = document.createElement("div");
+    const header = document.createElement("div");
     header.className = "node-group-header";
     if (group.ws_attention > 0) header.classList.add("has-attention");
     else if (group.ws_running > 0) header.classList.add("has-running");
@@ -939,19 +939,19 @@ function renderNodeGroups(nodes, total) {
         (group.versions.size > 1 ? ", version drift detected" : ""),
     );
 
-    var chevronClass = "node-group-chevron" + (isExpanded ? " expanded" : "");
-    var totalMaxWs = 0;
+    const chevronClass = "node-group-chevron" + (isExpanded ? " expanded" : "");
+    let totalMaxWs = 0;
     group.nodes.forEach(function (n) {
       totalMaxWs += n.max_ws || 10;
     });
-    var healthPct =
+    const healthPct =
       totalMaxWs > 0
         ? Math.min(Math.round((group.ws_total / totalMaxWs) * 100), 100)
         : 0;
-    var healthFillClass =
+    const healthFillClass =
       healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
-    var groupVersionText = "";
-    var groupVersionDrift = false;
+    let groupVersionText = "";
+    let groupVersionDrift = false;
     if (group.versions.size === 1) {
       groupVersionText = Array.from(group.versions)[0];
     } else if (group.versions.size > 1) {
@@ -960,18 +960,18 @@ function renderNodeGroups(nodes, total) {
     }
 
     // Group-name cell: chevron + prefix + node count + optional degraded badge.
-    var nameCell = document.createElement("span");
+    const nameCell = document.createElement("span");
     nameCell.className = "node-group-name";
-    var chevron = document.createElement("span");
+    const chevron = document.createElement("span");
     chevron.className = chevronClass;
     chevron.setAttribute("aria-hidden", "true");
     chevron.textContent = "▸";
-    var badge = document.createElement("span");
+    const badge = document.createElement("span");
     badge.className = "node-group-badge";
     badge.textContent = group.nodes.length + " nodes";
     nameCell.append(chevron, group.prefix, badge);
     if (group.any_degraded) {
-      var degradedEl = document.createElement("span");
+      const degradedEl = document.createElement("span");
       degradedEl.className = "node-degraded-badge";
       degradedEl.textContent = "degraded";
       nameCell.appendChild(degradedEl);
@@ -1000,17 +1000,17 @@ function renderNodeGroups(nodes, total) {
       ),
     );
 
-    var groupTokensCell = document.createElement("span");
+    const groupTokensCell = document.createElement("span");
     groupTokensCell.className = "node-group-cell num";
     groupTokensCell.textContent = formatTokens(group.total_tokens);
     header.appendChild(groupTokensCell);
 
-    var groupVersionCell = document.createElement("span");
+    const groupVersionCell = document.createElement("span");
     groupVersionCell.className =
       "node-group-cell node-cell-version" + (groupVersionDrift ? " drift" : "");
     groupVersionCell.textContent = groupVersionText;
     if (groupVersionDrift) {
-      var driftBadge = document.createElement("span");
+      const driftBadge = document.createElement("span");
       driftBadge.className = "node-version-drift-badge";
       driftBadge.textContent = "drift";
       groupVersionCell.appendChild(driftBadge);
@@ -1025,7 +1025,7 @@ function renderNodeGroups(nodes, total) {
       ),
     );
 
-    var prefix = group.prefix;
+    const prefix = group.prefix;
     header.onclick = function () {
       toggleGroup(prefix);
     };
@@ -1038,11 +1038,11 @@ function renderNodeGroups(nodes, total) {
     groupEl.appendChild(header);
 
     // Group body
-    var body = document.createElement("div");
+    const body = document.createElement("div");
     body.className = "node-group-body" + (isExpanded ? "" : " collapsed");
     body.dataset.prefix = group.prefix;
 
-    var colHeaders = document.createElement("div");
+    const colHeaders = document.createElement("div");
     colHeaders.className = "node-colheaders";
     colHeaders.setAttribute("aria-hidden", "true");
     colHeaders.appendChild(buildColHeaders());
@@ -1062,15 +1062,15 @@ function drillDownByState(state) {
   currentView = "filtered";
   currentFilter = { state: state, node: null, page: 1, per_page: 50 };
   _setLandingView("filtered");
-  var adminView = document.getElementById("view-admin");
+  const adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
-  var adminBtn = document.getElementById("admin-btn");
+  const adminBtn = document.getElementById("admin-btn");
   if (adminBtn) {
     adminBtn.classList.remove("active");
     adminBtn.setAttribute("aria-expanded", "false");
   }
   document.getElementById("breadcrumb").style.display = "";
-  var sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
+  const sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
   document.getElementById("breadcrumb-label").textContent =
     sd.symbol + " " + sd.label;
   document.getElementById("filtered-title").textContent =
@@ -1087,9 +1087,9 @@ function drillDownByNode(nodeId) {
   currentView = "filtered";
   currentFilter = { state: null, node: nodeId, page: 1, per_page: 50 };
   _setLandingView("filtered");
-  var adminView = document.getElementById("view-admin");
+  const adminView = document.getElementById("view-admin");
   if (adminView) adminView.style.display = "none";
-  var adminBtn = document.getElementById("admin-btn");
+  const adminBtn = document.getElementById("admin-btn");
   if (adminBtn) {
     adminBtn.classList.remove("active");
     adminBtn.setAttribute("aria-expanded", "false");
@@ -1124,7 +1124,7 @@ function loadFilteredWorkstreams() {
 function renderPagination(container, page, pages) {
   container.replaceChildren();
   if (pages <= 1) return;
-  var prev = document.createElement("button");
+  const prev = document.createElement("button");
   prev.textContent = "\u25c4 Prev";
   prev.disabled = page <= 1;
   prev.onclick = function () {
@@ -1133,10 +1133,10 @@ function renderPagination(container, page, pages) {
     else loadFilteredWorkstreams();
   };
   container.appendChild(prev);
-  var info = document.createElement("span");
+  const info = document.createElement("span");
   info.textContent = page + " / " + pages;
   container.appendChild(info);
-  var next = document.createElement("button");
+  const next = document.createElement("button");
   next.textContent = "Next \u25ba";
   next.disabled = page >= pages;
   next.onclick = function () {
@@ -1157,12 +1157,12 @@ function renderPagination(container, page, pages) {
 //
 // Expansion state persists in localStorage keyed by coordinator ws_id so
 // the browser remembers the operator's preferred layout across reloads.
-var _DASH_EXPAND_KEY_PREFIX = "coord-dashboard-expanded-";
+const _DASH_EXPAND_KEY_PREFIX = "coord-dashboard-expanded-";
 
 function _isExpanded(coordWsId) {
   if (!coordWsId) return false;
   try {
-    var v = localStorage.getItem(_DASH_EXPAND_KEY_PREFIX + coordWsId);
+    const v = localStorage.getItem(_DASH_EXPAND_KEY_PREFIX + coordWsId);
     return v === "1";
   } catch (_) {
     return false;
@@ -1182,15 +1182,15 @@ function _setExpanded(coordWsId, expanded) {
 }
 
 function _bucketByParent(wsList) {
-  var byId = {};
+  const byId = {};
   wsList.forEach(function (ws) {
     if (ws.id) byId[ws.id] = ws;
   });
-  var childrenMap = {};
-  var roots = [];
-  var orphans = [];
+  const childrenMap = {};
+  const roots = [];
+  const orphans = [];
   wsList.forEach(function (ws) {
-    var parent = ws.parent_ws_id || null;
+    const parent = ws.parent_ws_id || null;
     if (parent && byId[parent]) {
       (childrenMap[parent] = childrenMap[parent] || []).push(ws);
     } else if (parent) {
@@ -1205,26 +1205,26 @@ function _bucketByParent(wsList) {
 function renderWsTable(container, wsList) {
   container.replaceChildren();
   if (!wsList.length) {
-    var empty = document.createElement("div");
+    const empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No workstreams";
     container.appendChild(empty);
     return;
   }
-  var groups = _bucketByParent(wsList);
+  const groups = _bucketByParent(wsList);
 
   function appendRow(ws, opts) {
     opts = opts || {};
-    var row = _renderWsRow(ws, opts, container);
+    const row = _renderWsRow(ws, opts, container);
     container.appendChild(row);
     // Render children ALWAYS — expand/collapse is a CSS display toggle
     // on the child rows.  This lets the caret swap a class instead of
     // rebuilding the table, which preserves focus, avoids SR re-
     // announcement, and stays cheap regardless of row count.
     if (opts.childCount != null) {
-      var kids = groups.childrenMap[ws.id] || [];
+      const kids = groups.childrenMap[ws.id] || [];
       kids.forEach(function (child) {
-        var childRow = _renderWsRow(
+        const childRow = _renderWsRow(
           child,
           { isChild: true, parentWsId: ws.id, collapsed: !opts.expanded },
           container,
@@ -1235,8 +1235,8 @@ function renderWsTable(container, wsList) {
   }
 
   groups.roots.forEach(function (ws) {
-    var kids = groups.childrenMap[ws.id] || [];
-    var isCoord = ws.kind === "coordinator" || kids.length > 0;
+    const kids = groups.childrenMap[ws.id] || [];
+    const isCoord = ws.kind === "coordinator" || kids.length > 0;
     if (isCoord) {
       appendRow(ws, {
         isCoordinator: true,
@@ -1254,10 +1254,10 @@ function renderWsTable(container, wsList) {
 
 function _renderWsRow(ws, opts, container) {
   opts = opts || {};
-  var state = ws.state || "idle";
-  var sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
+  const state = ws.state || "idle";
+  const sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
 
-  var row = document.createElement("div");
+  const row = document.createElement("div");
   row.className = "dash-row";
   if (opts.isCoordinator) row.classList.add("dash-row--coordinator");
   if (opts.isChild) {
@@ -1273,7 +1273,7 @@ function _renderWsRow(ws, opts, container) {
   row.dataset.state = state;
   row.setAttribute("tabindex", "0");
   row.setAttribute("role", "button");
-  var ariaLabel = sd.label + ": " + (ws.name || ws.id || "unnamed");
+  let ariaLabel = sd.label + ": " + (ws.name || ws.id || "unnamed");
   if (ws.model_alias || ws.model)
     ariaLabel += ", model: " + (ws.model_alias || ws.model);
   if (ws.node) ariaLabel += " on " + ws.node;
@@ -1286,14 +1286,14 @@ function _renderWsRow(ws, opts, container) {
   if (opts.isOrphan) ariaLabel += ", orphan";
   row.setAttribute("aria-label", ariaLabel);
 
-  var main = document.createElement("div");
+  const main = document.createElement("div");
   main.className = "dash-row-main";
 
   // Expand / collapse caret — coordinator rows only.  The caret is a
   // button so it's keyboard-reachable; clicking it toggles without
   // bubbling to the row-level deep link handler.
   if (opts.isCoordinator && opts.childCount != null && opts.childCount > 0) {
-    var caret = document.createElement("button");
+    const caret = document.createElement("button");
     caret.type = "button";
     caret.className = "dash-caret";
     caret.setAttribute("aria-expanded", opts.expanded ? "true" : "false");
@@ -1309,8 +1309,8 @@ function _renderWsRow(ws, opts, container) {
     caret.textContent = opts.expanded ? "\u25BE" : "\u25B8"; // ▾ / ▸
     caret.onclick = function (e) {
       e.stopPropagation();
-      var coordWsId = ws.id;
-      var nowExpanded = caret.getAttribute("aria-expanded") !== "true";
+      const coordWsId = ws.id;
+      const nowExpanded = caret.getAttribute("aria-expanded") !== "true";
       _setExpanded(coordWsId, nowExpanded);
       // Toggle CSS class on child rows — no table rebuild, so focus
       // stays on the caret and screen readers don't re-announce the
@@ -1324,9 +1324,9 @@ function _renderWsRow(ws, opts, container) {
       caret.textContent = nowExpanded ? "\u25BE" : "\u25B8";
       row.dataset.expanded = nowExpanded ? "true" : "false";
       if (container) {
-        var selector =
+        const selector =
           '.dash-row--child[data-parent-ws-id="' + cssEscape(coordWsId) + '"]';
-        var kids = container.querySelectorAll(selector);
+        const kids = container.querySelectorAll(selector);
         kids.forEach(function (k) {
           k.classList.toggle("dash-row--collapsed", !nowExpanded);
         });
@@ -1340,21 +1340,21 @@ function _renderWsRow(ws, opts, container) {
     // Indentation placeholder so child rows align visually with their
     // parent's post-caret content.  Not a caret — nested coordinators
     // aren't supported in v1.
-    var indent = document.createElement("span");
+    const indent = document.createElement("span");
     indent.className = "dash-caret-placeholder";
     indent.setAttribute("aria-hidden", "true");
     main.appendChild(indent);
   }
 
   // STATE
-  var stateCell = document.createElement("span");
+  const stateCell = document.createElement("span");
   stateCell.className = "dash-cell-state";
-  var dot = document.createElement("span");
+  const dot = document.createElement("span");
   dot.className = "dash-state-dot";
   dot.dataset.state = state;
   dot.setAttribute("aria-hidden", "true");
   stateCell.appendChild(dot);
-  var stateLabel = document.createElement("span");
+  const stateLabel = document.createElement("span");
   stateLabel.className = "dash-state-label";
   stateLabel.dataset.state = state;
   stateLabel.textContent = sd.symbol + " " + sd.label;
@@ -1362,9 +1362,9 @@ function _renderWsRow(ws, opts, container) {
   main.appendChild(stateCell);
 
   // NAME (with optional child-count summary for collapsed coordinators)
-  var nameCell = document.createElement("span");
+  const nameCell = document.createElement("span");
   nameCell.className = "dash-cell-name";
-  var nameText = ws.name || ws.title || ws.id || "";
+  const nameText = ws.name || ws.title || ws.id || "";
   nameCell.textContent = nameText;
   if (opts.isCoordinator && opts.childCount != null && opts.childCount > 0) {
     // Render the "(N children)" summary only when there actually are
@@ -1373,7 +1373,7 @@ function _renderWsRow(ws, opts, container) {
     // otherwise always print "(0 children)".  CSS hides it when the
     // row is expanded (see [data-expanded="true"] .dash-child-count
     // in style.css).
-    var summary = document.createElement("span");
+    const summary = document.createElement("span");
     summary.className = "dash-child-count";
     summary.textContent =
       " (" +
@@ -1382,7 +1382,7 @@ function _renderWsRow(ws, opts, container) {
     nameCell.appendChild(summary);
   }
   if (opts.isOrphan) {
-    var orphanBadge = document.createElement("span");
+    const orphanBadge = document.createElement("span");
     orphanBadge.className = "dash-orphan-badge";
     orphanBadge.textContent = " orphan";
     nameCell.appendChild(orphanBadge);
@@ -1390,14 +1390,14 @@ function _renderWsRow(ws, opts, container) {
   main.appendChild(nameCell);
 
   // MODEL
-  var modelCell = document.createElement("span");
+  const modelCell = document.createElement("span");
   modelCell.className = "dash-cell-model";
   modelCell.textContent = ws.model_alias || ws.model || "";
   if (ws.model) modelCell.title = ws.model;
   main.appendChild(modelCell);
 
   // NODE (clickable)
-  var nodeCell = document.createElement("span");
+  const nodeCell = document.createElement("span");
   nodeCell.className = "dash-cell-node";
   nodeCell.textContent = ws.node || "";
   nodeCell.onclick = function (e) {
@@ -1407,19 +1407,19 @@ function _renderWsRow(ws, opts, container) {
   main.appendChild(nodeCell);
 
   // TASK
-  var taskCell = document.createElement("span");
+  const taskCell = document.createElement("span");
   taskCell.className = "dash-cell-task";
   taskCell.textContent = ws.title || "";
   main.appendChild(taskCell);
 
   // TOKENS
-  var tokensCell = document.createElement("span");
+  const tokensCell = document.createElement("span");
   tokensCell.className = "dash-cell-tokens";
   tokensCell.textContent = ws.tokens ? formatTokens(ws.tokens) : "";
   main.appendChild(tokensCell);
 
   // CTX
-  var ctxCell = document.createElement("span");
+  const ctxCell = document.createElement("span");
   ctxCell.className = "dash-cell-ctx " + ctxClass(ws.context_ratio || 0);
   ctxCell.textContent =
     ws.context_ratio > 0 ? Math.round(ws.context_ratio * 100) + "%" : "";
@@ -1428,7 +1428,7 @@ function _renderWsRow(ws, opts, container) {
   row.appendChild(main);
 
   // Sub-line
-  var sub = document.createElement("div");
+  const sub = document.createElement("div");
   sub.className = "dash-row-sub";
   if (ws.activity_state === "approval") sub.classList.add("sub-attention");
   sub.textContent = ws.activity || "";
@@ -1437,7 +1437,7 @@ function _renderWsRow(ws, opts, container) {
   // Deep link: click opens proxied server UI at this workstream.
   // Coordinator rows route to /coordinator/{ws_id}; node-backed
   // workstreams route to the proxied /node/{node_id}/?ws_id=X UI.
-  var wsNodeId = ws.node;
+  const wsNodeId = ws.node;
   if (opts.isCoordinator || ws.kind === "coordinator") {
     row.classList.add("has-link");
     (function (wsId) {
@@ -1479,7 +1479,7 @@ function _renderWsRow(ws, opts, container) {
 
 // --- Navigation ---
 window.addEventListener("popstate", function (e) {
-  var overlay = document.getElementById("login-overlay");
+  const overlay = document.getElementById("login-overlay");
   if (overlay && overlay.style.display !== "none") return;
   _navigatingFromPopstate = true;
   try {
@@ -1507,7 +1507,7 @@ window.addEventListener("popstate", function (e) {
 // ---------------------------------------------------------------------------
 
 function _hasCoordPermission() {
-  var perms = sessionStorage.getItem("turnstone_permissions") || "";
+  const perms = sessionStorage.getItem("turnstone_permissions") || "";
   return perms.split(",").indexOf("admin.coordinator") !== -1;
 }
 
@@ -1517,14 +1517,14 @@ function _hasCoordPermission() {
 // On success redirects to /coordinator/{ws_id}; on failure surfaces
 // the server's error text inline through errEl.
 function _createCoordinator(opts) {
-  var name = (opts.name || "").trim();
-  var skill = opts.skill || "";
-  var model = (opts.model || "").trim();
-  var judgeModel = (opts.judge_model || "").trim();
-  var task = (opts.task || "").trim();
-  var errEl = opts.errEl;
-  var setBusy = opts.setBusy || function () {};
-  var onSuccess = opts.onSuccess || function () {};
+  const name = (opts.name || "").trim();
+  const skill = opts.skill || "";
+  const model = (opts.model || "").trim();
+  const judgeModel = (opts.judge_model || "").trim();
+  const task = (opts.task || "").trim();
+  const errEl = opts.errEl;
+  const setBusy = opts.setBusy || function () {};
+  const onSuccess = opts.onSuccess || function () {};
 
   // Error region is always rendered with reserved min-height (see
   // .home-composer-error in style.css) so toggling validation messages
@@ -1533,7 +1533,7 @@ function _createCoordinator(opts) {
   errEl.textContent = "";
   setBusy(true);
 
-  var body = {};
+  const body = {};
   if (name) body.name = name;
   if (skill) body.skill = skill;
   if (model) body.model = model;
@@ -1545,12 +1545,12 @@ function _createCoordinator(opts) {
   // reserves attachments for the very first turn (same flow the
   // interactive UI's new-ws modal uses against the server).  Plain
   // JSON stays the default when no files are attached.
-  var files = Array.isArray(opts.files) ? opts.files : [];
-  var fetchOpts;
+  const files = Array.isArray(opts.files) ? opts.files : [];
+  let fetchOpts;
   if (files.length > 0) {
-    var form = new FormData();
+    const form = new FormData();
     form.append("meta", JSON.stringify(body));
-    for (var i = 0; i < files.length; i++) {
+    for (let i = 0; i < files.length; i++) {
       form.append("file", files[i], files[i].name);
     }
     // Don't set Content-Type — the browser adds the correct boundary.
@@ -1594,31 +1594,31 @@ function _createCoordinator(opts) {
 // picks them up automatically via scheduleRender → renderFromState.
 // ---------------------------------------------------------------------------
 
-var _homeComposerInit = false;
-var _homeCoordComposer = null; // shared Composer instance
-var _homeCoordBusy = false;
+let _homeComposerInit = false;
+let _homeCoordComposer = null; // shared Composer instance
+let _homeCoordBusy = false;
 
 // Attachment staging for the home coord composer.  The coord ws_id
 // doesn't exist until the create POST resolves, so we hold File
 // objects in memory and ship them as multipart parts on submit (same
 // pattern interactive uses for its new-ws modal + dashboard composer).
-var _homeStagedFiles = [];
+let _homeStagedFiles = [];
 
 // Per-kind size caps + allowlist mirrored from turnstone/core/attachments.py
 // so the browser can fail fast.  Keep in sync with the interactive
 // UI's _ATTACH_* constants in turnstone/ui/static/app.js.
-var _HOME_IMAGE_CAP = 4 * 1024 * 1024;
-var _HOME_TEXT_CAP = 512 * 1024;
-var _HOME_MAX_FILES = 10;
-var _HOME_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
-var _HOME_TEXT_APP_MIMES = [
+const _HOME_IMAGE_CAP = 4 * 1024 * 1024;
+const _HOME_TEXT_CAP = 512 * 1024;
+const _HOME_MAX_FILES = 10;
+const _HOME_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+const _HOME_TEXT_APP_MIMES = [
   "application/json",
   "application/xml",
   "application/x-yaml",
   "application/yaml",
   "application/toml",
 ];
-var _HOME_TEXT_EXTENSIONS = [
+const _HOME_TEXT_EXTENSIONS = [
   ".c",
   ".conf",
   ".cpp",
@@ -1653,12 +1653,12 @@ function _homeFormatSize(n) {
 }
 
 function _homeIsAttachmentAllowed(file) {
-  var mime = (file.type || "").toLowerCase();
+  const mime = (file.type || "").toLowerCase();
   if (_HOME_IMAGE_MIMES.indexOf(mime) !== -1) return true;
   if (mime.indexOf("text/") === 0) return true;
   if (_HOME_TEXT_APP_MIMES.indexOf(mime) !== -1) return true;
-  var name = (file.name || "").toLowerCase();
-  var dot = name.lastIndexOf(".");
+  const name = (file.name || "").toLowerCase();
+  const dot = name.lastIndexOf(".");
   if (dot >= 0 && _HOME_TEXT_EXTENSIONS.indexOf(name.substr(dot)) !== -1) {
     return true;
   }
@@ -1666,7 +1666,7 @@ function _homeIsAttachmentAllowed(file) {
 }
 
 function _homeShowError(msg) {
-  var errEl = document.getElementById("home-coord-error");
+  const errEl = document.getElementById("home-coord-error");
   if (!errEl) return;
   // Element is always rendered (min-height reserves the row); just
   // toggle the message text so layout doesn't shift on validation.
@@ -1675,35 +1675,35 @@ function _homeShowError(msg) {
 
 function _homeRenderChips() {
   if (!_homeCoordComposer || !_homeCoordComposer.chipsEl) return;
-  var chipsEl = _homeCoordComposer.chipsEl;
+  const chipsEl = _homeCoordComposer.chipsEl;
   chipsEl.textContent = "";
-  for (var i = 0; i < _homeStagedFiles.length; i++) {
+  for (let i = 0; i < _homeStagedFiles.length; i++) {
     (function (idx) {
-      var f = _homeStagedFiles[idx];
-      var isImage = (f.type || "").indexOf("image/") === 0;
-      var chip = document.createElement("span");
+      const f = _homeStagedFiles[idx];
+      const isImage = (f.type || "").indexOf("image/") === 0;
+      const chip = document.createElement("span");
       chip.className =
         "composer-chip composer-chip-" + (isImage ? "image" : "text");
       chip.setAttribute("role", "listitem");
 
-      var icon = document.createElement("span");
+      const icon = document.createElement("span");
       icon.className = "composer-chip-icon";
       icon.setAttribute("aria-hidden", "true");
       icon.textContent = isImage ? "🖼" : "📄";
       chip.appendChild(icon);
 
-      var name = document.createElement("span");
+      const name = document.createElement("span");
       name.className = "composer-chip-name";
       name.textContent = f.name;
       name.title = f.name + " (" + f.size + " bytes)";
       chip.appendChild(name);
 
-      var size = document.createElement("span");
+      const size = document.createElement("span");
       size.className = "composer-chip-size";
       size.textContent = _homeFormatSize(f.size);
       chip.appendChild(size);
 
-      var rm = document.createElement("button");
+      const rm = document.createElement("button");
       rm.type = "button";
       rm.className = "composer-chip-remove";
       rm.setAttribute("aria-label", "Remove " + f.name);
@@ -1735,8 +1735,8 @@ function _homeStageFile(file) {
     );
     return;
   }
-  var isImage = (file.type || "").indexOf("image/") === 0;
-  var cap = isImage ? _HOME_IMAGE_CAP : _HOME_TEXT_CAP;
+  const isImage = (file.type || "").indexOf("image/") === 0;
+  const cap = isImage ? _HOME_IMAGE_CAP : _HOME_TEXT_CAP;
   if (file.size > cap) {
     _homeShowError(file.name + " exceeds the " + _homeFormatSize(cap) + " cap");
     return;
@@ -1767,7 +1767,7 @@ function _ensureHomeComposerInit() {
 }
 
 function _mountHomeCoordComposer() {
-  var mount = document.getElementById("home-coord-composer-mount");
+  const mount = document.getElementById("home-coord-composer-mount");
   if (!mount || _homeCoordComposer) return;
   _homeCoordComposer = new Composer(mount, {
     layout: "stacked",
@@ -1787,7 +1787,7 @@ function _mountHomeCoordComposer() {
     options: {
       storageKey: "turnstone.console.home_coord.options_open",
       summary: function (v) {
-        var bits = [];
+        const bits = [];
         if (v.name) bits.push(v.name);
         if (v.skill) bits.push(v.skill);
         if (v.model) bits.push(v.model);
@@ -1845,7 +1845,7 @@ function _populateHomeSkillDropdown() {
       return r.ok ? r.json() : { skills: [] };
     })
     .then(function (data) {
-      var choices = (data.skills || []).map(function (t) {
+      const choices = (data.skills || []).map(function (t) {
         return {
           value: t.name,
           text: t.is_default ? t.name + " (default)" : t.name,
@@ -1864,8 +1864,8 @@ function _populateHomeSkillDropdown() {
 // to a neutral placeholder.
 function _resolveModelLabel(alias, models) {
   if (!alias) return "";
-  for (var i = 0; i < (models || []).length; i++) {
-    var m = models[i];
+  for (let i = 0; i < (models || []).length; i++) {
+    const m = models[i];
     if (m.alias === alias) {
       return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
     }
@@ -1884,8 +1884,8 @@ function _populateHomeModelDropdowns() {
       return r.ok ? r.json() : { models: [] };
     })
     .then(function (data) {
-      var choices = (data.models || []).map(function (m) {
-        var label =
+      const choices = (data.models || []).map(function (m) {
+        let label =
           m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
         return { value: m.alias, text: label };
       });
@@ -1899,11 +1899,11 @@ function _populateHomeModelDropdowns() {
       // alias's "(model)" suffix legible and matches the
       // ``(default — alias (model))`` pattern used in the admin Roles
       // tab.
-      var coordDefault = _resolveModelLabel(
+      const coordDefault = _resolveModelLabel(
         data.coordinator_default_alias || "",
         data.models || [],
       );
-      var judgeDefault = _resolveModelLabel(
+      const judgeDefault = _resolveModelLabel(
         data.judge_default_alias || "",
         data.models || [],
       );
@@ -1922,7 +1922,7 @@ function _populateHomeModelDropdowns() {
 }
 
 function _refreshHomeComposerVisibility() {
-  var panel = document.getElementById("coord-composer-panel");
+  const panel = document.getElementById("coord-composer-panel");
   if (!panel) return;
   panel.style.display = _hasCoordPermission() ? "" : "none";
 }
@@ -1936,13 +1936,13 @@ function submitHomeCoord(textFromComposer) {
   // text arg is passed when the Composer's Enter-key handler fires;
   // direct callers (Ctrl/Cmd+Enter) invoke with no argument and we
   // read from the composer.
-  var task =
+  const task =
     textFromComposer != null ? textFromComposer : _homeCoordComposer.value;
-  var opts = _homeCoordComposer.getOptionValues();
+  let opts = _homeCoordComposer.getOptionValues();
   // Snapshot at submit time so a chip remove mid-request can't race
   // the multipart payload (the actual reset only fires on the success
   // branch, after the response lands).
-  var files = _homeStagedFiles.slice();
+  const files = _homeStagedFiles.slice();
   // Files-without-text would upload pending attachment rows but the
   // server's _coord_create_post_install only reserves+dispatches when
   // initial_message is non-empty — uploaded files would orphan as
@@ -1981,7 +1981,7 @@ function submitHomeCoord(textFromComposer) {
 document.addEventListener("keydown", function (e) {
   if (e.key !== "Enter" || !(e.ctrlKey || e.metaKey)) return;
   if (!_homeCoordComposer) return;
-  var mount = document.getElementById("home-coord-composer-mount");
+  const mount = document.getElementById("home-coord-composer-mount");
   if (!mount || !mount.contains(e.target)) return;
   e.preventDefault();
   if (!_homeCoordComposer.sendBtn.disabled) submitHomeCoord();
@@ -1992,7 +1992,7 @@ document.addEventListener("keydown", function (e) {
 // coord list has changed.  renderFromState fires on every SSE patch
 // (state_change, ws_created, ws_closed, ...) and most of those don't
 // affect the coord list.
-var _homeCoordsFingerprint = "";
+let _homeCoordsFingerprint = "";
 
 // Active-coordinators list is SSE-driven — the console collector
 // registers a "console" pseudo-node and the coordinator manager fans
@@ -2004,7 +2004,7 @@ var _homeCoordsFingerprint = "";
 
 function _activeCoordsFromClusterState() {
   if (!clusterState) return [];
-  var node = clusterState.nodes && clusterState.nodes["console"];
+  const node = clusterState.nodes && clusterState.nodes["console"];
   if (!node) return [];
   return (node.workstreams || []).filter(function (ws) {
     return ws && ws.kind === "coordinator";
@@ -2016,11 +2016,11 @@ function _renderHomeView() {
   // — the coordinator manager fans out ws_created / ws_closed /
   // cluster_state via the collector's pseudo-node so the home view
   // stays in sync without polling.
-  var coords = _activeCoordsFromClusterState();
+  const coords = _activeCoordsFromClusterState();
   coords.sort(function (a, b) {
     // Most-recently-active first.  updated is absent on freshly-created
     // rows; fall back to id so the ordering is stable either way.
-    var au = a.updated || 0,
+    const au = a.updated || 0,
       bu = b.updated || 0;
     if (au !== bu) return bu - au;
     return (a.id || "").localeCompare(b.id || "");
@@ -2034,9 +2034,9 @@ function _renderHomeView() {
   // stable enough that unrelated sub-hundred drift doesn't trigger
   // a full rebuild on every SSE tick; the rendered value still
   // re-renders when the bucket changes.
-  var coordsFp = coords.length + "|";
-  for (var i = 0; i < coords.length; i++) {
-    var c = coords[i];
+  let coordsFp = coords.length + "|";
+  for (let i = 0; i < coords.length; i++) {
+    const c = coords[i];
     coordsFp +=
       (c.id || "") +
       ":" +
@@ -2061,15 +2061,15 @@ function _renderHomeView() {
   }
   if (coordsFp !== _homeCoordsFingerprint) {
     _homeCoordsFingerprint = coordsFp;
-    var countEl = document.getElementById("active-coord-count");
+    const countEl = document.getElementById("active-coord-count");
     if (countEl) {
       countEl.textContent = coords.length ? "(" + coords.length + ")" : "";
     }
-    var listEl = document.getElementById("active-coord-list");
+    const listEl = document.getElementById("active-coord-list");
     if (listEl) {
       listEl.replaceChildren();
       if (!coords.length) {
-        var empty = document.createElement("div");
+        const empty = document.createElement("div");
         empty.className = "dashboard-empty";
         empty.textContent = "No active coordinator sessions. Start one above.";
         listEl.appendChild(empty);
@@ -2097,8 +2097,8 @@ function _renderHomeView() {
 // triggers a parallel fetch.  Single boolean is enough because the
 // renderer reads from the latest response — a coalesced re-fetch right
 // after the in-flight one resolves catches any state change.
-var _savedCoordsInFlight = false;
-var _savedCoordsRetry = false;
+let _savedCoordsInFlight = false;
+let _savedCoordsRetry = false;
 
 function loadSavedCoordinators() {
   if (!_hasCoordPermission()) return;
@@ -2155,10 +2155,10 @@ function loadSavedCoordinators() {
 // Pagination caps Select-All fan-out at COORD_PAGE_SIZE — the controller
 // only ever sees the visible page, so a confirm-all batch is bounded to
 // COORD_PAGE_SIZE parallel POSTs against the routing proxy.
-var COORD_PAGE_SIZE = 24;
-var _coordPage = 0;
-var _coordSavedItems = [];
-var _coordDeleteController = createSavedCardsController({
+const COORD_PAGE_SIZE = 24;
+let _coordPage = 0;
+let _coordSavedItems = [];
+const _coordDeleteController = createSavedCardsController({
   idPrefix: "coord-delete",
   buttonId: "coord-delete-btn",
   noun: "coordinator",
@@ -2195,9 +2195,9 @@ var _coordDeleteController = createSavedCardsController({
 
 function renderSavedCoordinators(items) {
   _coordSavedItems = items;
-  var section = document.getElementById("saved-coordinators");
-  var cards = document.getElementById("saved-coord-cards");
-  var countEl = document.getElementById("saved-coord-count");
+  const section = document.getElementById("saved-coordinators");
+  const cards = document.getElementById("saved-coord-cards");
+  const countEl = document.getElementById("saved-coord-count");
   if (!section || !cards) return;
   if (!items.length) {
     section.style.display = "none";
@@ -2209,10 +2209,10 @@ function renderSavedCoordinators(items) {
     return;
   }
   // Clamp the page index after deletes (or upstream churn) shrink the list.
-  var pages = Math.max(1, Math.ceil(items.length / COORD_PAGE_SIZE));
+  const pages = Math.max(1, Math.ceil(items.length / COORD_PAGE_SIZE));
   if (_coordPage > pages - 1) _coordPage = pages - 1;
   if (_coordPage < 0) _coordPage = 0;
-  var visible = items.slice(
+  const visible = items.slice(
     _coordPage * COORD_PAGE_SIZE,
     (_coordPage + 1) * COORD_PAGE_SIZE,
   );
@@ -2222,7 +2222,7 @@ function renderSavedCoordinators(items) {
   if (countEl) countEl.textContent = "(" + items.length + ")";
   cards.replaceChildren();
   visible.forEach(function (sess) {
-    var card = renderSessionCard(sess, {
+    const card = renderSessionCard(sess, {
       ariaLabel: _coordDeleteController.ariaLabel,
       onActivate: function (s, cardEl) {
         if (_coordDeleteController.blockActivate()) return;
@@ -2267,10 +2267,10 @@ function renderSavedCoordinators(items) {
 }
 
 function _renderCoordPagination() {
-  var pag = document.getElementById("coord-pagination");
+  const pag = document.getElementById("coord-pagination");
   if (!pag) return;
-  var total = _coordSavedItems.length;
-  var pages = Math.max(1, Math.ceil(total / COORD_PAGE_SIZE));
+  const total = _coordSavedItems.length;
+  const pages = Math.max(1, Math.ceil(total / COORD_PAGE_SIZE));
   // Single-page lists and delete-mode hide the controls — page changes
   // would invalidate the user's checkbox selections, so we lock them out.
   if (pages <= 1 || _coordDeleteController.inMode()) {
@@ -2278,7 +2278,7 @@ function _renderCoordPagination() {
     return;
   }
   pag.style.display = "";
-  var label = document.getElementById("coord-page-label");
+  const label = document.getElementById("coord-page-label");
   if (label) {
     /* Visible text uses the terse "X / Y" form to match the
        filtered-pagination control elsewhere in the console; the long
@@ -2293,9 +2293,9 @@ function _renderCoordPagination() {
         pages,
     );
   }
-  var prev = document.getElementById("coord-page-prev");
+  const prev = document.getElementById("coord-page-prev");
   if (prev) prev.disabled = _coordPage <= 0;
-  var next = document.getElementById("coord-page-next");
+  const next = document.getElementById("coord-page-next");
   if (next) next.disabled = _coordPage >= pages - 1;
 }
 
@@ -2307,7 +2307,7 @@ function coordPagePrev() {
 }
 
 function coordPageNext() {
-  var pages = Math.max(1, Math.ceil(_coordSavedItems.length / COORD_PAGE_SIZE));
+  const pages = Math.max(1, Math.ceil(_coordSavedItems.length / COORD_PAGE_SIZE));
   if (_coordPage < pages - 1) {
     _coordPage++;
     renderSavedCoordinators(_coordSavedItems);
@@ -2344,7 +2344,7 @@ function confirmCoordDelete() {
 // --- Init ---
 // SSE connects after auth is confirmed — either via onLoginSuccess after
 // login, or after the first successful data load (page refresh with valid cookie).
-var _sseStarted = false;
+let _sseStarted = false;
 function _ensureSSE() {
   if (!_sseStarted) {
     _sseStarted = true;

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -71,7 +71,7 @@ function _renderGovRoles(items) {
     const perms = (r.permissions || "").split(",");
     let badges = "";
     for (let j = 0; j < perms.length; j++) {
-      let p = perms[j].trim();
+      const p = perms[j].trim();
       if (!p) continue;
       let cls = "scope-badge";
       if (p === "approve" || p.indexOf("admin.") === 0) cls += " scope-approve";
@@ -82,7 +82,7 @@ function _renderGovRoles(items) {
     const typeLabel = r.builtin
       ? '<span class="scope-badge scope-channel">builtin</span>'
       : "";
-    let actions = r.builtin
+    const actions = r.builtin
       ? ""
       : '<button class="admin-btn-action" data-edit-role="' +
         escapeHtml(r.role_id) +
@@ -212,7 +212,7 @@ function _buildPermCheckboxes(prefix, selected) {
       "</div>" +
       '<div class="perm-grid">';
     for (let i = 0; i < section.permissions.length; i++) {
-      let p = section.permissions[i];
+      const p = section.permissions[i];
       const checked = selected && selected.indexOf(p) >= 0 ? " checked" : "";
       html +=
         '<label class="toggle-switch perm-toggle">' +
@@ -343,7 +343,7 @@ function hideEditRoleModal() {
 
 function submitEditRole() {
   const roleId = document.getElementById("er-id").value;
-  let dname = document.getElementById("er-name").value.trim();
+  const dname = document.getElementById("er-name").value.trim();
   const perms = _collectPermCheckboxes("er");
   document.getElementById("er-submit").disabled = true;
   authFetch("/v1/api/admin/roles/" + roleId, {
@@ -521,8 +521,8 @@ function _renderGovPolicies(items) {
   }
   let html = "";
   for (let i = 0; i < items.length; i++) {
-    let p = items[i];
-    let actionCls = "policy-badge policy-" + p.action;
+    const p = items[i];
+    const actionCls = "policy-badge policy-" + p.action;
     const statusDot = p.enabled
       ? '<span class="watch-active" title="Enabled">\u25CF active</span>'
       : '<span class="watch-completed" title="Disabled">\u25CB disabled</span>';
@@ -795,7 +795,7 @@ function _renderGovSkills(items) {
         }[t.risk_level] || "";
       const tipParts = [];
       try {
-        let report = JSON.parse(t.scan_report || "{}");
+        const report = JSON.parse(t.scan_report || "{}");
         if (report.composite != null) {
           tipParts.push("Score: " + report.composite.toFixed(2));
         }
@@ -1880,7 +1880,7 @@ function _renderPendingResources() {
   setSafeHtml(container, html);
   container.querySelectorAll("[data-remove-res]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      let idx = parseInt(this.getAttribute("data-remove-res"), 10);
+      const idx = parseInt(this.getAttribute("data-remove-res"), 10);
       _pendingResources.splice(idx, 1);
       _renderPendingResources();
     });
@@ -2494,7 +2494,7 @@ function showMemoryDetailModal(memoryId) {
       let scopeLabel = m.scope;
       if (m.scope_id) scopeLabel += ":" + m.scope_id;
 
-      let html =
+      const html =
         '<div class="mem-detail-grid">' +
         '<div class="mem-detail-field"><span class="mem-detail-label">Name</span>' +
         escapeHtml(m.name) +
@@ -2627,7 +2627,7 @@ function searchSkillDiscover() {
   const searchBtn = document.getElementById("skill-discover-search-btn");
   if (searchBtn) searchBtn.disabled = true;
 
-  let url = "/v1/api/admin/skills/discover?limit=20&q=" + encodeURIComponent(q);
+  const url = "/v1/api/admin/skills/discover?limit=20&q=" + encodeURIComponent(q);
 
   authFetch(url)
     .then(function (r) {
@@ -2745,7 +2745,7 @@ function _renderSkillDiscoverResults() {
   // Bind install handlers
   el.querySelectorAll("[data-skill-install]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      let idx = parseInt(this.getAttribute("data-skill-install"), 10);
+      const idx = parseInt(this.getAttribute("data-skill-install"), 10);
       installDiscoveredSkill(_skillDiscoverResults[idx]);
     });
   });
@@ -2757,7 +2757,7 @@ function installDiscoveredSkill(skill) {
   // Disable the button
   const btns = document.querySelectorAll("[data-skill-install]");
   for (let i = 0; i < btns.length; i++) {
-    let idx = parseInt(btns[i].getAttribute("data-skill-install"), 10);
+    const idx = parseInt(btns[i].getAttribute("data-skill-install"), 10);
     if (
       _skillDiscoverResults[idx] &&
       _skillDiscoverResults[idx].id === skill.id
@@ -2829,7 +2829,7 @@ function hideGitHubImportModal() {
 }
 
 function submitGitHubImport() {
-  let url = (document.getElementById("gi-url").value || "").trim();
+  const url = (document.getElementById("gi-url").value || "").trim();
   const errEl = document.getElementById("github-import-error");
   if (!url) {
     errEl.textContent = "URL is required";
@@ -2935,7 +2935,7 @@ function _renderPromptPolicies(items) {
     return;
   }
   for (let i = 0; i < items.length; i++) {
-    let p = items[i];
+    const p = items[i];
     const row = document.createElement("div");
     row.className = "admin-row";
     row.setAttribute("role", "listitem");
@@ -4014,7 +4014,7 @@ function renderOGPatterns() {
   }
   let html = "";
   for (let i = 0; i < _judgeOGPatterns.length; i++) {
-    let p = _judgeOGPatterns[i];
+    const p = _judgeOGPatterns[i];
     const sourceBadge =
       p.source === "builtin"
         ? '<span class="scope-badge">built-in</span>'

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -3,38 +3,38 @@
 // ---------------------------------------------------------------------------
 // Module state
 // ---------------------------------------------------------------------------
-var _govRoles = [];
-var _govPolicies = [];
-var _govSkills = [];
-var _govUsageRange = "7d";
-var _govUsageGroupBy = "day";
-var _govAuditEvents = [];
-var _govAuditTotal = 0;
-var _govAuditOffset = 0;
-var _skillCurrentView = "installed";
-var _skillDiscoverResults = [];
-var _skillDiscoverQuery = "";
-var _pendingResources = [];
-var _giTrapHandler = null;
-var _giTriggerEl = null;
+let _govRoles = [];
+let _govPolicies = [];
+let _govSkills = [];
+let _govUsageRange = "7d";
+let _govUsageGroupBy = "day";
+let _govAuditEvents = [];
+let _govAuditTotal = 0;
+let _govAuditOffset = 0;
+let _skillCurrentView = "installed";
+let _skillDiscoverResults = [];
+let _skillDiscoverQuery = "";
+let _pendingResources = [];
+let _giTrapHandler = null;
+let _giTriggerEl = null;
 
 // Trap handler refs for modals
-var _crTrapHandler = null; // create role
-var _erTrapHandler = null; // edit role
-var _urTrapHandler = null; // user roles
-var _cpTrapHandler = null; // create policy
-var _epTrapHandler = null; // edit policy
-var _ctmTrapHandler = null; // create template
-var _etmTrapHandler = null; // edit template
+let _crTrapHandler = null; // create role
+let _erTrapHandler = null; // edit role
+let _urTrapHandler = null; // user roles
+let _cpTrapHandler = null; // create policy
+let _epTrapHandler = null; // edit policy
+let _ctmTrapHandler = null; // create template
+let _etmTrapHandler = null; // edit template
 
 // Trigger element refs for focus restoration
-var _crTriggerEl = null;
-var _erTriggerEl = null;
-var _urTriggerEl = null;
-var _cpTriggerEl = null;
-var _epTriggerEl = null;
-var _ctmTriggerEl = null;
-var _etmTriggerEl = null;
+let _crTriggerEl = null;
+let _erTriggerEl = null;
+let _urTriggerEl = null;
+let _cpTriggerEl = null;
+let _epTriggerEl = null;
+let _ctmTriggerEl = null;
+let _etmTriggerEl = null;
 
 // ---------------------------------------------------------------------------
 // Roles
@@ -59,30 +59,30 @@ function loadGovRoles() {
 }
 
 function _renderGovRoles(items) {
-  var el = document.getElementById("admin-roles-table");
+  const el = document.getElementById("admin-roles-table");
   if (!items.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No roles defined</div>');
     return;
   }
-  var html = "";
-  for (var i = 0; i < items.length; i++) {
-    var r = items[i];
+  let html = "";
+  for (let i = 0; i < items.length; i++) {
+    const r = items[i];
     // Render permissions as badges
-    var perms = (r.permissions || "").split(",");
-    var badges = "";
-    for (var j = 0; j < perms.length; j++) {
-      var p = perms[j].trim();
+    const perms = (r.permissions || "").split(",");
+    let badges = "";
+    for (let j = 0; j < perms.length; j++) {
+      let p = perms[j].trim();
       if (!p) continue;
-      var cls = "scope-badge";
+      let cls = "scope-badge";
       if (p === "approve" || p.indexOf("admin.") === 0) cls += " scope-approve";
       else if (p === "write" || p.indexOf("workstreams.") === 0)
         cls += " scope-write";
       badges += '<span class="' + cls + '">' + escapeHtml(p) + "</span>";
     }
-    var typeLabel = r.builtin
+    const typeLabel = r.builtin
       ? '<span class="scope-badge scope-channel">builtin</span>'
       : "";
-    var actions = r.builtin
+    let actions = r.builtin
       ? ""
       : '<button class="admin-btn-action" data-edit-role="' +
         escapeHtml(r.role_id) +
@@ -108,18 +108,18 @@ function _renderGovRoles(items) {
   }
   setSafeHtml(el, html);
   // Bind edit
-  var editBtns = el.querySelectorAll("[data-edit-role]");
-  for (var k = 0; k < editBtns.length; k++) {
+  const editBtns = el.querySelectorAll("[data-edit-role]");
+  for (let k = 0; k < editBtns.length; k++) {
     editBtns[k].addEventListener("click", function () {
       showEditRoleModal(this.getAttribute("data-edit-role"));
     });
   }
   // Bind delete
-  var delBtns = el.querySelectorAll("[data-delete-role]");
-  for (var k = 0; k < delBtns.length; k++) {
+  const delBtns = el.querySelectorAll("[data-delete-role]");
+  for (let k = 0; k < delBtns.length; k++) {
     delBtns[k].addEventListener("click", function () {
-      var rid = this.getAttribute("data-delete-role");
-      var rname = this.getAttribute("data-role-name");
+      const rid = this.getAttribute("data-delete-role");
+      const rname = this.getAttribute("data-role-name");
       showConfirmModal(
         "Delete Role",
         'Delete role "' +
@@ -153,7 +153,7 @@ function _renderGovRoles(items) {
 // concept.  Each section's permissions render as a 2-column grid;
 // the ``Scopes`` and ``Workstreams & Tools`` sections are short
 // enough to fit one row, ``Admin`` carries the bulk.
-var _PERMISSION_SECTIONS = [
+const _PERMISSION_SECTIONS = [
   {
     label: "Scopes",
     permissions: ["read", "write", "approve"],
@@ -184,9 +184,9 @@ var _PERMISSION_SECTIONS = [
 
 // Flat list — kept for any caller that wants the full permission
 // inventory without caring about sectioning.
-var _ALL_PERMISSIONS = (function () {
-  var flat = [];
-  for (var i = 0; i < _PERMISSION_SECTIONS.length; i++) {
+const _ALL_PERMISSIONS = (function () {
+  let flat = [];
+  for (let i = 0; i < _PERMISSION_SECTIONS.length; i++) {
     flat = flat.concat(_PERMISSION_SECTIONS[i].permissions);
   }
   return flat;
@@ -202,18 +202,18 @@ function _buildPermCheckboxes(prefix, selected) {
   // The underlying ``<input type="checkbox" name="{prefix}-perm">``
   // shape is preserved so ``_collectPermCheckboxes`` still picks
   // them up regardless of section.
-  var html = "";
-  for (var s = 0; s < _PERMISSION_SECTIONS.length; s++) {
-    var section = _PERMISSION_SECTIONS[s];
+  let html = "";
+  for (let s = 0; s < _PERMISSION_SECTIONS.length; s++) {
+    const section = _PERMISSION_SECTIONS[s];
     html +=
       '<div class="perm-section">' +
       '<div class="perm-section-label">' +
       escapeHtml(section.label) +
       "</div>" +
       '<div class="perm-grid">';
-    for (var i = 0; i < section.permissions.length; i++) {
-      var p = section.permissions[i];
-      var checked = selected && selected.indexOf(p) >= 0 ? " checked" : "";
+    for (let i = 0; i < section.permissions.length; i++) {
+      let p = section.permissions[i];
+      const checked = selected && selected.indexOf(p) >= 0 ? " checked" : "";
       html +=
         '<label class="toggle-switch perm-toggle">' +
         '<input type="checkbox" value="' +
@@ -234,17 +234,17 @@ function _buildPermCheckboxes(prefix, selected) {
 }
 
 function _collectPermCheckboxes(prefix) {
-  var boxes = document.querySelectorAll(
+  const boxes = document.querySelectorAll(
     'input[name="' + prefix + '-perm"]:checked',
   );
-  var perms = [];
-  for (var i = 0; i < boxes.length; i++) perms.push(boxes[i].value);
+  const perms = [];
+  for (let i = 0; i < boxes.length; i++) perms.push(boxes[i].value);
   return perms.join(",");
 }
 
 function showCreateRoleModal() {
   _crTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-role-overlay");
+  const ov = document.getElementById("create-role-overlay");
   ov.style.display = "flex";
   document.getElementById("cr-name").value = "";
   document.getElementById("cr-displayname").value = "";
@@ -267,11 +267,11 @@ function hideCreateRoleModal() {
 }
 
 function submitCreateRole() {
-  var name = document.getElementById("cr-name").value.trim();
-  var dname = document.getElementById("cr-displayname").value.trim();
-  var perms = _collectPermCheckboxes("cr");
+  const name = document.getElementById("cr-name").value.trim();
+  let dname = document.getElementById("cr-displayname").value.trim();
+  const perms = _collectPermCheckboxes("cr");
   if (!name) {
-    var e = document.getElementById("create-role-error");
+    const e = document.getElementById("create-role-error");
     e.textContent = "Name is required";
     e.classList.add("is-visible");
     return;
@@ -300,7 +300,7 @@ function submitCreateRole() {
       loadGovRoles();
     })
     .catch(function (e) {
-      var el = document.getElementById("create-role-error");
+      const el = document.getElementById("create-role-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -311,19 +311,19 @@ function submitCreateRole() {
 
 function showEditRoleModal(roleId) {
   _erTriggerEl = document.activeElement;
-  var role = null;
-  for (var i = 0; i < _govRoles.length; i++) {
+  let role = null;
+  for (let i = 0; i < _govRoles.length; i++) {
     if (_govRoles[i].role_id === roleId) {
       role = _govRoles[i];
       break;
     }
   }
   if (!role) return;
-  var ov = document.getElementById("edit-role-overlay");
+  const ov = document.getElementById("edit-role-overlay");
   ov.style.display = "flex";
   document.getElementById("er-id").value = roleId;
   document.getElementById("er-name").value = role.display_name;
-  var selected = (role.permissions || "").split(",");
+  const selected = (role.permissions || "").split(",");
   setSafeHtml(
     document.getElementById("er-perms-container"),
     _buildPermCheckboxes("er", selected),
@@ -342,9 +342,9 @@ function hideEditRoleModal() {
 }
 
 function submitEditRole() {
-  var roleId = document.getElementById("er-id").value;
-  var dname = document.getElementById("er-name").value.trim();
-  var perms = _collectPermCheckboxes("er");
+  const roleId = document.getElementById("er-id").value;
+  let dname = document.getElementById("er-name").value.trim();
+  const perms = _collectPermCheckboxes("er");
   document.getElementById("er-submit").disabled = true;
   authFetch("/v1/api/admin/roles/" + roleId, {
     method: "PUT",
@@ -364,7 +364,7 @@ function submitEditRole() {
       loadGovRoles();
     })
     .catch(function (e) {
-      var el = document.getElementById("edit-role-error");
+      const el = document.getElementById("edit-role-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -376,10 +376,10 @@ function submitEditRole() {
 // User roles modal (launched from Users tab)
 function showUserRolesModal(userId) {
   _urTriggerEl = document.activeElement;
-  var ov = document.getElementById("user-roles-overlay");
+  const ov = document.getElementById("user-roles-overlay");
   ov.style.display = "flex";
   document.getElementById("ur-user-id").value = userId;
-  var container = document.getElementById("ur-roles-container");
+  const container = document.getElementById("ur-roles-container");
   setSafeHtml(container, '<div class="dashboard-empty">Loading...</div>');
   _urTrapHandler = _installTrap("user-roles-overlay", "user-roles-box");
   // Fetch all roles and user's current roles
@@ -392,18 +392,18 @@ function showUserRolesModal(userId) {
     }),
   ])
     .then(function (results) {
-      var allRoles = results[0].roles || [];
-      var userRoles = results[1].roles || [];
-      var assigned = {};
-      for (var i = 0; i < userRoles.length; i++)
+      const allRoles = results[0].roles || [];
+      const userRoles = results[1].roles || [];
+      const assigned = {};
+      for (let i = 0; i < userRoles.length; i++)
         assigned[userRoles[i].role_id] = true;
       // Role-assignment rows reuse the toggle-switch component for
       // consistency with the rest of the admin UX.  Role display names
       // are human-readable text, so no monospace override is needed.
-      var html = '<div class="user-roles-list">';
-      for (var j = 0; j < allRoles.length; j++) {
-        var r = allRoles[j];
-        var checked = assigned[r.role_id] ? " checked" : "";
+      let html = '<div class="user-roles-list">';
+      for (let j = 0; j < allRoles.length; j++) {
+        const r = allRoles[j];
+        const checked = assigned[r.role_id] ? " checked" : "";
         html +=
           '<label class="toggle-switch user-role-toggle">' +
           '<input type="checkbox" value="' +
@@ -437,10 +437,10 @@ function hideUserRolesModal() {
 }
 
 function submitUserRoles() {
-  var userId = document.getElementById("ur-user-id").value;
-  var boxes = document.querySelectorAll('input[name="ur-role"]');
-  var selected = [];
-  for (var i = 0; i < boxes.length; i++) {
+  const userId = document.getElementById("ur-user-id").value;
+  const boxes = document.querySelectorAll('input[name="ur-role"]');
+  const selected = [];
+  for (let i = 0; i < boxes.length; i++) {
     if (boxes[i].checked) selected.push(boxes[i].value);
   }
   // Get current user roles to diff
@@ -449,12 +449,12 @@ function submitUserRoles() {
       return r.json();
     })
     .then(function (data) {
-      var current = {};
-      var roles = data.roles || [];
-      for (var i = 0; i < roles.length; i++) current[roles[i].role_id] = true;
-      var promises = [];
+      const current = {};
+      const roles = data.roles || [];
+      for (let i = 0; i < roles.length; i++) current[roles[i].role_id] = true;
+      const promises = [];
       // Assign new
-      for (var j = 0; j < selected.length; j++) {
+      for (let j = 0; j < selected.length; j++) {
         if (!current[selected[j]]) {
           promises.push(
             authFetch("/v1/api/admin/users/" + userId + "/roles", {
@@ -466,9 +466,9 @@ function submitUserRoles() {
         }
       }
       // Unassign removed
-      var selMap = {};
-      for (var k = 0; k < selected.length; k++) selMap[selected[k]] = true;
-      for (var rid in current) {
+      const selMap = {};
+      for (let k = 0; k < selected.length; k++) selMap[selected[k]] = true;
+      for (let rid in current) {
         if (!selMap[rid]) {
           promises.push(
             authFetch("/v1/api/admin/users/" + userId + "/roles/" + rid, {
@@ -511,7 +511,7 @@ function loadGovPolicies() {
 }
 
 function _renderGovPolicies(items) {
-  var el = document.getElementById("admin-policies-table");
+  const el = document.getElementById("admin-policies-table");
   if (!items.length) {
     setSafeHtml(
       el,
@@ -519,11 +519,11 @@ function _renderGovPolicies(items) {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < items.length; i++) {
-    var p = items[i];
-    var actionCls = "policy-badge policy-" + p.action;
-    var statusDot = p.enabled
+  let html = "";
+  for (let i = 0; i < items.length; i++) {
+    let p = items[i];
+    let actionCls = "policy-badge policy-" + p.action;
+    const statusDot = p.enabled
       ? '<span class="watch-active" title="Enabled">\u25CF active</span>'
       : '<span class="watch-completed" title="Disabled">\u25CB disabled</span>';
     html +=
@@ -564,8 +564,8 @@ function _renderGovPolicies(items) {
   });
   el.querySelectorAll("[data-delete-policy]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var pid = this.getAttribute("data-delete-policy");
-      var pname = this.getAttribute("data-policy-name");
+      const pid = this.getAttribute("data-delete-policy");
+      const pname = this.getAttribute("data-policy-name");
       showConfirmModal(
         "Delete Policy",
         'Delete policy "' + pname + '"?',
@@ -591,7 +591,7 @@ function _renderGovPolicies(items) {
 
 function showCreatePolicyModal() {
   _cpTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-policy-overlay");
+  const ov = document.getElementById("create-policy-overlay");
   ov.style.display = "flex";
   document.getElementById("cp-name").value = "";
   document.getElementById("cp-pattern").value = "";
@@ -612,13 +612,13 @@ function hideCreatePolicyModal() {
 }
 
 function submitCreatePolicy() {
-  var name = document.getElementById("cp-name").value.trim();
-  var pattern = document.getElementById("cp-pattern").value.trim();
-  var action = document.getElementById("cp-action").value;
-  var priority =
+  const name = document.getElementById("cp-name").value.trim();
+  const pattern = document.getElementById("cp-pattern").value.trim();
+  const action = document.getElementById("cp-action").value;
+  const priority =
     parseInt(document.getElementById("cp-priority").value, 10) || 0;
   if (!name || !pattern) {
-    var e = document.getElementById("create-policy-error");
+    const e = document.getElementById("create-policy-error");
     e.textContent = "Name and pattern are required";
     e.classList.add("is-visible");
     return;
@@ -647,7 +647,7 @@ function submitCreatePolicy() {
       loadGovPolicies();
     })
     .catch(function (e) {
-      var el = document.getElementById("create-policy-error");
+      const el = document.getElementById("create-policy-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -658,15 +658,15 @@ function submitCreatePolicy() {
 
 function showEditPolicyModal(policyId) {
   _epTriggerEl = document.activeElement;
-  var policy = null;
-  for (var i = 0; i < _govPolicies.length; i++) {
+  let policy = null;
+  for (let i = 0; i < _govPolicies.length; i++) {
     if (_govPolicies[i].policy_id === policyId) {
       policy = _govPolicies[i];
       break;
     }
   }
   if (!policy) return;
-  var ov = document.getElementById("edit-policy-overlay");
+  const ov = document.getElementById("edit-policy-overlay");
   ov.style.display = "flex";
   document.getElementById("ep-id").value = policyId;
   document.getElementById("ep-name").value = policy.name;
@@ -688,7 +688,7 @@ function hideEditPolicyModal() {
 }
 
 function submitEditPolicy() {
-  var id = document.getElementById("ep-id").value;
+  const id = document.getElementById("ep-id").value;
   document.getElementById("ep-submit").disabled = true;
   authFetch("/v1/api/admin/policies/" + id, {
     method: "PUT",
@@ -714,7 +714,7 @@ function submitEditPolicy() {
       loadGovPolicies();
     })
     .catch(function (e) {
-      var el = document.getElementById("edit-policy-error");
+      const el = document.getElementById("edit-policy-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -746,38 +746,38 @@ function loadGovSkills() {
 }
 
 function _renderGovSkills(items) {
-  var el = document.getElementById("admin-skills-table");
+  const el = document.getElementById("admin-skills-table");
   if (!items.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No skills configured</div>');
     return;
   }
-  var html = "";
-  for (var i = 0; i < items.length; i++) {
-    var t = items[i];
-    var activationBadge = "";
-    var activation = t.activation || "named";
+  let html = "";
+  for (let i = 0; i < items.length; i++) {
+    const t = items[i];
+    let activationBadge = "";
+    const activation = t.activation || "named";
     if (activation === "default") {
       activationBadge =
         '<span class="scope-badge scope-approve">default</span>';
     } else if (activation === "search") {
       activationBadge = '<span class="scope-badge">search</span>';
     }
-    var defBadge =
+    const defBadge =
       t.is_default && activation !== "default"
         ? '<span class="scope-badge scope-approve">default</span>'
         : "";
-    var originBadge =
+    const originBadge =
       t.origin === "mcp"
         ? ' <span class="scope-badge scope-mcp">mcp:' +
           escapeHtml(t.mcp_server) +
           "</span>"
         : "";
-    var catBadge =
+    const catBadge =
       '<span class="scope-badge">' + escapeHtml(t.category) + "</span>";
     // Build risk column content with tooltip
-    var riskCell = "";
+    let riskCell = "";
     if (t.risk_level) {
-      var scanClass =
+      const scanClass =
         {
           safe: "scope-scan-safe",
           low: "scope-scan-low",
@@ -785,7 +785,7 @@ function _renderGovSkills(items) {
           high: "scope-scan-high",
           critical: "scope-scan-critical",
         }[t.risk_level] || "";
-      var scanIcon =
+      const scanIcon =
         {
           safe: "\u2713 ",
           low: "",
@@ -793,15 +793,15 @@ function _renderGovSkills(items) {
           high: "\u25C6 ",
           critical: "\u26A0 ",
         }[t.risk_level] || "";
-      var tipParts = [];
+      const tipParts = [];
       try {
-        var report = JSON.parse(t.scan_report || "{}");
+        let report = JSON.parse(t.scan_report || "{}");
         if (report.composite != null) {
           tipParts.push("Score: " + report.composite.toFixed(2));
         }
-        var axes = ["content", "supply_chain", "vulnerability", "capability"];
-        for (var ai = 0; ai < axes.length; ai++) {
-          var d = (report.details || {})[axes[ai]] || {};
+        const axes = ["content", "supply_chain", "vulnerability", "capability"];
+        for (let ai = 0; ai < axes.length; ai++) {
+          const d = (report.details || {})[axes[ai]] || {};
           if (d.flags && d.flags.length) {
             tipParts.push(
               axes[ai].replace(/_/g, " ") + ": " + d.flags.join(", "),
@@ -809,7 +809,7 @@ function _renderGovSkills(items) {
           }
         }
       } catch (e) {}
-      var tipText = tipParts.length ? tipParts.join("\n") : t.risk_level;
+      const tipText = tipParts.length ? tipParts.join("\n") : t.risk_level;
       riskCell =
         '<span class="scope-badge ' +
         scanClass +
@@ -825,7 +825,7 @@ function _renderGovSkills(items) {
       riskCell =
         '<span class="scope-badge" style="opacity:0.4" title="Not scanned">\u2014</span>';
     }
-    var resBadge = "";
+    let resBadge = "";
     if (t.resource_count > 0) {
       resBadge =
         ' <span class="scope-badge" title="' +
@@ -834,8 +834,8 @@ function _renderGovSkills(items) {
         t.resource_count +
         " res</span>";
     }
-    var editLabel = t.readonly ? "view" : "edit";
-    var deleteDisabled = "";
+    const editLabel = t.readonly ? "view" : "edit";
+    const deleteDisabled = "";
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col admin-col-tmcat">' +
@@ -880,8 +880,8 @@ function _renderGovSkills(items) {
   });
   el.querySelectorAll("[data-delete-tmpl]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var tid = this.getAttribute("data-delete-tmpl");
-      var tname = this.getAttribute("data-tmpl-name");
+      const tid = this.getAttribute("data-delete-tmpl");
+      const tname = this.getAttribute("data-tmpl-name");
       showConfirmModal(
         "Delete Skill",
         'Delete skill "' + tname + '"?',
@@ -914,9 +914,9 @@ function _renderGovSkills(items) {
 // Trigger on any paste whose first non-whitespace bytes look like an opening
 // YAML frontmatter delimiter — restrictive enough to ignore normal markdown
 // pastes, permissive enough to catch CRLF and trailing-space variants.
-var _SKILL_FRONTMATTER_RE = /^---\s*\r?\n/;
+const _SKILL_FRONTMATTER_RE = /^---\s*\r?\n/;
 
-var _SKILL_FIELD_MAP = {
+const _SKILL_FIELD_MAP = {
   name: "ctm-name",
   description: "skill-description",
   tags: "skill-tags",
@@ -932,21 +932,21 @@ var _SKILL_FIELD_MAP = {
 // fresh paste supersedes the previous one.  Acts as a generation token: any
 // callback that observes _ctmPasteController != its captured controller knows
 // the modal moved on and must not touch the DOM.
-var _ctmPasteController = null;
+let _ctmPasteController = null;
 
 // Returns "filled" if we set the value, "skipped" if the field was already
 // non-empty (we don't clobber user input), or "absent" if we couldn't find or
 // match the option.  Tracking this lets the caller report what actually
 // happened so the user knows whether their pre-typed values survived.
 function _setSkillFormField(id, value) {
-  var el = document.getElementById(id);
+  const el = document.getElementById(id);
   if (!el) return "absent";
   if (el.value && String(el.value).trim()) return "skipped";
   if (el.tagName === "SELECT") {
     // License is a fixed option list — only set the value if it matches an
     // option.  Custom licenses fall through to the default "— not specified —"
     // and the user can edit manually.
-    for (var i = 0; i < el.options.length; i++) {
+    for (let i = 0; i < el.options.length; i++) {
       if (el.options[i].value === value) {
         el.value = value;
         return "filled";
@@ -966,10 +966,10 @@ function _applyParsedSkill(parsed, contentTextarea, fieldMap) {
   contentTextarea.value = parsed.content || "";
   contentTextarea.dispatchEvent(new Event("input", { bubbles: true }));
 
-  var filled = 0;
-  var skipped = 0;
+  let filled = 0;
+  let skipped = 0;
   function _apply(id, value) {
-    var outcome = _setSkillFormField(id, value);
+    const outcome = _setSkillFormField(id, value);
     if (outcome === "filled") filled++;
     else if (outcome === "skipped") skipped++;
   }
@@ -990,28 +990,28 @@ function _applyParsedSkill(parsed, contentTextarea, fieldMap) {
 }
 
 function _setSkillPasteHintBusy(busy) {
-  var hint = document.getElementById("ctm-paste-hint");
+  const hint = document.getElementById("ctm-paste-hint");
   if (!hint) return;
-  var rest = hint.querySelector(".skill-paste-hint-rest");
-  var busyEl = hint.querySelector(".skill-paste-hint-busy");
+  const rest = hint.querySelector(".skill-paste-hint-rest");
+  const busyEl = hint.querySelector(".skill-paste-hint-busy");
   if (rest) rest.style.display = busy ? "none" : "";
   if (busyEl) busyEl.style.display = busy ? "" : "none";
 }
 
 function _handleSkillContentPaste(event, fieldMap) {
-  var clipboard = event.clipboardData || window.clipboardData;
+  const clipboard = event.clipboardData || window.clipboardData;
   if (!clipboard) return;
-  var text = clipboard.getData("text/plain");
+  const text = clipboard.getData("text/plain");
   if (!text || !_SKILL_FRONTMATTER_RE.test(text)) return;
 
   event.preventDefault();
-  var textarea = event.target;
+  const textarea = event.target;
 
   // Cancel any prior paste fetch — a fresh paste supersedes whatever was in
   // flight.  The previous handler's callbacks see _ctmPasteController !=
   // their captured controller and bail before touching the DOM.
   if (_ctmPasteController) _ctmPasteController.abort();
-  var controller = new AbortController();
+  const controller = new AbortController();
   _ctmPasteController = controller;
 
   // Optimistic paint — drop the raw text into the textarea immediately so the
@@ -1043,8 +1043,8 @@ function _handleSkillContentPaste(event, fieldMap) {
     .then(function (res) {
       if (!_isCurrent()) return;
       if (res.ok) {
-        var counts = _applyParsedSkill(res.data, textarea, fieldMap);
-        var msg = "Populated from SKILL.md";
+        const counts = _applyParsedSkill(res.data, textarea, fieldMap);
+        let msg = "Populated from SKILL.md";
         if (counts.skipped) {
           msg += " (" + counts.filled + " set, " + counts.skipped + " kept)";
         }
@@ -1079,11 +1079,11 @@ function _handleSkillContentPaste(event, fieldMap) {
 }
 
 function _detectTemplateVars(content) {
-  var matches = content.match(/\{\{(\w+)\}\}/g) || [];
-  var seen = {};
-  var result = [];
-  for (var i = 0; i < matches.length; i++) {
-    var v = matches[i].replace(/[{}]/g, "");
+  const matches = content.match(/\{\{(\w+)\}\}/g) || [];
+  const seen = {};
+  const result = [];
+  for (let i = 0; i < matches.length; i++) {
+    const v = matches[i].replace(/[{}]/g, "");
     if (!seen[v]) {
       seen[v] = true;
       result.push(v);
@@ -1093,8 +1093,8 @@ function _detectTemplateVars(content) {
 }
 
 function _updateVarsDisplay(contentId, displayId) {
-  var content = document.getElementById(contentId).value || "";
-  var vars = _detectTemplateVars(content);
+  const content = document.getElementById(contentId).value || "";
+  const vars = _detectTemplateVars(content);
   document.getElementById(displayId).textContent = vars.length
     ? vars.join(", ")
     : "(none)";
@@ -1102,7 +1102,7 @@ function _updateVarsDisplay(contentId, displayId) {
 
 function showCreateTemplateModal() {
   _ctmTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-template-overlay");
+  const ov = document.getElementById("create-template-overlay");
   ov.style.display = "flex";
   document.getElementById("ctm-name").value = "";
   document.getElementById("ctm-category").value = "general";
@@ -1113,7 +1113,7 @@ function showCreateTemplateModal() {
   document.getElementById("skill-license").value = "";
   document.getElementById("skill-compatibility").value = "";
   document.getElementById("skill-activation").value = "named";
-  var ctmContent = document.getElementById("ctm-content");
+  const ctmContent = document.getElementById("ctm-content");
   ctmContent.value = "";
   document.getElementById("ctm-variables").textContent = "(none)";
   ctmContent.oninput = function () {
@@ -1162,7 +1162,7 @@ function hideCreateTemplateModal() {
   if (_ctmPasteController) {
     _ctmPasteController.abort();
     _ctmPasteController = null;
-    var ctmContent = document.getElementById("ctm-content");
+    const ctmContent = document.getElementById("ctm-content");
     if (ctmContent) {
       ctmContent.disabled = false;
       ctmContent.removeAttribute("aria-busy");
@@ -1182,22 +1182,22 @@ function submitCreateTemplate() {
   // leave stale red text on-screen, and the in-flight PUT period shouldn't
   // either. Cheaper than reasoning about every catch path remembering to
   // clear on success.
-  var prevErr = document.getElementById("create-template-error");
+  const prevErr = document.getElementById("create-template-error");
   if (prevErr) {
     prevErr.classList.remove("is-visible");
     prevErr.textContent = "";
   }
-  var name = document.getElementById("ctm-name").value.trim();
-  var content = document.getElementById("ctm-content").value;
+  const name = document.getElementById("ctm-name").value.trim();
+  const content = document.getElementById("ctm-content").value;
   if (!name || !content) {
-    var e = document.getElementById("create-template-error");
+    const e = document.getElementById("create-template-error");
     e.textContent = "Name and content are required";
     e.classList.add("is-visible");
     return;
   }
-  var varList = _detectTemplateVars(content);
-  var tagsRaw = (document.getElementById("skill-tags").value || "").trim();
-  var tagsArray = tagsRaw
+  const varList = _detectTemplateVars(content);
+  const tagsRaw = (document.getElementById("skill-tags").value || "").trim();
+  const tagsArray = tagsRaw
     ? tagsRaw
         .split(",")
         .map(function (t) {
@@ -1206,14 +1206,14 @@ function submitCreateTemplate() {
         .filter(Boolean)
     : [];
   // Session config fields
-  var csTemp = document.getElementById("csk-temperature").value.trim();
-  var csMaxTok = document.getElementById("csk-max-tokens").value.trim();
-  var csBudget = document.getElementById("csk-token-budget").value.trim();
-  var csMaxTurns = document.getElementById("csk-agent-max-turns").value.trim();
-  var csAllowed = (
+  const csTemp = document.getElementById("csk-temperature").value.trim();
+  const csMaxTok = document.getElementById("csk-max-tokens").value.trim();
+  const csBudget = document.getElementById("csk-token-budget").value.trim();
+  const csMaxTurns = document.getElementById("csk-agent-max-turns").value.trim();
+  const csAllowed = (
     document.getElementById("csk-allowed-tools").value || ""
   ).trim();
-  var csAllowedArr = csAllowed
+  const csAllowedArr = csAllowed
     ? csAllowed
         .split(",")
         .map(function (t) {
@@ -1221,26 +1221,26 @@ function submitCreateTemplate() {
         })
         .filter(Boolean)
     : [];
-  var csNotifyRaw = (
+  const csNotifyRaw = (
     document.getElementById("csk-notify-on-complete").value || ""
   ).trim();
-  var csNotifyVal = "[]";
+  let csNotifyVal = "[]";
   if (csNotifyRaw) {
     try {
-      var csNotifyParsed = JSON.parse(csNotifyRaw);
+      const csNotifyParsed = JSON.parse(csNotifyRaw);
       if (!Array.isArray(csNotifyParsed))
         throw new Error("must be a JSON array");
       csNotifyVal = JSON.stringify(csNotifyParsed);
     } catch (ne) {
-      var ne2 = document.getElementById("create-template-error");
+      const ne2 = document.getElementById("create-template-error");
       ne2.textContent = "Notify on completion: " + ne.message;
       ne2.classList.add("is-visible");
       return;
     }
   }
   document.getElementById("ctm-submit").disabled = true;
-  var csVersion = (document.getElementById("skill-version").value || "").trim();
-  var createBody = {
+  const csVersion = (document.getElementById("skill-version").value || "").trim();
+  const createBody = {
     name: name,
     category: document.getElementById("ctm-category").value,
     description: (
@@ -1282,7 +1282,7 @@ function submitCreateTemplate() {
     })
     .then(function (data) {
       if (_pendingResources.length && data && data.template_id) {
-        var promises = _pendingResources.map(function (res) {
+        const promises = _pendingResources.map(function (res) {
           return authFetch(
             "/v1/api/admin/skills/" + data.template_id + "/resources",
             {
@@ -1315,7 +1315,7 @@ function submitCreateTemplate() {
       }
     })
     .catch(function (e) {
-      var el = document.getElementById("create-template-error");
+      const el = document.getElementById("create-template-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -1325,16 +1325,16 @@ function submitCreateTemplate() {
 }
 
 function showEditTemplateModal(tmplId) {
-  var ov = document.getElementById("edit-template-overlay");
+  const ov = document.getElementById("edit-template-overlay");
   // When called against an already-open modal (e.g. mutate-in-place after
   // unlock), preserve the original trigger so focus restores to the row
   // launcher on close, and don't reinstall the focus trap.
-  var alreadyOpen = ov && ov.style.display === "flex";
+  const alreadyOpen = ov && ov.style.display === "flex";
   if (!alreadyOpen) {
     _etmTriggerEl = document.activeElement;
   }
-  var tmpl = null;
-  for (var i = 0; i < _govSkills.length; i++) {
+  let tmpl = null;
+  for (let i = 0; i < _govSkills.length; i++) {
     if (_govSkills[i].template_id === tmplId) {
       tmpl = _govSkills[i];
       break;
@@ -1347,9 +1347,9 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("etm-category").value = tmpl.category;
   document.getElementById("etm-description").value = tmpl.description || "";
   // Parse tags from JSON array to comma-separated display
-  var tagsDisplay = "";
+  let tagsDisplay = "";
   try {
-    var tagsList = JSON.parse(tmpl.tags || "[]");
+    const tagsList = JSON.parse(tmpl.tags || "[]");
     tagsDisplay = tagsList.join(", ");
   } catch (e) {
     tagsDisplay = tmpl.tags || "";
@@ -1382,9 +1382,9 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("esk-auto-approve").checked =
     tmpl.auto_approve || false;
   // allowed_tools: parse JSON array to comma-separated display
-  var allowedDisplay = "";
+  let allowedDisplay = "";
   try {
-    var allowed = JSON.parse(tmpl.allowed_tools || "[]");
+    const allowed = JSON.parse(tmpl.allowed_tools || "[]");
     allowedDisplay = allowed.join(", ");
   } catch (e) {
     allowedDisplay = tmpl.allowed_tools || "";
@@ -1393,7 +1393,7 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("esk-allowed-tools").disabled =
     tmpl.auto_approve || false;
   document.getElementById("esk-enabled").checked = tmpl.enabled !== false;
-  var notifyVal = tmpl.notify_on_complete || "[]";
+  const notifyVal = tmpl.notify_on_complete || "[]";
   document.getElementById("esk-notify-on-complete").value =
     notifyVal && notifyVal !== "[]" ? notifyVal : "";
   document.getElementById("esk-auto-approve").onchange = function () {
@@ -1403,22 +1403,22 @@ function showEditTemplateModal(tmplId) {
   // .is-visible to show — so toggling style.display does nothing here.
   document.getElementById("edit-template-error").classList.remove("is-visible");
   // Scan report section
-  var scanSection = document.getElementById("etm-scan-section");
+  const scanSection = document.getElementById("etm-scan-section");
   if (scanSection) {
     if (tmpl.risk_level) {
       scanSection.style.display = "";
-      var scanClassMap = {
+      const scanClassMap = {
         safe: "scope-scan-safe",
         low: "scope-scan-low",
         medium: "scope-scan-medium",
         high: "scope-scan-high",
         critical: "scope-scan-critical",
       };
-      var report = {};
+      let report = {};
       try {
         report = JSON.parse(tmpl.scan_report || "{}");
       } catch (e) {}
-      var scanHtml =
+      let scanHtml =
         '<span class="scope-badge ' +
         (scanClassMap[tmpl.risk_level] || "") +
         '">' +
@@ -1436,10 +1436,10 @@ function showEditTemplateModal(tmplId) {
           escapeHtml(tmpl.scan_version) +
           "</span>";
       }
-      var axes = ["content", "supply_chain", "vulnerability", "capability"];
-      for (var ai = 0; ai < axes.length; ai++) {
-        var axis = axes[ai];
-        var d = (report.details || {})[axis] || {};
+      const axes = ["content", "supply_chain", "vulnerability", "capability"];
+      for (let ai = 0; ai < axes.length; ai++) {
+        const axis = axes[ai];
+        const d = (report.details || {})[axis] || {};
         scanHtml +=
           '<div class="scan-axis"><span class="scan-axis-name">' +
           escapeHtml(axis.replace(/_/g, " ")) +
@@ -1459,7 +1459,7 @@ function showEditTemplateModal(tmplId) {
       scanSection.style.display = "none";
     }
   }
-  var rescanBtn = document.getElementById("etm-rescan-btn");
+  const rescanBtn = document.getElementById("etm-rescan-btn");
   if (rescanBtn) {
     rescanBtn.onclick = function () {
       rescanBtn.disabled = true;
@@ -1492,22 +1492,22 @@ function showEditTemplateModal(tmplId) {
   }
   // Reset collapsible state before applying readonly rules (prevents state leak
   // when switching between readonly and editable skills in the same session)
-  var allDetails = document.querySelectorAll(
+  const allDetails = document.querySelectorAll(
     "#edit-template-box .admin-details",
   );
-  for (var d = 0; d < allDetails.length; d++) allDetails[d].open = false;
+  for (let d = 0; d < allDetails.length; d++) allDetails[d].open = false;
 
   // --- Readonly mode for imported skills ---
-  var isReadonly = tmpl.readonly || false;
+  const isReadonly = tmpl.readonly || false;
   // An unlocked install retains origin="source" — combined with !readonly it
   // means the operator detached the skill from upstream and may have edits.
-  var isUnlockedInstall =
+  const isUnlockedInstall =
     !isReadonly && tmpl.origin && tmpl.origin === "source";
-  var editTitle = document.getElementById("edit-template-title");
+  const editTitle = document.getElementById("edit-template-title");
   if (editTitle)
     editTitle.textContent = isReadonly ? "View Skill" : "Edit Skill";
   // Origin badge — show provenance for installed skills
-  var originBadge = document.getElementById("etm-origin-badge");
+  const originBadge = document.getElementById("etm-origin-badge");
   if (originBadge) {
     if (isReadonly && tmpl.source_url) {
       originBadge.textContent = "Installed from \u00a0" + tmpl.source_url;
@@ -1525,7 +1525,7 @@ function showEditTemplateModal(tmplId) {
       originBadge.style.display = "none";
     }
   }
-  var lockBtn = document.getElementById("etm-lock-btn");
+  const lockBtn = document.getElementById("etm-lock-btn");
   if (lockBtn) {
     // Inline-flex (not "") so display: none doesn't bleed into a
     // browser-default block reflow on re-show.
@@ -1533,7 +1533,7 @@ function showEditTemplateModal(tmplId) {
     lockBtn.dataset.skillId = tmplId;
     lockBtn.dataset.skillName = tmpl.name || "";
   }
-  var submitBtn = document.getElementById("etm-submit");
+  const submitBtn = document.getElementById("etm-submit");
   if (submitBtn) {
     submitBtn.style.display = "";
     submitBtn.textContent = isReadonly ? "Save Config" : "Save";
@@ -1559,7 +1559,7 @@ function showEditTemplateModal(tmplId) {
     "etm-content",
     "etm-default",
   ].forEach(function (id) {
-    var el = document.getElementById(id);
+    const el = document.getElementById(id);
     if (!el) return;
     el.disabled = isReadonly;
     if (isReadonly) {
@@ -1579,23 +1579,23 @@ function showEditTemplateModal(tmplId) {
     "esk-auto-approve",
     "esk-enabled",
   ].forEach(function (id) {
-    var el = document.getElementById(id);
+    const el = document.getElementById(id);
     if (el) el.disabled = false;
   });
   // esk-allowed-tools follows auto_approve state, not readonly state
-  var allowedToolsEl = document.getElementById("esk-allowed-tools");
+  const allowedToolsEl = document.getElementById("esk-allowed-tools");
   if (allowedToolsEl) allowedToolsEl.disabled = tmpl.auto_approve || false;
-  var cancelBtn = document.querySelector("#edit-template-box .modal-cancel");
+  const cancelBtn = document.querySelector("#edit-template-box .modal-cancel");
   if (cancelBtn) cancelBtn.textContent = isReadonly ? "Close" : "Cancel";
   // Auto-expand Runtime Config collapsible for installed skills so config is visible
   if (isReadonly) {
-    var details = document.querySelectorAll(
+    const details = document.querySelectorAll(
       "#edit-template-box .admin-details",
     );
-    for (var d = 0; d < details.length; d++) details[d].open = true;
+    for (let d = 0; d < details.length; d++) details[d].open = true;
   }
   // --- Skill Resources ---
-  var resSection = document.getElementById("etm-resources-section");
+  const resSection = document.getElementById("etm-resources-section");
   if (resSection) {
     _loadSkillResources(tmplId, isReadonly);
   }
@@ -1631,10 +1631,10 @@ function hideEditTemplateModal() {
 }
 
 function unlockSkill() {
-  var btn = document.getElementById("etm-lock-btn");
+  const btn = document.getElementById("etm-lock-btn");
   if (!btn) return;
-  var skillId = btn.dataset.skillId;
-  var skillName = btn.dataset.skillName || "this skill";
+  const skillId = btn.dataset.skillId;
+  const skillName = btn.dataset.skillName || "this skill";
   if (!skillId) return;
   showConfirmModal(
     "Customize " + skillName + "?",
@@ -1650,7 +1650,7 @@ function unlockSkill() {
 }
 
 function _performUnlockSkill(skillId) {
-  var btn = document.getElementById("etm-lock-btn");
+  const btn = document.getElementById("etm-lock-btn");
   if (btn) btn.disabled = true;
   authFetch("/v1/api/admin/skills/" + skillId + "/unlock", {
     method: "POST",
@@ -1686,9 +1686,9 @@ function _performUnlockSkill(skillId) {
 // ---------------------------------------------------------------------------
 
 function _loadSkillResources(skillId, readonly) {
-  var container = document.getElementById("etm-resources-list");
-  var addBtn = document.getElementById("etm-add-resource-btn");
-  var addForm = document.getElementById("etm-add-resource-form");
+  const container = document.getElementById("etm-resources-list");
+  const addBtn = document.getElementById("etm-add-resource-btn");
+  const addForm = document.getElementById("etm-add-resource-form");
   if (!container) return;
   setSafeHtml(container, '<div class="dashboard-empty">Loading...</div>');
   if (addBtn) addBtn.style.display = readonly ? "none" : "";
@@ -1700,7 +1700,7 @@ function _loadSkillResources(skillId, readonly) {
       return r.json();
     })
     .then(function (data) {
-      var resources = data.resources || [];
+      const resources = data.resources || [];
       if (!resources.length) {
         setSafeHtml(
           container,
@@ -1708,10 +1708,10 @@ function _loadSkillResources(skillId, readonly) {
         );
         return;
       }
-      var html = "";
-      for (var i = 0; i < resources.length; i++) {
-        var res = resources[i];
-        var sizeStr =
+      let html = "";
+      for (let i = 0; i < resources.length; i++) {
+        const res = resources[i];
+        const sizeStr =
           res.size > 1024
             ? (res.size / 1024).toFixed(1) + " KB"
             : res.size + " B";
@@ -1737,7 +1737,7 @@ function _loadSkillResources(skillId, readonly) {
       if (!readonly) {
         container.querySelectorAll("[data-del-res]").forEach(function (btn) {
           btn.addEventListener("click", function () {
-            var path = this.getAttribute("data-del-res");
+            const path = this.getAttribute("data-del-res");
             showConfirmModal(
               "Delete Resource",
               'Delete "' + path + '"?',
@@ -1758,7 +1758,7 @@ function _loadSkillResources(skillId, readonly) {
                     showToast("Resource deleted");
                     _loadSkillResources(skillId, readonly);
                     loadGovSkills();
-                    var addBtn = document.getElementById(
+                    const addBtn = document.getElementById(
                       "etm-add-resource-btn",
                     );
                     if (addBtn) addBtn.focus();
@@ -1781,16 +1781,16 @@ function _loadSkillResources(skillId, readonly) {
 }
 
 function _showAddResourceForm(skillId) {
-  var form = document.getElementById("etm-add-resource-form");
+  const form = document.getElementById("etm-add-resource-form");
   if (!form) return;
   form.style.display = "";
   document.getElementById("etm-res-path").value = "";
   document.getElementById("etm-res-content").value = "";
   document.getElementById("etm-res-content-type").value = "text/plain";
   document.getElementById("etm-res-submit").onclick = function () {
-    var path = (document.getElementById("etm-res-path").value || "").trim();
-    var content = document.getElementById("etm-res-content").value || "";
-    var contentType = document.getElementById("etm-res-content-type").value;
+    const path = (document.getElementById("etm-res-path").value || "").trim();
+    const content = document.getElementById("etm-res-content").value || "";
+    const contentType = document.getElementById("etm-res-content-type").value;
     if (!path || !content) {
       showToast("Path and content are required");
       return;
@@ -1831,7 +1831,7 @@ function _showAddResourceForm(skillId) {
         showToast(e.message || "Failed to add resource");
       })
       .finally(function () {
-        var btn = document.getElementById("etm-res-submit");
+        const btn = document.getElementById("etm-res-submit");
         if (btn) {
           btn.disabled = false;
           btn.textContent = "Upload";
@@ -1845,7 +1845,7 @@ function _showAddResourceForm(skillId) {
 // ---------------------------------------------------------------------------
 
 function _renderPendingResources() {
-  var container = document.getElementById("ctm-resources-list");
+  const container = document.getElementById("ctm-resources-list");
   if (!container) return;
   if (!_pendingResources.length) {
     setSafeHtml(
@@ -1854,10 +1854,10 @@ function _renderPendingResources() {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < _pendingResources.length; i++) {
-    var r = _pendingResources[i];
-    var sizeStr =
+  let html = "";
+  for (let i = 0; i < _pendingResources.length; i++) {
+    const r = _pendingResources[i];
+    const sizeStr =
       r.content.length > 1024
         ? (r.content.length / 1024).toFixed(1) + " KB"
         : r.content.length + " B";
@@ -1880,7 +1880,7 @@ function _renderPendingResources() {
   setSafeHtml(container, html);
   container.querySelectorAll("[data-remove-res]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var idx = parseInt(this.getAttribute("data-remove-res"), 10);
+      let idx = parseInt(this.getAttribute("data-remove-res"), 10);
       _pendingResources.splice(idx, 1);
       _renderPendingResources();
     });
@@ -1888,9 +1888,9 @@ function _renderPendingResources() {
 }
 
 function _addPendingResource() {
-  var path = (document.getElementById("ctm-res-path").value || "").trim();
-  var content = document.getElementById("ctm-res-content").value || "";
-  var contentType = document.getElementById("ctm-res-content-type").value;
+  const path = (document.getElementById("ctm-res-path").value || "").trim();
+  const content = document.getElementById("ctm-res-content").value || "";
+  const contentType = document.getElementById("ctm-res-content-type").value;
   if (!path || !content) {
     showToast("Path and content are required");
     return;
@@ -1931,16 +1931,16 @@ function submitEditTemplate() {
   // leave stale red text visible during the in-flight PUT, and a successful
   // PUT shouldn't either. Cheaper than reasoning about every catch path
   // remembering to clear on success.
-  var prevErr = document.getElementById("edit-template-error");
+  const prevErr = document.getElementById("edit-template-error");
   if (prevErr) {
     prevErr.classList.remove("is-visible");
     prevErr.textContent = "";
   }
-  var id = document.getElementById("etm-id").value;
-  var content = document.getElementById("etm-content").value;
-  var varList = _detectTemplateVars(content);
-  var tagsRaw = (document.getElementById("etm-tags").value || "").trim();
-  var tagsArray = tagsRaw
+  const id = document.getElementById("etm-id").value;
+  const content = document.getElementById("etm-content").value;
+  const varList = _detectTemplateVars(content);
+  const tagsRaw = (document.getElementById("etm-tags").value || "").trim();
+  const tagsArray = tagsRaw
     ? tagsRaw
         .split(",")
         .map(function (t) {
@@ -1949,14 +1949,14 @@ function submitEditTemplate() {
         .filter(Boolean)
     : [];
   // Session config fields
-  var esTemp = document.getElementById("esk-temperature").value.trim();
-  var esMaxTok = document.getElementById("esk-max-tokens").value.trim();
-  var esBudget = document.getElementById("esk-token-budget").value.trim();
-  var esMaxTurns = document.getElementById("esk-agent-max-turns").value.trim();
-  var esAllowed = (
+  const esTemp = document.getElementById("esk-temperature").value.trim();
+  const esMaxTok = document.getElementById("esk-max-tokens").value.trim();
+  const esBudget = document.getElementById("esk-token-budget").value.trim();
+  const esMaxTurns = document.getElementById("esk-agent-max-turns").value.trim();
+  const esAllowed = (
     document.getElementById("esk-allowed-tools").value || ""
   ).trim();
-  var esAllowedArr = esAllowed
+  const esAllowedArr = esAllowed
     ? esAllowed
         .split(",")
         .map(function (t) {
@@ -1964,26 +1964,26 @@ function submitEditTemplate() {
         })
         .filter(Boolean)
     : [];
-  var esNotifyRaw = (
+  const esNotifyRaw = (
     document.getElementById("esk-notify-on-complete").value || ""
   ).trim();
-  var esNotifyVal = "[]";
+  let esNotifyVal = "[]";
   if (esNotifyRaw) {
     try {
-      var esNotifyParsed = JSON.parse(esNotifyRaw);
+      const esNotifyParsed = JSON.parse(esNotifyRaw);
       if (!Array.isArray(esNotifyParsed))
         throw new Error("must be a JSON array");
       esNotifyVal = JSON.stringify(esNotifyParsed);
     } catch (ne) {
-      var ne3 = document.getElementById("edit-template-error");
+      const ne3 = document.getElementById("edit-template-error");
       ne3.textContent = "Notify on completion: " + ne.message;
       ne3.classList.add("is-visible");
       return;
     }
   }
   document.getElementById("etm-submit").disabled = true;
-  var esVersion = (document.getElementById("etm-version").value || "").trim();
-  var updateBody = {
+  const esVersion = (document.getElementById("etm-version").value || "").trim();
+  const updateBody = {
     name: document.getElementById("etm-name").value.trim(),
     category: document.getElementById("etm-category").value,
     description: (
@@ -2029,7 +2029,7 @@ function submitEditTemplate() {
       loadGovSkills();
     })
     .catch(function (e) {
-      var el = document.getElementById("edit-template-error");
+      const el = document.getElementById("edit-template-error");
       el.textContent = e.message;
       el.classList.add("is-visible");
     })
@@ -2043,17 +2043,17 @@ function submitEditTemplate() {
 // ---------------------------------------------------------------------------
 
 function loadGovUsage() {
-  var now = new Date();
-  var since;
+  const now = new Date();
+  let since;
   if (_govUsageRange === "24h") since = new Date(now - 24 * 60 * 60 * 1000);
   else if (_govUsageRange === "30d")
     since = new Date(now - 30 * 24 * 60 * 60 * 1000);
   else since = new Date(now - 7 * 24 * 60 * 60 * 1000);
-  var sinceStr = since.toISOString().slice(0, 19);
+  const sinceStr = since.toISOString().slice(0, 19);
 
   // Fetch summary + breakdown in parallel
-  var summaryUrl = "/v1/api/admin/usage?since=" + encodeURIComponent(sinceStr);
-  var breakdownUrl = summaryUrl + "&group_by=" + _govUsageGroupBy;
+  const summaryUrl = "/v1/api/admin/usage?since=" + encodeURIComponent(sinceStr);
+  const breakdownUrl = summaryUrl + "&group_by=" + _govUsageGroupBy;
 
   Promise.all([
     authFetch(summaryUrl).then(function (r) {
@@ -2075,21 +2075,21 @@ function loadGovUsage() {
 }
 
 function _renderGovUsage(summary, breakdown) {
-  var container = document.getElementById("admin-usage-content");
-  var s = (summary.breakdown && summary.breakdown[0]) || {};
-  var prompt = s.prompt_tokens || 0;
-  var completion = s.completion_tokens || 0;
-  var total = prompt + completion;
-  var tools = s.tool_calls_count || 0;
-  var cacheWrite = s.cache_creation_tokens || 0;
-  var cacheRead = s.cache_read_tokens || 0;
+  const container = document.getElementById("admin-usage-content");
+  const s = (summary.breakdown && summary.breakdown[0]) || {};
+  const prompt = s.prompt_tokens || 0;
+  const completion = s.completion_tokens || 0;
+  const total = prompt + completion;
+  const tools = s.tool_calls_count || 0;
+  const cacheWrite = s.cache_creation_tokens || 0;
+  const cacheRead = s.cache_read_tokens || 0;
 
-  var cacheZero = cacheWrite === 0 && cacheRead === 0;
-  var cacheCls =
+  const cacheZero = cacheWrite === 0 && cacheRead === 0;
+  const cacheCls =
     "usage-readout usage-readout-secondary" +
     (cacheZero ? " usage-readout-zero" : "");
 
-  var html =
+  let html =
     '<div class="usage-summary">' +
     '<div class="usage-readout"><span class="usage-readout-value">' +
     formatTokens(total) +
@@ -2117,19 +2117,19 @@ function _renderGovUsage(summary, breakdown) {
     "</div>";
 
   // Bar chart breakdown
-  var items = breakdown.breakdown || [];
+  const items = breakdown.breakdown || [];
   if (items.length) {
-    var maxVal = 0;
-    for (var i = 0; i < items.length; i++) {
-      var v = (items[i].prompt_tokens || 0) + (items[i].completion_tokens || 0);
+    let maxVal = 0;
+    for (let i = 0; i < items.length; i++) {
+      const v = (items[i].prompt_tokens || 0) + (items[i].completion_tokens || 0);
       if (v > maxVal) maxVal = v;
     }
     html += '<div class="usage-chart">';
-    for (var j = 0; j < items.length; j++) {
-      var item = items[j];
-      var val = (item.prompt_tokens || 0) + (item.completion_tokens || 0);
-      var pct = maxVal > 0 ? Math.round((val / maxVal) * 100) : 0;
-      var label = item.key || "\u2014";
+    for (let j = 0; j < items.length; j++) {
+      const item = items[j];
+      const val = (item.prompt_tokens || 0) + (item.completion_tokens || 0);
+      const pct = maxVal > 0 ? Math.round((val / maxVal) * 100) : 0;
+      const label = item.key || "\u2014";
       html +=
         '<div class="usage-bar-row">' +
         '<span class="usage-bar-label">' +
@@ -2154,8 +2154,8 @@ function _renderGovUsage(summary, breakdown) {
 function setUsageRange(range) {
   _govUsageRange = range;
   // Update button states
-  var btns = document.querySelectorAll(".usage-range-btn");
-  for (var i = 0; i < btns.length; i++) {
+  const btns = document.querySelectorAll(".usage-range-btn");
+  for (let i = 0; i < btns.length; i++) {
     btns[i].classList.toggle(
       "active",
       btns[i].getAttribute("data-range") === range,
@@ -2170,8 +2170,8 @@ function setUsageRange(range) {
 
 function setUsageGroupBy(groupBy) {
   _govUsageGroupBy = groupBy;
-  var btns = document.querySelectorAll(".usage-group-btn");
-  for (var i = 0; i < btns.length; i++) {
+  const btns = document.querySelectorAll(".usage-group-btn");
+  for (let i = 0; i < btns.length; i++) {
     btns[i].classList.toggle(
       "active",
       btns[i].getAttribute("data-group") === groupBy,
@@ -2193,9 +2193,9 @@ function loadGovAudit(append) {
     _govAuditOffset = 0;
     _govAuditEvents = [];
   }
-  var url = "/v1/api/admin/audit?limit=50&offset=" + _govAuditOffset;
-  var actionFilter = document.getElementById("audit-action-filter");
-  var userFilter = document.getElementById("audit-user-filter");
+  let url = "/v1/api/admin/audit?limit=50&offset=" + _govAuditOffset;
+  const actionFilter = document.getElementById("audit-action-filter");
+  const userFilter = document.getElementById("audit-user-filter");
   if (actionFilter && actionFilter.value)
     url += "&action=" + encodeURIComponent(actionFilter.value);
   if (userFilter && userFilter.value)
@@ -2208,7 +2208,7 @@ function loadGovAudit(append) {
     })
     .then(function (data) {
       _govAuditTotal = data.total || 0;
-      var events = data.events || [];
+      const events = data.events || [];
       _govAuditEvents = _govAuditEvents.concat(events);
       _renderGovAudit(_govAuditEvents, _govAuditTotal);
     })
@@ -2221,9 +2221,9 @@ function loadGovAudit(append) {
 }
 
 function _relativeTime(isoStr) {
-  var now = Date.now();
-  var then = new Date(isoStr + "Z").getTime();
-  var diff = Math.max(0, Math.floor((now - then) / 1000));
+  const now = Date.now();
+  const then = new Date(isoStr + "Z").getTime();
+  const diff = Math.max(0, Math.floor((now - then) / 1000));
   if (diff < 60) return diff + "s ago";
   if (diff < 3600) return Math.floor(diff / 60) + "m ago";
   if (diff < 86400) return Math.floor(diff / 3600) + "h ago";
@@ -2231,21 +2231,21 @@ function _relativeTime(isoStr) {
 }
 
 function _renderGovAudit(events, total) {
-  var el = document.getElementById("admin-audit-table");
+  const el = document.getElementById("admin-audit-table");
   if (!events.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No audit events</div>');
     return;
   }
-  var html = "";
-  for (var i = 0; i < events.length; i++) {
-    var ev = events[i];
-    var detail = "";
+  let html = "";
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    let detail = "";
     try {
-      var d = JSON.parse(ev.detail || "{}");
-      var keys = Object.keys(d);
+      const d = JSON.parse(ev.detail || "{}");
+      const keys = Object.keys(d);
       if (keys.length) {
-        var parts = [];
-        for (var k = 0; k < Math.min(keys.length, 3); k++) {
+        const parts = [];
+        for (let k = 0; k < Math.min(keys.length, 3); k++) {
           parts.push(keys[k] + "=" + String(d[keys[k]]).slice(0, 30));
         }
         detail = parts.join(", ");
@@ -2254,7 +2254,7 @@ function _renderGovAudit(events, total) {
       detail = ev.detail;
     }
 
-    var actionCls = "audit-badge";
+    let actionCls = "audit-badge";
     if (ev.action.indexOf("delete") >= 0 || ev.action.indexOf("revoke") >= 0)
       actionCls += " audit-danger";
     else if (
@@ -2305,7 +2305,7 @@ function _renderGovAudit(events, total) {
   }
   setSafeHtml(el, html);
 
-  var loadMoreBtn = el.querySelector(".audit-load-more");
+  const loadMoreBtn = el.querySelector(".audit-load-more");
   if (loadMoreBtn) loadMoreBtn.addEventListener("click", loadMoreAudit);
 }
 
@@ -2316,10 +2316,10 @@ function loadMoreAudit() {
 
 // Populate audit user filter from admin users list
 function _populateAuditUserFilter() {
-  var sel = document.getElementById("audit-user-filter");
+  const sel = document.getElementById("audit-user-filter");
   if (!sel) return;
-  var html = '<option value="">All users</option>';
-  for (var i = 0; i < _adminUsers.length; i++) {
+  let html = '<option value="">All users</option>';
+  for (let i = 0; i < _adminUsers.length; i++) {
     html +=
       '<option value="' +
       escapeHtml(_adminUsers[i].user_id) +
@@ -2334,17 +2334,17 @@ function _populateAuditUserFilter() {
 // Memories tab
 // ---------------------------------------------------------------------------
 
-var _adminMemories = [];
-var _memDetailTrap = null;
-var _memDetailTrigger = null;
-var _memSearchTimer = null;
-var _memSearchBound = false;
+let _adminMemories = [];
+let _memDetailTrap = null;
+let _memDetailTrigger = null;
+let _memSearchTimer = null;
+let _memSearchBound = false;
 
 function loadAdminMemories() {
   clearTimeout(_memSearchTimer);
   // Bind search debounce on first load
   if (!_memSearchBound) {
-    var searchEl = document.getElementById("mem-search");
+    const searchEl = document.getElementById("mem-search");
     if (searchEl) {
       searchEl.addEventListener("input", function () {
         clearTimeout(_memSearchTimer);
@@ -2354,11 +2354,11 @@ function loadAdminMemories() {
     _memSearchBound = true;
   }
 
-  var memType = document.getElementById("mem-filter-type").value;
-  var scope = document.getElementById("mem-filter-scope").value;
-  var query = (document.getElementById("mem-search").value || "").trim();
+  const memType = document.getElementById("mem-filter-type").value;
+  const scope = document.getElementById("mem-filter-scope").value;
+  const query = (document.getElementById("mem-search").value || "").trim();
 
-  var url;
+  let url;
   if (query) {
     url =
       "/v1/api/admin/memories/search?q=" +
@@ -2390,30 +2390,30 @@ function loadAdminMemories() {
 }
 
 function _renderAdminMemories(items, total) {
-  var el = document.getElementById("admin-memories-table");
+  const el = document.getElementById("admin-memories-table");
   if (!items.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No memories found</div>');
     return;
   }
 
-  var html = "";
-  for (var i = 0; i < items.length; i++) {
-    var m = items[i];
+  let html = "";
+  for (let i = 0; i < items.length; i++) {
+    const m = items[i];
 
     // Type badge
-    var typeCls = "scope-badge mem-type-" + escapeHtml(m.type);
-    var typeBadge =
+    const typeCls = "scope-badge mem-type-" + escapeHtml(m.type);
+    const typeBadge =
       '<span class="' + typeCls + '">' + escapeHtml(m.type) + "</span>";
 
     // Scope badge
-    var scopeLabel = m.scope;
+    let scopeLabel = m.scope;
     if (m.scope_id) scopeLabel += ":" + m.scope_id;
-    var scopeCls = "scope-badge mem-scope-" + escapeHtml(m.scope);
-    var scopeBadge =
+    const scopeCls = "scope-badge mem-scope-" + escapeHtml(m.scope);
+    const scopeBadge =
       '<span class="' + scopeCls + '">' + escapeHtml(scopeLabel) + "</span>";
 
     // Description (truncated)
-    var desc = m.description || "";
+    let desc = m.description || "";
     if (desc.length > 60) desc = desc.substring(0, 57) + "…";
 
     html +=
@@ -2449,19 +2449,19 @@ function _renderAdminMemories(items, total) {
   setSafeHtml(el, html);
 
   // Bind view buttons
-  var viewBtns = el.querySelectorAll("[data-view-memory]");
-  for (var v = 0; v < viewBtns.length; v++) {
+  const viewBtns = el.querySelectorAll("[data-view-memory]");
+  for (let v = 0; v < viewBtns.length; v++) {
     viewBtns[v].addEventListener("click", function () {
       showMemoryDetailModal(this.getAttribute("data-view-memory"));
     });
   }
 
   // Bind delete buttons
-  var delBtns = el.querySelectorAll("[data-delete-memory]");
-  for (var d = 0; d < delBtns.length; d++) {
+  const delBtns = el.querySelectorAll("[data-delete-memory]");
+  for (let d = 0; d < delBtns.length; d++) {
     delBtns[d].addEventListener("click", function () {
-      var mid = this.getAttribute("data-delete-memory");
-      var mname = this.getAttribute("data-delete-name");
+      const mid = this.getAttribute("data-delete-memory");
+      const mname = this.getAttribute("data-delete-name");
       deleteAdminMemory(mid, mname);
     });
   }
@@ -2469,7 +2469,7 @@ function _renderAdminMemories(items, total) {
 
 function showMemoryDetailModal(memoryId) {
   _memDetailTrigger = document.activeElement;
-  var ov = document.getElementById("memory-detail-overlay");
+  const ov = document.getElementById("memory-detail-overlay");
   ov.style.display = "flex";
   setSafeHtml(
     document.getElementById("memory-detail-body"),
@@ -2477,12 +2477,12 @@ function showMemoryDetailModal(memoryId) {
   );
 
   // Disable delete button and clear stale handler while loading
-  var delBtn = document.getElementById("mem-detail-delete");
+  const delBtn = document.getElementById("mem-detail-delete");
   delBtn.disabled = true;
   delBtn.onclick = null;
 
   // Focus close button for keyboard accessibility
-  var closeBtn = ov.querySelector(".modal-cancel");
+  const closeBtn = ov.querySelector(".modal-cancel");
   if (closeBtn) closeBtn.focus();
 
   authFetch("/v1/api/admin/memories/" + encodeURIComponent(memoryId))
@@ -2491,10 +2491,10 @@ function showMemoryDetailModal(memoryId) {
       return r.json();
     })
     .then(function (m) {
-      var scopeLabel = m.scope;
+      let scopeLabel = m.scope;
       if (m.scope_id) scopeLabel += ":" + m.scope_id;
 
-      var html =
+      let html =
         '<div class="mem-detail-grid">' +
         '<div class="mem-detail-field"><span class="mem-detail-label">Name</span>' +
         escapeHtml(m.name) +
@@ -2590,9 +2590,9 @@ function deleteAdminMemory(memoryId, memoryName) {
 
 function switchSkillView(view) {
   _skillCurrentView = view;
-  var btns = document.querySelectorAll("#admin-skills [data-skill-view]");
-  for (var i = 0; i < btns.length; i++) {
-    var isActive = btns[i].getAttribute("data-skill-view") === view;
+  const btns = document.querySelectorAll("#admin-skills [data-skill-view]");
+  for (let i = 0; i < btns.length; i++) {
+    const isActive = btns[i].getAttribute("data-skill-view") === view;
     btns[i].classList.toggle("active", isActive);
     btns[i].setAttribute("aria-selected", isActive ? "true" : "false");
     btns[i].setAttribute("tabindex", isActive ? "0" : "-1");
@@ -2601,19 +2601,19 @@ function switchSkillView(view) {
     view === "installed" ? "" : "none";
   document.getElementById("skill-view-discover").style.display =
     view === "discover" ? "" : "none";
-  var toolbar = document.getElementById("skill-installed-toolbar");
+  const toolbar = document.getElementById("skill-installed-toolbar");
   if (toolbar) toolbar.style.display = view === "installed" ? "" : "none";
 
   if (view === "installed") {
     loadGovSkills();
   } else {
-    var q = document.getElementById("skill-discover-q");
+    const q = document.getElementById("skill-discover-q");
     if (q) q.focus();
   }
 }
 
 function searchSkillDiscover() {
-  var q = (document.getElementById("skill-discover-q").value || "").trim();
+  const q = (document.getElementById("skill-discover-q").value || "").trim();
   if (!q) {
     showToast("Enter a search query");
     return;
@@ -2621,13 +2621,13 @@ function searchSkillDiscover() {
   _skillDiscoverResults = [];
   _skillDiscoverQuery = q;
 
-  var el = document.getElementById("skill-discover-results");
+  const el = document.getElementById("skill-discover-results");
   setSafeHtml(el, '<div class="dashboard-empty">Searching\u2026</div>');
 
-  var searchBtn = document.getElementById("skill-discover-search-btn");
+  const searchBtn = document.getElementById("skill-discover-search-btn");
   if (searchBtn) searchBtn.disabled = true;
 
-  var url = "/v1/api/admin/skills/discover?limit=20&q=" + encodeURIComponent(q);
+  let url = "/v1/api/admin/skills/discover?limit=20&q=" + encodeURIComponent(q);
 
   authFetch(url)
     .then(function (r) {
@@ -2653,21 +2653,21 @@ function searchSkillDiscover() {
 }
 
 function _renderSkillDiscoverResults() {
-  var el = document.getElementById("skill-discover-results");
+  const el = document.getElementById("skill-discover-results");
   if (!_skillDiscoverResults.length) {
     setSafeHtml(el, '<div class="dashboard-empty">No skills found</div>');
     return;
   }
 
-  var html = "";
-  for (var i = 0; i < _skillDiscoverResults.length; i++) {
-    var s = _skillDiscoverResults[i];
-    var nameLabel = escapeHtml(s.name || "");
-    var actionHtml;
+  let html = "";
+  for (let i = 0; i < _skillDiscoverResults.length; i++) {
+    const s = _skillDiscoverResults[i];
+    const nameLabel = escapeHtml(s.name || "");
+    let actionHtml;
     if (s.installed) {
-      var scanBadgeHtml = "";
+      let scanBadgeHtml = "";
       if (s.risk_level) {
-        var scanCls =
+        const scanCls =
           {
             safe: "scope-scan-safe",
             low: "scope-scan-low",
@@ -2694,14 +2694,14 @@ function _renderSkillDiscoverResults() {
     }
 
     // Tags
-    var tagHtml = "";
-    var tags = s.tags || [];
-    for (var t = 0; t < tags.length && t < 4; t++) {
+    let tagHtml = "";
+    const tags = s.tags || [];
+    for (let t = 0; t < tags.length && t < 4; t++) {
       tagHtml += '<span class="scope-badge">' + escapeHtml(tags[t]) + "</span>";
     }
 
     // Source + install count badge
-    var metaHtml = "";
+    let metaHtml = "";
     if (s.source) {
       metaHtml +=
         '<span class="scope-badge mcp-transport-http">' +
@@ -2745,7 +2745,7 @@ function _renderSkillDiscoverResults() {
   // Bind install handlers
   el.querySelectorAll("[data-skill-install]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var idx = parseInt(this.getAttribute("data-skill-install"), 10);
+      let idx = parseInt(this.getAttribute("data-skill-install"), 10);
       installDiscoveredSkill(_skillDiscoverResults[idx]);
     });
   });
@@ -2755,9 +2755,9 @@ function installDiscoveredSkill(skill) {
   if (!skill) return;
 
   // Disable the button
-  var btns = document.querySelectorAll("[data-skill-install]");
-  for (var i = 0; i < btns.length; i++) {
-    var idx = parseInt(btns[i].getAttribute("data-skill-install"), 10);
+  const btns = document.querySelectorAll("[data-skill-install]");
+  for (let i = 0; i < btns.length; i++) {
+    let idx = parseInt(btns[i].getAttribute("data-skill-install"), 10);
     if (
       _skillDiscoverResults[idx] &&
       _skillDiscoverResults[idx].id === skill.id
@@ -2768,7 +2768,7 @@ function installDiscoveredSkill(skill) {
     }
   }
 
-  var body;
+  let body;
   if (skill.source === "github") {
     body = { source: "github", url: skill.source_url };
   } else {
@@ -2788,11 +2788,11 @@ function installDiscoveredSkill(skill) {
       return r.json();
     })
     .then(function (data) {
-      var first = (data.installed && data.installed[0]) || {};
-      var tierMsg = first.risk_level ? " [" + first.risk_level + "]" : "";
+      const first = (data.installed && data.installed[0]) || {};
+      const tierMsg = first.risk_level ? " [" + first.risk_level + "]" : "";
       showToast("Skill installed: " + (skill.name || skill.id) + tierMsg);
       // Mark as installed in results with scan data
-      for (var j = 0; j < _skillDiscoverResults.length; j++) {
+      for (let j = 0; j < _skillDiscoverResults.length; j++) {
         if (_skillDiscoverResults[j].id === skill.id) {
           _skillDiscoverResults[j].installed = true;
           _skillDiscoverResults[j].risk_level = first.risk_level || "";
@@ -2810,9 +2810,9 @@ function installDiscoveredSkill(skill) {
 function showGitHubImportModal() {
   _giTriggerEl = document.activeElement;
   document.getElementById("github-import-overlay").style.display = "";
-  var urlInput = document.getElementById("gi-url");
+  const urlInput = document.getElementById("gi-url");
   urlInput.value = "";
-  var errEl = document.getElementById("github-import-error");
+  const errEl = document.getElementById("github-import-error");
   errEl.textContent = "";
   errEl.classList.remove("is-visible");
   _giTrapHandler = _installTrap("github-import-overlay", "github-import-box");
@@ -2829,8 +2829,8 @@ function hideGitHubImportModal() {
 }
 
 function submitGitHubImport() {
-  var url = (document.getElementById("gi-url").value || "").trim();
-  var errEl = document.getElementById("github-import-error");
+  let url = (document.getElementById("gi-url").value || "").trim();
+  const errEl = document.getElementById("github-import-error");
   if (!url) {
     errEl.textContent = "URL is required";
     errEl.classList.add("is-visible");
@@ -2842,7 +2842,7 @@ function submitGitHubImport() {
     return;
   }
 
-  var submitBtn = document.getElementById("gi-submit");
+  const submitBtn = document.getElementById("gi-submit");
   submitBtn.disabled = true;
   submitBtn.textContent = "Installing\u2026";
   errEl.classList.remove("is-visible");
@@ -2861,12 +2861,12 @@ function submitGitHubImport() {
     })
     .then(function (data) {
       hideGitHubImportModal();
-      var count = data.installed.length;
-      var skipCount = (data.skipped || []).length;
-      var msg;
+      const count = data.installed.length;
+      const skipCount = (data.skipped || []).length;
+      let msg;
       if (count === 1 && !skipCount) {
-        var name = data.installed[0].name || "";
-        var tierMsg = data.installed[0].risk_level
+        const name = data.installed[0].name || "";
+        const tierMsg = data.installed[0].risk_level
           ? " [" + data.installed[0].risk_level + "]"
           : "";
         msg = "Skill installed: " + name + tierMsg;
@@ -2898,11 +2898,11 @@ function submitGitHubImport() {
 // Prompt Policies (system message composition)
 // ---------------------------------------------------------------------------
 
-var _promptPolicies = [];
-var _cppTrapHandler = null;
-var _cppTriggerEl = null;
-var _eppTrapHandler = null;
-var _eppTriggerEl = null;
+let _promptPolicies = [];
+let _cppTrapHandler = null;
+let _cppTriggerEl = null;
+let _eppTrapHandler = null;
+let _eppTriggerEl = null;
 
 function loadPromptPolicies() {
   authFetch("/v1/api/admin/prompt-policies")
@@ -2915,9 +2915,9 @@ function loadPromptPolicies() {
       _renderPromptPolicies(_promptPolicies);
     })
     .catch(function () {
-      var el = document.getElementById("admin-prompt-policies-table");
+      const el = document.getElementById("admin-prompt-policies-table");
       el.textContent = "";
-      var empty = document.createElement("div");
+      const empty = document.createElement("div");
       empty.className = "dashboard-empty";
       empty.textContent = "Failed to load prompts";
       el.appendChild(empty);
@@ -2925,62 +2925,62 @@ function loadPromptPolicies() {
 }
 
 function _renderPromptPolicies(items) {
-  var el = document.getElementById("admin-prompt-policies-table");
+  const el = document.getElementById("admin-prompt-policies-table");
   el.textContent = "";
   if (!items.length) {
-    var empty = document.createElement("div");
+    const empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No prompts defined";
     el.appendChild(empty);
     return;
   }
-  for (var i = 0; i < items.length; i++) {
-    var p = items[i];
-    var row = document.createElement("div");
+  for (let i = 0; i < items.length; i++) {
+    let p = items[i];
+    const row = document.createElement("div");
     row.className = "admin-row";
     row.setAttribute("role", "listitem");
 
-    var colName = document.createElement("span");
+    const colName = document.createElement("span");
     colName.className = "admin-col admin-col-pname";
     colName.textContent = p.name;
     row.appendChild(colName);
 
-    var colGate = document.createElement("span");
+    const colGate = document.createElement("span");
     colGate.className = "admin-col admin-col-ppattern";
     if (p.tool_gate) {
-      var code = document.createElement("code");
+      const code = document.createElement("code");
       code.textContent = p.tool_gate;
       colGate.appendChild(code);
     } else {
-      var em = document.createElement("em");
+      const em = document.createElement("em");
       em.textContent = "unconditional";
       colGate.appendChild(em);
     }
     row.appendChild(colGate);
 
-    var colPri = document.createElement("span");
+    const colPri = document.createElement("span");
     colPri.className = "admin-col admin-col-ppriority";
     colPri.textContent = String(p.priority);
     row.appendChild(colPri);
 
-    var colStatus = document.createElement("span");
+    const colStatus = document.createElement("span");
     colStatus.className = "admin-col admin-col-pstatus";
-    var dot = document.createElement("span");
+    const dot = document.createElement("span");
     dot.className = p.enabled ? "watch-active" : "watch-completed";
     dot.title = p.enabled ? "Enabled" : "Disabled";
     dot.textContent = p.enabled ? "\u25CF active" : "\u25CB disabled";
     colStatus.appendChild(dot);
     row.appendChild(colStatus);
 
-    var colActions = document.createElement("span");
+    const colActions = document.createElement("span");
     colActions.className = "admin-col admin-col-actions";
-    var editBtn = document.createElement("button");
+    const editBtn = document.createElement("button");
     editBtn.className = "admin-btn-action";
     editBtn.textContent = "edit";
     editBtn.setAttribute("data-edit-ppolicy", p.policy_id);
     editBtn.setAttribute("aria-label", "Edit prompt " + p.name);
     colActions.appendChild(editBtn);
-    var delBtn = document.createElement("button");
+    const delBtn = document.createElement("button");
     delBtn.className = "admin-btn-danger";
     delBtn.textContent = "delete";
     delBtn.setAttribute("data-delete-ppolicy", p.policy_id);
@@ -2998,8 +2998,8 @@ function _renderPromptPolicies(items) {
   });
   el.querySelectorAll("[data-delete-ppolicy]").forEach(function (btn) {
     btn.addEventListener("click", function () {
-      var pid = this.getAttribute("data-delete-ppolicy");
-      var pname = this.getAttribute("data-ppolicy-name");
+      const pid = this.getAttribute("data-delete-ppolicy");
+      const pname = this.getAttribute("data-ppolicy-name");
       showConfirmModal(
         "Delete Prompt",
         'Delete prompt "' + pname + '"?',
@@ -3027,7 +3027,7 @@ function _renderPromptPolicies(items) {
 
 function showCreatePromptPolicyModal() {
   _cppTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-ppolicy-overlay");
+  const ov = document.getElementById("create-ppolicy-overlay");
   ov.style.display = "flex";
   document.getElementById("cpp-name").value = "";
   document.getElementById("cpp-gate").value = "";
@@ -3051,16 +3051,16 @@ function hideCreatePromptPolicyModal() {
 }
 
 function submitCreatePromptPolicy() {
-  var errEl = document.getElementById("cpp-error");
-  var name = document.getElementById("cpp-name").value.trim();
-  var content = document.getElementById("cpp-content").value.trim();
+  const errEl = document.getElementById("cpp-error");
+  const name = document.getElementById("cpp-name").value.trim();
+  const content = document.getElementById("cpp-content").value.trim();
   if (!name || !content) {
     errEl.textContent = "Name and content are required";
     errEl.classList.add("is-visible");
     return;
   }
   errEl.classList.remove("is-visible");
-  var submitBtn = document.getElementById("cpp-submit");
+  const submitBtn = document.getElementById("cpp-submit");
   submitBtn.disabled = true;
   authFetch("/v1/api/admin/prompt-policies", {
     method: "POST",
@@ -3097,8 +3097,8 @@ function submitCreatePromptPolicy() {
 
 function showEditPromptPolicyModal(policyId) {
   _eppTriggerEl = document.activeElement;
-  var p = null;
-  for (var i = 0; i < _promptPolicies.length; i++) {
+  let p = null;
+  for (let i = 0; i < _promptPolicies.length; i++) {
     if (_promptPolicies[i].policy_id === policyId) {
       p = _promptPolicies[i];
       break;
@@ -3112,7 +3112,7 @@ function showEditPromptPolicyModal(policyId) {
   document.getElementById("epp-priority").value = p.priority || 0;
   document.getElementById("epp-enabled").checked = p.enabled;
   document.getElementById("epp-error").classList.remove("is-visible");
-  var ov = document.getElementById("edit-ppolicy-overlay");
+  const ov = document.getElementById("edit-ppolicy-overlay");
   ov.style.display = "flex";
   document.getElementById("epp-name").focus();
   _eppTrapHandler = _installTrap("edit-ppolicy-overlay", "edit-ppolicy-box");
@@ -3128,17 +3128,17 @@ function hideEditPromptPolicyModal() {
 }
 
 function submitEditPromptPolicy() {
-  var errEl = document.getElementById("epp-error");
-  var policyId = document.getElementById("epp-id").value;
-  var name = document.getElementById("epp-name").value.trim();
-  var content = document.getElementById("epp-content").value.trim();
+  const errEl = document.getElementById("epp-error");
+  const policyId = document.getElementById("epp-id").value;
+  const name = document.getElementById("epp-name").value.trim();
+  const content = document.getElementById("epp-content").value.trim();
   if (!name || !content) {
     errEl.textContent = "Name and content are required";
     errEl.classList.add("is-visible");
     return;
   }
   errEl.classList.remove("is-visible");
-  var submitBtn = document.getElementById("epp-submit");
+  const submitBtn = document.getElementById("epp-submit");
   submitBtn.disabled = true;
   authFetch("/v1/api/admin/prompt-policies/" + policyId, {
     method: "PUT",
@@ -3177,48 +3177,48 @@ function submitEditPromptPolicy() {
 // Judge tab — settings, heuristic rules, output guard patterns
 // ---------------------------------------------------------------------------
 
-var _judgeSettings = [];
-var _judgeHeuristicRules = [];
-var _judgeOGPatterns = [];
-var _judgeModelDefs = [];
-var _chrTrapHandler = null; // create heuristic rule
-var _cogpTrapHandler = null; // create output guard pattern
-var _chrTriggerEl = null;
-var _cogpTriggerEl = null;
-var _ehrTrapHandler = null; // edit heuristic rule
-var _eogpTrapHandler = null; // edit output guard pattern
-var _ehrTriggerEl = null;
-var _eogpTriggerEl = null;
+let _judgeSettings = [];
+let _judgeHeuristicRules = [];
+let _judgeOGPatterns = [];
+let _judgeModelDefs = [];
+let _chrTrapHandler = null; // create heuristic rule
+let _cogpTrapHandler = null; // create output guard pattern
+let _chrTriggerEl = null;
+let _cogpTriggerEl = null;
+let _ehrTrapHandler = null; // edit heuristic rule
+let _eogpTrapHandler = null; // edit output guard pattern
+let _ehrTriggerEl = null;
+let _eogpTriggerEl = null;
 
 // -- Sub-section switcher ---------------------------------------------------
 
 function switchJudgeSection(section) {
-  var sections = document.querySelectorAll(".judge-section");
-  for (var i = 0; i < sections.length; i++) sections[i].style.display = "none";
-  var switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
-  var btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
-  for (var i = 0; i < btns.length; i++) {
-    var isActive = btns[i].getAttribute("data-section") === section;
+  const sections = document.querySelectorAll(".judge-section");
+  for (let i = 0; i < sections.length; i++) sections[i].style.display = "none";
+  const switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
+  const btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
+  for (let i = 0; i < btns.length; i++) {
+    const isActive = btns[i].getAttribute("data-section") === section;
     btns[i].classList.toggle("active", isActive);
     btns[i].setAttribute("aria-selected", isActive ? "true" : "false");
     btns[i].setAttribute("tabindex", isActive ? "0" : "-1");
   }
-  var target = document.getElementById(section + "-section");
+  const target = document.getElementById(section + "-section");
   if (target) target.style.display = "";
 }
 
 // Arrow key navigation for judge sub-section tabs
 (function () {
-  var switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
+  const switcher = document.querySelector("#admin-judge .admin-subtab-switcher");
   if (!switcher) return;
   switcher.addEventListener("keydown", function (e) {
     if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-    var btns = switcher.querySelectorAll(".admin-subtab-btn");
-    var secs = [];
-    for (var i = 0; i < btns.length; i++)
+    const btns = switcher.querySelectorAll(".admin-subtab-btn");
+    const secs = [];
+    for (let i = 0; i < btns.length; i++)
       secs.push(btns[i].getAttribute("data-section"));
-    var current = switcher.querySelector(".admin-subtab-btn.active");
-    var idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
+    const current = switcher.querySelector(".admin-subtab-btn.active");
+    let idx = secs.indexOf(current ? current.getAttribute("data-section") : "");
     if (e.key === "ArrowRight") idx = (idx + 1) % secs.length;
     else idx = (idx - 1 + secs.length) % secs.length;
     e.preventDefault();
@@ -3270,7 +3270,7 @@ function loadJudgeSettings() {
 }
 
 function renderJudgeSettings() {
-  var c = document.getElementById("judge-settings-container");
+  const c = document.getElementById("judge-settings-container");
   if (!_judgeSettings.length) {
     setSafeHtml(
       c,
@@ -3278,16 +3278,16 @@ function renderJudgeSettings() {
     );
     return;
   }
-  var html = "";
-  for (var i = 0; i < _judgeSettings.length; i++) {
-    var s = _judgeSettings[i];
+  let html = "";
+  for (let i = 0; i < _judgeSettings.length; i++) {
+    const s = _judgeSettings[i];
     if (s.key === "judge.model") continue;
-    var shortKey = s.key.replace("judge.", "");
-    var inputHtml = "";
-    var currentVal = s.value;
-    var isDefault = s.source === "default";
+    const shortKey = s.key.replace("judge.", "");
+    let inputHtml = "";
+    const currentVal = s.value;
+    const isDefault = s.source === "default";
 
-    var eKey = escapeHtml(s.key);
+    const eKey = escapeHtml(s.key);
     if (s.type === "bool") {
       // Toggle switch — same component used by the admin modals.
       // The delegated change handler (wired after setSafeHtml below)
@@ -3358,7 +3358,7 @@ function renderJudgeSettings() {
         '">Save</button></div>';
     }
 
-    var resetBtn = !isDefault
+    const resetBtn = !isDefault
       ? ' <button class="admin-action-btn" style="font-size:11px;padding:2px 6px" data-judge-reset-key="' +
         eKey +
         '">Reset</button>'
@@ -3390,9 +3390,9 @@ function renderJudgeSettings() {
   // would break out if a key ever contained an apostrophe.  Bool
   // checkboxes auto-save on change; text/number/password inputs are
   // paired with an explicit Save button (no per-keystroke save).
-  var inputs = c.querySelectorAll("[data-judge-key]");
-  for (var ii = 0; ii < inputs.length; ii++) {
-    var inp = inputs[ii];
+  const inputs = c.querySelectorAll("[data-judge-key]");
+  for (let ii = 0; ii < inputs.length; ii++) {
+    const inp = inputs[ii];
     if (inp.type === "checkbox") {
       inp.addEventListener("change", function () {
         saveJudgeSetting(this.getAttribute("data-judge-key"), this.checked);
@@ -3401,14 +3401,14 @@ function renderJudgeSettings() {
     // text/number/password: no auto-save listener — the adjacent Save
     // button (data-judge-save-key) is the commit gesture.
   }
-  var saveBtns = c.querySelectorAll("[data-judge-save-key]");
-  for (var sb = 0; sb < saveBtns.length; sb++) {
+  const saveBtns = c.querySelectorAll("[data-judge-save-key]");
+  for (let sb = 0; sb < saveBtns.length; sb++) {
     saveBtns[sb].addEventListener("click", function () {
       saveJudgeSettingFromInput(this.getAttribute("data-judge-save-key"));
     });
   }
-  var resetBtns = c.querySelectorAll("[data-judge-reset-key]");
-  for (var rb = 0; rb < resetBtns.length; rb++) {
+  const resetBtns = c.querySelectorAll("[data-judge-reset-key]");
+  for (let rb = 0; rb < resetBtns.length; rb++) {
     resetBtns[rb].addEventListener("click", function () {
       resetJudgeSetting(this.getAttribute("data-judge-reset-key"));
     });
@@ -3442,7 +3442,7 @@ function saveJudgeSettingFromInput(key) {
   // CSS attribute-selector metacharacters (``"``, ``\``).  Keys today
   // come from a static server-side registry without those chars, but
   // the helper is cheap and makes the selector future-proof.
-  var input = document.querySelector(
+  const input = document.querySelector(
     '[data-judge-key="' + cssEscape(key) + '"]',
   );
   if (!input) return;
@@ -3490,15 +3490,15 @@ function loadJudgeHeuristicRules() {
 }
 
 function renderHeuristicRules() {
-  var c = document.getElementById("judge-heuristic-table-container");
+  const c = document.getElementById("judge-heuristic-table-container");
   if (!_judgeHeuristicRules.length) {
     setSafeHtml(c, '<div class="dashboard-empty">No rules found</div>');
     return;
   }
-  var html = "";
-  for (var i = 0; i < _judgeHeuristicRules.length; i++) {
-    var r = _judgeHeuristicRules[i];
-    var sourceBadge =
+  let html = "";
+  for (let i = 0; i < _judgeHeuristicRules.length; i++) {
+    const r = _judgeHeuristicRules[i];
+    const sourceBadge =
       r.source === "builtin"
         ? '<span class="scope-badge">built-in</span>'
         : r.source === "builtin-overridden"
@@ -3506,11 +3506,11 @@ function renderHeuristicRules() {
           : r.source === "builtin-disabled"
             ? '<span class="scope-badge">built-in</span>'
             : '<span class="scope-badge scope-write">custom</span>';
-    var statusBadge = r.enabled
+    const statusBadge = r.enabled
       ? '<span class="scope-badge scope-scan-safe">active</span>'
       : '<span class="scope-badge scope-deny">disabled</span>';
-    var actions = "";
-    var eName = escapeHtml(r.name);
+    let actions = "";
+    const eName = escapeHtml(r.name);
     if (!r.rule_id) {
       // Pure built-in: Disable + Edit
       actions =
@@ -3662,8 +3662,8 @@ function toggleHeuristicRule(ruleId, enabled) {
 }
 
 function deleteHeuristicRule(ruleId) {
-  var ruleName = "";
-  for (var j = 0; j < _judgeHeuristicRules.length; j++) {
+  let ruleName = "";
+  for (let j = 0; j < _judgeHeuristicRules.length; j++) {
     if (_judgeHeuristicRules[j].rule_id === ruleId) {
       ruleName = _judgeHeuristicRules[j].name;
       break;
@@ -3697,7 +3697,7 @@ function deleteHeuristicRule(ruleId) {
 
 function showCreateHeuristicRuleModal() {
   _chrTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-hr-overlay");
+  const ov = document.getElementById("create-hr-overlay");
   ov.style.display = "flex";
   document.getElementById("hr-name").value = "";
   document.getElementById("hr-tier").value = "medium";
@@ -3722,15 +3722,15 @@ function hideCreateHRModal() {
 }
 
 function submitCreateHeuristicRule() {
-  var errEl = document.getElementById("create-hr-error");
+  const errEl = document.getElementById("create-hr-error");
   errEl.classList.remove("is-visible");
-  var argsText = document.getElementById("hr-args").value.trim();
-  var argPatterns = argsText
+  const argsText = document.getElementById("hr-args").value.trim();
+  const argPatterns = argsText
     ? argsText.split("\n").filter(function (l) {
         return l.trim();
       })
     : [];
-  var payload = {
+  const payload = {
     name: document.getElementById("hr-name").value.trim(),
     tier: document.getElementById("hr-tier").value,
     risk_level: document.getElementById("hr-risk").value,
@@ -3742,7 +3742,7 @@ function submitCreateHeuristicRule() {
     reasoning_template: document.getElementById("hr-reason").value.trim(),
     enabled: true,
   };
-  var btn = document.getElementById("hr-submit");
+  const btn = document.getElementById("hr-submit");
   btn.disabled = true;
   authFetch("/v1/api/admin/judge/heuristic-rules", {
     method: "POST",
@@ -3773,15 +3773,15 @@ function submitCreateHeuristicRule() {
 // -- Heuristic Rule: disable / edit / reset ---------------------------------
 
 function disableBuiltinHeuristicRule(name) {
-  var rule = null;
-  for (var i = 0; i < _judgeHeuristicRules.length; i++) {
+  let rule = null;
+  for (let i = 0; i < _judgeHeuristicRules.length; i++) {
     if (_judgeHeuristicRules[i].name === name) {
       rule = _judgeHeuristicRules[i];
       break;
     }
   }
   if (!rule) return;
-  var payload = {
+  const payload = {
     name: rule.name,
     risk_level: rule.risk_level,
     confidence: rule.confidence,
@@ -3817,8 +3817,8 @@ function disableBuiltinHeuristicRule(name) {
 }
 
 function resetHeuristicRule(ruleId) {
-  var ruleName = "";
-  for (var j = 0; j < _judgeHeuristicRules.length; j++) {
+  let ruleName = "";
+  for (let j = 0; j < _judgeHeuristicRules.length; j++) {
     if (_judgeHeuristicRules[j].rule_id === ruleId) {
       ruleName = _judgeHeuristicRules[j].name;
       break;
@@ -3863,7 +3863,7 @@ function _populateEditHRModal(rule, isBuiltin) {
   document.getElementById("ehr-rec").value = rule.recommendation;
   document.getElementById("ehr-tool").value = rule.tool_pattern;
   // arg_patterns comes as JSON string from API
-  var args = rule.arg_patterns || "[]";
+  let args = rule.arg_patterns || "[]";
   if (typeof args === "string") {
     try {
       args = JSON.parse(args);
@@ -3881,8 +3881,8 @@ function _populateEditHRModal(rule, isBuiltin) {
 
 function showEditHeuristicRuleModal(ruleId) {
   _ehrTriggerEl = document.activeElement;
-  var rule = null;
-  for (var i = 0; i < _judgeHeuristicRules.length; i++) {
+  let rule = null;
+  for (let i = 0; i < _judgeHeuristicRules.length; i++) {
     if (_judgeHeuristicRules[i].rule_id === ruleId) {
       rule = _judgeHeuristicRules[i];
       break;
@@ -3890,7 +3890,7 @@ function showEditHeuristicRuleModal(ruleId) {
   }
   if (!rule) return;
   _populateEditHRModal(rule, !!rule.builtin);
-  var ov = document.getElementById("edit-hr-overlay");
+  const ov = document.getElementById("edit-hr-overlay");
   ov.style.display = "flex";
   document.getElementById("ehr-tier").focus();
   _ehrTrapHandler = _installTrap("edit-hr-overlay", "edit-hr-box");
@@ -3898,8 +3898,8 @@ function showEditHeuristicRuleModal(ruleId) {
 
 function showEditBuiltinHeuristicRuleModal(name) {
   _ehrTriggerEl = document.activeElement;
-  var rule = null;
-  for (var i = 0; i < _judgeHeuristicRules.length; i++) {
+  let rule = null;
+  for (let i = 0; i < _judgeHeuristicRules.length; i++) {
     if (
       _judgeHeuristicRules[i].name === name &&
       !_judgeHeuristicRules[i].rule_id
@@ -3910,7 +3910,7 @@ function showEditBuiltinHeuristicRuleModal(name) {
   }
   if (!rule) return;
   _populateEditHRModal(rule, true);
-  var ov = document.getElementById("edit-hr-overlay");
+  const ov = document.getElementById("edit-hr-overlay");
   ov.style.display = "flex";
   document.getElementById("ehr-tier").focus();
   _ehrTrapHandler = _installTrap("edit-hr-overlay", "edit-hr-box");
@@ -3924,16 +3924,16 @@ function hideEditHRModal() {
 }
 
 function submitEditHeuristicRule() {
-  var errEl = document.getElementById("edit-hr-error");
+  const errEl = document.getElementById("edit-hr-error");
   errEl.classList.remove("is-visible");
-  var argsText = document.getElementById("ehr-args").value.trim();
-  var argPatterns = argsText
+  const argsText = document.getElementById("ehr-args").value.trim();
+  const argPatterns = argsText
     ? argsText.split("\n").filter(function (l) {
         return l.trim();
       })
     : [];
-  var ruleId = document.getElementById("ehr-id").value;
-  var payload = {
+  const ruleId = document.getElementById("ehr-id").value;
+  const payload = {
     name: document.getElementById("ehr-name").value.trim(),
     tier: document.getElementById("ehr-tier").value,
     risk_level: document.getElementById("ehr-risk").value,
@@ -3945,10 +3945,10 @@ function submitEditHeuristicRule() {
     reasoning_template: document.getElementById("ehr-reason").value.trim(),
     priority: parseInt(document.getElementById("ehr-priority").value, 10) || 0,
   };
-  var btn = document.getElementById("ehr-submit");
+  const btn = document.getElementById("ehr-submit");
   btn.disabled = true;
 
-  var url, method;
+  let url, method;
   if (ruleId) {
     // Existing DB row — update in place
     url = "/v1/api/admin/judge/heuristic-rules/" + ruleId;
@@ -4007,15 +4007,15 @@ function loadJudgeOGPatterns() {
 }
 
 function renderOGPatterns() {
-  var c = document.getElementById("judge-og-table-container");
+  const c = document.getElementById("judge-og-table-container");
   if (!_judgeOGPatterns.length) {
     setSafeHtml(c, '<div class="dashboard-empty">No patterns found</div>');
     return;
   }
-  var html = "";
-  for (var i = 0; i < _judgeOGPatterns.length; i++) {
-    var p = _judgeOGPatterns[i];
-    var sourceBadge =
+  let html = "";
+  for (let i = 0; i < _judgeOGPatterns.length; i++) {
+    let p = _judgeOGPatterns[i];
+    const sourceBadge =
       p.source === "builtin"
         ? '<span class="scope-badge">built-in</span>'
         : p.source === "builtin-overridden"
@@ -4023,11 +4023,11 @@ function renderOGPatterns() {
           : p.source === "builtin-disabled"
             ? '<span class="scope-badge">built-in</span>'
             : '<span class="scope-badge scope-write">custom</span>';
-    var statusBadge = p.enabled
+    const statusBadge = p.enabled
       ? '<span class="scope-badge scope-scan-safe">active</span>'
       : '<span class="scope-badge scope-deny">disabled</span>';
-    var actions = "";
-    var eName = escapeHtml(p.name);
+    let actions = "";
+    const eName = escapeHtml(p.name);
     if (!p.pattern_id) {
       // Pure built-in: Disable + Edit
       actions =
@@ -4174,8 +4174,8 @@ function toggleOGPattern(patternId, enabled) {
 }
 
 function deleteOGPattern(patternId) {
-  var patName = "";
-  for (var j = 0; j < _judgeOGPatterns.length; j++) {
+  let patName = "";
+  for (let j = 0; j < _judgeOGPatterns.length; j++) {
     if (_judgeOGPatterns[j].pattern_id === patternId) {
       patName = _judgeOGPatterns[j].name;
       break;
@@ -4209,7 +4209,7 @@ function deleteOGPattern(patternId) {
 
 function showCreateOutputGuardPatternModal() {
   _cogpTriggerEl = document.activeElement;
-  var ov = document.getElementById("create-ogp-overlay");
+  const ov = document.getElementById("create-ogp-overlay");
   ov.style.display = "flex";
   document.getElementById("ogp-name").value = "";
   document.getElementById("ogp-cat").value = "prompt_injection";
@@ -4235,8 +4235,8 @@ function hideCreateOGPModal() {
 }
 
 function validateOGRegex() {
-  var pattern = document.getElementById("ogp-pattern").value;
-  var resultEl = document.getElementById("ogp-regex-result");
+  const pattern = document.getElementById("ogp-pattern").value;
+  const resultEl = document.getElementById("ogp-regex-result");
   if (!pattern) {
     resultEl.textContent = "";
     return;
@@ -4266,9 +4266,9 @@ function validateOGRegex() {
 }
 
 function submitCreateOGPattern() {
-  var errEl = document.getElementById("create-ogp-error");
+  const errEl = document.getElementById("create-ogp-error");
   errEl.classList.remove("is-visible");
-  var payload = {
+  const payload = {
     name: document.getElementById("ogp-name").value.trim(),
     category: document.getElementById("ogp-cat").value,
     risk_level: document.getElementById("ogp-risk").value,
@@ -4280,7 +4280,7 @@ function submitCreateOGPattern() {
     redact_label: document.getElementById("ogp-redact").value.trim(),
     enabled: true,
   };
-  var btn = document.getElementById("ogp-submit");
+  const btn = document.getElementById("ogp-submit");
   btn.disabled = true;
   authFetch("/v1/api/admin/judge/output-guard-patterns", {
     method: "POST",
@@ -4311,15 +4311,15 @@ function submitCreateOGPattern() {
 // -- Output Guard Pattern: disable / edit / reset ---------------------------
 
 function disableBuiltinOGPattern(name) {
-  var pat = null;
-  for (var i = 0; i < _judgeOGPatterns.length; i++) {
+  let pat = null;
+  for (let i = 0; i < _judgeOGPatterns.length; i++) {
     if (_judgeOGPatterns[i].name === name) {
       pat = _judgeOGPatterns[i];
       break;
     }
   }
   if (!pat) return;
-  var payload = {
+  const payload = {
     name: pat.name,
     category: pat.category,
     risk_level: pat.risk_level,
@@ -4355,8 +4355,8 @@ function disableBuiltinOGPattern(name) {
 }
 
 function resetOGPattern(patternId) {
-  var patName = "";
-  for (var j = 0; j < _judgeOGPatterns.length; j++) {
+  let patName = "";
+  for (let j = 0; j < _judgeOGPatterns.length; j++) {
     if (_judgeOGPatterns[j].pattern_id === patternId) {
       patName = _judgeOGPatterns[j].name;
       break;
@@ -4412,8 +4412,8 @@ function _populateEditOGPModal(pat, isBuiltin) {
 
 function showEditOGPatternModal(patternId) {
   _eogpTriggerEl = document.activeElement;
-  var pat = null;
-  for (var i = 0; i < _judgeOGPatterns.length; i++) {
+  let pat = null;
+  for (let i = 0; i < _judgeOGPatterns.length; i++) {
     if (_judgeOGPatterns[i].pattern_id === patternId) {
       pat = _judgeOGPatterns[i];
       break;
@@ -4421,7 +4421,7 @@ function showEditOGPatternModal(patternId) {
   }
   if (!pat) return;
   _populateEditOGPModal(pat, !!pat.builtin);
-  var ov = document.getElementById("edit-ogp-overlay");
+  const ov = document.getElementById("edit-ogp-overlay");
   ov.style.display = "flex";
   document.getElementById("eogp-cat").focus();
   _eogpTrapHandler = _installTrap("edit-ogp-overlay", "edit-ogp-box");
@@ -4429,8 +4429,8 @@ function showEditOGPatternModal(patternId) {
 
 function showEditBuiltinOGPatternModal(name) {
   _eogpTriggerEl = document.activeElement;
-  var pat = null;
-  for (var i = 0; i < _judgeOGPatterns.length; i++) {
+  let pat = null;
+  for (let i = 0; i < _judgeOGPatterns.length; i++) {
     if (_judgeOGPatterns[i].name === name && !_judgeOGPatterns[i].pattern_id) {
       pat = _judgeOGPatterns[i];
       break;
@@ -4438,7 +4438,7 @@ function showEditBuiltinOGPatternModal(name) {
   }
   if (!pat) return;
   _populateEditOGPModal(pat, true);
-  var ov = document.getElementById("edit-ogp-overlay");
+  const ov = document.getElementById("edit-ogp-overlay");
   ov.style.display = "flex";
   document.getElementById("eogp-cat").focus();
   _eogpTrapHandler = _installTrap("edit-ogp-overlay", "edit-ogp-box");
@@ -4452,8 +4452,8 @@ function hideEditOGPModal() {
 }
 
 function validateEditOGRegex() {
-  var pattern = document.getElementById("eogp-pattern").value;
-  var resultEl = document.getElementById("eogp-regex-result");
+  const pattern = document.getElementById("eogp-pattern").value;
+  const resultEl = document.getElementById("eogp-regex-result");
   if (!pattern) {
     resultEl.textContent = "";
     return;
@@ -4483,10 +4483,10 @@ function validateEditOGRegex() {
 }
 
 function submitEditOGPattern() {
-  var errEl = document.getElementById("edit-ogp-error");
+  const errEl = document.getElementById("edit-ogp-error");
   errEl.classList.remove("is-visible");
-  var patternId = document.getElementById("eogp-id").value;
-  var payload = {
+  const patternId = document.getElementById("eogp-id").value;
+  const payload = {
     name: document.getElementById("eogp-name").value.trim(),
     category: document.getElementById("eogp-cat").value,
     risk_level: document.getElementById("eogp-risk").value,
@@ -4498,10 +4498,10 @@ function submitEditOGPattern() {
     redact_label: document.getElementById("eogp-redact").value.trim(),
     priority: parseInt(document.getElementById("eogp-priority").value, 10) || 0,
   };
-  var btn = document.getElementById("eogp-submit");
+  const btn = document.getElementById("eogp-submit");
   btn.disabled = true;
 
-  var url, method;
+  let url, method;
   if (patternId) {
     url = "/v1/api/admin/judge/output-guard-patterns/" + patternId;
     method = "PUT";

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -8,14 +8,14 @@
    3. If auth_enabled + has_users → show login (username:password)
    4. Legacy: token-based login still supported via toggle */
 
-var _AUTH_TITLE = window.TURNSTONE_AUTH_TITLE || "turnstone";
-var _loginTrapHandler = null;
-var _loginBusy = false;
-var _authMode = "login"; // "login", "setup", "token"
-var _authUpgradeReload = false;
+const _AUTH_TITLE = window.TURNSTONE_AUTH_TITLE || "turnstone";
+let _loginTrapHandler = null;
+let _loginBusy = false;
+let _authMode = "login"; // "login", "setup", "token"
+let _authUpgradeReload = false;
 
 // Cross-tab auth sync — when one tab logs in/out, others follow.
-var _authChannel =
+const _authChannel =
   typeof BroadcastChannel !== "undefined"
     ? new BroadcastChannel("turnstone_auth")
     : null;
@@ -37,12 +37,12 @@ if (_authChannel) {
 }
 
 async function authFetch(url, opts) {
-  var maxRetries = 2;
-  for (var attempt = 0; attempt <= maxRetries; attempt++) {
-    var r = await fetch(url, opts);
+  const maxRetries = 2;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const r = await fetch(url, opts);
     if (r.status === 401) {
       try {
-        var body = await r.clone().json();
+        const body = await r.clone().json();
         if (body && body.code === "version_mismatch") {
           _authUpgradeReload = true;
           showLogin("upgrade");
@@ -62,7 +62,7 @@ async function authFetch(url, opts) {
       throw new Error("auth");
     }
     if (r.status === 429 && attempt < maxRetries) {
-      var retryAfter = parseInt(r.headers.get("Retry-After") || "1", 10);
+      const retryAfter = parseInt(r.headers.get("Retry-After") || "1", 10);
       showToast("Rate limited \u2014 retrying in " + retryAfter + "s");
       await new Promise(function (resolve) {
         setTimeout(resolve, retryAfter * 1000);
@@ -70,7 +70,7 @@ async function authFetch(url, opts) {
       continue;
     }
     // Successful auth — ensure logout button and SSE connection
-    var _lb = document.getElementById("logout-btn");
+    const _lb = document.getElementById("logout-btn");
     if (_lb) _lb.style.display = "";
     if (typeof _ensureSSE === "function") _ensureSSE();
     return r;
@@ -86,22 +86,22 @@ async function authFetch(url, opts) {
 // hammering the server for every authFetch.  The reactive _tryRefresh()
 // path above covers cases where the timer didn't fire (tab restored from
 // disk cache after expiry, system clock jump, etc).
-var _REFRESH_AT_FRACTION = 0.9;
+const _REFRESH_AT_FRACTION = 0.9;
 // Floor so we don't spin on tiny lifetimes; ceil so very long-lived
 // cookies still refresh once a day for permission re-resolution.
-var _REFRESH_MIN_DELAY_MS = 30 * 1000;
-var _REFRESH_MAX_DELAY_MS = 24 * 60 * 60 * 1000;
-var _refreshTimer = null;
-var _refreshInFlight = null;
+const _REFRESH_MIN_DELAY_MS = 30 * 1000;
+const _REFRESH_MAX_DELAY_MS = 24 * 60 * 60 * 1000;
+let _refreshTimer = null;
+let _refreshInFlight = null;
 // Logout race guard: a refresh (or whoami) in flight when the user
 // clicks Logout can land AFTER /logout and re-populate state, silently
 // undoing the logout.  _loggedOut is set synchronously in logout() and
 // every fetch's .then bails on its post-fetch effects when it sees the
 // flag.  _refreshAbort / _whoamiAbort are the AbortControllers for any
 // in-flight /refresh and /whoami respectively.
-var _loggedOut = false;
-var _refreshAbort = null;
-var _whoamiAbort = null;
+let _loggedOut = false;
+let _refreshAbort = null;
+let _whoamiAbort = null;
 
 // Permissions-ready: one-shot promise resolved after the initial whoami
 // completes (success OR failure).  Lets permission-gated UI await the
@@ -109,13 +109,13 @@ var _whoamiAbort = null;
 // guessing a setTimeout duration.  Subsequent logins/logouts refresh
 // permissions through the existing onLoginSuccess / onLogout hooks, so
 // one-shot is sufficient for the page-load gate problem.
-var _permissionsReadyResolve = null;
-var _permissionsReady = new Promise(function (resolve) {
+let _permissionsReadyResolve = null;
+const _permissionsReady = new Promise(function (resolve) {
   _permissionsReadyResolve = resolve;
 });
 function _markPermissionsReady() {
   if (_permissionsReadyResolve) {
-    var r = _permissionsReadyResolve;
+    const r = _permissionsReadyResolve;
     _permissionsReadyResolve = null;
     r();
   }
@@ -140,14 +140,14 @@ async function _tryRefresh() {
     typeof AbortController !== "undefined" ? new AbortController() : null;
   _refreshInFlight = (async function () {
     try {
-      var r = await fetch("/v1/api/auth/refresh", {
+      const r = await fetch("/v1/api/auth/refresh", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "same-origin",
         signal: _refreshAbort ? _refreshAbort.signal : undefined,
       });
       if (!r.ok) return false;
-      var data = null;
+      let data = null;
       try {
         data = await r.json();
       } catch (_e) {
@@ -197,11 +197,11 @@ function _scheduleRefreshAt(epochSeconds) {
     _refreshTimer = null;
   }
   if (typeof epochSeconds !== "number" || !isFinite(epochSeconds)) return;
-  var nowMs = Date.now();
-  var expMs = epochSeconds * 1000;
-  var remaining = expMs - nowMs;
+  const nowMs = Date.now();
+  const expMs = epochSeconds * 1000;
+  const remaining = expMs - nowMs;
   if (remaining <= 0) return; // already expired; reactive path handles it
-  var delay = Math.floor(remaining * _REFRESH_AT_FRACTION);
+  let delay = Math.floor(remaining * _REFRESH_AT_FRACTION);
   if (delay < _REFRESH_MIN_DELAY_MS) delay = _REFRESH_MIN_DELAY_MS;
   if (delay > _REFRESH_MAX_DELAY_MS) delay = _REFRESH_MAX_DELAY_MS;
   _refreshTimer = setTimeout(function () {
@@ -239,7 +239,7 @@ function _scheduleRefreshFromWhoami() {
   // prior in-flight whoami before starting a new one AND guard the
   // post-fetch effects with `_whoamiAbort === ctrl` so a late arrival
   // from a superseded call is fully neutralised.
-  var prior = _whoamiAbort;
+  const prior = _whoamiAbort;
   if (prior) {
     try {
       prior.abort();
@@ -247,7 +247,7 @@ function _scheduleRefreshFromWhoami() {
       /* AbortController not available; the equality check below covers it */
     }
   }
-  var ctrl =
+  const ctrl =
     typeof AbortController !== "undefined" ? new AbortController() : null;
   _whoamiAbort = ctrl;
   fetch("/v1/api/auth/whoami", {
@@ -293,7 +293,7 @@ function _cancelRefreshTimer() {
 }
 
 function initLogin() {
-  var overlay = document.createElement("div");
+  const overlay = document.createElement("div");
   overlay.id = "login-overlay";
   overlay.style.display = "none";
   overlay.setAttribute("role", "dialog");
@@ -304,8 +304,8 @@ function initLogin() {
   _bindLoginEvents();
 
   // OIDC callback: detect success or error from URL params
-  var _oidcParams = new URLSearchParams(window.location.search);
-  var _oidcError = _oidcParams.get("oidc_error");
+  const _oidcParams = new URLSearchParams(window.location.search);
+  const _oidcError = _oidcParams.get("oidc_error");
   if (_oidcError) {
     history.replaceState({}, "", window.location.pathname);
     // showLogin's status-fetch resolves _switchMode (which clears errors)
@@ -382,8 +382,8 @@ function _bindLoginEvents() {
   });
 
   // Escape key clears errors
-  var inputs = document.querySelectorAll("#login-box input");
-  for (var i = 0; i < inputs.length; i++) {
+  const inputs = document.querySelectorAll("#login-box input");
+  for (let i = 0; i < inputs.length; i++) {
     inputs[i].addEventListener("keydown", function (e) {
       if (e.key === "Escape") _clearError();
     });
@@ -401,13 +401,13 @@ function _bindLoginEvents() {
 
 function _switchMode(mode) {
   _authMode = mode;
-  var setupFields = document.getElementById("setup-fields");
-  var loginFields = document.getElementById("login-fields");
-  var tokenFields = document.getElementById("token-fields");
-  var toggleDiv = document.getElementById("login-toggle");
-  var toggleBtn = document.getElementById("toggle-token");
-  var subtitle = document.getElementById("login-subtitle");
-  var btn = document.getElementById("login-submit");
+  const setupFields = document.getElementById("setup-fields");
+  const loginFields = document.getElementById("login-fields");
+  const tokenFields = document.getElementById("token-fields");
+  const toggleDiv = document.getElementById("login-toggle");
+  const toggleBtn = document.getElementById("toggle-token");
+  const subtitle = document.getElementById("login-subtitle");
+  const btn = document.getElementById("login-submit");
 
   setupFields.style.display = "none";
   loginFields.style.display = "none";
@@ -444,9 +444,9 @@ function _switchMode(mode) {
 }
 
 function _updateOIDCUI(data) {
-  var section = document.getElementById("oidc-section");
-  var btn = document.getElementById("oidc-btn");
-  var divider = document.getElementById("oidc-divider");
+  const section = document.getElementById("oidc-section");
+  const btn = document.getElementById("oidc-btn");
+  const divider = document.getElementById("oidc-divider");
   if (!section) return;
 
   if (!data.oidc_enabled || _authMode === "setup") {
@@ -469,7 +469,7 @@ function _updateOIDCUI(data) {
 }
 
 function _clearError() {
-  var errEl = document.getElementById("login-error");
+  const errEl = document.getElementById("login-error");
   if (errEl && errEl.style.display !== "none") {
     errEl.style.display = "none";
     errEl.textContent = "";
@@ -477,7 +477,7 @@ function _clearError() {
 }
 
 function _showError(msg) {
-  var errEl = document.getElementById("login-error");
+  const errEl = document.getElementById("login-error");
   if (errEl) {
     errEl.textContent = msg;
     errEl.style.display = "block";
@@ -485,17 +485,17 @@ function _showError(msg) {
 }
 
 function showLogin(reason, oidcError) {
-  var overlay = document.getElementById("login-overlay");
+  const overlay = document.getElementById("login-overlay");
   if (!overlay) return;
   overlay.style.display = "flex";
   document.body.style.overflow = "hidden";
-  var logoutBtn = document.getElementById("logout-btn");
+  const logoutBtn = document.getElementById("logout-btn");
   if (logoutBtn) logoutBtn.style.display = "none";
   _clearError();
 
   // Check auth status to determine mode
-  var _loginReason = reason;
-  var _oidcError = oidcError;
+  const _loginReason = reason;
+  const _oidcError = oidcError;
   fetch("/v1/api/auth/status")
     .then(function (r) {
       return r.json();
@@ -506,7 +506,7 @@ function showLogin(reason, oidcError) {
       } else {
         _switchMode("login");
         if (_loginReason === "upgrade") {
-          var subtitle = document.getElementById("login-subtitle");
+          const subtitle = document.getElementById("login-subtitle");
           if (subtitle)
             subtitle.textContent =
               "The server was updated \u2014 please sign in again";
@@ -526,18 +526,18 @@ function showLogin(reason, oidcError) {
     document.removeEventListener("keydown", _loginTrapHandler);
   _loginTrapHandler = function (e) {
     if (e.key === "Tab") {
-      var box = document.getElementById("login-box");
-      var focusable = box.querySelectorAll(
+      const box = document.getElementById("login-box");
+      const focusable = box.querySelectorAll(
         'input:not([style*="display: none"]):not([style*="display:none"]), button:not([style*="display: none"]):not([style*="display:none"])',
       );
       // Filter to visible elements
-      var visible = [];
-      for (var i = 0; i < focusable.length; i++) {
+      const visible = [];
+      for (let i = 0; i < focusable.length; i++) {
         if (focusable[i].offsetParent !== null) visible.push(focusable[i]);
       }
       if (visible.length === 0) return;
-      var first = visible[0];
-      var last = visible[visible.length - 1];
+      const first = visible[0];
+      const last = visible[visible.length - 1];
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault();
@@ -555,7 +555,7 @@ function showLogin(reason, oidcError) {
 }
 
 function hideLogin() {
-  var overlay = document.getElementById("login-overlay");
+  const overlay = document.getElementById("login-overlay");
   if (overlay) overlay.style.display = "none";
   document.body.style.overflow = "";
   if (_loginTrapHandler) {
@@ -572,8 +572,8 @@ function _handleSubmit() {
 }
 
 function _submitLogin() {
-  var username = (document.getElementById("login-username").value || "").trim();
-  var password = document.getElementById("login-password").value || "";
+  const username = (document.getElementById("login-username").value || "").trim();
+  const password = document.getElementById("login-password").value || "";
 
   if (!username) {
     _showError("Username is required");
@@ -611,7 +611,7 @@ function _submitLogin() {
 }
 
 function _submitToken() {
-  var token = (document.getElementById("login-token").value || "").trim();
+  const token = (document.getElementById("login-token").value || "").trim();
   if (!token) {
     _showError("Token is required");
     return;
@@ -644,12 +644,12 @@ function _submitToken() {
 }
 
 function _submitSetup() {
-  var username = (document.getElementById("setup-username").value || "").trim();
-  var displayName = (
+  const username = (document.getElementById("setup-username").value || "").trim();
+  const displayName = (
     document.getElementById("setup-displayname").value || ""
   ).trim();
-  var password = document.getElementById("setup-password").value || "";
-  var confirm = document.getElementById("setup-confirm").value || "";
+  const password = document.getElementById("setup-password").value || "";
+  const confirm = document.getElementById("setup-confirm").value || "";
 
   if (!username) {
     _showError("Username is required");
@@ -713,15 +713,15 @@ function _storePermissions(data) {
 
 function _setBusy(busy, label) {
   _loginBusy = busy;
-  var btn = document.getElementById("login-submit");
-  var inputs = document.querySelectorAll("#login-box input");
+  const btn = document.getElementById("login-submit");
+  const inputs = document.querySelectorAll("#login-box input");
   btn.disabled = busy;
   if (busy) {
     btn.textContent = label || "Signing in\u2026";
   } else {
     btn.textContent = _authMode === "setup" ? "Create account" : "Sign in";
   }
-  for (var i = 0; i < inputs.length; i++) {
+  for (let i = 0; i < inputs.length; i++) {
     inputs[i].disabled = busy;
   }
 }
@@ -738,7 +738,7 @@ function _onSuccess() {
   // refreshes work again.
   _loggedOut = false;
   hideLogin();
-  var logoutBtn = document.getElementById("logout-btn");
+  const logoutBtn = document.getElementById("logout-btn");
   if (logoutBtn) logoutBtn.style.display = "";
   if (_authChannel) _authChannel.postMessage("login");
   if (typeof window.onLoginSuccess === "function") window.onLoginSuccess();

--- a/turnstone/shared_static/kb.js
+++ b/turnstone/shared_static/kb.js
@@ -1,14 +1,14 @@
 /* Shared keyboard shortcuts overlay — turnstone design system
    Configure: window.TURNSTONE_KB_SHORTCUTS = [{title, keys: [{desc, badge}]}] */
 
-var _kbPreviousFocus = null;
+let _kbPreviousFocus = null;
 
 function showKbHelp() {
   _kbPreviousFocus = document.activeElement;
-  var existing = document.getElementById("kb-overlay");
+  const existing = document.getElementById("kb-overlay");
   if (existing) existing.remove();
-  var shortcuts = window.TURNSTONE_KB_SHORTCUTS || [];
-  var html =
+  const shortcuts = window.TURNSTONE_KB_SHORTCUTS || [];
+  let html =
     '<div id="kb-box" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" tabindex="-1">' +
     "<h2>Keyboard shortcuts</h2>";
   shortcuts.forEach(function (section) {
@@ -25,7 +25,7 @@ function showKbHelp() {
   html +=
     '<div class="kb-hint">Press <span class="kb-key">Esc</span> to close</div>' +
     "</div>";
-  var overlay = document.createElement("div");
+  const overlay = document.createElement("div");
   overlay.id = "kb-overlay";
   setSafeHtml(overlay, html);
   overlay.onclick = function (e) {
@@ -36,7 +36,7 @@ function showKbHelp() {
 }
 
 function hideKbHelp() {
-  var el = document.getElementById("kb-overlay");
+  const el = document.getElementById("kb-overlay");
   if (el) el.remove();
   if (_kbPreviousFocus && _kbPreviousFocus.focus) {
     _kbPreviousFocus.focus();
@@ -46,7 +46,7 @@ function hideKbHelp() {
 
 document.addEventListener("keydown", function (e) {
   if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
-  var login = document.getElementById("login-overlay");
+  const login = document.getElementById("login-overlay");
   if (login && login.style.display !== "none") return;
   if (e.key === "?" && !e.ctrlKey && !e.metaKey) {
     e.preventDefault();
@@ -54,7 +54,7 @@ document.addEventListener("keydown", function (e) {
     return;
   }
   if (e.key === "Escape") {
-    var kb = document.getElementById("kb-overlay");
+    const kb = document.getElementById("kb-overlay");
     if (kb) {
       e.preventDefault();
       hideKbHelp();

--- a/turnstone/shared_static/utils.js
+++ b/turnstone/shared_static/utils.js
@@ -1,7 +1,7 @@
 /* Shared utility functions — turnstone design system */
 
 function escapeHtml(text) {
-  var el = document.createElement("span");
+  const el = document.createElement("span");
   el.textContent = text;
   return el.innerHTML.replace(/'/g, "&#39;").replace(/"/g, "&quot;");
 }
@@ -14,7 +14,7 @@ function formatTokens(n) {
 
 function ctxClass(ratio) {
   if (ratio <= 0) return "ctx-idle";
-  var pct = ratio * 100;
+  const pct = ratio * 100;
   if (pct < 30) return "ctx-low";
   if (pct < 50) return "ctx-mid";
   if (pct < 80) return "ctx-high";
@@ -24,9 +24,9 @@ function ctxClass(ratio) {
 function formatUptime(seconds) {
   if (!seconds) return "";
   if (seconds < 60) return seconds + "s";
-  var min = Math.floor(seconds / 60);
+  const min = Math.floor(seconds / 60);
   if (min < 60) return min + "m";
-  var hr = Math.floor(min / 60);
+  const hr = Math.floor(min / 60);
   return hr + "h " + (min % 60) + "m";
 }
 
@@ -40,17 +40,17 @@ function formatCount(n) {
 // (assumes UTC, matching the storage layer's stamp).
 function formatRelativeTime(iso) {
   if (!iso) return "";
-  var s = String(iso).replace(" ", "T");
+  let s = String(iso).replace(" ", "T");
   if (!s.endsWith("Z") && !s.includes("+")) s += "Z";
-  var d = new Date(s);
+  const d = new Date(s);
   if (isNaN(d)) return "";
-  var ms = new Date() - d;
-  var min = Math.floor(ms / 60000);
+  const ms = new Date() - d;
+  const min = Math.floor(ms / 60000);
   if (min < 1) return "just now";
   if (min < 60) return min + "m ago";
-  var hr = Math.floor(min / 60);
+  const hr = Math.floor(min / 60);
   if (hr < 24) return hr + "h ago";
-  var day = Math.floor(hr / 24);
+  const day = Math.floor(hr / 24);
   if (day < 30) return day + "d ago";
   return d.toLocaleDateString();
 }
@@ -64,7 +64,7 @@ function formatRelativeTime(iso) {
 // node_ids — and escapes the characters a CSS attribute selector
 // treats specially.
 function cssEscape(s) {
-  var str = String(s == null ? "" : s);
+  const str = String(s == null ? "" : s);
   if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
     return CSS.escape(str);
   }
@@ -134,8 +134,8 @@ function setMarkdown(el, content) {
 // advisory shape change lands once.
 function replayAdvisoriesAfterTool(advisories, renderUserText) {
   if (!Array.isArray(advisories) || !advisories.length) return;
-  for (var ai = 0; ai < advisories.length; ai++) {
-    var adv = advisories[ai];
+  for (let ai = 0; ai < advisories.length; ai++) {
+    const adv = advisories[ai];
     if (!adv || adv.type !== "user_interjection") continue;
     renderUserText(adv.text || "");
   }

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -7,7 +7,7 @@
 //  1. Pane class — per-workstream UI state
 // ===========================================================================
 
-const _paneCounter = 0;
+let _paneCounter = 0;
 
 class Pane {
   constructor(wsId) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -7,7 +7,7 @@
 //  1. Pane class — per-workstream UI state
 // ===========================================================================
 
-var _paneCounter = 0;
+const _paneCounter = 0;
 
 class Pane {
   constructor(wsId) {
@@ -50,7 +50,7 @@ class Pane {
   }
 
   updateWsName() {
-    var nameEl = this.headerEl.querySelector(".pane-ws-name");
+    const nameEl = this.headerEl.querySelector(".pane-ws-name");
     if (nameEl) {
       nameEl.textContent = this.wsId
         ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
@@ -81,17 +81,17 @@ class Pane {
   // the heavier work (querySelectorAll-driven promote sweep + cancel-
   // timer cleanup wired via the queue's onIdle hook).
   setBusy(b) {
-    var next = !!b;
+    const next = !!b;
     this.composer.setBusy(next);
     this.messagesEl.dataset.busy = next ? "true" : "false";
-    var edge = next !== this.busy;
+    const edge = next !== this.busy;
     this.busy = next;
     if (edge && !next) this.queue.onIdleEdge();
   }
 
   showEmptyState() {
     if (!this.messagesEl.querySelector(".empty-state")) {
-      var el = document.createElement("div");
+      const el = document.createElement("div");
       el.className = "empty-state";
       el.textContent = "Type a message to start";
       this.messagesEl.appendChild(el);
@@ -99,13 +99,13 @@ class Pane {
   }
 
   removeEmptyState() {
-    var el = this.messagesEl.querySelector(".empty-state");
+    const el = this.messagesEl.querySelector(".empty-state");
     if (el) el.remove();
   }
 
   addThinkingIndicator() {
     if (this.messagesEl.querySelector(".thinking-indicator")) return;
-    var el = document.createElement("div");
+    const el = document.createElement("div");
     el.className = "thinking-indicator";
     el.textContent = "Thinking";
     this.messagesEl.appendChild(el);
@@ -113,7 +113,7 @@ class Pane {
   }
 
   removeThinkingIndicator() {
-    var el = this.messagesEl.querySelector(".thinking-indicator");
+    const el = this.messagesEl.querySelector(".thinking-indicator");
     if (el) el.remove();
   }
 
@@ -124,7 +124,7 @@ class Pane {
     // the bubble below it lands in the right place even when the wake
     // fires long after the user's last real message.
     this.removeEmptyState();
-    var el = document.createElement("div");
+    const el = document.createElement("div");
     el.className = "msg user system-nudge";
     el.setAttribute("data-source", "system_nudge");
     el.setAttribute("aria-label", "system nudge");
@@ -151,18 +151,18 @@ class Pane {
     // ``watch_triggered`` reminders branch off into a structured
     // .msg.watch-result card.
     this.removeEmptyState();
-    var anchor;
+    let anchor;
     if (source === "system_nudge") {
       anchor = this.addSystemNudgeMarker();
     } else {
-      var userBubbles = this.messagesEl.querySelectorAll(
+      const userBubbles = this.messagesEl.querySelectorAll(
         ".msg.user:not(.system-nudge)",
       );
       anchor = userBubbles.length ? userBubbles[userBubbles.length - 1] : null;
     }
-    for (var i = 0; i < reminders.length; i++) {
-      var r = reminders[i] || {};
-      var el =
+    for (let i = 0; i < reminders.length; i++) {
+      const r = reminders[i] || {};
+      const el =
         r.type === "watch_triggered"
           ? _buildWatchResultBubble(r)
           : _buildDefaultReminderBubble(r);
@@ -192,10 +192,10 @@ class Pane {
     // reminders also branch on r.type so a watch_triggered drained at
     // the tool seam (channel="any") renders the structured card.
     this.removeEmptyState();
-    var anchor = null;
+    let anchor = null;
     if (toolCallId) {
-      var escapedId = CSS.escape(toolCallId);
-      var toolEl = this.messagesEl.querySelector(
+      const escapedId = CSS.escape(toolCallId);
+      const toolEl = this.messagesEl.querySelector(
         '.ts-approval-tool[data-call-id="' + escapedId + '"]',
       );
       if (toolEl) {
@@ -203,12 +203,12 @@ class Pane {
       }
     }
     if (!anchor) {
-      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+      const blocks = this.messagesEl.querySelectorAll(".ts-approval");
       if (blocks.length) anchor = blocks[blocks.length - 1];
     }
-    for (var i = 0; i < reminders.length; i++) {
-      var r = reminders[i] || {};
-      var el =
+    for (let i = 0; i < reminders.length; i++) {
+      const r = reminders[i] || {};
+      const el =
         r.type === "watch_triggered"
           ? _buildWatchResultBubble(r)
           : _buildDefaultReminderBubble(r);
@@ -224,25 +224,25 @@ class Pane {
 
   addUserMessage(text, attachments) {
     this.removeEmptyState();
-    var el = document.createElement("div");
+    const el = document.createElement("div");
     el.className = "msg user";
-    var textEl = document.createElement("div");
+    const textEl = document.createElement("div");
     textEl.className = "msg-user-text";
     textEl.textContent = text;
     el.appendChild(textEl);
     if (Array.isArray(attachments) && attachments.length > 0) {
-      var pills = document.createElement("div");
+      const pills = document.createElement("div");
       pills.className = "msg-user-attach";
       attachments.forEach(function (a) {
-        var pill = document.createElement("span");
+        const pill = document.createElement("span");
         pill.className =
           "msg-user-attach-pill msg-user-attach-pill-" + (a.kind || "other");
-        var icon = document.createElement("span");
+        const icon = document.createElement("span");
         icon.className = "msg-user-attach-icon";
         icon.setAttribute("aria-hidden", "true");
         icon.textContent = a.kind === "image" ? "\ud83d\uddbc" : "\ud83d\udcc4";
         pill.appendChild(icon);
-        var nameEl = document.createElement("span");
+        const nameEl = document.createElement("span");
         nameEl.className = "msg-user-attach-name";
         nameEl.textContent =
           a.filename || (a.kind === "image" ? "image" : "document");
@@ -258,37 +258,37 @@ class Pane {
 
   getFeedback() {
     if (!this.approvalBlockEl) return null;
-    var inp = this.approvalBlockEl.querySelector(".ts-approval-feedback");
+    const inp = this.approvalBlockEl.querySelector(".ts-approval-feedback");
     return inp && inp.value.trim() ? inp.value.trim() : null;
   }
 
   appendToolOutputChunk(callId, chunk) {
     if (!chunk) return;
-    var stripped = stripAnsi(chunk);
+    const stripped = stripAnsi(chunk);
     if (!stripped) return;
 
-    var escapedId = callId ? CSS.escape(callId) : "";
-    var el = escapedId
+    const escapedId = callId ? CSS.escape(callId) : "";
+    let el = escapedId
       ? this.messagesEl.querySelector(
           '.tool-output-stream[data-call-id="' + escapedId + '"]',
         )
       : null;
     if (!el) {
-      var target = escapedId
+      let target = escapedId
         ? this.messagesEl.querySelector(
             '.ts-approval-tool[data-call-id="' + escapedId + '"]',
           )
         : null;
       if (!target) {
-        var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+        const blocks = this.messagesEl.querySelectorAll(".ts-approval");
         if (!blocks.length) return;
-        var block = blocks[blocks.length - 1];
-        var tools = block.querySelectorAll(
+        const block = blocks[blocks.length - 1];
+        const tools = block.querySelectorAll(
           '.ts-approval-tool[data-func-name="bash"]',
         );
         target = tools.length ? tools[tools.length - 1] : null;
         if (!target) {
-          var allTools = block.querySelectorAll(".ts-approval-tool");
+          const allTools = block.querySelectorAll(".ts-approval-tool");
           target = allTools.length ? allTools[allTools.length - 1] : null;
         }
       }
@@ -310,20 +310,20 @@ class Pane {
 
   showOutputWarning(evt) {
     if (!evt.call_id || evt.risk_level === "none") return;
-    var escapedId = CSS.escape(evt.call_id);
-    var toolDiv = this.messagesEl.querySelector(
+    const escapedId = CSS.escape(evt.call_id);
+    const toolDiv = this.messagesEl.querySelector(
       '.ts-approval-tool[data-call-id="' + escapedId + '"]',
     );
     if (!toolDiv) return;
     // Shared DOM-builder with replayHistory \u2014 single source of truth for
     // role / class / escape semantics.  Argument shape mirrors the
     // server-side output_assessment dict (risk_level / flags / redacted).
-    var warning = _buildOutputWarningEl({
+    const warning = _buildOutputWarningEl({
       risk_level: evt.risk_level,
       flags: evt.flags,
       redacted: evt.redacted,
     });
-    var nextEl = toolDiv.nextElementSibling;
+    const nextEl = toolDiv.nextElementSibling;
     if (nextEl && nextEl.classList.contains("tool-output")) {
       nextEl.insertAdjacentElement("afterend", warning);
     } else {
@@ -333,16 +333,16 @@ class Pane {
 
   updateVerdictBadge(verdict) {
     if (!verdict || !verdict.call_id) return;
-    var escapedId = CSS.escape(verdict.call_id);
-    var badge = this.messagesEl.querySelector(
+    const escapedId = CSS.escape(verdict.call_id);
+    const badge = this.messagesEl.querySelector(
       '.verdict-badge[data-call-id="' + escapedId + '"]',
     );
     if (!badge) {
       // Badge no longer in DOM (tool block replaced by output) — show
       // a toast so the user still sees the late-arriving verdict.
-      var conf = Math.round((verdict.confidence || 0) * 100);
-      var rec = verdict.recommendation || "review";
-      var func = verdict.func_name || "";
+      const conf = Math.round((verdict.confidence || 0) * 100);
+      const rec = verdict.recommendation || "review";
+      const func = verdict.func_name || "";
       showToast(
         "Judge verdict for " + func + ": " + rec + " (" + conf + "%)",
         rec === "approve" ? "success" : rec === "deny" ? "error" : "warning",
@@ -350,26 +350,26 @@ class Pane {
       return;
     }
 
-    var risk = verdict.risk_level || "medium";
+    const risk = verdict.risk_level || "medium";
     badge.className = "verdict-badge verdict-" + risk + " ts-verdict-badge";
     badge.setAttribute("data-risk", risk);
 
-    var riskEl = badge.querySelector(".verdict-risk");
-    var recEl = badge.querySelector(".verdict-rec");
-    var confEl = badge.querySelector(".verdict-conf");
+    const riskEl = badge.querySelector(".verdict-risk");
+    const recEl = badge.querySelector(".verdict-rec");
+    const confEl = badge.querySelector(".verdict-conf");
     if (riskEl) riskEl.textContent = risk.toUpperCase();
     if (recEl) recEl.textContent = verdict.recommendation || "review";
     if (confEl)
       confEl.textContent = Math.round((verdict.confidence || 0) * 100) + "%";
 
-    var spinner = badge.querySelector(".verdict-judge-spinner");
+    const spinner = badge.querySelector(".verdict-judge-spinner");
     if (spinner) spinner.remove();
 
-    var detail = badge.nextElementSibling;
+    const detail = badge.nextElementSibling;
     if (detail && detail.classList.contains("verdict-detail")) {
-      var summaryEl = detail.querySelector(".verdict-summary");
-      var reasonEl = detail.querySelector(".verdict-reasoning");
-      var tierEl = detail.querySelector(".verdict-tier");
+      const summaryEl = detail.querySelector(".verdict-summary");
+      const reasonEl = detail.querySelector(".verdict-reasoning");
+      const tierEl = detail.querySelector(".verdict-tier");
       if (summaryEl) summaryEl.textContent = verdict.intent_summary || "";
       if (reasonEl) reasonEl.textContent = verdict.reasoning || "";
       if (tierEl)
@@ -377,18 +377,18 @@ class Pane {
           (verdict.tier || "llm") +
           " tier" +
           (verdict.judge_model ? " | " + verdict.judge_model : "");
-      var evidenceEl = detail.querySelector(".verdict-evidence");
+      let evidenceEl = detail.querySelector(".verdict-evidence");
       if (verdict.evidence && verdict.evidence.length) {
         if (!evidenceEl) {
           evidenceEl = document.createElement("div");
           evidenceEl.className = "verdict-evidence";
-          var tierDiv = detail.querySelector(".verdict-tier");
+          const tierDiv = detail.querySelector(".verdict-tier");
           if (tierDiv) detail.insertBefore(evidenceEl, tierDiv);
           else detail.appendChild(evidenceEl);
         }
         evidenceEl.replaceChildren(
           ...verdict.evidence.map(function (e) {
-            var div = document.createElement("div");
+            const div = document.createElement("div");
             div.textContent = "\u2022 " + e;
             return div;
           }),
@@ -403,16 +403,16 @@ class Pane {
 
   updateVerdictGlow(recommendation) {
     if (!this.approvalBlockEl) return;
-    var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
+    const prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
     if (!prompt) return;
 
     // Collect all verdict badges currently visible in this approval block
-    var badges = this.approvalBlockEl.querySelectorAll(".verdict-badge");
-    var worst = recommendation;
-    for (var i = 0; i < badges.length; i++) {
-      var recEl = badges[i].querySelector(".verdict-rec");
+    const badges = this.approvalBlockEl.querySelectorAll(".verdict-badge");
+    let worst = recommendation;
+    for (let i = 0; i < badges.length; i++) {
+      const recEl = badges[i].querySelector(".verdict-rec");
       if (recEl) {
-        var r = recEl.textContent;
+        const r = recEl.textContent;
         if (r === "deny") {
           worst = "deny";
           break;
@@ -432,7 +432,7 @@ class Pane {
   }
 
   addInfoMessage(text) {
-    var el = document.createElement("div");
+    const el = document.createElement("div");
     el.className = "msg info";
     el.textContent = stripAnsi(text);
     this.messagesEl.appendChild(el);
@@ -440,7 +440,7 @@ class Pane {
   }
 
   addErrorMessage(text) {
-    var el = document.createElement("div");
+    const el = document.createElement("div");
     el.className = "msg error";
     el.setAttribute("role", "alert");
     el.textContent = stripAnsi(text);
@@ -499,7 +499,7 @@ class Pane {
     // Right-click context menu for split/close actions — skip interactive
     // elements (textareas, links, buttons) so native copy/paste works
     this.el.addEventListener("contextmenu", (e) => {
-      var tag = e.target.tagName;
+      const tag = e.target.tagName;
       if (
         tag === "TEXTAREA" ||
         tag === "INPUT" ||
@@ -508,7 +508,7 @@ class Pane {
         e.target.isContentEditable
       )
         return;
-      var sel = window.getSelection();
+      const sel = window.getSelection();
       if (sel && sel.toString().length > 0) return;
       e.preventDefault();
       setFocusedPane(this.id);
@@ -519,7 +519,7 @@ class Pane {
     this.headerEl = document.createElement("div");
     this.headerEl.className = "pane-header";
 
-    var wsName = document.createElement("span");
+    const wsName = document.createElement("span");
     wsName.className = "pane-ws-name";
     wsName.textContent = this.wsId
       ? (workstreams[this.wsId] && workstreams[this.wsId].name) ||
@@ -527,10 +527,10 @@ class Pane {
       : "";
     this.headerEl.appendChild(wsName);
 
-    var actions = document.createElement("div");
+    const actions = document.createElement("div");
     actions.className = "pane-actions";
 
-    var splitRightBtn = document.createElement("button");
+    const splitRightBtn = document.createElement("button");
     splitRightBtn.className = "pane-action-btn";
     splitRightBtn.title = "Split right";
     splitRightBtn.setAttribute("aria-label", "Split right");
@@ -541,7 +541,7 @@ class Pane {
     };
     actions.appendChild(splitRightBtn);
 
-    var splitDownBtn = document.createElement("button");
+    const splitDownBtn = document.createElement("button");
     splitDownBtn.className = "pane-action-btn";
     splitDownBtn.title = "Split down";
     splitDownBtn.setAttribute("aria-label", "Split down");
@@ -552,7 +552,7 @@ class Pane {
     };
     actions.appendChild(splitDownBtn);
 
-    var closeBtn = document.createElement("button");
+    const closeBtn = document.createElement("button");
     closeBtn.className = "pane-action-btn pane-close-btn";
     closeBtn.title = "Close pane";
     closeBtn.setAttribute("aria-label", "Close pane");
@@ -667,7 +667,7 @@ class Pane {
 
   connectSSE(wsId) {
     this.disconnectSSE();
-    var wsChanged = this.wsId !== wsId;
+    const wsChanged = this.wsId !== wsId;
     this.wsId = wsId;
     if (wsChanged) {
       this.attachments.clearChips();
@@ -685,14 +685,14 @@ class Pane {
     };
 
     this.evtSource.onmessage = (e) => {
-      var data = JSON.parse(e.data);
+      const data = JSON.parse(e.data);
       this.handleEvent(data);
     };
 
     this.evtSource.onerror = () => {
       this.evtSource.close();
       this.evtSource = null;
-      var loginOverlay = document.getElementById("login-overlay");
+      const loginOverlay = document.getElementById("login-overlay");
       if (loginOverlay && loginOverlay.style.display !== "none") return;
       this.statusBarEl.classList.add("ws-sb-disconnected");
       this._sbTokens.textContent = "Reconnecting\u2026";
@@ -714,21 +714,21 @@ class Pane {
               // Reconnect all disconnected panes, reassigning stale ws_ids.
               // Two passes: (1) reassign stale panes, (2) reconnect all.
               // Track assigned ws_ids to avoid multiple panes on the same ws.
-              var remaining = Object.keys(workstreams);
+              const remaining = Object.keys(workstreams);
               if (!remaining.length) {
                 showDashboard();
                 return;
               }
-              var usedWsIds = {};
-              for (var pid in panes) {
+              const usedWsIds = {};
+              for (let pid in panes) {
                 if (panes[pid].wsId && workstreams[panes[pid].wsId])
                   usedWsIds[panes[pid].wsId] = true;
               }
-              for (var pid2 in panes) {
-                var p2 = panes[pid2];
+              for (let pid2 in panes) {
+                const p2 = panes[pid2];
                 if (p2.wsId && !workstreams[p2.wsId]) {
-                  var newWsId = null;
-                  for (var ri = 0; ri < remaining.length; ri++) {
+                  let newWsId = null;
+                  for (let ri = 0; ri < remaining.length; ri++) {
                     if (!usedWsIds[remaining[ri]]) {
                       newWsId = remaining[ri];
                       break;
@@ -748,8 +748,8 @@ class Pane {
                 }
               }
               // Pass 2: reconnect all panes and sync focused pane
-              for (var pid3 in panes) {
-                var p3 = panes[pid3];
+              for (let pid3 in panes) {
+                const p3 = panes[pid3];
                 if (pid3 === focusedPaneId) currentWsId = p3.wsId;
                 if (!p3.evtSource && p3.wsId && workstreams[p3.wsId]) {
                   setTimeout(
@@ -867,7 +867,7 @@ class Pane {
             this.currentReasoningEl.className = "msg reasoning";
             this.messagesEl.appendChild(this.currentReasoningEl);
           }
-          var curReason = this.currentReasoningEl.textContent || "";
+          const curReason = this.currentReasoningEl.textContent || "";
           if (curReason.length < evt.reasoning.length) {
             this.currentReasoningEl.textContent = evt.reasoning;
           }
@@ -1071,9 +1071,9 @@ class Pane {
         this._sbModel.textContent = this.modelAlias || this.model || "—";
         this._sbModel.title = this.model || "";
         if (evt.skip_permissions) {
-          var existing = document.querySelector(".skip-permissions-warning");
+          const existing = document.querySelector(".skip-permissions-warning");
           if (!existing) {
-            var warn = document.createElement("div");
+            const warn = document.createElement("div");
             warn.className = "skip-permissions-warning";
             warn.textContent =
               "\u26a0 Running with --skip-permissions: all tool calls are auto-approved";
@@ -1086,7 +1086,7 @@ class Pane {
         this.replayHistory(evt.messages);
         // Dispatch pending edit-and-resend after rewind history arrives
         if (this._pendingEditSend) {
-          var editText = this._pendingEditSend;
+          const editText = this._pendingEditSend;
           this._pendingEditSend = null;
           this.setBusy(true);
           this.addUserMessage(editText);
@@ -1111,16 +1111,16 @@ class Pane {
   }
 
   _addUserMsgActions(el, text) {
-    var bar = document.createElement("div");
+    const bar = document.createElement("div");
     bar.className = "msg-actions";
     bar.setAttribute("role", "toolbar");
     bar.setAttribute("aria-label", "Message actions");
     // Edit button
-    var editBtn = document.createElement("button");
+    const editBtn = document.createElement("button");
     editBtn.className = "msg-action-btn";
     editBtn.title = "Edit & resend";
     editBtn.setAttribute("aria-label", "Edit and resend this message");
-    var editIcon = document.createElement("span");
+    const editIcon = document.createElement("span");
     editIcon.className = "icon-edit";
     editIcon.setAttribute("aria-hidden", "true");
     editBtn.appendChild(editIcon);
@@ -1130,14 +1130,14 @@ class Pane {
     });
     bar.appendChild(editBtn);
     // Rewind-to-here button
-    var rewindBtn = document.createElement("button");
+    const rewindBtn = document.createElement("button");
     rewindBtn.className = "msg-action-btn";
     rewindBtn.title = "Rewind to before this message";
     rewindBtn.setAttribute(
       "aria-label",
       "Rewind conversation to before this message",
     );
-    var rewindIcon = document.createElement("span");
+    const rewindIcon = document.createElement("span");
     rewindIcon.className = "icon-rewind";
     rewindIcon.setAttribute("aria-hidden", "true");
     rewindBtn.appendChild(rewindIcon);
@@ -1150,7 +1150,7 @@ class Pane {
   }
 
   _addRetryAction(el) {
-    var bar = el.querySelector(".msg-actions");
+    let bar = el.querySelector(".msg-actions");
     if (!bar) {
       bar = document.createElement("div");
       bar.className = "msg-actions";
@@ -1158,11 +1158,11 @@ class Pane {
       bar.setAttribute("aria-label", "Message actions");
       el.appendChild(bar);
     }
-    var btn = document.createElement("button");
+    const btn = document.createElement("button");
     btn.className = "msg-action-btn";
     btn.title = "Retry (regenerate response)";
     btn.setAttribute("aria-label", "Retry last response");
-    var icon = document.createElement("span");
+    const icon = document.createElement("span");
     icon.className = "icon-retry";
     icon.setAttribute("aria-hidden", "true");
     btn.appendChild(icon);
@@ -1187,10 +1187,10 @@ class Pane {
   _rewindToMessage(msgEl) {
     if (this.busy) return;
     // Count how many user messages come at or after this one
-    var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
-    var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
+    const userMsgs = this.messagesEl.querySelectorAll(".msg.user");
+    const idx = Array.prototype.indexOf.call(userMsgs, msgEl);
     if (idx < 0) return;
-    var turnsToRewind = userMsgs.length - idx;
+    const turnsToRewind = userMsgs.length - idx;
     if (turnsToRewind < 1) return;
     authFetch("/v1/api/command", {
       method: "POST",
@@ -1207,26 +1207,26 @@ class Pane {
   _startEdit(msgEl, originalText) {
     if (this.busy) return;
     // Save current child nodes for cancel restoration
-    var savedNodes = [];
+    const savedNodes = [];
     while (msgEl.firstChild) {
       savedNodes.push(msgEl.removeChild(msgEl.firstChild));
     }
     msgEl.classList.add("msg-editing");
 
-    var form = document.createElement("div");
+    const form = document.createElement("div");
     form.className = "msg-edit-form";
 
-    var textarea = document.createElement("textarea");
+    const textarea = document.createElement("textarea");
     textarea.className = "msg-edit-textarea";
     textarea.setAttribute("aria-label", "Edit message text");
     textarea.value = originalText;
     textarea.rows = Math.min(originalText.split("\n").length + 1, 8);
     form.appendChild(textarea);
 
-    var actions = document.createElement("div");
+    const actions = document.createElement("div");
     actions.className = "msg-edit-actions";
 
-    var cancelBtn = document.createElement("button");
+    const cancelBtn = document.createElement("button");
     cancelBtn.className = "msg-edit-btn";
     cancelBtn.textContent = "Cancel";
     cancelBtn.addEventListener("click", () => {
@@ -1239,11 +1239,11 @@ class Pane {
     });
     actions.appendChild(cancelBtn);
 
-    var sendBtn = document.createElement("button");
+    const sendBtn = document.createElement("button");
     sendBtn.className = "msg-edit-btn msg-edit-btn-send";
     sendBtn.textContent = "Send";
     sendBtn.addEventListener("click", () => {
-      var newText = textarea.value.trim();
+      const newText = textarea.value.trim();
       if (!newText) return;
       this._editAndResend(msgEl, newText);
     });
@@ -1269,10 +1269,10 @@ class Pane {
   _editAndResend(msgEl, newText) {
     if (this.busy) return;
     // Count turns to rewind (from this message onward)
-    var userMsgs = this.messagesEl.querySelectorAll(".msg.user");
-    var idx = Array.prototype.indexOf.call(userMsgs, msgEl);
+    const userMsgs = this.messagesEl.querySelectorAll(".msg.user");
+    const idx = Array.prototype.indexOf.call(userMsgs, msgEl);
     if (idx < 0) return;
-    var turnsToRewind = userMsgs.length - idx;
+    const turnsToRewind = userMsgs.length - idx;
 
     this.setBusy(true);
     // Store pending send — dispatched when the rewind history event arrives
@@ -1319,10 +1319,10 @@ class Pane {
     // (or after the loop, for legacy rows missing tool_call_id).
     // Replaces a JSON.stringify→dataset→JSON.parse round-trip with an
     // in-memory map keyed by call_id.
-    var pendingAssessments = {};
-    var lastToolBlock = null;
-    for (var i = 0; i < messages.length; i++) {
-      var msg = messages[i];
+    const pendingAssessments = {};
+    let lastToolBlock = null;
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
       if (msg.role === "user") {
         if (msg.source === "system_nudge") {
           // Wake-driven empty user turn: render the thin marker
@@ -1355,7 +1355,7 @@ class Pane {
         // surfaces when the active model's surface_persisted_reasoning flag is
         // true and the message round-tripped a thinking lane.
         if (msg.reasoning && msg.reasoning.length) {
-          var reasonEl = document.createElement("div");
+          const reasonEl = document.createElement("div");
           reasonEl.className = "msg reasoning";
           reasonEl.textContent = msg.reasoning;
           this.messagesEl.appendChild(reasonEl);
@@ -1376,9 +1376,9 @@ class Pane {
         // surfacing one on replay would be a phantom card that diverges
         // from what the originating tab saw.
         if (msg.content && msg.content.trim()) {
-          var el = document.createElement("div");
+          const el = document.createElement("div");
           el.className = "msg assistant";
-          var bodyEl = document.createElement("div");
+          const bodyEl = document.createElement("div");
           bodyEl.className = "msg-body";
           el.appendChild(bodyEl);
           setMarkdown(bodyEl, msg.content);
@@ -1389,36 +1389,36 @@ class Pane {
           if (msg.pending) {
             lastToolBlock = null;
           } else {
-            var wasDenied = !!msg.denied;
-            var block = document.createElement("div");
+            const wasDenied = !!msg.denied;
+            const block = document.createElement("div");
             block.className =
               "msg ts-approval ts-approval--inline " +
               (wasDenied ? "denied" : "approved");
             msg.tool_calls.forEach((tc) => {
-              var div = document.createElement("div");
+              const div = document.createElement("div");
               div.className = "ts-approval-tool";
               div.dataset.funcName = tc.name;
               div.dataset.callId = tc.id || "";
-              var nameEl = document.createElement("div");
+              const nameEl = document.createElement("div");
               nameEl.className = "tool-name";
               nameEl.textContent = tc.name;
               div.appendChild(nameEl);
-              var cmd = document.createElement("div");
+              const cmd = document.createElement("div");
               cmd.className = "tool-cmd";
               try {
-                var args = JSON.parse(tc.arguments);
+                const args = JSON.parse(tc.arguments);
                 if (tc.name === "bash") {
-                  var preview = Object.values(args)[0] || "";
-                  var dollar = document.createElement("span");
+                  const preview = Object.values(args)[0] || "";
+                  const dollar = document.createElement("span");
                   dollar.className = "dollar";
                   dollar.textContent = "$ ";
                   cmd.append(dollar, String(preview));
                 } else {
-                  var parts = [];
-                  var keys = Object.keys(args);
-                  for (var k = 0; k < keys.length; k++) {
-                    var val = args[keys[k]];
-                    var valStr =
+                  const parts = [];
+                  const keys = Object.keys(args);
+                  for (let k = 0; k < keys.length; k++) {
+                    const val = args[keys[k]];
+                    let valStr =
                       val === null || val === undefined ? "null" : String(val);
                     if (valStr.length > 80)
                       valStr = valStr.substring(0, 77) + "...";
@@ -1460,7 +1460,7 @@ class Pane {
                 };
               }
             });
-            var badge = document.createElement("div");
+            const badge = document.createElement("div");
             badge.setAttribute("role", "status");
             if (wasDenied) {
               badge.className = "ts-approval-badge ts-approval-badge--denied";
@@ -1476,19 +1476,19 @@ class Pane {
         }
       } else if (msg.role === "tool") {
         if (lastToolBlock) {
-          var stripped = stripAnsi(msg.content || "").trim();
-          var isDenied =
+          const stripped = stripAnsi(msg.content || "").trim();
+          const isDenied =
             msg.denied ||
             /^Denied by user/.test(stripped) ||
             /^Blocked/.test(stripped);
-          var isToolError = !!msg.is_error;
+          const isToolError = !!msg.is_error;
           // Anchor the rendered output to the specific .ts-approval-tool
           // element matching this result's tool_call_id — mirrors the
           // live appendToolOutput path so multi-tool batches show
           // [hdr A][out A][hdr B][out B] rather than [A][B][out A][out B].
           // Falls back to "before badge" when tool_call_id is absent
           // (legacy rows pre-dating the wire-format addition).
-          var resultTarget = null;
+          let resultTarget = null;
           if (msg.tool_call_id) {
             resultTarget = lastToolBlock.querySelector(
               '.ts-approval-tool[data-call-id="' +
@@ -1503,23 +1503,23 @@ class Pane {
           // .after call was always relative to the same anchor).
           // Resulting order with all present:
           //   [tool div][output][output-warning]
-          var insertCursor = resultTarget;
-          var insertChained = (node) => {
+          let insertCursor = resultTarget;
+          const insertChained = (node) => {
             if (insertCursor) {
               insertCursor.after(node);
               insertCursor = node;
             } else {
-              var bdg = lastToolBlock.querySelector(".ts-approval-badge");
+              const bdg = lastToolBlock.querySelector(".ts-approval-badge");
               if (bdg) lastToolBlock.insertBefore(node, bdg);
               else lastToolBlock.appendChild(node);
             }
           };
           if (stripped && !isDenied) {
-            var media = !isToolError ? tryParseMedia(stripped) : null;
+            const media = !isToolError ? tryParseMedia(stripped) : null;
             if (media) {
               insertChained(buildMediaEmbed(media, stripped));
             } else {
-              var out = renderToolOutput(stripped, isToolError);
+              const out = renderToolOutput(stripped, isToolError);
               if (out.textContent.split("\n").length > 10) {
                 makeCollapsible(out);
               }
@@ -1535,7 +1535,7 @@ class Pane {
           // assistant branch).  Skip when the tool result was denied —
           // the ✗ denied badge already signals the deny path.
           if (!isDenied && msg.tool_call_id) {
-            var pending = pendingAssessments[msg.tool_call_id];
+            const pending = pendingAssessments[msg.tool_call_id];
             if (pending) {
               insertChained(_buildOutputWarningEl(pending.assessment));
               delete pendingAssessments[msg.tool_call_id];
@@ -1571,9 +1571,9 @@ class Pane {
     // tool_call_id (legacy / migrated rows pre-dating the wire-format
     // addition).  Render the warning under the tool div itself rather
     // than dropping the safety information silently.
-    var leftoverIds = Object.keys(pendingAssessments);
-    for (var p = 0; p < leftoverIds.length; p++) {
-      var leftover = pendingAssessments[leftoverIds[p]];
+    const leftoverIds = Object.keys(pendingAssessments);
+    for (let p = 0; p < leftoverIds.length; p++) {
+      const leftover = pendingAssessments[leftoverIds[p]];
       if (!leftover) continue;
       leftover.toolDiv.insertAdjacentElement(
         "afterend",
@@ -1606,8 +1606,8 @@ class Pane {
 
   _attachRetryToLastAssistant() {
     // Remove any previous retry buttons
-    var old = this.messagesEl.querySelectorAll(".msg.assistant .msg-actions");
-    for (var i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
+    const old = this.messagesEl.querySelectorAll(".msg.assistant .msg-actions");
+    for (let i = 0; i < old.length; i++) old[i].parentNode.removeChild(old[i]);
     // Find the last assistant message with content and add retry.
     // Reasoning blocks emit as .msg.reasoning (distinct modifier) so the
     // .msg.assistant selector already excludes them — no extra guard needed.
@@ -1619,21 +1619,21 @@ class Pane {
     // guard fires correctly even when the tool turn carried a metacog
     // reminder.  Without this skip, retry lands on a stale prior
     // assistant content bubble belonging to an earlier turn.
-    var lastChild = this.messagesEl.lastElementChild;
+    let lastChild = this.messagesEl.lastElementChild;
     while (lastChild && lastChild.classList.contains("user-reminder")) {
       lastChild = lastChild.previousElementSibling;
     }
     if (lastChild && lastChild.classList.contains("ts-approval")) {
       return;
     }
-    var assistants = this.messagesEl.querySelectorAll(".msg.assistant");
+    const assistants = this.messagesEl.querySelectorAll(".msg.assistant");
     if (assistants.length) {
       this._addRetryAction(assistants[assistants.length - 1]);
     }
   }
 
   showInlineToolBlock(items, autoApproved, judgePending) {
-    var block = document.createElement("div");
+    const block = document.createElement("div");
     block.className =
       "msg ts-approval ts-approval--inline" + (autoApproved ? " approved" : "");
     if (!autoApproved) {
@@ -1642,7 +1642,7 @@ class Pane {
     }
 
     // Track the highest-priority recommendation for glow
-    var glowRec = null;
+    let glowRec = null;
 
     items.forEach((item) => {
       block.appendChild(buildToolDiv(item));
@@ -1650,13 +1650,13 @@ class Pane {
       // verdict under ``heuristic_verdict`` (matches the api/server_schemas
       // PendingApprovalItem shape).  Falls back to the legacy ``verdict``
       // key in case a stale SSE payload arrives mid-deploy.
-      var heuristic = item.heuristic_verdict || item.verdict;
+      const heuristic = item.heuristic_verdict || item.verdict;
       if (heuristic) {
         block.insertAdjacentHTML(
           "beforeend",
           renderVerdictBadge(heuristic, judgePending),
         );
-        var rec = heuristic.recommendation || "review";
+        const rec = heuristic.recommendation || "review";
         if (
           !glowRec ||
           rec === "deny" ||
@@ -1668,13 +1668,13 @@ class Pane {
     });
 
     if (autoApproved) {
-      var badge = document.createElement("div");
+      const badge = document.createElement("div");
       badge.setAttribute("role", "status");
       badge.className = "ts-approval-badge ts-approval-badge--approved";
       badge.textContent = "\u2713 auto-approved";
       block.appendChild(badge);
     } else {
-      var prompt = document.createElement("div");
+      const prompt = document.createElement("div");
       prompt.className = "ts-approval-body";
 
       // Apply verdict glow on initial heuristic verdict
@@ -1686,7 +1686,7 @@ class Pane {
         else prompt.classList.add("ts-verdict-glow--review");
       }
 
-      var alwaysNames = items
+      const alwaysNames = items
         .filter((it) => {
           return (
             it.needs_approval &&
@@ -1699,14 +1699,14 @@ class Pane {
           return it.approval_label || it.func_name;
         });
       block.dataset.alwaysNames = JSON.stringify(alwaysNames);
-      var alwaysTitle = alwaysNames.length
+      const alwaysTitle = alwaysNames.length
         ? "Always approve " + alwaysNames.join(", ")
         : "Always approve this tool type";
 
-      var actionsDiv = document.createElement("div");
+      const actionsDiv = document.createElement("div");
       actionsDiv.className = "ts-approval-actions";
 
-      var approveBtn = document.createElement("button");
+      const approveBtn = document.createElement("button");
       approveBtn.className = "ts-approval-btn ts-approval-btn--approve";
       approveBtn.append(makeKeyLabel("y", "Approve"));
       approveBtn.onclick = () => {
@@ -1714,7 +1714,7 @@ class Pane {
       };
       actionsDiv.appendChild(approveBtn);
 
-      var denyBtn = document.createElement("button");
+      const denyBtn = document.createElement("button");
       denyBtn.className = "ts-approval-btn ts-approval-btn--deny";
       denyBtn.append(makeKeyLabel("n", "Deny"));
       denyBtn.onclick = () => {
@@ -1723,7 +1723,7 @@ class Pane {
       actionsDiv.appendChild(denyBtn);
 
       if (alwaysNames.length) {
-        var alwaysBtn = document.createElement("button");
+        const alwaysBtn = document.createElement("button");
         alwaysBtn.className = "ts-approval-btn ts-approval-btn--always";
         alwaysBtn.title = alwaysTitle;
         alwaysBtn.setAttribute("aria-label", alwaysTitle);
@@ -1736,7 +1736,7 @@ class Pane {
 
       prompt.appendChild(actionsDiv);
 
-      var fbInput = document.createElement("input");
+      const fbInput = document.createElement("input");
       fbInput.type = "text";
       fbInput.className = "ts-approval-feedback";
       fbInput.placeholder = "feedback (optional)";
@@ -1761,18 +1761,18 @@ class Pane {
     this.pendingApproval = false;
 
     // Remove prompt
-    var prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
+    const prompt = this.approvalBlockEl.querySelector(".ts-approval-body");
     if (prompt) prompt.remove();
 
     // Add badge
-    var badge = document.createElement("div");
+    const badge = document.createElement("div");
     badge.setAttribute("role", "status");
     if (approved) {
       badge.className = "ts-approval-badge ts-approval-badge--approved";
-      var label = "\u2713 approved";
+      let label = "\u2713 approved";
       if (always) {
-        var raw = this.approvalBlockEl.dataset.alwaysNames;
-        var names = raw ? JSON.parse(raw) : [];
+        const raw = this.approvalBlockEl.dataset.alwaysNames;
+        const names = raw ? JSON.parse(raw) : [];
         label = names.length
           ? "\u2713 always approve " + names.join(", ")
           : "\u2713 always approve";
@@ -1814,18 +1814,18 @@ class Pane {
   }
 
   appendToolOutput(callId, name, output, isError) {
-    var escapedId = callId ? CSS.escape(callId) : "";
-    var target = escapedId
+    const escapedId = callId ? CSS.escape(callId) : "";
+    let target = escapedId
       ? this.messagesEl.querySelector(
           '.ts-approval-tool[data-call-id="' + escapedId + '"]',
         )
       : null;
     if (!target) {
-      var blocks = this.messagesEl.querySelectorAll(".ts-approval");
+      const blocks = this.messagesEl.querySelectorAll(".ts-approval");
       if (!blocks.length) return;
-      var block = blocks[blocks.length - 1];
-      var tools = block.querySelectorAll(".ts-approval-tool");
-      for (var i = tools.length - 1; i >= 0; i--) {
+      const block = blocks[blocks.length - 1];
+      const tools = block.querySelectorAll(".ts-approval-tool");
+      for (let i = tools.length - 1; i >= 0; i--) {
         if (tools[i].dataset.funcName === name) {
           target = tools[i];
           break;
@@ -1836,20 +1836,20 @@ class Pane {
     if (!target) return;
 
     // Remove the streaming output element for this tool
-    var streamEl = null;
+    let streamEl = null;
     if (escapedId) {
       streamEl = this.messagesEl.querySelector(
         '.tool-output-stream[data-call-id="' + escapedId + '"]',
       );
     } else {
-      var next = target.nextElementSibling;
+      const next = target.nextElementSibling;
       if (next && next.classList.contains("tool-output-stream")) {
         streamEl = next;
       }
     }
     if (streamEl) streamEl.remove();
 
-    var stripped = stripAnsi(output || "").trim();
+    const stripped = stripAnsi(output || "").trim();
     if (!stripped) return;
 
     // Skip rendering for denied/blocked tool results — the ✗ denied
@@ -1858,8 +1858,8 @@ class Pane {
     // the guard in the history-replay path (the live path used to be
     // safe because no tool_result event was ever emitted for denied
     // items, but we now emit one so _tool_error_flags gets set).
-    var parentBlock = target.closest(".ts-approval");
-    var isDenied =
+    const parentBlock = target.closest(".ts-approval");
+    const isDenied =
       (parentBlock && parentBlock.classList.contains("denied")) ||
       /^Denied by user/.test(stripped) ||
       /^Blocked/.test(stripped);
@@ -1867,9 +1867,9 @@ class Pane {
 
     // Detect structured media output and render interactive embed
     if (!isError) {
-      var media = tryParseMedia(stripped);
+      const media = tryParseMedia(stripped);
       if (media) {
-        var embed = buildMediaEmbed(media, stripped);
+        const embed = buildMediaEmbed(media, stripped);
         target.after(embed);
         this.scrollToBottom();
         return;
@@ -1880,7 +1880,7 @@ class Pane {
     // consent / re-consent / forbidden / operator card.  The existing
     // ✗ error badge from appendToolErrorBadge still fires below.
     if (isError) {
-      var mcpErr = tryParseMcpError(stripped);
+      const mcpErr = tryParseMcpError(stripped);
       if (mcpErr) {
         if (parentBlock && !parentBlock.classList.contains("denied")) {
           parentBlock.classList.add("error");
@@ -1892,7 +1892,7 @@ class Pane {
       }
     }
 
-    var out = renderToolOutput(stripped, isError);
+    const out = renderToolOutput(stripped, isError);
 
     // Mark the parent approval block as errored
     if (isError && parentBlock && !parentBlock.classList.contains("denied")) {
@@ -1909,7 +1909,7 @@ class Pane {
   }
 
   sendMessage() {
-    var text = this.inputEl.value.trim();
+    const text = this.inputEl.value.trim();
     if (!text) return;
 
     if (text.startsWith("/")) {
@@ -1924,15 +1924,15 @@ class Pane {
       return;
     }
 
-    var isBusy = this.busy;
-    var queuedEl = null;
-    var snap = this.attachments.snapshot();
+    const isBusy = this.busy;
+    let queuedEl = null;
+    const snap = this.attachments.snapshot();
 
     if (isBusy) {
       // Server re-parses the !!! prefix to set queue priority — the
       // optimistic bubble strips it for display.
-      var displayText = text;
-      var priority = "notice";
+      let displayText = text;
+      let priority = "notice";
       if (text.startsWith("!!!")) {
         displayText = text.slice(3).trimStart();
         priority = "important";
@@ -2008,7 +2008,7 @@ class Pane {
 
   cancelGeneration() {
     if (!this.busy || !this.wsId || this.stopBtn.disabled) return;
-    var isForce = this.stopBtn.dataset.forceCancel === "true";
+    const isForce = this.stopBtn.dataset.forceCancel === "true";
     this.stopBtn.disabled = true;
     authFetch(
       "/v1/api/workstreams/" + encodeURIComponent(this.wsId) + "/cancel",
@@ -2048,30 +2048,30 @@ class Pane {
 // rendering only.  All text goes through textContent so shell output
 // containing angle brackets / scripts / steering bytes renders inertly.
 function _buildWatchResultBubble(r) {
-  var el = document.createElement("div");
+  const el = document.createElement("div");
   el.className = "msg watch-result";
   el.setAttribute("role", "article");
   el.setAttribute("data-ts-role", "watch");
   el.setAttribute("aria-label", "watch");
-  var header = document.createElement("div");
+  const header = document.createElement("div");
   header.className = "msg-watch-header";
   header.textContent =
     "watch" + (r.watch_name ? " · " + String(r.watch_name) : "");
   el.appendChild(header);
   if (r.command) {
-    var cmd = document.createElement("div");
+    const cmd = document.createElement("div");
     cmd.className = "msg-watch-cmd";
     cmd.textContent = "$ " + String(r.command);
     el.appendChild(cmd);
   }
-  var body = document.createElement("pre");
+  const body = document.createElement("pre");
   body.className = "msg-watch-body";
   body.textContent = r.text || "";
   el.appendChild(body);
   if (r.poll_count != null && r.max_polls != null) {
-    var footer = document.createElement("div");
+    const footer = document.createElement("div");
     footer.className = "msg-watch-footer";
-    var finalSuffix = r.is_final ? " · final" : "";
+    const finalSuffix = r.is_final ? " · final" : "";
     footer.textContent =
       "poll " + String(r.poll_count) + "/" + String(r.max_polls) + finalSuffix;
     el.appendChild(footer);
@@ -2082,15 +2082,15 @@ function _buildWatchResultBubble(r) {
 // Default ``.msg.user-reminder`` bubble — yellow themed advisory used
 // for every metacog nudge other than ``watch_triggered``.
 function _buildDefaultReminderBubble(r) {
-  var el = document.createElement("div");
+  const el = document.createElement("div");
   el.className = "msg user-reminder";
-  var body = document.createElement("div");
+  const body = document.createElement("div");
   body.className = "msg-body";
-  var labelEl = document.createElement("span");
+  const labelEl = document.createElement("span");
   labelEl.className = "msg-user-reminder-label";
   labelEl.textContent =
     "metacognition" + (r.type ? " · " + String(r.type) : "");
-  var textEl = document.createElement("span");
+  const textEl = document.createElement("span");
   textEl.className = "msg-user-reminder-text";
   textEl.textContent = r.text || "";
   body.appendChild(labelEl);
@@ -2104,16 +2104,16 @@ function _buildDefaultReminderBubble(r) {
 // via showOutputWarning.  Single source of truth keeps the two
 // surfaces from drifting on role / class / escape semantics.
 function _buildOutputWarningEl(assessment) {
-  var risk = (assessment && assessment.risk_level) || "medium";
-  var flags = (assessment && assessment.flags) || [];
-  var warning = document.createElement("div");
+  const risk = (assessment && assessment.risk_level) || "medium";
+  const flags = (assessment && assessment.flags) || [];
+  const warning = document.createElement("div");
   warning.className = "output-warning output-warning-" + risk;
   // role="status" (polite) rather than "alert" (assertive) — these
   // are findings, not emergencies; the assertive announcement live
   // would interrupt the user mid-typing on a high-risk match, which
   // is more disruptive than informative.
   warning.setAttribute("role", "status");
-  var labelEl = document.createElement("span");
+  const labelEl = document.createElement("span");
   labelEl.className = "output-warning-label";
   labelEl.textContent = "⚠ " + String(risk).toUpperCase();
   warning.appendChild(labelEl);
@@ -2121,7 +2121,7 @@ function _buildOutputWarningEl(assessment) {
     warning.appendChild(document.createTextNode(" " + flags.join(", ")));
   }
   if (assessment && assessment.redacted) {
-    var redacted = document.createElement("span");
+    const redacted = document.createElement("span");
     redacted.className = "output-warning-redacted";
     redacted.textContent = " (credentials redacted)";
     warning.appendChild(redacted);
@@ -2133,10 +2133,10 @@ function _buildOutputWarningEl(assessment) {
 //  2. Layout tree + rendering
 // ===========================================================================
 
-var panes = {};
-var focusedPaneId = null;
-var splitRoot = null;
-var MAX_PANES = 6;
+const panes = {};
+let focusedPaneId = null;
+let splitRoot = null;
+const MAX_PANES = 6;
 
 function getFocusedPane() {
   return panes[focusedPaneId] || null;
@@ -2157,21 +2157,21 @@ function setFocusedPane(paneId) {
 }
 
 function createPane(wsId) {
-  var p = new Pane(wsId);
+  const p = new Pane(wsId);
   panes[p.id] = p;
   return p;
 }
 
 function updatePaneHeaders() {
-  var root = document.getElementById("split-root");
-  var leafCount = countLeaves(splitRoot);
+  const root = document.getElementById("split-root");
+  const leafCount = countLeaves(splitRoot);
   if (leafCount > 1) {
     root.classList.add("multi-pane");
   } else {
     root.classList.remove("multi-pane");
   }
   // Hide tab-bar split button when already in multi-pane mode
-  var splitBtn = document.getElementById("split-btn");
+  const splitBtn = document.getElementById("split-btn");
   if (splitBtn) {
     if (leafCount > 1) {
       splitBtn.classList.add("hidden");
@@ -2196,8 +2196,8 @@ function findLeafAndParent(node, paneId, parent, childIndex) {
     return null;
   }
   // split
-  for (var i = 0; i < node.children.length; i++) {
-    var result = findLeafAndParent(node.children[i], paneId, node, i);
+  for (let i = 0; i < node.children.length; i++) {
+    const result = findLeafAndParent(node.children[i], paneId, node, i);
     if (result) return result;
   }
   return null;
@@ -2206,8 +2206,8 @@ function findLeafAndParent(node, paneId, parent, childIndex) {
 function countLeaves(node) {
   if (!node) return 0;
   if (node.type === "leaf") return 1;
-  var count = 0;
-  for (var i = 0; i < node.children.length; i++) {
+  let count = 0;
+  for (let i = 0; i < node.children.length; i++) {
     count += countLeaves(node.children[i]);
   }
   return count;
@@ -2222,12 +2222,12 @@ function getFirstLeaf(node) {
 function replaceNode(tree, target, replacement) {
   if (tree === target) return replacement;
   if (tree.type === "split") {
-    for (var i = 0; i < tree.children.length; i++) {
+    for (let i = 0; i < tree.children.length; i++) {
       if (tree.children[i] === target) {
         tree.children[i] = replacement;
         return tree;
       }
-      var result = replaceNode(tree.children[i], target, replacement);
+      const result = replaceNode(tree.children[i], target, replacement);
       if (result !== tree.children[i]) {
         tree.children[i] = result;
         return tree;
@@ -2240,23 +2240,23 @@ function replaceNode(tree, target, replacement) {
 function splitPane(paneId, direction) {
   if (countLeaves(splitRoot) >= MAX_PANES) return;
   // Guard: viewport too narrow/short to fit another pane
-  var root = document.getElementById("split-root");
-  var minDim = direction === "horizontal" ? 200 : 150;
-  var available =
+  const root = document.getElementById("split-root");
+  const minDim = direction === "horizontal" ? 200 : 150;
+  const available =
     direction === "horizontal" ? root.clientWidth : root.clientHeight;
   if (available < minDim * 2 + 4) {
     showToast("Not enough space to split");
     return;
   }
-  var found = findLeafAndParent(splitRoot, paneId, null, -1);
+  const found = findLeafAndParent(splitRoot, paneId, null, -1);
   if (!found) return;
 
   // Find a workstream not already shown in any pane
-  var wsIds = Object.keys(workstreams);
-  var newWsId = null;
-  for (var i = 0; i < wsIds.length; i++) {
-    var inUse = false;
-    for (var pid in panes) {
+  const wsIds = Object.keys(workstreams);
+  let newWsId = null;
+  for (let i = 0; i < wsIds.length; i++) {
+    let inUse = false;
+    for (let pid in panes) {
       if (panes[pid].wsId === wsIds[i]) {
         inUse = true;
         break;
@@ -2272,9 +2272,9 @@ function splitPane(paneId, direction) {
     return;
   }
 
-  var newPane = createPane(newWsId);
-  var newLeaf = { type: "leaf", pane: newPane };
-  var newSplit = {
+  const newPane = createPane(newWsId);
+  const newLeaf = { type: "leaf", pane: newPane };
+  const newSplit = {
     type: "split",
     direction: direction,
     children: [found.node, newLeaf],
@@ -2290,14 +2290,14 @@ function splitPane(paneId, direction) {
 
 function closePane(paneId) {
   if (countLeaves(splitRoot) <= 1) return;
-  var found = findLeafAndParent(splitRoot, paneId, null, -1);
+  let found = findLeafAndParent(splitRoot, paneId, null, -1);
   if (!found || !found.parent) {
     // paneId is the root leaf — shouldn't happen if count > 1
     // but handle: root must be a split
     if (splitRoot.type === "split") {
       // Find which child contains our pane
-      for (var ci = 0; ci < splitRoot.children.length; ci++) {
-        var childFound = findLeafAndParent(
+      for (let ci = 0; ci < splitRoot.children.length; ci++) {
+        const childFound = findLeafAndParent(
           splitRoot.children[ci],
           paneId,
           splitRoot,
@@ -2313,14 +2313,14 @@ function closePane(paneId) {
   }
 
   // Sibling is the other child
-  var siblingIdx = found.childIndex === 0 ? 1 : 0;
-  var sibling = found.parent.children[siblingIdx];
+  const siblingIdx = found.childIndex === 0 ? 1 : 0;
+  const sibling = found.parent.children[siblingIdx];
 
   // Replace parent split with sibling
   splitRoot = replaceNode(splitRoot, found.parent, sibling);
 
   // Cleanup the closed pane
-  var closedPane = panes[paneId];
+  const closedPane = panes[paneId];
   if (closedPane) {
     closedPane.disconnectSSE();
     delete panes[paneId];
@@ -2328,7 +2328,7 @@ function closePane(paneId) {
 
   // If focused pane was closed, focus first available
   if (focusedPaneId === paneId) {
-    var first = getFirstLeaf(splitRoot);
+    const first = getFirstLeaf(splitRoot);
     if (first) {
       focusedPaneId = null; // reset so setFocusedPane triggers
       setFocusedPane(first.id);
@@ -2339,11 +2339,11 @@ function closePane(paneId) {
 }
 
 function renderLayout() {
-  var root = document.getElementById("split-root");
+  const root = document.getElementById("split-root");
 
   // Save scroll positions before clearing
-  var scrollPositions = {};
-  for (var pid in panes) {
+  const scrollPositions = {};
+  for (let pid in panes) {
     scrollPositions[pid] = panes[pid].messagesEl.scrollTop;
   }
 
@@ -2354,7 +2354,7 @@ function renderLayout() {
   }
 
   // Restore scroll positions
-  for (var pid2 in panes) {
+  for (let pid2 in panes) {
     if (scrollPositions[pid2] !== undefined) {
       panes[pid2].messagesEl.scrollTop = scrollPositions[pid2];
     }
@@ -2371,16 +2371,16 @@ function _renderLayoutNode(node, container) {
   }
 
   // split node
-  var splitContainer = document.createElement("div");
+  const splitContainer = document.createElement("div");
   splitContainer.className = "split-container split-" + node.direction;
 
-  var child0 = document.createElement("div");
+  const child0 = document.createElement("div");
   child0.className = "split-child";
   child0.style.flex = String(node.ratio);
   _renderLayoutNode(node.children[0], child0);
   splitContainer.appendChild(child0);
 
-  var handle = document.createElement("div");
+  const handle = document.createElement("div");
   handle.className = "split-handle";
   handle.setAttribute("role", "separator");
   handle.setAttribute("tabindex", "0");
@@ -2399,7 +2399,7 @@ function _renderLayoutNode(node, container) {
   );
   splitContainer.appendChild(handle);
 
-  var child1 = document.createElement("div");
+  const child1 = document.createElement("div");
   child1.className = "split-child";
   child1.style.flex = String(1 - node.ratio);
   _renderLayoutNode(node.children[1], child1);
@@ -2411,16 +2411,16 @@ function _renderLayoutNode(node, container) {
 
 function _dragBounds(node, handle) {
   // Compute min/max ratio from container size and CSS min dimensions
-  var container = handle.parentElement;
-  var totalSize =
+  const container = handle.parentElement;
+  const totalSize =
     node.direction === "horizontal"
       ? container.clientWidth
       : container.clientHeight;
-  var minPx = node.direction === "horizontal" ? 200 : 150; // match CSS min-width/min-height
-  var handlePx = 4;
-  var usable = totalSize - handlePx;
-  var minRatio = usable > 0 ? Math.max(0.05, minPx / usable) : 0.1;
-  var maxRatio = usable > 0 ? Math.min(0.95, 1 - minPx / usable) : 0.9;
+  const minPx = node.direction === "horizontal" ? 200 : 150; // match CSS min-width/min-height
+  const handlePx = 4;
+  const usable = totalSize - handlePx;
+  const minRatio = usable > 0 ? Math.max(0.05, minPx / usable) : 0.1;
+  const maxRatio = usable > 0 ? Math.min(0.95, 1 - minPx / usable) : 0.9;
   return { minRatio: minRatio, maxRatio: maxRatio, totalSize: totalSize };
 }
 
@@ -2439,23 +2439,23 @@ function setupDragHandle(handle, node, children) {
     e.preventDefault();
     handle.setPointerCapture(e.pointerId);
     handle.classList.add("dragging");
-    var startRatio = node.ratio;
-    var bounds = _dragBounds(node, handle);
-    var startPos = node.direction === "horizontal" ? e.clientX : e.clientY;
+    const startRatio = node.ratio;
+    const bounds = _dragBounds(node, handle);
+    const startPos = node.direction === "horizontal" ? e.clientX : e.clientY;
     document.body.style.cursor =
       node.direction === "horizontal" ? "col-resize" : "row-resize";
     document.body.style.userSelect = "none";
 
-    var onMove = function (e2) {
-      var delta =
+    const onMove = function (e2) {
+      const delta =
         (node.direction === "horizontal" ? e2.clientX : e2.clientY) - startPos;
-      var newRatio = Math.max(
+      const newRatio = Math.max(
         bounds.minRatio,
         Math.min(bounds.maxRatio, startRatio + delta / bounds.totalSize),
       );
       _applyRatio(node, children, handle, newRatio);
     };
-    var onUp = function () {
+    const onUp = function () {
       handle.classList.remove("dragging");
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -2471,16 +2471,16 @@ function setupDragHandle(handle, node, children) {
 
   // Keyboard resizing (arrow keys)
   handle.addEventListener("keydown", function (e) {
-    var bounds = _dragBounds(node, handle);
-    var step = e.shiftKey ? 0.1 : 0.02;
-    var delta = 0;
+    const bounds = _dragBounds(node, handle);
+    const step = e.shiftKey ? 0.1 : 0.02;
+    let delta = 0;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") delta = step;
     else if (e.key === "ArrowLeft" || e.key === "ArrowUp") delta = -step;
     else if (e.key === "Home") delta = -(node.ratio - bounds.minRatio);
     else if (e.key === "End") delta = bounds.maxRatio - node.ratio;
     else return;
     e.preventDefault();
-    var newRatio = Math.max(
+    const newRatio = Math.max(
       bounds.minRatio,
       Math.min(bounds.maxRatio, node.ratio + delta),
     );
@@ -2516,12 +2516,12 @@ function deserializeLayout(data, _seen) {
     if (!data.wsId || !workstreams[data.wsId] || _seen[data.wsId]) return null;
     if (Object.keys(panes).length >= MAX_PANES) return null;
     _seen[data.wsId] = true;
-    var p = createPane(data.wsId);
+    const p = createPane(data.wsId);
     return { type: "leaf", pane: p };
   }
   if (data.type === "split") {
-    var left = deserializeLayout(data.children[0], _seen);
-    var right = deserializeLayout(data.children[1], _seen);
+    const left = deserializeLayout(data.children[0], _seen);
+    const right = deserializeLayout(data.children[1], _seen);
     if (!left && !right) return null;
     if (!left) return right;
     if (!right) return left;
@@ -2537,7 +2537,7 @@ function deserializeLayout(data, _seen) {
 
 function saveLayout() {
   try {
-    var data = serializeLayout(splitRoot);
+    const data = serializeLayout(splitRoot);
     if (data) {
       localStorage.setItem("turnstone_split_layout", JSON.stringify(data));
     }
@@ -2548,13 +2548,13 @@ function saveLayout() {
 
 function restoreLayout() {
   try {
-    var raw = localStorage.getItem("turnstone_split_layout");
+    const raw = localStorage.getItem("turnstone_split_layout");
     if (!raw) return false;
-    var data = JSON.parse(raw);
-    var tree = deserializeLayout(data);
+    const data = JSON.parse(raw);
+    const tree = deserializeLayout(data);
     if (!tree) return false;
     splitRoot = tree;
-    var first = getFirstLeaf(splitRoot);
+    const first = getFirstLeaf(splitRoot);
     if (first) {
       setFocusedPane(first.id);
     }
@@ -2568,20 +2568,20 @@ function restoreLayout() {
 //  3b. Pane context menu
 // ===========================================================================
 
-var _ctxMenu = null;
-var _ctxCloseHandler = null;
-var _ctxTriggerElement = null;
+let _ctxMenu = null;
+let _ctxCloseHandler = null;
+let _ctxTriggerElement = null;
 
-var _tabDropdown = null;
-var _tabDropdownCloseHandler = null;
-var _tabDropdownTrigger = null;
+let _tabDropdown = null;
+let _tabDropdownCloseHandler = null;
+let _tabDropdownTrigger = null;
 
 function showPaneContextMenu(x, y, paneId) {
   closeTabDropdown();
   closePaneContextMenu();
   _ctxTriggerElement = document.activeElement;
 
-  var menu = document.createElement("div");
+  const menu = document.createElement("div");
   menu.className = "pane-ctx-menu";
   menu.setAttribute("role", "menu");
   menu.setAttribute("aria-label", "Pane actions");
@@ -2589,16 +2589,16 @@ function showPaneContextMenu(x, y, paneId) {
     e.preventDefault();
   });
 
-  var canClose = splitRoot && countLeaves(splitRoot) > 1;
+  const canClose = splitRoot && countLeaves(splitRoot) > 1;
   // Can split only if under pane limit AND there's an unused workstream
-  var usedWs = {};
-  for (var pid in panes) usedWs[panes[pid].wsId] = true;
-  var hasUnused = Object.keys(workstreams).some(function (id) {
+  const usedWs = {};
+  for (let pid in panes) usedWs[panes[pid].wsId] = true;
+  const hasUnused = Object.keys(workstreams).some(function (id) {
     return !usedWs[id];
   });
-  var canSplit = countLeaves(splitRoot) < MAX_PANES && hasUnused;
+  const canSplit = countLeaves(splitRoot) < MAX_PANES && hasUnused;
 
-  var items = [
+  const items = [
     {
       label: "Split Right",
       key: "Ctrl+\\",
@@ -2628,23 +2628,23 @@ function showPaneContextMenu(x, y, paneId) {
 
   items.forEach(function (item) {
     if (item.separator) {
-      var sep = document.createElement("div");
+      const sep = document.createElement("div");
       sep.className = "pane-ctx-sep";
       sep.setAttribute("role", "separator");
       menu.appendChild(sep);
       return;
     }
-    var btn = document.createElement("button");
+    const btn = document.createElement("button");
     btn.className = "pane-ctx-item";
     btn.setAttribute("role", "menuitem");
     btn.setAttribute("tabindex", "-1");
     btn.disabled = !!item.disabled;
-    var labelSpan = document.createElement("span");
+    const labelSpan = document.createElement("span");
     labelSpan.className = "pane-ctx-label";
     labelSpan.textContent = item.label;
     btn.appendChild(labelSpan);
     if (item.key) {
-      var keySpan = document.createElement("span");
+      const keySpan = document.createElement("span");
       keySpan.className = "pane-ctx-key";
       keySpan.textContent = item.key;
       btn.appendChild(keySpan);
@@ -2658,9 +2658,9 @@ function showPaneContextMenu(x, y, paneId) {
 
   // Position: ensure menu stays within viewport
   document.body.appendChild(menu);
-  var rect = menu.getBoundingClientRect();
-  var mx = x;
-  var my = y;
+  const rect = menu.getBoundingClientRect();
+  let mx = x;
+  let my = y;
   if (mx + rect.width > window.innerWidth)
     mx = window.innerWidth - rect.width - 4;
   if (my + rect.height > window.innerHeight)
@@ -2684,11 +2684,11 @@ function showPaneContextMenu(x, y, paneId) {
         e.key === "End"
       ) {
         e.preventDefault();
-        var btns = Array.from(
+        const btns = Array.from(
           menu.querySelectorAll(".pane-ctx-item:not(:disabled)"),
         );
         if (!btns.length) return;
-        var idx = btns.indexOf(document.activeElement);
+        const idx = btns.indexOf(document.activeElement);
         if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
         else if (e.key === "ArrowUp")
           btns[(idx - 1 + btns.length) % btns.length].focus();
@@ -2703,7 +2703,7 @@ function showPaneContextMenu(x, y, paneId) {
     document.addEventListener("mousedown", _ctxCloseHandler);
     document.addEventListener("keydown", _ctxCloseHandler);
     // Focus first enabled item
-    var first = menu.querySelector(".pane-ctx-item:not(:disabled)");
+    const first = menu.querySelector(".pane-ctx-item:not(:disabled)");
     if (first) first.focus();
   }, 0);
 }
@@ -2734,7 +2734,7 @@ function showTabDropdown(chevronEl, wsId) {
   _tabDropdownTrigger = chevronEl;
   chevronEl.setAttribute("aria-expanded", "true");
 
-  var menu = document.createElement("div");
+  const menu = document.createElement("div");
   menu.className = "ws-tab-dropdown";
   menu.setAttribute("role", "menu");
   menu.setAttribute("aria-label", "Workstream actions");
@@ -2742,8 +2742,8 @@ function showTabDropdown(chevronEl, wsId) {
     e.preventDefault();
   });
 
-  var isLastWs = Object.keys(workstreams).length <= 1;
-  var items = [
+  const isLastWs = Object.keys(workstreams).length <= 1;
+  const items = [
     {
       label: "Refresh title",
       cls: "mobile-hide",
@@ -2787,13 +2787,13 @@ function showTabDropdown(chevronEl, wsId) {
 
   items.forEach(function (item) {
     if (item.separator) {
-      var sep = document.createElement("div");
+      const sep = document.createElement("div");
       sep.className = "ws-tab-dropdown-sep";
       sep.setAttribute("role", "separator");
       menu.appendChild(sep);
       return;
     }
-    var btn = document.createElement("button");
+    const btn = document.createElement("button");
     btn.className = "ws-tab-dropdown-item" + (item.cls ? " " + item.cls : "");
     btn.setAttribute("role", "menuitem");
     btn.setAttribute("tabindex", "-1");
@@ -2804,12 +2804,12 @@ function showTabDropdown(chevronEl, wsId) {
         "Cannot " + item.label.toLowerCase() + " the last workstream",
       );
     }
-    var labelSpan = document.createElement("span");
+    const labelSpan = document.createElement("span");
     labelSpan.className = "ws-tab-dropdown-label";
     labelSpan.textContent = item.label;
     btn.appendChild(labelSpan);
     if (item.key) {
-      var keySpan = document.createElement("span");
+      const keySpan = document.createElement("span");
       keySpan.className = "ws-tab-dropdown-key";
       keySpan.textContent = item.key;
       keySpan.setAttribute("aria-hidden", "true");
@@ -2826,10 +2826,10 @@ function showTabDropdown(chevronEl, wsId) {
   document.body.appendChild(menu);
 
   // Position below chevron, right-aligned
-  var cr = chevronEl.getBoundingClientRect();
-  var mr = menu.getBoundingClientRect();
-  var mx = cr.right - mr.width;
-  var my = cr.bottom + 2;
+  const cr = chevronEl.getBoundingClientRect();
+  const mr = menu.getBoundingClientRect();
+  let mx = cr.right - mr.width;
+  let my = cr.bottom + 2;
   if (mx < 0) mx = 4;
   if (my + mr.height > window.innerHeight) my = cr.top - mr.height - 2;
   if (mx + mr.width > window.innerWidth) mx = window.innerWidth - mr.width - 4;
@@ -2852,9 +2852,9 @@ function showTabDropdown(chevronEl, wsId) {
         e.key === "End"
       ) {
         e.preventDefault();
-        var btns = Array.from(menu.querySelectorAll(".ws-tab-dropdown-item"));
+        const btns = Array.from(menu.querySelectorAll(".ws-tab-dropdown-item"));
         if (!btns.length) return;
-        var idx = btns.indexOf(document.activeElement);
+        const idx = btns.indexOf(document.activeElement);
         if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
         // idx <= 0 covers both "first item" (wrap to last) and "no
         // current focus" (idx === -1, which would otherwise yield
@@ -2873,13 +2873,13 @@ function showTabDropdown(chevronEl, wsId) {
       closeTabDropdown();
     }
   };
-  var closeHandler = _tabDropdownCloseHandler;
-  var activeMenu = menu;
+  const closeHandler = _tabDropdownCloseHandler;
+  const activeMenu = menu;
   setTimeout(function () {
     if (_tabDropdown !== activeMenu || !closeHandler) return;
     document.addEventListener("mousedown", closeHandler);
     document.addEventListener("keydown", closeHandler);
-    var first = activeMenu.querySelector(".ws-tab-dropdown-item");
+    const first = activeMenu.querySelector(".ws-tab-dropdown-item");
     if (first) first.focus();
   }, 0);
 }
@@ -2907,15 +2907,15 @@ function closeTabDropdown() {
 //  4. Global state
 // ===========================================================================
 
-var workstreams = {};
-var currentWsId = null;
-var globalEvtSource = null;
-var globalRetryDelay = 1000;
-var dashboardVisible = false;
-var _historyNavigation = false;
-var _lastHealth = null;
+let workstreams = {};
+let currentWsId = null;
+let globalEvtSource = null;
+let globalRetryDelay = 1000;
+let dashboardVisible = false;
+let _historyNavigation = false;
+let _lastHealth = null;
 
-var STATE_DISPLAY = {
+const STATE_DISPLAY = {
   running: { symbol: "\u25b8", label: "run" },
   thinking: { symbol: "\u25cc", label: "think" },
   attention: { symbol: "\u25c6", label: "attn" },
@@ -2935,7 +2935,7 @@ function pollHealth() {
     .then(function (data) {
       pollHealth._failCount = 0;
       _lastHealth = data;
-      var mcpEl = document.getElementById("mcp-status");
+      const mcpEl = document.getElementById("mcp-status");
       if (mcpEl) {
         if (data.mcp && data.mcp.servers > 0) {
           mcpEl.textContent =
@@ -2955,7 +2955,7 @@ function pollHealth() {
           mcpEl.style.opacity = "0";
         }
       }
-      var el = document.getElementById("health-indicator");
+      const el = document.getElementById("health-indicator");
       if (!el) return;
       if (data.status === "degraded") {
         el.textContent = "backend degraded";
@@ -2978,7 +2978,7 @@ function pollHealth() {
       if (!pollHealth._failCount) pollHealth._failCount = 0;
       pollHealth._failCount++;
       if (pollHealth._failCount >= 2) {
-        var el = document.getElementById("health-indicator");
+        const el = document.getElementById("health-indicator");
         if (!el) return;
         el.textContent = "health unknown";
         el.className = "health-degraded";
@@ -2997,7 +2997,7 @@ window.onLoginSuccess = function () {
 };
 
 window.onLogout = function () {
-  for (var id in panes) {
+  for (let id in panes) {
     panes[id].disconnectSSE();
     delete panes[id];
   }
@@ -3017,9 +3017,9 @@ window.onLogout = function () {
 // ===========================================================================
 
 window.onThemeChange = function (next) {
-  var btn = document.getElementById("theme-toggle");
+  const btn = document.getElementById("theme-toggle");
   if (btn) {
-    var isLight = next === "light";
+    const isLight = next === "light";
     btn.textContent = isLight ? "\u2600" : "\u263E";
     btn.title = isLight ? "Switch to dark theme" : "Switch to light theme";
     btn.setAttribute(
@@ -3029,7 +3029,7 @@ window.onThemeChange = function (next) {
   }
   reRenderAllMermaid();
   // Persist theme to server settings so it propagates to other clients
-  var themeValue = next === "light" ? "light" : "dark";
+  const themeValue = next === "light" ? "light" : "dark";
   authFetch("/v1/api/admin/settings/interface.theme", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -3037,9 +3037,9 @@ window.onThemeChange = function (next) {
   }).catch(function () {});
 };
 (function () {
-  var btn = document.getElementById("theme-toggle");
+  const btn = document.getElementById("theme-toggle");
   if (btn) {
-    var isLight = document.documentElement.dataset.theme === "light";
+    const isLight = document.documentElement.dataset.theme === "light";
     btn.textContent = isLight ? "\u2600" : "\u263E";
     btn.title = isLight ? "Switch to dark theme" : "Switch to light theme";
     btn.setAttribute(
@@ -3053,9 +3053,9 @@ window.onThemeChange = function (next) {
 //  8. Tab bar
 // ===========================================================================
 
-var tabBar = document.getElementById("tab-bar");
-var tabList = document.getElementById("tab-list");
-var newTabBtn = document.getElementById("new-tab-btn");
+const tabBar = document.getElementById("tab-bar");
+const tabList = document.getElementById("tab-list");
+const newTabBtn = document.getElementById("new-tab-btn");
 
 function renderTabBar() {
   closeTabDropdown();
@@ -3063,10 +3063,10 @@ function renderTabBar() {
     t.remove();
   });
 
-  var wsIds = Object.keys(workstreams);
+  const wsIds = Object.keys(workstreams);
   wsIds.forEach(function (wsId) {
-    var ws = workstreams[wsId];
-    var tab = document.createElement("div");
+    const ws = workstreams[wsId];
+    const tab = document.createElement("div");
     tab.className = "ws-tab" + (wsId === currentWsId ? " active" : "");
     tab.dataset.wsId = wsId;
     tab.setAttribute("role", "tab");
@@ -3083,23 +3083,23 @@ function renderTabBar() {
       }
     };
 
-    var indicator = document.createElement("span");
+    const indicator = document.createElement("span");
     indicator.className = "tab-indicator";
     indicator.dataset.state = ws.state || "idle";
     indicator.setAttribute("aria-label", ws.state || "idle");
     tab.appendChild(indicator);
 
-    var name = document.createElement("span");
+    const name = document.createElement("span");
     name.className = "tab-name";
     name.textContent = ws.name || wsId.substring(0, 6);
     tab.appendChild(name);
 
-    var wsidBadge = document.createElement("span");
+    const wsidBadge = document.createElement("span");
     wsidBadge.className = "tab-wsid";
     wsidBadge.textContent = wsId.substring(0, 7);
     tab.appendChild(wsidBadge);
 
-    var chevron = document.createElement("button");
+    const chevron = document.createElement("button");
     chevron.className = "tab-chevron";
     chevron.textContent = "\u25BE";
     chevron.title = "Workstream actions";
@@ -3126,31 +3126,31 @@ function renderTabBar() {
 function updateTabIndicator(wsId, state, extra) {
   workstreams[wsId] = workstreams[wsId] || {};
   workstreams[wsId].state = state;
-  var tab = tabBar.querySelector('.ws-tab[data-ws-id="' + wsId + '"]');
+  const tab = tabBar.querySelector('.ws-tab[data-ws-id="' + wsId + '"]');
   if (tab) {
-    var ind = tab.querySelector(".tab-indicator");
+    const ind = tab.querySelector(".tab-indicator");
     if (ind) ind.dataset.state = state;
   }
-  var row = document.querySelector(
+  const row = document.querySelector(
     '#dash-ws-table .dash-row[data-ws-id="' + wsId + '"]',
   );
   if (row) {
-    var sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
+    const sd = STATE_DISPLAY[state] || STATE_DISPLAY.idle;
     row.dataset.state = state;
-    var dot = row.querySelector(".dash-state-dot");
+    const dot = row.querySelector(".dash-state-dot");
     if (dot) dot.dataset.state = state;
-    var label = row.querySelector(".dash-state-label");
+    const label = row.querySelector(".dash-state-label");
     if (label) {
       label.dataset.state = state;
       label.textContent = sd.symbol + " " + sd.label;
     }
     if (extra) {
       if (extra.tokens !== undefined) {
-        var tokEl = row.querySelector(".dash-cell-tokens");
+        const tokEl = row.querySelector(".dash-cell-tokens");
         if (tokEl) tokEl.textContent = formatTokens(extra.tokens);
       }
       if (extra.context_ratio !== undefined) {
-        var ctxEl = row.querySelector(".dash-cell-ctx");
+        const ctxEl = row.querySelector(".dash-cell-ctx");
         if (ctxEl) {
           ctxEl.className = "dash-cell-ctx " + ctxClass(extra.context_ratio);
           ctxEl.textContent =
@@ -3160,7 +3160,7 @@ function updateTabIndicator(wsId, state, extra) {
         }
       }
       if (extra.activity !== undefined) {
-        var sub = row.querySelector(".dash-row-sub");
+        const sub = row.querySelector(".dash-row-sub");
         if (sub) {
           sub.textContent = extra.activity || "";
           if (extra.activity_state === "approval")
@@ -3174,7 +3174,7 @@ function updateTabIndicator(wsId, state, extra) {
 
 function switchTab(wsId) {
   closeTabDropdown();
-  var pane = getFocusedPane();
+  let pane = getFocusedPane();
   if (!pane) {
     // Bootstrap the first pane on a fresh-loaded page that had no
     // workstreams to render at init time. Without this, creating
@@ -3199,7 +3199,7 @@ function switchTab(wsId) {
 
   // In multi-pane mode, focus an existing pane showing this ws
   if (splitRoot && countLeaves(splitRoot) > 1) {
-    for (var pid in panes) {
+    for (let pid in panes) {
       if (panes[pid].wsId === wsId && pid !== focusedPaneId) {
         setFocusedPane(pid);
         return;
@@ -3227,40 +3227,40 @@ function switchTab(wsId) {
 //  9. New workstream modal
 // ===========================================================================
 
-var _newWsTrapHandler = null;
-var _forkFromWsId = "";
+let _newWsTrapHandler = null;
+let _forkFromWsId = "";
 
 // Staged files for the new-workstream modal.  Distinct from the pane's
 // chip strip: there's no ws_id yet, so we hold File objects in memory
 // and ship them all in one multipart create request on submit.
-var _newWsStagedFiles = [];
+let _newWsStagedFiles = [];
 
 // Per-kind size caps (mirrored from turnstone/core/attachments.py so the
 // browser can fail fast before uploading).  Keep in sync.
-var _NEW_WS_IMAGE_CAP = 4 * 1024 * 1024;
-var _NEW_WS_TEXT_CAP = 512 * 1024;
-var _NEW_WS_MAX_FILES = 10;
+const _NEW_WS_IMAGE_CAP = 4 * 1024 * 1024;
+const _NEW_WS_TEXT_CAP = 512 * 1024;
+const _NEW_WS_MAX_FILES = 10;
 
 function _newWsRenderChips() {
-  var chipsEl = document.getElementById("new-ws-attach-chips");
+  const chipsEl = document.getElementById("new-ws-attach-chips");
   if (!chipsEl) return;
   chipsEl.textContent = "";
-  for (var i = 0; i < _newWsStagedFiles.length; i++) {
+  for (let i = 0; i < _newWsStagedFiles.length; i++) {
     (function (idx) {
-      var f = _newWsStagedFiles[idx];
-      var chip = document.createElement("span");
+      const f = _newWsStagedFiles[idx];
+      const chip = document.createElement("span");
       chip.className = "new-ws-attach-chip";
       chip.setAttribute("role", "listitem");
-      var label = document.createElement("span");
+      const label = document.createElement("span");
       label.className = "new-ws-attach-chip-name";
       label.textContent = f.name;
       label.title = f.name + " (" + f.size + " bytes)";
       chip.appendChild(label);
-      var size = document.createElement("span");
+      const size = document.createElement("span");
       size.className = "new-ws-attach-chip-size";
       size.textContent = _formatAttachSize(f.size);
       chip.appendChild(size);
-      var rm = document.createElement("button");
+      const rm = document.createElement("button");
       rm.type = "button";
       rm.className = "new-ws-attach-chip-remove";
       rm.setAttribute("aria-label", "Remove " + f.name);
@@ -3279,20 +3279,20 @@ function _newWsRenderChips() {
 // text/* MIMEs, allowlisted application/* MIMEs, and known text extensions.
 // Surfaces unsupported types client-side so the user sees a clear error
 // instead of a generic create failure after the server rejects.
-var _ATTACH_IMAGE_MIMES = [
+const _ATTACH_IMAGE_MIMES = [
   "image/png",
   "image/jpeg",
   "image/gif",
   "image/webp",
 ];
-var _ATTACH_TEXT_APP_MIMES = [
+const _ATTACH_TEXT_APP_MIMES = [
   "application/json",
   "application/xml",
   "application/x-yaml",
   "application/yaml",
   "application/toml",
 ];
-var _ATTACH_TEXT_EXTENSIONS = [
+const _ATTACH_TEXT_EXTENSIONS = [
   ".c",
   ".conf",
   ".cpp",
@@ -3321,12 +3321,12 @@ var _ATTACH_TEXT_EXTENSIONS = [
 ];
 
 function _isAttachmentAllowed(file) {
-  var mime = (file.type || "").toLowerCase();
+  const mime = (file.type || "").toLowerCase();
   if (_ATTACH_IMAGE_MIMES.indexOf(mime) !== -1) return true;
   if (mime.indexOf("text/") === 0) return true;
   if (_ATTACH_TEXT_APP_MIMES.indexOf(mime) !== -1) return true;
-  var name = (file.name || "").toLowerCase();
-  var dot = name.lastIndexOf(".");
+  const name = (file.name || "").toLowerCase();
+  const dot = name.lastIndexOf(".");
   if (dot >= 0 && _ATTACH_TEXT_EXTENSIONS.indexOf(name.substr(dot)) !== -1) {
     return true;
   }
@@ -3334,9 +3334,9 @@ function _isAttachmentAllowed(file) {
 }
 
 function _newWsAddFiles(files) {
-  var errEl = document.getElementById("new-ws-error");
-  for (var i = 0; i < files.length; i++) {
-    var f = files[i];
+  const errEl = document.getElementById("new-ws-error");
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
     if (_newWsStagedFiles.length >= _NEW_WS_MAX_FILES) {
       errEl.textContent =
         "At most " + _NEW_WS_MAX_FILES + " attachments per workstream";
@@ -3351,8 +3351,8 @@ function _newWsAddFiles(files) {
       errEl.style.display = "block";
       return;
     }
-    var isImage = (f.type || "").indexOf("image/") === 0;
-    var cap = isImage ? _NEW_WS_IMAGE_CAP : _NEW_WS_TEXT_CAP;
+    const isImage = (f.type || "").indexOf("image/") === 0;
+    const cap = isImage ? _NEW_WS_IMAGE_CAP : _NEW_WS_TEXT_CAP;
     if (f.size > cap) {
       errEl.textContent =
         f.name + " exceeds the " + _formatAttachSize(cap) + " cap";
@@ -3371,13 +3371,13 @@ function newWorkstream() {
 
 function showNewWsModal(forkFromWsId) {
   _forkFromWsId = forkFromWsId || "";
-  var overlay = document.getElementById("new-ws-overlay");
+  const overlay = document.getElementById("new-ws-overlay");
   overlay.style.display = "flex";
   document.body.style.overflow = "hidden";
 
   // Update title and button text based on mode
-  var titleEl = document.getElementById("new-ws-title");
-  var submitBtn = document.getElementById("new-ws-submit");
+  const titleEl = document.getElementById("new-ws-title");
+  const submitBtn = document.getElementById("new-ws-submit");
   if (_forkFromWsId) {
     titleEl.textContent = "Fork Workstream";
     submitBtn.textContent = "Fork";
@@ -3387,8 +3387,8 @@ function showNewWsModal(forkFromWsId) {
   }
 
   // Hide skill dropdown when forking (not relevant — fork copies history)
-  var skillLabel = document.querySelector('label[for="new-ws-skill"]');
-  var skillSelect = document.getElementById("new-ws-skill");
+  const skillLabel = document.querySelector('label[for="new-ws-skill"]');
+  const skillSelect = document.getElementById("new-ws-skill");
   if (_forkFromWsId) {
     if (skillLabel) skillLabel.style.display = "none";
     if (skillSelect) skillSelect.style.display = "none";
@@ -3402,19 +3402,19 @@ function showNewWsModal(forkFromWsId) {
   };
 
   // Populate model dropdown
-  var modelSelect = document.getElementById("new-ws-model");
-  var judgeSelect = document.getElementById("new-ws-judge-model");
-  var fp = getFocusedPane();
-  var curModel = fp ? fp.modelAlias || fp.model || "" : "";
+  const modelSelect = document.getElementById("new-ws-model");
+  const judgeSelect = document.getElementById("new-ws-judge-model");
+  const fp = getFocusedPane();
+  const curModel = fp ? fp.modelAlias || fp.model || "" : "";
   modelSelect.textContent = "";
   judgeSelect.textContent = "";
-  var defaultOpt = document.createElement("option");
+  const defaultOpt = document.createElement("option");
   defaultOpt.value = "";
   defaultOpt.textContent = curModel
     ? "Default (" + curModel + ")"
     : "Default model";
   modelSelect.appendChild(defaultOpt);
-  var defJudgeOpt = document.createElement("option");
+  const defJudgeOpt = document.createElement("option");
   defJudgeOpt.value = "";
   defJudgeOpt.textContent = "Default (agent model)";
   judgeSelect.appendChild(defJudgeOpt);
@@ -3424,13 +3424,13 @@ function showNewWsModal(forkFromWsId) {
     })
     .then(function (data) {
       (data.models || []).forEach(function (m) {
-        var opt = document.createElement("option");
+        const opt = document.createElement("option");
         opt.value = m.alias;
         opt.textContent =
           m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
         modelSelect.appendChild(opt);
 
-        var judgeOpt = document.createElement("option");
+        const judgeOpt = document.createElement("option");
         judgeOpt.value = m.alias;
         judgeOpt.textContent = opt.textContent;
         judgeSelect.appendChild(judgeOpt);
@@ -3440,20 +3440,20 @@ function showNewWsModal(forkFromWsId) {
       /* ignore — default model still works */
     });
 
-  var tplSelect = document.getElementById("new-ws-skill");
-  var defaultOpt = document.createElement("option");
-  defaultOpt.value = "";
-  defaultOpt.textContent = "Use defaults";
-  tplSelect.replaceChildren(defaultOpt);
+  const tplSelect = document.getElementById("new-ws-skill");
+  const tplDefaultOpt = document.createElement("option");
+  tplDefaultOpt.value = "";
+  tplDefaultOpt.textContent = "Use defaults";
+  tplSelect.replaceChildren(tplDefaultOpt);
   authFetch("/v1/api/skills")
     .then(function (r) {
       return r.json();
     })
     .then(function (data) {
       (data.skills || []).forEach(function (t) {
-        var opt = document.createElement("option");
+        const opt = document.createElement("option");
         opt.value = t.name;
-        var label = t.name;
+        let label = t.name;
         if (t.is_default) label += " (default)";
         if (t.origin === "mcp") label += " [MCP]";
         opt.textContent = label;
@@ -3465,22 +3465,20 @@ function showNewWsModal(forkFromWsId) {
     });
 
   document.getElementById("new-ws-name").value = "";
-  var initEl = document.getElementById("new-ws-initial-message");
+  const initEl = document.getElementById("new-ws-initial-message");
   if (initEl) initEl.value = "";
-  var errEl = document.getElementById("new-ws-error");
+  const errEl = document.getElementById("new-ws-error");
   errEl.style.display = "none";
   errEl.textContent = "";
-  var submitBtn = document.getElementById("new-ws-submit");
   submitBtn.disabled = false;
-  submitBtn.textContent = _forkFromWsId ? "Fork" : "Create";
 
   // Reset attachment staging.  Forks don't carry attachments —
   // disable the attach UI in that case (the fork inherits its
   // parent's history; new attachments go on the next manual send).
   _newWsStagedFiles = [];
-  var attachRow = document.getElementById("new-ws-attach-row");
-  var attachInput = document.getElementById("new-ws-attach-input");
-  var attachBtn = document.getElementById("new-ws-attach-btn");
+  const attachRow = document.getElementById("new-ws-attach-row");
+  const attachInput = document.getElementById("new-ws-attach-input");
+  const attachBtn = document.getElementById("new-ws-attach-btn");
   if (attachRow) attachRow.style.display = _forkFromWsId ? "none" : "";
   if (attachInput) attachInput.value = "";
   _newWsRenderChips();
@@ -3515,12 +3513,12 @@ function showNewWsModal(forkFromWsId) {
       return;
     }
     if (e.key !== "Tab") return;
-    var box = document.getElementById("new-ws-box");
-    var focusable = box.querySelectorAll(
+    const box = document.getElementById("new-ws-box");
+    const focusable = box.querySelectorAll(
       'input, select, button, [tabindex]:not([tabindex="-1"])',
     );
     if (!focusable.length) return;
-    var first = focusable[0],
+    const first = focusable[0],
       last = focusable[focusable.length - 1];
     if (e.shiftKey) {
       if (document.activeElement === first) {
@@ -3552,18 +3550,20 @@ function hideNewWsModal() {
 }
 
 function submitNewWs() {
-  var submitBtn = document.getElementById("new-ws-submit");
+  const submitBtn = document.getElementById("new-ws-submit");
   if (submitBtn.disabled) return;
   submitBtn.disabled = true;
   submitBtn.textContent = _forkFromWsId ? "Forking\u2026" : "Creating\u2026";
 
-  var body = {};
-  var name = document.getElementById("new-ws-name").value.trim();
-  var model = document.getElementById("new-ws-model").value.trim();
-  var judge_model = document.getElementById("new-ws-judge-model").value.trim();
-  var skill = document.getElementById("new-ws-skill").value;
-  var initEl = document.getElementById("new-ws-initial-message");
-  var initial_message = initEl ? initEl.value.trim() : "";
+  const body = {};
+  const name = document.getElementById("new-ws-name").value.trim();
+  const model = document.getElementById("new-ws-model").value.trim();
+  const judge_model = document
+    .getElementById("new-ws-judge-model")
+    .value.trim();
+  const skill = document.getElementById("new-ws-skill").value;
+  const initEl = document.getElementById("new-ws-initial-message");
+  const initial_message = initEl ? initEl.value.trim() : "";
   if (name) body.name = name;
   if (model) body.model = model;
   if (judge_model) body.judge_model = judge_model;
@@ -3571,15 +3571,15 @@ function submitNewWs() {
   if (_forkFromWsId) body.resume_ws = _forkFromWsId;
   if (initial_message) body.initial_message = initial_message;
 
-  var errEl = document.getElementById("new-ws-error");
+  const errEl = document.getElementById("new-ws-error");
   errEl.style.display = "none";
 
-  var fetchOpts;
-  var staged = _forkFromWsId ? [] : _newWsStagedFiles.slice();
+  let fetchOpts;
+  const staged = _forkFromWsId ? [] : _newWsStagedFiles.slice();
   if (staged.length > 0) {
-    var form = new FormData();
+    const form = new FormData();
     form.append("meta", JSON.stringify(body));
-    for (var i = 0; i < staged.length; i++) {
+    for (let i = 0; i < staged.length; i++) {
       form.append("file", staged[i], staged[i].name);
     }
     // Don't set Content-Type — the browser adds the correct boundary.
@@ -3622,16 +3622,16 @@ function submitNewWs() {
 }
 
 function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
-  var remaining = Object.keys(workstreams);
+  const remaining = Object.keys(workstreams);
   // Collect panes showing the closed ws
-  var affected = [];
-  for (var pid in panes) {
+  const affected = [];
+  for (let pid in panes) {
     if (panes[pid].wsId === closedWsId) affected.push(pid);
   }
   if (!affected.length) return;
 
   // Determine target ws based on close_tab_action setting
-  var action = "last_used";
+  let action = "last_used";
   try {
     action =
       localStorage.getItem("turnstone_interface.close_tab_action") ||
@@ -3640,8 +3640,8 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
 
   if (action === "dashboard" && remaining.length > 0) {
     // Show dashboard, but still need to reassign panes to valid ws
-    for (var di = 0; di < affected.length; di++) {
-      var dp = panes[affected[di]];
+    for (let di = 0; di < affected.length; di++) {
+      const dp = panes[affected[di]];
       dp.disconnectSSE();
       if (remaining.length) {
         dp.wsId = remaining[0];
@@ -3661,7 +3661,7 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
   }
 
   // Determine preferred target ws_id
-  var preferredWsId = null;
+  let preferredWsId = null;
   if (action === "last_used") {
     if (
       _lastActiveWsId &&
@@ -3671,18 +3671,18 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
       preferredWsId = _lastActiveWsId;
     }
   } else if (action === "nearest_left" || action === "nearest_right") {
-    var idx = tabIdsBeforeClose ? tabIdsBeforeClose.indexOf(closedWsId) : -1;
+    const idx = tabIdsBeforeClose ? tabIdsBeforeClose.indexOf(closedWsId) : -1;
     if (idx >= 0) {
       if (action === "nearest_left") {
         // Walk left, then right
-        for (var li = idx - 1; li >= 0; li--) {
+        for (let li = idx - 1; li >= 0; li--) {
           if (workstreams[tabIdsBeforeClose[li]]) {
             preferredWsId = tabIdsBeforeClose[li];
             break;
           }
         }
         if (!preferredWsId) {
-          for (var ri = idx + 1; ri < tabIdsBeforeClose.length; ri++) {
+          for (let ri = idx + 1; ri < tabIdsBeforeClose.length; ri++) {
             if (workstreams[tabIdsBeforeClose[ri]]) {
               preferredWsId = tabIdsBeforeClose[ri];
               break;
@@ -3691,14 +3691,14 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
         }
       } else {
         // Walk right, then left
-        for (var ri2 = idx + 1; ri2 < tabIdsBeforeClose.length; ri2++) {
+        for (let ri2 = idx + 1; ri2 < tabIdsBeforeClose.length; ri2++) {
           if (workstreams[tabIdsBeforeClose[ri2]]) {
             preferredWsId = tabIdsBeforeClose[ri2];
             break;
           }
         }
         if (!preferredWsId) {
-          for (var li2 = idx - 1; li2 >= 0; li2--) {
+          for (let li2 = idx - 1; li2 >= 0; li2--) {
             if (workstreams[tabIdsBeforeClose[li2]]) {
               preferredWsId = tabIdsBeforeClose[li2];
               break;
@@ -3710,19 +3710,19 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
   }
 
   // Build set of ws_ids already shown by non-affected panes
-  var usedWsIds = {};
-  for (var pid2 in panes) {
+  const usedWsIds = {};
+  for (let pid2 in panes) {
     if (affected.indexOf(pid2) === -1) usedWsIds[panes[pid2].wsId] = true;
   }
 
-  for (var i = 0; i < affected.length; i++) {
-    var p = panes[affected[i]];
+  for (let i = 0; i < affected.length; i++) {
+    const p = panes[affected[i]];
     // Try the preferred ws first, then fall back to first unused
-    var newWsId = null;
+    let newWsId = null;
     if (preferredWsId && !usedWsIds[preferredWsId]) {
       newWsId = preferredWsId;
     } else {
-      for (var j = 0; j < remaining.length; j++) {
+      for (let j = 0; j < remaining.length; j++) {
         if (!usedWsIds[remaining[j]]) {
           newWsId = remaining[j];
           break;
@@ -3764,7 +3764,7 @@ function _reassignPanesForClosedWs(closedWsId, tabIdsBeforeClose) {
 
 function closeWorkstream(wsId) {
   // Capture tab order from DOM (visual order) before deletion for close_tab_action=nearest_left/right
-  var tabIdsBeforeClose = Array.from(
+  const tabIdsBeforeClose = Array.from(
     document.querySelectorAll("#tab-list .ws-tab"),
   ).map(function (tab) {
     return tab.dataset.wsId;
@@ -3783,7 +3783,7 @@ function closeWorkstream(wsId) {
         delete workstreams[wsId];
         renderTabBar();
         _reassignPanesForClosedWs(wsId, tabIdsBeforeClose);
-        var remaining = Object.keys(workstreams);
+        const remaining = Object.keys(workstreams);
         if (remaining.length === 0) {
           loadDashboard();
           showDashboard();
@@ -3826,7 +3826,7 @@ function hideDashboard() {
   _dashboardStagedFiles = [];
   _renderDashboardChips();
   _refreshDashboardSubmitLabel();
-  var pane = getFocusedPane();
+  const pane = getFocusedPane();
   if (pane) pane.inputEl.focus();
 }
 
@@ -3836,28 +3836,28 @@ function toggleDashboard() {
 }
 
 function loadDashboard() {
-  var tableEl = document.getElementById("dash-ws-table");
+  const tableEl = document.getElementById("dash-ws-table");
   tableEl.replaceChildren(makeEmptyState("Loading\u2026"));
   document
     .getElementById("dashboard-saved-cards")
     .replaceChildren(makeEmptyState("Loading\u2026"));
-  var dashP = authFetch("/v1/api/dashboard").then(function (r) {
+  const dashP = authFetch("/v1/api/dashboard").then(function (r) {
     return r.json();
   });
-  var sessP = authFetch("/v1/api/workstreams/saved").then(function (r) {
+  const sessP = authFetch("/v1/api/workstreams/saved").then(function (r) {
     return r.json();
   });
   Promise.all([dashP, sessP])
     .then(function (res) {
-      var dashData = res[0];
-      var wsList = dashData.workstreams || [];
-      var agg = dashData.aggregate || {};
+      const dashData = res[0];
+      const wsList = dashData.workstreams || [];
+      const agg = dashData.aggregate || {};
       renderDashboardTable(wsList, agg);
-      var activeWsIds = {};
+      const activeWsIds = {};
       wsList.forEach(function (ws) {
         activeWsIds[ws.ws_id] = true;
       });
-      var savedList = (res[1].workstreams || []).filter(function (s) {
+      const savedList = (res[1].workstreams || []).filter(function (s) {
         return !activeWsIds[s.ws_id];
       });
       renderSavedWorkstreams(savedList);
@@ -3871,12 +3871,12 @@ function loadDashboard() {
 }
 
 function renderDashboardTable(wsList, agg) {
-  var activeCount = wsList.filter(function (w) {
+  const activeCount = wsList.filter(function (w) {
     return w.state !== "idle";
   }).length;
   document.getElementById("dash-summary").textContent =
     activeCount + " active \u00b7 " + wsList.length + " total";
-  var table = document.getElementById("dash-ws-table");
+  const table = document.getElementById("dash-ws-table");
   table.replaceChildren();
   if (!wsList.length) {
     table.replaceChildren(makeEmptyState("No active workstreams"));
@@ -3884,23 +3884,23 @@ function renderDashboardTable(wsList, agg) {
     return;
   }
   wsList.forEach(function (ws) {
-    var liveState =
+    const liveState =
       (workstreams[ws.ws_id] && workstreams[ws.ws_id].state) ||
       ws.state ||
       "idle";
-    var liveName =
+    const liveName =
       (workstreams[ws.ws_id] && workstreams[ws.ws_id].name) ||
       ws.name ||
       ws.ws_id;
-    var sd = STATE_DISPLAY[liveState] || STATE_DISPLAY.idle;
+    const sd = STATE_DISPLAY[liveState] || STATE_DISPLAY.idle;
 
-    var row = document.createElement("div");
+    const row = document.createElement("div");
     row.className = "dash-row";
     row.dataset.wsId = ws.ws_id;
     row.dataset.state = liveState;
     row.setAttribute("role", "button");
     row.setAttribute("tabindex", "0");
-    var ariaLabel = liveName + " \u2014 " + sd.label;
+    let ariaLabel = liveName + " \u2014 " + sd.label;
     if (ws.model_alias || ws.model)
       ariaLabel += ", model: " + (ws.model_alias || ws.model);
     if (ws.title) ariaLabel += ", task: " + ws.title;
@@ -3909,50 +3909,50 @@ function renderDashboardTable(wsList, agg) {
       ariaLabel += ", " + Math.round(ws.context_ratio * 100) + "% context";
     row.setAttribute("aria-label", ariaLabel);
 
-    var main = document.createElement("div");
+    const main = document.createElement("div");
     main.className = "dash-row-main";
 
-    var stateCell = document.createElement("span");
+    const stateCell = document.createElement("span");
     stateCell.className = "dash-cell-state";
-    var stateDot = document.createElement("span");
+    const stateDot = document.createElement("span");
     stateDot.className = "dash-state-dot";
     stateDot.setAttribute("data-state", liveState);
     stateDot.setAttribute("aria-hidden", "true");
-    var stateLabel = document.createElement("span");
+    const stateLabel = document.createElement("span");
     stateLabel.className = "dash-state-label";
     stateLabel.setAttribute("data-state", liveState);
     stateLabel.textContent = sd.symbol + " " + sd.label;
     stateCell.append(stateDot, stateLabel);
     main.appendChild(stateCell);
 
-    var nameCell = document.createElement("span");
+    const nameCell = document.createElement("span");
     nameCell.className = "dash-cell-name";
     nameCell.textContent = liveName;
     main.appendChild(nameCell);
 
-    var modelCell = document.createElement("span");
+    const modelCell = document.createElement("span");
     modelCell.className = "dash-cell-model";
     modelCell.textContent = ws.model_alias || ws.model || "";
     if (ws.model) modelCell.title = ws.model;
     main.appendChild(modelCell);
 
-    var nodeCell = document.createElement("span");
+    const nodeCell = document.createElement("span");
     nodeCell.className = "dash-cell-node";
     nodeCell.textContent = ws.node || "local";
     if (ws.node) nodeCell.title = ws.node;
     main.appendChild(nodeCell);
 
-    var taskCell = document.createElement("span");
+    const taskCell = document.createElement("span");
     taskCell.className = "dash-cell-task";
     taskCell.textContent = ws.title || "";
     main.appendChild(taskCell);
 
-    var tokensCell = document.createElement("span");
+    const tokensCell = document.createElement("span");
     tokensCell.className = "dash-cell-tokens";
     tokensCell.textContent = ws.tokens ? formatTokens(ws.tokens) : "";
     main.appendChild(tokensCell);
 
-    var ctxCell = document.createElement("span");
+    const ctxCell = document.createElement("span");
     ctxCell.className = "dash-cell-ctx " + ctxClass(ws.context_ratio);
     ctxCell.textContent =
       ws.context_ratio > 0 ? Math.round(ws.context_ratio * 100) + "%" : "";
@@ -3960,7 +3960,7 @@ function renderDashboardTable(wsList, agg) {
 
     row.appendChild(main);
 
-    var sub = document.createElement("div");
+    const sub = document.createElement("div");
     sub.className = "dash-row-sub";
     if (ws.activity_state === "approval") sub.classList.add("sub-attention");
     sub.textContent = ws.activity || "";
@@ -3982,8 +3982,8 @@ function renderDashboardTable(wsList, agg) {
   table.onkeydown = function (e) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
     e.preventDefault();
-    var rows = Array.from(table.querySelectorAll(".dash-row"));
-    var idx = rows.indexOf(document.activeElement);
+    const rows = Array.from(table.querySelectorAll(".dash-row"));
+    const idx = rows.indexOf(document.activeElement);
     if (idx === -1) return;
     if (e.key === "ArrowDown" && idx < rows.length - 1) rows[idx + 1].focus();
     if (e.key === "ArrowUp" && idx > 0) rows[idx - 1].focus();
@@ -3992,15 +3992,15 @@ function renderDashboardTable(wsList, agg) {
 
 function updateDashFooter(agg) {
   if (!agg) return;
-  var nodesEl = document.getElementById("dash-footer-nodes");
-  var statsEl = document.getElementById("dash-footer-stats");
-  var footerDot = document.createElement("span");
+  const nodesEl = document.getElementById("dash-footer-nodes");
+  const statsEl = document.getElementById("dash-footer-stats");
+  const footerDot = document.createElement("span");
   footerDot.className = "dash-footer-node-dot";
   nodesEl.replaceChildren(
     footerDot,
     " " + (agg.node || "local") + " (" + (agg.total_count || 0) + " ws)",
   );
-  var parts = [];
+  const parts = [];
   if (agg.total_tokens) parts.push(formatTokens(agg.total_tokens) + " tokens");
   if (agg.total_tool_calls) parts.push(agg.total_tool_calls + " tool calls");
   if (agg.uptime_seconds)
@@ -4015,8 +4015,8 @@ function updateDashFooter(agg) {
 // controller (from /shared/cards.js) owns mode state, checkbox
 // decoration, the toolbar wiring, and the confirmation modal — see
 // createSavedCardsController for the shared bits.
-var _wsSavedItems = [];
-var _wsDeleteController = createSavedCardsController({
+let _wsSavedItems = [];
+const _wsDeleteController = createSavedCardsController({
   idPrefix: "ws-delete",
   buttonId: "ws-delete-btn",
   noun: "workstream",
@@ -4040,17 +4040,17 @@ var _wsDeleteController = createSavedCardsController({
 function renderSavedWorkstreams(items) {
   _wsSavedItems = items;
   _wsDeleteController.setItems(items);
-  var c = document.getElementById("dashboard-saved-cards");
+  const c = document.getElementById("dashboard-saved-cards");
   c.replaceChildren();
   if (!items.length) {
-    var empty = document.createElement("div");
+    const empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No saved workstreams";
     c.appendChild(empty);
     return;
   }
   items.forEach(function (sess) {
-    var card = renderSessionCard(sess, {
+    const card = renderSessionCard(sess, {
       ariaLabel: _wsDeleteController.ariaLabel,
       onActivate: function (s) {
         if (_wsDeleteController.blockActivate()) return;
@@ -4087,13 +4087,13 @@ function confirmWsDelete() {
 
 // --- Workstream title management ---
 
-var _lastActiveWsId = null;
+let _lastActiveWsId = null;
 
 function refreshWorkstreamTitle(optWsId) {
-  var wsId = optWsId || getCurrentWsId();
+  const wsId = optWsId || getCurrentWsId();
   if (!wsId) return;
 
-  var url =
+  const url =
     "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/refresh-title";
 
   authFetch(url, { method: "POST" })
@@ -4110,19 +4110,19 @@ function refreshWorkstreamTitle(optWsId) {
     });
 }
 
-var _editTitleTrap = null;
+let _editTitleTrap = null;
 
 function editWorkstreamTitle(optWsId) {
-  var wsId = optWsId || getCurrentWsId();
+  const wsId = optWsId || getCurrentWsId();
   if (!wsId) return;
-  var currentTitle = "";
-  var tabEl = document.querySelector(
+  let currentTitle = "";
+  const tabEl = document.querySelector(
     '.ws-tab[data-ws-id="' + wsId + '"] .tab-name',
   );
   if (tabEl) currentTitle = tabEl.textContent.trim();
 
-  var overlay = document.getElementById("edit-title-overlay");
-  var input = document.getElementById("edit-title-input");
+  const overlay = document.getElementById("edit-title-overlay");
+  const input = document.getElementById("edit-title-input");
   input.value = currentTitle;
   overlay.style.display = "flex";
   overlay.onclick = function (e) {
@@ -4138,10 +4138,10 @@ function editWorkstreamTitle(optWsId) {
       return;
     }
     if (e.key === "Tab") {
-      var box = document.getElementById("edit-title-box");
-      var focusable = box.querySelectorAll("input, button");
-      var first = focusable[0];
-      var last = focusable[focusable.length - 1];
+      const box = document.getElementById("edit-title-box");
+      const focusable = box.querySelectorAll("input, button");
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last.focus();
@@ -4165,21 +4165,21 @@ function cancelEditTitle() {
     document.removeEventListener("keydown", _editTitleTrap);
     _editTitleTrap = null;
   }
-  var chevron = document.querySelector(".ws-tab.active .tab-chevron");
+  const chevron = document.querySelector(".ws-tab.active .tab-chevron");
   if (chevron) chevron.focus();
 }
 
 function submitEditTitle() {
-  var wsId = getCurrentWsId();
+  const wsId = getCurrentWsId();
   if (!wsId) return;
-  var input = document.getElementById("edit-title-input");
-  var newTitle = input.value.trim();
+  const input = document.getElementById("edit-title-input");
+  const newTitle = input.value.trim();
   if (!newTitle) {
     showToast("Title cannot be empty", "warning");
     return;
   }
 
-  var url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/title";
+  const url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/title";
 
   authFetch(url, {
     method: "POST",
@@ -4193,7 +4193,7 @@ function submitEditTitle() {
     .then(function (data) {
       cancelEditTitle();
       // Optimistic update — SSE ws_rename will confirm
-      var nameEls = document.querySelectorAll(
+      const nameEls = document.querySelectorAll(
         '[data-ws-id="' + wsId + '"] .tab-name',
       );
       nameEls.forEach(function (el) {
@@ -4209,21 +4209,21 @@ function submitEditTitle() {
 
 // --- Workstream deletion ---
 
-var _pendingDeleteWsId = null;
-var _deleteWsTrap = null;
+let _pendingDeleteWsId = null;
+let _deleteWsTrap = null;
 
 function confirmDeleteWorkstream(optWsId) {
-  var wsId = optWsId || getCurrentWsId();
+  const wsId = optWsId || getCurrentWsId();
   if (!wsId) return;
   if (Object.keys(workstreams).length <= 1) return;
-  var tabEl = document.querySelector(
+  const tabEl = document.querySelector(
     '.ws-tab[data-ws-id="' + wsId + '"] .tab-name',
   );
-  var name = tabEl ? tabEl.textContent.trim() : wsId.substring(0, 12);
+  const name = tabEl ? tabEl.textContent.trim() : wsId.substring(0, 12);
 
   _pendingDeleteWsId = wsId;
-  var overlay = document.getElementById("delete-ws-overlay");
-  var msg = document.getElementById("delete-ws-message");
+  const overlay = document.getElementById("delete-ws-overlay");
+  const msg = document.getElementById("delete-ws-message");
   msg.textContent = 'Delete "' + name + '"? This cannot be undone.';
   overlay.style.display = "flex";
 
@@ -4236,10 +4236,10 @@ function confirmDeleteWorkstream(optWsId) {
       return;
     }
     if (e.key === "Tab") {
-      var box = document.getElementById("delete-ws-box");
-      var focusable = box.querySelectorAll("button");
-      var first = focusable[0];
-      var last = focusable[focusable.length - 1];
+      const box = document.getElementById("delete-ws-box");
+      const focusable = box.querySelectorAll("button");
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last.focus();
@@ -4251,7 +4251,7 @@ function confirmDeleteWorkstream(optWsId) {
   };
   document.addEventListener("keydown", _deleteWsTrap);
 
-  var cancelBtn = overlay.querySelector("button");
+  const cancelBtn = overlay.querySelector("button");
   if (cancelBtn) cancelBtn.focus();
 }
 
@@ -4262,21 +4262,21 @@ function cancelDeleteWs() {
     document.removeEventListener("keydown", _deleteWsTrap);
     _deleteWsTrap = null;
   }
-  var chevron = document.querySelector(".ws-tab.active .tab-chevron");
+  const chevron = document.querySelector(".ws-tab.active .tab-chevron");
   if (chevron) {
     chevron.focus();
   } else {
-    var fallback = document.getElementById("new-tab-btn");
+    const fallback = document.getElementById("new-tab-btn");
     if (fallback) fallback.focus();
   }
 }
 
 function executeDeleteWs() {
-  var wsId = _pendingDeleteWsId;
+  const wsId = _pendingDeleteWsId;
   if (!wsId) return;
   cancelDeleteWs();
 
-  var url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/delete";
+  const url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/delete";
 
   authFetch(url, { method: "POST" })
     .then(function (r) {
@@ -4302,13 +4302,13 @@ function executeDeleteWs() {
 }
 
 function getCurrentWsId() {
-  var activeTab = document.querySelector(".ws-tab.active");
+  const activeTab = document.querySelector(".ws-tab.active");
   if (activeTab) return activeTab.dataset.wsId || "";
   return "";
 }
 
 function forkWorkstream(optWsId) {
-  var wsId = optWsId || getCurrentWsId();
+  const wsId = optWsId || getCurrentWsId();
   if (!wsId) return;
   showNewWsModal(wsId);
 }
@@ -4345,33 +4345,33 @@ function dashboardResumeSession(wsId) {
 // Staged files for the dashboard composer. Reuses the same file-list pattern
 // as the new-workstream modal but lives independently so the two flows don't
 // stomp on each other's state.
-var _dashboardStagedFiles = [];
+let _dashboardStagedFiles = [];
 
 // Per-kind size caps mirrored from turnstone/core/attachments.py — keep in sync.
-var _DASH_IMAGE_CAP = 4 * 1024 * 1024;
-var _DASH_TEXT_CAP = 512 * 1024;
-var _DASH_MAX_FILES = 10;
+const _DASH_IMAGE_CAP = 4 * 1024 * 1024;
+const _DASH_TEXT_CAP = 512 * 1024;
+const _DASH_MAX_FILES = 10;
 
 function _renderDashboardChips() {
-  var chipsEl = document.getElementById("dashboard-attach-chips");
+  const chipsEl = document.getElementById("dashboard-attach-chips");
   if (!chipsEl) return;
   chipsEl.textContent = "";
-  for (var i = 0; i < _dashboardStagedFiles.length; i++) {
+  for (let i = 0; i < _dashboardStagedFiles.length; i++) {
     (function (idx) {
-      var f = _dashboardStagedFiles[idx];
-      var chip = document.createElement("span");
+      const f = _dashboardStagedFiles[idx];
+      const chip = document.createElement("span");
       chip.className = "new-ws-attach-chip";
       chip.setAttribute("role", "listitem");
-      var label = document.createElement("span");
+      const label = document.createElement("span");
       label.className = "new-ws-attach-chip-name";
       label.textContent = f.name;
       label.title = f.name + " (" + f.size + " bytes)";
       chip.appendChild(label);
-      var size = document.createElement("span");
+      const size = document.createElement("span");
       size.className = "new-ws-attach-chip-size";
       size.textContent = _formatAttachSize(f.size);
       chip.appendChild(size);
-      var rm = document.createElement("button");
+      const rm = document.createElement("button");
       rm.type = "button";
       rm.className = "new-ws-attach-chip-remove";
       rm.setAttribute("aria-label", "Remove " + f.name);
@@ -4388,8 +4388,8 @@ function _renderDashboardChips() {
 }
 
 function _addDashboardFiles(files) {
-  for (var i = 0; i < files.length; i++) {
-    var f = files[i];
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
     if (_dashboardStagedFiles.length >= _DASH_MAX_FILES) {
       _dashboardError(
         "At most " + _DASH_MAX_FILES + " attachments per workstream",
@@ -4406,8 +4406,8 @@ function _addDashboardFiles(files) {
       );
       return;
     }
-    var isImage = (f.type || "").indexOf("image/") === 0;
-    var cap = isImage ? _DASH_IMAGE_CAP : _DASH_TEXT_CAP;
+    const isImage = (f.type || "").indexOf("image/") === 0;
+    const cap = isImage ? _DASH_IMAGE_CAP : _DASH_TEXT_CAP;
     if (f.size > cap) {
       _dashboardError(
         f.name + " exceeds the " + _formatAttachSize(cap) + " cap",
@@ -4420,14 +4420,14 @@ function _addDashboardFiles(files) {
   _refreshDashboardSubmitLabel();
 }
 
-var _dashboardErrorTimer = null;
+let _dashboardErrorTimer = null;
 
 function _dashboardError(msg) {
   // Live-region message + outline.  title= alone is invisible to screen
   // readers and on touch devices, so we surface the message visibly
   // beneath the textarea via aria-live="polite".
-  var input = document.getElementById("dashboard-input");
-  var errEl = document.getElementById("dashboard-error");
+  const input = document.getElementById("dashboard-input");
+  const errEl = document.getElementById("dashboard-error");
   if (errEl) {
     errEl.textContent = msg;
   }
@@ -4443,18 +4443,18 @@ function _dashboardError(msg) {
 }
 
 function _refreshDashboardSubmitLabel() {
-  var btn = document.getElementById("dashboard-submit-btn");
+  const btn = document.getElementById("dashboard-submit-btn");
   if (!btn) return;
-  var input = document.getElementById("dashboard-input");
-  var hasText = input && input.value.trim().length > 0;
-  var hasFiles = _dashboardStagedFiles.length > 0;
+  const input = document.getElementById("dashboard-input");
+  const hasText = input && input.value.trim().length > 0;
+  const hasFiles = _dashboardStagedFiles.length > 0;
   btn.textContent = hasText || hasFiles ? "Send" : "Create";
 }
 
 function _loadDashboardOptionsLists() {
   // Models
-  var modelSel = document.getElementById("dashboard-model");
-  var judgeSel = document.getElementById("dashboard-judge-model");
+  const modelSel = document.getElementById("dashboard-model");
+  const judgeSel = document.getElementById("dashboard-judge-model");
   if (modelSel && modelSel.options.length <= 1) {
     authFetch("/v1/api/models")
       .then(function (r) {
@@ -4462,13 +4462,13 @@ function _loadDashboardOptionsLists() {
       })
       .then(function (data) {
         (data.models || []).forEach(function (m) {
-          var opt = document.createElement("option");
+          const opt = document.createElement("option");
           opt.value = m.alias;
           opt.textContent =
             m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
           modelSel.appendChild(opt);
           if (judgeSel) {
-            var jOpt = document.createElement("option");
+            const jOpt = document.createElement("option");
             jOpt.value = m.alias;
             jOpt.textContent = opt.textContent;
             judgeSel.appendChild(jOpt);
@@ -4480,7 +4480,7 @@ function _loadDashboardOptionsLists() {
       });
   }
   // Skills
-  var skillSel = document.getElementById("dashboard-skill");
+  const skillSel = document.getElementById("dashboard-skill");
   if (skillSel && skillSel.options.length <= 1) {
     authFetch("/v1/api/skills")
       .then(function (r) {
@@ -4488,9 +4488,9 @@ function _loadDashboardOptionsLists() {
       })
       .then(function (data) {
         (data.skills || []).forEach(function (t) {
-          var opt = document.createElement("option");
+          const opt = document.createElement("option");
           opt.value = t.name;
-          var label = t.name;
+          let label = t.name;
           if (t.is_default) label += " (default)";
           if (t.origin === "mcp") label += " [MCP]";
           opt.textContent = label;
@@ -4506,15 +4506,15 @@ function _loadDashboardOptionsLists() {
 // localStorage key for the dashboard composer's Options-panel disclosure
 // state — power users who set non-default model/skill repeatedly want the
 // panel to stay open across reloads instead of clicking it every time.
-var _DASH_OPTIONS_LS_KEY = "turnstone.dashboard.options_open";
+const _DASH_OPTIONS_LS_KEY = "turnstone.dashboard.options_open";
 // In-memory fallback for environments where localStorage throws (private
 // mode, storage quota, embedded WebViews).  null means "no preference
 // recorded this session yet — use the closed default".
-var _dashOptionsOpenSession = null;
+let _dashOptionsOpenSession = null;
 
 function _setDashboardOptionsOpen(open) {
-  var panel = document.getElementById("dashboard-options");
-  var btn = document.getElementById("dashboard-options-btn");
+  const panel = document.getElementById("dashboard-options");
+  const btn = document.getElementById("dashboard-options-btn");
   if (!panel || !btn) return;
   if (open) {
     panel.removeAttribute("hidden");
@@ -4526,9 +4526,9 @@ function _setDashboardOptionsOpen(open) {
 }
 
 function _toggleDashboardOptions() {
-  var panel = document.getElementById("dashboard-options");
+  const panel = document.getElementById("dashboard-options");
   if (!panel) return;
-  var nextOpen = panel.hasAttribute("hidden");
+  const nextOpen = panel.hasAttribute("hidden");
   _setDashboardOptionsOpen(nextOpen);
   _dashOptionsOpenSession = nextOpen;
   try {
@@ -4544,14 +4544,14 @@ function _restoreDashboardOptionsState() {
   // → closed default.  Only override based on a genuinely-successful
   // localStorage read; on throw, fall back to the session value so the
   // panel stays where the user last put it within the same tab.
-  var saved = null;
-  var lsAvailable = true;
+  let saved = null;
+  let lsAvailable = true;
   try {
     saved = localStorage.getItem(_DASH_OPTIONS_LS_KEY);
   } catch (_) {
     lsAvailable = false;
   }
-  var open;
+  let open;
   if (lsAvailable && saved !== null) {
     open = saved === "1";
   } else if (_dashOptionsOpenSession !== null) {
@@ -4567,12 +4567,12 @@ function _restoreDashboardOptionsState() {
 // glance that they've overridden defaults — without having to expand
 // the panel.  Hidden when everything is default.
 function _refreshDashboardOptionsSummary() {
-  var summary = document.getElementById("dashboard-options-summary");
+  const summary = document.getElementById("dashboard-options-summary");
   if (!summary) return;
-  var bits = [];
-  var modelSel = document.getElementById("dashboard-model");
-  var judgeSel = document.getElementById("dashboard-judge-model");
-  var skillSel = document.getElementById("dashboard-skill");
+  const bits = [];
+  const modelSel = document.getElementById("dashboard-model");
+  const judgeSel = document.getElementById("dashboard-judge-model");
+  const skillSel = document.getElementById("dashboard-skill");
   if (modelSel && modelSel.value) bits.push(modelSel.value);
   if (judgeSel && judgeSel.value) bits.push("judge: " + judgeSel.value);
   if (skillSel && skillSel.value) bits.push(skillSel.value);
@@ -4589,15 +4589,15 @@ function _refreshDashboardOptionsSummary() {
 // "press Enter → quick-send-empty-config" split. One path: build the
 // create payload from text + attachments + options, send it, switch.
 function dashboardSubmit() {
-  var input = document.getElementById("dashboard-input");
-  var btn = document.getElementById("dashboard-submit-btn");
-  var text = input.value.trim();
-  var staged = _dashboardStagedFiles.slice();
+  const input = document.getElementById("dashboard-input");
+  const btn = document.getElementById("dashboard-submit-btn");
+  const text = input.value.trim();
+  const staged = _dashboardStagedFiles.slice();
 
-  var body = {};
-  var model = document.getElementById("dashboard-model").value.trim();
-  var judge = document.getElementById("dashboard-judge-model").value.trim();
-  var skill = document.getElementById("dashboard-skill").value;
+  const body = {};
+  const model = document.getElementById("dashboard-model").value.trim();
+  const judge = document.getElementById("dashboard-judge-model").value.trim();
+  const skill = document.getElementById("dashboard-skill").value;
   if (model) body.model = model;
   if (judge) body.judge_model = judge;
   if (skill) body.skill = skill;
@@ -4606,11 +4606,11 @@ function dashboardSubmit() {
   input.disabled = true;
   btn.disabled = true;
 
-  var fetchOpts;
+  let fetchOpts;
   if (staged.length > 0) {
-    var form = new FormData();
+    const form = new FormData();
     form.append("meta", JSON.stringify(body));
-    for (var i = 0; i < staged.length; i++) {
+    for (let i = 0; i < staged.length; i++) {
       form.append("file", staged[i], staged[i].name);
     }
     fetchOpts = { method: "POST", body: form };
@@ -4640,7 +4640,7 @@ function dashboardSubmit() {
       // dispatched it. Echo into the pane so the user sees their own text
       // immediately rather than waiting for SSE to backfill.
       if (text) {
-        var pane = getFocusedPane();
+        const pane = getFocusedPane();
         if (pane) {
           pane.setBusy(true);
           pane.addUserMessage(text);
@@ -4655,7 +4655,7 @@ function dashboardSubmit() {
       // error toast in that case.  Otherwise fall back to a generic
       // string so we never render "Connection error: undefined".
       if (err && err.message === "auth") return;
-      var detail = (err && err.message) || "Unable to reach the server";
+      const detail = (err && err.message) || "Unable to reach the server";
       _dashboardError("Connection error: " + detail);
     });
 }
@@ -4674,7 +4674,7 @@ function connectGlobalSSE() {
     globalRetryDelay = 1000;
   };
   globalEvtSource.onmessage = function (e) {
-    var data = JSON.parse(e.data);
+    const data = JSON.parse(e.data);
     if (data.type === "ws_state") {
       updateTabIndicator(data.ws_id, data.state, {
         tokens: data.tokens,
@@ -4683,11 +4683,11 @@ function connectGlobalSSE() {
         activity_state: data.activity_state,
       });
     } else if (data.type === "ws_activity") {
-      var row = document.querySelector(
+      const row = document.querySelector(
         '#dash-ws-table .dash-row[data-ws-id="' + data.ws_id + '"]',
       );
       if (row) {
-        var sub = row.querySelector(".dash-row-sub");
+        const sub = row.querySelector(".dash-row-sub");
         if (sub) {
           sub.textContent = data.activity || "";
           if (data.activity_state === "approval")
@@ -4698,14 +4698,14 @@ function connectGlobalSSE() {
     } else if (data.type === "ws_rename") {
       if (workstreams[data.ws_id]) workstreams[data.ws_id].name = data.name;
       // Update ALL matching tab elements (not just first one)
-      var nameEls = document.querySelectorAll(
+      const nameEls = document.querySelectorAll(
         '[data-ws-id="' + data.ws_id + '"] .tab-name',
       );
       nameEls.forEach(function (el) {
         el.textContent = data.name;
       });
       // Update all panes showing this workstream
-      for (var id in panes) {
+      for (let id in panes) {
         if (panes[id].wsId === data.ws_id) panes[id].updateWsName();
       }
     } else if (data.type === "ws_created") {
@@ -4714,16 +4714,16 @@ function connectGlobalSSE() {
       workstreams[data.ws_id].state = "idle";
       renderTabBar();
     } else if (data.type === "ws_closed") {
-      var wsId = data.ws_id;
+      const wsId = data.ws_id;
       // Capture tab order from DOM (visual order) before deletion for close_tab_action=nearest_left/right
-      var sseTabIds = Array.from(
+      const sseTabIds = Array.from(
         document.querySelectorAll("#tab-list .ws-tab"),
       ).map(function (tab) {
         return tab.dataset.wsId;
       });
       // Disconnect per-ws SSE on affected panes immediately so stale
       // events from the dying workstream don't leak into reassigned panes.
-      for (var cid in panes) {
+      for (let cid in panes) {
         if (panes[cid].wsId === wsId) panes[cid].disconnectSSE();
       }
       delete workstreams[wsId];
@@ -4771,12 +4771,12 @@ function stripAnsi(s) {
 }
 
 function buildToolDiv(item) {
-  var div = document.createElement("div");
+  const div = document.createElement("div");
   div.className = "ts-approval-tool";
   div.dataset.funcName = item.func_name || "";
   div.dataset.callId = item.call_id || "";
 
-  var name = document.createElement("div");
+  const name = document.createElement("div");
   name.className = "tool-name" + (item.error ? " tool-name--error" : "");
   name.textContent = item.func_name || "";
   // Inline auto-approve indicator — surfaces tools that bypassed the
@@ -4786,21 +4786,21 @@ function buildToolDiv(item) {
   // gives the operator the same signal on the per-ws page they
   // navigated into.
   if (item.auto_approved) {
-    var badge = document.createElement("span");
+    const badge = document.createElement("span");
     badge.className = "tool-auto-approved";
-    var reason = item.auto_approve_reason || "auto_approve_tools";
+    const reason = item.auto_approve_reason || "auto_approve_tools";
     badge.textContent = " auto: " + reason;
     badge.title = "Tool auto-approved (no operator prompt) — reason: " + reason;
     name.appendChild(badge);
   }
   div.appendChild(name);
 
-  var cmd = document.createElement("div");
+  const cmd = document.createElement("div");
   cmd.className = "tool-cmd";
-  var headerText = stripAnsi(item.header || "");
-  var cleaned = headerText.replace(/^[^\s]+\s+\w+:\s*/, "");
+  const headerText = stripAnsi(item.header || "");
+  const cleaned = headerText.replace(/^[^\s]+\s+\w+:\s*/, "");
   if (item.func_name === "bash" && cleaned) {
-    var dollarSpan = document.createElement("span");
+    const dollarSpan = document.createElement("span");
     dollarSpan.className = "dollar";
     dollarSpan.textContent = "$ ";
     cmd.append(dollarSpan, cleaned);
@@ -4810,19 +4810,19 @@ function buildToolDiv(item) {
   div.appendChild(cmd);
 
   if (item.preview) {
-    var diff = document.createElement("div");
+    const diff = document.createElement("div");
     diff.className = "tool-diff";
-    var lines = stripAnsi(item.preview).split("\n");
-    var diffNodes = [];
+    const lines = stripAnsi(item.preview).split("\n");
+    const diffNodes = [];
     lines.forEach(function (line, i) {
       if (i > 0) diffNodes.push("\n");
-      var trimmed = line.trim();
-      var cls = null;
+      const trimmed = line.trim();
+      let cls = null;
       if (trimmed.startsWith("-")) cls = "diff-del";
       else if (trimmed.startsWith("+")) cls = "diff-add";
       else if (trimmed.startsWith("Warning:")) cls = "diff-warn";
       if (cls !== null) {
-        var span = document.createElement("span");
+        const span = document.createElement("span");
         span.className = cls;
         span.textContent = line;
         diffNodes.push(span);
@@ -4839,17 +4839,17 @@ function buildToolDiv(item) {
 
 function renderVerdictBadge(verdict, judgePending) {
   if (!verdict) return "";
-  var risk = verdict.risk_level || "medium";
-  var rec = verdict.recommendation || "review";
-  var conf = Math.round((verdict.confidence || 0) * 100);
-  var summary = verdict.intent_summary || "";
-  var spinnerHtml = "";
+  const risk = verdict.risk_level || "medium";
+  const rec = verdict.recommendation || "review";
+  const conf = Math.round((verdict.confidence || 0) * 100);
+  const summary = verdict.intent_summary || "";
+  let spinnerHtml = "";
   if (judgePending) {
     spinnerHtml =
       '<span class="verdict-judge-spinner">' +
       '<span class="judge-spinner-dot"></span> judge analyzing\u2026</span>';
   }
-  var callId = escapeHtml(verdict.call_id || "");
+  const callId = escapeHtml(verdict.call_id || "");
   return (
     '<div class="verdict-badge verdict-' +
     escapeHtml(risk) +
@@ -4896,10 +4896,10 @@ function renderVerdictBadge(verdict, judgePending) {
 }
 
 function toggleVerdictDetail(btn) {
-  var badge = btn.closest(".verdict-badge");
-  var detail = badge ? badge.nextElementSibling : null;
+  const badge = btn.closest(".verdict-badge");
+  const detail = badge ? badge.nextElementSibling : null;
   if (detail && detail.classList.contains("verdict-detail")) {
-    var isHidden = detail.style.display === "none";
+    const isHidden = detail.style.display === "none";
     detail.style.display = isHidden ? "block" : "none";
     btn.textContent = isHidden ? "hide" : "details";
   }
@@ -4912,7 +4912,7 @@ function toggleVerdictDetail(btn) {
 function appendToolErrorBadge(blockEl) {
   if (!blockEl) return;
   if (blockEl.querySelector(".ts-approval-badge--error")) return;
-  var errBadge = document.createElement("div");
+  const errBadge = document.createElement("div");
   errBadge.setAttribute("role", "status");
   errBadge.className = "ts-approval-badge ts-approval-badge--error";
   errBadge.textContent = "✗ error";
@@ -4924,7 +4924,7 @@ function makeCollapsible(el) {
   el.setAttribute("tabindex", "0");
   el.setAttribute("role", "button");
   el.setAttribute("aria-label", "Tool output (collapsed). Activate to expand.");
-  var handler = function () {
+  const handler = function () {
     this.classList.remove("collapsed");
     this.removeAttribute("tabindex");
     this.removeAttribute("role");
@@ -4944,8 +4944,9 @@ function makeCollapsible(el) {
 // ===========================================================================
 
 function tryParseMedia(text) {
+  let obj;
   try {
-    var obj = JSON.parse(text);
+    obj = JSON.parse(text);
   } catch (e) {
     return null;
   }
@@ -4957,21 +4958,21 @@ function tryParseMedia(text) {
 }
 
 function _formatRuntime(item) {
-  var mins = 0;
+  let mins = 0;
   if (typeof item.runtime_minutes === "number") {
     mins = Math.round(item.runtime_minutes);
   } else if (typeof item.runtime_ticks === "number") {
     mins = Math.round(item.runtime_ticks / 600000000);
   }
   if (!mins) return "";
-  var h = Math.floor(mins / 60);
-  var m = mins % 60;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
   return h > 0 ? h + "h " + m + "m" : m + "m";
 }
 
 function _redactApiKeys(text) {
   // Query-string style: api_key=VALUE
-  var redacted = text.replace(
+  let redacted = text.replace(
     /(?:api_key|apiKey|api-key|token)=[^&\s"]+/g,
     function (m) {
       return m.split("=")[0] + "=***";
@@ -4990,8 +4991,9 @@ function _redactApiKeys(text) {
  * Returns a formatted string if valid JSON, otherwise null.
  */
 function _tryPrettyJson(text) {
+  let obj;
   try {
-    var obj = JSON.parse(text);
+    obj = JSON.parse(text);
   } catch (e) {
     return null;
   }
@@ -5004,10 +5006,10 @@ function _tryPrettyJson(text) {
  * Otherwise renders as plain text. Always redacts API keys.
  */
 function renderToolOutput(stripped, isError) {
-  var out = document.createElement("div");
+  const out = document.createElement("div");
   out.className = "tool-output" + (isError ? " tool-output-error" : "");
   if (!isError) {
-    var pretty = _tryPrettyJson(stripped);
+    const pretty = _tryPrettyJson(stripped);
     if (pretty) {
       out.textContent = pretty;
       return out;
@@ -5018,11 +5020,11 @@ function renderToolOutput(stripped, isError) {
 }
 
 function buildMediaEmbed(media, rawJson) {
-  var wrapper = document.createElement("div");
+  const wrapper = document.createElement("div");
   wrapper.className = "media-embed";
 
   if (media.stream_url) {
-    var card = buildMediaCard(media);
+    const card = buildMediaCard(media);
     card.querySelector(".media-card-info").appendChild(buildPlayButton(media));
     wrapper.appendChild(card);
   } else if (media.results) {
@@ -5036,7 +5038,7 @@ function buildMediaEmbed(media, rawJson) {
   }
 
   // Collapsed raw JSON for inspection (with redacted API keys)
-  var raw = document.createElement("div");
+  const raw = document.createElement("div");
   raw.className = "tool-output";
   raw.textContent = _tryPrettyJson(rawJson) || _redactApiKeys(rawJson);
   makeCollapsible(raw);
@@ -5046,13 +5048,13 @@ function buildMediaEmbed(media, rawJson) {
 }
 
 function buildMediaCard(item) {
-  var card = document.createElement("div");
+  const card = document.createElement("div");
   card.className = "media-card";
 
   // Thumbnail
-  var thumbUrl = item.thumbnail_url || item.image_url || "";
+  const thumbUrl = item.thumbnail_url || item.image_url || "";
   if (thumbUrl) {
-    var img = document.createElement("img");
+    const img = document.createElement("img");
     img.className = "media-card-thumb";
     img.loading = "lazy";
     img.alt = item.title || item.name || "Media thumbnail";
@@ -5064,13 +5066,13 @@ function buildMediaCard(item) {
   }
 
   // Info container
-  var info = document.createElement("div");
+  const info = document.createElement("div");
   info.className = "media-card-info";
 
   // Title (Year)
-  var title = document.createElement("div");
+  const title = document.createElement("div");
   title.className = "media-card-title";
-  var titleText = item.title || item.name || "Untitled";
+  let titleText = item.title || item.name || "Untitled";
   if (item.year || item.production_year) {
     titleText += " (" + (item.year || item.production_year) + ")";
   }
@@ -5078,17 +5080,17 @@ function buildMediaCard(item) {
   info.appendChild(title);
 
   // Metadata line: type, runtime, genres
-  var metaParts = [];
+  const metaParts = [];
   if (item.type || item.media_type) {
     metaParts.push(item.type || item.media_type);
   }
-  var runtime = _formatRuntime(item);
+  const runtime = _formatRuntime(item);
   if (runtime) metaParts.push(runtime);
   if (item.genres && item.genres.length) {
     metaParts.push(item.genres.join(", "));
   }
   if (metaParts.length) {
-    var meta = document.createElement("div");
+    const meta = document.createElement("div");
     meta.className = "media-card-meta";
     meta.textContent = metaParts.join(" \u00b7 ");
     info.appendChild(meta);
@@ -5099,7 +5101,7 @@ function buildMediaCard(item) {
 }
 
 function buildPlayButton(media) {
-  var btn = document.createElement("button");
+  const btn = document.createElement("button");
   btn.className = "media-play-btn";
   btn.type = "button";
   btn.dataset.streamUrl = media.stream_url || "";
@@ -5120,28 +5122,28 @@ function buildPlayButton(media) {
     "Play " + (media.title || media.name || "media"),
   );
 
-  var icon = document.createElement("span");
+  const icon = document.createElement("span");
   icon.textContent = "\u25b6";
   btn.appendChild(icon);
-  var label = document.createElement("span");
+  const label = document.createElement("span");
   label.textContent = "Play";
   btn.appendChild(label);
   return btn;
 }
 
 function buildMediaResultsList(results, totalCount) {
-  var container = document.createElement("div");
+  const container = document.createElement("div");
   container.className = "media-results-list";
 
-  for (var i = 0; i < results.length; i++) {
-    var item = results[i];
-    var row = document.createElement("div");
+  for (let i = 0; i < results.length; i++) {
+    const item = results[i];
+    const row = document.createElement("div");
     row.className = "media-result-row";
 
     // Small thumbnail
-    var thumbUrl = item.thumbnail_url || item.image_url || "";
+    const thumbUrl = item.thumbnail_url || item.image_url || "";
     if (thumbUrl) {
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.className = "media-result-thumb";
       img.loading = "lazy";
       img.alt = item.name || item.title || "Media thumbnail";
@@ -5153,9 +5155,9 @@ function buildMediaResultsList(results, totalCount) {
     }
 
     // Title (Year)
-    var titleSpan = document.createElement("span");
+    const titleSpan = document.createElement("span");
     titleSpan.className = "media-result-title";
-    var titleText = item.name || item.title || "Untitled";
+    let titleText = item.name || item.title || "Untitled";
     if (item.year || item.production_year) {
       titleText += " (" + (item.year || item.production_year) + ")";
     }
@@ -5163,11 +5165,11 @@ function buildMediaResultsList(results, totalCount) {
     row.appendChild(titleSpan);
 
     // Metadata: type, runtime or season info
-    var metaParts = [];
+    const metaParts = [];
     if (item.type || item.media_type) {
       metaParts.push(item.type || item.media_type);
     }
-    var runtime = _formatRuntime(item);
+    const runtime = _formatRuntime(item);
     if (runtime) metaParts.push(runtime);
     if (item.season_name) metaParts.push(item.season_name);
     if (
@@ -5182,7 +5184,7 @@ function buildMediaResultsList(results, totalCount) {
       );
     }
     if (metaParts.length) {
-      var metaSpan = document.createElement("span");
+      const metaSpan = document.createElement("span");
       metaSpan.className = "media-result-meta";
       metaSpan.textContent = " \u00b7 " + metaParts.join(" \u00b7 ");
       row.appendChild(metaSpan);
@@ -5193,7 +5195,7 @@ function buildMediaResultsList(results, totalCount) {
 
   // "showing X of Y results" footer
   if (typeof totalCount === "number" && totalCount > results.length) {
-    var count = document.createElement("div");
+    const count = document.createElement("div");
     count.className = "media-results-count";
     count.textContent =
       "showing " + results.length + " of " + totalCount + " results";
@@ -5210,7 +5212,7 @@ function buildMediaResultsList(results, totalCount) {
 // Module-level set of servers with an unresolved consent prompt; drives the
 // gear-icon badge so the user has a stable signal that re-consent is pending
 // after the inline card scrolls out of view.
-var _pendingConsentServers = new Set();
+const _pendingConsentServers = new Set();
 
 function _onConsentDetected(server) {
   if (typeof server === "string" && server) {
@@ -5240,8 +5242,8 @@ function loadPendingConsents() {
     })
     .then(function (data) {
       if (!data || !Array.isArray(data.servers)) return;
-      for (var i = 0; i < data.servers.length; i++) {
-        var row = data.servers[i];
+      for (let i = 0; i < data.servers.length; i++) {
+        const row = data.servers[i];
         if (row && typeof row.server_name === "string") {
           _pendingConsentServers.add(row.server_name);
         }
@@ -5254,10 +5256,10 @@ function loadPendingConsents() {
 }
 
 function _refreshConsentBadge() {
-  var btn = document.getElementById("settings-btn");
+  const btn = document.getElementById("settings-btn");
   if (!btn) return;
-  var existing = btn.querySelector(".settings-consent-badge");
-  var n = _pendingConsentServers.size;
+  let existing = btn.querySelector(".settings-consent-badge");
+  const n = _pendingConsentServers.size;
   // Keep the visible badge and the accessible name in lockstep so screen-
   // reader users get the same pending-consent signal that sighted users
   // get from the red dot. The badge itself stays aria-hidden because the
@@ -5275,7 +5277,7 @@ function _refreshConsentBadge() {
     btn.appendChild(existing);
   }
   existing.textContent = String(n);
-  var label =
+  const label =
     "Settings (" + n + " MCP consent" + (n === 1 ? "" : "s") + " pending)";
   btn.setAttribute("aria-label", label);
   btn.setAttribute("title", label);
@@ -5291,13 +5293,14 @@ function _refreshConsentBadge() {
  *   - mcp_oauth_url_insecure (operator action)
  */
 function tryParseMcpError(text) {
+  let obj;
   try {
-    var obj = JSON.parse(text);
+    obj = JSON.parse(text);
   } catch (e) {
     return null;
   }
   if (!obj || typeof obj !== "object") return null;
-  var err = obj.error;
+  const err = obj.error;
   if (!err || typeof err !== "object") return null;
   if (typeof err.code !== "string" || err.code.indexOf("mcp_") !== 0)
     return null;
@@ -5337,47 +5340,47 @@ function _mcpErrorTitle(err) {
  * media-embed pattern: visible card on top, collapsible raw JSON below.
  */
 function buildMcpErrorEmbed(err, rawJson) {
-  var category = _mcpErrorCategory(err.code);
-  var wrapper = document.createElement("div");
+  const category = _mcpErrorCategory(err.code);
+  const wrapper = document.createElement("div");
   wrapper.className = "mcp-error-card mcp-error-" + category;
 
-  var icon = document.createElement("div");
+  const icon = document.createElement("div");
   icon.className = "mcp-error-icon";
   icon.setAttribute("aria-hidden", "true");
   icon.textContent = "⚠";
   wrapper.appendChild(icon);
 
-  var body = document.createElement("div");
+  const body = document.createElement("div");
   body.className = "mcp-error-body";
 
-  var title = document.createElement("div");
+  const title = document.createElement("div");
   title.className = "mcp-error-title";
   title.textContent = _mcpErrorTitle(err);
   body.appendChild(title);
 
   if (err.detail) {
-    var detail = document.createElement("div");
+    const detail = document.createElement("div");
     detail.className = "mcp-error-detail";
     detail.textContent = String(err.detail);
     body.appendChild(detail);
   }
 
   if (err.server) {
-    var serverLine = document.createElement("div");
+    const serverLine = document.createElement("div");
     serverLine.className = "mcp-error-server";
     serverLine.appendChild(document.createTextNode("server: "));
-    var serverCode = document.createElement("code");
+    const serverCode = document.createElement("code");
     serverCode.textContent = String(err.server);
     serverLine.appendChild(serverCode);
     body.appendChild(serverLine);
   }
 
   if (Array.isArray(err.scopes_required) && err.scopes_required.length) {
-    var scopesLine = document.createElement("div");
+    const scopesLine = document.createElement("div");
     scopesLine.className = "mcp-error-scopes";
     scopesLine.appendChild(document.createTextNode("scopes: "));
-    for (var i = 0; i < err.scopes_required.length; i++) {
-      var pill = document.createElement("span");
+    for (let i = 0; i < err.scopes_required.length; i++) {
+      const pill = document.createElement("span");
       pill.className = "mcp-scope-pill";
       pill.textContent = String(err.scopes_required[i]);
       scopesLine.appendChild(pill);
@@ -5386,10 +5389,10 @@ function buildMcpErrorEmbed(err, rawJson) {
   }
 
   if (category === "actionable") {
-    var btn = document.createElement("button");
+    const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "mcp-error-action-btn";
-    var serverLabel = err.server ? String(err.server) : "server";
+    const serverLabel = err.server ? String(err.server) : "server";
     btn.textContent =
       err.code === "mcp_insufficient_scope"
         ? "Re-consent with new scopes →"
@@ -5401,7 +5404,7 @@ function buildMcpErrorEmbed(err, rawJson) {
         : "Connect to " + serverLabel,
     );
     btn.addEventListener("click", function () {
-      var consentUrl = err.consent_url;
+      const consentUrl = err.consent_url;
       if (!consentUrl || typeof consentUrl !== "string") {
         // Defensive: should always be present per the dispatcher.  If a
         // path forgets to include it the user can still connect via the
@@ -5419,8 +5422,8 @@ function buildMcpErrorEmbed(err, rawJson) {
         showToast("Invalid consent URL");
         return;
       }
-      var sep = consentUrl.indexOf("?") >= 0 ? "&" : "?";
-      var url =
+      const sep = consentUrl.indexOf("?") >= 0 ? "&" : "?";
+      const url =
         consentUrl +
         sep +
         "return_url=" +
@@ -5433,11 +5436,11 @@ function buildMcpErrorEmbed(err, rawJson) {
 
   wrapper.appendChild(body);
 
-  var details = document.createElement("details");
-  var summary = document.createElement("summary");
+  const details = document.createElement("details");
+  const summary = document.createElement("summary");
   summary.textContent = "raw payload";
   details.appendChild(summary);
-  var pre = document.createElement("pre");
+  const pre = document.createElement("pre");
   pre.className = "tool-output";
   pre.textContent = _tryPrettyJson(rawJson) || _redactApiKeys(rawJson);
   details.appendChild(pre);
@@ -5450,8 +5453,8 @@ function buildMcpErrorEmbed(err, rawJson) {
 //  HLS lazy-loader (follows the mermaid.js lazy-load pattern in
 //  /shared/renderer.js)
 // ---------------------------------------------------------------------------
-var _hlsState = "idle";
-var _hlsQueue = [];
+let _hlsState = "idle";
+let _hlsQueue = [];
 
 function _loadHls(callback) {
   if (_hlsState === "ready") {
@@ -5461,20 +5464,20 @@ function _loadHls(callback) {
   _hlsQueue.push(callback);
   if (_hlsState === "loading") return;
   _hlsState = "loading";
-  var script = document.createElement("script");
+  const script = document.createElement("script");
   script.src = "/shared/hls-1.6.16/hls.min.js";
   script.onload = function () {
     _hlsState = "ready";
-    var q = _hlsQueue;
+    const q = _hlsQueue;
     _hlsQueue = [];
-    for (var i = 0; i < q.length; i++) q[i]();
+    for (let i = 0; i < q.length; i++) q[i]();
   };
   script.onerror = function () {
     _hlsState = "idle";
-    var q = _hlsQueue;
+    const q = _hlsQueue;
     _hlsQueue = [];
     // Fall through — _activatePlayer will use stream_url since Hls is undefined
-    for (var i = 0; i < q.length; i++) q[i]();
+    for (let i = 0; i < q.length; i++) q[i]();
   };
   document.head.appendChild(script);
 }
@@ -5487,12 +5490,12 @@ function _isHlsUrl(url) {
 //  Click-to-play delegated handler (follows img-placeholder pattern)
 // ---------------------------------------------------------------------------
 function _activatePlayer(btn) {
-  var url = btn.dataset.streamUrl;
-  var hlsUrl = btn.dataset.hlsUrl;
-  var isAudio = btn.dataset.audioOnly === "true";
-  var directStream = btn.dataset.directStream === "true";
+  const url = btn.dataset.streamUrl;
+  const hlsUrl = btn.dataset.hlsUrl;
+  const isAudio = btn.dataset.audioOnly === "true";
+  const directStream = btn.dataset.directStream === "true";
 
-  var player = document.createElement(isAudio ? "audio" : "video");
+  const player = document.createElement(isAudio ? "audio" : "video");
   player.controls = true;
   player.autoplay = true;
   player.className = "media-player";
@@ -5507,7 +5510,7 @@ function _activatePlayer(btn) {
     typeof Hls !== "undefined" &&
     Hls.isSupported()
   ) {
-    var hls = new Hls();
+    const hls = new Hls();
     hls.loadSource(hlsUrl);
     hls.attachMedia(player);
   } else if (
@@ -5521,16 +5524,16 @@ function _activatePlayer(btn) {
   }
 
   player.addEventListener("error", function () {
-    var card = player.closest(".media-embed");
-    var titleEl = card ? card.querySelector(".media-card-title") : null;
-    var label = titleEl ? ": " + titleEl.textContent : "";
+    const card = player.closest(".media-embed");
+    const titleEl = card ? card.querySelector(".media-card-title") : null;
+    const label = titleEl ? ": " + titleEl.textContent : "";
 
-    var err = document.createElement("div");
+    const err = document.createElement("div");
     err.className = "media-player-error";
     err.setAttribute("role", "alert");
     err.textContent = "Failed to load stream" + label;
 
-    var retry = document.createElement("button");
+    const retry = document.createElement("button");
     retry.className = "media-play-btn";
     retry.type = "button";
     retry.dataset.streamUrl = url;
@@ -5540,7 +5543,7 @@ function _activatePlayer(btn) {
     retry.setAttribute("aria-label", "Retry" + label);
     retry.appendChild(document.createTextNode("\u25b6 Retry"));
 
-    var container = document.createElement("div");
+    const container = document.createElement("div");
     container.appendChild(err);
     container.appendChild(retry);
     player.replaceWith(container);
@@ -5550,19 +5553,19 @@ function _activatePlayer(btn) {
 }
 
 document.addEventListener("click", function (e) {
-  var btn = e.target.closest(".media-play-btn");
+  const btn = e.target.closest(".media-play-btn");
   if (!btn) return;
   e.preventDefault();
   btn.disabled = true;
-  var labelEl = btn.querySelector("span:last-child");
+  const labelEl = btn.querySelector("span:last-child");
   if (labelEl) {
     labelEl.textContent = "Loading\u2026";
   } else {
     btn.textContent = "\u25b6 Loading\u2026";
   }
 
-  var hlsUrl = btn.dataset.hlsUrl;
-  var isAudio = btn.dataset.audioOnly === "true";
+  const hlsUrl = btn.dataset.hlsUrl;
+  const isAudio = btn.dataset.audioOnly === "true";
 
   // If HLS URL present and not audio, ensure hls.js is loaded first
   if (hlsUrl && !isAudio && _isHlsUrl(hlsUrl)) {
@@ -5576,7 +5579,7 @@ document.addEventListener("click", function (e) {
 
 document.addEventListener("keydown", function (e) {
   if (e.key !== "Enter") return;
-  var btn = e.target.closest(".media-play-btn");
+  const btn = e.target.closest(".media-play-btn");
   if (!btn) return;
   btn.click();
 });
@@ -5585,22 +5588,22 @@ document.addEventListener("keydown", function (e) {
 //  13. Plan review dialog
 // ===========================================================================
 
-var _planContent = "";
-var _planPaneId = null;
-var _planWsId = null;
+let _planContent = "";
+let _planPaneId = null;
+let _planWsId = null;
 
 function showPlanDialog(content) {
   _planContent = content;
   _planPaneId = focusedPaneId;
-  var paneNow = panes[_planPaneId];
+  const paneNow = panes[_planPaneId];
   _planWsId = paneNow ? paneNow.wsId : currentWsId;
   document.getElementById("plan-content").textContent = content;
-  var feedbackEl = document.getElementById("plan-feedback");
+  const feedbackEl = document.getElementById("plan-feedback");
   feedbackEl.value = "";
   _updatePlanRejectBtn();
 
   // Disable focused pane input
-  var pane = panes[_planPaneId];
+  const pane = panes[_planPaneId];
   if (pane) {
     pane.inputEl.disabled = true;
     pane.sendBtn.disabled = true;
@@ -5613,8 +5616,8 @@ function showPlanDialog(content) {
 }
 
 function _updatePlanRejectBtn() {
-  var btn = document.getElementById("btn-plan-reject");
-  var hasFeedback =
+  const btn = document.getElementById("btn-plan-reject");
+  const hasFeedback =
     document.getElementById("plan-feedback").value.trim().length > 0;
   btn.replaceChildren(makeKeyLabel("Esc", hasFeedback ? "Amend" : "Reject"));
   btn.style.background = hasFeedback ? "var(--accent)" : "";
@@ -5625,13 +5628,13 @@ function _updatePlanRejectBtn() {
 }
 
 function resolvePlan(defaultFeedback) {
-  var feedback = document.getElementById("plan-feedback").value.trim();
+  let feedback = document.getElementById("plan-feedback").value.trim();
   if (!feedback && defaultFeedback) feedback = defaultFeedback;
   // Removing 'active' synchronously is what lets dismissPlanDialog's
   // early-return guard treat the server's echoed plan_resolved as a no-op.
   document.getElementById("plan-overlay").classList.remove("active");
 
-  var pane = panes[_planPaneId];
+  const pane = panes[_planPaneId];
   if (pane) {
     pane.inputEl.disabled = false;
     pane.sendBtn.disabled = false;
@@ -5641,7 +5644,7 @@ function resolvePlan(defaultFeedback) {
   // Critical: fire the API call first — this unblocks the server.
   // Use the ws_id captured when the dialog opened, not the current pane
   // (user may have switched tabs while the dialog was open).
-  var wsId = _planWsId || (pane ? pane.wsId : currentWsId);
+  const wsId = _planWsId || (pane ? pane.wsId : currentWsId);
   _planWsId = null;
   authFetch("/v1/api/plan", {
     method: "POST",
@@ -5651,11 +5654,14 @@ function resolvePlan(defaultFeedback) {
     if (pane) pane.addErrorMessage("Connection error: " + err.message);
   });
 
-  // Render plan inline in the chat (best-effort)
+  // Render plan inline in the chat (best-effort).  `action` is hoisted so
+  // the catch handler can still build a fallback message if the inline
+  // render throws after the action label was computed.
+  let action;
   try {
-    var isReject = feedback === "reject";
-    var isAmend = feedback && !isReject;
-    var action = isReject ? "rejected" : isAmend ? "amending" : "approved";
+    const isReject = feedback === "reject";
+    const isAmend = feedback && !isReject;
+    action = isReject ? "rejected" : isAmend ? "amending" : "approved";
     _addInlinePlan(_planContent, action, feedback);
   } catch (err) {
     console.error("Failed to render inline plan:", err);
@@ -5673,11 +5679,11 @@ function dismissPlanDialog(feedback) {
   // Do NOT call /v1/api/plan — the server has already moved on.  The early
   // return also handles self-receipt: the client that called resolvePlan()
   // already removed the active class, so this is a no-op for that client.
-  var overlay = document.getElementById("plan-overlay");
+  const overlay = document.getElementById("plan-overlay");
   if (!overlay.classList.contains("active")) return;
   overlay.classList.remove("active");
 
-  var pane = panes[_planPaneId];
+  const pane = panes[_planPaneId];
   if (pane) {
     pane.inputEl.disabled = false;
     pane.sendBtn.disabled = false;
@@ -5686,10 +5692,10 @@ function dismissPlanDialog(feedback) {
     if (!matchMedia("(pointer: coarse)").matches) pane.inputEl.focus();
   }
 
-  var fb = feedback || "";
-  var isReject = fb === "reject";
-  var isAmend = fb && !isReject;
-  var action = isReject ? "rejected" : isAmend ? "amending" : "approved";
+  const fb = feedback || "";
+  const isReject = fb === "reject";
+  const isAmend = fb && !isReject;
+  const action = isReject ? "rejected" : isAmend ? "amending" : "approved";
 
   // Race fallback: if plan_resolved arrives before plan_review (e.g. SSE
   // reconnect ordering), _planContent is empty and _addInlinePlan early-
@@ -5721,7 +5727,7 @@ function dismissPlanDialog(feedback) {
 }
 
 function _announce(text) {
-  var el = document.getElementById("toast");
+  const el = document.getElementById("toast");
   if (!el) return;
   // Re-set textContent in two ticks so screen readers re-announce even
   // when the message is identical to the previous one.
@@ -5733,15 +5739,15 @@ function _announce(text) {
 
 function _addInlinePlan(content, action, feedback, origin) {
   if (!content) return;
-  var pane = panes[_planPaneId];
+  const pane = panes[_planPaneId];
   if (!pane) return;
 
-  var wrapper = document.createElement("div");
+  const wrapper = document.createElement("div");
   wrapper.className = "plan-inline";
 
-  var header = document.createElement("div");
+  const header = document.createElement("div");
   header.className = "plan-inline-header";
-  var label =
+  let label =
     action === "rejected"
       ? "Plan rejected"
       : action === "amending"
@@ -5750,13 +5756,13 @@ function _addInlinePlan(content, action, feedback, origin) {
   // Disambiguate remote dismissal — otherwise the desktop user sees "Plan
   // approved" with no attribution and may wonder if the agent self-approved.
   if (origin === "remote") label += " (synced)";
-  var labelEl = document.createElement("span");
+  const labelEl = document.createElement("span");
   labelEl.className = "plan-inline-label plan-" + action;
   labelEl.textContent = label;
   header.appendChild(labelEl);
   wrapper.appendChild(header);
 
-  var body = document.createElement("div");
+  const body = document.createElement("div");
   body.className = "plan-inline-body";
   try {
     setMarkdown(body, content);
@@ -5773,7 +5779,7 @@ function _addInlinePlan(content, action, feedback, origin) {
   wrapper.appendChild(body);
 
   if (feedback && action === "amending") {
-    var fb = document.createElement("div");
+    const fb = document.createElement("div");
     fb.className = "plan-inline-feedback";
     fb.textContent = "Feedback: " + feedback;
     wrapper.appendChild(fb);
@@ -5795,11 +5801,11 @@ document
 // button label, paperclip + drag-drop + paste-image stage files, options
 // toggle expands the dropdown panel.
 (function () {
-  var input = document.getElementById("dashboard-input");
-  var attachBtn = document.getElementById("dashboard-attach-btn");
-  var attachInput = document.getElementById("dashboard-attach-input");
-  var optionsBtn = document.getElementById("dashboard-options-btn");
-  var composer = document.getElementById("dashboard-composer");
+  const input = document.getElementById("dashboard-input");
+  const attachBtn = document.getElementById("dashboard-attach-btn");
+  const attachInput = document.getElementById("dashboard-attach-input");
+  const optionsBtn = document.getElementById("dashboard-options-btn");
+  const composer = document.getElementById("dashboard-composer");
   if (!input) return;
 
   input.addEventListener("keydown", function (e) {
@@ -5811,11 +5817,11 @@ document
   input.addEventListener("input", _refreshDashboardSubmitLabel);
   input.addEventListener("paste", function (e) {
     if (!e.clipboardData) return;
-    var items = e.clipboardData.items || [];
-    var pasted = [];
-    for (var i = 0; i < items.length; i++) {
+    const items = e.clipboardData.items || [];
+    const pasted = [];
+    for (let i = 0; i < items.length; i++) {
       if (items[i].kind === "file") {
-        var f = items[i].getAsFile();
+        const f = items[i].getAsFile();
         if (f) pasted.push(f);
       }
     }
@@ -5842,7 +5848,7 @@ document
   // Keep the inline summary chip in sync with whichever non-default
   // model / judge / skill is selected.  Listening on the options panel
   // catches all three selects with one handler.
-  var optionsPanel = document.getElementById("dashboard-options");
+  const optionsPanel = document.getElementById("dashboard-options");
   if (optionsPanel) {
     optionsPanel.addEventListener("change", _refreshDashboardOptionsSummary);
   }
@@ -5878,13 +5884,13 @@ document
 //  15. MCP server connections settings panel
 // ===========================================================================
 
-var _pendingRevokeServer = null;
-var _settingsTrap = null;
-var _revokeMcpTrap = null;
-var _settingsReturnFocus = null;
+let _pendingRevokeServer = null;
+let _settingsTrap = null;
+let _revokeMcpTrap = null;
+let _settingsReturnFocus = null;
 
 function openSettingsPanel() {
-  var overlay = document.getElementById("settings-overlay");
+  const overlay = document.getElementById("settings-overlay");
   if (!overlay) return;
   _settingsReturnFocus = document.activeElement;
   overlay.style.display = "flex";
@@ -5894,21 +5900,21 @@ function openSettingsPanel() {
     if (e.key === "Escape") {
       // If the nested revoke confirmation is open, let its own trap
       // handle Escape — closing inner-first matches the delete-ws flow.
-      var inner = document.getElementById("revoke-mcp-overlay");
+      const inner = document.getElementById("revoke-mcp-overlay");
       if (inner && inner.style.display !== "none") return;
       e.preventDefault();
       closeSettingsPanel();
       return;
     }
     if (e.key === "Tab") {
-      var box = document.getElementById("settings-box");
+      const box = document.getElementById("settings-box");
       if (!box) return;
-      var focusable = box.querySelectorAll(
+      const focusable = box.querySelectorAll(
         "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
       );
       if (!focusable.length) return;
-      var first = focusable[0];
-      var last = focusable[focusable.length - 1];
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last.focus();
@@ -5922,7 +5928,7 @@ function openSettingsPanel() {
 
   loadMcpConnections();
 
-  var closeBtn = document.getElementById("settings-close-btn");
+  const closeBtn = document.getElementById("settings-close-btn");
   if (closeBtn) closeBtn.focus();
 }
 
@@ -5933,11 +5939,11 @@ function closeSettingsPanel() {
   // Escape-key path inside the parent's keydown trap defers to the
   // inner trap; this branch is the close-button path that doesn't go
   // through that trap.
-  var inner = document.getElementById("revoke-mcp-overlay");
+  const inner = document.getElementById("revoke-mcp-overlay");
   if (inner && inner.style.display !== "none") {
     cancelRevokeMcp();
   }
-  var overlay = document.getElementById("settings-overlay");
+  const overlay = document.getElementById("settings-overlay");
   if (overlay) overlay.style.display = "none";
   if (_settingsTrap) {
     document.removeEventListener("keydown", _settingsTrap);
@@ -5970,13 +5976,13 @@ function closeSettingsPanel() {
 // to the last item rather than the second-to-last — same shape as
 // showTabDropdown and the proxy node-picker.
 
-var _settingsMenu = null;
-var _settingsMenuCloseHandler = null;
+let _settingsMenu = null;
+let _settingsMenuCloseHandler = null;
 // Cached at open time so closeSettingsMenu can reset ARIA without
 // re-querying by id, and so the menu-item click path can refocus
 // the trigger BEFORE close — that way openSettingsPanel captures
 // the gear (not <body>) as _settingsReturnFocus.
-var _settingsMenuTrigger = null;
+let _settingsMenuTrigger = null;
 
 function toggleSettingsMenu(triggerEl) {
   if (_settingsMenu) closeSettingsMenu();
@@ -5989,7 +5995,7 @@ function openSettingsMenu(triggerEl) {
   triggerEl.setAttribute("aria-expanded", "true");
   triggerEl.setAttribute("aria-controls", "settings-menu");
 
-  var menu = document.createElement("div");
+  const menu = document.createElement("div");
   menu.id = "settings-menu";
   menu.className = "ws-tab-dropdown";
   menu.setAttribute("role", "menu");
@@ -5998,8 +6004,8 @@ function openSettingsMenu(triggerEl) {
     e.preventDefault();
   });
 
-  var pendingCount = _pendingConsentServers.size;
-  var items = [
+  const pendingCount = _pendingConsentServers.size;
+  const items = [
     {
       label:
         "MCP connections" + (pendingCount ? " (" + pendingCount + ")" : ""),
@@ -6022,18 +6028,18 @@ function openSettingsMenu(triggerEl) {
 
   items.forEach(function (item) {
     if (item.separator) {
-      var sep = document.createElement("div");
+      const sep = document.createElement("div");
       sep.className = "ws-tab-dropdown-sep";
       sep.setAttribute("role", "separator");
       menu.appendChild(sep);
       return;
     }
-    var btn = document.createElement("button");
+    const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "ws-tab-dropdown-item" + (item.cls ? " " + item.cls : "");
     btn.setAttribute("role", "menuitem");
     btn.setAttribute("tabindex", "-1");
-    var labelSpan = document.createElement("span");
+    const labelSpan = document.createElement("span");
     labelSpan.className = "ws-tab-dropdown-label";
     labelSpan.textContent = item.label;
     btn.appendChild(labelSpan);
@@ -6058,10 +6064,10 @@ function openSettingsMenu(triggerEl) {
   // runs BEFORE the left-edge floor so a menu wider than the viewport
   // still gets clamped to mx=4 instead of going negative — matches the
   // proxy node-picker order in turnstone/console/server.py:307-309.
-  var tr = triggerEl.getBoundingClientRect();
-  var mr = menu.getBoundingClientRect();
-  var mx = tr.right - mr.width;
-  var my = tr.bottom + 4;
+  const tr = triggerEl.getBoundingClientRect();
+  const mr = menu.getBoundingClientRect();
+  let mx = tr.right - mr.width;
+  let my = tr.bottom + 4;
   if (my + mr.height > window.innerHeight) my = tr.top - mr.height - 4;
   if (mx + mr.width > window.innerWidth) mx = window.innerWidth - mr.width - 4;
   if (mx < 4) mx = 4;
@@ -6087,9 +6093,9 @@ function openSettingsMenu(triggerEl) {
         e.key === "End"
       ) {
         e.preventDefault();
-        var btns = Array.from(menu.querySelectorAll(".ws-tab-dropdown-item"));
+        const btns = Array.from(menu.querySelectorAll(".ws-tab-dropdown-item"));
         if (!btns.length) return;
-        var idx = btns.indexOf(document.activeElement);
+        const idx = btns.indexOf(document.activeElement);
         if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
         // idx <= 0 covers both "first item" (wrap to last) and "no
         // current focus" (idx === -1, which would otherwise yield
@@ -6121,12 +6127,12 @@ function openSettingsMenu(triggerEl) {
   // focus because the menu DOM needs a tick to settle layout before
   // we call focus() on its first item.
   document.addEventListener("keydown", _settingsMenuCloseHandler);
-  var activeMenu = menu;
-  var closeHandler = _settingsMenuCloseHandler;
+  const activeMenu = menu;
+  const closeHandler = _settingsMenuCloseHandler;
   setTimeout(function () {
     if (_settingsMenu !== activeMenu || !closeHandler) return;
     document.addEventListener("mousedown", closeHandler);
-    var first = activeMenu.querySelector(".ws-tab-dropdown-item");
+    const first = activeMenu.querySelector(".ws-tab-dropdown-item");
     if (first) first.focus();
   }, 0);
 }
@@ -6149,10 +6155,10 @@ function closeSettingsMenu() {
 }
 
 function loadMcpConnections() {
-  var loadingEl = document.getElementById("settings-mcp-loading");
-  var emptyEl = document.getElementById("settings-mcp-empty");
-  var tableEl = document.getElementById("settings-mcp-table");
-  var errorEl = document.getElementById("settings-mcp-error");
+  const loadingEl = document.getElementById("settings-mcp-loading");
+  const emptyEl = document.getElementById("settings-mcp-empty");
+  const tableEl = document.getElementById("settings-mcp-table");
+  const errorEl = document.getElementById("settings-mcp-error");
   if (!loadingEl || !emptyEl || !tableEl || !errorEl) return;
   loadingEl.style.display = "";
   emptyEl.style.display = "none";
@@ -6166,7 +6172,7 @@ function loadMcpConnections() {
     })
     .then(function (data) {
       loadingEl.style.display = "none";
-      var connections =
+      const connections =
         data && Array.isArray(data.connections) ? data.connections : [];
       renderMcpConnections(connections);
       // Clear AFTER the table renders so the badge reflects "user has
@@ -6193,9 +6199,9 @@ function _clearChildren(node) {
 }
 
 function renderMcpConnections(list) {
-  var emptyEl = document.getElementById("settings-mcp-empty");
-  var tableEl = document.getElementById("settings-mcp-table");
-  var tbody = document.getElementById("settings-mcp-tbody");
+  const emptyEl = document.getElementById("settings-mcp-empty");
+  const tableEl = document.getElementById("settings-mcp-table");
+  const tbody = document.getElementById("settings-mcp-tbody");
   if (!emptyEl || !tableEl || !tbody) return;
   if (!list.length) {
     tableEl.style.display = "none";
@@ -6205,24 +6211,24 @@ function renderMcpConnections(list) {
   emptyEl.style.display = "none";
   tableEl.style.display = "";
   _clearChildren(tbody);
-  for (var i = 0; i < list.length; i++) {
-    var conn = list[i];
-    var tr = document.createElement("tr");
+  for (let i = 0; i < list.length; i++) {
+    const conn = list[i];
+    const tr = document.createElement("tr");
 
-    var serverTd = document.createElement("td");
+    const serverTd = document.createElement("td");
     serverTd.textContent = conn.server_name || "";
     tr.appendChild(serverTd);
 
-    var scopesTd = document.createElement("td");
+    const scopesTd = document.createElement("td");
     scopesTd.textContent = conn.scopes || "(none)";
     tr.appendChild(scopesTd);
 
-    var createdTd = document.createElement("td");
+    const createdTd = document.createElement("td");
     createdTd.textContent = _formatRelativeTimestamp(conn.created);
     createdTd.title = conn.created || "";
     tr.appendChild(createdTd);
 
-    var refreshedTd = document.createElement("td");
+    const refreshedTd = document.createElement("td");
     if (conn.last_refreshed) {
       refreshedTd.textContent = _formatRelativeTimestamp(conn.last_refreshed);
       refreshedTd.title = conn.last_refreshed;
@@ -6231,12 +6237,12 @@ function renderMcpConnections(list) {
     }
     tr.appendChild(refreshedTd);
 
-    var actionTd = document.createElement("td");
-    var btn = document.createElement("button");
+    const actionTd = document.createElement("td");
+    const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "settings-revoke-btn";
     btn.textContent = "Revoke";
-    var serverNameForRevoke = conn.server_name || "";
+    const serverNameForRevoke = conn.server_name || "";
     btn.setAttribute(
       "aria-label",
       "Revoke connection to " + serverNameForRevoke,
@@ -6256,8 +6262,8 @@ function renderMcpConnections(list) {
 function promptRevokeMcp(server) {
   if (!server) return;
   _pendingRevokeServer = server;
-  var msg = document.getElementById("revoke-mcp-message");
-  var overlay = document.getElementById("revoke-mcp-overlay");
+  const msg = document.getElementById("revoke-mcp-message");
+  const overlay = document.getElementById("revoke-mcp-overlay");
   if (msg) {
     msg.textContent =
       "Disconnect " +
@@ -6274,12 +6280,12 @@ function promptRevokeMcp(server) {
       return;
     }
     if (e.key === "Tab") {
-      var box = document.getElementById("revoke-mcp-box");
+      const box = document.getElementById("revoke-mcp-box");
       if (!box) return;
-      var focusable = box.querySelectorAll("button");
+      const focusable = box.querySelectorAll("button");
       if (!focusable.length) return;
-      var first = focusable[0];
-      var last = focusable[focusable.length - 1];
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last.focus();
@@ -6291,13 +6297,15 @@ function promptRevokeMcp(server) {
   };
   document.addEventListener("keydown", _revokeMcpTrap);
 
-  var cancelBtn = overlay ? overlay.querySelector("button:not(.danger)") : null;
+  const cancelBtn = overlay
+    ? overlay.querySelector("button:not(.danger)")
+    : null;
   if (cancelBtn) cancelBtn.focus();
 }
 
 function cancelRevokeMcp() {
   _pendingRevokeServer = null;
-  var overlay = document.getElementById("revoke-mcp-overlay");
+  const overlay = document.getElementById("revoke-mcp-overlay");
   if (overlay) overlay.style.display = "none";
   if (_revokeMcpTrap) {
     document.removeEventListener("keydown", _revokeMcpTrap);
@@ -6306,7 +6314,7 @@ function cancelRevokeMcp() {
 }
 
 function confirmRevokeMcp() {
-  var server = _pendingRevokeServer;
+  const server = _pendingRevokeServer;
   if (!server) {
     cancelRevokeMcp();
     return;
@@ -6329,11 +6337,11 @@ function confirmRevokeMcp() {
 function _formatRelativeTimestamp(iso) {
   if (!iso) return "—";
   try {
-    var d = new Date(iso);
+    const d = new Date(iso);
     if (isNaN(d.getTime())) return iso;
-    var now = new Date();
-    var diffMs = now.getTime() - d.getTime();
-    var sec = Math.round(diffMs / 1000);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const sec = Math.round(diffMs / 1000);
     if (sec < 60) return "just now";
     if (sec < 3600) return Math.round(sec / 60) + "m ago";
     if (sec < 86400) return Math.round(sec / 3600) + "h ago";
@@ -6345,7 +6353,7 @@ function _formatRelativeTimestamp(iso) {
 
 document.addEventListener("keydown", function (e) {
   // Defer to modal's own keydown handler when any modal is open
-  var modalIds = [
+  const modalIds = [
     "new-ws-overlay",
     "edit-title-overlay",
     "delete-ws-overlay",
@@ -6353,8 +6361,8 @@ document.addEventListener("keydown", function (e) {
     "settings-overlay",
     "revoke-mcp-overlay",
   ];
-  for (var mi = 0; mi < modalIds.length; mi++) {
-    var modal = document.getElementById(modalIds[mi]);
+  for (let mi = 0; mi < modalIds.length; mi++) {
+    const modal = document.getElementById(modalIds[mi]);
     if (modal && modal.style.display !== "none") return;
   }
   // Settings menu is a transient dropdown, not a modal overlay, but
@@ -6372,7 +6380,7 @@ document.addEventListener("keydown", function (e) {
   }
 
   // Get focused pane for approval / busy checks
-  var pane = getFocusedPane();
+  const pane = getFocusedPane();
 
   // Escape: cancel generation when busy
   if (e.key === "Escape" && pane && pane.busy && !pane.pendingApproval) {
@@ -6396,8 +6404,8 @@ document.addEventListener("keydown", function (e) {
   // Ctrl+1..9: switch tabs
   if (e.ctrlKey && e.key >= "1" && e.key <= "9") {
     e.preventDefault();
-    var idx = parseInt(e.key) - 1;
-    var wsIds = Object.keys(workstreams);
+    const idx = parseInt(e.key) - 1;
+    const wsIds = Object.keys(workstreams);
     if (idx < wsIds.length) switchTab(wsIds[idx]);
     return;
   }
@@ -6414,8 +6422,8 @@ document.addEventListener("keydown", function (e) {
   // still work when no workstream is focused.
   if (e.ctrlKey && e.shiftKey) {
     closeTabDropdown();
-    var wsActionKey = e.key.toLowerCase();
-    var activeWsId = !dashboardVisible && getCurrentWsId();
+    const wsActionKey = e.key.toLowerCase();
+    const activeWsId = !dashboardVisible && getCurrentWsId();
     if (wsActionKey === "e" && activeWsId) {
       e.preventDefault();
       editWorkstreamTitle();
@@ -6454,7 +6462,7 @@ document.addEventListener("keydown", function (e) {
     (e.key === "ArrowLeft" || e.key === "ArrowRight")
   ) {
     e.preventDefault();
-    var paneIds = [];
+    const paneIds = [];
     (function collectIds(n) {
       if (!n) return;
       if (n.type === "leaf") {
@@ -6465,7 +6473,7 @@ document.addEventListener("keydown", function (e) {
       }
     })(splitRoot);
     if (paneIds.length > 1) {
-      var ci = paneIds.indexOf(focusedPaneId);
+      let ci = paneIds.indexOf(focusedPaneId);
       if (e.key === "ArrowRight") ci = (ci + 1) % paneIds.length;
       else ci = (ci - 1 + paneIds.length) % paneIds.length;
       setFocusedPane(paneIds[ci]);
@@ -6484,7 +6492,7 @@ document.addEventListener("keydown", function (e) {
 
   // Inline approval keybindings
   if (pane && pane.pendingApproval) {
-    var fbInput =
+    const fbInput =
       pane.approvalBlockEl &&
       pane.approvalBlockEl.querySelector(".ts-approval-feedback");
     if (fbInput && document.activeElement === fbInput) {
@@ -6507,13 +6515,13 @@ document.addEventListener("keydown", function (e) {
     } else if (e.key === "a") {
       pane.resolveApproval(true, true, pane.getFeedback());
     } else if (e.key === "d") {
-      var details = pane.approvalBlockEl
+      const details = pane.approvalBlockEl
         ? pane.approvalBlockEl.querySelectorAll(".verdict-detail")
         : [];
       details.forEach(function (d) {
-        var isHidden = d.style.display === "none";
+        const isHidden = d.style.display === "none";
         d.style.display = isHidden ? "block" : "none";
-        var btn2 = d.previousElementSibling
+        const btn2 = d.previousElementSibling
           ? d.previousElementSibling.querySelector(".verdict-expand")
           : null;
         if (btn2) btn2.textContent = isHidden ? "hide" : "details";
@@ -6529,14 +6537,14 @@ document.addEventListener("keydown", function (e) {
       resolvePlan("");
     } else if (e.key === "Escape") {
       e.preventDefault();
-      var hasFb =
+      const hasFb =
         document.getElementById("plan-feedback").value.trim().length > 0;
       resolvePlan(hasFb ? "" : "reject");
     } else if (e.key === "Tab") {
-      var focusable = document.querySelectorAll(
+      const focusable = document.querySelectorAll(
         "#plan-dialog input, #plan-dialog button",
       );
-      var first = focusable[0],
+      const first = focusable[0],
         last = focusable[focusable.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
@@ -6563,7 +6571,7 @@ function initWorkstreams() {
         workstreams[ws.ws_id] = { name: ws.name, state: ws.state };
       });
       connectGlobalSSE();
-      var wsIds = Object.keys(workstreams);
+      const wsIds = Object.keys(workstreams);
       if (!wsIds.length) {
         renderTabBar();
         showDashboard();
@@ -6571,21 +6579,21 @@ function initWorkstreams() {
       }
       if (!Object.keys(panes).length) {
         if (!restoreLayout()) {
-          var p = createPane(wsIds[0]);
+          const p = createPane(wsIds[0]);
           splitRoot = { type: "leaf", pane: p };
           setFocusedPane(p.id);
         }
         renderLayout();
       }
       renderTabBar();
-      for (var id in panes) {
+      for (let id in panes) {
         if (!panes[id].evtSource) {
           panes[id].showEmptyState();
           panes[id].connectSSE(panes[id].wsId);
         }
       }
-      var params = new URLSearchParams(location.search);
-      var targetWs = params.get("ws_id");
+      const params = new URLSearchParams(location.search);
+      const targetWs = params.get("ws_id");
       if (targetWs && workstreams[targetWs]) {
         history.replaceState(
           { turnstone: "workstream", wsId: targetWs },
@@ -6617,11 +6625,11 @@ function loadInterfaceSettings() {
       return r.json();
     })
     .then(function (data) {
-      var settings = data.settings || [];
-      for (var i = 0; i < settings.length; i++) {
-        var s = settings[i];
+      const settings = data.settings || [];
+      for (let i = 0; i < settings.length; i++) {
+        const s = settings[i];
         if (s.key && s.key.indexOf("interface.") === 0) {
-          var lsKey = "turnstone_" + s.key;
+          const lsKey = "turnstone_" + s.key;
           try {
             // Only write server value if no local value exists — this
             // preserves the user's theme choice when switching between
@@ -6635,13 +6643,13 @@ function loadInterfaceSettings() {
       }
       // Apply theme from localStorage (set by theme.js initTheme or
       // a previous toggle) — don't let a node's default override it.
-      var theme = localStorage.getItem("turnstone_interface.theme");
-      var currentTheme = document.documentElement.dataset.theme;
+      const theme = localStorage.getItem("turnstone_interface.theme");
+      const currentTheme = document.documentElement.dataset.theme;
       if (theme) {
-        var effectiveTheme = theme === "light" ? "light" : "";
+        const effectiveTheme = theme === "light" ? "light" : "";
         if (effectiveTheme !== currentTheme) {
           document.documentElement.dataset.theme = effectiveTheme;
-          var btn = document.getElementById("theme-toggle");
+          const btn = document.getElementById("theme-toggle");
           if (btn) {
             btn.textContent = theme === "light" ? "\u2600" : "\u263E";
             btn.title =


### PR DESCRIPTION
## Summary

- Mechanical `var` → `const`/`let` sweep across 6 legacy JS bundles + `ui/static/app.js`: **2542 declarations** converted, ending at **77% `const` / 23% `let`** (line-start, excluding for-init counters).
- Three CI guards added to keep the post-sweep state honest: `node --check` per bundle, static var-free assertion, scope-aware const-reassign guard with regex-literal-aware brace tracking, and a runtime smoke for `_redactApiKeys` via `node -e`.
- Two latent bugs surfaced during the sweep (both `const X = …; X = …`) and fixed with regression tests:
  - `_redactApiKeys`'s `let redacted` was tightened to `const` by the walker (regex-literal-blindness in `find_decl_extent` over-extended the declaration span and skipped the JSON-pass reassignment); would have thrown `TypeError` on every tool-output render.
  - `_paneCounter` was tightened to `const`; `class Pane { constructor() { … ++_paneCounter … }}` would have thrown `TypeError` on every `new Pane()`.  The lint regex initially matched postfix `X++` but not prefix `++X` — that gap is now closed.

## Commit shape (10 commits, smallest-first)

| # | File | `var → ` | const | let | for-let |
|---|---|---:|---:|---:|---:|
| 1 | `shared_static/kb.js` | 8 | 6 | 2 | 0 |
| 2 | `shared_static/utils.js` | 13 | 15 | 1 | 1 |
| 3 | `shared_static/auth.js` | 71 | 55 | 12 | 4 |
| 4 | `console/static/app.js` | 275 | 232 | 38 | 5 |
| 5 | `console/static/governance.js` | 534 | 337 | 133 | 64 |
| 6 | `console/static/admin.js` | 831 | 606 | 138 | 87 |
| 7 | `ui/static/app.js` | 810 | 663 | 96 | 50 |
| 8 | scope-aware const-tightening on 3 console bundles (+46 const) | | | | |
| 9 | lint guards in `tests/test_app_js.py` (+22 new tests, 49 total) | | | | |
| 10 | post-review fix: `_paneCounter` const-reassign + extend lint regex to prefix `++X` / `--X` | | | | |

Each per-file commit is independently mechanical and independently verifiable (`node --check` + `pytest tests/test_app_js.py`).

## Out of scope (deliberate)

- `function () {}` → arrow conversion.
- `for (var i; …)` → `for…of` / `.forEach` rewrites.
- Template literal conversion, spread-operator adoption, ES modules.
- `coordinator.js` (already modern; 3 surviving `var` are intentional per the original DOM-cleanup sweep).
- `shared_static/renderer.js` (trusted boundary; out of scope by design).

## Known follow-up

Multi-pane refresh through the console proxy can leave the dashboard stuck on \"Loading…\" with 4 SSE connections interrupted.  Surfaced during manual smoke; appears latent since PR A's class-Pane refactor (the dashboard load / restore / SSE flow itself was unchanged by this sweep beyond keyword swaps).  Will open a follow-up issue with the exact reproducer.

## Test plan
- [x] `node --check` clean on all 7 swept bundles.
- [x] `pytest tests/test_app_js.py` — 49/49 (27 pre-existing + 22 new).
- [x] `ruff check` + `mypy` clean on `tests/test_app_js.py`.
- [x] Lint guards verified by injection (revert `_paneCounter` or `redacted` to `const` → static guard fires + runtime smoke fires).
- [x] Multi-pass `/review` pipeline against the stack — 1 critical (redacted) + 1 critical (_paneCounter) + 1 major (test gap) + 2 minor caught and fixed across three review passes.
- [ ] Manual browser smoke for the multi-pane refresh case (deferred to follow-up issue).