### PR TITLE
feat(skills): parse and store Anthropic spec `paths` + uplift columns (#569 PR1)

### DIFF
--- a/tests/test_canonicalize_skill_string_list.py
+++ b/tests/test_canonicalize_skill_string_list.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``_canonicalize_skill_string_list`` in console.server.
+
+Backs the admin create/update handlers' wire-shape normalization for
+JSON-array-string skill fields (``paths`` today; ``arguments`` once
+#572 wires its consumer).  The interesting cases are the corruption
+paths the regex / split previously took on ``None``/empty input —
+without explicit None handling, ``str(None)`` slid through CSV-split
+and stored the literal value ``["None"]``.
+"""
+
+from __future__ import annotations
+
+from turnstone.console.server import _canonicalize_skill_string_list
+
+
+class TestList:
+    def test_list_of_strings(self) -> None:
+        assert _canonicalize_skill_string_list(["**/*.py", "docs/**"]) == '["**/*.py", "docs/**"]'
+
+    def test_list_trims_and_drops_blank(self) -> None:
+        assert _canonicalize_skill_string_list(["  a  ", "", "b"]) == '["a", "b"]'
+
+    def test_empty_list(self) -> None:
+        assert _canonicalize_skill_string_list([]) == "[]"
+
+
+class TestJsonString:
+    def test_valid_json_array(self) -> None:
+        assert _canonicalize_skill_string_list('["**/*.py", "docs/**"]') == '["**/*.py", "docs/**"]'
+
+    def test_json_array_trims_elements(self) -> None:
+        assert _canonicalize_skill_string_list('["  a  ", " ", "b"]') == '["a", "b"]'
+
+    def test_malformed_json_array_collapses_to_empty(self) -> None:
+        """``[``-prefixed unparseable input → empty array, not CSV-split."""
+        assert _canonicalize_skill_string_list("[not-json") == "[]"
+
+    def test_non_array_json_treated_as_csv(self) -> None:
+        """A string that doesn't start with ``[`` is CSV input by contract,
+        even if it happens to be valid JSON for some other shape.  No commas
+        means a single-element list.  Pragmatic over strict — the admin UI
+        round-trips through this helper and a typo doesn't need to error."""
+        assert _canonicalize_skill_string_list('{"k": "v"}') == '["{\\"k\\": \\"v\\"}"]'
+
+
+class TestCsvString:
+    def test_comma_separated(self) -> None:
+        assert (
+            _canonicalize_skill_string_list("**/*.py, docs/**, src/api/**")
+            == '["**/*.py", "docs/**", "src/api/**"]'
+        )
+
+    def test_csv_trims_and_drops_blank(self) -> None:
+        assert _canonicalize_skill_string_list("a , , b ,") == '["a", "b"]'
+
+    def test_single_value_no_comma(self) -> None:
+        assert _canonicalize_skill_string_list("**/*.py") == '["**/*.py"]'
+
+
+class TestNullAndEmpty:
+    def test_none_returns_empty_array(self) -> None:
+        """``None`` must NOT corrupt into ``'["None"]'`` (regression bug-1/bug-2)."""
+        assert _canonicalize_skill_string_list(None) == "[]"
+
+    def test_empty_string(self) -> None:
+        assert _canonicalize_skill_string_list("") == "[]"
+
+    def test_whitespace_only_string(self) -> None:
+        assert _canonicalize_skill_string_list("   ") == "[]"
+
+    def test_empty_json_array_string(self) -> None:
+        assert _canonicalize_skill_string_list("[]") == "[]"

--- a/tests/test_skill_parse_api.py
+++ b/tests/test_skill_parse_api.py
@@ -85,6 +85,7 @@ author: Test Author
 version: 2.0.0
 tags: [python, review, quality]
 allowed-tools: [read_file, list_directory]
+paths: ["**/*.py", "src/api/**"]
 license: MIT
 compatibility: ">=0.7"
 ---
@@ -114,6 +115,7 @@ class TestParseSkill:
         assert data["version"] == "2.0.0"
         assert data["tags"] == ["python", "review", "quality"]
         assert data["allowed_tools"] == ["read_file", "list_directory"]
+        assert data["paths"] == ["**/*.py", "src/api/**"]
         assert data["license"] == "MIT"
         assert data["compatibility"] == ">=0.7"
         assert "# Code Review" in data["content"]
@@ -134,6 +136,7 @@ class TestParseSkill:
         assert data["version"] == "1.0.0"
         assert data["tags"] == []
         assert data["allowed_tools"] == []
+        assert data["paths"] == []
         assert data["license"] == ""
 
     def test_anthropic_nested_metadata_tags(self, client: TestClient) -> None:

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -239,6 +239,62 @@ Content.
         assert result.allowed_tools == []
 
 
+class TestPaths:
+    """Anthropic Claude Code spec ``paths:`` — glob patterns gating autoload."""
+
+    def test_list_format(self) -> None:
+        raw = """\
+---
+name: paths-list
+paths: ["**/*.py", "packages/api/**"]
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.paths == ["**/*.py", "packages/api/**"]
+
+    def test_comma_separated_string(self) -> None:
+        """Spec accepts comma-separated string OR YAML list."""
+        raw = """\
+---
+name: paths-csv
+paths: "**/*.py, packages/api/**"
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.paths == ["**/*.py", "packages/api/**"]
+
+    def test_empty_paths(self) -> None:
+        raw = """\
+---
+name: no-paths
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.paths == []
+
+    def test_paths_with_full_frontmatter(self) -> None:
+        """``paths`` round-trips alongside the other spec fields."""
+        raw = """\
+---
+name: full
+description: Has every field
+allowed-tools: [bash]
+paths: ["**/*.md"]
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.allowed_tools == ["bash"]
+        assert result.paths == ["**/*.md"]
+
+
 class TestValidateSkillName:
     """Name validation edge cases."""
 

--- a/tests/test_storage_skill_spec_uplift.py
+++ b/tests/test_storage_skill_spec_uplift.py
@@ -1,0 +1,100 @@
+"""Storage round-trip for the Anthropic spec-uplift columns (migration 056).
+
+Each column is parsed/stored/editable in PR1 (#569); the consumers
+(autoload filter / menu hide / argument substitution) land in
+follow-up PRs.  These tests cover only the persistence layer — that
+the four new fields survive create + read + update without loss.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _create(storage: Any, **kw: Any) -> str:
+    template_id = kw.pop("template_id", "spec1")
+    storage.create_prompt_template(
+        template_id=template_id,
+        name=kw.pop("name", "skill-one"),
+        category="general",
+        content="",
+        variables="[]",
+        is_default=False,
+        org_id="",
+        created_by="test",
+        **kw,
+    )
+    return template_id
+
+
+class TestPathsRoundTrip:
+    def test_default_empty_array(self, storage: Any) -> None:
+        _create(storage)
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["paths"] == "[]"
+
+    def test_create_with_paths(self, storage: Any) -> None:
+        _create(storage, paths=json.dumps(["**/*.py", "packages/api/**"]))
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert json.loads(row["paths"]) == ["**/*.py", "packages/api/**"]
+
+    def test_update_paths(self, storage: Any) -> None:
+        _create(storage)
+        ok = storage.update_prompt_template("spec1", paths=json.dumps(["docs/**"]))
+        assert ok is True
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert json.loads(row["paths"]) == ["docs/**"]
+
+
+class TestHiddenFromMenu:
+    def test_default_false(self, storage: Any) -> None:
+        _create(storage)
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["hidden_from_menu"] is False
+
+    def test_create_hidden(self, storage: Any) -> None:
+        _create(storage, hidden_from_menu=True)
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["hidden_from_menu"] is True
+
+    def test_update_hidden(self, storage: Any) -> None:
+        _create(storage)
+        ok = storage.update_prompt_template("spec1", hidden_from_menu=1)
+        assert ok is True
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["hidden_from_menu"] is True
+
+
+class TestArguments:
+    def test_default_empty_array(self, storage: Any) -> None:
+        _create(storage)
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["arguments"] == "[]"
+
+    def test_create_with_arguments(self, storage: Any) -> None:
+        _create(storage, arguments=json.dumps(["issue", "branch"]))
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert json.loads(row["arguments"]) == ["issue", "branch"]
+
+
+class TestArgumentHint:
+    def test_default_empty_string(self, storage: Any) -> None:
+        _create(storage)
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["argument_hint"] == ""
+
+    def test_create_with_argument_hint(self, storage: Any) -> None:
+        _create(storage, argument_hint="[issue-number]")
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["argument_hint"] == "[issue-number]"

--- a/tests/test_storage_skill_spec_uplift.py
+++ b/tests/test_storage_skill_spec_uplift.py
@@ -71,6 +71,25 @@ class TestHiddenFromMenu:
         assert row is not None
         assert row["hidden_from_menu"] is True
 
+    def test_update_hidden_with_bool(self, storage: Any) -> None:
+        """``hidden_from_menu`` lives on an INTEGER column but the wire type
+        from JSON / Pydantic is ``bool``.  ``update_prompt_template`` must
+        coerce explicitly — without coercion, a PG INSERT of ``True`` into
+        an Integer column is driver-dependent and was the gap Copilot
+        review on PR #574 flagged."""
+        _create(storage)
+        ok = storage.update_prompt_template("spec1", hidden_from_menu=True)
+        assert ok is True
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["hidden_from_menu"] is True
+        # Also round-trips the false transition.
+        ok = storage.update_prompt_template("spec1", hidden_from_menu=False)
+        assert ok is True
+        row = storage.get_prompt_template("spec1")
+        assert row is not None
+        assert row["hidden_from_menu"] is False
+
 
 class TestArguments:
     def test_default_empty_array(self, storage: Any) -> None:

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -329,6 +329,15 @@ class SkillInfo(BaseModel):
     risk_level: str = ""
     scan_report: str = "{}"
     scan_version: str = ""
+    # Anthropic spec uplift (migration 056).  JSON-array strings on
+    # the wire to match the shape of ``allowed_tools`` /
+    # ``notify_on_complete``; admin UI parses client-side.  Consumer
+    # PRs (#569 filter, #571 menu hide, #572 substitution) will wire
+    # each of these to runtime behaviour.
+    paths: str = "[]"
+    hidden_from_menu: bool = False
+    arguments: str = "[]"
+    argument_hint: str = ""
     resource_count: int = 0
     created: str
     updated: str
@@ -369,6 +378,18 @@ class CreateSkillRequest(BaseModel):
     allowed_tools: str = "[]"
     license: str = ""
     compatibility: str = ""
+    # Anthropic spec ``paths:`` — glob patterns gating autoload.
+    # Accepts either a JSON-array string or a list; the admin handler
+    # canonicalizes via ``_canonicalize_skill_string_list``.  The
+    # filter consumer lands in a follow-up PR (#569).
+    #
+    # ``hidden_from_menu`` / ``arguments`` / ``argument_hint`` columns
+    # exist on the row (migration 056) and surface in ``SkillInfo`` for
+    # read, but the create/update handlers don't read them yet — the
+    # consumer PRs (#571, #572) will add their input branches.  Keeping
+    # them off the request schemas avoids advertising a writable field
+    # the handler silently ignores.
+    paths: str | list[str] = "[]"
     kind: SkillKind = Field(
         default=SkillKind.ANY,
         description=(
@@ -418,6 +439,11 @@ class UpdateSkillRequest(BaseModel):
     allowed_tools: str | None = None
     license: str | None = None
     compatibility: str | None = None
+    # Anthropic spec ``paths:``.  ``hidden_from_menu`` / ``arguments``
+    # / ``argument_hint`` are deliberately absent from the update
+    # schema until their consumer PRs (#571, #572) wire input branches
+    # — see ``CreateSkillRequest`` for the rationale.
+    paths: str | list[str] | None = None
     kind: SkillKind | None = Field(
         default=None,
         description=(
@@ -823,6 +849,7 @@ class ParseSkillResponse(BaseModel):
     allowed_tools: list[str] = Field(default_factory=list)
     license: str = ""
     compatibility: str = ""
+    paths: list[str] = Field(default_factory=list)
 
 
 class SkillInstallRequest(BaseModel):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6488,6 +6488,14 @@ def _canonicalize_skill_string_list(raw: Any) -> str:
     a CSV-split corruption of the literal string ``"None"``.  Empty
     list elements are trimmed out so the stored array never carries
     blank strings.
+
+    Note: this helper's ``None``-to-``"[]"`` rule is the **normalization**
+    contract.  The update endpoint (`admin_update_skill`) intercepts
+    ``body["paths"] is None`` *before* calling this helper and treats
+    it as "leave unchanged" — that's the update-semantics contract,
+    layered on top of normalization rather than baked in here.  Both
+    contracts coexist intentionally: create defaults to empty, update
+    skips no-ops.
     """
     import json as _json
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6474,6 +6474,41 @@ def _parse_skill_session_config(body: dict[str, Any]) -> tuple[dict[str, Any], J
     return fields, None
 
 
+def _canonicalize_skill_string_list(raw: Any) -> str:
+    """Normalize the wire shape of a JSON-array-string skill field.
+
+    Accepts a Python list, a JSON-array string, a comma-separated
+    string, ``None``, or an empty value, and returns the canonical
+    JSON-array string ready for storage.  Used for ``paths`` today;
+    follow-up PRs (#572) reuse this for ``arguments`` once the wire
+    contract on that field stabilises.
+
+    ``None`` and unparseable JSON both collapse to ``"[]"`` — a client
+    that sends ``{"paths": null}`` deliberately intends "no value", not
+    a CSV-split corruption of the literal string ``"None"``.  Empty
+    list elements are trimmed out so the stored array never carries
+    blank strings.
+    """
+    import json as _json
+
+    if raw is None:
+        return "[]"
+    if isinstance(raw, list):
+        return _json.dumps([str(p).strip() for p in raw if str(p).strip()])
+    candidate = str(raw).strip()
+    if not candidate:
+        return "[]"
+    if candidate.startswith("["):
+        try:
+            parsed = _json.loads(candidate)
+        except (ValueError, TypeError):
+            return "[]"
+        if not isinstance(parsed, list):
+            return "[]"
+        return _json.dumps([str(p).strip() for p in parsed if str(p).strip()])
+    return _json.dumps([p.strip() for p in candidate.split(",") if p.strip()])
+
+
 def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, Any]:
     """Convert a storage skill dict to a JSON-safe response dict."""
     import json as _json
@@ -6524,6 +6559,14 @@ def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, 
         "risk_level": r.get("risk_level", ""),
         "scan_report": r.get("scan_report", "{}"),
         "scan_version": r.get("scan_version", ""),
+        # Anthropic spec uplift (migration 056).  ``paths`` and
+        # ``arguments`` are JSON-array strings on the wire to match
+        # ``allowed_tools`` / ``notify_on_complete``; the admin UI
+        # parses them client-side.
+        "paths": r.get("paths", "[]"),
+        "hidden_from_menu": r.get("hidden_from_menu", False),
+        "arguments": r.get("arguments", "[]"),
+        "argument_hint": r.get("argument_hint", ""),
         "resource_count": resource_count,
         "created": r.get("created", ""),
         "updated": r.get("updated", ""),
@@ -6628,6 +6671,13 @@ async def admin_create_skill(request: Request) -> JSONResponse:
         except (ValueError, TypeError):
             tags_str = "[]"
 
+    # Anthropic spec ``paths:`` — glob patterns gating autoload.
+    # ``_canonicalize_skill_string_list`` accepts a list, a JSON-array
+    # string, a comma-separated string, or ``None``, and returns the
+    # canonical JSON-array string for storage.  Same helper will back
+    # ``arguments`` once #572 lands its consumer.
+    paths_str = _canonicalize_skill_string_list(body.get("paths"))
+
     token_estimate = len(content) // 4 if content else 0
 
     # Session config fields via shared helper
@@ -6678,6 +6728,7 @@ async def admin_create_skill(request: Request) -> JSONResponse:
         token_estimate=token_estimate,
         priority=priority,
         kind=kind,
+        paths=paths_str,
         **session_fields,
     )
 
@@ -6784,6 +6835,11 @@ async def admin_update_skill(request: Request) -> JSONResponse:
             except (ValueError, TypeError):
                 tag_str = "[]"
             updates["tags"] = tag_str
+    if "paths" in body and body["paths"] is not None:
+        # ``None`` is treated as "leave unchanged" to match
+        # UpdateSkillRequest's optional-None semantics.  See
+        # ``_canonicalize_skill_string_list``.
+        updates["paths"] = _canonicalize_skill_string_list(body["paths"])
     if "priority" in body:
         try:
             updates["priority"] = max(-1000, min(1000, int(body["priority"] or 0)))
@@ -7480,6 +7536,7 @@ async def admin_parse_skill(request: Request) -> JSONResponse:
             "allowed_tools": list(parsed.allowed_tools),
             "license": parsed.license,
             "compatibility": parsed.compatibility,
+            "paths": list(parsed.paths),
         }
     )
 
@@ -7678,6 +7735,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
         parsed = package.parsed
         tags_str = _json.dumps(parsed.tags)
         allowed_tools_str = _json.dumps(parsed.allowed_tools)
+        paths_str = _json.dumps(parsed.paths)
         content = parsed.content[:32768]
         token_estimate = len(content) // 4 if content else 0
 
@@ -7709,6 +7767,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 activation="named",
                 token_estimate=token_estimate,
                 allowed_tools=allowed_tools_str,
+                paths=paths_str,
             )
         except StorageConflictError as exc:
             # Genuine uniqueness/constraint violation racing past the

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -929,6 +929,7 @@ const _SKILL_FIELD_MAP = {
   license: "skill-license",
   compatibility: "skill-compatibility",
   allowed_tools: "csk-allowed-tools",
+  paths: "skill-paths",
 };
 
 // Inflight paste-parse fetch — referenced from hideCreateTemplateModal so a
@@ -989,6 +990,8 @@ function _applyParsedSkill(parsed, contentTextarea, fieldMap) {
     _apply(fieldMap.compatibility, parsed.compatibility);
   if (parsed.allowed_tools && parsed.allowed_tools.length)
     _apply(fieldMap.allowed_tools, parsed.allowed_tools.join(", "));
+  if (parsed.paths && parsed.paths.length)
+    _apply(fieldMap.paths, parsed.paths.join(", "));
 
   return { filled: filled, skipped: skipped };
 }
@@ -1116,6 +1119,7 @@ function showCreateTemplateModal() {
   document.getElementById("skill-version").value = "";
   document.getElementById("skill-license").value = "";
   document.getElementById("skill-compatibility").value = "";
+  document.getElementById("skill-paths").value = "";
   document.getElementById("skill-activation").value = "named";
   const ctmContent = document.getElementById("ctm-content");
   ctmContent.value = "";
@@ -1248,6 +1252,12 @@ function submitCreateTemplate() {
   const csVersion = (
     document.getElementById("skill-version").value || ""
   ).trim();
+  const csPathsArr = (document.getElementById("skill-paths").value || "")
+    .split(",")
+    .map(function (p) {
+      return p.trim();
+    })
+    .filter(Boolean);
   const createBody = {
     name: name,
     category: document.getElementById("ctm-category").value,
@@ -1272,6 +1282,7 @@ function submitCreateTemplate() {
     token_budget: csBudget ? parseInt(csBudget, 10) : 0,
     agent_max_turns: csMaxTurns ? parseInt(csMaxTurns, 10) : null,
     allowed_tools: JSON.stringify(csAllowedArr),
+    paths: JSON.stringify(csPathsArr),
     notify_on_complete: csNotifyVal,
     enabled: document.getElementById("csk-enabled").checked,
   };
@@ -1367,6 +1378,14 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("etm-version").value = tmpl.version || "";
   document.getElementById("etm-license").value = tmpl.license || "";
   document.getElementById("etm-compatibility").value = tmpl.compatibility || "";
+  let pathsDisplay = "";
+  try {
+    const pathsList = JSON.parse(tmpl.paths || "[]");
+    pathsDisplay = pathsList.join(", ");
+  } catch (e) {
+    pathsDisplay = tmpl.paths || "";
+  }
+  document.getElementById("etm-paths").value = pathsDisplay;
   document.getElementById("etm-activation").value = tmpl.activation || "named";
   document.getElementById("etm-content").value = tmpl.content;
   _updateVarsDisplay("etm-content", "etm-variables");
@@ -1563,6 +1582,7 @@ function showEditTemplateModal(tmplId) {
     "etm-version",
     "etm-license",
     "etm-compatibility",
+    "etm-paths",
     "etm-activation",
     "etm-content",
     "etm-default",
@@ -1993,6 +2013,12 @@ function submitEditTemplate() {
   }
   document.getElementById("etm-submit").disabled = true;
   const esVersion = (document.getElementById("etm-version").value || "").trim();
+  const esPathsArr = (document.getElementById("etm-paths").value || "")
+    .split(",")
+    .map(function (p) {
+      return p.trim();
+    })
+    .filter(Boolean);
   const updateBody = {
     name: document.getElementById("etm-name").value.trim(),
     category: document.getElementById("etm-category").value,
@@ -2005,6 +2031,7 @@ function submitEditTemplate() {
     compatibility: (
       document.getElementById("etm-compatibility").value || ""
     ).trim(),
+    paths: JSON.stringify(esPathsArr),
     activation: document.getElementById("etm-activation").value,
     content: content,
     variables: JSON.stringify(varList),

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3077,7 +3077,7 @@
                 >Paths
                 <span class="label-hint"
                   >glob patterns (comma-separated) — Anthropic spec
-                  ``paths:``; filter consumer pending</span
+                  <code>paths:</code>; filter consumer pending</span
                 ></label
               >
               <input
@@ -3405,7 +3405,7 @@
                 >Paths
                 <span class="label-hint"
                   >glob patterns (comma-separated) — Anthropic spec
-                  ``paths:``; filter consumer pending</span
+                  <code>paths:</code>; filter consumer pending</span
                 ></label
               >
               <input

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3073,6 +3073,18 @@
                 placeholder="Requires git, docker, etc."
                 maxlength="500"
               />
+              <label for="skill-paths"
+                >Paths
+                <span class="label-hint"
+                  >glob patterns (comma-separated) — Anthropic spec
+                  ``paths:``; filter consumer pending</span
+                ></label
+              >
+              <input
+                id="skill-paths"
+                type="text"
+                placeholder="**/*.py, packages/api/**"
+              />
             </div>
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>
@@ -3388,6 +3400,18 @@
                 type="text"
                 placeholder="Requires git, docker, etc."
                 maxlength="500"
+              />
+              <label for="etm-paths"
+                >Paths
+                <span class="label-hint"
+                  >glob patterns (comma-separated) — Anthropic spec
+                  ``paths:``; filter consumer pending</span
+                ></label
+              >
+              <input
+                id="etm-paths"
+                type="text"
+                placeholder="**/*.py, packages/api/**"
               />
             </div>
             <div class="skill-spec-section">

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -50,6 +50,11 @@ class ParsedSkill:
     allowed_tools: list[str] = field(default_factory=list)
     license: str = ""
     compatibility: str = ""
+    # Anthropic Claude Code spec ``paths:`` — glob patterns gating
+    # model-initiated autoload.  Filter consumer lands in a follow-up
+    # PR (issue #569); parsed here so the value round-trips through
+    # install / admin edit / export without loss.
+    paths: list[str] = field(default_factory=list)
     raw_frontmatter: dict[str, Any] = field(default_factory=dict)
 
 
@@ -242,5 +247,8 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
         allowed_tools=_extract_list(meta, "allowed-tools"),
         license=_extract_str(meta, "license"),
         compatibility=compatibility,
+        # Spec accepts ``paths:`` as a comma-separated string or YAML
+        # list; ``_extract_list`` handles both shapes via ``_LIST_SPLIT_RE``.
+        paths=_extract_list(meta, "paths"),
         raw_frontmatter=meta,
     )

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2744,6 +2744,8 @@ class PostgreSQLBackend:
             fields["auto_approve"] = int(fields["auto_approve"])
         if "enabled" in fields:
             fields["enabled"] = int(fields["enabled"])
+        if "hidden_from_menu" in fields:
+            fields["hidden_from_menu"] = int(fields["hidden_from_menu"])
         # Re-scan if content or allowed_tools changed
         if "content" in fields or "allowed_tools" in fields:
             content = fields.get("content")

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -2576,6 +2576,10 @@ class PostgreSQLBackend:
         compatibility: str = "",
         priority: int = 0,
         kind: str = "any",
+        paths: str = "[]",
+        hidden_from_menu: bool = False,
+        arguments: str = "[]",
+        argument_hint: str = "",
     ) -> None:
         # Sync is_default from activation when activation is explicitly set
         if activation == "default":
@@ -2627,6 +2631,10 @@ class PostgreSQLBackend:
                         "notify_on_complete": notify_on_complete,
                         "enabled": 1 if enabled else 0,
                         "priority": priority,
+                        "paths": paths,
+                        "hidden_from_menu": 1 if hidden_from_menu else 0,
+                        "arguments": arguments,
+                        "argument_hint": argument_hint,
                         "created": now,
                         "updated": now,
                     },
@@ -2645,7 +2653,9 @@ class PostgreSQLBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.template_id == template_id)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def get_prompt_template_by_name(self, name: str) -> dict[str, Any] | None:
@@ -2654,7 +2664,9 @@ class PostgreSQLBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.name == name)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def list_prompt_templates(
@@ -2670,7 +2682,10 @@ class PostgreSQLBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def count_prompt_templates(self, org_id: str = "") -> int:
@@ -2692,7 +2707,10 @@ class PostgreSQLBackend:
                 q = q.where(prompt_templates.c.org_id == org_id)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def list_prompt_templates_by_origin(self, origin: str) -> list[dict[str, Any]]:
@@ -2703,7 +2721,10 @@ class PostgreSQLBackend:
                 .order_by(prompt_templates.c.name)
             ).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def update_prompt_template(self, template_id: str, **fields: Any) -> bool:
@@ -2815,7 +2836,10 @@ class PostgreSQLBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def list_skills_filtered(
@@ -2865,7 +2889,10 @@ class PostgreSQLBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def get_skill_by_name(self, name: str) -> dict[str, Any] | None:
@@ -2877,7 +2904,9 @@ class PostgreSQLBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.source_url == source_url)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def list_installed_skill_urls(self) -> list[dict[str, str]]:

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1291,6 +1291,10 @@ class StorageBackend(Protocol):
         compatibility: str = "",
         priority: int = 0,
         kind: str = "any",
+        paths: str = "[]",
+        hidden_from_menu: bool = False,
+        arguments: str = "[]",
+        argument_hint: str = "",
     ) -> None:
         """Create a prompt template (skill)."""
         ...

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -433,8 +433,19 @@ prompt_templates = sa.Table(
     sa.Column("version", sa.Text, nullable=False, server_default="1.0.0"),
     sa.Column("author", sa.Text, nullable=False, server_default=""),
     sa.Column("activation", sa.Text, nullable=False, server_default="named"),
+    # Anthropic skill spec ``user-invocable: false`` — hide from /-menu picker.
+    sa.Column("hidden_from_menu", sa.Integer, nullable=False, server_default="0"),
     sa.Column("token_estimate", sa.Integer, nullable=False, server_default="0"),
     sa.Column("allowed_tools", sa.Text, nullable=False, server_default="[]"),  # JSON array
+    # Anthropic skill spec ``paths:`` — glob patterns gating autoload.
+    # Consumer (filter logic) lands in a follow-up PR; field is
+    # parsed/stored/editable but not yet acted on.
+    sa.Column("paths", sa.Text, nullable=False, server_default="[]"),  # JSON array
+    # Anthropic skill spec ``arguments:`` + ``argument-hint:`` —
+    # named positional slots and autocomplete display string.  Consumed
+    # by the $N / $<name> substitution PR (issue #572).
+    sa.Column("arguments", sa.Text, nullable=False, server_default="[]"),  # JSON array
+    sa.Column("argument_hint", sa.Text, nullable=False, server_default=""),
     sa.Column("license", sa.Text, nullable=False, server_default=""),
     sa.Column("compatibility", sa.Text, nullable=False, server_default=""),
     # interactive / coordinator / any — governs which list_skills call

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2737,6 +2737,10 @@ class SQLiteBackend:
         compatibility: str = "",
         priority: int = 0,
         kind: str = "any",
+        paths: str = "[]",
+        hidden_from_menu: bool = False,
+        arguments: str = "[]",
+        argument_hint: str = "",
     ) -> None:
         # Sync is_default from activation when activation is explicitly set
         if activation == "default":
@@ -2788,6 +2792,10 @@ class SQLiteBackend:
                         "notify_on_complete": notify_on_complete,
                         "enabled": 1 if enabled else 0,
                         "priority": priority,
+                        "paths": paths,
+                        "hidden_from_menu": 1 if hidden_from_menu else 0,
+                        "arguments": arguments,
+                        "argument_hint": argument_hint,
                         "created": now,
                         "updated": now,
                     },
@@ -2806,7 +2814,9 @@ class SQLiteBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.template_id == template_id)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def get_prompt_template_by_name(self, name: str) -> dict[str, Any] | None:
@@ -2815,7 +2825,9 @@ class SQLiteBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.name == name)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def list_prompt_templates(
@@ -2831,7 +2843,10 @@ class SQLiteBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def count_prompt_templates(self, org_id: str = "") -> int:
@@ -2853,7 +2868,10 @@ class SQLiteBackend:
                 q = q.where(prompt_templates.c.org_id == org_id)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def list_prompt_templates_by_origin(self, origin: str) -> list[dict[str, Any]]:
@@ -2864,7 +2882,10 @@ class SQLiteBackend:
                 .order_by(prompt_templates.c.name)
             ).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def update_prompt_template(self, template_id: str, **fields: Any) -> bool:
@@ -2974,7 +2995,10 @@ class SQLiteBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def list_skills_filtered(
@@ -3021,7 +3045,10 @@ class SQLiteBackend:
                 q = q.limit(limit)
             rows = conn.execute(q).fetchall()
             return [
-                _row_to_dict(r, "is_default", "readonly", "auto_approve", "enabled") for r in rows
+                _row_to_dict(
+                    r, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
+                for r in rows
             ]
 
     def get_skill_by_name(self, name: str) -> dict[str, Any] | None:
@@ -3033,7 +3060,9 @@ class SQLiteBackend:
                 sa.select(prompt_templates).where(prompt_templates.c.source_url == source_url)
             ).fetchone()
             if row:
-                return _row_to_dict(row, "is_default", "readonly", "auto_approve", "enabled")
+                return _row_to_dict(
+                    row, "is_default", "readonly", "auto_approve", "enabled", "hidden_from_menu"
+                )
             return None
 
     def list_installed_skill_urls(self) -> list[dict[str, str]]:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -2905,6 +2905,8 @@ class SQLiteBackend:
             fields["auto_approve"] = int(fields["auto_approve"])
         if "enabled" in fields:
             fields["enabled"] = int(fields["enabled"])
+        if "hidden_from_menu" in fields:
+            fields["hidden_from_menu"] = int(fields["hidden_from_menu"])
         # Re-scan if content or allowed_tools changed
         if "content" in fields or "allowed_tools" in fields:
             content = fields.get("content")

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -181,6 +181,11 @@ SKILL_MUTABLE = frozenset(
         "scan_report",
         "priority",
         "kind",
+        # Anthropic spec uplift (migration 056)
+        "paths",
+        "hidden_from_menu",
+        "arguments",
+        "argument_hint",
     }
 )
 STRUCTURED_MEMORY_MUTABLE = frozenset({"content", "description", "type"})

--- a/turnstone/core/storage/migrations/versions/056_skill_spec_uplift_columns.py
+++ b/turnstone/core/storage/migrations/versions/056_skill_spec_uplift_columns.py
@@ -1,0 +1,52 @@
+"""Add Anthropic spec-uplift columns to prompt_templates.
+
+The Anthropic Claude Code skill spec defines four frontmatter fields
+that map to new columns on ``prompt_templates``:
+
+* ``paths`` — JSON list of glob patterns that gate model-initiated
+  autoload.  Consumed by issue #569 (filter logic deferred to a
+  follow-up PR pending the workstream-CWD design).
+* ``hidden_from_menu`` — boolean; corresponds to the spec's
+  ``user-invocable: false``.  When true, hide from the ``/``-menu
+  skill picker.  Consumed by issue #571.
+* ``arguments`` — JSON list of named positional-argument slots that
+  pair with the spec's ``$<name>`` substitution in skill bodies.
+  Consumed by issue #572.
+* ``argument_hint`` — display string for autocomplete (e.g.
+  ``[issue-number]``).  Consumed by issue #572.
+
+Boolean fields stored as INTEGER to match the existing convention
+(``is_default``, ``readonly``, ``auto_approve``, ``enabled``).  JSON
+list fields default to ``"[]"`` to match ``allowed_tools`` /
+``notify_on_complete``.
+
+Revision ID: 056
+Revises: 055
+Create Date: 2026-05-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "056"
+down_revision = "055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("prompt_templates") as batch_op:
+        batch_op.add_column(sa.Column("paths", sa.Text, nullable=False, server_default="[]"))
+        batch_op.add_column(
+            sa.Column("hidden_from_menu", sa.Integer, nullable=False, server_default="0")
+        )
+        batch_op.add_column(sa.Column("arguments", sa.Text, nullable=False, server_default="[]"))
+        batch_op.add_column(sa.Column("argument_hint", sa.Text, nullable=False, server_default=""))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("prompt_templates") as batch_op:
+        batch_op.drop_column("argument_hint")
+        batch_op.drop_column("arguments")
+        batch_op.drop_column("hidden_from_menu")
+        batch_op.drop_column("paths")


### PR DESCRIPTION
## Summary

PR1 of 2 for #569 — parser + storage + admin UI for the Anthropic Claude Code skill spec `paths:` SKILL.md frontmatter field (glob patterns gating model-initiated autoload). The filter that consumes `paths` is deferred to PR2 pending the workstream-CWD design discussion noted on the issue.

Migration 056 bundles three additional Anthropic-spec columns whose consumer PRs are filed but not yet implemented, so the storage shape lands once:

- `hidden_from_menu` (boolean) — backs spec `user-invocable: false` (consumer: #571)
- `arguments` (JSON list) — backs spec `arguments:` named slots (consumer: #572)
- `argument_hint` (string) — autocomplete display (consumer: #572)

The deferred columns surface in `SkillInfo` (response) so consumers can read them, but are deliberately absent from `CreateSkillRequest` / `UpdateSkillRequest` — advertising a writable field the handler would silently ignore would be an OpenAPI lie. Their input branches land with their consumer PRs.

`_canonicalize_skill_string_list` collapses the list-or-CSV-or-JSON-string normalization shared between the create + update admin handlers, and will back `arguments` once #572 lands. Treats `None` as no-value so a body containing `{"paths": null}` doesn't CSV-split through `str(None)` and store the literal `["None"]`.

Surface touched: Alembic migration, `_schema.py`, `SKILL_MUTABLE`, protocol + SQLite + PostgreSQL `create_prompt_template`, parser, admin create/update/install/parse HTTP handlers, Pydantic schemas, admin UI HTML + JS (create + edit modals, paste-parse fill, reset, send).

Closes #569 (partial — autoload filter deferred to PR2).

## Test plan

- [x] `ruff` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Full non-live pytest suite: 6430 pass, 17 skipped, 3 deselected (+14 over baseline)
- [x] New tests:
  - `TestPaths` in `tests/test_skill_parser.py` — YAML list, CSV string, empty, full-frontmatter integration
  - `tests/test_storage_skill_spec_uplift.py` — round-trip create/read/update for each of the four columns on both backends
  - `tests/test_canonicalize_skill_string_list.py` — focused unit coverage of the new helper including the null-corruption regression net
  - `paths` assertions added to `test_parses_full_frontmatter` and `test_parses_minimal_frontmatter` in `tests/test_skill_parse_api.py`
- [ ] Manual smoke: paste a SKILL.md with `paths: ["**/*.py"]` into the admin create modal, verify the field auto-fills, save, re-open the edit modal, confirm round-trip