### PR TITLE
fix(renderer): drop single-$ inline math to stop false positives in prose

### DIFF
--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -89,11 +89,30 @@ def _render(markdown: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_tex_inline_math_renders() -> None:
+def test_single_dollar_inline_math_is_not_supported() -> None:
+    """Single-$ inline math is intentionally disabled — $ collides
+    with currency, env vars, and shell prompts in prose. Inline math
+    must use the unambiguous \\(...\\) form. This test pins the
+    behavior so a regex regression doesn't quietly resurrect it."""
     out = _render("The formula $E = mc^2$ is famous.")
-    assert '<span class="katex">' in out
-    assert "[KATEX:E = mc^2:inline]" in out
-    assert "$E = mc^2$" not in out  # raw delimiters consumed
+    assert '<span class="katex">' not in out
+    assert "$E = mc^2$" in out  # raw delimiters preserved
+
+
+def test_dollar_currency_does_not_trigger_math() -> None:
+    """The actual bug single-$ removal fixes: prose mentioning
+    multiple currency amounts on one line used to get the span
+    between two dollar signs eaten as a math expression."""
+    out = _render("It costs $5 and the other is $10 each.")
+    assert '<span class="katex">' not in out
+    assert "$5" in out and "$10" in out
+
+
+def test_dollar_env_vars_do_not_trigger_math() -> None:
+    """Same class of bug as currency, with shell-style variables."""
+    out = _render("Set $HOME and $PATH before running.")
+    assert '<span class="katex">' not in out
+    assert "$HOME" in out and "$PATH" in out
 
 
 def test_tex_display_math_renders() -> None:
@@ -145,10 +164,12 @@ def test_latex_math_in_bold_renders() -> None:
 
 
 def test_mixed_tex_and_latex_styles() -> None:
+    """Only \\(...\\) renders; the $...$ form is left as raw prose
+    (see test_single_dollar_inline_math_is_not_supported)."""
     out = _render(r"Here $x$ then \(y\) end.")
-    assert out.count('<span class="katex">') == 2
-    assert "[KATEX:x:inline]" in out
+    assert out.count('<span class="katex">') == 1
     assert "[KATEX:y:inline]" in out
+    assert "$x$" in out  # untouched
 
 
 def test_latex_math_inside_inline_code_preserved() -> None:
@@ -224,12 +245,15 @@ def test_inline_latex_math_does_not_span_paragraphs() -> None:
     assert "unterminated" in out
 
 
-def test_inline_tex_math_does_not_span_newlines() -> None:
-    """Existing $...$ behavior — regression guard."""
+def test_dollar_signs_never_render_as_math_across_paragraphs() -> None:
+    """Pre-removal regression covered the cross-paragraph eating bug
+    for $...$. With single-$ inline math gone, the stronger guarantee
+    is simply that no arrangement of $ signs ever produces math."""
     src = "Open $unterminated\n\nNext paragraph $x$ here."
     out = _render(src)
-    assert out.count('<span class="katex">') == 1
-    assert "[KATEX:x:inline]" in out
+    assert '<span class="katex">' not in out
+    assert "$unterminated" in out
+    assert "$x$" in out
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/prompts/env/web.md
+++ b/turnstone/prompts/env/web.md
@@ -6,7 +6,7 @@ Your responses are rendered in a rich web client with full markdown support. Use
 
 - **Code blocks** — Syntax-highlighted via highlight.js. Always specify the language tag (```python, ```sql, ```yaml, etc.) for proper highlighting.
 - **Diagrams** — Mermaid.js is supported via ```mermaid code blocks. Use flowcharts, sequence diagrams, state diagrams, ER diagrams, and Gantt charts when explaining flows, architectures, or processes. Prefer a diagram over a verbal description of a system or sequence.
-- **Math** — KaTeX is supported for both inline (`$...$`) and display (`$$...$$`) notation. Use proper mathematical typesetting when discussing formulas, equations, or formal notation rather than ASCII approximations.
+- **Math** — KaTeX is supported for both inline (`\(...\)`) and display (`$$...$$` or `\[...\]`) notation. Use proper mathematical typesetting when discussing formulas, equations, or formal notation rather than ASCII approximations. Single-`$` inline math is intentionally not supported — `$` is too ambiguous with currency and shell variables in prose.
 - **Standard markdown** — Tables, headings, bold, italic, lists, blockquotes, horizontal rules, footnotes, and definition lists all render correctly. Use tables for structured comparisons. Use headings to organize long responses.
 - **GFM callouts** — `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` render as styled alert boxes. Use them for important caveats or warnings.
 

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -432,18 +432,21 @@ function renderMarkdown(text) {
     return "\x00MB" + (mathBlocks.length - 1) + "\x00";
   });
 
-  // Protect inline math — both delimiter styles ($...$ and \(...\)).
-  // Both regexes explicitly forbid newlines inside the captured
-  // group: an unterminated \(...\) (or $...$) on one line would
-  // otherwise eat the next paragraph until it found a closing
-  // delimiter, which is jarring on streaming markdown where the
-  // closer hasn't arrived yet. Display math (\[...\] / $$...$$)
-  // is the multi-line form by design.
+  // Protect inline math — LaTeX-style \(...\) only.
+  //
+  // Single-$ delimiters were dropped because $ is overloaded in
+  // prose: currency ("$5 and $10"), env vars ("$HOME and $PATH"),
+  // and shell prompts all produced false-positive math spans.
+  // \(...\) is unambiguous and is what GPT-5 / o-series / Claude
+  // with reasoning effort emit by default anyway. Display math
+  // ($$...$$ and \[...\]) is unchanged; it has enough delimiter
+  // mass that ambiguity is not a practical problem.
+  //
+  // Newlines inside the captured group are forbidden: an
+  // unterminated \(...\) on one line would otherwise eat the next
+  // paragraph until it found a closing \), which is jarring on
+  // streaming markdown where the closer hasn't arrived yet.
   var inlineMaths = [];
-  text = text.replace(/\$([^\$\n]+?)\$/g, function (m, tex) {
-    inlineMaths.push(renderLatex(tex, false));
-    return "\x00IM" + (inlineMaths.length - 1) + "\x00";
-  });
   text = text.replace(/\\\(([^\n]+?)\\\)/g, function (m, tex) {
     inlineMaths.push(renderLatex(tex.trim(), false));
     return "\x00IM" + (inlineMaths.length - 1) + "\x00";


### PR DESCRIPTION
Single-`$` inline math is too ambiguous in conversational text: currency amounts ("$5 and $10 each"), shell variables ("$HOME and $PATH"), and shell prompts all produced false-positive KaTeX spans because the regex matched any non-`$`/non-newline span between two dollar signs.

Inline math now requires the unambiguous `\(...\)` form, which is what GPT-5 / o-series / Claude with reasoning effort emit by default anyway. Display math (`$$...$$` and `\[...\]`) is unchanged — the doubled delimiter has enough mass that ambiguity is not a practical problem.

Three former positive tests are inverted into regression guards so a future regex change can't quietly resurrect the bug, and new tests name the currency and env-var cases explicitly. The web env prompt is updated to advertise `\(...\)` and to tell the model why `$...$` is gone.

## Test plan
- [x] `tests/test_renderer_js.py` — 71 pass, including new currency / env-var / cross-paragraph regression guards
- [x] `tests/test_prompts.py` — 29 pass (web env prompt change does not break assertions)
- [x] `tests/test_web_helpers.py` — passes
- [x] ruff + mypy clean on touched Python files