### PR TITLE
chore(skills): drop Anthropic attribution from SKILL.md spec references

### DIFF
--- a/tests/test_skill_discovery_api.py
+++ b/tests/test_skill_discovery_api.py
@@ -281,7 +281,7 @@ class TestSkillInstall:
         assert resp.json()["installed"][0]["name"] == "test-skill"
 
     def test_install_seeds_model_and_effort_from_frontmatter(self, client: TestClient) -> None:
-        """Anthropic spec ``model:`` + ``effort:`` survive into the row.
+        """SKILL.md spec ``model:`` + ``effort:`` survive into the row.
 
         The SKILL.md author's per-skill model and reasoning_effort
         intent must round-trip through install — they were dropped
@@ -305,7 +305,7 @@ class TestSkillInstall:
         assert skill["reasoning_effort"] == "high"
 
     def test_install_user_invocable_false_sets_hidden_from_menu(self, client: TestClient) -> None:
-        """Anthropic spec ``user-invocable: false`` lands as
+        """SKILL.md spec ``user-invocable: false`` lands as
         ``hidden_from_menu=true`` on the row.  The skill stays available
         to the model but disappears from the user-facing picker."""
         package = _sample_package(user_invocable=False)
@@ -341,7 +341,7 @@ class TestSkillInstall:
         assert skill["hidden_from_menu"] is False
 
     def test_install_seeds_arguments_and_argument_hint(self, client: TestClient) -> None:
-        """Anthropic spec ``arguments:`` + ``argument-hint:`` round-trip
+        """SKILL.md spec ``arguments:`` + ``argument-hint:`` round-trip
         through install onto the row.  Verified end-to-end: parser
         extracted them, install handler persisted them, the response
         echoes the stored value."""

--- a/tests/test_skill_parse_api.py
+++ b/tests/test_skill_parse_api.py
@@ -165,8 +165,8 @@ class TestParseSkill:
         assert data["argument_hint"] == ""
         assert data["license"] == ""
 
-    def test_anthropic_nested_metadata_tags(self, client: TestClient) -> None:
-        # Anthropic-style skill puts tags under metadata.tags rather than
+    def test_nested_metadata_tags(self, client: TestClient) -> None:
+        # Some SKILL.md authors put tags under metadata.tags rather than
         # at the top level — the parser must handle both layouts.
         raw = """\
 ---
@@ -174,7 +174,7 @@ name: nested-meta
 description: A skill using nested metadata
 metadata:
   tags: [alpha, beta]
-  author: Anthropic
+  author: Acme
   version: 3.1.4
 ---
 
@@ -184,7 +184,7 @@ Body.
         assert resp.status_code == 200
         data = resp.json()
         assert data["tags"] == ["alpha", "beta"]
-        assert data["author"] == "Anthropic"
+        assert data["author"] == "Acme"
         assert data["version"] == "3.1.4"
 
     def test_unquoted_colon_in_description(self, client: TestClient) -> None:

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -158,10 +158,10 @@ Content.
         result = parse_skill_md(raw)
         assert result.tags == ["ai", "assistant"]
 
-    def test_anthropic_tags(self) -> None:
+    def test_nested_metadata_tags(self) -> None:
         raw = """\
 ---
-name: anthropic-skill
+name: nested-tags-skill
 metadata:
   tags: [claude, coding]
 ---
@@ -240,7 +240,7 @@ Content.
 
 
 class TestPaths:
-    """Anthropic Claude Code spec ``paths:`` — glob patterns gating autoload."""
+    """SKILL.md spec ``paths:`` — glob patterns gating autoload."""
 
     def test_list_format(self) -> None:
         raw = """\
@@ -296,7 +296,7 @@ Content.
 
 
 class TestWhenToUse:
-    """Anthropic spec ``when_to_use:`` — appended to description at parse time."""
+    """SKILL.md spec ``when_to_use:`` — appended to description at parse time."""
 
     def test_appended_to_description(self) -> None:
         raw = """\
@@ -364,7 +364,7 @@ Content.
 
 
 class TestModelAndEffort:
-    """Anthropic spec ``model:`` / ``effort:`` — per-skill overrides."""
+    """SKILL.md spec ``model:`` / ``effort:`` — per-skill overrides."""
 
     def test_model_extracted(self) -> None:
         raw = """\
@@ -404,7 +404,7 @@ Content.
 
 
 class TestInvocationControl:
-    """Anthropic spec ``disable-model-invocation:`` + ``user-invocable:``."""
+    """SKILL.md spec ``disable-model-invocation:`` + ``user-invocable:``."""
 
     def test_disable_model_invocation_true(self) -> None:
         raw = """\
@@ -518,7 +518,7 @@ Content.
 
 
 class TestArgumentsAndHint:
-    """Anthropic spec ``arguments:`` (named positional slots) +
+    """SKILL.md spec ``arguments:`` (named positional slots) +
     ``argument-hint:`` (autocomplete display)."""
 
     def test_yaml_list_format(self) -> None:

--- a/tests/test_skills_tool.py
+++ b/tests/test_skills_tool.py
@@ -712,7 +712,7 @@ class TestExecSkillsLoad:
         assert session._set_skill_called == [("universal", "")]
 
     def test_load_forwards_arguments_to_set_skill(self) -> None:
-        """Anthropic spec ``$ARGUMENTS`` payload (#572) — the model
+        """SKILL.md spec ``$ARGUMENTS`` payload (#572) — the model
         passes an ``arguments`` string in the load call, prepare carries
         it on the approval item, exec forwards it to ``set_skill`` for
         the renderer to consume.  Pins the wire path end-to-end."""

--- a/tests/test_storage_skill_spec_uplift.py
+++ b/tests/test_storage_skill_spec_uplift.py
@@ -1,4 +1,4 @@
-"""Storage round-trip for the Anthropic spec-uplift columns (migration 056).
+"""Storage round-trip for the SKILL.md spec-uplift columns (migration 056).
 
 Each column is parsed/stored/editable in PR1 (#569); the consumers
 (autoload filter / menu hide / argument substitution) land in

--- a/tests/test_substitute_skill_args.py
+++ b/tests/test_substitute_skill_args.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``_substitute_skill_args`` — Anthropic spec placeholder
+"""Unit tests for ``_substitute_skill_args`` — SKILL.md spec placeholder
 substitution applied to skill bodies at load time.
 
 Covers every placeholder form Turnstone implements (``${CLAUDE_SKILL_DIR}``

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -330,7 +330,7 @@ class SkillInfo(BaseModel):
     risk_level: str = ""
     scan_report: str = "{}"
     scan_version: str = ""
-    # Anthropic spec uplift (migration 056).  JSON-array strings on
+    # SKILL.md spec uplift (migration 056).  JSON-array strings on
     # the wire to match the shape of ``allowed_tools`` /
     # ``notify_on_complete``; admin UI parses client-side.  Consumer
     # PRs (#569 filter, #571 menu hide, #572 substitution) will wire
@@ -379,17 +379,17 @@ class CreateSkillRequest(BaseModel):
     allowed_tools: str = "[]"
     license: str = ""
     compatibility: str = ""
-    # Anthropic spec ``paths:`` — glob patterns gating autoload.
+    # SKILL.md spec ``paths:`` — glob patterns gating autoload.
     # Accepts either a JSON-array string or a list; the admin handler
     # canonicalizes via ``_canonicalize_skill_string_list``.  The
     # filter consumer lands in a follow-up PR (#569).
     paths: str | list[str] = "[]"
-    # Anthropic spec ``user-invocable: false`` lands here as
+    # SKILL.md spec ``user-invocable: false`` lands here as
     # ``hidden_from_menu=true`` (#571).  Hides the skill from the
     # user-facing picker (``/v1/api/skills``) while keeping it
     # available to the model.
     hidden_from_menu: bool = False
-    # Anthropic spec ``arguments:`` + ``argument-hint:`` — named
+    # SKILL.md spec ``arguments:`` + ``argument-hint:`` — named
     # positional slots for ``$<name>`` substitution + autocomplete
     # display.  Consumer is ``session._substitute_skill_args`` at skill
     # render time (#572).  ``arguments`` uses the same wire shape as
@@ -445,7 +445,7 @@ class UpdateSkillRequest(BaseModel):
     allowed_tools: str | None = None
     license: str | None = None
     compatibility: str | None = None
-    # Anthropic spec ``paths:`` (#569 — filter consumer pending),
+    # SKILL.md spec ``paths:`` (#569 — filter consumer pending),
     # ``user-invocable: false`` mapped to ``hidden_from_menu=true``
     # (#571), and ``arguments:`` / ``argument-hint:`` (#572 —
     # substitution consumer).
@@ -859,7 +859,7 @@ class ParseSkillResponse(BaseModel):
     license: str = ""
     compatibility: str = ""
     paths: list[str] = Field(default_factory=list)
-    # Anthropic spec extras (#570).  ``when_to_use`` is already
+    # SKILL.md spec extras (#570).  ``when_to_use`` is already
     # concatenated into ``description``; surfaced separately so the
     # admin parse-preview UI can show what the source SKILL.md
     # provided in each field.
@@ -872,7 +872,7 @@ class ParseSkillResponse(BaseModel):
     # can echo them on the parse-preview.
     disable_model_invocation: bool = False
     user_invocable: bool = True
-    # Anthropic spec ``arguments:`` + ``argument-hint:`` (#572).
+    # SKILL.md spec ``arguments:`` + ``argument-hint:`` (#572).
     # Named positional slots + autocomplete display string; surfaced
     # so the admin parse-preview UI can echo what came from the source
     # SKILL.md.

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6596,7 +6596,7 @@ def _skill_to_response(r: dict[str, Any], resource_count: int = 0) -> dict[str, 
         "risk_level": r.get("risk_level", ""),
         "scan_report": r.get("scan_report", "{}"),
         "scan_version": r.get("scan_version", ""),
-        # Anthropic spec uplift (migration 056).  ``paths`` and
+        # SKILL.md spec uplift (migration 056).  ``paths`` and
         # ``arguments`` are JSON-array strings on the wire to match
         # ``allowed_tools`` / ``notify_on_complete``; the admin UI
         # parses them client-side.
@@ -6708,13 +6708,13 @@ async def admin_create_skill(request: Request) -> JSONResponse:
         except (ValueError, TypeError):
             tags_str = "[]"
 
-    # Anthropic spec ``paths:`` — glob patterns gating autoload.
+    # SKILL.md spec ``paths:`` — glob patterns gating autoload.
     # ``_canonicalize_skill_string_list`` accepts a list, a JSON-array
     # string, a comma-separated string, or ``None``, and returns the
     # canonical JSON-array string for storage.
     paths_str = _canonicalize_skill_string_list(body.get("paths"))
 
-    # Anthropic spec ``user-invocable: false`` lands here as
+    # SKILL.md spec ``user-invocable: false`` lands here as
     # ``hidden_from_menu=true`` — the user-facing picker
     # (``/v1/api/skills``) filters these out while the model still
     # sees them.  Strict-bool parse so a string like ``"false"`` (which
@@ -6723,7 +6723,7 @@ async def admin_create_skill(request: Request) -> JSONResponse:
     if hidden_err is not None:
         return hidden_err
 
-    # Anthropic spec ``arguments:`` — named positional slots for
+    # SKILL.md spec ``arguments:`` — named positional slots for
     # $<name> substitution.  Same wire shape as ``paths:`` — JSON-array
     # string in storage, list-or-CSV-or-JSON-string on the wire.
     arguments_str = _canonicalize_skill_string_list(body.get("arguments"))
@@ -7803,7 +7803,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
         # operator doesn't control.
         skill_description = parsed.description.strip() or f"Skill: {parsed.name}"
 
-        # Anthropic invocation-control axes (#571).  The install
+        # Invocation-control axes (#571).  The install
         # default is ``activation="named"`` already (user invokes by
         # name); ``disable-model-invocation: true`` reinforces that
         # but doesn't change the install-time value.  The interesting
@@ -7836,7 +7836,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 allowed_tools=allowed_tools_str,
                 paths=paths_str,
                 hidden_from_menu=install_hidden_from_menu,
-                # Anthropic spec ``model:`` + ``effort:`` — seed the
+                # SKILL.md spec ``model:`` + ``effort:`` — seed the
                 # corresponding ``model`` / ``reasoning_effort`` columns
                 # at install time so the SKILL.md author's intent
                 # survives the import.  Only fires on initial create —
@@ -7844,7 +7844,7 @@ async def admin_skill_install(request: Request) -> JSONResponse:
                 # protect admin-set values on re-install.
                 model=parsed.model,
                 reasoning_effort=parsed.effort,
-                # Anthropic spec ``arguments:`` + ``argument-hint:`` —
+                # SKILL.md spec ``arguments:`` + ``argument-hint:`` —
                 # named positional slots + autocomplete display.  Round-
                 # trip through install so the renderer's $<name>
                 # substitution finds the slot map at load time.

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -289,7 +289,9 @@ function switchAdminTab(tab) {
   if (tab === "judge") loadJudgeTab();
 
   // Update breadcrumb with active tab label
-  const activeNav = document.querySelector('.admin-nav[data-tab="' + tab + '"]');
+  const activeNav = document.querySelector(
+    '.admin-nav[data-tab="' + tab + '"]',
+  );
   const label = activeNav ? activeNav.textContent : tab;
   const bcLabel = document.getElementById("breadcrumb-label");
   if (bcLabel) bcLabel.textContent = "Admin / " + label;
@@ -895,7 +897,9 @@ function _renderChannels(channels) {
     // adapters render with their own color.  Falls back to the generic
     // scope-channel for unknown platforms; the per-platform class wins
     // by being the only class set, not by source order.
-    const ctSlug = (c.channel_type || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+    const ctSlug = (c.channel_type || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "");
     const ctClass =
       ctSlug && (ctSlug === "discord" || ctSlug === "slack")
         ? "scope-badge scope-" + ctSlug
@@ -1003,7 +1007,8 @@ function _renderSchedules(schedules) {
   for (let i = 0; i < schedules.length; i++) {
     const s = schedules[i];
     const typeLabel = s.schedule_type === "cron" ? "cron" : "at";
-    const typeCls = s.schedule_type === "cron" ? "scope-write" : "scope-approve";
+    const typeCls =
+      s.schedule_type === "cron" ? "scope-write" : "scope-approve";
     const schedule =
       s.schedule_type === "cron"
         ? s.cron_expr
@@ -1313,7 +1318,8 @@ function _collectNotifyTargets(prefix) {
     .querySelectorAll(".notify-row");
   const targets = [];
   for (let i = 0; i < rows.length; i++) {
-    const ct = (rows[i].querySelector(".notify-row-ct") || {}).value || "discord";
+    const ct =
+      (rows[i].querySelector(".notify-row-ct") || {}).value || "discord";
     const type =
       (rows[i].querySelector(".notify-row-target") || {}).value || "channel_id";
     const idEl = rows[i].querySelector(".notify-row-id");
@@ -3064,29 +3070,62 @@ function _renderSettingRow(item) {
 }
 
 function _toggleSettingsHelp(e, btn) {
+  // Stop both flavours of cascade: bubble to label/checkbox parents (would
+  // toggle the form control behind the button) AND any default action on
+  // the button click itself (irrelevant for type="button" but cheap insurance).
   e.stopPropagation();
-  const popover = btn
-    .closest(".settings-label-col")
-    .querySelector(".settings-help-popover");
+  e.preventDefault();
+  // Two lookup paths:
+  //   (a) data-help-target="popover-id" — used by the skill modals where
+  //       the popover is a sibling of the label, not wrapped in a column.
+  //   (b) Ancestor .settings-label-col → child .settings-help-popover —
+  //       the original Settings-tab structure.
+  const targetId = btn.getAttribute("data-help-target");
+  let popover = null;
+  if (targetId) {
+    popover = document.getElementById(targetId);
+  } else {
+    const col = btn.closest(".settings-label-col");
+    if (col) popover = col.querySelector(".settings-help-popover");
+  }
   if (!popover) return;
   const isVisible = popover.style.display !== "none";
-  // Close any other open popovers and reset their buttons
   _closeAllSettingsHelp(popover);
   popover.style.display = isVisible ? "none" : "";
   btn.setAttribute("aria-expanded", isVisible ? "false" : "true");
 }
 
+// Document-delegated click handler for help buttons that opt in via
+// ``data-help-target``.  Settings-tab buttons keep their per-button
+// listeners (bound at render time) so this only fires for the static-HTML
+// buttons in the skill modals.  Bound once at module load.
+document.addEventListener("click", function (e) {
+  const btn = e.target.closest(".settings-help-btn[data-help-target]");
+  if (btn) _toggleSettingsHelp(e, btn);
+});
+
 function _closeAllSettingsHelp(except) {
   const allOpen = document.querySelectorAll('.settings-help-popover[style=""]');
   for (let i = 0; i < allOpen.length; i++) {
-    if (allOpen[i] !== except) {
-      allOpen[i].style.display = "none";
-      const col = allOpen[i].closest(".settings-label-col");
-      if (col) {
-        const helpBtn = col.querySelector(".settings-help-btn");
-        if (helpBtn) helpBtn.setAttribute("aria-expanded", "false");
-      }
+    if (allOpen[i] === except) continue;
+    const popover = allOpen[i];
+    popover.style.display = "none";
+    // Reverse-resolve the button so we can clear aria-expanded.  Two paths,
+    // mirroring _toggleSettingsHelp's lookup:
+    //   (a) Skill modals — button sits outside .settings-label-col but its
+    //       data-help-target attribute points at this popover's id.
+    //   (b) Settings tab — button is a sibling inside .settings-label-col.
+    let helpBtn = null;
+    if (popover.id) {
+      helpBtn = document.querySelector(
+        '.settings-help-btn[data-help-target="' + popover.id + '"]',
+      );
     }
+    if (!helpBtn) {
+      const col = popover.closest(".settings-label-col");
+      if (col) helpBtn = col.querySelector(".settings-help-btn");
+    }
+    if (helpBtn) helpBtn.setAttribute("aria-expanded", "false");
   }
 }
 
@@ -4976,7 +5015,9 @@ function loadAdminModels() {
 function switchModelsSection(section) {
   const sections = document.querySelectorAll("#admin-models .models-section");
   for (let i = 0; i < sections.length; i++) sections[i].style.display = "none";
-  const switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  const switcher = document.querySelector(
+    "#admin-models .admin-subtab-switcher",
+  );
   const btns = switcher ? switcher.querySelectorAll(".admin-subtab-btn") : [];
   for (let k = 0; k < btns.length; k++) {
     const isActive = btns[k].getAttribute("data-section") === section;
@@ -4990,7 +5031,9 @@ function switchModelsSection(section) {
 
 // Arrow key navigation for Models sub-tabs (matches the Judge tab).
 (function () {
-  const switcher = document.querySelector("#admin-models .admin-subtab-switcher");
+  const switcher = document.querySelector(
+    "#admin-models .admin-subtab-switcher",
+  );
   if (!switcher) return;
   switcher.addEventListener("keydown", function (e) {
     if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -912,7 +912,7 @@ function _renderGovSkills(items) {
 // ---------------------------------------------------------------------------
 // SKILL.md paste auto-fill — sniff frontmatter on paste, hit the parse
 // endpoint, and populate the form so users don't have to retype name /
-// description / tags / etc. when importing an Anthropic-style skill.
+// description / tags / etc. when importing a SKILL.md-style skill.
 // ---------------------------------------------------------------------------
 
 // Trigger on any paste whose first non-whitespace bytes look like an opening

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3062,11 +3062,24 @@
                 <option value="Proprietary">Proprietary</option>
               </select>
               <label for="skill-compatibility"
-                >Compatibility
-                <span class="label-hint"
-                  >environment requirements, max 500 chars</span
+                >Compatibility<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="skill-compatibility-help"
+                  aria-label="Help for Compatibility"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="skill-compatibility-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Environment requirements like other tools, services, or
+                runtimes the skill expects. Max 500 chars.
+              </div>
               <input
                 id="skill-compatibility"
                 type="text"
@@ -3074,12 +3087,25 @@
                 maxlength="500"
               />
               <label for="skill-paths"
-                >Paths
-                <span class="label-hint"
-                  >glob patterns (comma-separated) — Anthropic spec
-                  <code>paths:</code>; filter consumer pending</span
+                >Paths<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="skill-paths-help"
+                  aria-label="Help for Paths"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="skill-paths-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Glob patterns gating model-initiated autoload, e.g.
+                <code>**/*.py</code>. Comma-separated. Maps to SKILL.md
+                <code>paths:</code>. Filter consumer pending.
+              </div>
               <input
                 id="skill-paths"
                 type="text"
@@ -3089,35 +3115,72 @@
                 <input id="skill-hidden-from-menu" type="checkbox" />
                 <span class="toggle-track" aria-hidden="true"></span>
                 <span class="toggle-label"
-                  >Hide from skill picker
-                  <span class="label-hint"
-                    >Anthropic spec <code>user-invocable: false</code> — skill
-                    stays available to the model but disappears from the
-                    user-facing picker.</span
+                  >Hide from skill picker<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="skill-hidden-from-menu-help"
+                    aria-label="Help for Hide from skill picker"
+                    aria-expanded="false"
+                  >
+                    ?</button
                   ></span
                 >
               </label>
+              <div
+                id="skill-hidden-from-menu-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Hides the skill from the user-facing <code>/skill</code>
+                picker. The model can still load it via the
+                <code>skills</code> tool. Maps to SKILL.md
+                <code>user-invocable: false</code>.
+              </div>
               <label for="skill-arguments"
-                >Arguments
-                <span class="label-hint"
-                  >named positional slots (comma-separated) — Anthropic
-                  spec <code>arguments:</code>; substituted as
-                  <code>$&lt;name&gt;</code> in the skill body</span
+                >Arguments<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="skill-arguments-help"
+                  aria-label="Help for Arguments"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="skill-arguments-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Named positional slots substituted as
+                <code>$&lt;name&gt;</code> in the skill body.
+                Comma-separated. Maps to SKILL.md <code>arguments:</code>.
+              </div>
               <input
                 id="skill-arguments"
                 type="text"
                 placeholder="issue, branch"
               />
               <label for="skill-argument-hint"
-                >Argument hint
-                <span class="label-hint"
-                  >autocomplete display string — Anthropic spec
-                  <code>argument-hint:</code>, e.g.
-                  <code>[issue-number]</code></span
+                >Argument hint<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="skill-argument-hint-help"
+                  aria-label="Help for Argument hint"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="skill-argument-hint-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Display string shown next to slash-command autocomplete,
+                e.g. <code>[issue-number]</code>. Maps to SKILL.md
+                <code>argument-hint:</code>.
+              </div>
               <input
                 id="skill-argument-hint"
                 type="text"
@@ -3128,11 +3191,26 @@
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>
               <label for="skill-activation"
-                >Activation
-                <span class="label-hint"
-                  >how models discover this skill</span
+                >Activation<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="skill-activation-help"
+                  aria-label="Help for Activation"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="skill-activation-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                How models discover this skill. <strong>Named</strong>
+                requires explicit <code>/skill</code> invocation;
+                <strong>Default</strong> is applied to every session;
+                <strong>Search</strong> is BM25-discoverable.
+              </div>
               <select id="skill-activation">
                 <option value="named">
                   Named — explicit /skill invocation
@@ -3429,11 +3507,24 @@
                 <option value="Proprietary">Proprietary</option>
               </select>
               <label for="etm-compatibility"
-                >Compatibility
-                <span class="label-hint"
-                  >environment requirements, max 500 chars</span
+                >Compatibility<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="etm-compatibility-help"
+                  aria-label="Help for Compatibility"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="etm-compatibility-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Environment requirements like other tools, services, or
+                runtimes the skill expects. Max 500 chars.
+              </div>
               <input
                 id="etm-compatibility"
                 type="text"
@@ -3441,12 +3532,25 @@
                 maxlength="500"
               />
               <label for="etm-paths"
-                >Paths
-                <span class="label-hint"
-                  >glob patterns (comma-separated) — Anthropic spec
-                  <code>paths:</code>; filter consumer pending</span
+                >Paths<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="etm-paths-help"
+                  aria-label="Help for Paths"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="etm-paths-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Glob patterns gating model-initiated autoload, e.g.
+                <code>**/*.py</code>. Comma-separated. Maps to SKILL.md
+                <code>paths:</code>. Filter consumer pending.
+              </div>
               <input
                 id="etm-paths"
                 type="text"
@@ -3456,34 +3560,72 @@
                 <input id="etm-hidden-from-menu" type="checkbox" />
                 <span class="toggle-track" aria-hidden="true"></span>
                 <span class="toggle-label"
-                  >Hide from skill picker
-                  <span class="label-hint"
-                    >Anthropic spec <code>user-invocable: false</code> — skill
-                    stays available to the model but disappears from the
-                    user-facing picker.</span
+                  >Hide from skill picker<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="etm-hidden-from-menu-help"
+                    aria-label="Help for Hide from skill picker"
+                    aria-expanded="false"
+                  >
+                    ?</button
                   ></span
                 >
               </label>
+              <div
+                id="etm-hidden-from-menu-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Hides the skill from the user-facing <code>/skill</code>
+                picker. The model can still load it via the
+                <code>skills</code> tool. Maps to SKILL.md
+                <code>user-invocable: false</code>.
+              </div>
               <label for="etm-arguments"
-                >Arguments
-                <span class="label-hint"
-                  >named positional slots (comma-separated) — Anthropic
-                  spec <code>arguments:</code>; substituted as
-                  <code>$&lt;name&gt;</code> in the skill body</span
+                >Arguments<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="etm-arguments-help"
+                  aria-label="Help for Arguments"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="etm-arguments-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Named positional slots substituted as
+                <code>$&lt;name&gt;</code> in the skill body.
+                Comma-separated. Maps to SKILL.md <code>arguments:</code>.
+              </div>
               <input
                 id="etm-arguments"
                 type="text"
                 placeholder="issue, branch"
               />
               <label for="etm-argument-hint"
-                >Argument hint
-                <span class="label-hint"
-                  >autocomplete display string — Anthropic spec
-                  <code>argument-hint:</code></span
+                >Argument hint<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="etm-argument-hint-help"
+                  aria-label="Help for Argument hint"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="etm-argument-hint-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                Display string shown next to slash-command autocomplete,
+                e.g. <code>[issue-number]</code>. Maps to SKILL.md
+                <code>argument-hint:</code>.
+              </div>
               <input
                 id="etm-argument-hint"
                 type="text"
@@ -3494,11 +3636,26 @@
             <div class="skill-spec-section">
               <h3 class="skill-spec-heading">Deployment</h3>
               <label for="etm-activation"
-                >Activation
-                <span class="label-hint"
-                  >how models discover this skill</span
+                >Activation<button
+                  type="button"
+                  class="settings-help-btn"
+                  data-help-target="etm-activation-help"
+                  aria-label="Help for Activation"
+                  aria-expanded="false"
+                >
+                  ?</button
                 ></label
               >
+              <div
+                id="etm-activation-help"
+                class="settings-help-popover"
+                style="display: none"
+              >
+                How models discover this skill. <strong>Named</strong>
+                requires explicit <code>/skill</code> invocation;
+                <strong>Default</strong> is applied to every session;
+                <strong>Search</strong> is BM25-discoverable.
+              </div>
               <select id="etm-activation">
                 <option value="named">
                   Named — explicit /skill invocation

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -3393,7 +3393,13 @@ textarea.skill-content-area {
   background: var(--yellow-glow);
 }
 
-/* Help tooltip */
+/* Help tooltip.  The glyph is painted by ``::after`` rather than HTML
+   text content so the button renders identically whether the markup
+   has literal ``>?</button>`` text (settings-tab buttons assembled in
+   admin.js) or prettier-introduced whitespace around the glyph (skill
+   modal buttons in index.html).  Any literal text content is hidden
+   via ``font-size: 0`` on the button; the pseudo restores its own
+   size so the glyph centers cleanly via flex. */
 .settings-help-btn {
   display: inline-flex;
   align-items: center;
@@ -3404,7 +3410,7 @@ textarea.skill-content-area {
   border: 1px solid var(--accent);
   background: var(--accent-dim);
   color: var(--accent);
-  font-size: 10px;
+  font-size: 0;
   font-weight: 600;
   font-family: var(--font-ui);
   cursor: pointer;
@@ -3416,6 +3422,11 @@ textarea.skill-content-area {
   transition:
     background 0.15s,
     color 0.15s;
+}
+.settings-help-btn::after {
+  content: "?";
+  font-size: 10px;
+  line-height: 1;
 }
 /* Expand tap target to ~26px without changing visual size */
 .settings-help-btn::before {
@@ -3434,6 +3445,7 @@ textarea.skill-content-area {
 
 .settings-help-popover {
   margin-top: 4px;
+  margin-bottom: 4px;
   padding: 6px 8px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -3441,6 +3453,21 @@ textarea.skill-content-area {
   border-radius: 3px;
   font-size: 11px;
   line-height: 1.4;
+  color: var(--fg);
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+.settings-help-popover code {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 0 4px;
+  background: var(--code-bg);
+  border-radius: 2px;
+  color: var(--fg);
+}
+.settings-help-popover strong {
+  font-weight: 600;
   color: var(--fg);
 }
 .settings-help-text {

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -548,7 +548,7 @@ _RESOURCE_PATH_RE = re.compile(
 _TEMPLATE_VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 
 
-# Anthropic Claude Code skill spec placeholders.  Single combined
+# SKILL.md spec placeholders.  Single combined
 # regex so substitution is one-pass — a positional arg whose VALUE
 # happens to contain ``$ARGUMENTS`` (etc.) doesn't get re-expanded
 # on a second sweep.  The verbose form keeps the alternation
@@ -631,7 +631,7 @@ def _substitute_skill_args(
     ws_id: str,
     effort: str,
 ) -> str:
-    """Apply Anthropic Claude Code skill-spec placeholder substitution.
+    """Apply SKILL.md spec placeholder substitution.
 
     Handles every spec form except ``${CLAUDE_SKILL_DIR}`` (which
     requires a filesystem-shaped skill layout Turnstone doesn't have
@@ -1517,7 +1517,7 @@ class ChatSession:
                 "instructions": self.instructions or "",
                 "creative_mode": str(self.creative_mode),
                 "skill": self._skill_name or "",
-                # Anthropic spec ``$ARGUMENTS`` payload (#572).  Stored
+                # SKILL.md spec ``$ARGUMENTS`` payload (#572).  Stored
                 # so a resumed workstream re-renders the skill with the
                 # same args the original load supplied — otherwise the
                 # rehydrate path would silently swap to empty args.
@@ -8488,7 +8488,7 @@ class ChatSession:
         name = self._coord_str_arg(args, "name").strip()
         if not name:
             return self._coord_tool_error(call_id, "skills", "load: 'name' is required")
-        # Anthropic spec ``$ARGUMENTS`` payload — optional.  Mirror
+        # SKILL.md spec ``$ARGUMENTS`` payload — optional.  Mirror
         # the spec's free-form string shape (``/skill-name a b "c d"``)
         # rather than a list, so the model can pass quoted positional
         # args and have ``shlex.split`` at substitution time produce

--- a/turnstone/core/skill_parser.py
+++ b/turnstone/core/skill_parser.py
@@ -33,7 +33,7 @@ _LIST_SPLIT_RE = re.compile(r"[\s,]+")
 _BARE_DESC_RE = re.compile(r"^(description:\s*)(.+)$", re.MULTILINE)
 
 # Field length caps.  ``MAX_SKILL_DESCRIPTION_LEN`` matches the
-# Anthropic Claude Code skill spec's combined ``description`` +
+# SKILL.md spec's combined ``description`` +
 # ``when_to_use`` listing budget (1,536 chars).  Exported (no leading
 # underscore) because the same cap must be enforced at every write
 # surface — Pydantic schemas, the admin HTTP handlers, and the
@@ -56,18 +56,18 @@ class ParsedSkill:
     allowed_tools: list[str] = field(default_factory=list)
     license: str = ""
     compatibility: str = ""
-    # Anthropic Claude Code spec ``paths:`` — glob patterns gating
+    # SKILL.md spec ``paths:`` — glob patterns gating
     # model-initiated autoload.  Filter consumer lands in a follow-up
     # PR (issue #569); parsed here so the value round-trips through
     # install / admin edit / export without loss.
     paths: list[str] = field(default_factory=list)
-    # Anthropic spec ``when_to_use:`` — additional trigger context for
+    # SKILL.md spec ``when_to_use:`` — additional trigger context for
     # when the skill should be invoked.  Concatenated into
     # ``description`` (capped at ``MAX_SKILL_DESCRIPTION_LEN``) so the model
     # sees both in the listing; kept here separately for the admin
     # parse-preview UI which surfaces it as its own field.
     when_to_use: str = ""
-    # Anthropic spec ``model:`` and ``effort:`` — per-skill model
+    # SKILL.md spec ``model:`` and ``effort:`` — per-skill model
     # override + reasoning effort.  Fields keep their spec names here
     # for fidelity at the parser layer; the install handler translates
     # ``effort`` → ``prompt_templates.reasoning_effort`` at the storage
@@ -75,7 +75,7 @@ class ParsedSkill:
     # short-circuits at the source_url dedup so admin overrides survive.
     model: str = ""
     effort: str = ""
-    # Anthropic spec ``disable-model-invocation:`` and ``user-invocable:``
+    # SKILL.md spec ``disable-model-invocation:`` and ``user-invocable:``
     # — invocation-control axes.  Stored in raw spec shape on the
     # dataclass; defaults match spec (both invokers can use the skill
     # unless gated).
@@ -95,14 +95,14 @@ class ParsedSkill:
     # field that gates flipping back.
     disable_model_invocation: bool = False
     user_invocable: bool = True
-    # Anthropic spec ``arguments:`` — named positional argument slots
+    # SKILL.md spec ``arguments:`` — named positional argument slots
     # that pair with ``$<name>`` substitution in the skill body.
     # Accepts the spec's space-separated string or YAML list shape.
     # Stored as a JSON-array column on ``prompt_templates`` (added by
     # migration 056); the renderer in ``session._substitute_skill_args``
     # binds positional args to these names at skill-load time.
     arguments: list[str] = field(default_factory=list)
-    # Anthropic spec ``argument-hint:`` — display string for slash-
+    # SKILL.md spec ``argument-hint:`` — display string for slash-
     # command autocomplete, e.g. ``"[issue-number]"``.  Surfaced in
     # the admin UI and round-tripped through install; no runtime
     # behaviour today since Turnstone doesn't have a slash-command
@@ -112,13 +112,13 @@ class ParsedSkill:
 
 
 def _extract_tags(meta: dict[str, Any]) -> list[str]:
-    """Extract tags from frontmatter, handling both Anthropic and Hermes formats."""
+    """Extract tags from frontmatter, handling both nested-metadata and Hermes formats."""
     # Direct tags field
     tags = meta.get("tags")
     if isinstance(tags, list):
         return [str(t) for t in tags if t]
 
-    # Nested metadata.tags (Anthropic format)
+    # Nested metadata.tags (SKILL.md spec format)
     metadata = meta.get("metadata")
     if isinstance(metadata, dict):
         nested = metadata.get("tags")
@@ -317,7 +317,7 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
             first_line = first_line.lstrip("# ").strip()
         description = first_line[:256]
 
-    # Anthropic spec ``when_to_use:`` — appended to description so the
+    # SKILL.md spec ``when_to_use:`` — appended to description so the
     # model sees both signals on the listing.  Separated by a blank
     # line + "When to use:" prefix; budgeted against the combined cap
     # below so the truncation never lands inside the separator and
@@ -375,7 +375,7 @@ def parse_skill_md(raw: str, *, lenient: bool = False) -> ParsedSkill | None:
         when_to_use=when_to_use,
         model=_extract_str(meta, "model"),
         effort=_extract_str(meta, "effort"),
-        # Anthropic invocation-control axes — spec defaults: model can
+        # Invocation-control axes — spec defaults: model can
         # autoload (disable-model-invocation=False) AND user can pick
         # from the menu (user-invocable=True).
         disable_model_invocation=_extract_bool(meta, "disable-model-invocation", default=False),

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -433,15 +433,15 @@ prompt_templates = sa.Table(
     sa.Column("version", sa.Text, nullable=False, server_default="1.0.0"),
     sa.Column("author", sa.Text, nullable=False, server_default=""),
     sa.Column("activation", sa.Text, nullable=False, server_default="named"),
-    # Anthropic skill spec ``user-invocable: false`` — hide from /-menu picker.
+    # SKILL.md spec ``user-invocable: false`` — hide from /-menu picker.
     sa.Column("hidden_from_menu", sa.Integer, nullable=False, server_default="0"),
     sa.Column("token_estimate", sa.Integer, nullable=False, server_default="0"),
     sa.Column("allowed_tools", sa.Text, nullable=False, server_default="[]"),  # JSON array
-    # Anthropic skill spec ``paths:`` — glob patterns gating autoload.
+    # SKILL.md spec ``paths:`` — glob patterns gating autoload.
     # Consumer (filter logic) lands in a follow-up PR; field is
     # parsed/stored/editable but not yet acted on.
     sa.Column("paths", sa.Text, nullable=False, server_default="[]"),  # JSON array
-    # Anthropic skill spec ``arguments:`` + ``argument-hint:`` —
+    # SKILL.md spec ``arguments:`` + ``argument-hint:`` —
     # named positional slots and autocomplete display string.  Consumed
     # by the $N / $<name> substitution PR (issue #572).
     sa.Column("arguments", sa.Text, nullable=False, server_default="[]"),  # JSON array

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -181,7 +181,7 @@ SKILL_MUTABLE = frozenset(
         "scan_report",
         "priority",
         "kind",
-        # Anthropic spec uplift (migration 056)
+        # SKILL.md spec uplift (migration 056)
         "paths",
         "hidden_from_menu",
         "arguments",

--- a/turnstone/core/storage/migrations/versions/056_skill_spec_uplift_columns.py
+++ b/turnstone/core/storage/migrations/versions/056_skill_spec_uplift_columns.py
@@ -1,6 +1,6 @@
-"""Add Anthropic spec-uplift columns to prompt_templates.
+"""Add SKILL.md spec-uplift columns to prompt_templates.
 
-The Anthropic Claude Code skill spec defines four frontmatter fields
+The SKILL.md frontmatter spec defines four fields
 that map to new columns on ``prompt_templates``:
 
 * ``paths`` — JSON list of glob patterns that gate model-initiated

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -27,7 +27,7 @@ def skill_summary_rows(storage: Any) -> list[dict[str, Any]]:
 
     Filters:
     * ``enabled=False`` rows are dropped.
-    * ``hidden_from_menu=True`` rows are dropped (Anthropic spec
+    * ``hidden_from_menu=True`` rows are dropped (SKILL.md spec
       ``user-invocable: false`` — model still sees the skill via the
       ``skills`` tool, but the user picker hides it).
 

--- a/turnstone/tools/skills.json
+++ b/turnstone/tools/skills.json
@@ -23,7 +23,7 @@
       },
       "arguments": {
         "type": "string",
-        "description": "For `load`: optional invocation arguments for Anthropic-spec `$ARGUMENTS` / `$N` / `$<name>` substitution in the skill body. Free-form string parsed with shell-style quoting via `shlex.split` — quotes are stripped, so `\"hello world\" second` yields $0=hello world, $1=second (no surrounding quotes in the substituted value). Skills declaring `arguments: [issue, branch]` in their frontmatter expose `$issue` and `$branch` bound by position. Omit or pass an empty string when the skill has no `$ARGUMENTS`/`$N`/`$<name>` placeholders; `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` env-var substitution still runs regardless."
+        "description": "For `load`: optional invocation arguments for SKILL.md `$ARGUMENTS` / `$N` / `$<name>` substitution in the skill body. Free-form string parsed with shell-style quoting via `shlex.split` — quotes are stripped, so `\"hello world\" second` yields $0=hello world, $1=second (no surrounding quotes in the substituted value). Skills declaring `arguments: [issue, branch]` in their frontmatter expose `$issue` and `$branch` bound by position. Omit or pass an empty string when the skill has no `$ARGUMENTS`/`$N`/`$<name>` placeholders; `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` env-var substitution still runs regardless."
       },
       "query": {
         "type": "string",


### PR DESCRIPTION
## Summary

Two related cleanups touching the same surface as the skill-spec uplift PRs (#569/#570/#571/#572):

1. **Wording**: replace `Anthropic spec` / `Anthropic Claude Code skill spec` with `SKILL.md spec` across admin UI tooltips, code comments, test docstrings, migration 056's module docstring, and the user-facing `arguments` description in `tools/skills.json`. Legitimate provider/SDK/API references (provider name, `api.anthropic.com`, `_anthropic.py`, capability comments) are intentionally untouched.

2. **Admin UX**: in the Create + Edit Skill modals, six fields per modal (Compatibility, Paths, Hide-from-skill-picker, Arguments, Argument hint, Activation) had long uppercase label-hint spans crammed into the visible label. Migrated each to the existing `.settings-help-btn` + `.settings-help-popover` pattern already used in the Settings tab — short label + inline `?` button that opens a styled popover with proper `<code>` formatting for technical tokens.

## Pattern-reuse changes

In `turnstone/console/static/admin.js`:

- `_toggleSettingsHelp` now resolves the popover via a new `data-help-target="<id>"` attribute first, falling back to the settings-tab `.settings-label-col` ancestor lookup.
- `_closeAllSettingsHelp` mirrors the same dual-path lookup when resetting `aria-expanded`, so modal buttons don't get stuck on `aria-expanded="true"` after another popover opens.
- Added a document-delegated click handler that fires only for buttons with `data-help-target`. Existing per-button binding in the settings-tab render path is unchanged.

In `turnstone/console/static/style.css`:

- `.settings-help-btn` now paints its `?` via `::after` with the button's own `font-size: 0`, so prettier-introduced whitespace inside the new HTML buttons can't off-center the glyph. Same rule applies to existing admin.js-generated buttons (text content hidden, pseudo identical).
- Small additions for `.settings-help-popover code` / `strong` styling so technical tokens render with the same monospace pill treatment used elsewhere in skill UI.

## Verified

- `ruff check` clean
- `mypy` clean (200 source files)
- 215 skill-related tests pass (`test_skill_parser`, `test_skill_parse_api`, `test_skill_discovery_api`, `test_substitute_skill_args`, `test_storage_skill_spec_uplift`, `test_skills_tool`, `test_canonicalize_skill_string_list`)
- Full review pipeline run on the diff; one a11y bug (`aria-expanded` stuck on closed modal popovers) was identified and fixed in this PR

## Known follow-ups (intentionally NOT in this PR)

- Migrate `_renderSettingRow` button assembly in admin.js to the empty-`<button>` + `data-help-target` form so the per-button `addEventListener` loop can be dropped in favour of pure document delegation, and the `font-size: 0` rule stops being a workaround for two markup styles.
- The 12 new popover blocks are duplicated verbatim between Create and Edit modals (same as the rest of the modal pair). A small renderer emitting popovers from a shared data object would eliminate drift risk but is unrelated cleanup.

## Test plan

- [ ] Open Create Skill modal; verify each short label has a `?` next to it
- [ ] Click `?` on Paths → popover expands inline with `<code>` formatting on `**/*.py`, `paths:`
- [ ] Click `?` on Hide-from-skill-picker → popover opens WITHOUT toggling the checkbox
- [ ] Open second popover → first popover closes AND its button's `aria-expanded` resets to `false`
- [ ] Open Edit Skill modal on an installed (readonly) skill — verify `?` buttons still clickable to read help even when input is disabled
- [ ] Settings tab → confirm existing `?` buttons still render their glyph correctly (now via `::after`) and toggle as before