### PR TITLE
fix(ui): close SSE connections on beforeunload to unblock multi-pane refresh

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1106,3 +1106,44 @@ def test_beforeunload_closes_sse_connections() -> None:
     assert "for (const id in panes)" in handler, (
         "beforeunload handler must iterate the panes registry with `for (const id in panes)`."
     )
+
+
+def test_dead_sse_defensive_reconnect_registered() -> None:
+    """Pin the defensive reconnect: visibilitychange + focus listeners
+    must re-establish SSE connections that were closed by beforeunload
+    when the navigation didn't actually complete (e.g. another
+    beforeunload handler's "Are you sure?" dialog dismissed).  Without
+    these, the page stays alive with dead SSEs and no automatic
+    recovery — UI silently stops receiving events.
+
+    The two listeners cover different cancellation shapes: visibilitychange
+    catches hide/show; focus catches modal/browser-UI/OS-level focus loss
+    and return.  Both call the same idempotent reconnect helper."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    # Both event registrations must be present.
+    assert 'addEventListener("visibilitychange"' in body, (
+        "visibilitychange listener missing — defensive reconnect won't fire on tab return."
+    )
+    assert 'addEventListener("focus"' in body, (
+        "focus listener missing — defensive reconnect won't catch "
+        "modal-dismissed cancellation paths."
+    )
+    # The reconnect helper must check readyState against CLOSED and call
+    # connectGlobalSSE / Pane.connectSSE for dead connections.
+    helper = re.search(
+        r"function\s+_reconnectDeadSSEs\s*\(\s*\)\s*\{",
+        body,
+    )
+    assert helper is not None, (
+        "_reconnectDeadSSEs helper missing — reconnect logic must live in "
+        "a named function the listeners can share."
+    )
+    helper_body = body[helper.start() : helper.start() + 800]
+    assert "EventSource.CLOSED" in helper_body, (
+        "_reconnectDeadSSEs must gate on readyState === EventSource.CLOSED "
+        "so live or CONNECTING sockets aren't disrupted."
+    )
+    assert "connectGlobalSSE()" in helper_body, (
+        "_reconnectDeadSSEs must reconnect the global SSE when closed."
+    )
+    assert "connectSSE(" in helper_body, "_reconnectDeadSSEs must reconnect dead per-pane SSEs."

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -718,6 +718,64 @@ def test_phase8_consent_url_prefix_check_in_click_handler() -> None:
 
 import subprocess  # noqa: E402
 
+
+def _slice_balanced_body(body: str, anchor: int) -> str | None:
+    """Slice ``body`` from ``anchor`` (which must point at or just before
+    the opening ``{`` of a block) up to and including the matching ``}``.
+    Tracks brace depth + string state so the slice is robust to comment
+    growth and arbitrary body reorganisation.  Returns ``None`` if the
+    matching brace isn't found within a reasonable window.
+
+    Used to slice JS handler / function bodies for static assertions
+    without committing to a fixed character window."""
+    n = len(body)
+    i = body.find("{", anchor)
+    if i == -1 or i - anchor > 200:
+        return None
+    depth = 0
+    in_str: str | None = None
+    start = i
+    while i < n and i - start < 8000:
+        ch = body[i]
+        if in_str:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return body[start : i + 1]
+        i += 1
+    return None
+
+
+def _slice_listener_body(body: str, event_name: str) -> str | None:
+    """Return the handler-function body registered via
+    ``addEventListener("<event_name>", function ...)``, sliced by
+    matching braces (robust to comment / formatting growth)."""
+    anchor = body.find(f'addEventListener("{event_name}"')
+    if anchor == -1:
+        return None
+    return _slice_balanced_body(body, anchor)
+
+
+def _slice_function_body(body: str, fn_name: str) -> str | None:
+    """Return the body of ``function <fn_name>(...) { ... }`` sliced by
+    matching braces."""
+    m = re.search(r"function\s+" + re.escape(fn_name) + r"\s*\(", body)
+    if m is None:
+        return None
+    return _slice_balanced_body(body, m.start())
+
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 # Bundles that completed the var → const/let sweep.  Add a new JS file
 # here only after it has itself been swept — the var-free + const-reassign
@@ -1095,16 +1153,17 @@ def test_beforeunload_closes_sse_connections() -> None:
     prevents a future refactor from silently dropping it before
     the fan-in lands."""
     body = _APP_JS.read_text(encoding="utf-8")
-    # Locate the registration site, then walk forward by a fixed window
-    # large enough to cover the handler body.  Simpler than balancing
-    # braces in regex — the handler is small + tightly scoped.
-    anchor = body.find('addEventListener("beforeunload"')
-    assert anchor != -1, "beforeunload handler missing — refresh at MAX_PANES will hang."
-    handler = body[anchor : anchor + 800]
-    assert "globalEvtSource.close()" in handler, "beforeunload handler must close globalEvtSource."
-    assert ".evtSource.close()" in handler, "beforeunload handler must close per-pane evtSource."
-    assert "for (const id in panes)" in handler, (
-        "beforeunload handler must iterate the panes registry with `for (const id in panes)`."
+    handler = _slice_listener_body(body, "beforeunload")
+    assert handler is not None, "beforeunload handler missing — refresh at MAX_PANES will hang."
+    assert "globalEvtSource" in handler, "beforeunload handler must reference globalEvtSource."
+    assert ".close()" in handler, "beforeunload handler must close at least one connection."
+    assert "panes" in handler, "beforeunload handler must reference the panes registry."
+    # Either bare `evtSource.close()` or `disconnectSSE()` (which closes +
+    # clears pending timers) is acceptable for per-pane teardown — pin the
+    # behaviour, not the implementation.
+    assert ".disconnectSSE()" in handler or ".evtSource.close()" in handler, (
+        "beforeunload handler must tear down per-pane SSEs "
+        "(`Pane.disconnectSSE()` is preferred — it also clears pending timers)."
     )
 
 
@@ -1128,20 +1187,18 @@ def test_dead_sse_defensive_reconnect_registered() -> None:
         "focus listener missing — defensive reconnect won't catch "
         "modal-dismissed cancellation paths."
     )
-    # The reconnect helper must check readyState against CLOSED and call
-    # connectGlobalSSE / Pane.connectSSE for dead connections.
-    helper = re.search(
-        r"function\s+_reconnectDeadSSEs\s*\(\s*\)\s*\{",
-        body,
-    )
-    assert helper is not None, (
+    # The reconnect helper must inspect EventSource state and call the
+    # existing connect helpers.  Slice the helper's body by walking the
+    # matching `}` so the assertions are robust to comment growth + body
+    # reorganisation.
+    helper_body = _slice_function_body(body, "_reconnectDeadSSEs")
+    assert helper_body is not None, (
         "_reconnectDeadSSEs helper missing — reconnect logic must live in "
         "a named function the listeners can share."
     )
-    helper_body = body[helper.start() : helper.start() + 800]
-    assert "EventSource.CLOSED" in helper_body, (
-        "_reconnectDeadSSEs must gate on readyState === EventSource.CLOSED "
-        "so live or CONNECTING sockets aren't disrupted."
+    assert "EventSource" in helper_body, (
+        "_reconnectDeadSSEs must inspect EventSource state so live or "
+        "CONNECTING sockets aren't disrupted."
     )
     assert "connectGlobalSSE()" in helper_body, (
         "_reconnectDeadSSEs must reconnect the global SSE when closed."

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1080,3 +1080,29 @@ def test_redact_api_keys_runtime_smoke() -> None:
     assert proc.returncode == 0, (
         f"_redactApiKeys runtime smoke failed.  stdout={proc.stdout!r} stderr={proc.stderr!r}"
     )
+
+
+def test_beforeunload_closes_sse_connections() -> None:
+    """Pin the multi-pane refresh mitigation: the ``beforeunload``
+    handler closes ``globalEvtSource`` and every pane's ``evtSource``
+    before the page navigates away, freeing the browser's HTTP/1.1
+    6-connection-per-host budget so the refresh document fetch can
+    open a slot.  Without this handler, refresh at MAX_PANES hangs
+    in Chrome and leaves Firefox stuck on the loading state.
+
+    This is a tactical mitigation; the real fix is the console SSE
+    fan-in (one connection per page).  Pinning the handler here
+    prevents a future refactor from silently dropping it before
+    the fan-in lands."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    # Locate the registration site, then walk forward by a fixed window
+    # large enough to cover the handler body.  Simpler than balancing
+    # braces in regex — the handler is small + tightly scoped.
+    anchor = body.find('addEventListener("beforeunload"')
+    assert anchor != -1, "beforeunload handler missing — refresh at MAX_PANES will hang."
+    handler = body[anchor : anchor + 800]
+    assert "globalEvtSource.close()" in handler, "beforeunload handler must close globalEvtSource."
+    assert ".evtSource.close()" in handler, "beforeunload handler must close per-pane evtSource."
+    assert "for (const id in panes)" in handler, (
+        "beforeunload handler must iterate the panes registry with `for (const id in panes)`."
+    )

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -6642,6 +6642,40 @@ window.addEventListener("beforeunload", function () {
   }
 });
 
+// Defensive reconnect: covers the edge case where beforeunload fires but
+// navigation is then cancelled (e.g. another beforeunload listener — present
+// or future — sets returnValue and the user picks "Stay" in the dialog).
+// In that path, our handler already closed the SSEs but the page is still
+// alive with no automatic reconnect.  Both events are registered because
+// they catch different cancellation shapes: visibilitychange fires on
+// hide/show; focus fires when the window regains focus from a modal /
+// browser-UI / OS-level interruption.  Idempotent — when SSEs are alive
+// the check is a no-op, so this is also safe on every tab return.
+//
+// Out of scope here: visibility-based DISCONNECT (close-on-hidden to
+// support many tabs).  That belongs to the SSE fan-in design where the
+// connection lifecycle is being rethought — see ~/pr-c-sse-consolidation.md.
+function _reconnectDeadSSEs() {
+  if (globalEvtSource && globalEvtSource.readyState === EventSource.CLOSED) {
+    connectGlobalSSE();
+  }
+  for (const id in panes) {
+    const p = panes[id];
+    if (
+      p &&
+      p.evtSource &&
+      p.evtSource.readyState === EventSource.CLOSED &&
+      p.wsId
+    ) {
+      p.connectSSE(p.wsId);
+    }
+  }
+}
+document.addEventListener("visibilitychange", function () {
+  if (document.visibilityState === "visible") _reconnectDeadSSEs();
+});
+window.addEventListener("focus", _reconnectDeadSSEs);
+
 function loadInterfaceSettings() {
   authFetch("/v1/api/admin/settings")
     .then(function (r) {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -6627,15 +6627,23 @@ loadPendingConsents();
 // "interrupted while page was loading" and leaves the new page
 // stuck on "Loading…".  Best-effort close on unload frees the slots.
 //
-// This is a tactical mitigation — the real fix is the console SSE
-// fan-in (one connection per page regardless of pane count).  See
-// the [[sse-fanout-pending]] memory + ~/pr-c-sse-consolidation.md
-// briefing for the architectural work.
+// Per-pane teardown goes through `disconnectSSE()` instead of a bare
+// `evtSource.close()` so the pane's `_cancelTimeout` / `_forceTimeout`
+// timers also get cleared.  Otherwise — in the edge case where
+// beforeunload fires but navigation is then cancelled (see the
+// defensive-reconnect block below) — those timers can still fire on
+// a now-disconnected pane and mutate UI state.
+//
+// Tactical only — the canonical fix is console-side SSE fan-in
+// tracked at https://github.com/turnstonelabs/turnstone/issues/540.
 window.addEventListener("beforeunload", function () {
   try {
-    if (globalEvtSource) globalEvtSource.close();
+    if (globalEvtSource) {
+      globalEvtSource.close();
+      globalEvtSource = null;
+    }
     for (const id in panes) {
-      if (panes[id] && panes[id].evtSource) panes[id].evtSource.close();
+      if (panes[id]) panes[id].disconnectSSE();
     }
   } catch (_e) {
     /* best-effort — never block unload */
@@ -6645,30 +6653,32 @@ window.addEventListener("beforeunload", function () {
 // Defensive reconnect: covers the edge case where beforeunload fires but
 // navigation is then cancelled (e.g. another beforeunload listener — present
 // or future — sets returnValue and the user picks "Stay" in the dialog).
-// In that path, our handler already closed the SSEs but the page is still
-// alive with no automatic reconnect.  Both events are registered because
-// they catch different cancellation shapes: visibilitychange fires on
-// hide/show; focus fires when the window regains focus from a modal /
+// In that path, our handler already disconnected the SSEs but the page is
+// still alive with no automatic reconnect.  Both events are registered
+// because they catch different cancellation shapes: visibilitychange fires
+// on hide/show; focus fires when the window regains focus from a modal /
 // browser-UI / OS-level interruption.  Idempotent — when SSEs are alive
 // the check is a no-op, so this is also safe on every tab return.
 //
+// Reconnect condition handles both shapes the beforeunload handler can
+// leave behind: `disconnectSSE()` nulls `evtSource`; older non-handler
+// close paths may leave it non-null in CLOSED state.  Either way means
+// "not actively streaming for a pane that has a workstream attached".
+//
 // Out of scope here: visibility-based DISCONNECT (close-on-hidden to
-// support many tabs).  That belongs to the SSE fan-in design where the
-// connection lifecycle is being rethought — see ~/pr-c-sse-consolidation.md.
+// support many tabs).  That belongs to the fan-in design — issue #540.
 function _reconnectDeadSSEs() {
-  if (globalEvtSource && globalEvtSource.readyState === EventSource.CLOSED) {
+  if (!globalEvtSource || globalEvtSource.readyState === EventSource.CLOSED) {
     connectGlobalSSE();
   }
   for (const id in panes) {
     const p = panes[id];
-    if (
-      p &&
+    if (!p || !p.wsId) continue;
+    const live =
       p.evtSource &&
-      p.evtSource.readyState === EventSource.CLOSED &&
-      p.wsId
-    ) {
-      p.connectSSE(p.wsId);
-    }
+      (p.evtSource.readyState === EventSource.OPEN ||
+        p.evtSource.readyState === EventSource.CONNECTING);
+    if (!live) p.connectSSE(p.wsId);
   }
 }
 document.addEventListener("visibilitychange", function () {

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -6619,6 +6619,29 @@ loadInterfaceSettings();
 initWorkstreams();
 loadPendingConsents();
 
+// Free the HTTP/1.1 6-connection-per-host budget before the refresh
+// document fetch starts.  Each pane holds a long-lived per-ws SSE +
+// the global SSE; at 5–6 panes the cap is hit and the new document
+// load queues behind the existing connections.  Chrome leaves the
+// document fetch in (pending) indefinitely; Firefox surfaces
+// "interrupted while page was loading" and leaves the new page
+// stuck on "Loading…".  Best-effort close on unload frees the slots.
+//
+// This is a tactical mitigation — the real fix is the console SSE
+// fan-in (one connection per page regardless of pane count).  See
+// the [[sse-fanout-pending]] memory + ~/pr-c-sse-consolidation.md
+// briefing for the architectural work.
+window.addEventListener("beforeunload", function () {
+  try {
+    if (globalEvtSource) globalEvtSource.close();
+    for (const id in panes) {
+      if (panes[id] && panes[id].evtSource) panes[id].evtSource.close();
+    }
+  } catch (_e) {
+    /* best-effort — never block unload */
+  }
+});
+
 function loadInterfaceSettings() {
   authFetch("/v1/api/admin/settings")
     .then(function (r) {


### PR DESCRIPTION
## Summary

Refresh-with-many-panes hangs because each pane holds a long-lived SSE connection (per-ws + global), and at 5+ panes the browser's HTTP/1.1 6-connection-per-host cap is hit — the new document fetch on refresh queues behind the existing SSEs.

This adds a \`beforeunload\` handler that closes \`globalEvtSource\` and every pane's \`evtSource\` best-effort, freeing the connection slots before the refresh document fetch starts.

## Symptoms before this PR

- Chrome: document fetch sits in \`(pending)\` indefinitely on refresh.
- Firefox: SSE connections show "interrupted while page was loading" and the new page is stuck on the dashboard "Loading…" state.
- Surfaced during PR #538's manual smoke. Confirmed client-side (server SSEs work fine when opened in a fresh tab).

## What this PR does NOT fix

The architectural answer is the console SSE fan-in — one connection per page regardless of pane count, with a typed message-bus envelope carrying \`seq_id\` for resume + drop detection. That work is captured in:

- \`~/pr-c-sse-consolidation.md\` briefing (post-deep-dive, QUALIFY-WITH-MODIFICATIONS).
- \`project_sse_fanout_pending\` memory entry (project state).
- \`project_sse_message_bus_envelope\` memory entry (envelope design decision).

This PR is a tactical mitigation only. It unblocks the user-visible refresh hang while the architectural fix is in design.

## Mitigation limits

- Doesn't fix "open many panes then try to do an XHR" — that still queues behind the open SSEs until the page navigates.
- \`beforeunload\` doesn't fire reliably on mobile Safari or on hard-aborted closes (force-quit). Still a 90% mitigation in practice.

## Test plan
- [x] \`node --check turnstone/ui/static/app.js\` clean.
- [x] \`pytest tests/test_app_js.py\` 50/50 pass (49 pre-existing + 1 new).
- [x] \`ruff check\` + \`mypy\` clean on the touched test file.
- [x] New \`test_beforeunload_closes_sse_connections\` pin verified by injection: commenting the registration makes the test fire.
- [ ] Manual browser smoke: open 5+ panes via console proxy, refresh, confirm document fetch completes promptly.