### PR TITLE
fix(ui): renderer local-escape + attribute-context CI lint

### DIFF
--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -16,6 +16,7 @@ placeholder and not the raw delimiter.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -1273,3 +1274,152 @@ def test_streaming_render_invokes_hljs() -> None:
         "_streamingRenderApply must call postRenderHljs for progressive "
         "syntax highlighting during streaming"
     )
+
+
+# ---------------------------------------------------------------------------
+# Attribute-context interpolation lint + pin tests
+# ---------------------------------------------------------------------------
+
+# The JS source uses `'...attr="' + var + '"...'` — so the literal text
+# between `=` and `+` is `"` (the HTML-attribute opener inside the
+# JS string) followed by `'` (the JS-string closer). Match that pair,
+# then optional whitespace + `+` + whitespace + an identifier.
+_RENDERER_ATTR_INTERP_RE = re.compile(
+    r"=[\"'][\"']\s*\+\s*(?!escapeHtml\b)([a-zA-Z_][a-zA-Z0-9_]*)"
+)
+
+# Identifiers exempted from the lint. Each entry is reviewer-approved
+# as known-safe; adding a new one requires a comment explaining why.
+_RENDERER_KNOWN_SAFE_IDENTIFIERS = {
+    # CALLOUT_TYPES enum lookup ({label, icon} of fixed strings — Note,
+    # Tip, Important, Warning, Caution). `alertType` matched by regex
+    # /(NOTE|TIP|IMPORTANT|WARNING|CAUTION)/, so .toLowerCase() output
+    # is also a fixed set; flows through `info`.
+    "info",
+}
+
+
+def test_renderer_attribute_context_interpolation_is_safe() -> None:
+    """Pin: every `attr="' + var` string-concat interpolation in
+    renderer.js must use one of:
+
+    * `escapeHtml(...)` at the call site (allowed by the negative
+      lookahead in the regex),
+    * an identifier matching `safe[A-Z_]…` (convention: the value is
+      pre-escaped at assignment), or
+    * an identifier in :data:`_RENDERER_KNOWN_SAFE_IDENTIFIERS`
+      (reviewer-approved enum lookups / counters).
+
+    Defence-in-depth lint per issue #553. The current call sites are
+    already safe today via ``inlineMarkdown``'s leading ``escapeHtml``
+    pass, but that invariant is non-local — a refactor moving image
+    or link rendering out of ``inlineMarkdown`` would silently
+    regress it. The lint locks in the local-escape posture so the
+    safety property is structural rather than emergent.
+    """
+    body = _RENDERER_JS.read_text(encoding="utf-8")
+    lines = body.splitlines()
+    offenders: list[tuple[int, str, str]] = []
+    for m in _RENDERER_ATTR_INTERP_RE.finditer(body):
+        ident = m.group(1)
+        if len(ident) > 4 and ident.startswith("safe") and ident[4].isupper():
+            continue
+        if ident in _RENDERER_KNOWN_SAFE_IDENTIFIERS:
+            continue
+        line_no = body.count("\n", 0, m.start()) + 1
+        offenders.append((line_no, ident, lines[line_no - 1].rstrip()))
+    assert not offenders, (
+        f"Found {len(offenders)} unsafe attribute-context "
+        f"interpolation(s) in renderer.js:\n"
+        + "\n".join(
+            f"  line {n}: {ident!r}  in  {line.strip()[:100]}" for n, ident, line in offenders[:10]
+        )
+        + "\nEither wrap with escapeHtml() at the call site, rename "
+        "the variable to safeXxx (after verifying it is pre-escaped "
+        "at assignment), or add the identifier to "
+        "_RENDERER_KNOWN_SAFE_IDENTIFIERS with a comment explaining "
+        "why it is known-safe (e.g. enum lookup, integer counter)."
+    )
+
+
+_HANDLER_ATTRS = frozenset(
+    {
+        "onerror",
+        "onload",
+        "onmouseover",
+        "onclick",
+        "onmouseout",
+        "onfocus",
+        "onblur",
+        "onchange",
+        "onsubmit",
+        "onkeydown",
+        "onkeyup",
+        "onkeypress",
+    }
+)
+
+
+def _all_attr_names(html: str) -> list[tuple[str, str]]:
+    """Parse ``html`` and return a flat list of ``(tag, attr_name)`` for
+    every attribute on every element. Used by the attacker-URL pin
+    tests to assert no event-handler attribute ever materializes —
+    substring checks on the raw output are too noisy because the
+    literal text ``onerror=&amp;quot;`` is safe when it sits inside
+    a parsed attribute value, but the substring still matches."""
+    from html.parser import HTMLParser
+
+    class _Collector(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attrs: list[tuple[str, str]] = []
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            for name, _value in attrs:
+                self.attrs.append((tag, name))
+
+    p = _Collector()
+    p.feed(html)
+    return p.attrs
+
+
+def _assert_no_handler_attrs(html: str) -> None:
+    handlers = [(tag, name) for tag, name in _all_attr_names(html) if name in _HANDLER_ATTRS]
+    assert not handlers, (
+        f"Renderer output materialized event-handler attribute(s) "
+        f"{handlers!r} — attribute-boundary escape regression. "
+        f"Full output:\n{html}"
+    )
+
+
+def test_attacker_image_url_with_quote_does_not_break_attribute() -> None:
+    """Pin: an image URL containing embedded double-quote characters
+    must NOT escape the ``data-src``/``data-alt`` attribute boundary.
+    The injected text remains inside the attribute value; no extra
+    attributes (``onerror``, etc.) materialize on the rendered span."""
+    out = _render('![alt](https://x/y.png" onerror="alert(1))')
+    _assert_no_handler_attrs(out)
+
+
+def test_attacker_image_alt_with_quote_does_not_break_attribute() -> None:
+    """Pin: an image alt text containing embedded double-quote
+    characters must not break the ``data-alt`` / ``aria-label``
+    attribute boundaries."""
+    out = _render('![alt" onerror="alert(1)](https://x/y.png)')
+    _assert_no_handler_attrs(out)
+
+
+def test_attacker_link_url_with_quote_does_not_break_attribute() -> None:
+    """Pin: a link URL containing embedded double-quote characters
+    must not escape the ``href`` attribute boundary."""
+    out = _render('[click](https://x/y" onmouseover="alert(1))')
+    _assert_no_handler_attrs(out)
+
+
+def test_attacker_link_label_with_quote_renders_as_text() -> None:
+    """Pin: a link label containing embedded ``<`` characters must
+    render as escaped text inside the anchor, not as a real tag."""
+    out = _render("[<script>alert(1)</script>](https://x/y)")
+    # No <script> tag should appear in the parsed output.
+    tags = {tag for tag, _ in _all_attr_names(out)}
+    assert "script" not in tags, "Link label leaked a real <script> element:\n" + out

--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -1305,8 +1305,8 @@ def test_renderer_attribute_context_interpolation_is_safe() -> None:
 
     * `escapeHtml(...)` at the call site (allowed by the negative
       lookahead in the regex),
-    * an identifier matching `safe[A-Z_]…` (convention: the value is
-      pre-escaped at assignment), or
+    * an identifier matching `safe[A-Z]…` (camelCase convention: the
+      value is pre-escaped at assignment), or
     * an identifier in :data:`_RENDERER_KNOWN_SAFE_IDENTIFIERS`
       (reviewer-approved enum lookups / counters).
 
@@ -1360,31 +1360,41 @@ _HANDLER_ATTRS = frozenset(
 )
 
 
-def _all_attr_names(html: str) -> list[tuple[str, str]]:
-    """Parse ``html`` and return a flat list of ``(tag, attr_name)`` for
-    every attribute on every element. Used by the attacker-URL pin
-    tests to assert no event-handler attribute ever materializes —
-    substring checks on the raw output are too noisy because the
-    literal text ``onerror=&amp;quot;`` is safe when it sits inside
-    a parsed attribute value, but the substring still matches."""
+def _parse_renderer_html(html: str) -> tuple[list[str], list[tuple[str, str]]]:
+    """Parse ``html`` and return ``(start_tags, (tag, attr_name) pairs)``.
+
+    Two return values because:
+
+    * ``start_tags`` records every start tag regardless of whether it
+      carries attributes, so a bare ``<script>`` injection (no attrs)
+      cannot slip past a tag-presence check.
+    * ``attr_pairs`` records every attribute-bearing tag for the
+      event-handler-attribute assertion.
+
+    Substring checks on the raw output are too noisy: the literal text
+    ``onerror=&amp;quot;`` is safe when it sits inside a parsed
+    attribute value, but the substring still matches."""
     from html.parser import HTMLParser
 
     class _Collector(HTMLParser):
         def __init__(self) -> None:
             super().__init__()
+            self.tags: list[str] = []
             self.attrs: list[tuple[str, str]] = []
 
         def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            self.tags.append(tag)
             for name, _value in attrs:
                 self.attrs.append((tag, name))
 
     p = _Collector()
     p.feed(html)
-    return p.attrs
+    return p.tags, p.attrs
 
 
 def _assert_no_handler_attrs(html: str) -> None:
-    handlers = [(tag, name) for tag, name in _all_attr_names(html) if name in _HANDLER_ATTRS]
+    _tags, attrs = _parse_renderer_html(html)
+    handlers = [(tag, name) for tag, name in attrs if name in _HANDLER_ATTRS]
     assert not handlers, (
         f"Renderer output materialized event-handler attribute(s) "
         f"{handlers!r} — attribute-boundary escape regression. "
@@ -1418,8 +1428,38 @@ def test_attacker_link_url_with_quote_does_not_break_attribute() -> None:
 
 def test_attacker_link_label_with_quote_renders_as_text() -> None:
     """Pin: a link label containing embedded ``<`` characters must
-    render as escaped text inside the anchor, not as a real tag."""
+    render as escaped text inside the anchor, not as a real tag.
+
+    Uses :func:`_parse_renderer_html` (not the attr-pairs accessor)
+    because a bare ``<script>`` injection has no attributes and would
+    be invisible to a (tag, attr) pair listing."""
     out = _render("[<script>alert(1)</script>](https://x/y)")
-    # No <script> tag should appear in the parsed output.
-    tags = {tag for tag, _ in _all_attr_names(out)}
+    tags, _attrs = _parse_renderer_html(out)
     assert "script" not in tags, "Link label leaked a real <script> element:\n" + out
+
+
+def test_image_url_with_ampersand_not_double_escaped() -> None:
+    """Pin: a query-string URL must not double-escape ``&``.
+
+    inlineMarkdown's leading ``escapeHtml(text)`` turns ``&`` into
+    ``&amp;`` once. Any local re-escape on the captured ``url`` would
+    produce ``&amp;amp;`` in the attribute — which decodes to literal
+    ``&amp;`` at attribute-parse time, breaks ``getAttribute`` +
+    ``new URL`` round-trip, and silently corrupts query strings."""
+    out = _render("![alt](https://x/y?a=1&b=2)")
+    assert 'data-src="https://x/y?a=1&amp;b=2"' in out, (
+        "Expected single &amp; encoding for `&`; got:\n" + out
+    )
+    assert "&amp;amp;" not in out, (
+        "URL was double-escaped (`&` → `&amp;amp;`); breaks getAttribute "
+        "+ new URL round-trip. Full output:\n" + out
+    )
+
+
+def test_link_url_with_ampersand_not_double_escaped() -> None:
+    """Same as the image case, for link ``href``."""
+    out = _render("[docs](https://example.com/p?a=1&b=2)")
+    assert 'href="https://example.com/p?a=1&amp;b=2"' in out, (
+        "Expected single &amp; encoding for `&`; got:\n" + out
+    )
+    assert "&amp;amp;" not in out

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -24,15 +24,19 @@ function inlineMarkdown(text) {
   );
   // Strikethrough
   text = text.replace(/~~(.+?)~~/g, "<del>$1</del>");
-  // Images (must come before links — render as click-to-load placeholder)
+  // Images (must come before links — render as click-to-load placeholder).
+  // Every interpolated value is locally escaped: defence-in-depth against
+  // future refactors that might call this regex from a context that
+  // bypasses inlineMarkdown's leading escapeHtml.
   text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, function (m, alt, url) {
     if (!/^\s*(https?:\/\/|data:image\/)/i.test(url)) return m;
-    var safeAlt = alt || "Image";
-    var domain = "";
+    var safeAlt = escapeHtml(alt || "Image");
+    var safeUrl = escapeHtml(url);
+    var domain;
     try {
       domain = escapeHtml(new URL(url).hostname);
     } catch (e) {
-      domain = url.length > 40 ? url.slice(0, 40) + "…" : url;
+      domain = escapeHtml(url.length > 40 ? url.slice(0, 40) + "…" : url);
     }
     return (
       '<span class="img-placeholder" tabindex="0" role="button" ' +
@@ -40,7 +44,7 @@ function inlineMarkdown(text) {
       safeAlt +
       '" ' +
       'data-src="' +
-      url +
+      safeUrl +
       '" data-alt="' +
       safeAlt +
       '">' +
@@ -54,14 +58,15 @@ function inlineMarkdown(text) {
       "</span>"
     );
   });
-  // Links (allow http, https, and same-origin relative URLs only)
+  // Links (allow http, https, and same-origin relative URLs only).
+  // Same defence-in-depth posture as images above.
   text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (m, label, url) {
     if (!/^\s*(https?:\/\/|\/(?!\/))/i.test(url)) return m;
     return (
       '<a href="' +
-      url +
+      escapeHtml(url) +
       '" target="_blank" rel="noopener noreferrer">' +
-      label +
+      escapeHtml(label) +
       "</a>"
     );
   });

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -25,51 +25,63 @@ function inlineMarkdown(text) {
   // Strikethrough
   text = text.replace(/~~(.+?)~~/g, "<del>$1</del>");
   // Images (must come before links — render as click-to-load placeholder).
-  // Every interpolated value is locally escaped: defence-in-depth against
-  // future refactors that might call this regex from a context that
-  // bypasses inlineMarkdown's leading escapeHtml.
-  text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, function (m, alt, url) {
-    if (!/^\s*(https?:\/\/|data:image\/)/i.test(url)) return m;
-    var safeAlt = escapeHtml(alt || "Image");
-    var safeUrl = escapeHtml(url);
-    var domain;
-    try {
-      domain = escapeHtml(new URL(url).hostname);
-    } catch (e) {
-      domain = escapeHtml(url.length > 40 ? url.slice(0, 40) + "…" : url);
-    }
-    return (
-      '<span class="img-placeholder" tabindex="0" role="button" ' +
-      'aria-label="Load image: ' +
-      safeAlt +
-      '" ' +
-      'data-src="' +
-      safeUrl +
-      '" data-alt="' +
-      safeAlt +
-      '">' +
-      '<span class="img-placeholder-icon">&#x1F5BC;</span> ' +
-      '<span class="img-placeholder-label">' +
-      safeAlt +
-      "</span>" +
-      '<span class="img-placeholder-domain">' +
-      domain +
-      "</span>" +
-      "</span>"
-    );
-  });
-  // Links (allow http, https, and same-origin relative URLs only).
-  // Same defence-in-depth posture as images above.
-  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (m, label, url) {
-    if (!/^\s*(https?:\/\/|\/(?!\/))/i.test(url)) return m;
-    return (
-      '<a href="' +
-      escapeHtml(url) +
-      '" target="_blank" rel="noopener noreferrer">' +
-      escapeHtml(label) +
-      "</a>"
-    );
-  });
+  // Captured groups inherit inlineMarkdown's leading escapeHtml(text) —
+  // they are already entity-encoded by the time this regex runs. Don't
+  // re-escape them: double-encoding turns `&` into `&amp;amp;`, which
+  // breaks query-string URLs after browser parse + getAttribute. The
+  // `safe*` rename signals the pre-escape invariant; the attribute-
+  // context lint in tests/test_renderer_js.py enforces that future
+  // attribute-context concat sites maintain the convention or call
+  // escapeHtml explicitly.
+  text = text.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    function (m, safeAlt, safeUrl) {
+      if (!/^\s*(https?:\/\/|data:image\/)/i.test(safeUrl)) return m;
+      if (!safeAlt) safeAlt = "Image";
+      var safeDomain;
+      try {
+        // hostname is freshly extracted, not from the regex capture,
+        // so it does NOT carry the upstream escape — escape locally.
+        safeDomain = escapeHtml(new URL(safeUrl).hostname);
+      } catch (e) {
+        safeDomain = safeUrl.length > 40 ? safeUrl.slice(0, 40) + "…" : safeUrl;
+      }
+      return (
+        '<span class="img-placeholder" tabindex="0" role="button" ' +
+        'aria-label="Load image: ' +
+        safeAlt +
+        '" ' +
+        'data-src="' +
+        safeUrl +
+        '" data-alt="' +
+        safeAlt +
+        '">' +
+        '<span class="img-placeholder-icon">&#x1F5BC;</span> ' +
+        '<span class="img-placeholder-label">' +
+        safeAlt +
+        "</span>" +
+        '<span class="img-placeholder-domain">' +
+        safeDomain +
+        "</span>" +
+        "</span>"
+      );
+    },
+  );
+  // Links — same upstream-escape invariant as images. `safeLabel` and
+  // `safeUrl` are entity-encoded via inlineMarkdown's leading pass.
+  text = text.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    function (m, safeLabel, safeUrl) {
+      if (!/^\s*(https?:\/\/|\/(?!\/))/i.test(safeUrl)) return m;
+      return (
+        '<a href="' +
+        safeUrl +
+        '" target="_blank" rel="noopener noreferrer">' +
+        safeLabel +
+        "</a>"
+      );
+    },
+  );
   // Footnote references [^id] — after links (link regex requires (url), so no conflict)
   text = text.replace(/\[\^([^\]]+)\]/g, function (m, fnId) {
     var safeFnId = escapeHtml(fnId);


### PR DESCRIPTION
## Summary

- `inlineMarkdown`'s image and link renderers now `escapeHtml` each interpolated value (url, alt, label, domain) at the call site instead of relying on the upstream `escapeHtml(text)` pass at `renderer.js:13`. The current safety invariant is non-local — a future refactor calling those renderers from outside `inlineMarkdown` would silently regress. Locally-escaping makes the safety structural.
- New CI lint in `tests/test_renderer_js.py` scans `renderer.js` for `attr="' + ident` patterns; `ident` must be `escapeHtml(...)`, `safe*`-prefixed, or in the reviewer-approved `_RENDERER_KNOWN_SAFE_IDENTIFIERS` allowlist (currently just `"info"` for the `CALLOUT_TYPES` enum).
- Four pin tests use Python's `html.parser.HTMLParser` to verify attacker URLs and labels don't materialize event-handler attributes on rendered DOM.

**Defense-in-depth, not exploit fix.** The bug as originally described in #553 is not actively exploitable today because `inlineMarkdown` pre-escapes the captured URL/alt/label before the image/link regex runs. See the issue's spike comment for the boundary-spike finding. The local-escape and lint together prevent future regression if anyone calls those renderers from outside `inlineMarkdown`.

One known cosmetic effect: attribute values now double-escape (`&amp;quot;` instead of `&quot;`) since `inlineMarkdown` already escaped once. Functionally identical — the click handler at `renderer.js:93` calls `new URL(raw)` which rejects malformed URLs either way.

## Test plan

- [x] `pytest tests/test_renderer_js.py` — 67 passed (4.10s) including 4 new attacker-URL pin tests
- [x] `pytest tests/test_app_js.py` — 51 passed (1.91s, confirms existing `innerHTML` sink lint still green; renderer.js is intentionally outside `_UNSAFE_CODE_SINK_LINT_TARGETS` since it IS the trusted markdown→HTML transformer)
- [x] `ruff check tests/test_renderer_js.py` — clean
- [x] `/review` 4-finder pipeline — bug ✓, security ✓, perf ✓, quality found 2 (triplicate rationale + `#553` source-ref); verify confirmed 1, refuted 1 (PR/issue refs are established codebase pattern per spot-check); confirmed finding applied
- [ ] Optional manual smoke: render a markdown image with quote-in-URL in the browser, confirm placeholder displays and click-to-load rejects safely. Not strictly required since the Node-driven harness exercises the rendering path end-to-end.

Fixes #553.