### PR TITLE
feat(sse): reconnect-with-replay foundation (PR-D for issue #540)

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1205,3 +1205,185 @@ def test_dead_sse_defensive_reconnect_registered() -> None:
         "_reconnectDeadSSEs must reconnect the global SSE when closed."
     )
     assert "connectSSE(" in helper_body, "_reconnectDeadSSEs must reconnect dead per-pane SSEs."
+
+
+# ---------------------------------------------------------------------------
+# PR-D reconnect-with-replay: onerror must preserve native EventSource
+# auto-reconnect for transient errors
+# ---------------------------------------------------------------------------
+#
+# PR-D adds a server-side per-ws ring buffer + ``Last-Event-ID`` replay so
+# a brief disconnect transparently replays the missed events.  That whole
+# foundation is defeated if the browser's ``onerror`` handler explicitly
+# closes the EventSource on a transient network error — closing forces a
+# CONNECTING -> CLOSED state transition that prevents native auto-reconnect
+# from firing.  The post-PR-D contract is: never call ``.close()`` on a
+# transient error; let native reconnect run with the ``Last-Event-ID``
+# header.  Explicit closes survive only on terminal branches (401 expired
+# session, workstream-reassignment to a different ws).  These guards pin
+# the contract so a future refactor can't silently regress it.
+
+
+def _strip_js_comments(src: str) -> str:
+    """Strip ``//`` and ``/* */`` comments while preserving string/regex
+    literals and keeping byte length identical (comments replaced with
+    spaces).  ``_slice_balanced_body`` doesn't skip comments, so an
+    apostrophe inside a comment (``can't``, ``don't``) opens a fake
+    string state that swallows braces until the next ``'``.  The new
+    onerror handlers carry these comments routinely; stripping comments
+    before brace-walking removes the hazard without re-architecting
+    the existing slice helper.
+    """
+    out: list[str] = []
+    n = len(src)
+    i = 0
+    in_str: str | None = None
+    while i < n:
+        ch = src[i]
+        if in_str:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        # Line comment: replace with spaces up to newline (preserve
+        # length so downstream offset math still works).
+        if ch == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            if j == -1:
+                j = n
+            out.append(" " * (j - i))
+            i = j
+            continue
+        # Block comment: replace with spaces up to closing */.
+        if ch == "/" and i + 1 < n and src[i + 1] == "*":
+            j = src.find("*/", i + 2)
+            if j == -1:
+                out.append(" " * (n - i))
+                i = n
+                continue
+            out.append(" " * (j + 2 - i))
+            i = j + 2
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = ch
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _onerror_block(body: str, anchor_substring: str) -> str | None:
+    """Slice an ``X.onerror = ...`` handler body by matching braces.
+
+    ``anchor_substring`` is something that uniquely identifies the
+    enclosing function so we don't accidentally pick the wrong
+    ``.onerror = function ...`` (the file has several).  Returns the
+    body between the matching braces, or ``None`` if not found.
+    Strips comments first so apostrophes in comment prose can't
+    desync the brace walker.
+    """
+    stripped = _strip_js_comments(body)
+    anchor = stripped.find(anchor_substring)
+    if anchor == -1:
+        return None
+    onerror = stripped.find(".onerror", anchor)
+    if onerror == -1:
+        return None
+    return _slice_balanced_body(stripped, onerror)
+
+
+def _onerror_preserves_native_reconnect(body: str, source_var: str) -> tuple[bool, str]:
+    """Return (passed, reason).
+
+    ``source_var`` is the EventSource handle (e.g. ``this.evtSource``,
+    ``globalEvtSource``, ``evtSource``).  An onerror handler passes if:
+      1. Either it never calls ``source_var.close()`` directly OR every
+         such close is inside a 401-detection branch / login-overlay
+         early-return / wsId-reassignment branch (allowed terminal
+         exits).
+      2. OR the handler explicitly references ``last_event_id`` —
+         escape hatch for a future redesign that abandons native
+         reconnect entirely but takes explicit responsibility for the
+         replay header.
+    """
+    # If the body threads last_event_id, the implementer has taken
+    # explicit responsibility for the replay header — escape hatch.
+    if "last_event_id" in body or "lastEventId" in body:
+        # Caller still has to ensure the body doesn't ALSO have a
+        # naked close() outside a terminal branch; rely on the regex
+        # search below as well.
+        pass
+    # Walk lines, track depth of common terminal branches.  Simple
+    # heuristic: any ``source_var.close()`` line that isn't preceded by
+    # ``status === 401`` or ``loginOverlay`` or ``disconnectSSE()`` in
+    # the surrounding line window is a defect.
+    pattern = re.compile(
+        re.escape(source_var) + r"\.close\(\s*\)",
+    )
+    matches = list(pattern.finditer(body))
+    if not matches:
+        return True, "no close() calls — native reconnect preserved"
+    for m in matches:
+        start = m.start()
+        # Look back ~400 chars for a terminal-branch marker on the
+        # same conditional path.  ``r.status === 401`` is the canonical
+        # 401-detection guard; ``loginOverlay`` is the login-modal
+        # early-return; ``disconnectSSE()`` immediately followed by
+        # setting a new wsId is the reassignment path.
+        window = body[max(0, start - 400) : start]
+        is_401_branch = "status === 401" in window or "r.status === 401" in window
+        is_login_branch = "loginOverlay" in window
+        is_reassign_branch = "disconnectSSE()" in window
+        if not (is_401_branch or is_login_branch or is_reassign_branch):
+            snippet = body[max(0, start - 80) : min(len(body), start + 80)]
+            return False, (
+                f"naked {source_var}.close() at offset {start} — would "
+                f"defeat native auto-reconnect for transient errors. "
+                f"Context: ...{snippet}..."
+            )
+    return True, "all close() calls are in terminal branches (401 / login / reassign)"
+
+
+def test_pane_connectsse_onerror_preserves_native_reconnect() -> None:
+    """``Pane.connectSSE``'s onerror must not close evtSource on
+    transient errors — PR-D's reconnect-with-replay depends on native
+    EventSource auto-reconnect firing with the ``Last-Event-ID`` header."""
+    body = _strip_js_comments(_APP_JS.read_text(encoding="utf-8"))
+    # Slice the Pane.connectSSE method body, then the onerror handler
+    # inside it.  Reuse the indent-agnostic class-method finder.
+    method_start = _pane_method_offset(body, "connectSSE")
+    method = _slice_balanced_body(body, method_start)
+    assert method is not None, "Pane.connectSSE method body not found"
+    # ``_onerror_block`` re-strips internally; passing the already-
+    # stripped method body is idempotent (no comments left to strip).
+    onerror = _onerror_block(method, "this.evtSource.onerror")
+    assert onerror is not None, "Pane.connectSSE.onerror not found"
+    passed, reason = _onerror_preserves_native_reconnect(onerror, "this.evtSource")
+    assert passed, f"Pane.connectSSE.onerror regressed: {reason}"
+
+
+def test_connectglobalsse_onerror_preserves_native_reconnect() -> None:
+    """``connectGlobalSSE`` is the global-SSE counterpart of
+    Pane.connectSSE — same close-defeats-reconnect contract."""
+    body = _strip_js_comments(_APP_JS.read_text(encoding="utf-8"))
+    fn = _slice_function_body(body, "connectGlobalSSE")
+    assert fn is not None, "connectGlobalSSE not found"
+    onerror = _onerror_block(fn, "globalEvtSource.onerror")
+    assert onerror is not None, "globalEvtSource.onerror not found"
+    passed, reason = _onerror_preserves_native_reconnect(onerror, "globalEvtSource")
+    assert passed, f"connectGlobalSSE.onerror regressed: {reason}"
+
+
+def test_coord_connectsse_onerror_preserves_native_reconnect() -> None:
+    """Coordinator's connectSSE has the same contract — without the
+    guard the coord's per-ws SSE silently drops events on any blip."""
+    coord_js = _REPO_ROOT / "turnstone/console/static/coordinator/coordinator.js"
+    body = _strip_js_comments(coord_js.read_text(encoding="utf-8"))
+    onerror = _onerror_block(body, "evtSource.onerror")
+    assert onerror is not None, "coordinator.js evtSource.onerror not found"
+    passed, reason = _onerror_preserves_native_reconnect(onerror, "evtSource")
+    assert passed, f"coordinator.js connectSSE.onerror regressed: {reason}"

--- a/tests/test_service_auth_boundary.py
+++ b/tests/test_service_auth_boundary.py
@@ -441,6 +441,108 @@ class TestProxySseNon200LogLevel:
 
 
 # ---------------------------------------------------------------------------
+# _proxy_sse — Last-Event-ID forwarding (PR-D reconnect-with-replay)
+# ---------------------------------------------------------------------------
+
+
+class TestProxySseLastEventIdForwarding:
+    """The console SSE proxy is the inbound SSE path for multi-node
+    deployments — every browser EventSource traverses it.  Without
+    forwarding ``Last-Event-ID``, the per-ws / global SSE handlers on
+    the node would treat every reconnect as a fresh connect and silently
+    drop events emitted during the disconnect window.  PR-D's whole
+    reconnect-with-replay foundation depends on these tests passing."""
+
+    @pytest.mark.anyio
+    async def test_forwards_last_event_id_header_to_upstream(self):
+        """Browser sends ``Last-Event-ID``; upstream node must receive it."""
+        from starlette.requests import Request
+
+        from turnstone.console.server import _proxy_sse
+
+        captured_headers: dict[str, str] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            # httpx headers are case-insensitive; capture lowercased.
+            captured_headers.update({k.lower(): v for k, v in req.headers.items()})
+            return httpx.Response(
+                200, text="data: {}\n\n", headers={"content-type": "text/event-stream"}
+            )
+
+        sse_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        proxy_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/node/n/api/workstreams/ws-1/events",
+            "headers": [(b"last-event-id", b"42")],
+            "query_string": b"",
+            "app": MagicMock(
+                state=SimpleNamespace(proxy_sse_client=sse_client, proxy_client=proxy_client)
+            ),
+        }
+
+        async def _receive():
+            return {"type": "http.request", "body": b""}
+
+        request = Request(scope, receive=_receive)
+        response = await _proxy_sse(
+            request, "http://node-1:8001", "workstreams/ws-1/events", api_prefix="api"
+        )
+        # Drain so the upstream call actually fires.
+        async for _ in response.body_iterator:  # type: ignore[attr-defined]
+            pass
+
+        assert captured_headers.get("last-event-id") == "42", (
+            f"Last-Event-ID not forwarded to upstream; got headers={captured_headers!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_omits_last_event_id_when_client_did_not_send_one(self):
+        """Fresh connect (no header on the browser side) → no header
+        added on the upstream side either.  Guards against
+        accidentally injecting a stale or fabricated value."""
+        from starlette.requests import Request
+
+        from turnstone.console.server import _proxy_sse
+
+        captured_headers: dict[str, str] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured_headers.update({k.lower(): v for k, v in req.headers.items()})
+            return httpx.Response(
+                200, text="data: {}\n\n", headers={"content-type": "text/event-stream"}
+            )
+
+        sse_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        proxy_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/node/n/api/workstreams/ws-1/events",
+            "headers": [],
+            "query_string": b"",
+            "app": MagicMock(
+                state=SimpleNamespace(proxy_sse_client=sse_client, proxy_client=proxy_client)
+            ),
+        }
+
+        async def _receive():
+            return {"type": "http.request", "body": b""}
+
+        request = Request(scope, receive=_receive)
+        response = await _proxy_sse(
+            request, "http://node-1:8001", "workstreams/ws-1/events", api_prefix="api"
+        )
+        async for _ in response.body_iterator:  # type: ignore[attr-defined]
+            pass
+
+        assert "last-event-id" not in captured_headers, (
+            f"upstream got an unexpected Last-Event-ID; headers={captured_headers!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Gated cluster_events_sse — 503 on scope error (0a)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -50,8 +50,13 @@ def test_enqueue_fans_out_to_all_listeners() -> None:
     lq1 = ui._register_listener()
     lq2 = ui._register_listener()
     ui._enqueue({"type": "hello"})
-    assert lq1.get_nowait() == {"type": "hello", "ws_id": "ws-1"}
-    assert lq2.get_nowait() == {"type": "hello", "ws_id": "ws-1"}
+    # ``_enqueue`` stamps ``_event_id`` on every event so the ring
+    # buffer can key replay against ``Last-Event-ID``; non-token
+    # events (``hello`` isn't ``content`` / ``reasoning``) skip
+    # ``_seq``.  Both listeners observe the SAME dict reference
+    # (covered by ``test_listeners_share_dict_reference_warning``).
+    assert lq1.get_nowait() == {"type": "hello", "ws_id": "ws-1", "_event_id": 1}
+    assert lq2.get_nowait() == {"type": "hello", "ws_id": "ws-1", "_event_id": 1}
 
 
 def test_enqueue_preserves_existing_ws_id() -> None:
@@ -124,7 +129,12 @@ def test_resolve_plan_with_pending_broadcasts_plan_resolved() -> None:
     lq = ui._register_listener()
     ui.resolve_plan("accept")
     event = lq.get_nowait()
-    assert event == {"type": "plan_resolved", "feedback": "accept", "ws_id": "ws-1"}
+    assert event == {
+        "type": "plan_resolved",
+        "feedback": "accept",
+        "ws_id": "ws-1",
+        "_event_id": 1,
+    }
     assert ui._pending_plan_review is None
     assert ui._plan_event.is_set()
 
@@ -1072,7 +1082,7 @@ def test_on_content_token_writes_to_both_buffers() -> None:
     ui.on_content_token("hello")
     assert ui._ws_turn_content == ["hello"]
     assert ui._ws_inflight_content == ["hello"]
-    assert ui._ws_inflight_seq == 1
+    assert ui._event_id == 1
 
 
 def test_on_reasoning_token_writes_to_inflight_buffer_only() -> None:
@@ -1081,13 +1091,13 @@ def test_on_reasoning_token_writes_to_inflight_buffer_only() -> None:
     ui = _make_ui()
     ui.on_reasoning_token("thinking...")
     assert ui._ws_inflight_reasoning == ["thinking..."]
-    assert ui._ws_inflight_seq == 1
+    assert ui._event_id == 1
     # Multi-turn buffer is content-only and untouched by reasoning.
     assert ui._ws_turn_content == []
 
 
 def test_inflight_seq_advances_on_every_emit_even_at_cap() -> None:
-    """Cap-hit content tokens MUST advance ``_ws_inflight_seq``,
+    """Cap-hit content tokens MUST advance ``_event_id``,
     even though the buffer rejected the append. If seq stalled at
     high-water-pre-cap, a subscriber registering AFTER the cap is
     hit would capture ``snap_seq == stalled_seq`` and every
@@ -1101,12 +1111,12 @@ def test_inflight_seq_advances_on_every_emit_even_at_cap() -> None:
     chunk = "x" * 1024
     while ui._ws_inflight_content_size < _MAX_TURN_CONTENT_CHARS:
         ui.on_content_token(chunk)
-    seq_at_cap = ui._ws_inflight_seq
+    seq_at_cap = ui._event_id
 
     # Cap-hit token: seq MUST advance (no buffer append, but the
     # event still gets a fresh seq for the dedup filter).
     ui.on_content_token(chunk)
-    assert ui._ws_inflight_seq == seq_at_cap + 1
+    assert ui._event_id == seq_at_cap + 1
     # Buffer remains bounded — the cap-hit token is NOT in inflight.
     assert ui._ws_inflight_content_size <= _MAX_TURN_CONTENT_CHARS + len(chunk)
 
@@ -1198,7 +1208,7 @@ def test_inflight_snapshot_empty_during_post_commit_tool_window() -> None:
     monotonic (carries the high-water mark across turn boundaries)."""
     ui = _make_ui()
     ui.on_content_token("Calling tool with these args: ")
-    seq_pre_commit = ui._ws_inflight_seq
+    seq_pre_commit = ui._event_id
     ui.on_turn_committed()  # session.py fires this after messages.append
     # We're now in the tool-execution window. A reconnecting client
     # would call register_listener_with_in_progress_snapshot.
@@ -1394,13 +1404,13 @@ def test_snapshot_and_consume_does_not_reset_seq_at_idle_or_error() -> None:
     ui = _make_ui()
     ui.on_content_token("a")
     ui.on_content_token("b")
-    assert ui._ws_inflight_seq == 2
+    assert ui._event_id == 2
 
     ui.snapshot_and_consume_state_payload("idle")
-    assert ui._ws_inflight_seq == 2
+    assert ui._event_id == 2
 
     ui.snapshot_and_consume_state_payload("error")
-    assert ui._ws_inflight_seq == 2
+    assert ui._event_id == 2
 
 
 def test_listeners_share_dict_reference_warning() -> None:

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -1,0 +1,505 @@
+"""Tests for the SSE reconnect-with-replay foundation.
+
+Covers the three commits of the reconnect-with-replay PR at the
+boundaries that matter:
+
+  - :meth:`SessionUIBase.register_listener_with_replay` — the
+    per-ws ring buffer + ``Last-Event-ID`` slice semantics
+    (replay_ok / truncated / empty-buffer edge cases, order
+    preservation under concurrent emit, no skipped ids on
+    ``queue.Full``, cross-thread emit/replay consistency).
+  - :func:`make_events_handler` — ``id:`` field on every yielded
+    event from the buffer (replay or live), jittered ``retry:`` on
+    the first yield, ``replay_truncated`` envelope on stale
+    ``Last-Event-ID``, snapshot skip when replay covers the gap.
+
+The browser-side guard for the ``onerror`` close pattern lives in
+``test_app_js.py`` alongside the other static JS guards.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace as SimpleNS
+from typing import Any
+from unittest.mock import MagicMock
+
+from starlette.requests import Request
+
+from turnstone.core.session_routes import (
+    SessionEndpointConfig,
+    make_events_handler,
+)
+from turnstone.core.session_ui_base import SessionUIBase
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteUI(SessionUIBase):
+    """Minimal concrete subclass for direct UI tests."""
+
+
+def _make_ui(ws_id: str = "ws-1") -> _ConcreteUI:
+    return _ConcreteUI(ws_id=ws_id, user_id="u1")
+
+
+def _fake_request(
+    *,
+    headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
+    path_params: dict[str, str] | None = None,
+) -> Request:
+    """Construct a Starlette ``Request`` for the events handler.
+
+    The handler reads ``request.headers``, ``request.query_params``,
+    ``request.path_params``, and awaits ``request.is_disconnected()``.
+    Building a real ASGI scope keeps the test honest about the values
+    those properties resolve from.
+    """
+    header_list = []
+    if headers:
+        for k, v in headers.items():
+            header_list.append((k.lower().encode(), v.encode()))
+    query_string = "&".join(f"{k}={v}" for k, v in query.items()).encode() if query else b""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "headers": header_list,
+        "path": "/events",
+        "raw_path": b"/events",
+        "query_string": query_string,
+        "path_params": path_params or {},
+        "app": MagicMock(),
+    }
+
+    async def _recv() -> dict[str, Any]:  # noqa: RUF029 — async signature required
+        return {"type": "http.disconnect"}
+
+    return Request(scope, receive=_recv)
+
+
+async def _drain_until(
+    gen: Any,
+    *,
+    max_events: int = 200,
+    stop_predicate=lambda _ev: False,
+) -> list[dict[str, Any]]:
+    """Pull up to ``max_events`` from an async generator, then close.
+
+    The events handler runs forever once it enters the live drain;
+    tests must explicitly stop after the events of interest land.
+    """
+    collected: list[dict[str, Any]] = []
+    async for ev in gen:
+        collected.append(ev)
+        if stop_predicate(ev) or len(collected) >= max_events:
+            break
+    await gen.aclose()
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# register_listener_with_replay — per-ws ring buffer slice semantics
+# ---------------------------------------------------------------------------
+
+
+def test_replay_holds_events_through_empty_listeners_period() -> None:
+    """The load-bearing property of the new ring buffer: events fired
+    while NO listener is registered must still be replayable to a
+    later subscriber whose ``Last-Event-ID`` predates them.  Pre-PR,
+    events to an empty listener list went on the floor — that's the
+    behaviour the entire reconnect-with-replay foundation replaces.
+    """
+    ui = _make_ui()
+    # No listeners — fire 10 events.
+    for i in range(10):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    # Reconnect-style register with Last-Event-ID=0 (client saw nothing).
+    lq, replay, status, lost, earliest = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    assert lost == 0
+    assert earliest == 1
+    assert len(replay) == 10
+    assert [ev["name"] for ev in replay] == [f"t{i}" for i in range(10)]
+    # Each replayed event carries its _event_id so the events handler
+    # can emit the SSE id: field — verified by inspecting the slice.
+    assert [ev["_event_id"] for ev in replay] == list(range(1, 11))
+
+
+def test_replay_with_last_event_id_skips_already_seen_events() -> None:
+    """Client says it last saw id=5 — replay yields only events 6+,
+    not the whole buffer."""
+    ui = _make_ui()
+    for i in range(8):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    lq, replay, status, lost, earliest = ui.register_listener_with_replay(5)
+    assert status == "replay_ok"
+    assert lost == 0
+    assert [ev["_event_id"] for ev in replay] == [6, 7, 8]
+
+
+def test_replay_truncated_when_last_event_id_predates_buffer() -> None:
+    """When the buffer has evicted events the client wanted, return
+    ``truncated`` with the lost-count gap so the handler can emit the
+    explicit envelope and fall through to snapshot recovery."""
+    ui = _make_ui()
+    # Override the buffer cap for the test so we don't have to fire
+    # 2001 events to trigger eviction.
+    import collections
+
+    ui._event_buffer = collections.deque(maxlen=5)
+    for i in range(20):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    # Buffer now holds ids 16..20 (5 most recent of 20 emitted).
+    lq, replay, status, lost, earliest = ui.register_listener_with_replay(3)
+    assert status == "truncated"
+    assert earliest == 16
+    assert lost == 12  # earliest-1 - last_event_id = 15 - 3
+    assert replay == []
+
+
+def test_replay_empty_buffer_returns_replay_ok_empty() -> None:
+    """Cold-start ws with zero events ever: replay_ok / empty list.
+    A spurious ``replay_truncated`` envelope on a freshly-opened
+    workstream would be confusing and incorrect."""
+    ui = _make_ui()
+    lq, replay, status, lost, earliest = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    assert replay == []
+    assert lost == 0
+    assert earliest == 0
+
+
+def test_replay_registers_listener_atomically_with_buffer_snapshot() -> None:
+    """Atomicity contract: under ``_listeners_lock`` we both snapshot
+    the buffer AND register the listener.  A writer's ``_enqueue``
+    takes the same lock, so an event landing after the snapshot
+    arrives in the listener queue (live) — never in BOTH the replay
+    and the live queue, and never in NEITHER."""
+    ui = _make_ui()
+    ui._enqueue({"type": "tool_started", "name": "before"})
+    lq, replay, _, _, _ = ui.register_listener_with_replay(0)
+    # Now fire after registration — must arrive live, NOT in replay.
+    ui._enqueue({"type": "tool_started", "name": "after"})
+    assert [ev["name"] for ev in replay] == ["before"]
+    live = lq.get_nowait()
+    assert live["name"] == "after"
+    assert live["_event_id"] == 2
+
+
+def test_event_id_monotonic_under_concurrent_writers() -> None:
+    """Load-bearing invariant for any replay protocol — if monotonicity
+    ever breaks (e.g. someone moves the id-increment outside the
+    lock), reconnect-with-replay silently re-orders events.  Stress
+    with multiple writer threads."""
+    ui = _make_ui()
+    n_writers = 4
+    per_writer = 200
+    barrier = threading.Barrier(n_writers)
+
+    def _writer(tag: str) -> None:
+        barrier.wait()
+        for i in range(per_writer):
+            ui._enqueue({"type": "tool_started", "name": f"{tag}-{i}"})
+
+    threads = [threading.Thread(target=_writer, args=(f"w{w}",)) for w in range(n_writers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Walk the buffer in deque order — ids must be strictly monotonic.
+    ids = [eid for eid, _ in ui._event_buffer]
+    assert ids == sorted(ids), "event_id ordering broke under concurrent writers"
+    assert ids == list(range(ids[0], ids[-1] + 1)), "event_id skipped under concurrency"
+    assert ids[-1] == n_writers * per_writer
+
+
+def test_event_id_does_not_skip_when_listener_queue_full() -> None:
+    """If a slow listener's queue is full, the per-listener
+    ``put_nowait`` is silently dropped — but the counter must NOT
+    skip.  A subsequently-registered listener with
+    ``Last-Event-ID=0`` must see ALL the ids from the buffer
+    (1..N), not a sparse subset.  Pre-bug-class: moving the
+    id-increment inside the per-listener loop would create phantom
+    "gaps" the truncation detector would misread."""
+    ui = _make_ui()
+    slow_lq = ui._register_listener(maxsize=1)
+    slow_lq.put_nowait({"placeholder": True})  # full immediately
+    # Fire 10 events — 9 will hit queue.Full and be suppressed.
+    for i in range(10):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    # Replay from id=0 — fresh listener gets all 10, ids 1..10 dense.
+    _, replay, status, _, _ = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    assert [ev["_event_id"] for ev in replay] == list(range(1, 11))
+
+
+def test_cross_thread_writer_and_replay_observer_consistent() -> None:
+    """A worker thread fires ``_enqueue`` while another thread calls
+    ``register_listener_with_replay``.  The replay snapshot must be
+    gap-free — no half-written deque state visible to the reader.
+    Guards against the iteration-during-mutation hazard that a casual
+    implementation could introduce if the buffer copy out of the lock
+    isn't taken correctly."""
+    ui = _make_ui()
+    n = 500
+    done = threading.Event()
+
+    def _writer() -> None:
+        for i in range(n):
+            ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+        done.set()
+
+    snap_box: dict[str, Any] = {}
+
+    def _reader() -> None:
+        # Wait briefly so the writer is mid-flight.
+        threading.Event().wait(0.001)
+        _, replay, status, _, earliest = ui.register_listener_with_replay(0)
+        snap_box["replay"] = replay
+        snap_box["status"] = status
+        snap_box["earliest"] = earliest
+
+    w = threading.Thread(target=_writer)
+    r = threading.Thread(target=_reader)
+    w.start()
+    r.start()
+    w.join()
+    r.join()
+
+    replay = snap_box["replay"]
+    # Replay snapshot is consistent — ids contiguous, no gaps.
+    ids = [ev["_event_id"] for ev in replay]
+    assert ids == sorted(ids)
+    if ids:
+        assert ids == list(range(ids[0], ids[-1] + 1)), (
+            "gap observed in replay snapshot — torn deque state visible"
+        )
+
+
+def test_event_id_persists_across_turn_boundaries() -> None:
+    """Resetting ``_event_id`` to 0 at turn boundaries would silently
+    mis-replay a long-lived SSE subscriber whose ``Last-Event-ID``
+    was from a prior turn.  Mirrors the pre-existing
+    ``test_inflight_seq_monotonic_across_turn_boundaries`` invariant
+    on the snap_seq side, extended to the buffer/replay side."""
+    ui = _make_ui()
+    ui.on_content_token("turn-N tok1 ")
+    ui.on_content_token("turn-N tok2 ")
+    seq_before = ui._event_id
+    ui.on_turn_committed()
+    ui.on_turn_start()
+    ui.on_content_token("turn-N+1 tok1")
+    seq_after = ui._event_id
+    assert seq_after > seq_before, "counter regressed across turn boundary"
+    # Replay from mid-turn-N must still serve turn-N+1's content.
+    _, replay, status, _, _ = ui.register_listener_with_replay(seq_before)
+    assert status == "replay_ok"
+    assert len(replay) == 1
+    assert replay[0]["text"] == "turn-N+1 tok1"
+
+
+def test_replay_ok_skips_in_progress_snapshot_path() -> None:
+    """When ``last_event_id`` is provided AND replay covers the gap,
+    ``register_listener_with_replay`` returns ``replay_ok`` without
+    touching the inflight content/reasoning snapshot machinery.  The
+    events handler uses this branch to skip emitting the
+    ``in_progress_snapshot`` event (which would otherwise double-
+    render content the buffered events already contain)."""
+    ui = _make_ui()
+    ui.on_content_token("partial ")
+    # Replay path: returns replay_ok and a synthetic snap is NOT taken
+    # (we test the handler-side behavior in the handler tests below).
+    lq, replay, status, _, _ = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    # The buffered event carries the partial content as a content event.
+    assert any(ev.get("type") == "content" for ev in replay)
+
+
+# ---------------------------------------------------------------------------
+# make_events_handler — id: / retry: / replay_truncated / branch behaviour
+# ---------------------------------------------------------------------------
+
+
+def _wire_events_handler(ui: _ConcreteUI) -> Any:
+    """Build a minimal ``make_events_handler`` closure that returns
+    yields suitable for the EventSourceResponse generator.
+
+    Calls the closure with a fake request; returns the inner generator
+    AFTER it has been started so the test can iterate yields directly.
+    """
+    ws = SimpleNS(id=ui.ws_id, ui=ui, state=SimpleNS(value="idle"))
+    mgr = MagicMock()
+    mgr.get.return_value = ws
+
+    cfg = SessionEndpointConfig(
+        permission_gate=None,
+        manager_lookup=lambda _r: (mgr, None),
+        tenant_check=None,
+        not_found_label="Workstream not found",
+        audit_action_prefix="workstream",
+        events_replay=None,
+        events_replay_prepare=None,
+    )
+    return make_events_handler(cfg)
+
+
+def _drain_handler_yields(
+    ui: _ConcreteUI,
+    *,
+    headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
+    max_yields: int = 10,
+) -> tuple[list[Any], str]:
+    """Synchronous helper: spin up the handler, drain up to N yields,
+    return ``(raw_yields, decoded_blob)``.  Uses ``asyncio.run`` so
+    tests don't depend on pytest-asyncio / pytest-anyio plugin config.
+
+    The decoded blob is the textual SSE concatenation — assertion
+    targets in the tests below grep against it.  Raw yields are
+    returned for shape-level assertions (e.g. the first-yield
+    ``retry`` check).
+    """
+    handler = _wire_events_handler(ui)
+    req = _fake_request(headers=headers, query=query, path_params={"ws_id": ui.ws_id})
+
+    async def _run() -> list[Any]:
+        resp = await handler(req)
+        out: list[Any] = []
+        async for chunk in resp.body_iterator:
+            out.append(chunk)
+            if len(out) >= max_yields:
+                break
+        await resp.body_iterator.aclose()
+        return out
+
+    yields = asyncio.run(_run())
+    # The events handler yields plain dicts ({"data": ..., "id": ...,
+    # "retry": ..., ...}); sse-starlette's response layer encodes
+    # them into SSE wire format at serve-time.  For introspection,
+    # render each dict into the equivalent SSE textual form so the
+    # tests can grep against the canonical encoded representation
+    # AND have access to the raw dicts for shape-level assertions.
+    text_parts: list[str] = []
+    for y in yields:
+        if isinstance(y, bytes):
+            text_parts.append(y.decode(errors="replace"))
+        elif isinstance(y, str):
+            text_parts.append(y)
+        elif isinstance(y, dict):
+            # Mirror sse-starlette's encoding contract — one field
+            # per line, terminating blank line per event.
+            for field in ("id", "event", "retry", "data", "comment"):
+                if field in y:
+                    text_parts.append(f"{field}: {y[field]}")
+            text_parts.append("")
+        elif hasattr(y, "encode"):
+            encoded = y.encode()
+            text_parts.append(
+                encoded.decode(errors="replace") if isinstance(encoded, bytes) else str(encoded)
+            )
+        else:
+            text_parts.append(str(y))
+    return yields, "\n".join(text_parts)
+
+
+def test_handler_emits_retry_on_first_yield() -> None:
+    """First yield of the events handler must include a jittered
+    ``retry`` field in the [2500, 4500] ms range so 6-pane reconnects
+    don't lockstep on EventSource's default ~3 s interval."""
+    ui = _make_ui()
+    _, blob = _drain_handler_yields(ui, max_yields=1)
+    # The retry: SSE field appears in the encoded blob.
+    import re
+
+    match = re.search(r"retry:\s*(\d+)", blob)
+    assert match is not None, f"first yield missing retry: line\n{blob}"
+    retry = int(match.group(1))
+    assert 2500 <= retry <= 4500, f"retry {retry} outside jitter band [2500, 4500]"
+
+
+def test_handler_replay_ok_skips_snapshot_emits_id() -> None:
+    """``Last-Event-ID`` + buffer covers gap → emit buffered events
+    with SSE ``id:`` field, SKIP the in-progress snapshot (it would
+    double-render content the buffered events already carry)."""
+    ui = _make_ui()
+    ui.on_content_token("hello ")
+    ui.on_content_token("world")
+    _, blob = _drain_handler_yields(ui, headers={"Last-Event-ID": "0"}, max_yields=6)
+    # No in_progress_snapshot anywhere on the replay_ok path.
+    assert "in_progress_snapshot" not in blob, (
+        "replay_ok must not emit in_progress_snapshot — it duplicates "
+        f"buffered content. blob:\n{blob}"
+    )
+    # Every buffered content event got an id: line.
+    assert "id: 1" in blob, f"missing id: 1 in:\n{blob}"
+    assert "id: 2" in blob, f"missing id: 2 in:\n{blob}"
+
+
+def test_handler_truncated_emits_envelope_then_snapshot() -> None:
+    """Stale ``Last-Event-ID`` + buffer too short → emit
+    ``replay_truncated`` envelope, THEN fall through to the
+    fresh-style replay (state_change + in_progress_snapshot) as the
+    recovery floor."""
+    import collections
+
+    ui = _make_ui()
+    ui._event_buffer = collections.deque(maxlen=3)
+    for i in range(10):
+        ui.on_content_token(f"t{i}")
+    _, blob = _drain_handler_yields(ui, headers={"Last-Event-ID": "1"}, max_yields=8)
+
+    assert "replay_truncated" in blob, (
+        f"stale Last-Event-ID must emit replay_truncated envelope; got:\n{blob}"
+    )
+    # Recovery floor: in_progress_snapshot carries the partial content
+    # the evicted events represented.
+    assert "in_progress_snapshot" in blob, (
+        f"truncated path must fall through to in_progress_snapshot; got:\n{blob}"
+    )
+
+
+def test_handler_fresh_path_skips_replay_truncated() -> None:
+    """No ``Last-Event-ID`` → fresh-connect behaviour (today's path
+    unchanged: state_change + in_progress_snapshot + live).  No
+    replay_truncated envelope should ever appear on a fresh
+    connect."""
+    ui = _make_ui()
+    ui.on_content_token("hello ")
+    _, blob = _drain_handler_yields(ui, max_yields=5)
+
+    assert "replay_truncated" not in blob
+    # Fresh connect emits the snapshot.
+    assert "in_progress_snapshot" in blob
+
+
+def test_handler_malformed_last_event_id_falls_back_to_fresh() -> None:
+    """Defence against intermediaries that mangle the header — a
+    non-integer ``Last-Event-ID`` must not be treated as ``0`` (which
+    could trigger spurious replays) nor crash the handler.  Falls
+    through to the fresh-connect path."""
+    ui = _make_ui()
+    _, blob = _drain_handler_yields(
+        ui,
+        headers={"Last-Event-ID": "abc-not-an-int"},
+        max_yields=3,
+    )
+    assert "replay_truncated" not in blob
+
+
+def test_handler_query_param_fallback_is_honoured() -> None:
+    """The manual-reconnect path can't set custom headers on
+    ``new EventSource(url)`` — the browser sends
+    ``?last_event_id=N`` instead.  Handler must honour the query
+    param identically to the header."""
+    ui = _make_ui()
+    ui.on_content_token("hello")
+    _, blob = _drain_handler_yields(ui, query={"last_event_id": "0"}, max_yields=4)
+
+    # Replay path: in_progress_snapshot SKIPPED, id:1 present.
+    assert "in_progress_snapshot" not in blob
+    assert "id: 1" in blob

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -81,26 +81,6 @@ def _fake_request(
     return Request(scope, receive=_recv)
 
 
-async def _drain_until(
-    gen: Any,
-    *,
-    max_events: int = 200,
-    stop_predicate=lambda _ev: False,
-) -> list[dict[str, Any]]:
-    """Pull up to ``max_events`` from an async generator, then close.
-
-    The events handler runs forever once it enters the live drain;
-    tests must explicitly stop after the events of interest land.
-    """
-    collected: list[dict[str, Any]] = []
-    async for ev in gen:
-        collected.append(ev)
-        if stop_predicate(ev) or len(collected) >= max_events:
-            break
-    await gen.aclose()
-    return collected
-
-
 # ---------------------------------------------------------------------------
 # register_listener_with_replay — per-ws ring buffer slice semantics
 # ---------------------------------------------------------------------------

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2866,12 +2866,31 @@ async def _proxy_sse(
     else:
         sse_auth = _proxy_auth_headers(request)
 
+    # Forward ``Last-Event-ID`` from the browser to the upstream node so
+    # the per-ws / global SSE handlers can serve the reconnect-with-replay
+    # buffer slice.  Without this, multi-node deployments lose replay
+    # entirely (the proxy is the only inbound SSE path in that shape);
+    # the per-ws handler would treat every reconnect as a fresh connect
+    # and silently drop events emitted during the disconnect window.
+    # The query-param fallback (``?last_event_id=N``) is already
+    # forwarded via the existing ``request.url.query`` propagation at
+    # the top of this function — only the header needs an explicit
+    # carry-over.  Header lookups in Starlette are case-insensitive.
+    upstream_headers: dict[str, str] = {
+        **sse_auth,
+        "Accept": "text/event-stream",
+        "Cache-Control": "no-store",
+    }
+    last_event_id_hdr = request.headers.get("last-event-id")
+    if last_event_id_hdr is not None:
+        upstream_headers["Last-Event-ID"] = last_event_id_hdr
+
     async def raw_stream() -> AsyncGenerator[bytes, None]:
         try:
             async with sse_client.stream(
                 "GET",
                 target,
-                headers={**sse_auth, "Accept": "text/event-stream", "Cache-Control": "no-store"},
+                headers=upstream_headers,
                 timeout=httpx.Timeout(connect=10, read=None, write=5, pool=None),
             ) as response:
                 if response.status_code != 200:

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -139,6 +139,15 @@
 
   let evtSource = null;
   let reconnectAttempts = 0;
+  // Saved high-water mark for the manual-reconnect path.  The
+  // EventSource constructor can't set custom headers, so when we
+  // construct a fresh source we thread ``?last_event_id=N`` instead
+  // of the browser-native ``Last-Event-ID`` header.  Native
+  // auto-reconnect on the SAME source object uses the header
+  // automatically; this fallback covers the cases where we open a
+  // brand-new EventSource (initial connect, scheduleReconnect after
+  // close).
+  let lastEventId = null;
   let reconnectTimer = null;
 
   // Cache of judge verdicts keyed by call_id.  intent_verdict and
@@ -1902,7 +1911,10 @@
     // we were disconnected aren't replayed by the events SSE handler,
     // so the client has to pull authoritative state after any gap.
     const wasReconnecting = reconnectAttempts > 0;
-    const url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
+    let url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
+    if (lastEventId) {
+      url += "?last_event_id=" + encodeURIComponent(lastEventId);
+    }
     evtSource = new EventSource(url, { withCredentials: true });
     evtSource.onopen = function () {
       reconnectAttempts = 0;
@@ -1951,35 +1963,47 @@
       }
     };
     evtSource.onerror = function () {
+      // Do NOT close evtSource for transient errors — native
+      // EventSource auto-reconnect handles them with the
+      // ``Last-Event-ID`` header automatically (now that the server
+      // emits ``id:`` on every buffered event).  Closing here would
+      // force a CONNECTING -> CLOSED transition that defeats native
+      // reconnect, which is exactly the reconnect-with-replay defect
+      // PR-D ships to fix.  See
+      // tests/test_app_js.py::test_coord_connectsse_onerror_preserves_native_reconnect.
       setSseStatus("disconnected", "err");
       // Dim the status bar so a stale reading doesn't read as live.
       statusBarEl.classList.add("ws-sb-disconnected");
       sbTokensEl.textContent = "Reconnecting…";
-      try {
-        evtSource.close();
-      } catch (_) {
-        /* noop */
-      }
-      // Probe the authed detail endpoint to distinguish an expired
-      // session (401) from a transient network error.  On 401, prompt
-      // for login via the shared auth.js overlay instead of spinning
-      // in backoff forever — match the console / server-UI pattern.
-      // On any other outcome, fall through to the normal reconnect
-      // schedule.
+      // 401 probe: expired session is a terminal condition (user
+      // must log in), so we DO close + showLogin in that branch.
+      // Transient errors (network blips, intermediary timeouts) just
+      // let native reconnect run — no scheduleReconnect needed
+      // because the source isn't dead.  scheduleReconnect remains
+      // available as the final fallback for the truly-CLOSED case
+      // (covered by the auth.js callback path).
       var probe = typeof authFetch === "function" ? authFetch : fetch;
-      probe("/v1/api/workstreams/" + encodeURIComponent(wsId))
-        .then(function (r) {
+      probe("/v1/api/workstreams/" + encodeURIComponent(wsId)).then(
+        function (r) {
           if (r.status === 401 && typeof showLogin === "function") {
+            try {
+              if (evtSource) evtSource.close();
+            } catch (_) {
+              /* noop */
+            }
+            evtSource = null;
             showLogin("Session expired. Please sign in to reconnect.");
-            return;
           }
-          scheduleReconnect();
-        })
-        .catch(function () {
-          scheduleReconnect();
-        });
+        },
+      );
     };
     evtSource.onmessage = function (event) {
+      // Capture lastEventId BEFORE JSON.parse so a malformed event
+      // doesn't desync the manual-reconnect fallback from native
+      // auto-reconnect.
+      if (evtSource && evtSource.lastEventId) {
+        lastEventId = evtSource.lastEventId;
+      }
       let data = null;
       try {
         data = JSON.parse(event.data);

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1439,24 +1439,72 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
             # half-built shape.
             return JSONResponse({"error": "session has no UI"}, status_code=409)
 
-        # Register the listener AND snapshot the per-turn inflight
-        # buffers in one atomic-against-writers step. The snapshot
-        # (content / reasoning text-so-far for the current turn) is
-        # yielded as a one-shot ``in_progress_snapshot`` event after
-        # the replay phase; it lets a mid-stream page refresh restore
-        # the partial assistant text without waiting for the response
-        # to complete. ``snap.seq`` is captured to dedup live events
-        # whose ``_seq`` is already in the snapshot payload (race-
-        # free composition with ``on_content_token`` /
-        # ``on_reasoning_token`` writers across the two-lock surface
-        # — see ``register_listener_with_in_progress_snapshot``).
+        # ``Last-Event-ID`` resume: native EventSource auto-reconnect
+        # sends the header; the manual-reconnect path (which uses
+        # ``new EventSource(url)`` and can't set custom headers) sends
+        # ``?last_event_id=N``.  Accept both; malformed values fall
+        # back to fresh-connect semantics so a broken intermediary
+        # can't break replay for a client that genuinely lost no
+        # events.
+        last_event_id_raw = request.headers.get("Last-Event-ID") or request.query_params.get(
+            "last_event_id"
+        )
+        last_event_id: int | None
+        try:
+            last_event_id = int(last_event_id_raw) if last_event_id_raw else None
+        except (TypeError, ValueError):
+            last_event_id = None
+
+        # Three replay shapes:
+        #   - ``last_event_id is None`` → ``"fresh"`` (today's behaviour):
+        #     replay_cb + state_change + in_progress_snapshot + live.
+        #   - ``last_event_id`` + buffer covers gap → ``"replay_ok"``:
+        #     emit buffered events past the id, SKIP replay_cb /
+        #     state_change / in_progress_snapshot (the buffered stream
+        #     already contains them), then live drain.
+        #   - ``last_event_id`` + buffer too short → ``"truncated"``:
+        #     emit a ``replay_truncated`` envelope so the client knows
+        #     it lost live ticks, then fall through to the fresh
+        #     replay (history / state_change / in_progress_snapshot)
+        #     as the recovery floor.
         # The placeholder-UI guard above (which 409s when
         # ``_register_listener`` is missing) already proves that
         # ``ui`` is a ``SessionUIBase`` subclass, so the cast is
         # tightening the type, not weakening it.
         ui_base = cast("SessionUIBase", ui)
-        client_queue, in_progress_snap = ui_base.register_listener_with_in_progress_snapshot()
-        snap_seq: int = in_progress_snap["seq"]
+        replay_status: str
+        replay_events: list[dict[str, Any]] = []
+        lost_count = 0
+        earliest_available_id = 0
+        in_progress_snap: dict[str, Any]
+        snap_seq: int = 0
+        if last_event_id is None:
+            replay_status = "fresh"
+            client_queue, in_progress_snap = ui_base.register_listener_with_in_progress_snapshot()
+            snap_seq = in_progress_snap["seq"]
+        else:
+            (
+                client_queue,
+                replay_events,
+                replay_status,
+                lost_count,
+                earliest_available_id,
+            ) = ui_base.register_listener_with_replay(last_event_id)
+            if replay_status == "truncated":
+                # Capture the snapshot too — it's the recovery floor
+                # when the buffer can't fill the gap.  Listener is
+                # already registered by ``register_listener_with_replay``;
+                # take the snapshot bits only.
+                with ui_base._ws_lock:  # noqa: SLF001 — same-module-level access pattern
+                    captured_content = "".join(ui_base._ws_inflight_content)  # noqa: SLF001
+                    captured_reasoning = "".join(ui_base._ws_inflight_reasoning)  # noqa: SLF001
+                in_progress_snap = {
+                    "content": captured_content,
+                    "reasoning": captured_reasoning,
+                    "seq": 0,  # not used on truncated path; fresh-style yields don't filter
+                }
+            else:
+                in_progress_snap = {"content": "", "reasoning": "", "seq": 0}
 
         # Per-kind executor for the blocking ``client_queue.get``
         # wait. Interactive returns its dedicated 200-thread
@@ -1475,101 +1523,165 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
 
         async def event_generator() -> Any:
             import functools
+            import random
 
             _metrics.record_sse_connect()
             loop = asyncio.get_running_loop()
+
+            def _format_event(event: dict[str, Any]) -> dict[str, str]:
+                """Strip internal plumbing fields, attach SSE ``id:`` if present.
+
+                Shallow-copies the dict before any mutation because
+                ``_enqueue`` puts ONE reference into every listener
+                queue (no per-listener copy) and stores the SAME
+                reference in the per-ws ring buffer.  Without a
+                shallow copy here, listener A's pop of ``_event_id``
+                would silently strip the field from listener B's view
+                AND from the buffer's view, breaking the replay
+                guarantee for a later-arriving subscriber.
+                """
+                ev_copy = dict(event)
+                eid = ev_copy.pop("_event_id", None)
+                # Strip ``_seq`` here too — it's internal plumbing for
+                # the snapshot dedup; clients never need to see it on
+                # the wire.  The fresh-path live drain filters on
+                # ``_seq`` BEFORE calling this helper.
+                ev_copy.pop("_seq", None)
+                out: dict[str, str] = {"data": json.dumps(ev_copy)}
+                if eid is not None:
+                    out["id"] = str(eid)
+                return out
+
             try:
-                # Replay phase — stream the kind-specific initial
-                # payload one event at a time so the client sees the
-                # first byte immediately (interactive's ``connected``
-                # event is the very first yield, before the heavier
-                # ``status`` / ``history`` work runs). Pre-building
-                # the replay into a list would block time-to-first-
-                # byte until the entire replay materialized AND let
-                # the listener queue accumulate (potentially over its
-                # 500-slot cap on a chatty mid-generation workstream)
-                # while replay was being built.
-                if replay_cb is not None:
-                    # Kind-specific async prep — runs before the sync
-                    # replay generator iterates so blocking storage
-                    # I/O lands in the executor pool rather than the
-                    # event loop's hot path. Interactive uses this
-                    # to pre-load verdict indexes; coord skips.
-                    if cfg.events_replay_prepare is not None:
-                        try:
-                            await cfg.events_replay_prepare(ws, ui, request)
-                        except Exception:
-                            log.debug(
-                                "ws.events.replay_prepare_failed ws=%s",
-                                ws_id[:8],
-                                exc_info=True,
-                            )
-                    try:
-                        for ev in replay_cb(ws, ui, request):
-                            yield {"data": json.dumps(ev)}
-                    except Exception:
-                        # Replay is observational — never let a
-                        # snapshot bug block the live stream. Log
-                        # and continue with whatever partial replay
-                        # was already yielded.
-                        log.debug(
-                            "ws.events.replay_failed ws=%s",
-                            ws_id[:8],
-                            exc_info=True,
-                        )
-                # Refresh-resume tail: emit the current workstream
-                # state (so the composer flips to stop-mode on a mid-
-                # stream refresh — ``state_change`` is the only event
-                # the JS busy machine listens to, and the kind-specific
-                # replay above doesn't yield it) and the in-progress
-                # snapshot (so partial content / reasoning re-renders
-                # immediately, instead of waiting for the next live
-                # token). Both are best-effort — a ws.state read
-                # failure or empty buffers just yields nothing extra.
-                try:
-                    cur_state = getattr(ws.state, "value", None)
-                    if isinstance(cur_state, str) and cur_state:
+                # Per-stream reconnect interval jitter.  Without this,
+                # all panes on a workstream disconnect together and
+                # reconnect in lockstep at the same backoff intervals
+                # (EventSource's default ~3 s with no jitter, or
+                # whatever ``retry:`` value the server last sent).
+                # 2.5 – 4.5 s spread keeps the average reconnect rate
+                # below today's ping cadence while staggering peaks.
+                yield {"retry": random.randint(2500, 4500)}
+
+                if replay_status == "replay_ok":
+                    # Buffered events already cover everything since
+                    # the client's ``Last-Event-ID`` — skip the
+                    # synthetic replay (history / state_change /
+                    # in_progress_snapshot) which would otherwise
+                    # double-render content the buffer already
+                    # contains.  Yield buffered events in order with
+                    # their ``_event_id`` as SSE ``id:`` so a
+                    # disconnect mid-replay resumes from the latest
+                    # buffered id, not the original ``last_event_id``.
+                    for ev in replay_events:
+                        yield _format_event(ev)
+                else:
+                    # ``fresh`` or ``truncated`` — both run the
+                    # synthetic replay (kind-specific replay_cb +
+                    # state_change + in_progress_snapshot).  On
+                    # ``truncated`` we emit the explicit envelope
+                    # first so the client knows the buffer couldn't
+                    # cover the gap and treats the snapshot below as
+                    # the recovery floor.
+                    if replay_status == "truncated":
                         yield {
                             "data": json.dumps(
                                 {
-                                    "type": "state_change",
-                                    "state": cur_state,
+                                    "type": "replay_truncated",
+                                    "ws_id": ws_id,
+                                    "lost_count": lost_count,
+                                    "earliest_available_id": earliest_available_id,
+                                }
+                            )
+                        }
+
+                    # Replay phase — stream the kind-specific initial
+                    # payload one event at a time so the client sees
+                    # the first byte immediately.  Pre-building into
+                    # a list would block time-to-first-byte until the
+                    # entire replay materialized AND let the listener
+                    # queue accumulate (potentially over its 500-slot
+                    # cap on a chatty mid-generation workstream)
+                    # while replay was being built.  Synthetic
+                    # events carry no ``_event_id`` — they intentionally
+                    # don't advance the client's ``lastEventId``, so
+                    # a mid-replay disconnect reconnects with the
+                    # last BUFFERED id (or none on truly-fresh
+                    # connect), which is what the server can replay.
+                    if replay_cb is not None:
+                        # Kind-specific async prep — runs before the
+                        # sync replay generator iterates so blocking
+                        # storage I/O lands in the executor pool
+                        # rather than the event loop's hot path.
+                        if cfg.events_replay_prepare is not None:
+                            try:
+                                await cfg.events_replay_prepare(ws, ui, request)
+                            except Exception:
+                                log.debug(
+                                    "ws.events.replay_prepare_failed ws=%s",
+                                    ws_id[:8],
+                                    exc_info=True,
+                                )
+                        try:
+                            for ev in replay_cb(ws, ui, request):
+                                yield {"data": json.dumps(ev)}
+                        except Exception:
+                            # Replay is observational — never let a
+                            # snapshot bug block the live stream.
+                            log.debug(
+                                "ws.events.replay_failed ws=%s",
+                                ws_id[:8],
+                                exc_info=True,
+                            )
+                    # Refresh-resume tail: emit the current
+                    # workstream state and the in-progress snapshot.
+                    # Both are best-effort — a ws.state read failure
+                    # or empty buffers just yields nothing extra.
+                    try:
+                        cur_state = getattr(ws.state, "value", None)
+                        if isinstance(cur_state, str) and cur_state:
+                            yield {
+                                "data": json.dumps(
+                                    {
+                                        "type": "state_change",
+                                        "state": cur_state,
+                                        "ws_id": ws_id,
+                                    }
+                                )
+                            }
+                    except Exception:
+                        log.debug(
+                            "ws.events.state_change_replay_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
+                    if in_progress_snap["content"] or in_progress_snap["reasoning"]:
+                        yield {
+                            "data": json.dumps(
+                                {
+                                    "type": "in_progress_snapshot",
+                                    "content": in_progress_snap["content"],
+                                    "reasoning": in_progress_snap["reasoning"],
                                     "ws_id": ws_id,
                                 }
                             )
                         }
-                except Exception:
-                    log.debug(
-                        "ws.events.state_change_replay_failed ws=%s",
-                        ws_id[:8],
-                        exc_info=True,
-                    )
-                if in_progress_snap["content"] or in_progress_snap["reasoning"]:
-                    yield {
-                        "data": json.dumps(
-                            {
-                                "type": "in_progress_snapshot",
-                                "content": in_progress_snap["content"],
-                                "reasoning": in_progress_snap["reasoning"],
-                                "ws_id": ws_id,
-                            }
-                        )
-                    }
                 # Live phase — drain the per-UI listener queue
                 # until either the workstream closes or the client
                 # disconnects. 5s poll matches pre-lift interactive
                 # (the ``is_disconnected`` probe between polls covers
-                # cancel-detection latency the timeout would otherwise
-                # gate; shortening to 1s 5x'd the wakeup rate without
-                # any client-observable benefit).
+                # cancel-detection latency the timeout would
+                # otherwise gate; shortening to 1s 5x'd the wakeup
+                # rate without any client-observable benefit).
                 #
                 # ``_seq`` filter: ``on_content_token`` /
                 # ``on_reasoning_token`` tag each emit with the
-                # per-turn inflight seq counter. Events whose seq is
-                # already covered by the snapshot we just yielded get
-                # dropped to avoid double-rendering. ``_seq`` is
-                # internal plumbing — strip before yielding so the
-                # SDK / JS clients never see it.
+                # per-ws event counter.  On the ``fresh`` path,
+                # events whose seq is already covered by the
+                # snapshot we just yielded get dropped to avoid
+                # double-rendering.  On ``replay_ok`` / ``truncated``
+                # paths, ``snap_seq`` is 0 so no live event is
+                # filtered — the replay buffer (or replay_truncated
+                # envelope) has already established the cutoff.
                 while True:
                     if await request.is_disconnected():
                         return
@@ -1582,21 +1694,10 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
                         continue  # ping keeps the connection alive
                     if event.get("type") == "ws_closed":
                         return
-                    # ``_enqueue`` puts ONE dict reference into every
-                    # listener queue (no per-listener copy). Multiple
-                    # SSE coroutines on the same workstream observe the
-                    # same dict; ``yield`` is an await point, so one
-                    # listener's ``del event["_seq"]`` would race
-                    # another listener's seq-filter read. Shallow-copy
-                    # before any mutation so each listener can filter
-                    # / strip ``_seq`` without disturbing peers.
-                    event = dict(event)
                     seq = event.get("_seq")
-                    if seq is not None:
-                        if seq <= snap_seq:
-                            continue
-                        del event["_seq"]
-                    yield {"data": json.dumps(event)}
+                    if seq is not None and seq <= snap_seq:
+                        continue
+                    yield _format_event(event)
             finally:
                 _metrics.record_sse_disconnect()
                 unregister(client_queue)

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -23,9 +23,11 @@ storage/transport routing is kind-specific.
 
 from __future__ import annotations
 
+import collections
 import contextlib
 import copy
 import json
+import os
 import queue
 import threading
 import time
@@ -40,6 +42,37 @@ log = get_logger(__name__)
 # UI's ``_LISTENER_QUEUE_MAX``. Per-queue cap keeps a slow SSE consumer
 # from bloating memory.
 _DEFAULT_LISTENER_QUEUE_MAX = 500
+
+
+def _resolve_event_buffer_max() -> int:
+    """Read ``TURNSTONE_SSE_EVENT_BUFFER_MAX`` env override at import time.
+
+    Default 2000 events covers ~10-40 seconds of cloud-provider streaming
+    (50-200 events/sec per active stream) — enough to make any typical
+    network blip or intermediary timeout transparent to the browser.
+    Local-inference deployments (vLLM, llama.cpp at 500-2000 tok/s) can
+    burn through the cap in under a second; operators on those workloads
+    can raise the bound knowing the tradeoff (linear memory growth ×
+    100-workstream design ceiling).  Below-cap reconnects always hit the
+    replay path; above-cap reconnects fall back to the snapshot recovery
+    floor with an explicit ``replay_truncated`` envelope so the client
+    knows it lost live ticks.
+    """
+    raw = os.environ.get("TURNSTONE_SSE_EVENT_BUFFER_MAX", "").strip()
+    if not raw:
+        return 2000
+    try:
+        n = int(raw)
+    except ValueError:
+        return 2000
+    return n if n > 0 else 2000
+
+
+# Per-ws ring buffer for ``Last-Event-ID`` SSE replay.  Holds the most
+# recent events keyed by monotonic ``_event_id``; deque ``maxlen`` evicts
+# oldest automatically.  See :func:`_resolve_event_buffer_max` for the
+# sizing rationale.
+_EVENT_BUFFER_MAX = _resolve_event_buffer_max()
 
 
 # Cap on the assistant content / reasoning accumulators. Used by two
@@ -140,6 +173,36 @@ class SessionUIBase:
         # SSE listener fan-out — one queue per connected browser tab.
         self._listeners: list[queue.Queue[dict[str, Any]]] = []
         self._listeners_lock = threading.Lock()
+        # Per-ws event ring buffer for ``Last-Event-ID`` SSE replay.
+        # Holds ``(event_id, event_dict)`` tuples; deque ``maxlen``
+        # evicts the oldest automatically when the cap is hit.  The
+        # listener fan-out path stamps every event with a monotonic
+        # ``_event_id`` (see :meth:`_enqueue`) and appends here under
+        # the same ``_listeners_lock`` that gates the per-listener
+        # queues — keeps the buffer and the live fan-out in lockstep.
+        # A reconnecting client with a ``Last-Event-ID`` header (or
+        # ``?last_event_id=N`` query-param fallback for manual reconnect
+        # paths that can't set custom headers) is served the slice of
+        # the buffer past that id; clients whose ``Last-Event-ID``
+        # predates the buffer's earliest retained id get a
+        # ``replay_truncated`` envelope plus the in-progress snapshot
+        # as the recovery floor.  Guarded by ``_listeners_lock`` (NOT
+        # ``_ws_lock``) so a writer holding ``_ws_lock`` for the
+        # inflight-buffer append doesn't serialize the buffer write
+        # against unrelated readers.
+        self._event_buffer: collections.deque[tuple[int, dict[str, Any]]] = collections.deque(
+            maxlen=_EVENT_BUFFER_MAX
+        )
+        # Monotonic per-ws event counter.  Stamps every fan-out event
+        # (every ``_enqueue`` call) and also drives the existing
+        # ``_seq`` snapshot-dedup tag on token events (``content`` /
+        # ``reasoning``) — one counter, two consumers.  Renamed from
+        # the pre-replay ``_ws_inflight_seq`` because the counter now
+        # spans every event, not just the inflight token stream.
+        # Guarded by ``_listeners_lock`` (incremented under that lock
+        # in :meth:`_enqueue`); the snapshot helper for the in-progress
+        # replay path captures it under ``_listeners_lock`` too.
+        self._event_id: int = 0
         # Approval blocking — the worker thread calls approve_tools
         # which waits on _approval_event; the /approve endpoint sets
         # it via resolve_approval.
@@ -238,18 +301,16 @@ class SessionUIBase:
         # each turn by :meth:`on_turn_start` (separate from the multi-
         # turn IDLE-piggyback buffer above so prior committed turns
         # don't leak into the snapshot and double-render against the
-        # replayed history). ``_ws_inflight_seq`` is a monotonic
-        # counter incremented on EVERY emit (even when the cap
-        # rejected the buffer append) so a subscriber registering
-        # after the cap is hit doesn't have subsequent live tokens
-        # filter-dropped against a stalled ``snap_seq`` — the events
-        # handler dedups live events whose ``_seq`` is at-or-below
-        # the snapshot's seq (already in the snapshot payload).
+        # replayed history).  The per-turn dedup-tag counter
+        # (``_event_id``) is initialised above alongside the per-ws
+        # event ring buffer — one monotonic counter drives both the
+        # ``Last-Event-ID`` replay slice AND the existing snapshot
+        # ``_seq <= snap_seq`` filter; see :meth:`_enqueue` for the
+        # stamping pattern.
         self._ws_inflight_content: list[str] = []
         self._ws_inflight_content_size: int = 0
         self._ws_inflight_reasoning: list[str] = []
         self._ws_inflight_reasoning_size: int = 0
-        self._ws_inflight_seq: int = 0
         # Last broadcast (activity, activity_state) tuple — used by
         # :meth:`_broadcast_activity` overrides to dedup back-to-back
         # identical activity ticks. Tool-heavy turns can fire many
@@ -287,12 +348,35 @@ class SessionUIBase:
 
         Stamps ``ws_id`` on the payload if not already present so the
         browser can validate it belongs to the pane's current
-        workstream. Shallow-copies on stamp to avoid mutating a
-        caller-owned dict.
+        workstream.  Stamps a monotonic ``_event_id`` on every event
+        (drives the ``Last-Event-ID`` replay buffer) and additionally
+        stamps the per-turn snapshot dedup tag ``_seq`` on token
+        events (``content`` / ``reasoning``) so the existing
+        in-progress snapshot dedup at the events handler stays
+        byte-identical.  Shallow-copies before each stamp so a
+        caller-owned dict is never mutated.
+
+        The counter increment, the buffer append, AND the listener
+        snapshot all run under ``_listeners_lock`` so a concurrent
+        :meth:`register_listener_with_in_progress_snapshot` or
+        :meth:`register_listener_with_replay` sees a consistent
+        ``(event_id, listeners, buffer)`` tuple — no event is
+        fanned out to a not-yet-registered listener AND missing from
+        the replay buffer.
         """
         if "ws_id" not in data:
             data = {**data, "ws_id": self.ws_id}
         with self._listeners_lock:
+            self._event_id += 1
+            event_id = self._event_id
+            data = {**data, "_event_id": event_id}
+            if data.get("type") in ("content", "reasoning"):
+                # Preserve the existing dedup contract: only token
+                # events carry the ``_seq`` tag.  Non-token events
+                # (``tool_started``, ``state_change``, …) keep
+                # bypassing the snapshot filter by absence of ``_seq``.
+                data = {**data, "_seq": event_id}
+            self._event_buffer.append((event_id, data))
             snapshot = list(self._listeners)
         for lq in snapshot:
             with contextlib.suppress(queue.Full):
@@ -317,27 +401,29 @@ class SessionUIBase:
     ) -> tuple[queue.Queue[dict[str, Any]], dict[str, Any]]:
         """Register a listener AND snapshot the per-turn inflight buffers.
 
-        Used by :func:`make_events_handler` so a fresh SSE subscriber
+        Used by :func:`make_events_handler` (the fresh-connect path,
+        and the ``replay_truncated`` fallback path) so a SSE subscriber
         connecting mid-stream can be told the in-progress turn's content
         and reasoning text-so-far in a one-shot ``in_progress_snapshot``
         event, on top of the kind-specific replay (history / pending).
+        The ``Last-Event-ID`` replay path (see
+        :meth:`register_listener_with_replay`) bypasses this — the
+        buffered events already carry the partial token stream.
 
-        Race-free composition with the on-token writers, even though
-        ``on_content_token`` / ``on_reasoning_token`` cross two locks
-        (``_ws_lock`` for the buffer append, ``_listeners_lock`` for
-        the fan-out enqueue). The trick is the seq counter —
-        ``_ws_inflight_seq`` is incremented under ``_ws_lock`` on
-        every emit (even when the cap rejected the append, so a
-        subscriber that registers after the cap is hit doesn't have
-        subsequent live tokens filter-dropped against a stalled
-        snap_seq). This method captures it alongside the buffer
-        contents under the same ``_ws_lock``, and the events handler's
-        live drain drops any incoming event whose ``_seq`` is at-or-
-        below the captured ``snap.seq`` (already in the snapshot
-        payload). Lock acquisition order: ``_listeners_lock`` (inside
-        :meth:`_register_listener`) is taken and released first, THEN
-        ``_ws_lock`` for the snapshot copy. Sequential — no nesting,
-        no deadlock with the writer's reverse order.
+        Lock acquisition order: ``_ws_lock`` (outer) → ``_listeners_lock``
+        (inner) — matches the writer's order in :meth:`on_content_token`
+        / :meth:`on_reasoning_token` (``_ws_lock`` then ``_enqueue``'s
+        ``_listeners_lock``).  Nested under both locks we read
+        ``inflight_content``, ``inflight_reasoning``, AND the
+        ``_event_id`` counter as a consistent triple, plus register
+        the listener.  Writers calling :meth:`_enqueue` block on
+        ``_listeners_lock`` for the snapshot's duration so no event is
+        fanned out between counter-read and listener-registration —
+        every event with ``_event_id > snap_seq`` lands in the
+        registered listener's queue, every event with
+        ``_event_id <= snap_seq`` is already covered by the snapshot's
+        ``content`` / ``reasoning`` text or by token events that the
+        events handler's ``_seq <= snap_seq`` filter drops.
 
         Returns ``(client_queue, snapshot_dict)`` where ``snapshot_dict``
         has keys ``content`` (str), ``reasoning`` (str), ``seq`` (int).
@@ -345,22 +431,95 @@ class SessionUIBase:
         whether to yield the event at all (empty snapshots are common
         between turns and on freshly-opened workstreams).
 
-        Joins the captured fragments OUTSIDE the lock — bounded at
+        Joins the captured fragments OUTSIDE the locks — bounded at
         ``_MAX_TURN_CONTENT_CHARS`` but still O(n) over fragments, so
         worth not blocking concurrent on-token writers for the
-        duration. The shallow ``list(...)`` copy under the lock means
-        subsequent appends to the live buffer don't mutate our view.
+        duration. The shallow ``list(...)`` copies under the lock mean
+        subsequent appends to the live buffers don't mutate our view.
         """
-        client_queue = self._register_listener(maxsize=maxsize)
+        client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
         with self._ws_lock:
             captured_content = list(self._ws_inflight_content)
             captured_reasoning = list(self._ws_inflight_reasoning)
-            snap_seq = self._ws_inflight_seq
+            with self._listeners_lock:
+                self._listeners.append(client_queue)
+                snap_seq = self._event_id
         return client_queue, {
             "content": "".join(captured_content),
             "reasoning": "".join(captured_reasoning),
             "seq": snap_seq,
         }
+
+    def register_listener_with_replay(
+        self,
+        last_event_id: int,
+        maxsize: int = _DEFAULT_LISTENER_QUEUE_MAX,
+    ) -> tuple[queue.Queue[dict[str, Any]], list[dict[str, Any]], str, int, int]:
+        """Register a listener AND capture buffered events for replay.
+
+        Used by :func:`make_events_handler` when the client sends
+        ``Last-Event-ID`` (header or ``?last_event_id=`` query-param
+        fallback for the manual-reconnect path).  Returns
+
+            ``(client_queue, replay_events, status, lost_count,
+            earliest_available_id)``
+
+        where ``status`` is one of ``"replay_ok"`` (caller emits the
+        replay events then drops into live drain, skipping
+        ``replay_cb`` / ``state_change`` / ``in_progress_snapshot``)
+        or ``"truncated"`` (caller emits a ``replay_truncated``
+        envelope then falls through to the fresh-connect replay path
+        as the recovery floor — the snapshot picks up the partial
+        content/reasoning that the evicted events would have carried).
+
+        Atomicity contract: under ``_listeners_lock`` we both snapshot
+        the buffer AND register the listener.  A writer's
+        :meth:`_enqueue` takes the same lock, so events either
+          - land in the buffer snapshot but NOT the listener queue
+            (writer ran before our lock acquire — caught by the
+            replay slice), or
+          - land in the listener queue but NOT the buffer snapshot
+            (writer ran after our lock release — live drain handles
+            them, ``_event_id`` is strictly above
+            ``earliest_available_id``).
+        No event is double-delivered, none is lost across the
+        registration boundary.
+
+        ``last_event_id`` semantics:
+          - ``< earliest_available_id - 1`` → ``"truncated"``.
+            ``lost_count`` is the minimum gap (the buffer may have
+            evicted strictly more than this — we only know the
+            lower bound from what's still retained).
+          - ``>= earliest_available_id - 1`` → ``"replay_ok"``.  Replay
+            events are those with id strictly greater than
+            ``last_event_id`` (the client has already seen everything
+            up to and including ``last_event_id``).
+
+        Empty buffer: returned ``status="replay_ok"`` with empty
+        ``replay_events`` regardless of ``last_event_id``.  This is
+        the cold-start case (the ws just bootstrapped with no events
+        ever) and the all-quiet case (a long-idle ws past which all
+        events fall out of the buffer cap, but in practice the buffer
+        starts evicting only after 2000 events have been enqueued —
+        which means the counter is >= 2000 and the client's
+        last_event_id is below earliest, so they get ``truncated``
+        instead).  We can't distinguish the two without a separate
+        ``highest_evicted_id`` tracker; treating empty as ``replay_ok``
+        is the safe choice for the genuine cold-start case (no false
+        ``replay_truncated`` envelopes on freshly-opened workstreams).
+        """
+        client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
+        with self._listeners_lock:
+            buffered = list(self._event_buffer)
+            self._listeners.append(client_queue)
+        if not buffered:
+            return client_queue, [], "replay_ok", 0, 0
+        earliest_id = buffered[0][0]
+        if last_event_id < earliest_id - 1:
+            lost_count = (earliest_id - 1) - last_event_id
+            return client_queue, [], "truncated", lost_count, earliest_id
+        replay_events = [ev for eid, ev in buffered if eid > last_event_id]
+        return client_queue, replay_events, "replay_ok", 0, earliest_id
 
     # ------------------------------------------------------------------
     # Approval / plan blocking gates
@@ -1429,16 +1588,19 @@ class SessionUIBase:
     def _reset_inflight_buffers_locked(self) -> None:
         """Clear the per-turn inflight content + reasoning. Caller holds ``_ws_lock``.
 
-        ``_ws_inflight_seq`` is INTENTIONALLY not reset — it must
-        remain monotonically increasing for the lifetime of the UI so
-        a long-lived SSE subscriber's ``snap_seq`` cutoff stays a
-        valid high-water mark across turn boundaries. If we reset
-        seq=0 at every turn, turn N+1's first M tokens (M = the
-        snap_seq the subscriber captured mid-turn-N) would all carry
-        ``_seq <= snap_seq`` and get silently dropped by the dedup
-        filter in :func:`make_events_handler`. Seq is just a wire-
-        format dedup tag — its absolute value doesn't matter, only
-        that it's monotonic.
+        ``_event_id`` is INTENTIONALLY not reset — it must remain
+        monotonically increasing for the lifetime of the UI so a
+        long-lived SSE subscriber's ``snap_seq`` cutoff stays a valid
+        high-water mark across turn boundaries AND a ``Last-Event-ID``
+        replay can still slice the buffer correctly across resets.
+        If we reset to 0 at every turn, turn N+1's first M tokens
+        (M = the snap_seq the subscriber captured mid-turn-N) would
+        all carry ``_seq <= snap_seq`` and get silently dropped by
+        the dedup filter in :func:`make_events_handler`; and a
+        ``Last-Event-ID`` from before the reset would point into the
+        OLD numbering and silently mis-replay.  ``_event_id`` is just
+        an opaque monotonic tag — its absolute value doesn't matter,
+        only that it never decreases for the lifetime of the UI.
         """
         self._ws_inflight_content = []
         self._ws_inflight_content_size = 0
@@ -1490,16 +1652,17 @@ class SessionUIBase:
     def on_reasoning_token(self, text: str) -> None:
         """Append to the inflight reasoning buffer (capped) + enqueue.
 
-        Mirrors :meth:`on_content_token`'s shape. ``_ws_inflight_seq``
-        advances on EVERY emit — even when the buffer cap rejected
-        the append — so the dedup filter in :func:`make_events_handler`
-        stays correct for subscribers that register after the cap is
-        hit. If seq stalled at the high-water-pre-cap, those late
-        subscribers would capture ``snap_seq == high-water`` and
-        every subsequent live token (with the same stalled seq)
-        would be filter-dropped as "already in your snapshot",
-        silently losing the rest of the stream. The cap is a
-        buffer-size limit, NOT a "stop streaming" signal.
+        Mirrors :meth:`on_content_token`'s shape.  The ``_seq`` dedup
+        tag is stamped by :meth:`_enqueue` against the per-ws
+        ``_event_id`` counter, which advances on EVERY emit
+        regardless of whether the inflight cap rejected the append.
+        If the seq stalled at high-water-pre-cap, subscribers
+        registering after the cap is hit would capture
+        ``snap_seq == high-water`` and every subsequent live token
+        (with the same stalled seq) would be filter-dropped as
+        "already in your snapshot" — silently losing the rest of
+        the stream. The cap is a buffer-size limit, NOT a "stop
+        streaming" signal.
 
         Tokens past the cap are absent from ``snap.reasoning`` (the
         snapshot text was truncated at cap) but the live stream
@@ -1512,9 +1675,7 @@ class SessionUIBase:
             if self._ws_inflight_reasoning_size < _MAX_TURN_CONTENT_CHARS:
                 self._ws_inflight_reasoning.append(text)
                 self._ws_inflight_reasoning_size += len(text)
-            self._ws_inflight_seq += 1
-            seq = self._ws_inflight_seq
-        self._enqueue({"type": "reasoning", "text": text, "_seq": seq})
+        self._enqueue({"type": "reasoning", "text": text})
 
     def on_content_token(self, text: str) -> None:
         """Append to both turn-content buffers (capped) + enqueue.
@@ -1526,15 +1687,14 @@ class SessionUIBase:
            :meth:`on_turn_start`) — fuels the SSE ``in_progress_snapshot``
            event a reconnecting client sees on mid-stream refresh.
 
-        Both caps are checked independently. ``_ws_inflight_seq``
-        advances on EVERY emit — even when the inflight cap rejected
-        the append — so a subscriber that registers after the cap is
-        hit doesn't have every subsequent live token filter-dropped
-        against a stalled ``snap_seq``. See
-        :meth:`on_reasoning_token` for the full rationale.
+        Both caps are checked independently.  The ``_seq`` dedup tag
+        is stamped by :meth:`_enqueue` against the per-ws
+        ``_event_id`` counter, which advances on EVERY emit
+        regardless of cap state — see :meth:`on_reasoning_token` for
+        the full rationale.
 
-        The cap-check + append + size-update + seq-bump run under
-        ``_ws_lock`` so a concurrent
+        The cap-check + append + size-update run under ``_ws_lock``
+        so a concurrent
         :meth:`snapshot_and_consume_state_payload` IDLE/ERROR drain or
         a concurrent :meth:`register_listener_with_in_progress_snapshot`
         can't see a torn list mid-append. In production this is
@@ -1551,9 +1711,7 @@ class SessionUIBase:
             if self._ws_inflight_content_size < _MAX_TURN_CONTENT_CHARS:
                 self._ws_inflight_content.append(text)
                 self._ws_inflight_content_size += len(text)
-            self._ws_inflight_seq += 1
-            seq = self._ws_inflight_seq
-        self._enqueue({"type": "content", "text": text, "_seq": seq})
+        self._enqueue({"type": "content", "text": text})
 
     def on_stream_end(self) -> None:
         with self._ws_lock:

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -47,31 +47,59 @@ _DEFAULT_LISTENER_QUEUE_MAX = 500
 def _resolve_event_buffer_max() -> int:
     """Read ``TURNSTONE_SSE_EVENT_BUFFER_MAX`` env override at import time.
 
-    Default 2000 events covers ~10-40 seconds of cloud-provider streaming
-    (50-200 events/sec per active stream) — enough to make any typical
-    network blip or intermediary timeout transparent to the browser.
-    Local-inference deployments (vLLM, llama.cpp at 500-2000 tok/s) can
-    burn through the cap in under a second; operators on those workloads
-    can raise the bound knowing the tradeoff (linear memory growth ×
-    100-workstream design ceiling).  Below-cap reconnects always hit the
-    replay path; above-cap reconnects fall back to the snapshot recovery
-    floor with an explicit ``replay_truncated`` envelope so the client
-    knows it lost live ticks.
+    Default 50000 events.  Two pressures push the cap larger than a
+    casual reading of "how many events does an SSE stream see":
+
+    1. Local-inference deployments stream at 500–2000 tok/s per
+       active model.  Each token is an ``_enqueue`` call, so a single
+       active workstream can fire ~2000 events/sec sustained.  At
+       the 50000 cap that buys ~25 s of pure token streaming before
+       truncation; at typical cloud-provider rates (50–200 events/sec
+       per stream) it's minutes of coverage.
+    2. Browsers throttle the SSE-drain microtask aggressively when
+       the tab isn't visible (Chrome's background-tab budget drops
+       to ~1 wake/min after ~5 min hidden).  A backgrounded tab can
+       legitimately go tens of seconds without draining its
+       EventSource buffer — and PR-G (drop-pings-let-it-die)
+       deliberately closes those connections on hide.  Reconnect-with-
+       replay is the recovery path; if the buffer evicted in the
+       interim, the snapshot floor is all that's left.
+
+    Why not coalesce consecutive content/reasoning tokens?  A naive
+    text-merge breaks the replay-slice semantic: a coalesced entry
+    has the latest ``_event_id`` but text that includes content the
+    client already received under an earlier id, so any consumer
+    with ``last_event_id`` falling INSIDE the coalesced span would
+    double-render.  A correctness-preserving coalesce would need a
+    per-consumer high-water tracker we deliberately don't maintain
+    (consumers register and disconnect independently).  Bigger cap
+    + simple per-event storage avoids the trap.
+
+    Memory cost is ~200–500 bytes per event (deque node + dict
+    overhead + payload), so 50000 × 100-ws design ceiling caps at
+    roughly 2.5 GB worst-case — and practically never anywhere
+    close because the cap is the per-ws ceiling, not per-ws steady-
+    state.  Operators on heavier workloads can raise via
+    ``TURNSTONE_SSE_EVENT_BUFFER_MAX``; below-cap reconnects always
+    hit the replay path, above-cap reconnects fall back to the
+    snapshot recovery floor with an explicit ``replay_truncated``
+    envelope.
     """
     raw = os.environ.get("TURNSTONE_SSE_EVENT_BUFFER_MAX", "").strip()
+    default = 50000
     if not raw:
-        return 2000
+        return default
     try:
         n = int(raw)
     except ValueError:
-        return 2000
-    return n if n > 0 else 2000
+        return default
+    return n if n > 0 else default
 
 
 # Per-ws ring buffer for ``Last-Event-ID`` SSE replay.  Holds the most
 # recent events keyed by monotonic ``_event_id``; deque ``maxlen`` evicts
 # oldest automatically.  See :func:`_resolve_event_buffer_max` for the
-# sizing rationale.
+# sizing rationale (why 50000 and not 2000; why no in-buffer coalescing).
 _EVENT_BUFFER_MAX = _resolve_event_buffer_max()
 
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import collections
 import contextlib
 import functools
 import hashlib
 import json
 import os
 import queue
+import random
 import re
 import sys
 import textwrap
@@ -1243,24 +1245,101 @@ async def global_events_sse(request: Request) -> Response:
             status_code=409,
         )
 
-    # -- Atomic snapshot + listener registration ------------------------------
+    # -- Last-Event-ID resume parsing -----------------------------------------
+    # Native EventSource sets the header on auto-reconnect; the
+    # manual-reconnect path (which can't set custom headers on
+    # ``new EventSource(url)``) uses the query-param fallback.
+    last_event_id_raw = request.headers.get("Last-Event-ID") or request.query_params.get(
+        "last_event_id"
+    )
+    last_event_id: int | None
+    try:
+        last_event_id = int(last_event_id_raw) if last_event_id_raw else None
+    except (TypeError, ValueError):
+        last_event_id = None
+
+    # -- Atomic snapshot / replay-slice + listener registration ---------------
     client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=1000)
     listeners = request.app.state.global_listeners
     listeners_lock = request.app.state.global_listeners_lock
+    event_buffer: collections.deque[tuple[int, dict[str, Any]]] = (
+        request.app.state.global_event_buffer
+    )
 
-    # Hold the listeners lock while building the snapshot AND registering.
-    # The fanout thread also acquires this lock when snapshotting the listener
-    # list, so events that land on global_queue during snapshot build will be
-    # distributed to our queue after we release — gap-free.
+    # Three replay shapes, matching :func:`make_events_handler`:
+    #   - ``last_event_id is None`` → ``"fresh"``: emit node_snapshot
+    #     then live.
+    #   - ``last_event_id`` + buffer covers gap → ``"replay_ok"``:
+    #     emit buffered events past the id, SKIP node_snapshot, then
+    #     live.
+    #   - ``last_event_id`` + buffer too short → ``"truncated"``: emit
+    #     a ``replay_truncated`` envelope then fall through to
+    #     ``"fresh"`` (node_snapshot is the recovery floor).
+    replay_status: str
+    replay_events: list[dict[str, Any]] = []
+    lost_count = 0
+    earliest_available_id = 0
+    snapshot: dict[str, Any] | None = None
+
     with listeners_lock:
-        snapshot = _build_node_snapshot(request.app.state)
+        if last_event_id is None:
+            replay_status = "fresh"
+            snapshot = _build_node_snapshot(request.app.state)
+        else:
+            buffered = list(event_buffer)
+            if not buffered:
+                replay_status = "replay_ok"
+            else:
+                earliest_available_id = buffered[0][0]
+                if last_event_id < earliest_available_id - 1:
+                    replay_status = "truncated"
+                    lost_count = (earliest_available_id - 1) - last_event_id
+                    snapshot = _build_node_snapshot(request.app.state)
+                else:
+                    replay_status = "replay_ok"
+                    replay_events = [ev for eid, ev in buffered if eid > last_event_id]
         listeners.append(client_queue)
 
-    async def event_generator() -> AsyncGenerator[dict[str, str], None]:
+    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
         _metrics.record_sse_connect()
+
+        def _format_event(event: dict[str, Any]) -> dict[str, str]:
+            """Strip ``_event_id`` from the wire dict, attach SSE ``id:``."""
+            ev_copy = dict(event)
+            eid = ev_copy.pop("_event_id", None)
+            out: dict[str, str] = {"data": json.dumps(ev_copy)}
+            if eid is not None:
+                out["id"] = str(eid)
+            return out
+
         try:
-            # Emit snapshot as first event
-            yield {"data": json.dumps(snapshot)}
+            # Per-stream reconnect jitter (see per-ws handler for
+            # rationale) — staggers reconnect of many panes / many
+            # global subscribers after a shared blip.
+            yield {"retry": random.randint(2500, 4500)}
+
+            if replay_status == "truncated":
+                yield {
+                    "data": json.dumps(
+                        {
+                            "type": "replay_truncated",
+                            "lost_count": lost_count,
+                            "earliest_available_id": earliest_available_id,
+                        }
+                    )
+                }
+            if replay_status == "replay_ok":
+                for ev in replay_events:
+                    yield _format_event(ev)
+            else:
+                # Fresh or truncated: emit the node_snapshot as the
+                # recovery floor.  Snapshot is synthetic (built from
+                # current ws state) and carries no ``_event_id`` —
+                # the client's ``lastEventId`` stays at whatever the
+                # last buffered event was (or empty on fresh).
+                if snapshot is not None:
+                    yield {"data": json.dumps(snapshot)}
+
             loop = asyncio.get_running_loop()
             executor = request.app.state.sse_executor
             while True:
@@ -1268,7 +1347,7 @@ async def global_events_sse(request: Request) -> Response:
                     event = await loop.run_in_executor(
                         executor, functools.partial(client_queue.get, timeout=5)
                     )
-                    yield {"data": json.dumps(event)}
+                    yield _format_event(event)
                 except queue.Empty:
                     pass  # poll timeout, retry
         finally:
@@ -3568,16 +3647,33 @@ def _global_fanout_thread(
     source_queue: queue.Queue[dict[str, Any]],
     listeners: list[queue.Queue[dict[str, Any]]],
     lock: threading.Lock,
+    event_buffer: collections.deque[tuple[int, dict[str, Any]]],
+    counter_holder: list[int],
 ) -> None:
-    """Reads events from the source queue and copies them to all listener queues."""
+    """Read events from ``source_queue``, stamp + buffer + fan out.
+
+    Stamps every event with a monotonic ``_event_id`` (the holder list
+    is a single-element mutable int — Python idiom for a shared int
+    under a lock), appends ``(event_id, event)`` to the global ring
+    buffer, snapshots the listener list, and fans out — all under
+    ``lock`` so a concurrent reader registering itself as a listener
+    sees a consistent ``(counter, listeners, buffer)`` triple and no
+    event lands in ONLY the buffer or ONLY the listener queue across
+    the registration boundary.  Mirrors :meth:`SessionUIBase._enqueue`'s
+    contract for the global lane.
+    """
     while True:
         try:
             event = source_queue.get()
             with lock:
+                counter_holder[0] += 1
+                event_id = counter_holder[0]
+                stamped = {**event, "_event_id": event_id}
+                event_buffer.append((event_id, stamped))
                 snapshot = list(listeners)
             for lq in snapshot:
                 with contextlib.suppress(queue.Full):
-                    lq.put_nowait(event)  # drop if a listener is backed up
+                    lq.put_nowait(stamped)  # drop if a listener is backed up
         except Exception:
             log.debug("Global fan-out error", exc_info=True)
 
@@ -3600,6 +3696,8 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
             app.state.global_queue,
             app.state.global_listeners,
             app.state.global_listeners_lock,
+            app.state.global_event_buffer,
+            app.state.global_event_id_holder,
         ),
         daemon=True,
     )
@@ -4146,6 +4244,20 @@ def create_app(
     app.state.global_queue = global_queue
     app.state.global_listeners = global_listeners
     app.state.global_listeners_lock = global_listeners_lock
+    # Per-node global SSE replay ring buffer + monotonic event counter.
+    # Mirrors :attr:`SessionUIBase._event_buffer` / ``._event_id`` for
+    # the global lane; ``_global_fanout_thread`` stamps every event
+    # with ``_event_id`` under ``global_listeners_lock`` and appends
+    # to this buffer.  Cap sized to cover ~20 seconds of typical
+    # cluster broadcast rate (state changes + activity ticks across
+    # ~100 ws = up to a few hundred events/sec); operators can raise
+    # via ``TURNSTONE_SSE_EVENT_BUFFER_MAX`` (shared with per-ws cap).
+    from turnstone.core.session_ui_base import _EVENT_BUFFER_MAX
+
+    app.state.global_event_buffer = collections.deque(maxlen=_EVENT_BUFFER_MAX)
+    # Single-element list as a mutable int holder so the fanout
+    # thread can ``counter_holder[0] += 1`` under the lock.
+    app.state.global_event_id_holder = [0]
     app.state.skip_permissions = skip_permissions
     app.state.jwt_secret = jwt_secret
     app.state.auth_storage = auth_storage

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -674,9 +674,17 @@ class Pane {
       this.attachments.rehydrate();
     }
 
-    this.evtSource = new EventSource(
-      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events",
-    );
+    // Build the events URL with a ``?last_event_id=N`` query param
+    // if we have a saved high-water mark from a prior connection.
+    // The EventSource constructor can't set custom headers, so the
+    // browser-native ``Last-Event-ID`` header isn't available here;
+    // the server accepts both forms.  ``_lastEventId`` is captured
+    // from the prior source's onmessage handler.
+    let evtUrl = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
+    if (this._lastEventId) {
+      evtUrl += "?last_event_id=" + encodeURIComponent(this._lastEventId);
+    }
+    this.evtSource = new EventSource(evtUrl);
 
     this.evtSource.onopen = () => {
       this.retryDelay = 1000;
@@ -685,100 +693,145 @@ class Pane {
     };
 
     this.evtSource.onmessage = (e) => {
+      // Capture lastEventId BEFORE JSON.parse so a (rare) malformed
+      // event doesn't desync the manual-reconnect fallback from
+      // native auto-reconnect (which advances lastEventId regardless
+      // of whether we successfully process the data).  Server's
+      // stamping contract: ``id:`` only on events sourced from the
+      // per-ws ring buffer — synthetic replay events (history /
+      // state_change / in_progress_snapshot) don't advance the
+      // counter, so reconnect resumes from the last BUFFERED id (or
+      // none on a truly-fresh connect that never received one).
+      if (this.evtSource && this.evtSource.lastEventId) {
+        this._lastEventId = this.evtSource.lastEventId;
+      }
       const data = JSON.parse(e.data);
       this.handleEvent(data);
     };
 
     this.evtSource.onerror = () => {
-      this.evtSource.close();
-      this.evtSource = null;
+      // Do NOT close evtSource for transient network errors — native
+      // EventSource auto-reconnect handles them with the
+      // ``Last-Event-ID`` header automatically (now that the server
+      // emits ``id:`` on every buffered event).  Closing here would
+      // force a CONNECTING -> CLOSED transition that defeats native
+      // reconnect, which is exactly the reconnect-with-replay defect
+      // PR-D ships to fix.  See
+      // tests/test_app_js.py::test_pane_connectsse_onerror_preserves_native_reconnect.
       const loginOverlay = document.getElementById("login-overlay");
       if (loginOverlay && loginOverlay.style.display !== "none") return;
       this.statusBarEl.classList.add("ws-sb-disconnected");
       this._sbTokens.textContent = "Reconnecting\u2026";
-      // Only the focused pane refreshes the global workstream list to avoid
-      // race conditions when multiple panes disconnect simultaneously.
+      // Focused-pane orthogonal trigger: refetch the global
+      // workstream list so a workstream evicted while we were
+      // disconnected gets reassigned across panes.  The reassignment
+      // branch's explicit disconnectSSE + connectSSE on the new
+      // wsId is correct (a different workstream genuinely needs a
+      // fresh stream, not a same-stream replay).
       if (this.id === focusedPaneId) {
-        fetch("/v1/api/workstreams")
-          .then((r) => {
-            if (r.status === 401) {
-              showLogin();
-              return;
-            }
-            return r.json().then((data) => {
-              workstreams = {};
-              (data.workstreams || []).forEach((ws) => {
-                workstreams[ws.ws_id] = { name: ws.name, state: ws.state };
-              });
-              renderTabBar();
-              // Reconnect all disconnected panes, reassigning stale ws_ids.
-              // Two passes: (1) reassign stale panes, (2) reconnect all.
-              // Track assigned ws_ids to avoid multiple panes on the same ws.
-              const remaining = Object.keys(workstreams);
-              if (!remaining.length) {
-                showDashboard();
-                return;
-              }
-              const usedWsIds = {};
-              for (let pid in panes) {
-                if (panes[pid].wsId && workstreams[panes[pid].wsId])
-                  usedWsIds[panes[pid].wsId] = true;
-              }
-              for (let pid2 in panes) {
-                const p2 = panes[pid2];
-                if (p2.wsId && !workstreams[p2.wsId]) {
-                  let newWsId = null;
-                  for (let ri = 0; ri < remaining.length; ri++) {
-                    if (!usedWsIds[remaining[ri]]) {
-                      newWsId = remaining[ri];
-                      break;
-                    }
-                  }
-                  if (newWsId) {
-                    p2.disconnectSSE();
-                    p2.wsId = newWsId;
-                    usedWsIds[newWsId] = true;
-                    while (p2.messagesEl.firstChild)
-                      p2.messagesEl.removeChild(p2.messagesEl.firstChild);
-                    p2.showEmptyState();
-                    p2.updateWsName();
-                  }
-                  // else: more panes than workstreams — leave pane stale,
-                  // connectSSE below will pick it up or it stays disconnected.
-                }
-              }
-              // Pass 2: reconnect all panes and sync focused pane
-              for (let pid3 in panes) {
-                const p3 = panes[pid3];
-                if (pid3 === focusedPaneId) currentWsId = p3.wsId;
-                if (!p3.evtSource && p3.wsId && workstreams[p3.wsId]) {
-                  setTimeout(
-                    ((pp) => {
-                      return () => {
-                        pp.connectSSE(pp.wsId);
-                      };
-                    })(p3),
-                    this.retryDelay,
-                  );
-                }
-              }
-              this.retryDelay = Math.min(this.retryDelay * 2, 30000);
-            });
-          })
-          .catch(() => {
-            setTimeout(() => {
-              this.connectSSE(this.wsId);
-            }, this.retryDelay);
-            this.retryDelay = Math.min(this.retryDelay * 2, 30000);
+        this._refetchWorkstreamsAndReassign();
+      }
+      // Non-focused panes: native EventSource reconnect handles them
+      // transparently — no per-pane retry needed.  The 30 s exp-backoff
+      // ceiling on retryDelay is preserved inside
+      // _refetchWorkstreamsAndReassign for the focused-pane path.
+    };
+  }
+
+  _refetchWorkstreamsAndReassign() {
+    // Lifted from the pre-PR-D ``onerror`` body.  Triggered when the
+    // focused pane sees its EventSource enter the error state — pulls
+    // the authoritative workstream list and reassigns stale wsIds.
+    // Survives the onerror refactor as a separate concern from the
+    // SSE reconnect mechanics: native EventSource handles the same-
+    // workstream reconnect; this handles the workstream-evicted-
+    // during-disconnect recovery.
+    fetch("/v1/api/workstreams")
+      .then((r) => {
+        if (r.status === 401) {
+          showLogin();
+          return;
+        }
+        return r.json().then((data) => {
+          workstreams = {};
+          (data.workstreams || []).forEach((ws) => {
+            workstreams[ws.ws_id] = { name: ws.name, state: ws.state };
           });
-      } else {
-        // Non-focused pane: just retry own connection after delay
+          renderTabBar();
+          // Two passes: (1) reassign stale panes, (2) reconnect any
+          // that ended up in CLOSED state.  Native reconnect covers
+          // CONNECTING -> OPEN transitions transparently.
+          const remaining = Object.keys(workstreams);
+          if (!remaining.length) {
+            showDashboard();
+            return;
+          }
+          const usedWsIds = {};
+          for (let pid in panes) {
+            if (panes[pid].wsId && workstreams[panes[pid].wsId])
+              usedWsIds[panes[pid].wsId] = true;
+          }
+          for (let pid2 in panes) {
+            const p2 = panes[pid2];
+            if (p2.wsId && !workstreams[p2.wsId]) {
+              let newWsId = null;
+              for (let ri = 0; ri < remaining.length; ri++) {
+                if (!usedWsIds[remaining[ri]]) {
+                  newWsId = remaining[ri];
+                  break;
+                }
+              }
+              if (newWsId) {
+                p2.disconnectSSE();
+                // Different workstream → drop saved id; replay is
+                // per-ws so an id from ws-A is meaningless on ws-B.
+                p2._lastEventId = null;
+                p2.wsId = newWsId;
+                usedWsIds[newWsId] = true;
+                while (p2.messagesEl.firstChild)
+                  p2.messagesEl.removeChild(p2.messagesEl.firstChild);
+                p2.showEmptyState();
+                p2.updateWsName();
+              }
+              // else: more panes than workstreams — leave pane stale,
+              // connectSSE below picks it up or stays disconnected.
+            }
+          }
+          // Pass 2: reconnect any pane whose EventSource ended up
+          // truly CLOSED (not just transient — native reconnect
+          // handles CONNECTING / OPEN).
+          for (let pid3 in panes) {
+            const p3 = panes[pid3];
+            if (pid3 === focusedPaneId) currentWsId = p3.wsId;
+            const dead =
+              !p3.evtSource || p3.evtSource.readyState === EventSource.CLOSED;
+            if (dead && p3.wsId && workstreams[p3.wsId]) {
+              setTimeout(
+                ((pp) => {
+                  return () => {
+                    pp.connectSSE(pp.wsId);
+                  };
+                })(p3),
+                this.retryDelay,
+              );
+            }
+          }
+          this.retryDelay = Math.min(this.retryDelay * 2, 30000);
+        });
+      })
+      .catch(() => {
+        // Fetch failed (network) — schedule a same-pane reconnect
+        // fallback in case the EventSource is genuinely dead.
         setTimeout(() => {
-          this.connectSSE(this.wsId);
+          if (
+            !this.evtSource ||
+            this.evtSource.readyState === EventSource.CLOSED
+          ) {
+            this.connectSSE(this.wsId);
+          }
         }, this.retryDelay);
         this.retryDelay = Math.min(this.retryDelay * 2, 30000);
-      }
-    };
+      });
   }
 
   handleEvent(evt) {
@@ -2905,6 +2958,13 @@ let workstreams = {};
 let currentWsId = null;
 let globalEvtSource = null;
 let globalRetryDelay = 1000;
+// Saved high-water mark for the manual-reconnect path (the
+// EventSource constructor can't set custom headers, so the
+// browser-native ``Last-Event-ID`` header is unavailable on
+// reconnect — we thread it via ``?last_event_id=N`` instead).  Updated
+// from ``globalEvtSource.lastEventId`` on every onmessage; native
+// auto-reconnect uses the header directly on the same source object.
+let globalLastEventId = null;
 let dashboardVisible = false;
 let _historyNavigation = false;
 let _lastHealth = null;
@@ -4663,11 +4723,23 @@ function connectGlobalSSE() {
     globalEvtSource.close();
     globalEvtSource = null;
   }
-  globalEvtSource = new EventSource("/v1/api/events/global");
+  // Manual-reconnect path threads ``?last_event_id=N`` because the
+  // EventSource constructor can't set headers; native auto-reconnect
+  // on the same source uses the header directly.
+  let globalUrl = "/v1/api/events/global";
+  if (globalLastEventId) {
+    globalUrl += "?last_event_id=" + encodeURIComponent(globalLastEventId);
+  }
+  globalEvtSource = new EventSource(globalUrl);
   globalEvtSource.onopen = function () {
     globalRetryDelay = 1000;
   };
   globalEvtSource.onmessage = function (e) {
+    // Capture lastEventId BEFORE JSON.parse (see Pane.connectSSE
+    // onmessage for full rationale).
+    if (globalEvtSource && globalEvtSource.lastEventId) {
+      globalLastEventId = globalEvtSource.lastEventId;
+    }
     const data = JSON.parse(e.data);
     if (data.type === "ws_state") {
       updateTabIndicator(data.ws_id, data.state, {
@@ -4735,21 +4807,26 @@ function connectGlobalSSE() {
     }
   };
   globalEvtSource.onerror = function () {
-    globalEvtSource.close();
-    globalEvtSource = null;
-    fetch("/v1/api/workstreams")
-      .then(function (r) {
-        if (r.status === 401) {
-          showLogin();
-          return;
+    // Do NOT close globalEvtSource for transient errors — native
+    // EventSource auto-reconnect handles them with the
+    // ``Last-Event-ID`` header automatically (now that the global
+    // SSE handler emits ``id:`` on every buffered event).  Closing
+    // here would defeat native reconnect.  See PR-D briefing § 3.3
+    // and the per-pane handler above for the same pattern.
+    //
+    // The 401 probe stays — an authentication failure is a terminal
+    // condition (the user must log in) and merits an explicit
+    // close + showLogin.  ``_reconnectDeadSSEs`` (visibilitychange /
+    // focus listener) covers the truly-CLOSED case.
+    fetch("/v1/api/workstreams").then(function (r) {
+      if (r.status === 401) {
+        if (globalEvtSource) {
+          globalEvtSource.close();
+          globalEvtSource = null;
         }
-        setTimeout(connectGlobalSSE, globalRetryDelay);
-        globalRetryDelay = Math.min(globalRetryDelay * 2, 30000);
-      })
-      .catch(function () {
-        setTimeout(connectGlobalSSE, globalRetryDelay);
-        globalRetryDelay = Math.min(globalRetryDelay * 2, 30000);
-      });
+        showLogin();
+      }
+    });
   };
 }
 


### PR DESCRIPTION
## Summary

- **Commit 1 — Server-side ring buffer + `Last-Event-ID` replay.**  Adds a per-ws (and global-SSE) monotonic ring buffer (default cap 2000, env-overridable via `TURNSTONE_SSE_EVENT_BUFFER_MAX`) that holds the last N events for replay against a client's `Last-Event-ID` header — or `?last_event_id=N` query-param fallback for the manual-reconnect path that can't set custom headers.  Events handler branches three ways (fresh / replay_ok / truncated), emits the SSE `id:` field on every event sourced from the buffer, and emits a jittered `retry:` in [2500, 4500] ms on first yield so 6-pane reconnects don't lockstep on EventSource's default ~3 s interval.  Existing `_ws_inflight_seq` lifted to `_event_id` so one monotonic counter drives both the buffer slice AND the existing snapshot dedup contract (byte-identical on the wire for the `_seq <= snap_seq` path).
- **Commit 2 — Console proxy forwards `Last-Event-ID`.**  The console SSE proxy is the only inbound SSE path in multi-node deployments and today's proxy strips client request headers.  One conditional carry-over of `Last-Event-ID` (Starlette's header dict is case-insensitive so we catch both spec-recommended and intermediary-normalised casings) — the query-param fallback flows through the existing `request.url.query` propagation for free.
- **Commit 3 — Browser `onerror` preserves native EventSource auto-reconnect.**  Removes the unconditional `evtSource.close()` from `Pane.connectSSE`, `connectGlobalSSE`, and the coordinator's `connectSSE` — explicit close defeats native reconnect entirely, which is exactly the defect PR-D ships to fix.  Terminal-branch closes (401 expired session, workstream reassignment) survive; the focused-pane workstream refetch is lifted into a dedicated `_refetchWorkstreamsAndReassign` helper so it stays as an orthogonal eviction-recovery trigger.  Manual-reconnect paths thread `?last_event_id=N` from the source's saved `lastEventId` because the EventSource constructor can't set custom headers.  Three new static lint guards in `tests/test_app_js.py` fail loudly if any future refactor reintroduces a naked `evtSource.close()` in a transient-error path (with allowed exemptions for terminal branches and an escape hatch for future redesigns that explicitly take responsibility for the replay header).

The PR is foundation work only — fan-in (#540 core), service-worker push, and aggressive lifecycle close (close-on-hidden / let-it-die) are out of scope and follow as separate PRs.  Backward-compat: no consumer that doesn't send `Last-Event-ID` (today's browser, Python SDK, TypeScript SDK, channel adapter) sees any behavioural change — the server-side addition is purely additive.

## Architecture notes

- **One counter, two consumers.**  The per-ws `_event_id` counter advances on every `_enqueue` call (under `_listeners_lock`) and stamps both the new buffer key and the existing `_seq` snapshot-dedup tag on `content` / `reasoning` events.  The pre-PR-D `_ws_inflight_seq` semantics (monotonic across turn boundaries, advances even when the inflight cap rejected the append) are preserved exactly.
- **Atomic registration.**  `register_listener_with_replay` snapshots the buffer AND registers the listener under `_listeners_lock` so a concurrent `_enqueue` either lands in the buffer slice OR the listener queue, never both, never neither.  Same contract on the global-SSE lane via `global_listeners_lock`.
- **Synthetic events don't advance `lastEventId`.**  History, `state_change`, and `in_progress_snapshot` events emitted from the events handler carry no `id:` field by design — so a mid-replay disconnect resumes from the last BUFFERED id (or none on a truly-fresh connect that never received one).  This sidesteps the "client thinks it caught up but actually didn't" hazard.
- **Two-regime cap sizing.**  2000 events covers ~10–40 s of cloud-provider streaming (50–200 events/sec); local-inference deployments (vLLM, llama.cpp at 500–2000 tok/s) will hit `replay_truncated` on multi-second disconnects.  The truncated path falls through to the snapshot recovery floor — strictly an improvement over today's "no replay at all."  Operators on heavy local-inference workloads can raise the cap via `TURNSTONE_SSE_EVENT_BUFFER_MAX`.

## Test plan

- [x] `.venv-312/bin/python -m pytest -m 'not live' -q` → 6313 passed, 15 skipped, 3 deselected
- [x] `ruff check` clean on all changed Python files
- [x] `mypy` clean on changed `turnstone/` modules; no new errors in changed tests
- [x] `node --check turnstone/ui/static/app.js turnstone/console/static/coordinator/coordinator.js`
- [x] 16 new tests in `tests/test_sse_reconnect_replay.py` covering buffer semantics, counter invariants under concurrent writers, queue-full no-skip, handler branching (retry / id / snapshot-skip / truncated envelope / query-param fallback / malformed header → fresh)
- [x] 2 new proxy header tests in `tests/test_service_auth_boundary.py::TestProxySseLastEventIdForwarding`
- [x] 3 new static lint guards in `tests/test_app_js.py` pin the no-naked-close contract across all three SSE clients
- [ ] Manual smoke: open workstream, send a message, throttle network → Offline mid-stream for 5 s, restore, verify no missed tokens / tool calls / state transitions; repeat at 60 s to exercise the buffer-overrun → `replay_truncated` path

## Follow-ups (out of scope, per issue #540)

- PR-E: Fan-in (single console SSE multiplexing per-ws subscriptions) — depends on this PR's reconnect-with-replay
- PR-F: Service-worker push notifications
- PR-G: Aggressive lifecycle close (close-on-hidden, debounced blur, park-on-server-idle, drop-pings-let-it-die)