### PR TITLE
fix(coord): strip intent-judge verdicts from inspect_workstream output

### DIFF
--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -635,7 +635,8 @@ def test_inspect_returns_persisted_fields(populated_storage):
         assert key in result
     assert result["parent_ws_id"] == "coord-1"
     assert isinstance(result["messages"], list)
-    # Verdicts deliberately not surfaced — see inspect() docstring.
+    # Verdicts deliberately not surfaced — see the inline comment in
+    # CoordinatorClient.inspect().
     assert "verdicts" not in result
 
 

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -635,7 +635,8 @@ def test_inspect_returns_persisted_fields(populated_storage):
         assert key in result
     assert result["parent_ws_id"] == "coord-1"
     assert isinstance(result["messages"], list)
-    assert isinstance(result["verdicts"], list)
+    # Verdicts deliberately not surfaced — see inspect() docstring.
+    assert "verdicts" not in result
 
 
 def test_inspect_refuses_workstreams_outside_coordinator_subtree(populated_storage):
@@ -2462,7 +2463,6 @@ def _make_inspect_result(
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i} content"}
             for i in range(n_messages)
         ],
-        "verdicts": [],
     }
 
 
@@ -2495,7 +2495,6 @@ def test_format_inspect_tiered_compact_when_full_exceeds_budget():
         "id": "ws-fat",
         "state": "running",
         "messages": [{"role": "assistant", "content": fat} for _ in range(20)],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2541,7 +2540,6 @@ def test_format_inspect_tiered_compact_when_content_below_snip_threshold():
         "messages": [
             {"role": "assistant" if i % 2 == 0 else "user", "content": smallish} for i in range(400)
         ],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2586,7 +2584,6 @@ def test_format_inspect_tiered_skeleton_when_compact_also_exceeds_budget():
             }
             for i in range(50)
         ],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2620,7 +2617,6 @@ def test_format_inspect_tiered_skeleton_keeps_terminal_state_fields():
         "title": "done",
         "skill_id": "researcher",
         "messages": [{"role": "user", "content": [fat_block] * 10} for _ in range(50)],
-        "verdicts": [],
         "close_reason": "task complete: report attached",
         "live": None,  # filtered by truthy check
     }
@@ -2666,7 +2662,6 @@ def test_format_inspect_tiered_compact_preserves_tool_call_linkage():
             }
             for _ in range(20)
         ],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2715,7 +2710,6 @@ def test_format_inspect_tiered_compact_preserves_assistant_tool_calls():
             {"role": "assistant", "content": fat_content, "tool_calls": tool_calls}
             for _ in range(20)
         ],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2751,7 +2745,6 @@ def test_format_inspect_tiered_compact_passes_small_messages_through_unsnipped()
         "state": "running",
         "messages": [{"role": "assistant", "content": big} for _ in range(15)]
         + [{"role": "user", "content": small}],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)
@@ -2771,7 +2764,6 @@ def test_format_inspect_tiered_emits_tier_note_when_compressed():
         "id": "ws-noted",
         "state": "running",
         "messages": [{"role": "assistant", "content": fat} for _ in range(20)],
-        "verdicts": [],
     }
     out = _format_inspect_tiered(result)
     parsed = json.loads(out)

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -319,7 +319,6 @@ def test_inspect_exec_dispatches_to_client(coord_session):
         "ws_id": "child-x",
         "state": "idle",
         "messages": [],
-        "verdicts": [],
     }
     item = sess._prepare_tool(_tc("inspect_workstream", {"ws_id": "child-x"}))
     _call_id, output = sess._exec_inspect_workstream(item)

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -1479,7 +1479,7 @@ class CoordinatorClient:
         message_limit: int = 20,
         include_provider_content: bool = False,
     ) -> dict[str, Any]:
-        """Return persisted workstream state + tail-N messages + recent verdicts.
+        """Return persisted workstream state + tail-N messages.
 
         Cross-tenant guard: the coordinator's LLM input is untrusted, so
         the inspectable scope is restricted to (a) the coordinator
@@ -1526,19 +1526,20 @@ class CoordinatorClient:
                 messages = all_msgs
         except Exception:
             log.debug("coord_client.load_messages.failed ws=%s", ws_id, exc_info=True)
-        # Recent intent-judge verdicts — useful for "did this child go off
-        # the rails?" inspection.  Capped at 10; advisory, so swallow failures.
-        verdicts: list[Any] = []
-        try:
-            verdicts = self._storage.list_intent_verdicts(ws_id=ws_id, limit=10)
-        except Exception:
-            log.debug("coord_client.list_verdicts.failed ws=%s", ws_id, exc_info=True)
+        # Intent-judge verdicts are deliberately NOT surfaced here.
+        # Their fields (``recommendation="review"``, ``user_decision="policy"``
+        # for auto-approved-by-policy, etc.) read as workflow status to
+        # coordinator LLMs and produced repeated misreads of healthy
+        # children as "stuck on policy review".  The child's actual
+        # blocking status lives on the ``state`` field (``"attention"``)
+        # and the ``live.pending_approval`` block — both still present
+        # in the result below.  Verdict history remains queryable
+        # through the admin / audit surfaces.
         result: dict[str, Any] = {
             **full,
             "messages": _serialize_messages(
                 messages, include_provider_content=include_provider_content
             ),
-            "verdicts": _serialize_verdicts(verdicts),
         }
         # Surface the operator-supplied close reason (persisted via
         # workstream_config by the server's close handler) and any
@@ -1695,19 +1696,6 @@ def _serialize_messages(
     return out
 
 
-def _serialize_verdicts(rows: list[Any]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    for r in rows:
-        if isinstance(r, dict):
-            out.append(r)
-        else:
-            try:
-                out.append(dict(r._mapping))  # SQLAlchemy Row
-            except Exception:
-                out.append({"raw": str(r)})
-    return out
-
-
 # ---------------------------------------------------------------------------
 # inspect_workstream — tiered output compression
 # ---------------------------------------------------------------------------
@@ -1851,24 +1839,18 @@ def _inspect_skeleton(result: dict[str, Any]) -> dict[str, Any]:
     """Tier-3 fallback: state + counts + last assistant preview + terminal info.
 
     Drops every message, keeping only aggregate signal: state, message
-    count, role distribution, verdict count + risk distribution, and a
-    short preview of the most recent assistant turn (the "what did this
-    child last say" signal).  Terminal-state fields (``close_reason``,
-    ``last_error``) and the ``live`` block pass through unchanged
-    because they're already small and load-bearing.
+    count, role distribution, and a short preview of the most recent
+    assistant turn (the "what did this child last say" signal).
+    Terminal-state fields (``close_reason``, ``last_error``) and the
+    ``live`` block pass through unchanged because they're already small
+    and load-bearing.
     """
     messages = result.get("messages") or []
-    verdicts = result.get("verdicts") or []
     role_counts: dict[str, int] = {}
     for m in messages:
         role = m.get("role") if isinstance(m, dict) else None
         if role:
             role_counts[role] = role_counts.get(role, 0) + 1
-    verdicts_by_risk: dict[str, int] = {}
-    for v in verdicts:
-        if isinstance(v, dict):
-            risk = v.get("risk_level") or "unknown"
-            verdicts_by_risk[risk] = verdicts_by_risk.get(risk, 0) + 1
     last_preview = ""
     for m in reversed(messages):
         if not isinstance(m, dict) or m.get("role") != "assistant":
@@ -1891,8 +1873,6 @@ def _inspect_skeleton(result: dict[str, Any]) -> dict[str, Any]:
         "skill": result["skill_id"],
         "message_count": len(messages),
         "roles": role_counts,
-        "verdict_count": len(verdicts),
-        "verdicts_by_risk": verdicts_by_risk,
         "last_assistant_preview": last_preview,
         "_tier": "skeleton",
         "_tier_note": (


### PR DESCRIPTION
## Summary

- Coordinator LLMs were repeatedly misreading `user_decision="policy"` (the label meaning "auto-approved by an admin policy allow rule") as "blocked, waiting for policy review". Combined with `recommendation="review"` (the heuristic judge's risk class, not a workflow state), the verdict fields read end-to-end as "stuck on policy review" and triggered incorrect cancel-and-respawn behaviour against healthy children.
- The actual blocking signal already lives on `state == "attention"` and `live.pending_approval`, both still in the result. The verdict block was advisory and ambiguous on the LLM surface — drop it.
- Verdict history remains queryable through the admin / audit surfaces; only `CoordinatorClient.inspect()` (the path that backs the coordinator's `inspect_workstream` tool) loses the field.

## Changes

- `coordinator_client.py:inspect()` — drop the `list_intent_verdicts` fetch and the `verdicts` key; replaced with a comment explaining *why* it's deliberately omitted so a future author doesn't re-add it.
- `coordinator_client.py:_inspect_skeleton()` — drop `verdict_count` / `verdicts_by_risk` aggregates from the tier-3 fallback.
- `coordinator_client.py` — delete the now-dead `_serialize_verdicts` helper.
- `tests/test_coordinator_client.py` — flip the inspect-shape assertion to `"verdicts" not in result`; clear 9 stale `"verdicts": []` keys from `_format_inspect_tiered` fixtures.
- `tests/test_coordinator_tools.py` — clear 1 stale `"verdicts": []` key from a mock inspect response.

Net: +17 / -46.

## Test plan
- [x] `pytest tests/test_coordinator_client.py tests/test_coordinator_tools.py` — 241 pass
- [x] `ruff check` + `mypy` clean on changed files
- [ ] Manual: coordinator session against a child with an autoapproval policy — confirm inspect output no longer carries the misleading verdict block