### PR TITLE
refactor(ui): renderVerdictBadge → DocumentFragment + insertAdjacent-HTML lint coverage

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -284,7 +284,7 @@ _UNSAFE_CODE_SINK_RE = re.compile(
     r"\.(?:inner|outer)"
     + r"HTML\s*\+?=(?!=)"
     + r"|\.insertAdjacent"
-    + r"HTML\("
+    + r"HTML\s*\("
     + r"|"
     + r"document"
     + r"\."

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -264,7 +264,10 @@ _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style
 #   * concat HTML-assignment  — inner/outer-HTML += value (the
 #     ``\+?`` makes the ``+`` optional so a regression switching the
 #     sink to concat-assignment doesn't bypass the lint)
-#   * legacy doc-write        — ``document.write(...)``
+#   * insertAdjacent HTML     — ``insertAdjacentHTML(...)`` (the
+#     ``HTML\(`` suffix excludes ``insertAdjacentElement``, which
+#     takes a DOM node and is not an XSS sink)
+#   * legacy doc-write        — ``document`` + ``.write(...)``
 #   * string-to-code helpers  — the JS ``ev`` + ``al`` builtin, the
 #     dynamic-Function constructor (``new`` + ``Function(...)``), and
 #     ``setTimeout``/``setInterval`` whose first arg is a string
@@ -277,15 +280,16 @@ _STYLE_CSS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/style
 # regex over the *entire file body* (not line-by-line) so that ``\s*``
 # can span newlines and catch multi-line sinks like
 # ``el.innerHTML\n  = X``.
-#
-# ``insertAdjacent`` + HTML is *not* covered here because two existing
-# call sites in ``ui/static/app.js`` consume ``renderVerdictBadge``
-# HTML output; broadening the lint would require cleaning that
-# helper first.  Tracked as a follow-up.
 _UNSAFE_CODE_SINK_RE = re.compile(
     r"\.(?:inner|outer)"
     + r"HTML\s*\+?=(?!=)"
-    + r"|document\.write\("
+    + r"|\.insertAdjacent"
+    + r"HTML\("
+    + r"|"
+    + r"document"
+    + r"\."
+    + r"write"
+    + r"\("
     + r"|\b"
     + r"eval\s*\("
     + r"|\bnew\s+"
@@ -404,9 +408,9 @@ def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
     """Whole-file pin: no direct DOM-write *or* dynamic-code sinks
     in any of the static JS bundles that render LLM output, tool
     results, operator-supplied data, or user input.  Covers
-    inner/outer-HTML assignment (plain and concat), legacy doc-write,
-    string-eval, dynamic-Function constructor, and string-first-arg
-    timer scheduling.
+    inner/outer-HTML assignment (plain and concat), insertAdjacentHTML,
+    legacy doc-write, string-eval, dynamic-Function constructor, and
+    string-first-arg timer scheduling.
 
     Two distinct cleanup postures across the targets:
 
@@ -429,13 +433,10 @@ def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
     All admin-side bundles are now covered.
 
     The regex covers inner/outer-HTML assignment (plain and
-    concat-assignment), legacy doc-write, and the dynamic-code
-    constructors (string-eval, dynamic-Function, string-first-arg
-    timer scheduling).  ``insertAdjacent`` + HTML is deliberately
-    *not* covered yet; two existing ``ui/static/app.js`` sites — the
-    verdict-badge writers — consume the HTML-string output of
-    ``renderVerdictBadge``, so broadening the lint requires cleaning
-    that helper first.
+    concat-assignment), ``insertAdjacentHTML``, legacy doc-write, and
+    the dynamic-code constructors (string-eval, dynamic-Function,
+    string-first-arg timer scheduling).  ``insertAdjacentElement`` is
+    intentionally not flagged — it takes a DOM node, not a string.
 
     Parametrized so each target is its own pytest case — a failure on
     one file is attributed precisely without masking offenders in the

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1437,10 +1437,7 @@ class Pane {
               // judgePending=false because any verdict on replay is
               // final — no spinner.
               if (tc.verdict) {
-                div.insertAdjacentHTML(
-                  "beforeend",
-                  renderVerdictBadge(tc.verdict, false),
-                );
+                div.appendChild(renderVerdictBadge(tc.verdict, false));
               }
               block.appendChild(div);
               // Output-guard finding — defer insertion until the tool
@@ -1652,10 +1649,7 @@ class Pane {
       // key in case a stale SSE payload arrives mid-deploy.
       const heuristic = item.heuristic_verdict || item.verdict;
       if (heuristic) {
-        block.insertAdjacentHTML(
-          "beforeend",
-          renderVerdictBadge(heuristic, judgePending),
-        );
+        block.appendChild(renderVerdictBadge(heuristic, judgePending));
         const rec = heuristic.recommendation || "review";
         if (
           !glowRec ||
@@ -4838,61 +4832,83 @@ function buildToolDiv(item) {
 }
 
 function renderVerdictBadge(verdict, judgePending) {
-  if (!verdict) return "";
+  if (!verdict) return document.createDocumentFragment();
   const risk = verdict.risk_level || "medium";
   const rec = verdict.recommendation || "review";
   const conf = Math.round((verdict.confidence || 0) * 100);
-  const summary = verdict.intent_summary || "";
-  let spinnerHtml = "";
+
+  const badge = document.createElement("div");
+  badge.className = "verdict-badge verdict-" + risk + " ts-verdict-badge";
+  badge.setAttribute("data-risk", risk);
+  if (verdict.call_id) badge.setAttribute("data-call-id", verdict.call_id);
+
+  const riskSpan = document.createElement("span");
+  riskSpan.className = "verdict-risk";
+  riskSpan.textContent = risk.toUpperCase();
+
+  const recSpan = document.createElement("span");
+  recSpan.className = "verdict-rec";
+  recSpan.textContent = rec;
+
+  const confSpan = document.createElement("span");
+  confSpan.className = "verdict-conf";
+  confSpan.textContent = conf + "%";
+
+  badge.append(riskSpan, recSpan, confSpan);
+
   if (judgePending) {
-    spinnerHtml =
-      '<span class="verdict-judge-spinner">' +
-      '<span class="judge-spinner-dot"></span> judge analyzing\u2026</span>';
+    const spinner = document.createElement("span");
+    spinner.className = "verdict-judge-spinner";
+    const dot = document.createElement("span");
+    dot.className = "judge-spinner-dot";
+    spinner.append(dot, " judge analyzing\u2026");
+    badge.appendChild(spinner);
   }
-  const callId = escapeHtml(verdict.call_id || "");
-  return (
-    '<div class="verdict-badge verdict-' +
-    escapeHtml(risk) +
-    ' ts-verdict-badge" data-risk="' +
-    escapeHtml(risk) +
-    '" data-call-id="' +
-    callId +
-    '">' +
-    '<span class="verdict-risk">' +
-    escapeHtml(risk.toUpperCase()) +
-    "</span>" +
-    '<span class="verdict-rec">' +
-    escapeHtml(rec) +
-    "</span>" +
-    '<span class="verdict-conf">' +
-    conf +
-    "%</span>" +
-    spinnerHtml +
-    '<button class="verdict-expand" onclick="toggleVerdictDetail(this)">details</button>' +
-    "</div>" +
-    '<div class="verdict-detail" style="display:none">' +
-    '<div class="verdict-summary">' +
-    escapeHtml(summary) +
-    "</div>" +
-    '<div class="verdict-reasoning">' +
-    escapeHtml(verdict.reasoning || "") +
-    "</div>" +
-    ((verdict.evidence || []).length
-      ? '<div class="verdict-evidence">' +
-        (verdict.evidence || [])
-          .map(function (e) {
-            return "<div>\u2022 " + escapeHtml(e) + "</div>";
-          })
-          .join("") +
-        "</div>"
-      : "") +
-    '<div class="verdict-tier">' +
-    escapeHtml(verdict.tier || "heuristic") +
-    " tier" +
-    (verdict.judge_model ? " | " + escapeHtml(verdict.judge_model) : "") +
-    "</div>" +
-    "</div>"
-  );
+
+  const expand = document.createElement("button");
+  expand.className = "verdict-expand";
+  expand.textContent = "details";
+  expand.addEventListener("click", function () {
+    toggleVerdictDetail(this);
+  });
+  badge.appendChild(expand);
+
+  const detail = document.createElement("div");
+  detail.className = "verdict-detail";
+  detail.style.display = "none";
+
+  const summaryEl = document.createElement("div");
+  summaryEl.className = "verdict-summary";
+  summaryEl.textContent = verdict.intent_summary || "";
+
+  const reasoningEl = document.createElement("div");
+  reasoningEl.className = "verdict-reasoning";
+  reasoningEl.textContent = verdict.reasoning || "";
+
+  detail.append(summaryEl, reasoningEl);
+
+  const evidence = verdict.evidence || [];
+  if (evidence.length) {
+    const evEl = document.createElement("div");
+    evEl.className = "verdict-evidence";
+    for (const ev of evidence) {
+      const row = document.createElement("div");
+      row.textContent = "\u2022 " + ev;
+      evEl.appendChild(row);
+    }
+    detail.appendChild(evEl);
+  }
+
+  const tierEl = document.createElement("div");
+  tierEl.className = "verdict-tier";
+  let tierText = (verdict.tier || "heuristic") + " tier";
+  if (verdict.judge_model) tierText += " | " + verdict.judge_model;
+  tierEl.textContent = tierText;
+  detail.appendChild(tierEl);
+
+  const frag = document.createDocumentFragment();
+  frag.append(badge, detail);
+  return frag;
 }
 
 function toggleVerdictDetail(btn) {


### PR DESCRIPTION
## Summary

Closes the DOM-cleanup arc started in #532. Two commits:

1. **`refactor(ui)`** — `renderVerdictBadge` (the verdict-badge HTML builder, ~50 lines) rewritten from string-concat + `insertAdjacentHTML("beforeend", ...)` into DOM construction (`createElement` + `textContent` + `setAttribute` + `append`) returning a `DocumentFragment` of two top-level siblings (`.verdict-badge` + `.verdict-detail`). Both call sites (`replayHistory` at the persisted-verdict path, the live approval flow) swap `insertAdjacentHTML` → `appendChild`. Inline `onclick="toggleVerdictDetail(this)"` replaced with `addEventListener("click", function () { toggleVerdictDetail(this); })` — non-arrow callback so `this` still binds to the button.

2. **`test(ci)`** — broadens `_UNSAFE_CODE_SINK_RE` in `tests/test_app_js.py` with an `.insertAdjacent` + `HTML\(` alternation, retires the two carve-out paragraphs (file-level comment + function docstring) that named `renderVerdictBadge` as the reason this sink was previously exempted. The `HTML\(` suffix excludes `insertAdjacentElement` — the five remaining `insertAdjacentElement` sites in `app.js` (lines 170, 216, 328, 330, 1578) stay clear (DOM-node arg, not an XSS sink).

After this PR every unsafe-write sink family — inner/outer-HTML assignment (plain + concat), `insertAdjacentHTML`, `document.write`, string-eval, dynamic-`Function`, string-first-arg `setTimeout`/`setInterval` — is forbidden across all 8 LLM-rendering bundles. The only remaining out-of-scope notes in the lint docstring are `shared_static/renderer.js` (the trusted boundary) and `coordinator.js` (cleaned in #532).

## Structural invariants preserved

The new `DocumentFragment` shape is load-bearing — three pre-existing consumers traverse `badge ↔ detail` as direct siblings:
- `Pane.updateVerdictBadge` at `app.js:368` (`badge.nextElementSibling`)
- `toggleVerdictDetail` (`badge.nextElementSibling`)
- The `d`-key keyboard handler (`d.previousElementSibling.querySelector(".verdict-expand")`)

`appendChild(fragment)` expands the fragment into siblings of the parent — preserving the invariant. A wrapper `<div>` would silently break all three.

CSS selectors are all class-based (no `>` / `+` / `~` combinators) — robust under either shape.

## Test plan

- [x] `node --check turnstone/ui/static/app.js` — clean
- [x] `pytest tests/test_app_js.py` — 51/51 pass, including all 8 sink-lint parametrized cases under the broadened regex
- [x] `pytest tests/test_app_js.py tests/test_admin*.py tests/test_console*.py tests/test_renderer_js.py` — 395/395 pass
- [x] `ruff check tests/test_app_js.py` — clean
- [x] Multi-stage `/review` pipeline run on the staged diff — one nit (pre-existing class-injection on `risk_level` via `className` interpolation, present in both old and new code; deferred as follow-up — out of scope for this DOM-conversion PR)
- [ ] Manual smoke (reviewer): trigger a tool call hitting the approval flow → badge shows risk/rec/conf + spinner + expand; click "details" → toggle works; reload a saved workstream with persisted verdicts → `replayHistory` paints the badge without spinner; click "details" → evidence/reasoning/tier render correctly

## Out of scope

- CSS changes (untouched).
- `toggleVerdictDetail` behavior (unchanged — stays a top-level free function).
- Other `Pane` methods or class structure.
- Other helpers in `app.js` beyond `renderVerdictBadge` and its 2 callers.
- New sink families beyond `insertAdjacent`-HTML.
- `coordinator.js`, `console/static/*.js`, `shared_static/*` files.

## Follow-up (not in this PR)

- Defensive enum-normalization of `verdict.risk_level` before interpolation into `className` / `data-risk` — flagged by `/review` as a nit, pre-existing (the old `escapeHtml` form didn't strip whitespace either). Worth doing alongside the next pass through this helper.