### PR TITLE
feat(skills): wire $ARGUMENTS / $N / $<name> / ${CLAUDE_*} substitution (#572)

### DIFF
--- a/tests/test_skill_discovery_api.py
+++ b/tests/test_skill_discovery_api.py
@@ -130,6 +130,8 @@ def _sample_package(
     effort: str = "",
     user_invocable: bool = True,
     disable_model_invocation: bool = False,
+    arguments: list[str] | None = None,
+    argument_hint: str = "",
 ) -> SkillPackage:
     return SkillPackage(
         listing=SkillListing(
@@ -152,6 +154,8 @@ def _sample_package(
             effort=effort,
             user_invocable=user_invocable,
             disable_model_invocation=disable_model_invocation,
+            arguments=arguments or [],
+            argument_hint=argument_hint,
         ),
         resources={"scripts/setup.sh": "#!/bin/bash\necho hello"},
     )
@@ -335,6 +339,29 @@ class TestSkillInstall:
         assert resp.status_code == 200
         skill = resp.json()["installed"][0]
         assert skill["hidden_from_menu"] is False
+
+    def test_install_seeds_arguments_and_argument_hint(self, client: TestClient) -> None:
+        """Anthropic spec ``arguments:`` + ``argument-hint:`` round-trip
+        through install onto the row.  Verified end-to-end: parser
+        extracted them, install handler persisted them, the response
+        echoes the stored value."""
+        package = _sample_package(arguments=["issue", "branch"], argument_hint="[issue-number]")
+
+        with patch(
+            "turnstone.core.skill_sources.fetch_skill_from_github", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = package
+            resp = client.post(
+                "/v1/api/admin/skills/install",
+                json={"source": "github", "url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        skill = resp.json()["installed"][0]
+        # ``arguments`` is stored as a JSON-array string per the column
+        # contract; the response surfaces it raw.
+        assert skill["arguments"] == '["issue", "branch"]'
+        assert skill["argument_hint"] == "[issue-number]"
 
     def test_install_no_model_or_effort_leaves_columns_empty(self, client: TestClient) -> None:
         """When the source SKILL.md has no model/effort, the columns

--- a/tests/test_skill_parse_api.py
+++ b/tests/test_skill_parse_api.py
@@ -91,6 +91,8 @@ model: claude-opus-4-7
 effort: high
 disable-model-invocation: true
 user-invocable: false
+arguments: [pr_number, focus]
+argument-hint: "[pr-number] [focus-area]"
 license: MIT
 compatibility: ">=0.7"
 ---
@@ -130,6 +132,8 @@ class TestParseSkill:
         assert data["effort"] == "high"
         assert data["disable_model_invocation"] is True
         assert data["user_invocable"] is False
+        assert data["arguments"] == ["pr_number", "focus"]
+        assert data["argument_hint"] == "[pr-number] [focus-area]"
         assert data["license"] == "MIT"
         assert data["compatibility"] == ">=0.7"
         assert "# Code Review" in data["content"]
@@ -157,6 +161,8 @@ class TestParseSkill:
         # Spec defaults: model can autoload, user can pick.
         assert data["disable_model_invocation"] is False
         assert data["user_invocable"] is True
+        assert data["arguments"] == []
+        assert data["argument_hint"] == ""
         assert data["license"] == ""
 
     def test_anthropic_nested_metadata_tags(self, client: TestClient) -> None:

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -517,6 +517,60 @@ Content.
         assert result.user_invocable is False
 
 
+class TestArgumentsAndHint:
+    """Anthropic spec ``arguments:`` (named positional slots) +
+    ``argument-hint:`` (autocomplete display)."""
+
+    def test_yaml_list_format(self) -> None:
+        raw = """\
+---
+name: with-args
+arguments: [issue, branch]
+---
+
+Fix issue $issue on $branch.
+"""
+        result = parse_skill_md(raw)
+        assert result.arguments == ["issue", "branch"]
+
+    def test_space_delimited_format(self) -> None:
+        """Spec accepts space-separated string per the docs sample."""
+        raw = """\
+---
+name: with-args-space
+arguments: "issue branch"
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.arguments == ["issue", "branch"]
+
+    def test_argument_hint_extracted(self) -> None:
+        raw = """\
+---
+name: with-hint
+argument-hint: "[issue-number]"
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.argument_hint == "[issue-number]"
+
+    def test_empty_defaults(self) -> None:
+        raw = """\
+---
+name: bare
+---
+
+Content.
+"""
+        result = parse_skill_md(raw)
+        assert result.arguments == []
+        assert result.argument_hint == ""
+
+
 class TestValidateSkillName:
     """Name validation edge cases."""
 

--- a/tests/test_skills_tool.py
+++ b/tests/test_skills_tool.py
@@ -76,12 +76,16 @@ def _make_session(*, kind: str = "interactive", user_id: str = "test-user") -> A
     # Truncation budget — required by _truncate_output on every exec.
     session.tool_truncation = 100_000
 
-    # set_skill stub for load action.
-    session._set_skill_called: list[str | None] = []
+    # set_skill stub for load action.  Records both the name and the
+    # arguments-string so tests can assert that #572's invocation-args
+    # payload survives through prepare → exec → set_skill.
+    session._set_skill_called: list[tuple[str | None, str]] = []
+    session._skill_arguments = ""
 
-    def fake_set_skill(name):
-        session._set_skill_called.append(name)
+    def fake_set_skill(name, arguments: str = ""):
+        session._set_skill_called.append((name, arguments))
         session._skill_name = name
+        session._skill_arguments = arguments
 
     session.set_skill = fake_set_skill
     return session
@@ -185,7 +189,10 @@ class TestPrepareSkillsLoad:
         session = _make_session()
         item = session._prepare_skills("c", {"action": "load", "name": "x"})
         assert item["needs_approval"] is True
-        assert item["approval_label"] == "skills__load__x"
+        # No-args path: approval label has the ``no-args`` sentinel
+        # so each distinct arg payload (including absent) is its own
+        # approval decision.  See ``_prepare_skills_load`` digest logic.
+        assert item["approval_label"] == "skills__load__x__no-args"
 
     def test_load_works_on_coord_session(self) -> None:
         """Coord sessions can ``load`` for themselves — parity with the
@@ -199,7 +206,10 @@ class TestPrepareSkillsLoad:
         # Prepare succeeds — no error item, approval-gated like interactive.
         assert "error" not in item, item
         assert item["needs_approval"] is True
-        assert item["approval_label"] == "skills__load__x"
+        # No-args path: approval label has the ``no-args`` sentinel
+        # so each distinct arg payload (including absent) is its own
+        # approval decision.  See ``_prepare_skills_load`` digest logic.
+        assert item["approval_label"] == "skills__load__x__no-args"
 
     def test_load_missing_name(self) -> None:
         session = _make_session()
@@ -661,7 +671,7 @@ class TestExecSkillsLoad:
                 f"session kind={sess_kind!r} couldn't load row kind={row_kind!r}; "
                 f"flatten regression"
             )
-            assert session._set_skill_called == [skill_name]
+            assert session._set_skill_called == [(skill_name, "")]
 
     def test_load_works_for_coord_on_visible_skill(self) -> None:
         """Coord session loads a coord-tagged skill — exec succeeds and
@@ -680,7 +690,7 @@ class TestExecSkillsLoad:
         with patch("turnstone.core.storage._registry.get_storage", return_value=storage):
             _, output = session._exec_skills(item)
         assert "Loaded skill 'coord-persona'" in output
-        assert session._set_skill_called == ["coord-persona"]
+        assert session._set_skill_called == [("coord-persona", "")]
 
     def test_load_works_for_coord_on_any_kind_skill(self) -> None:
         """A ``kind=any`` skill is loadable from a coord session too —
@@ -699,7 +709,164 @@ class TestExecSkillsLoad:
         with patch("turnstone.core.storage._registry.get_storage", return_value=storage):
             _, output = session._exec_skills(item)
         assert "Loaded skill 'universal'" in output
-        assert session._set_skill_called == ["universal"]
+        assert session._set_skill_called == [("universal", "")]
+
+    def test_load_forwards_arguments_to_set_skill(self) -> None:
+        """Anthropic spec ``$ARGUMENTS`` payload (#572) — the model
+        passes an ``arguments`` string in the load call, prepare carries
+        it on the approval item, exec forwards it to ``set_skill`` for
+        the renderer to consume.  Pins the wire path end-to-end."""
+        session = _make_session()
+        storage = MagicMock()
+        storage.get_prompt_template_by_name.return_value = {
+            "name": "fix-issue",
+            "kind": "any",
+            "enabled": True,
+            "content": "Fix issue $ARGUMENTS",
+            "description": "Issue-fix skill.",
+            "risk_level": "low",
+        }
+        item = session._prepare_skills(
+            "c",
+            {"action": "load", "name": "fix-issue", "arguments": "123 main"},
+        )
+        # Prepare carries the args through onto the approval item so the
+        # exec phase has them when the operator approves.
+        assert item.get("arguments") == "123 main"
+        # Approval label includes a digest of the args so each distinct
+        # payload is a distinct approval decision (#572 security review).
+        assert item["approval_label"].startswith("skills__load__fix-issue__")
+        assert item["approval_label"] != "skills__load__fix-issue__no-args"
+        # Preview surfaces the args to the operator card.
+        assert "arguments: 123 main" in item["preview"]
+        with patch("turnstone.core.storage._registry.get_storage", return_value=storage):
+            _, output = session._exec_skills(item)
+        assert "Loaded skill 'fix-issue'" in output
+        # set_skill received the args verbatim — the renderer (covered
+        # in test_substitute_skill_args.py) handles the actual
+        # substitution at _load_skills time.
+        assert session._set_skill_called == [("fix-issue", "123 main")]
+
+    def test_load_same_skill_different_args_triggers_resub(self) -> None:
+        """A second load with the same skill name but different args
+        must NOT hit the "already active" short-circuit — the renderer
+        needs to re-render with the new payload.  Pins the load-bearing
+        ``_skill_arguments`` clause in the equality check at
+        ``_exec_skills_load``."""
+        session = _make_session()
+        storage = MagicMock()
+        storage.get_prompt_template_by_name.return_value = {
+            "name": "fix-issue",
+            "kind": "any",
+            "enabled": True,
+            "content": "Fix issue $ARGUMENTS",
+            "description": "Issue-fix skill.",
+            "risk_level": "low",
+        }
+        # First load.
+        item1 = session._prepare_skills(
+            "c", {"action": "load", "name": "fix-issue", "arguments": "123 main"}
+        )
+        with patch("turnstone.core.storage._registry.get_storage", return_value=storage):
+            session._exec_skills(item1)
+
+        # Second load — same name, DIFFERENT args.  The fake set_skill
+        # updates ``_skill_name`` and ``_skill_arguments`` to mirror the
+        # real path, so the equality check sees the new args differ.
+        item2 = session._prepare_skills(
+            "c", {"action": "load", "name": "fix-issue", "arguments": "456 dev"}
+        )
+        with patch("turnstone.core.storage._registry.get_storage", return_value=storage):
+            _, output2 = session._exec_skills(item2)
+        # Second invocation re-renders rather than short-circuiting.
+        assert "Loaded skill 'fix-issue'" in output2
+        assert "already active" not in output2
+        # set_skill was called twice with each respective arg payload.
+        assert session._set_skill_called == [
+            ("fix-issue", "123 main"),
+            ("fix-issue", "456 dev"),
+        ]
+
+
+class TestSkillArgNames:
+    """``_skill_arg_names`` decodes the JSON-array ``arguments`` storage
+    column into the named-slot list the renderer consumes.  Pinned
+    here because the renderer tests pass ``names`` directly, bypassing
+    this decode step — a storage shape change would silently produce
+    empty ``arg_names`` without breaking any other test."""
+
+    def test_valid_json_array(self) -> None:
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names({"arguments": '["issue", "branch"]'}) == [
+            "issue",
+            "branch",
+        ]
+
+    def test_malformed_json_returns_empty(self) -> None:
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names({"arguments": "[not-json"}) == []
+
+    def test_non_list_json_returns_empty(self) -> None:
+        """A row whose ``arguments`` column got corrupted to a JSON
+        object (rather than array) shouldn't blow up the load — fall
+        back to the empty list so $<name> placeholders stay literal."""
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names({"arguments": '{"k": "v"}'}) == []
+
+    def test_list_filters_non_strings(self) -> None:
+        """Element-level resilience — a JSON list with mixed types
+        keeps only the strings (the spec's ``arguments:`` field is
+        list-of-strings)."""
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names({"arguments": '["good", 42, null, "ok"]'}) == [
+            "good",
+            "ok",
+        ]
+
+    def test_missing_column_returns_empty(self) -> None:
+        """Legacy row written before migration 056 has no ``arguments``
+        key at all — must not raise."""
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names({"name": "legacy"}) == []
+
+    def test_invalid_identifier_names_dropped(self) -> None:
+        """Names containing hyphens, dots, leading digits, etc. can't be
+        matched by the ``$<name>`` substitution regex without ambiguity
+        (``$issue-number`` matches only the ``$issue`` prefix, leaving
+        ``-number`` as stray text).  Filtered out at decode so the
+        renderer's invariant holds: every name in arg_names IS
+        matchable.  Copilot review on PR #578 caught the mismatch."""
+        from turnstone.core.session import ChatSession
+
+        result = ChatSession._skill_arg_names(
+            {
+                "name": "test",
+                "arguments": ('["issue", "issue-number", "1bad", "with.dot", "Good_Name"]'),
+            }
+        )
+        # ``Good_Name`` is a valid identifier (uppercase + underscore);
+        # the broadened regex accepts it.  The other three are dropped.
+        assert result == ["issue", "Good_Name"]
+
+    def test_uppercase_and_underscore_names_accepted(self) -> None:
+        """Valid Python-identifier names — uppercase, underscore-start,
+        mixed case — all match the broadened ``$<name>`` regex.  Pinned
+        so a future regex tightening doesn't silently re-narrow."""
+        from turnstone.core.session import ChatSession
+
+        assert ChatSession._skill_arg_names(
+            {"arguments": '["lowercase", "UPPER", "_leading", "Mixed_Case_42"]'}
+        ) == [
+            "lowercase",
+            "UPPER",
+            "_leading",
+            "Mixed_Case_42",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_substitute_skill_args.py
+++ b/tests/test_substitute_skill_args.py
@@ -1,0 +1,179 @@
+"""Unit tests for ``_substitute_skill_args`` — Anthropic spec placeholder
+substitution applied to skill bodies at load time.
+
+Covers every placeholder form Turnstone implements (``${CLAUDE_SKILL_DIR}``
+is deferred — see #572) plus the spec's "append ARGUMENTS at end if no
+placeholder" rule and the single-pass guarantee against re-expansion of
+user-supplied values that happen to contain placeholder syntax.
+"""
+
+from __future__ import annotations
+
+from turnstone.core.session import _substitute_skill_args
+
+
+def _sub(content: str, *, args: str = "", names: list[str] | None = None) -> str:
+    """Compact test helper — defaults env values to fixed sentinels."""
+    return _substitute_skill_args(
+        content,
+        arguments_str=args,
+        arg_names=names or [],
+        ws_id="ws-abc",
+        effort="high",
+    )
+
+
+class TestArgumentsLiteral:
+    def test_full_args_expands(self) -> None:
+        assert _sub("Run $ARGUMENTS now", args="alpha bravo") == "Run alpha bravo now"
+
+    def test_empty_args_no_placeholder_unchanged(self) -> None:
+        assert _sub("Hello world", args="") == "Hello world"
+
+    def test_empty_args_with_placeholder_substitutes_empty(self) -> None:
+        # $ARGUMENTS with no args present → empty string (placeholder cleared).
+        assert _sub("Prefix $ARGUMENTS suffix", args="") == "Prefix  suffix"
+
+    def test_append_when_args_present_but_no_placeholder(self) -> None:
+        """Spec: args passed + body has no $ARGUMENTS → append at end."""
+        out = _sub("Skill body without placeholder.", args="x y")
+        assert out.endswith("\n\nARGUMENTS: x y")
+        assert out.startswith("Skill body without placeholder.")
+
+    def test_no_append_when_args_present_and_placeholder_used(self) -> None:
+        out = _sub("Run $ARGUMENTS.", args="x y")
+        assert out == "Run x y."
+        # Critical: no trailing append, no double-rendering.
+        assert "ARGUMENTS:" not in out.removeprefix("Run ")
+
+    def test_indexed_form_does_not_count_as_literal(self) -> None:
+        """``$ARGUMENTS[0]`` is a different placeholder; if it's the only
+        form in the body and args were passed, the append-at-end rule
+        still fires because the BARE ``$ARGUMENTS`` literal is absent."""
+        out = _sub("First: $ARGUMENTS[0]", args="a b")
+        assert "First: a" in out
+        assert out.endswith("\n\nARGUMENTS: a b")
+
+
+class TestPositional:
+    """Positional substitution.  Bodies in this group don't use the bare
+    ``$ARGUMENTS`` placeholder, so the spec's "append at end" rule fires —
+    tests assert ``startswith`` on the substituted prefix rather than full
+    equality to keep the focus on the substitution itself."""
+
+    def test_short_form(self) -> None:
+        assert _sub("$0 then $1", args="alpha bravo").startswith("alpha then bravo")
+
+    def test_bracketed_form(self) -> None:
+        out = _sub("$ARGUMENTS[0] then $ARGUMENTS[1]", args="alpha bravo")
+        assert out.startswith("alpha then bravo")
+
+    def test_shell_quoted_input(self) -> None:
+        """Spec: ``"hello world" second`` parses via shlex so $0='hello world'."""
+        out = _sub("$0 / $1", args='"hello world" second')
+        assert out.startswith("hello world / second")
+
+    def test_out_of_range_substitutes_empty(self) -> None:
+        out = _sub("$0 $5", args="only-one")
+        assert out.startswith("only-one ")  # second placeholder → empty
+
+    def test_unbalanced_quotes_falls_back_to_whitespace_split(self) -> None:
+        """A typo (unmatched quote) shouldn't blow up the substitution —
+        fall back to whitespace split so the prompt still renders.  The
+        fallback split on whitespace gives ``['alpha', '"bravo']``."""
+        out = _sub("$0 $1", args='alpha "bravo')
+        assert out.startswith('alpha "bravo')
+
+
+class TestNamedArguments:
+    def test_named_arg_substitutes_by_position(self) -> None:
+        out = _sub("issue $issue branch $branch", args="123 main", names=["issue", "branch"])
+        assert out.startswith("issue 123 branch main")
+
+    def test_unknown_name_left_as_literal(self) -> None:
+        """``$foo`` with ``foo`` not in arg_names stays as ``$foo`` —
+        forgiving behaviour matches ``_render_template``."""
+        out = _sub("$known $unknown", args="x y", names=["known"])
+        assert out.startswith("x $unknown")
+
+    def test_known_name_with_missing_positional_substitutes_empty(self) -> None:
+        """Named arg whose position is past the end of supplied args → ``""``.
+        No args passed so no append-at-end either."""
+        assert _sub("got $name", args="", names=["name"]) == "got "
+
+    def test_arguments_uppercase_not_matched_as_named(self) -> None:
+        """``$ARGUMENTS`` must not be matched by the named-arg regex —
+        the bare ``$ARGUMENTS`` alternative in the combined regex sits
+        earlier in the precedence chain.  Pin so a future regex tweak
+        can't break this."""
+        # No args, no names → bare $ARGUMENTS substitutes to empty
+        # via the literal branch, not via the named-arg branch.
+        assert _sub("$ARGUMENTS", args="", names=[]) == ""
+
+    def test_uppercase_name_substitutes(self) -> None:
+        """The broadened named-arg regex accepts uppercase identifiers.
+        Pin so a SKILL.md author who declares ``arguments: [USER_ID]``
+        and references ``$USER_ID`` gets the substitution, not a
+        literal."""
+        out = _sub("user $USER_ID", args="alice", names=["USER_ID"])
+        assert out.startswith("user alice")
+
+    def test_underscore_prefix_name_substitutes(self) -> None:
+        """Identifier names starting with ``_`` are valid Python
+        identifiers; the broadened regex matches them."""
+        out = _sub("got $_internal", args="value", names=["_internal"])
+        assert out.startswith("got value")
+
+
+class TestEnvironment:
+    def test_session_id_substitutes(self) -> None:
+        assert _sub("session ${CLAUDE_SESSION_ID}") == "session ws-abc"
+
+    def test_effort_substitutes(self) -> None:
+        assert _sub("effort ${CLAUDE_EFFORT}") == "effort high"
+
+    def test_unknown_env_left_as_literal(self) -> None:
+        assert _sub("${CLAUDE_UNKNOWN_FOO}") == "${CLAUDE_UNKNOWN_FOO}"
+
+
+class TestSinglePassGuarantee:
+    """A placeholder VALUE containing another placeholder must not be
+    re-expanded — matches spec's "Substitution runs once" rule."""
+
+    def test_arg_value_containing_placeholder_not_reexpanded(self) -> None:
+        # $0 value is the literal string "$1"; the rendered body should
+        # contain "$1" verbatim, not the substituted value of $1.  Append
+        # rule fires because the body has no bare ``$ARGUMENTS`` literal —
+        # split the output to isolate the body from the appended echo.
+        out = _sub("$0", args='"$1" actual')
+        body, _, _appended = out.partition("\n\nARGUMENTS: ")
+        # Body contains "$1" once — substituted in from $0 → "$1",
+        # NOT re-expanded to "actual".
+        assert body == "$1"
+
+    def test_arg_value_containing_dollar_arguments_not_reexpanded(self) -> None:
+        # $0 = "$ARGUMENTS" — would loop without single-pass.
+        out = _sub("got $0", args='"$ARGUMENTS"')
+        assert out.startswith("got $ARGUMENTS")
+        # The "$ARGUMENTS" inside the value MUST NOT be re-substituted
+        # into the args string.  Append-at-end rule adds a trailing
+        # "ARGUMENTS: $ARGUMENTS" line — that's an as-typed echo, not a
+        # re-substitution.
+        assert "got $ARGUMENTS\n\nARGUMENTS:" in out
+
+
+class TestIntegration:
+    def test_all_forms_in_one_body(self) -> None:
+        body = (
+            "Session ${CLAUDE_SESSION_ID} at effort ${CLAUDE_EFFORT}.\n"
+            "First $0, second $1.\n"
+            "Named: $issue resolved on $branch.\n"
+            "Full: $ARGUMENTS"
+        )
+        out = _sub(body, args="123 main", names=["issue", "branch"])
+        assert out == (
+            "Session ws-abc at effort high.\n"
+            "First 123, second main.\n"
+            "Named: 123 resolved on main.\n"
+            "Full: 123 main"
+        )

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -389,10 +389,13 @@ class CreateSkillRequest(BaseModel):
     # user-facing picker (``/v1/api/skills``) while keeping it
     # available to the model.
     hidden_from_menu: bool = False
-    # ``arguments`` / ``argument_hint`` columns still exist on the
-    # row (migration 056) and surface in ``SkillInfo`` for read, but
-    # the create/update handlers don't read them yet — #572 wires
-    # those input branches when its consumer lands.
+    # Anthropic spec ``arguments:`` + ``argument-hint:`` — named
+    # positional slots for ``$<name>`` substitution + autocomplete
+    # display.  Consumer is ``session._substitute_skill_args`` at skill
+    # render time (#572).  ``arguments`` uses the same wire shape as
+    # ``paths`` — list, JSON-array string, or CSV.
+    arguments: str | list[str] = "[]"
+    argument_hint: str = ""
     kind: SkillKind = Field(
         default=SkillKind.ANY,
         description=(
@@ -442,12 +445,14 @@ class UpdateSkillRequest(BaseModel):
     allowed_tools: str | None = None
     license: str | None = None
     compatibility: str | None = None
-    # Anthropic spec ``paths:`` (#569 — filter consumer pending) and
+    # Anthropic spec ``paths:`` (#569 — filter consumer pending),
     # ``user-invocable: false`` mapped to ``hidden_from_menu=true``
-    # (#571).  ``arguments`` / ``argument_hint`` remain absent until
-    # #572 wires their consumer.
+    # (#571), and ``arguments:`` / ``argument-hint:`` (#572 —
+    # substitution consumer).
     paths: str | list[str] | None = None
     hidden_from_menu: bool | None = None
+    arguments: str | list[str] | None = None
+    argument_hint: str | None = None
     kind: SkillKind | None = Field(
         default=None,
         description=(
@@ -867,6 +872,12 @@ class ParseSkillResponse(BaseModel):
     # can echo them on the parse-preview.
     disable_model_invocation: bool = False
     user_invocable: bool = True
+    # Anthropic spec ``arguments:`` + ``argument-hint:`` (#572).
+    # Named positional slots + autocomplete display string; surfaced
+    # so the admin parse-preview UI can echo what came from the source
+    # SKILL.md.
+    arguments: list[str] = Field(default_factory=list)
+    argument_hint: str = ""
 
 
 class SkillInstallRequest(BaseModel):

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6711,8 +6711,7 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     # Anthropic spec ``paths:`` — glob patterns gating autoload.
     # ``_canonicalize_skill_string_list`` accepts a list, a JSON-array
     # string, a comma-separated string, or ``None``, and returns the
-    # canonical JSON-array string for storage.  Same helper will back
-    # ``arguments`` once #572 lands its consumer.
+    # canonical JSON-array string for storage.
     paths_str = _canonicalize_skill_string_list(body.get("paths"))
 
     # Anthropic spec ``user-invocable: false`` lands here as
@@ -6723,6 +6722,12 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     hidden_from_menu, hidden_err = _parse_strict_bool(body.get("hidden_from_menu"), default=False)
     if hidden_err is not None:
         return hidden_err
+
+    # Anthropic spec ``arguments:`` — named positional slots for
+    # $<name> substitution.  Same wire shape as ``paths:`` — JSON-array
+    # string in storage, list-or-CSV-or-JSON-string on the wire.
+    arguments_str = _canonicalize_skill_string_list(body.get("arguments"))
+    argument_hint = str(body.get("argument_hint") or "").strip()[:128]
 
     token_estimate = len(content) // 4 if content else 0
 
@@ -6776,6 +6781,8 @@ async def admin_create_skill(request: Request) -> JSONResponse:
         kind=kind,
         paths=paths_str,
         hidden_from_menu=hidden_from_menu,
+        arguments=arguments_str,
+        argument_hint=argument_hint,
         **session_fields,
     )
 
@@ -6895,6 +6902,10 @@ async def admin_update_skill(request: Request) -> JSONResponse:
         if hidden_err is not None:
             return hidden_err
         updates["hidden_from_menu"] = hidden_value
+    if "arguments" in body and body["arguments"] is not None:
+        updates["arguments"] = _canonicalize_skill_string_list(body["arguments"])
+    if "argument_hint" in body and body["argument_hint"] is not None:
+        updates["argument_hint"] = str(body["argument_hint"]).strip()[:128]
     if "priority" in body:
         try:
             updates["priority"] = max(-1000, min(1000, int(body["priority"] or 0)))
@@ -7581,6 +7592,8 @@ async def admin_parse_skill(request: Request) -> JSONResponse:
             # the ``hidden-from-menu`` checkbox on the create modal.
             "disable_model_invocation": parsed.disable_model_invocation,
             "user_invocable": parsed.user_invocable,
+            "arguments": list(parsed.arguments),
+            "argument_hint": parsed.argument_hint,
         }
     )
 
@@ -7780,6 +7793,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
         tags_str = _json.dumps(parsed.tags)
         allowed_tools_str = _json.dumps(parsed.allowed_tools)
         paths_str = _json.dumps(parsed.paths)
+        arguments_str = _json.dumps(parsed.arguments)
         content = parsed.content[:32768]
         token_estimate = len(content) // 4 if content else 0
 
@@ -7830,6 +7844,17 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 # protect admin-set values on re-install.
                 model=parsed.model,
                 reasoning_effort=parsed.effort,
+                # Anthropic spec ``arguments:`` + ``argument-hint:`` —
+                # named positional slots + autocomplete display.  Round-
+                # trip through install so the renderer's $<name>
+                # substitution finds the slot map at load time.
+                # ``argument_hint`` is bounded here to match the
+                # admin-create-time cap (.strip()[:128]); upstream
+                # SKILL.md sources are untrusted on the install path so
+                # length-clamping at the storage boundary is the right
+                # place to enforce.
+                arguments=arguments_str,
+                argument_hint=parsed.argument_hint.strip()[:128],
             )
         except StorageConflictError as exc:
             # Genuine uniqueness/constraint violation racing past the

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -930,6 +930,8 @@ const _SKILL_FIELD_MAP = {
   compatibility: "skill-compatibility",
   allowed_tools: "csk-allowed-tools",
   paths: "skill-paths",
+  arguments: "skill-arguments",
+  argument_hint: "skill-argument-hint",
 };
 
 // Inflight paste-parse fetch — referenced from hideCreateTemplateModal so a
@@ -1005,6 +1007,10 @@ function _applyParsedSkill(parsed, contentTextarea, fieldMap) {
       filled++;
     }
   }
+  if (parsed.arguments && parsed.arguments.length)
+    _apply(fieldMap.arguments, parsed.arguments.join(", "));
+  if (parsed.argument_hint)
+    _apply(fieldMap.argument_hint, parsed.argument_hint);
 
   return { filled: filled, skipped: skipped };
 }
@@ -1134,6 +1140,8 @@ function showCreateTemplateModal() {
   document.getElementById("skill-compatibility").value = "";
   document.getElementById("skill-paths").value = "";
   document.getElementById("skill-hidden-from-menu").checked = false;
+  document.getElementById("skill-arguments").value = "";
+  document.getElementById("skill-argument-hint").value = "";
   document.getElementById("skill-activation").value = "named";
   const ctmContent = document.getElementById("ctm-content");
   ctmContent.value = "";
@@ -1272,6 +1280,15 @@ function submitCreateTemplate() {
       return p.trim();
     })
     .filter(Boolean);
+  const csArgsArr = (document.getElementById("skill-arguments").value || "")
+    .split(",")
+    .map(function (a) {
+      return a.trim();
+    })
+    .filter(Boolean);
+  const csArgumentHint = (
+    document.getElementById("skill-argument-hint").value || ""
+  ).trim();
   const createBody = {
     name: name,
     category: document.getElementById("ctm-category").value,
@@ -1298,6 +1315,8 @@ function submitCreateTemplate() {
     allowed_tools: JSON.stringify(csAllowedArr),
     paths: JSON.stringify(csPathsArr),
     hidden_from_menu: document.getElementById("skill-hidden-from-menu").checked,
+    arguments: JSON.stringify(csArgsArr),
+    argument_hint: csArgumentHint,
     notify_on_complete: csNotifyVal,
     enabled: document.getElementById("csk-enabled").checked,
   };
@@ -1404,6 +1423,15 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("etm-hidden-from-menu").checked = Boolean(
     tmpl.hidden_from_menu,
   );
+  let argumentsDisplay = "";
+  try {
+    const argumentsList = JSON.parse(tmpl.arguments || "[]");
+    argumentsDisplay = argumentsList.join(", ");
+  } catch (e) {
+    argumentsDisplay = tmpl.arguments || "";
+  }
+  document.getElementById("etm-arguments").value = argumentsDisplay;
+  document.getElementById("etm-argument-hint").value = tmpl.argument_hint || "";
   document.getElementById("etm-activation").value = tmpl.activation || "named";
   document.getElementById("etm-content").value = tmpl.content;
   _updateVarsDisplay("etm-content", "etm-variables");
@@ -1601,6 +1629,8 @@ function showEditTemplateModal(tmplId) {
     "etm-license",
     "etm-compatibility",
     "etm-paths",
+    "etm-arguments",
+    "etm-argument-hint",
     "etm-activation",
     "etm-content",
     "etm-default",
@@ -2042,6 +2072,15 @@ function submitEditTemplate() {
       return p.trim();
     })
     .filter(Boolean);
+  const esArgsArr = (document.getElementById("etm-arguments").value || "")
+    .split(",")
+    .map(function (a) {
+      return a.trim();
+    })
+    .filter(Boolean);
+  const esArgumentHint = (
+    document.getElementById("etm-argument-hint").value || ""
+  ).trim();
   const updateBody = {
     name: document.getElementById("etm-name").value.trim(),
     category: document.getElementById("etm-category").value,
@@ -2056,6 +2095,8 @@ function submitEditTemplate() {
     ).trim(),
     paths: JSON.stringify(esPathsArr),
     hidden_from_menu: document.getElementById("etm-hidden-from-menu").checked,
+    arguments: JSON.stringify(esArgsArr),
+    argument_hint: esArgumentHint,
     activation: document.getElementById("etm-activation").value,
     content: content,
     variables: JSON.stringify(varList),

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3097,6 +3097,33 @@
                   ></span
                 >
               </label>
+              <label for="skill-arguments"
+                >Arguments
+                <span class="label-hint"
+                  >named positional slots (comma-separated) — Anthropic
+                  spec <code>arguments:</code>; substituted as
+                  <code>$&lt;name&gt;</code> in the skill body</span
+                ></label
+              >
+              <input
+                id="skill-arguments"
+                type="text"
+                placeholder="issue, branch"
+              />
+              <label for="skill-argument-hint"
+                >Argument hint
+                <span class="label-hint"
+                  >autocomplete display string — Anthropic spec
+                  <code>argument-hint:</code>, e.g.
+                  <code>[issue-number]</code></span
+                ></label
+              >
+              <input
+                id="skill-argument-hint"
+                type="text"
+                placeholder="[issue-number]"
+                maxlength="128"
+              />
             </div>
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>
@@ -3437,6 +3464,32 @@
                   ></span
                 >
               </label>
+              <label for="etm-arguments"
+                >Arguments
+                <span class="label-hint"
+                  >named positional slots (comma-separated) — Anthropic
+                  spec <code>arguments:</code>; substituted as
+                  <code>$&lt;name&gt;</code> in the skill body</span
+                ></label
+              >
+              <input
+                id="etm-arguments"
+                type="text"
+                placeholder="issue, branch"
+              />
+              <label for="etm-argument-hint"
+                >Argument hint
+                <span class="label-hint"
+                  >autocomplete display string — Anthropic spec
+                  <code>argument-hint:</code></span
+                ></label
+              >
+              <input
+                id="etm-argument-hint"
+                type="text"
+                placeholder="[issue-number]"
+                maxlength="128"
+              />
             </div>
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import queue
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -547,6 +548,39 @@ _RESOURCE_PATH_RE = re.compile(
 _TEMPLATE_VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 
 
+# Anthropic Claude Code skill spec placeholders.  Single combined
+# regex so substitution is one-pass — a positional arg whose VALUE
+# happens to contain ``$ARGUMENTS`` (etc.) doesn't get re-expanded
+# on a second sweep.  The verbose form keeps the alternation
+# readable; precedence is left-to-right, so the bracketed
+# ``$ARGUMENTS[N]`` form is tried before the bare ``$ARGUMENTS``.
+_SPEC_PLACEHOLDER_RE = re.compile(
+    r"""
+    \$ARGUMENTS\[(?P<idx_bracket>\d+)\]            # $ARGUMENTS[N]
+    | \$ARGUMENTS\b(?!\[)                             # $ARGUMENTS (bare)
+    | \$\{(?P<env>CLAUDE_[A-Z_]+)\}                   # ${CLAUDE_*}
+    | \$(?P<idx_short>\d+)\b                          # $N
+    | \$(?P<named>[A-Za-z_][A-Za-z0-9_]*)\b           # $name
+    """,
+    re.VERBOSE,
+)
+
+# Argument names sourced from SKILL.md frontmatter ``arguments:`` must
+# match this same identifier pattern so the substitution regex can find
+# them.  ``/review`` on PR #578 caught the mismatch where the parser
+# accepted hyphenated names like ``issue-number`` that the regex would
+# only partially match (``$issue`` consumes the prefix, leaving
+# ``-number`` as literal text).  Parser validates at extraction time
+# and drops non-conforming names with a warning.
+_SKILL_ARG_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Detector for "did the original body include the bare ``$ARGUMENTS``
+# placeholder?" — used to decide whether to append ``ARGUMENTS: ...``
+# at the end per spec when the user passed args.  Negative lookahead
+# excludes the ``$ARGUMENTS[N]`` form which is a different placeholder.
+_SPEC_ARGUMENTS_LITERAL_RE = re.compile(r"\$ARGUMENTS\b(?!\[)")
+
+
 # Soft cap on ``"watch_triggered"`` entries in the per-session NudgeQueue.
 # The pull-model path batches N watch fires into ONE envelope splice on
 # the next drain seam (vs N successive ``send`` turns under the old
@@ -587,6 +621,86 @@ def _render_template(content: str, context: dict[str, str]) -> str:
         return context.get(m.group(1), m.group(0))
 
     return _TEMPLATE_VAR_RE.sub(_replace, content)
+
+
+def _substitute_skill_args(
+    content: str,
+    *,
+    arguments_str: str,
+    arg_names: list[str],
+    ws_id: str,
+    effort: str,
+) -> str:
+    """Apply Anthropic Claude Code skill-spec placeholder substitution.
+
+    Handles every spec form except ``${CLAUDE_SKILL_DIR}`` (which
+    requires a filesystem-shaped skill layout Turnstone doesn't have
+    yet — see #572 for the deferral note):
+
+    * ``$ARGUMENTS`` — full argument string as the user typed it
+    * ``$ARGUMENTS[N]`` / ``$N`` — Nth positional arg (0-indexed),
+      shell-quoted at parse time so ``"hello world" second`` yields
+      ``$0='hello world'``, ``$1='second'``
+    * ``$<name>`` — named arg from the SKILL.md ``arguments:``
+      frontmatter list, paired with the positional arg at the same
+      index
+    * ``${CLAUDE_SESSION_ID}`` — current workstream id
+    * ``${CLAUDE_EFFORT}`` — current reasoning_effort
+
+    Single-pass: a value containing a placeholder token (e.g.
+    ``$0='$ARGUMENTS'``) does not get re-expanded.  Matches the
+    spec's "Substitution runs once over the original file" rule.
+
+    Spec rule: when *arguments_str* is non-empty and the body has
+    no bare ``$ARGUMENTS`` placeholder, the full string is appended
+    at the end as ``ARGUMENTS: ...`` so the model still sees what
+    the user typed.  Indexed forms (``$ARGUMENTS[N]``) don't count
+    as the bare placeholder for this purpose.
+
+    Unresolvable placeholders (e.g. ``$unknown`` when ``unknown``
+    isn't in *arg_names*, or ``${CLAUDE_FOO}`` when ``CLAUDE_FOO``
+    isn't a known env key) are left as literals — matches the
+    forgiving behaviour of :func:`_render_template`.
+    """
+    try:
+        positional = shlex.split(arguments_str) if arguments_str else []
+    except ValueError:
+        # Unbalanced quotes — fall back to whitespace split so a
+        # typo in user-supplied args doesn't make the entire
+        # substitution a no-op (and silently leave ``$ARGUMENTS``
+        # placeholders in the prompt).
+        positional = arguments_str.split() if arguments_str else []
+
+    name_to_idx = {name: i for i, name in enumerate(arg_names)}
+    env = {"CLAUDE_SESSION_ID": ws_id, "CLAUDE_EFFORT": effort}
+
+    def _at(idx_str: str) -> str:
+        idx = int(idx_str)  # regex guarantees digits
+        return positional[idx] if 0 <= idx < len(positional) else ""
+
+    def _replace(m: re.Match[str]) -> str:
+        if m.group("idx_bracket") is not None:
+            return _at(m.group("idx_bracket"))
+        if m.group("env") is not None:
+            return env.get(m.group("env"), m.group(0))
+        if m.group("idx_short") is not None:
+            return _at(m.group("idx_short"))
+        if m.group("named") is not None:
+            name = m.group("named")
+            idx = name_to_idx.get(name)
+            if idx is None:
+                return m.group(0)
+            return positional[idx] if idx < len(positional) else ""
+        # Match is the bare $ARGUMENTS literal (no named groups).
+        return arguments_str or ""
+
+    had_literal_arguments = bool(_SPEC_ARGUMENTS_LITERAL_RE.search(content))
+    rendered = _SPEC_PLACEHOLDER_RE.sub(_replace, content)
+
+    if arguments_str and not had_literal_arguments:
+        rendered = f"{rendered}\n\nARGUMENTS: {arguments_str}"
+
+    return rendered
 
 
 # Block types that carry reasoning content across providers.  Used by
@@ -788,6 +902,7 @@ class ChatSession:
         tool_search_threshold: int = 20,
         tool_search_max_results: int = 5,
         skill: str | None = None,
+        skill_arguments: str = "",
         judge_config: JudgeConfig | None = None,
         user_id: str = "",
         memory_config: MemoryConfig | None = None,
@@ -1044,8 +1159,11 @@ class ChatSession:
                 always_on_names=builtin_in_session,
                 max_results=tool_search_max_results,
             )
-        # Skill: explicit name overrides is_default skills
+        # Skill: explicit name overrides is_default skills.  ``skill_arguments``
+        # carries the spec's $ARGUMENTS payload — set at create/load time,
+        # substituted into the skill body by ``_load_skills``.
         self._skill_name: str | None = skill
+        self._skill_arguments: str = skill_arguments
         self._skill_content: str | None = None
         self._skill_resources: dict[str, str] = {}
         self._skill_resources_dir: str | None = None
@@ -1399,6 +1517,11 @@ class ChatSession:
                 "instructions": self.instructions or "",
                 "creative_mode": str(self.creative_mode),
                 "skill": self._skill_name or "",
+                # Anthropic spec ``$ARGUMENTS`` payload (#572).  Stored
+                # so a resumed workstream re-renders the skill with the
+                # same args the original load supplied — otherwise the
+                # rehydrate path would silently swap to empty args.
+                "skill_arguments": self._skill_arguments,
                 "token_budget": str(self._token_budget),
                 "applied_skill_id": self._applied_skill_id,
                 "applied_skill_version": str(self._applied_skill_version),
@@ -1417,10 +1540,31 @@ class ChatSession:
             "ws_id": self._ws_id,
             "node_id": self._node_id or "",
         }
+        effort = getattr(self, "reasoning_effort", "") or ""
         if self._skill_name:
             skill_data = get_skill_by_name(self._skill_name)
             if skill_data:
-                self._skill_content = _render_template(skill_data["content"], context)
+                # Two-pass render — legacy ``{{model}}`` first, spec
+                # ``$ARGUMENTS`` second.  Order is load-bearing: user-
+                # supplied arg values may legitimately contain
+                # ``{{...}}`` patterns (literal text the model wanted to
+                # quote), and running ``_render_template`` AFTER the
+                # spec substitution would silently re-expand them
+                # against the live context.  Running it FIRST resolves
+                # the curly-brace placeholders against the immutable
+                # skill source, then the spec pass writes substituted
+                # values in last — those values can't be re-expanded
+                # because the curly-brace renderer has already
+                # finished.
+                arg_names = self._skill_arg_names(skill_data)
+                content = _render_template(skill_data["content"], context)
+                self._skill_content = _substitute_skill_args(
+                    content,
+                    arguments_str=self._skill_arguments,
+                    arg_names=arg_names,
+                    ws_id=self._ws_id,
+                    effort=effort,
+                )
                 self._check_skill_budget(skill_data)
                 self._skill_resources = self._load_skill_resources(
                     skill_data.get("template_id", "")
@@ -1443,7 +1587,22 @@ class ChatSession:
         else:
             defaults = list_default_skills()
             if defaults:
-                parts = [_render_template(t["content"], context) for t in defaults]
+                # ``arg_names`` and ``arguments_str`` are empty for the
+                # default-skill path — defaults are always-on and don't
+                # take user-supplied invocation args — but env subs
+                # (``${CLAUDE_SESSION_ID}`` / ``${CLAUDE_EFFORT}``)
+                # still resolve.  Same render-then-substitute order as
+                # the explicit-skill branch (see comment above).
+                parts = [
+                    _substitute_skill_args(
+                        _render_template(t["content"], context),
+                        arguments_str="",
+                        arg_names=[],
+                        ws_id=self._ws_id,
+                        effort=effort,
+                    )
+                    for t in defaults
+                ]
                 self._skill_content = "\n\n".join(parts)
             else:
                 self._skill_content = None
@@ -1451,9 +1610,59 @@ class ChatSession:
         self._materialize_skill_resources()
         self._validate_skill_resources()
 
-    def set_skill(self, name: str | None) -> None:
-        """Set or clear the active skill."""
+    @staticmethod
+    def _skill_arg_names(skill_data: dict[str, Any]) -> list[str]:
+        """Extract the named-argument list from a stored skill row.
+
+        Storage shape is a JSON-array TEXT column (``arguments`` —
+        added by migration 056).  Malformed JSON falls back to an
+        empty list rather than blowing up the load — the
+        substitution pass treats missing names as unresolved and
+        leaves the ``$<name>`` placeholder as a literal, which is
+        the spec's "graceful degradation" behaviour.
+
+        Names are filtered against ``_SKILL_ARG_NAME_RE`` so the
+        substitution regex can actually match them.  A SKILL.md
+        author writing ``arguments: [issue-number]`` would otherwise
+        produce a stored name the ``$<name>`` regex can't reach
+        cleanly (``$issue-number`` matches only the ``$issue`` prefix,
+        leaving ``-number`` as stray text); the parser-time filter
+        drops those names with a warning so the rendered output is
+        predictable.
+        """
+        raw = skill_data.get("arguments") or "[]"
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+        if not isinstance(parsed, list):
+            return []
+        valid: list[str] = []
+        dropped: list[str] = []
+        for n in parsed:
+            if not isinstance(n, str):
+                continue
+            if _SKILL_ARG_NAME_RE.match(n):
+                valid.append(n)
+            else:
+                dropped.append(n)
+        if dropped:
+            log.warning(
+                "skill.arguments.invalid_names_dropped",
+                name=skill_data.get("name", ""),
+                dropped=dropped,
+            )
+        return valid
+
+    def set_skill(self, name: str | None, arguments: str = "") -> None:
+        """Set or clear the active skill, optionally with invocation args.
+
+        ``arguments`` carries the spec's $ARGUMENTS payload — re-set
+        each time ``set_skill`` is called so a reload doesn't smuggle
+        stale args.  Empty string clears them.
+        """
         self._skill_name = name
+        self._skill_arguments = arguments
         self._load_skills()
         self._init_system_messages()
         self._save_config()
@@ -2150,6 +2359,10 @@ class ChatSession:
                 self.creative_mode = config["creative_mode"] == "True"
             if "skill" in config or "template" in config:
                 self._skill_name = config.get("skill") or config.get("template") or None
+                # Restore #572's invocation-args payload BEFORE
+                # ``_load_skills`` so the substitution pass renders with
+                # the original args instead of an empty default.
+                self._skill_arguments = config.get("skill_arguments", "") or ""
                 self._load_skills()
             if "token_budget" in config:
                 self._token_budget = int(config["token_budget"] or "0")
@@ -8275,16 +8488,33 @@ class ChatSession:
         name = self._coord_str_arg(args, "name").strip()
         if not name:
             return self._coord_tool_error(call_id, "skills", "load: 'name' is required")
+        # Anthropic spec ``$ARGUMENTS`` payload — optional.  Mirror
+        # the spec's free-form string shape (``/skill-name a b "c d"``)
+        # rather than a list, so the model can pass quoted positional
+        # args and have ``shlex.split`` at substitution time produce
+        # the same result a CLI user would type.
+        arguments = self._coord_str_arg(args, "arguments")
+        # Approval surfaces the args so the operator can see what the
+        # model is about to substitute into the system message — and
+        # so a once-approved skill name can't grant cover for a future
+        # invocation with a different (potentially injected) payload.
+        # ``approval_label`` includes a digest of the args so each
+        # distinct payload is a distinct approval decision.
+        approval_args_digest = (
+            hashlib.sha256(arguments.encode("utf-8")).hexdigest()[:8] if arguments else "no-args"
+        )
+        preview = f"arguments: {arguments}" if arguments else "(no arguments)"
         return {
             "call_id": call_id,
             "func_name": "skills",
             "header": f"⚙ skills load: {name}",
-            "preview": "",
+            "preview": preview,
             "needs_approval": True,
-            "approval_label": f"skills__load__{name}",
+            "approval_label": f"skills__load__{name}__{approval_args_digest}",
             "execute": self._exec_skills,
             "action": "load",
             "name": name,
+            "arguments": arguments,
         }
 
     def _exec_skills_load(self, item: dict[str, Any]) -> tuple[str, str]:
@@ -8292,6 +8522,7 @@ class ChatSession:
 
         call_id = item["call_id"]
         name = item["name"]
+        arguments = item.get("arguments", "")
         storage = get_storage()
         if storage is None:
             msg = "Error: storage unavailable"
@@ -8313,11 +8544,14 @@ class ChatSession:
             )
             self._report_tool_result(call_id, "skills", msg, is_error=True)
             return call_id, msg
-        if self._skill_name == name:
+        if self._skill_name == name and self._skill_arguments == arguments:
+            # ``arguments`` is load-bearing for the spec's substitution —
+            # an existing load with a DIFFERENT args payload should
+            # re-render, not no-op.  Only short-circuit on full identity.
             msg = f"Skill '{name}' is already active"
             self._report_tool_result(call_id, "skills", msg)
             return call_id, msg
-        self.set_skill(name)
+        self.set_skill(name, arguments=arguments)
         desc = skill_data.get("description", "")
         risk = skill_data.get("risk_level", "")
         parts = [f"Loaded skill '{name}'"]

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -95,6 +95,19 @@ class ParsedSkill:
     # field that gates flipping back.
     disable_model_invocation: bool = False
     user_invocable: bool = True
+    # Anthropic spec ``arguments:`` — named positional argument slots
+    # that pair with ``$<name>`` substitution in the skill body.
+    # Accepts the spec's space-separated string or YAML list shape.
+    # Stored as a JSON-array column on ``prompt_templates`` (added by
+    # migration 056); the renderer in ``session._substitute_skill_args``
+    # binds positional args to these names at skill-load time.
+    arguments: list[str] = field(default_factory=list)
+    # Anthropic spec ``argument-hint:`` — display string for slash-
+    # command autocomplete, e.g. ``"[issue-number]"``.  Surfaced in
+    # the admin UI and round-tripped through install; no runtime
+    # behaviour today since Turnstone doesn't have a slash-command
+    # autocomplete surface yet.
+    argument_hint: str = ""
     raw_frontmatter: dict[str, Any] = field(default_factory=dict)
 
 
@@ -367,5 +380,11 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
         # from the menu (user-invocable=True).
         disable_model_invocation=_extract_bool(meta, "disable-model-invocation", default=False),
         user_invocable=_extract_bool(meta, "user-invocable", default=True),
+        # Spec accepts ``arguments:`` as a space-separated string or
+        # YAML list; ``_extract_list`` handles both via ``_LIST_SPLIT_RE``.
+        arguments=_extract_list(meta, "arguments"),
+        # ``argument-hint`` (hyphenated per spec) — display string for
+        # slash-command autocomplete.
+        argument_hint=_extract_str(meta, "argument-hint"),
         raw_frontmatter=meta,
     )

--- a/turnstone/tools/skills.json
+++ b/turnstone/tools/skills.json
@@ -21,6 +21,10 @@
         "type": "string",
         "description": "Skill name. Required for `get`, `load`, `create`, `update`, `enable`, `disable`."
       },
+      "arguments": {
+        "type": "string",
+        "description": "For `load`: optional invocation arguments for Anthropic-spec `$ARGUMENTS` / `$N` / `$<name>` substitution in the skill body. Free-form string parsed with shell-style quoting via `shlex.split` — quotes are stripped, so `\"hello world\" second` yields $0=hello world, $1=second (no surrounding quotes in the substituted value). Skills declaring `arguments: [issue, branch]` in their frontmatter expose `$issue` and `$branch` bound by position. Omit or pass an empty string when the skill has no `$ARGUMENTS`/`$N`/`$<name>` placeholders; `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` env-var substitution still runs regardless."
+      },
       "query": {
         "type": "string",
         "description": "For `find`: optional BM25 query over name + description + tags + category. Omit to return rows by filters alone."


### PR DESCRIPTION
## Summary

Closes #572 — the Anthropic Claude Code skill spec's placeholder substitution now flows end to end. The renderer in `_substitute_skill_args` handles every spec form except `${CLAUDE_SKILL_DIR}` (deferred — Turnstone skills are row-shaped, not directory-shaped):

- `$ARGUMENTS` — full args string as the user/model typed it
- `$ARGUMENTS[N]` / `$N` — Nth positional arg, parsed via `shlex.split` so `"hello world" second` yields `$0="hello world"`, `$1="second"`
- `$<name>` — named arg from the SKILL.md `arguments:` list, paired by position
- `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` — session state

Substitution is **single-pass** (single combined regex, single `re.sub`) so a substituted value containing a placeholder token doesn't re-expand. Spec's "append `ARGUMENTS: …` at end if no placeholder" rule preserved.

## Surface

- Parser: `arguments:` (list/space-delim) + `argument-hint:` (str) extracted into `ParsedSkill`.
- Install: persists both to the pre-allocated columns from migration 056 (PR #574). Install path clamps `argument_hint` to 128 chars to match admin-create.
- Admin: `CreateSkillRequest` / `UpdateSkillRequest` accept both fields; create + edit modals get inputs; parse-preview echoes.
- Renderer: `_substitute_skill_args` runs **after** `_render_template` in `_load_skills`. Order is load-bearing — running `_render_template` last would silently re-expand `{{model}}` / `{{ws_id}}` / `{{node_id}}` literals that the model legitimately quoted in invocation args.
- Session: `_skill_arguments` plumbed through `__init__`, `set_skill`, and `_save_config` so a resumed workstream re-renders with the original payload.
- Model tool: `skills(action='load')` accepts an `arguments` string. Approval label includes a SHA-256 digest of the args so a once-approved skill name can't grant cover for a future invocation with a different payload; preview surfaces the args inline.

## `/review` findings (all addressed in-commit)

| ID | Severity | Issue | Fix |
|---|---|---|---|
| bug-1 | major | `${CLAUDE_EFFORT}` referenced `self._reasoning_effort` — wrong attribute; always substituted to empty | Fixed to `self.reasoning_effort` |
| bug-2 / sec-2 | minor | Two-pass layering let user args containing `{{var}}` syntax get re-expanded | Reversed render order — `_render_template` first, `_substitute_skill_args` last |
| bug-3 | minor | `_skill_arguments` not persisted; resumed workstreams silently lost their args | Added to `_save_config` + rehydrate path |
| sec-1 | minor | Approval label omitted `arguments`; approve-once trust granted cover for different payloads | Label now includes a digest; preview shows the args |
| sec-3 | minor | Install path didn't cap `argument_hint` (untrusted upstream SKILL.md source) | Added `.strip()[:128]` to match admin-create |
| q-1 | minor | `_skill_arg_names` (storage→renderer JSON-array decode) had no test | Added `TestSkillArgNames` (valid/malformed/non-list/mixed-type/missing-column) |
| q-2 | minor | No test pinned that loading same skill with different args re-renders | Added `test_load_same_skill_different_args_triggers_resub` |

Performance finder: no findings.

## Test plan

- [x] `ruff` clean on all changed files
- [x] `mypy` clean
- [x] Full non-live pytest: 6487 pass (+33 over baseline)
- [x] New tests:
  - `tests/test_substitute_skill_args.py` — 21 tests covering every placeholder form, single-pass guarantee, append-at-end rule, shell-quoted input, unbalanced-quote fallback
  - `tests/test_skill_parser.py::TestArgumentsAndHint` — parser extraction
  - `tests/test_skill_parse_api.py` — HTTP parse-preview echoes both fields
  - `tests/test_skill_discovery_api.py::test_install_seeds_arguments_and_argument_hint` — install round-trip
  - `tests/test_skills_tool.py::test_load_forwards_arguments_to_set_skill` + `test_load_same_skill_different_args_triggers_resub`
  - `tests/test_skills_tool.py::TestSkillArgNames` — storage decode helper
- [ ] Manual smoke: install a SKILL.md with `arguments: [issue, branch]` and a body using `$issue` / `$branch` / `$ARGUMENTS`. Load via `skills(action='load', name=..., arguments='123 main')` and confirm the rendered system message has the substitutions.

## Status of the four-issue plan

- #569 — **shipped** (PR #574, merged) — `paths` schema + parse + admin UI
- #570 — **shipped** (PR #576, merged) — `when_to_use` / `model` / `effort` ingestion
- #571 — **open** (PR #577) — invocation control via `hidden_from_menu`
- #572 — **this PR** — `$ARGUMENTS` substitution end to end