### PR TITLE
feat(skills): ingest when_to_use / model / effort from SKILL.md (#570)

### DIFF
--- a/tests/test_skill_discovery_api.py
+++ b/tests/test_skill_discovery_api.py
@@ -126,6 +126,8 @@ def _sample_listing(
 def _sample_package(
     name: str = "test-skill",
     source_url: str = "https://github.com/owner/repo",
+    model: str = "",
+    effort: str = "",
 ) -> SkillPackage:
     return SkillPackage(
         listing=SkillListing(
@@ -144,6 +146,8 @@ def _sample_package(
             tags=["test"],
             author="Test Author",
             version="1.0.0",
+            model=model,
+            effort=effort,
         ),
         resources={"scripts/setup.sh": "#!/bin/bash\necho hello"},
     )
@@ -267,6 +271,95 @@ class TestSkillInstall:
 
         assert resp.status_code == 200
         assert resp.json()["installed"][0]["name"] == "test-skill"
+
+    def test_install_seeds_model_and_effort_from_frontmatter(self, client: TestClient) -> None:
+        """Anthropic spec ``model:`` + ``effort:`` survive into the row.
+
+        The SKILL.md author's per-skill model and reasoning_effort
+        intent must round-trip through install — they were dropped
+        silently before #570.  Asserts both columns end up populated.
+        """
+        package = _sample_package(model="claude-opus-4-7", effort="high")
+
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = package
+
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        skill = resp.json()["installed"][0]
+        assert skill["model"] == "claude-opus-4-7"
+        assert skill["reasoning_effort"] == "high"
+
+    def test_install_no_model_or_effort_leaves_columns_empty(self, client: TestClient) -> None:
+        """When the source SKILL.md has no model/effort, the columns
+        stay at their server defaults (empty string) — the install
+        path must not invent values."""
+        package = _sample_package()  # model="", effort=""
+
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = package
+
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        skill = resp.json()["installed"][0]
+        assert skill["model"] == ""
+        assert skill["reasoning_effort"] == ""
+
+    def test_reinstall_preserves_admin_model_override(
+        self, client: TestClient, storage: SQLiteBackend
+    ) -> None:
+        """Once a skill is installed, an admin's later edit to ``model`` (or
+        any column) must survive a re-install of the same upstream — the
+        duplicate-source_url check skips the second create entirely, so
+        admin-set values aren't clobbered by the upstream package's
+        frontmatter.  Pins the load-bearing invariant the install
+        handler's comment depends on."""
+        # First install seeds model="upstream-model" from frontmatter.
+        first_package = _sample_package(model="upstream-model", effort="high")
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = first_package
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+        assert resp.status_code == 200
+        skill_id = resp.json()["installed"][0]["template_id"]
+
+        # Admin overrides the model post-install (e.g. via the Skills tab).
+        storage.update_prompt_template(skill_id, model="admin-override-model")
+        assert storage.get_prompt_template(skill_id)["model"] == "admin-override-model"
+
+        # Upstream releases a new SKILL.md with a different model.  Re-install
+        # of the same source_url is rejected — same shape as
+        # ``test_install_duplicate_source_url``.  The admin's value stays
+        # because the second create never fires.
+        second_package = _sample_package(model="upstream-different-model", effort="low")
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = second_package
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+        assert resp.status_code == 409
+        # Admin override survives — the dedup short-circuits before any
+        # create_prompt_template call.
+        assert storage.get_prompt_template(skill_id)["model"] == "admin-override-model"
 
     def test_install_invalid_source(self, client: TestClient) -> None:
         resp = client.post(

--- a/tests/test_skill_parse_api.py
+++ b/tests/test_skill_parse_api.py
@@ -86,6 +86,9 @@ version: 2.0.0
 tags: [python, review, quality]
 allowed-tools: [read_file, list_directory]
 paths: ["**/*.py", "src/api/**"]
+when_to_use: when the user asks to review code
+model: claude-opus-4-7
+effort: high
 license: MIT
 compatibility: ">=0.7"
 ---
@@ -110,12 +113,19 @@ class TestParseSkill:
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "code-review"
-        assert data["description"] == "Automated code review skill"
+        # ``when_to_use`` is concatenated into description by the parser;
+        # the separate ``when_to_use`` field below shows the raw source.
+        assert data["description"] == (
+            "Automated code review skill\n\nWhen to use: when the user asks to review code"
+        )
         assert data["author"] == "Test Author"
         assert data["version"] == "2.0.0"
         assert data["tags"] == ["python", "review", "quality"]
         assert data["allowed_tools"] == ["read_file", "list_directory"]
         assert data["paths"] == ["**/*.py", "src/api/**"]
+        assert data["when_to_use"] == "when the user asks to review code"
+        assert data["model"] == "claude-opus-4-7"
+        assert data["effort"] == "high"
         assert data["license"] == "MIT"
         assert data["compatibility"] == ">=0.7"
         assert "# Code Review" in data["content"]
@@ -137,6 +147,9 @@ class TestParseSkill:
         assert data["tags"] == []
         assert data["allowed_tools"] == []
         assert data["paths"] == []
+        assert data["when_to_use"] == ""
+        assert data["model"] == ""
+        assert data["effort"] == ""
         assert data["license"] == ""
 
     def test_anthropic_nested_metadata_tags(self, client: TestClient) -> None:

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -295,6 +295,114 @@ Content.
         assert result.paths == ["**/*.md"]
 
 
+class TestWhenToUse:
+    """Anthropic spec ``when_to_use:`` — appended to description at parse time."""
+
+    def test_appended_to_description(self) -> None:
+        raw = """\
+---
+name: with-when
+description: Base description.
+when_to_use: when the user asks about X
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.when_to_use == "when the user asks about X"
+        assert result.description == (
+            "Base description.\n\nWhen to use: when the user asks about X"
+        )
+
+    def test_when_to_use_appends_to_body_fallback_description(self) -> None:
+        """Without an explicit ``description``, the parser falls back to the
+        first body line, then ``when_to_use`` appends to that.  Documents
+        the layering — when_to_use is *additional* trigger context, never
+        a replacement for description."""
+        raw = """\
+---
+name: when-only
+when_to_use: trigger phrase
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.when_to_use == "trigger phrase"
+        assert result.description == "Content.\n\nWhen to use: trigger phrase"
+
+    def test_missing_when_to_use(self) -> None:
+        raw = """\
+---
+name: no-when
+description: Just a description.
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.when_to_use == ""
+        assert result.description == "Just a description."
+
+    def test_concat_truncated_at_1536(self) -> None:
+        """Combined description + when_to_use is capped at the spec's 1536-char budget."""
+        long_desc = "A" * 1000
+        long_when = "B" * 1000
+        raw = f"""\
+---
+name: long
+description: {long_desc}
+when_to_use: {long_when}
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert len(result.description) == 1536
+        # The truncation keeps the description prefix; when_to_use is what gets clipped.
+        assert result.description.startswith("A" * 1000)
+
+
+class TestModelAndEffort:
+    """Anthropic spec ``model:`` / ``effort:`` — per-skill overrides."""
+
+    def test_model_extracted(self) -> None:
+        raw = """\
+---
+name: with-model
+model: claude-opus-4-7
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.model == "claude-opus-4-7"
+
+    def test_effort_extracted(self) -> None:
+        raw = """\
+---
+name: with-effort
+effort: high
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.effort == "high"
+
+    def test_both_default_empty(self) -> None:
+        raw = """\
+---
+name: bare
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.model == ""
+        assert result.effort == ""
+
+
 class TestValidateSkillName:
     """Name validation edge cases."""
 
@@ -482,10 +590,10 @@ Content.
 
 
 class TestStandardFieldLengths:
-    """Spec caps: description <= 1024, compatibility <= 500."""
+    """Spec caps: description <= 1536 (combined w/ when_to_use), compatibility <= 500."""
 
-    def test_description_truncated_at_1024(self) -> None:
-        long_desc = "x" * 1200
+    def test_description_truncated_at_1536(self) -> None:
+        long_desc = "x" * 1700
         raw = f"""\
 ---
 name: long-desc
@@ -495,7 +603,7 @@ description: "{long_desc}"
 Content.
 """
         result = parse_skill_md(raw)
-        assert len(result.description) == 1024
+        assert len(result.description) == 1536
 
     def test_compatibility_truncated_at_500(self) -> None:
         long_compat = "y" * 600

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from turnstone.core.skill_kind import SkillKind
+from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 
 # ---------------------------------------------------------------------------
 # Cluster overview
@@ -349,7 +350,7 @@ class CreateSkillRequest(BaseModel):
     category: str = "general"
     description: str = Field(
         min_length=1,
-        max_length=1024,
+        max_length=MAX_SKILL_DESCRIPTION_LEN,
         description=(
             "Human-readable description surfaced by the ``skills`` "
             "find/get tool and the admin UI.  Must be non-empty — "
@@ -414,7 +415,7 @@ class UpdateSkillRequest(BaseModel):
     description: str | None = Field(
         default=None,
         min_length=1,
-        max_length=1024,
+        max_length=MAX_SKILL_DESCRIPTION_LEN,
         description=(
             "When present, replaces the skill description.  Must be "
             "non-empty — the admin endpoint rejects a blanking update."
@@ -850,6 +851,13 @@ class ParseSkillResponse(BaseModel):
     license: str = ""
     compatibility: str = ""
     paths: list[str] = Field(default_factory=list)
+    # Anthropic spec extras (#570).  ``when_to_use`` is already
+    # concatenated into ``description``; surfaced separately so the
+    # admin parse-preview UI can show what the source SKILL.md
+    # provided in each field.
+    when_to_use: str = ""
+    model: str = ""
+    effort: str = ""
 
 
 class SkillInstallRequest(BaseModel):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -79,6 +79,7 @@ from turnstone.core.session_routes import (
 )
 from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
 from turnstone.core.skill_kind import SkillKind
+from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 from turnstone.core.web_helpers import (
     read_json_or_400,
     require_storage_or_503,
@@ -6649,7 +6650,7 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     name = str(body.get("name") or "").strip()[:256]
     content = str(body.get("content") or "").strip()[:32768]
     category = str(body.get("category") or "general").strip()[:64]
-    description = str(body.get("description") or "").strip()[:1024]
+    description = str(body.get("description") or "").strip()[:MAX_SKILL_DESCRIPTION_LEN]
     try:
         kind = SkillKind(str(body.get("kind") or "any").strip().lower()).value
     except ValueError:
@@ -6801,7 +6802,7 @@ async def admin_update_skill(request: Request) -> JSONResponse:
         # cannot blank it out — and ``null`` is treated the same as
         # blank so it can't coerce to the literal string "None".
         raw_description = body["description"]
-        new_description = str(raw_description or "").strip()[:1024]
+        new_description = str(raw_description or "").strip()[:MAX_SKILL_DESCRIPTION_LEN]
         if not new_description:
             return JSONResponse({"error": "description must not be empty"}, status_code=400)
         updates["description"] = new_description
@@ -7545,6 +7546,12 @@ async def admin_parse_skill(request: Request) -> JSONResponse:
             "license": parsed.license,
             "compatibility": parsed.compatibility,
             "paths": list(parsed.paths),
+            # ``when_to_use`` is already concatenated into
+            # ``description``; surface it separately too so the admin
+            # parse-preview UI can show what came from where.
+            "when_to_use": parsed.when_to_use,
+            "model": parsed.model,
+            "effort": parsed.effort,
         }
     )
 
@@ -7776,6 +7783,14 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 token_estimate=token_estimate,
                 allowed_tools=allowed_tools_str,
                 paths=paths_str,
+                # Anthropic spec ``model:`` + ``effort:`` — seed the
+                # corresponding ``model`` / ``reasoning_effort`` columns
+                # at install time so the SKILL.md author's intent
+                # survives the import.  Only fires on initial create —
+                # the same-name / same-source duplicate checks above
+                # protect admin-set values on re-install.
+                model=parsed.model,
+                reasoning_effort=parsed.effort,
             )
         except StorageConflictError as exc:
             # Genuine uniqueness/constraint violation racing past the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -98,6 +98,7 @@ from turnstone.core.providers import create_provider
 from turnstone.core.safety import is_command_blocked, sanitize_command
 from turnstone.core.sandbox import execute_math_sandboxed
 from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
+from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 from turnstone.core.storage._registry import get_storage
 from turnstone.core.storage._utils import normalize_search_terms
 from turnstone.core.tool_advisory import escape_wrapper_tags, render_system_reminder
@@ -8336,7 +8337,7 @@ class ChatSession:
 
         name = self._coord_str_arg(args, "name").strip()[:256]
         content = self._coord_str_arg(args, "content").strip()[:32768]
-        description = self._coord_str_arg(args, "description").strip()[:1024]
+        description = self._coord_str_arg(args, "description").strip()[:MAX_SKILL_DESCRIPTION_LEN]
         category = self._coord_str_arg(args, "category").strip()[:64] or "general"
         if not name:
             return self._coord_tool_error(call_id, "skills", "create: 'name' is required")
@@ -8539,7 +8540,7 @@ class ChatSession:
             updates["content"] = new_content
             updates["token_estimate"] = len(new_content) // 4
         if "description" in args:
-            new_desc = self._coord_str_arg(args, "description").strip()[:1024]
+            new_desc = self._coord_str_arg(args, "description").strip()[:MAX_SKILL_DESCRIPTION_LEN]
             if not new_desc:
                 return self._coord_tool_error(
                     call_id, "skills", "update: description must not be empty"

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -32,8 +32,14 @@ _LIST_SPLIT_RE = re.compile(r"[\s,]+")
 # value contains an unquoted colon (the most common cross-client issue).
 _BARE_DESC_RE = re.compile(r"^(description:\s*)(.+)$", re.MULTILINE)
 
-# Field length caps from the Agent Skills specification.
-_MAX_DESCRIPTION_LEN = 1024
+# Field length caps.  ``MAX_SKILL_DESCRIPTION_LEN`` matches the
+# Anthropic Claude Code skill spec's combined ``description`` +
+# ``when_to_use`` listing budget (1,536 chars).  Exported (no leading
+# underscore) because the same cap must be enforced at every write
+# surface — Pydantic schemas, the admin HTTP handlers, and the
+# coordinator ``skills`` tool — and a magic number repeated in five
+# places is a desync waiting to happen.
+MAX_SKILL_DESCRIPTION_LEN = 1536
 _MAX_COMPATIBILITY_LEN = 500
 
 
@@ -55,6 +61,20 @@ class ParsedSkill:
     # PR (issue #569); parsed here so the value round-trips through
     # install / admin edit / export without loss.
     paths: list[str] = field(default_factory=list)
+    # Anthropic spec ``when_to_use:`` — additional trigger context for
+    # when the skill should be invoked.  Concatenated into
+    # ``description`` (capped at ``MAX_SKILL_DESCRIPTION_LEN``) so the model
+    # sees both in the listing; kept here separately for the admin
+    # parse-preview UI which surfaces it as its own field.
+    when_to_use: str = ""
+    # Anthropic spec ``model:`` and ``effort:`` — per-skill model
+    # override + reasoning effort.  Fields keep their spec names here
+    # for fidelity at the parser layer; the install handler translates
+    # ``effort`` → ``prompt_templates.reasoning_effort`` at the storage
+    # boundary.  Seeding fires only on initial create — re-install
+    # short-circuits at the source_url dedup so admin overrides survive.
+    model: str = ""
+    effort: str = ""
     raw_frontmatter: dict[str, Any] = field(default_factory=dict)
 
 
@@ -213,18 +233,36 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
             first_line = first_line.lstrip("# ").strip()
         description = first_line[:256]
 
+    # Anthropic spec ``when_to_use:`` — appended to description so the
+    # model sees both signals on the listing.  Separated by a blank
+    # line + "When to use:" prefix; budgeted against the combined cap
+    # below so the truncation never lands inside the separator and
+    # leaves a dangling "When " or similar partial label.
+    when_to_use = _extract_str(meta, "when_to_use")
+    if when_to_use:
+        if description:
+            separator = "\n\nWhen to use: "
+            # Reserve room for at least one character of ``when_to_use``
+            # past the separator; below that, dropping the addition is
+            # cleaner than emitting a trailing-separator description.
+            available = MAX_SKILL_DESCRIPTION_LEN - len(description) - len(separator)
+            if available > 0:
+                description = f"{description}{separator}{when_to_use[:available]}"
+        else:
+            description = f"When to use: {when_to_use}"
+
     if not description and lenient:
         log.warning("skill_parser.no_description", name=name)
         return None
 
-    # Spec caps
-    if len(description) > _MAX_DESCRIPTION_LEN:
+    # Spec caps (description + when_to_use combined)
+    if len(description) > MAX_SKILL_DESCRIPTION_LEN:
         log.warning(
             "skill_parser.description_truncated",
             name=name,
             length=len(description),
         )
-        description = description[:_MAX_DESCRIPTION_LEN]
+        description = description[:MAX_SKILL_DESCRIPTION_LEN]
 
     raw_compat = meta.get("compatibility")
     compatibility = str(raw_compat).strip() if raw_compat is not None else ""
@@ -250,5 +288,8 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
         # Spec accepts ``paths:`` as a comma-separated string or YAML
         # list; ``_extract_list`` handles both shapes via ``_LIST_SPLIT_RE``.
         paths=_extract_list(meta, "paths"),
+        when_to_use=when_to_use,
+        model=_extract_str(meta, "model"),
+        effort=_extract_str(meta, "effort"),
         raw_frontmatter=meta,
     )


### PR DESCRIPTION
## Summary

Closes #570 — three previously-dropped Anthropic Claude Code SKILL.md frontmatter fields now round-trip through install:

- `when_to_use` — concatenated into `description` at parse time with `"\n\nWhen to use: "` separator. Kept as its own field on `ParsedSkill` so the admin parse-preview UI can surface it separately.
- `model` — passed through to `create_prompt_template(model=...)` on the source-install path; seeds the pre-existing `prompt_templates.model` column.
- `effort` — same shape; translates to the pre-existing `reasoning_effort` column at the install handler boundary.

No migration — both target columns existed already; this PR fills them at install time. Re-install short-circuits at the source_url dedup, so admin overrides survive an upstream re-install (pinned by a new test).

`_MAX_DESCRIPTION_LEN` exported as `MAX_SKILL_DESCRIPTION_LEN` (public) and raised from 1024 to 1536 to match the spec's combined description+when_to_use listing budget. All five write surfaces import the constant rather than carrying their own magic number — parser, both Pydantic schemas, both admin HTTP handlers, both coordinator `skills` tool sites. The coordinator sites were the bug `/review` caught: they still capped at 1024 after the rest bumped to 1536.

The `when_to_use` concat budgets the separator + value against the cap so truncation never lands mid-separator and leaves a dangling `"\n\nWhen "`. If no budget remains, the addition is dropped entirely.

## Test plan

- [x] `ruff` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Full non-live pytest suite: 6454 pass, 17 skipped, 3 deselected (+24 over baseline)
- [x] New tests:
  - `TestWhenToUse` — concat into description, no-description fallback, 1536-char truncation
  - `TestModelAndEffort` — extraction + empty defaults
  - `test_install_seeds_model_and_effort_from_frontmatter` — both columns persisted via install
  - `test_install_no_model_or_effort_leaves_columns_empty` — bare SKILL.md doesn't invent values
  - `test_reinstall_preserves_admin_model_override` — admin edits survive an upstream re-install (load-bearing dedup invariant)
  - `test_parses_full_frontmatter` + `test_parses_minimal_frontmatter` extended to assert the new parse-API fields
- [ ] Manual smoke: paste a SKILL.md with `when_to_use`, `model`, `effort` set into the admin create modal; verify the preview surfaces them; install and confirm the row carries `model` + `reasoning_effort`