### PR TITLE
feat(skills): wire disable-model-invocation / user-invocable (#571)

### DIFF
--- a/tests/test_skill_discovery_api.py
+++ b/tests/test_skill_discovery_api.py
@@ -128,6 +128,8 @@ def _sample_package(
     source_url: str = "https://github.com/owner/repo",
     model: str = "",
     effort: str = "",
+    user_invocable: bool = True,
+    disable_model_invocation: bool = False,
 ) -> SkillPackage:
     return SkillPackage(
         listing=SkillListing(
@@ -148,6 +150,8 @@ def _sample_package(
             version="1.0.0",
             model=model,
             effort=effort,
+            user_invocable=user_invocable,
+            disable_model_invocation=disable_model_invocation,
         ),
         resources={"scripts/setup.sh": "#!/bin/bash\necho hello"},
     )
@@ -295,6 +299,42 @@ class TestSkillInstall:
         skill = resp.json()["installed"][0]
         assert skill["model"] == "claude-opus-4-7"
         assert skill["reasoning_effort"] == "high"
+
+    def test_install_user_invocable_false_sets_hidden_from_menu(self, client: TestClient) -> None:
+        """Anthropic spec ``user-invocable: false`` lands as
+        ``hidden_from_menu=true`` on the row.  The skill stays available
+        to the model but disappears from the user-facing picker."""
+        package = _sample_package(user_invocable=False)
+
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = package
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        skill = resp.json()["installed"][0]
+        assert skill["hidden_from_menu"] is True
+
+    def test_install_user_invocable_default_unhidden(self, client: TestClient) -> None:
+        """Spec default ``user-invocable: true`` leaves ``hidden_from_menu`` off."""
+        package = _sample_package()  # user_invocable=True (default)
+
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = package
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        skill = resp.json()["installed"][0]
+        assert skill["hidden_from_menu"] is False
 
     def test_install_no_model_or_effort_leaves_columns_empty(self, client: TestClient) -> None:
         """When the source SKILL.md has no model/effort, the columns

--- a/tests/test_skill_parse_api.py
+++ b/tests/test_skill_parse_api.py
@@ -89,6 +89,8 @@ paths: ["**/*.py", "src/api/**"]
 when_to_use: when the user asks to review code
 model: claude-opus-4-7
 effort: high
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 compatibility: ">=0.7"
 ---
@@ -126,6 +128,8 @@ class TestParseSkill:
         assert data["when_to_use"] == "when the user asks to review code"
         assert data["model"] == "claude-opus-4-7"
         assert data["effort"] == "high"
+        assert data["disable_model_invocation"] is True
+        assert data["user_invocable"] is False
         assert data["license"] == "MIT"
         assert data["compatibility"] == ">=0.7"
         assert "# Code Review" in data["content"]
@@ -150,6 +154,9 @@ class TestParseSkill:
         assert data["when_to_use"] == ""
         assert data["model"] == ""
         assert data["effort"] == ""
+        # Spec defaults: model can autoload, user can pick.
+        assert data["disable_model_invocation"] is False
+        assert data["user_invocable"] is True
         assert data["license"] == ""
 
     def test_anthropic_nested_metadata_tags(self, client: TestClient) -> None:

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -479,6 +479,25 @@ Content.
         assert result.disable_model_invocation is True
         assert result.user_invocable is False
 
+    def test_other_ints_fall_back_to_default(self) -> None:
+        """Spec recognises only ``0``/``1`` as integer boolean forms.
+        ``2`` is ambiguous — silently coercing via Python truthiness
+        would disable model invocation on a typo without warning.  Copilot
+        review on PR #577 caught the too-permissive original."""
+        raw = """\
+---
+name: ambiguous-int
+disable-model-invocation: 2
+user-invocable: -1
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        # Both fall back to spec defaults (model can autoload, user can pick).
+        assert result.disable_model_invocation is False
+        assert result.user_invocable is True
+
     def test_quoted_yaml_1_1_variants(self) -> None:
         """YAML 1.1 spellings — ``yes``/``no``/``on``/``off`` — survive
         quoting.  Unquoted forms get coerced to bool by safe_load (covered

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -403,6 +403,101 @@ Content.
         assert result.effort == ""
 
 
+class TestInvocationControl:
+    """Anthropic spec ``disable-model-invocation:`` + ``user-invocable:``."""
+
+    def test_disable_model_invocation_true(self) -> None:
+        raw = """\
+---
+name: model-blocked
+disable-model-invocation: true
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.disable_model_invocation is True
+        # ``user_invocable`` defaults to True (spec default).
+        assert result.user_invocable is True
+
+    def test_user_invocable_false(self) -> None:
+        raw = """\
+---
+name: hidden
+user-invocable: false
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.user_invocable is False
+        # ``disable_model_invocation`` defaults to False.
+        assert result.disable_model_invocation is False
+
+    def test_both_unset_uses_spec_defaults(self) -> None:
+        """Spec default: both invokers can use the skill."""
+        raw = """\
+---
+name: bare
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.disable_model_invocation is False
+        assert result.user_invocable is True
+
+    def test_string_true_false_accepted(self) -> None:
+        """YAML can quote bools; the parser accepts ``"true"``/``"false"``."""
+        raw = """\
+---
+name: quoted-bools
+disable-model-invocation: "true"
+user-invocable: "false"
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.disable_model_invocation is True
+        assert result.user_invocable is False
+
+    def test_yaml_int_accepted(self) -> None:
+        """YAML safe_load returns ``int`` for unquoted ``0``/``1``.  Without
+        explicit handling these silently fall back to defaults, dropping the
+        author's intent."""
+        raw = """\
+---
+name: int-bools
+disable-model-invocation: 1
+user-invocable: 0
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.disable_model_invocation is True
+        assert result.user_invocable is False
+
+    def test_quoted_yaml_1_1_variants(self) -> None:
+        """YAML 1.1 spellings — ``yes``/``no``/``on``/``off`` — survive
+        quoting.  Unquoted forms get coerced to bool by safe_load (covered
+        by ``test_disable_model_invocation_true``), but a quoted variant
+        is a plain string that needs the broader match table."""
+        raw = """\
+---
+name: yaml-11-quoted
+disable-model-invocation: "yes"
+user-invocable: "OFF"
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.disable_model_invocation is True
+        assert result.user_invocable is False
+
+
 class TestValidateSkillName:
     """Name validation edge cases."""
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -996,6 +996,44 @@ class TestSkillAPI:
         # Spec fields must remain unchanged
         assert data["content"] == "external content"
 
+    def test_update_skill_readonly_hidden_from_menu_allowed(self, api_client, api_storage):
+        """``hidden_from_menu`` is in SKILL_RUNTIME_CONFIG_FIELDS so an admin
+        can hide/unhide an installed (readonly) skill from the user picker
+        without unlocking the row.  Pins the load-bearing invariant the
+        ``skill_field_validation`` comment depends on — a future refactor
+        that drops the field from runtime-config would silently break
+        admin's ability to toggle this on installed skills."""
+        _create_template(
+            api_storage,
+            "s1",
+            "installed-skill",
+            "external content",
+            origin="source",
+            readonly=True,
+        )
+        # Default after install: visible.  Verified via direct storage
+        # read rather than a GET — the api_client fixture doesn't wire
+        # the GET-by-id route.
+        assert api_storage.get_prompt_template("s1")["hidden_from_menu"] is False
+
+        # Hide.
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={"hidden_from_menu": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["hidden_from_menu"] is True
+        # Spec/content fields untouched.
+        assert resp.json()["content"] == "external content"
+
+        # Unhide round-trips back.
+        resp = api_client.put(
+            "/v1/api/admin/skills/s1",
+            json={"hidden_from_menu": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["hidden_from_menu"] is False
+
     def test_update_skill_readonly_mixed_body_filters_spec(self, api_client, api_storage):
         """When JS sends all fields for a readonly skill, spec fields are silently dropped."""
         _create_template(
@@ -1789,6 +1827,39 @@ class TestSkillAdminEndpoints:
         names = [s["name"] for s in resp.json()["skills"]]
         assert "enabled-skill" in names
         assert "disabled-skill" not in names
+
+    def test_list_skills_summary_excludes_hidden_from_menu(self, full_api_client, full_api_storage):
+        """GET /v1/api/skills excludes skills with ``hidden_from_menu=true``.
+
+        The admin Skills tab (``/v1/api/admin/skills``) still returns them
+        — the filter only applies to the user-facing picker.
+        """
+        full_api_client.post(
+            "/v1/api/admin/skills",
+            json={"name": "visible-skill", "content": "content", "description": "v"},
+        )
+        full_api_client.post(
+            "/v1/api/admin/skills",
+            json={
+                "name": "hidden-skill",
+                "content": "content",
+                "description": "h",
+                "hidden_from_menu": True,
+            },
+        )
+
+        # Picker filters out the hidden one.
+        resp = full_api_client.get("/v1/api/skills")
+        assert resp.status_code == 200
+        names = [s["name"] for s in resp.json()["skills"]]
+        assert "visible-skill" in names
+        assert "hidden-skill" not in names
+
+        # Admin tab still surfaces it.
+        admin_resp = full_api_client.get("/v1/api/admin/skills")
+        assert admin_resp.status_code == 200
+        admin_names = [s["name"] for s in admin_resp.json()["skills"]]
+        assert "hidden-skill" in admin_names
 
     def test_skill_version_history_via_api(self, full_api_client):
         """GET /v1/api/admin/skills/{id}/versions returns version history."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1034,6 +1034,66 @@ class TestSkillAPI:
         assert resp.status_code == 200
         assert resp.json()["hidden_from_menu"] is False
 
+    def test_create_skill_hidden_from_menu_string_rejected(self, api_client):
+        """``hidden_from_menu`` is bool-typed at the API boundary —
+        a malformed client sending the string ``"false"`` (which Python
+        truthiness would silently coerce to ``True``, flipping the flag
+        opposite to intent) must be rejected with a 400.  Copilot review
+        on PR #577 caught the loose ``bool()`` cast."""
+        resp = api_client.post(
+            "/v1/api/admin/skills",
+            json={
+                "name": "loose-bool",
+                "content": "...",
+                "description": "x",
+                "hidden_from_menu": "false",
+            },
+        )
+        assert resp.status_code == 400
+        assert "boolean" in resp.json()["error"].lower()
+
+    def test_create_skill_hidden_from_menu_int_zero_and_one_accepted(self, api_client, api_storage):
+        """Strict-bool parse accepts canonical JSON ``true``/``false``
+        AND integer ``0``/``1`` — the latter for clients that serialise
+        Postgres-style.  Other integers fall to 400."""
+        # int 1 → True
+        resp = api_client.post(
+            "/v1/api/admin/skills",
+            json={
+                "name": "intbool-true",
+                "content": "...",
+                "description": "x",
+                "hidden_from_menu": 1,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["hidden_from_menu"] is True
+
+        # int 0 → False (defaults check).
+        resp = api_client.post(
+            "/v1/api/admin/skills",
+            json={
+                "name": "intbool-false",
+                "content": "...",
+                "description": "x",
+                "hidden_from_menu": 0,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["hidden_from_menu"] is False
+
+        # int 2 → 400.
+        resp = api_client.post(
+            "/v1/api/admin/skills",
+            json={
+                "name": "intbool-ambiguous",
+                "content": "...",
+                "description": "x",
+                "hidden_from_menu": 2,
+            },
+        )
+        assert resp.status_code == 400
+
     def test_update_skill_readonly_mixed_body_filters_spec(self, api_client, api_storage):
         """When JS sends all fields for a readonly skill, spec fields are silently dropped."""
         _create_template(

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -383,14 +383,16 @@ class CreateSkillRequest(BaseModel):
     # Accepts either a JSON-array string or a list; the admin handler
     # canonicalizes via ``_canonicalize_skill_string_list``.  The
     # filter consumer lands in a follow-up PR (#569).
-    #
-    # ``hidden_from_menu`` / ``arguments`` / ``argument_hint`` columns
-    # exist on the row (migration 056) and surface in ``SkillInfo`` for
-    # read, but the create/update handlers don't read them yet — the
-    # consumer PRs (#571, #572) will add their input branches.  Keeping
-    # them off the request schemas avoids advertising a writable field
-    # the handler silently ignores.
     paths: str | list[str] = "[]"
+    # Anthropic spec ``user-invocable: false`` lands here as
+    # ``hidden_from_menu=true`` (#571).  Hides the skill from the
+    # user-facing picker (``/v1/api/skills``) while keeping it
+    # available to the model.
+    hidden_from_menu: bool = False
+    # ``arguments`` / ``argument_hint`` columns still exist on the
+    # row (migration 056) and surface in ``SkillInfo`` for read, but
+    # the create/update handlers don't read them yet — #572 wires
+    # those input branches when its consumer lands.
     kind: SkillKind = Field(
         default=SkillKind.ANY,
         description=(
@@ -440,11 +442,12 @@ class UpdateSkillRequest(BaseModel):
     allowed_tools: str | None = None
     license: str | None = None
     compatibility: str | None = None
-    # Anthropic spec ``paths:``.  ``hidden_from_menu`` / ``arguments``
-    # / ``argument_hint`` are deliberately absent from the update
-    # schema until their consumer PRs (#571, #572) wire input branches
-    # — see ``CreateSkillRequest`` for the rationale.
+    # Anthropic spec ``paths:`` (#569 — filter consumer pending) and
+    # ``user-invocable: false`` mapped to ``hidden_from_menu=true``
+    # (#571).  ``arguments`` / ``argument_hint`` remain absent until
+    # #572 wires their consumer.
     paths: str | list[str] | None = None
+    hidden_from_menu: bool | None = None
     kind: SkillKind | None = Field(
         default=None,
         description=(
@@ -858,6 +861,12 @@ class ParseSkillResponse(BaseModel):
     when_to_use: str = ""
     model: str = ""
     effort: str = ""
+    # Invocation-control axes (#571).  The install handler derives
+    # ``hidden_from_menu`` from ``user_invocable`` at the storage
+    # boundary; these raw spec fields surface here so the admin UI
+    # can echo them on the parse-preview.
+    disable_model_invocation: bool = False
+    user_invocable: bool = True
 
 
 class SkillInstallRequest(BaseModel):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6518,6 +6518,34 @@ def _canonicalize_skill_string_list(raw: Any) -> str:
     return _json.dumps([p.strip() for p in candidate.split(",") if p.strip()])
 
 
+def _parse_strict_bool(raw: Any, *, default: bool) -> tuple[bool, JSONResponse | None]:
+    """Strictly parse a boolean-shaped admin body field.
+
+    Accepts:
+    * Python ``bool`` (canonical JSON ``true``/``false``)
+    * ``int`` ``0`` or ``1``
+
+    Anything else returns a 400 ``JSONResponse`` — admin clients on
+    this surface speak typed JSON, and silently coercing the string
+    ``"false"`` (which Python truthiness reads as ``True``) would flip
+    a field opposite to the obvious intent.  Caught by ``/review`` on
+    PR #577: ``bool(body.get(..., False))`` accepted strings unsafely.
+
+    Returns ``(value, None)`` on success or ``(default, response_400)``
+    on failure — callers return the 400 early.
+    """
+    if isinstance(raw, bool):
+        return raw, None
+    if isinstance(raw, int) and raw in (0, 1):
+        return bool(raw), None
+    if raw is None:
+        return default, None
+    return default, JSONResponse(
+        {"error": "boolean field expects true/false (or 0/1)"},
+        status_code=400,
+    )
+
+
 def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, Any]:
     """Convert a storage skill dict to a JSON-safe response dict."""
     import json as _json
@@ -6690,8 +6718,11 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     # Anthropic spec ``user-invocable: false`` lands here as
     # ``hidden_from_menu=true`` — the user-facing picker
     # (``/v1/api/skills``) filters these out while the model still
-    # sees them.
-    hidden_from_menu = bool(body.get("hidden_from_menu", False))
+    # sees them.  Strict-bool parse so a string like ``"false"`` (which
+    # ``bool()`` would silently flip True) returns a 400 instead.
+    hidden_from_menu, hidden_err = _parse_strict_bool(body.get("hidden_from_menu"), default=False)
+    if hidden_err is not None:
+        return hidden_err
 
     token_estimate = len(content) // 4 if content else 0
 
@@ -6857,7 +6888,13 @@ async def admin_update_skill(request: Request) -> JSONResponse:
         # ``_canonicalize_skill_string_list``.
         updates["paths"] = _canonicalize_skill_string_list(body["paths"])
     if "hidden_from_menu" in body and body["hidden_from_menu"] is not None:
-        updates["hidden_from_menu"] = bool(body["hidden_from_menu"])
+        # Strict-bool parse — see ``_parse_strict_bool``.  A malformed
+        # client sending ``"false"`` would flip the flag the wrong way
+        # under plain ``bool()`` truthiness; 400 instead.
+        hidden_value, hidden_err = _parse_strict_bool(body["hidden_from_menu"], default=False)
+        if hidden_err is not None:
+            return hidden_err
+        updates["hidden_from_menu"] = hidden_value
     if "priority" in body:
         try:
             updates["priority"] = max(-1000, min(1000, int(body["priority"] or 0)))

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6687,6 +6687,12 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     # ``arguments`` once #572 lands its consumer.
     paths_str = _canonicalize_skill_string_list(body.get("paths"))
 
+    # Anthropic spec ``user-invocable: false`` lands here as
+    # ``hidden_from_menu=true`` — the user-facing picker
+    # (``/v1/api/skills``) filters these out while the model still
+    # sees them.
+    hidden_from_menu = bool(body.get("hidden_from_menu", False))
+
     token_estimate = len(content) // 4 if content else 0
 
     # Session config fields via shared helper
@@ -6738,6 +6744,7 @@ async def admin_create_skill(request: Request) -> JSONResponse:
         priority=priority,
         kind=kind,
         paths=paths_str,
+        hidden_from_menu=hidden_from_menu,
         **session_fields,
     )
 
@@ -6849,6 +6856,8 @@ async def admin_update_skill(request: Request) -> JSONResponse:
         # UpdateSkillRequest's optional-None semantics.  See
         # ``_canonicalize_skill_string_list``.
         updates["paths"] = _canonicalize_skill_string_list(body["paths"])
+    if "hidden_from_menu" in body and body["hidden_from_menu"] is not None:
+        updates["hidden_from_menu"] = bool(body["hidden_from_menu"])
     if "priority" in body:
         try:
             updates["priority"] = max(-1000, min(1000, int(body["priority"] or 0)))
@@ -6946,35 +6955,12 @@ async def admin_list_skill_versions(request: Request) -> JSONResponse:
 
 async def list_skills_summary(request: Request) -> JSONResponse:
     """GET /v1/api/skills — list available skills (summary)."""
-    import json as _json
-
-    from turnstone.core.web_helpers import require_storage_or_503
+    from turnstone.core.web_helpers import require_storage_or_503, skill_summary_rows
 
     storage, err = require_storage_or_503(request)
     if err:
         return err
-    rows = storage.list_prompt_templates()
-    skills = []
-    for r in rows:
-        if not r.get("enabled", True):
-            continue
-        tags: list[str] = []
-        with contextlib.suppress(ValueError, TypeError):
-            tags = _json.loads(r.get("tags", "[]"))
-        skills.append(
-            {
-                "name": r["name"],
-                "category": r.get("category", ""),
-                "description": r.get("description", ""),
-                "tags": tags,
-                "is_default": r.get("is_default", False),
-                "activation": r.get("activation", "named"),
-                "origin": r.get("origin", "manual"),
-                "author": r.get("author", ""),
-                "version": r.get("version", "1.0.0"),
-            }
-        )
-    return JSONResponse({"skills": skills})
+    return JSONResponse({"skills": skill_summary_rows(storage)})
 
 
 async def admin_usage(request: Request) -> JSONResponse:
@@ -7552,6 +7538,12 @@ async def admin_parse_skill(request: Request) -> JSONResponse:
             "when_to_use": parsed.when_to_use,
             "model": parsed.model,
             "effort": parsed.effort,
+            # Invocation-control axes (#571).  Echoed back to the admin
+            # UI so the parse-preview can show what the source SKILL.md
+            # gated; the UI also uses ``user_invocable`` to pre-fill
+            # the ``hidden-from-menu`` checkbox on the create modal.
+            "disable_model_invocation": parsed.disable_model_invocation,
+            "user_invocable": parsed.user_invocable,
         }
     )
 
@@ -7760,6 +7752,15 @@ async def admin_skill_install(request: Request) -> JSONResponse:
         # operator doesn't control.
         skill_description = parsed.description.strip() or f"Skill: {parsed.name}"
 
+        # Anthropic invocation-control axes (#571).  The install
+        # default is ``activation="named"`` already (user invokes by
+        # name); ``disable-model-invocation: true`` reinforces that
+        # but doesn't change the install-time value.  The interesting
+        # axis is ``user-invocable: false`` which sets
+        # ``hidden_from_menu`` so the skill doesn't show up in the
+        # user-facing picker but stays available to the model.
+        install_hidden_from_menu = not parsed.user_invocable
+
         try:
             storage.create_prompt_template(
                 template_id=skill_id,
@@ -7783,6 +7784,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 token_estimate=token_estimate,
                 allowed_tools=allowed_tools_str,
                 paths=paths_str,
+                hidden_from_menu=install_hidden_from_menu,
                 # Anthropic spec ``model:`` + ``effort:`` — seed the
                 # corresponding ``model`` / ``reasoning_effort`` columns
                 # at install time so the SKILL.md author's intent

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -992,6 +992,19 @@ function _applyParsedSkill(parsed, contentTextarea, fieldMap) {
     _apply(fieldMap.allowed_tools, parsed.allowed_tools.join(", "));
   if (parsed.paths && parsed.paths.length)
     _apply(fieldMap.paths, parsed.paths.join(", "));
+  // ``user-invocable: false`` from the parsed SKILL.md flips the
+  // hidden-from-menu checkbox.  Boolean coercion — the parse response
+  // can return either ``true``/``false`` or omit the field.  Mirrors
+  // the apply rule for other fields: only fill, never override an
+  // existing user choice (a checkbox the admin already ticked stays
+  // ticked even if the parsed value disagrees).
+  if (parsed.user_invocable === false) {
+    const hidden = document.getElementById("skill-hidden-from-menu");
+    if (hidden && !hidden.checked) {
+      hidden.checked = true;
+      filled++;
+    }
+  }
 
   return { filled: filled, skipped: skipped };
 }
@@ -1120,6 +1133,7 @@ function showCreateTemplateModal() {
   document.getElementById("skill-license").value = "";
   document.getElementById("skill-compatibility").value = "";
   document.getElementById("skill-paths").value = "";
+  document.getElementById("skill-hidden-from-menu").checked = false;
   document.getElementById("skill-activation").value = "named";
   const ctmContent = document.getElementById("ctm-content");
   ctmContent.value = "";
@@ -1283,6 +1297,7 @@ function submitCreateTemplate() {
     agent_max_turns: csMaxTurns ? parseInt(csMaxTurns, 10) : null,
     allowed_tools: JSON.stringify(csAllowedArr),
     paths: JSON.stringify(csPathsArr),
+    hidden_from_menu: document.getElementById("skill-hidden-from-menu").checked,
     notify_on_complete: csNotifyVal,
     enabled: document.getElementById("csk-enabled").checked,
   };
@@ -1386,6 +1401,9 @@ function showEditTemplateModal(tmplId) {
     pathsDisplay = tmpl.paths || "";
   }
   document.getElementById("etm-paths").value = pathsDisplay;
+  document.getElementById("etm-hidden-from-menu").checked = Boolean(
+    tmpl.hidden_from_menu,
+  );
   document.getElementById("etm-activation").value = tmpl.activation || "named";
   document.getElementById("etm-content").value = tmpl.content;
   _updateVarsDisplay("etm-content", "etm-variables");
@@ -1596,7 +1614,11 @@ function showEditTemplateModal(tmplId) {
       el.removeAttribute("aria-describedby");
     }
   });
-  // Runtime config fields: always editable (local settings, not part of SKILL.md spec)
+  // Runtime config fields: always editable, even for readonly skills.
+  // Admins should be able to override these local-UX-ish values
+  // (model, effort, hidden-from-menu, ...) on installed skills
+  // without unlocking the row.  Must match SKILL_RUNTIME_CONFIG_FIELDS
+  // in turnstone/core/skill_field_validation.py.
   [
     "esk-model",
     "esk-temperature",
@@ -1606,6 +1628,7 @@ function showEditTemplateModal(tmplId) {
     "esk-agent-max-turns",
     "esk-auto-approve",
     "esk-enabled",
+    "etm-hidden-from-menu",
   ].forEach(function (id) {
     const el = document.getElementById(id);
     if (el) el.disabled = false;
@@ -2032,6 +2055,7 @@ function submitEditTemplate() {
       document.getElementById("etm-compatibility").value || ""
     ).trim(),
     paths: JSON.stringify(esPathsArr),
+    hidden_from_menu: document.getElementById("etm-hidden-from-menu").checked,
     activation: document.getElementById("etm-activation").value,
     content: content,
     variables: JSON.stringify(varList),

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3085,6 +3085,18 @@
                 type="text"
                 placeholder="**/*.py, packages/api/**"
               />
+              <label class="toggle-switch">
+                <input id="skill-hidden-from-menu" type="checkbox" />
+                <span class="toggle-track" aria-hidden="true"></span>
+                <span class="toggle-label"
+                  >Hide from skill picker
+                  <span class="label-hint"
+                    >Anthropic spec <code>user-invocable: false</code> — skill
+                    stays available to the model but disappears from the
+                    user-facing picker.</span
+                  ></span
+                >
+              </label>
             </div>
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>
@@ -3413,6 +3425,18 @@
                 type="text"
                 placeholder="**/*.py, packages/api/**"
               />
+              <label class="toggle-switch">
+                <input id="etm-hidden-from-menu" type="checkbox" />
+                <span class="toggle-track" aria-hidden="true"></span>
+                <span class="toggle-label"
+                  >Hide from skill picker
+                  <span class="label-hint"
+                    >Anthropic spec <code>user-invocable: false</code> — skill
+                    stays available to the model but disappears from the
+                    user-facing picker.</span
+                  ></span
+                >
+              </label>
             </div>
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>

--- a/turnstone/core/skill_field_validation.py
+++ b/turnstone/core/skill_field_validation.py
@@ -35,6 +35,12 @@ SKILL_RUNTIME_CONFIG_FIELDS: frozenset[str] = frozenset(
         "enabled",
         "notify_on_complete",
         "priority",
+        # ``hidden_from_menu`` is technically a SKILL.md spec field
+        # (mapped from ``user-invocable: false``) but admin override
+        # is a local UX preference — operators should be able to
+        # hide / unhide an installed skill in the picker without
+        # unlocking the row.  Same precedent as ``model`` / ``effort``.
+        "hidden_from_menu",
     }
 )
 

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -171,10 +171,18 @@ def _extract_bool(meta: dict[str, Any], key: str, *, default: bool) -> bool:
     if isinstance(raw, int):
         # ``isinstance(True, int)`` is also True, but the bool branch
         # above already handled that — anything reaching here is an
-        # actual int.  0 → False, anything else → True (mirrors YAML's
-        # broader "any non-zero is truthy" intuition, though strictly
-        # the spec accepts only 0/1).
-        return bool(raw)
+        # actual int.  Spec mentions only ``0`` / ``1`` as the integer
+        # boolean forms; other ints (``2``, ``-1``, ...) are ambiguous
+        # and fall back to *default* rather than silently coercing via
+        # Python truthiness.  ``/review`` on PR #577 caught the
+        # too-permissive coerce — a SKILL.md with ``disable-model-
+        # invocation: 2`` would otherwise silently disable model
+        # invocation without warning the author about the typo.
+        if raw == 0:
+            return False
+        if raw == 1:
+            return True
+        return default
     if isinstance(raw, str):
         lowered = raw.strip().lower()
         if lowered in _YAML_BOOL_TRUE:

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -75,6 +75,26 @@ class ParsedSkill:
     # short-circuits at the source_url dedup so admin overrides survive.
     model: str = ""
     effort: str = ""
+    # Anthropic spec ``disable-model-invocation:`` and ``user-invocable:``
+    # — invocation-control axes.  Stored in raw spec shape on the
+    # dataclass; defaults match spec (both invokers can use the skill
+    # unless gated).
+    #
+    # ``user_invocable=False`` is the load-bearing one: the install
+    # handler derives ``hidden_from_menu=True`` from it, and
+    # ``list_skills_summary`` filters those rows out of the
+    # user-facing picker.  Round-trip works end to end.
+    #
+    # ``disable_model_invocation=True`` has NO install consumer today —
+    # Turnstone's install path hardcodes ``activation="named"`` already,
+    # so the spec field's intended translation is a no-op at create
+    # time.  We still parse it for fidelity (surface on the
+    # parse-preview UI, preserve in ``raw_frontmatter``) so an admin
+    # reviewing a SKILL.md sees what the author wrote.  If install
+    # ever supports a non-"named" default activation, this is the
+    # field that gates flipping back.
+    disable_model_invocation: bool = False
+    user_invocable: bool = True
     raw_frontmatter: dict[str, Any] = field(default_factory=dict)
 
 
@@ -118,6 +138,49 @@ def _extract_str(meta: dict[str, Any], key: str, default: str = "") -> str:
         val = str(raw).strip() if raw is not None else ""
         if val:
             return val
+    return default
+
+
+_YAML_BOOL_TRUE = frozenset({"true", "yes", "on", "1"})
+_YAML_BOOL_FALSE = frozenset({"false", "no", "off", "0"})
+
+
+def _extract_bool(meta: dict[str, Any], key: str, *, default: bool) -> bool:
+    """Extract a boolean field from frontmatter.
+
+    Accepts every shape a YAML 1.1 author or YAML library can plausibly
+    produce for a boolean value:
+
+    * Python ``bool`` — the natural unquoted ``true``/``false``/``yes``/
+      ``no``/``on``/``off`` (case-insensitive) coerced by ``safe_load``.
+    * Python ``int`` — unquoted ``1`` or ``0`` (``safe_load`` returns
+      ``int`` for these, not ``bool``).
+    * Python ``str`` — quoted variants (e.g. ``"true"``, ``"YES"``,
+      ``"off"``, ``"0"``) where the author wrapped the value to dodge
+      YAML interpretation.
+
+    Anything else (lists, dicts, unknown strings, ``None``) falls
+    back to *default*.  The asymmetry between quoted and unquoted
+    would silently drop the author's intent if we only matched the
+    canonical ``"true"`` / ``"false"`` pair (case study: ``/review``
+    on PR #571 caught this gap).
+    """
+    raw = meta.get(key)
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, int):
+        # ``isinstance(True, int)`` is also True, but the bool branch
+        # above already handled that — anything reaching here is an
+        # actual int.  0 → False, anything else → True (mirrors YAML's
+        # broader "any non-zero is truthy" intuition, though strictly
+        # the spec accepts only 0/1).
+        return bool(raw)
+    if isinstance(raw, str):
+        lowered = raw.strip().lower()
+        if lowered in _YAML_BOOL_TRUE:
+            return True
+        if lowered in _YAML_BOOL_FALSE:
+            return False
     return default
 
 
@@ -291,5 +354,10 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
         when_to_use=when_to_use,
         model=_extract_str(meta, "model"),
         effort=_extract_str(meta, "effort"),
+        # Anthropic invocation-control axes — spec defaults: model can
+        # autoload (disable-model-invocation=False) AND user can pick
+        # from the menu (user-invocable=True).
+        disable_model_invocation=_extract_bool(meta, "disable-model-invocation", default=False),
+        user_invocable=_extract_bool(meta, "user-invocable", default=True),
         raw_frontmatter=meta,
     )

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -11,6 +12,53 @@ if TYPE_CHECKING:
     from starlette.middleware import Middleware
     from starlette.requests import Request
     from starlette.responses import JSONResponse
+
+
+def skill_summary_rows(storage: Any) -> list[dict[str, Any]]:
+    """Build the public picker payload for ``/v1/api/skills``.
+
+    Shared between ``turnstone/server.py`` (standalone node) and
+    ``turnstone/console/server.py`` (console-managed cluster), both of
+    which expose ``/v1/api/skills`` to user-facing UI.  Bodies were
+    character-identical before #571 added the ``hidden_from_menu``
+    filter — extraction here keeps the two surfaces from drifting on
+    every future spec-uplift field (#572's ``argument_hint`` for
+    autocomplete is the next likely caller).
+
+    Filters:
+    * ``enabled=False`` rows are dropped.
+    * ``hidden_from_menu=True`` rows are dropped (Anthropic spec
+      ``user-invocable: false`` — model still sees the skill via the
+      ``skills`` tool, but the user picker hides it).
+
+    Filtering happens in Python rather than SQL to match the
+    pre-existing ``enabled`` pattern; pushing to SQL would be a
+    separate change to ``list_prompt_templates``.
+    """
+    rows = storage.list_prompt_templates()
+    skills: list[dict[str, Any]] = []
+    for r in rows:
+        if not r.get("enabled", True):
+            continue
+        if r.get("hidden_from_menu"):
+            continue
+        tags: list[str] = []
+        with contextlib.suppress(ValueError, TypeError):
+            tags = json.loads(r.get("tags", "[]"))
+        skills.append(
+            {
+                "name": r["name"],
+                "category": r.get("category", ""),
+                "description": r.get("description", ""),
+                "tags": tags,
+                "is_default": r.get("is_default", False),
+                "activation": r.get("activation", "named"),
+                "origin": r.get("origin", "manual"),
+                "author": r.get("author", ""),
+                "version": r.get("version", "1.0.0"),
+            }
+        )
+    return skills
 
 
 async def read_json_or_400(request: Request) -> dict[str, Any] | JSONResponse:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1430,36 +1430,14 @@ async def dashboard(request: Request) -> JSONResponse:
 
 async def list_skills_summary(request: Request) -> JSONResponse:
     """GET /v1/api/skills — list available skills (summary)."""
-    import json as _json
-
     from turnstone.core.storage._registry import get_storage
+    from turnstone.core.web_helpers import skill_summary_rows
 
     try:
         storage = get_storage()
     except Exception:
         return JSONResponse({"error": "Storage not available"}, status_code=503)
-    rows = storage.list_prompt_templates()
-    skills = []
-    for r in rows:
-        if not r.get("enabled", True):
-            continue
-        tags: list[str] = []
-        with contextlib.suppress(ValueError, TypeError):
-            tags = _json.loads(r.get("tags", "[]"))
-        skills.append(
-            {
-                "name": r["name"],
-                "category": r.get("category", ""),
-                "description": r.get("description", ""),
-                "tags": tags,
-                "is_default": r.get("is_default", False),
-                "activation": r.get("activation", "named"),
-                "origin": r.get("origin", "manual"),
-                "author": r.get("author", ""),
-                "version": r.get("version", "1.0.0"),
-            }
-        )
-    return JSONResponse({"skills": skills})
+    return JSONResponse({"skills": skill_summary_rows(storage)})
 
 
 async def list_available_models(request: Request) -> JSONResponse:


### PR DESCRIPTION
## Summary

Closes #571 — the two Anthropic SKILL.md invocation-control axes now flow end-to-end:

- `disable-model-invocation: true` (model can't autoload) — parsed and surfaced on the parse-preview UI; no install consumer because Turnstone hardcodes `activation="named"` on source-installs already. Dataclass docstring spells out the no-op so future readers don't try to wire a translation that's already implicit.
- `user-invocable: false` (hide from user picker, model still sees it) — maps to `hidden_from_menu=true` on `prompt_templates` (column pre-allocated by PR #574). Consumed by `list_skills_summary` filter.

The `hidden_from_menu` column joined `SKILL_RUNTIME_CONFIG_FIELDS` so admins can override on installed (readonly) skills — same precedent as `model` / `effort`.

## Notable

- **`_extract_bool` accepts every YAML 1.1 boolean spelling** (`true`/`false`/`yes`/`no`/`on`/`off`/`1`/`0`) plus their quoted variants. `/review` flagged that the original "true"/"false"-only match silently dropped author intent for unquoted `1` (YAML returns `int`) and quoted `"yes"` (stays `str`).
- **Shared `skill_summary_rows` helper** — two identical `list_skills_summary` impls had accreted in `turnstone/server.py` and `turnstone/console/server.py`. Both needed the new filter, so extracted the shared body to `turnstone/core/web_helpers.skill_summary_rows`. Future picker fields (e.g. #572's `argument_hint` for autocomplete) only touch one place now.
- **Admin parse-preview auto-fill** flips the hidden-from-menu checkbox when the source SKILL.md sets `user-invocable: false`.

## Test plan

- [x] `ruff` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Full non-live pytest suite: 6464 pass, 17 skipped (+10 over baseline)
- [x] New tests:
  - `TestInvocationControl` — bool / quoted / YAML 1.1 / int variants across both fields
  - `test_install_user_invocable_false_sets_hidden_from_menu` + default-unhidden case
  - `test_list_skills_summary_excludes_hidden_from_menu` — picker filter; admin tab unaffected
  - `test_update_skill_readonly_hidden_from_menu_allowed` — admin can hide/unhide installed skills via PUT (pins the `SKILL_RUNTIME_CONFIG_FIELDS` membership invariant)
  - Parse-API fixture extended with both new fields + default-case assertions
- [ ] Manual smoke: paste a SKILL.md with `user-invocable: false` into the admin create modal, verify the hidden-from-menu checkbox auto-flips; save; confirm the skill is absent from `/v1/api/skills` but present in `/v1/api/admin/skills`