### PR TITLE
feat(providers): xAI/Grok provider via OpenAIResponsesProvider subclass

### DIFF
--- a/tests/test_provider_xai.py
+++ b/tests/test_provider_xai.py
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from turnstone.core.model_registry import _detect_openai_compat
+from turnstone.core.model_registry import _detect_openai_compat, _select_best_model
 from turnstone.core.providers import (
     create_client,
     create_provider,
@@ -348,3 +348,40 @@ class TestProviderRegistration:
 
     def test_lookup_model_capabilities_returns_none_for_unknown(self) -> None:
         assert lookup_model_capabilities("xai", "grok-x-unreleased") is None
+
+
+# ---------------------------------------------------------------------------
+# _select_best_model — version-tuple ordering
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestModel:
+    """Verify dotted-version sorting uses tuple-of-ints, not float.
+
+    ``float("4.20") == 4.2``, so the float-based sort would route
+    ``grok-4.20`` (newer dated-snapshot line) under ``grok-4.3``.  The
+    fix parses each segment as an int so ``(4, 20) > (4, 3)`` as
+    intended.  Same fix applied symmetrically to the openai branch
+    guards against a future ``gpt-5.10`` regression."""
+
+    def test_xai_prefers_higher_minor_version(self) -> None:
+        # The bug: float("4.20") == 4.2 < 4.3, so the broken sort
+        # picked grok-4.3 over grok-4.20.  The fix routes correctly.
+        assert _select_best_model(["grok-4", "grok-4.3", "grok-4.20"], "xai") == "grok-4.20"
+
+    def test_xai_bare_major_below_dotted(self) -> None:
+        # (4,) < (4, 3) under tuple comparison, so a bare-major alias
+        # is correctly ordered below any minor-versioned sibling.
+        assert _select_best_model(["grok-4", "grok-4.3"], "xai") == "grok-4.3"
+
+    def test_xai_falls_back_when_no_base_match(self) -> None:
+        # No base-versioned entry → first model returned.  Mirrors the
+        # openai/anthropic fallback at end of _select_best_model.
+        assert (
+            _select_best_model(["grok-4.20-0309-reasoning", "grok-build-0.1"], "xai")
+            == "grok-4.20-0309-reasoning"
+        )
+
+    def test_openai_prefers_higher_minor_version(self) -> None:
+        # Symmetric guard against future gpt-5.10 vs gpt-5.2 confusion.
+        assert _select_best_model(["gpt-5", "gpt-5.2", "gpt-5.10"], "openai") == "gpt-5.10"

--- a/tests/test_provider_xai.py
+++ b/tests/test_provider_xai.py
@@ -1,0 +1,350 @@
+"""Tests for the xAI / Grok provider.
+
+Covers the boundaries the new code adds:
+
+* Capability-table prefix-match on ``GROK_CAPABILITIES`` (aliases like
+  ``grok-4.3-latest`` resolve to the documented ``grok-4.3`` row).
+* ``XAIProvider._build_kwargs`` merging ``<tool>_call_output`` strings
+  into ``include[]`` alongside the inherited ``reasoning.encrypted_content``
+  entry, so xAI's hidden server-tool outputs become visible.
+* ``resolve_server_side_tools`` folding the legacy
+  ``supports_web_search`` boolean into the effective tuple.
+* ``extra_headers`` forwarding through ``OpenAIResponsesProvider`` and
+  ``OpenAIChatCompletionsProvider`` (Anthropic also accepts the kwarg;
+  its streaming-context-manager shape is exercised by its own existing
+  tests).
+* ``model_registry._detect_openai_compat`` setting ``server_type="xai"``
+  for ``api.x.ai`` and its subdomains (and not for look-alikes).
+* End-to-end wiring via ``create_provider("xai")`` /
+  ``create_client("xai", ...)`` / ``list_known_models("xai")`` /
+  ``lookup_model_capabilities("xai", ...)``.
+
+All tests drive through the real provider; only the OpenAI/Anthropic
+SDK boundary is mocked, and the mock records call kwargs so the body
+shape can be inspected (per the project's
+``feedback_mock_transport_body_inspection`` rule).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from turnstone.core.model_registry import _detect_openai_compat
+from turnstone.core.providers import (
+    create_client,
+    create_provider,
+    list_known_models,
+    lookup_model_capabilities,
+)
+from turnstone.core.providers._openai_common import resolve_server_side_tools
+from turnstone.core.providers._protocol import ModelCapabilities
+from turnstone.core.providers._xai import (
+    _GROK_DEFAULT,
+    GROK_CAPABILITIES,
+    XAI_DEFAULT_BASE_URL,
+    XAIProvider,
+    lookup_grok_capabilities,
+)
+
+
+@pytest.fixture
+def provider() -> XAIProvider:
+    return XAIProvider()
+
+
+# ---------------------------------------------------------------------------
+# Capability table
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityTable:
+    def test_exact_match_grok_4_3(self) -> None:
+        caps = lookup_grok_capabilities("grok-4.3")
+        assert caps is GROK_CAPABILITIES["grok-4.3"]
+        assert caps.context_window == 1_000_000
+        assert caps.reasoning_effort_values == ("none", "low", "medium", "high")
+        assert caps.default_reasoning_effort == "low"
+        assert caps.supports_reasoning_replay is True
+        assert caps.server_side_tools == ("web_search",)
+
+    def test_latest_alias_resolves_via_longest_prefix(self) -> None:
+        # `grok-4.3-latest` is documented as an accepted alias.  The
+        # longest-prefix lookup must route it to the `grok-4.3` row
+        # rather than falling through to GROK_DEFAULT or matching some
+        # shorter prefix.
+        assert lookup_grok_capabilities("grok-4.3-latest") is GROK_CAPABILITIES["grok-4.3"]
+
+    def test_dated_snapshot_resolves(self) -> None:
+        # Dated snapshots (`grok-4.20-0309-*`) appear as explicit
+        # entries; bare prefix-match returns them.
+        caps = lookup_grok_capabilities("grok-4.20-0309-reasoning")
+        assert caps is GROK_CAPABILITIES["grok-4.20-0309-reasoning"]
+
+    def test_multi_agent_effort_uses_xhigh(self) -> None:
+        caps = lookup_grok_capabilities("grok-4.20-multi-agent-0309")
+        # Effort controls agent count on this variant per xAI docs;
+        # only the multi-agent table exposes `xhigh`.
+        assert "xhigh" in caps.reasoning_effort_values
+
+    def test_unknown_model_returns_default_identity(self) -> None:
+        # Identity check matters: lookup_model_capabilities relies on
+        # `caps is default` to return None for unknown rows.
+        assert lookup_grok_capabilities("grok-x-unreleased") is _GROK_DEFAULT
+        assert lookup_grok_capabilities("") is _GROK_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# resolve_server_side_tools — legacy supports_web_search fold
+# ---------------------------------------------------------------------------
+
+
+class TestResolveServerSideTools:
+    def test_explicit_tuple_used_directly(self) -> None:
+        caps = ModelCapabilities(server_side_tools=("web_search", "x_search"))
+        assert resolve_server_side_tools(caps) == ["web_search", "x_search"]
+
+    def test_legacy_supports_web_search_appends_when_missing(self) -> None:
+        # Capability rows that only set the legacy boolean still get
+        # `web_search` injected by the helper.
+        caps = ModelCapabilities(supports_web_search=True)
+        assert resolve_server_side_tools(caps) == ["web_search"]
+
+    def test_legacy_flag_does_not_duplicate(self) -> None:
+        caps = ModelCapabilities(
+            supports_web_search=True,
+            server_side_tools=("web_search",),
+        )
+        result = resolve_server_side_tools(caps)
+        assert result == ["web_search"]
+
+    def test_neither_flag_returns_empty(self) -> None:
+        assert resolve_server_side_tools(ModelCapabilities()) == []
+
+    def test_returned_list_is_independent_copy(self) -> None:
+        # Callers mutate the result (the OpenAIResponsesProvider
+        # injection appends `_call_output` strings in xAI's override);
+        # the helper must not hand back a shared reference.
+        caps = ModelCapabilities(server_side_tools=("web_search",))
+        first = resolve_server_side_tools(caps)
+        first.append("x_search")
+        second = resolve_server_side_tools(caps)
+        assert second == ["web_search"]
+
+
+# ---------------------------------------------------------------------------
+# XAIProvider._build_kwargs — include[] merge
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKwargs:
+    def test_include_merges_call_output_with_encrypted_content(self, provider: XAIProvider) -> None:
+        kwargs = provider._build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=512,
+            temperature=0.5,
+            reasoning_effort="low",
+            deferred_names=None,
+            capabilities=None,
+            replay_reasoning_to_model=True,
+        )
+        includes = kwargs.get("include") or []
+        # Both must be present; order matters less than the union.
+        assert "reasoning.encrypted_content" in includes
+        assert "web_search_call_output" in includes
+
+    def test_include_omits_encrypted_content_when_replay_false(self, provider: XAIProvider) -> None:
+        kwargs = provider._build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=512,
+            temperature=0.5,
+            reasoning_effort="low",
+            deferred_names=None,
+            capabilities=None,
+            replay_reasoning_to_model=False,
+        )
+        includes = kwargs.get("include") or []
+        assert "reasoning.encrypted_content" not in includes
+        # `*_call_output` still added because xAI hides those outputs
+        # regardless of the replay flag.
+        assert "web_search_call_output" in includes
+
+    def test_include_omitted_when_no_server_side_tools(self, provider: XAIProvider) -> None:
+        # Custom caps row with no server-side tools and no legacy
+        # web-search flag — include[] should carry only the
+        # encrypted_content entry (gated by replay).
+        bare_caps = ModelCapabilities(supports_reasoning_replay=True)
+        kwargs = provider._build_kwargs(
+            model="grok-bare-test",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=512,
+            temperature=0.5,
+            reasoning_effort="low",
+            deferred_names=None,
+            capabilities=bare_caps,
+            replay_reasoning_to_model=True,
+        )
+        includes = kwargs.get("include") or []
+        assert includes == ["reasoning.encrypted_content"]
+
+    def test_web_search_tool_injected_into_tools_list(self, provider: XAIProvider) -> None:
+        # The inherited generalised injection in
+        # OpenAIResponsesProvider._build_kwargs walks server_side_tools;
+        # grok-4.3 declares `("web_search",)`.
+        kwargs = provider._build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=512,
+            temperature=0.5,
+            reasoning_effort="low",
+            deferred_names=None,
+            capabilities=None,
+            replay_reasoning_to_model=False,
+        )
+        tools = kwargs.get("tools") or []
+        assert {"type": "web_search"} in tools
+
+
+# ---------------------------------------------------------------------------
+# extra_headers — protocol passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestExtraHeadersForwarding:
+    """The session layer doesn't populate ``extra_headers`` yet, but the
+    plumbing must be in place so a future change wiring
+    ``x-grok-conv-id`` for cache hinting reaches the SDK boundary."""
+
+    def test_responses_streaming_forwards_extra_headers(self, provider: XAIProvider) -> None:
+        client = MagicMock()
+        client.responses.create.return_value = iter([])
+        # Consume the iterator so the underlying call is made eagerly.
+        list(
+            provider.create_streaming(
+                client=client,
+                model="grok-4.3",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_headers={"x-grok-conv-id": "ws_abc"},
+            )
+        )
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs.get("extra_headers") == {"x-grok-conv-id": "ws_abc"}
+
+    def test_responses_streaming_omits_when_none(self, provider: XAIProvider) -> None:
+        client = MagicMock()
+        client.responses.create.return_value = iter([])
+        list(
+            provider.create_streaming(
+                client=client,
+                model="grok-4.3",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+        kwargs = client.responses.create.call_args.kwargs
+        assert "extra_headers" not in kwargs
+
+    def test_responses_completion_forwards_extra_headers(self, provider: XAIProvider) -> None:
+        client = MagicMock()
+        response = MagicMock()
+        response.output = []
+        response.status = "completed"
+        response.usage = None
+        client.responses.create.return_value = response
+        provider.create_completion(
+            client=client,
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_headers={"x-grok-conv-id": "ws_xyz"},
+        )
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs.get("extra_headers") == {"x-grok-conv-id": "ws_xyz"}
+
+    def test_chat_streaming_forwards_extra_headers(self) -> None:
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        chat_provider = OpenAIChatCompletionsProvider()
+        client = MagicMock()
+        client.chat.completions.create.return_value = iter([])
+        list(
+            chat_provider.create_streaming(
+                client=client,
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_headers={"x-custom": "value"},
+            )
+        )
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("extra_headers") == {"x-custom": "value"}
+
+
+# ---------------------------------------------------------------------------
+# Hostname detection — model_registry._detect_openai_compat
+# ---------------------------------------------------------------------------
+
+
+class TestHostnameDetection:
+    def _detect(self, base_url: str) -> str | None:
+        result: dict[str, object] = {"context_window": None, "server_type": None}
+        _detect_openai_compat(result, model_obj=None, model_id="grok-4.3", base_url=base_url)
+        return result["server_type"]  # type: ignore[return-value]
+
+    def test_api_x_ai_resolves_to_xai(self) -> None:
+        assert self._detect("https://api.x.ai/v1") == "xai"
+
+    def test_subdomain_x_ai_resolves_to_xai(self) -> None:
+        assert self._detect("https://eu.api.x.ai/v1") == "xai"
+
+    def test_lookalike_host_not_matched(self) -> None:
+        # `evil-x.ai` and `x.ai.attacker.com` must not collide with the
+        # `.x.ai` suffix check.  The hostname check is `endswith(".x.ai")`
+        # — a leading-dot anchor avoids matching `notx.ai` etc., but a
+        # full hostname *ending* in `.x.ai` is still matched; that's
+        # the intent (any subdomain of x.ai).  This test asserts the
+        # negative case where the suffix is not preceded by a dot.
+        assert self._detect("https://evil-x.ai/v1") != "xai"
+
+    def test_unrelated_hostname_falls_through(self) -> None:
+        # Should pick up the openai-compatible default for an
+        # unrecognised host.
+        assert self._detect("https://example.test/v1") == "openai-compatible"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistration:
+    def test_create_provider_returns_xai_singleton(self) -> None:
+        prov_1 = create_provider("xai")
+        prov_2 = create_provider("xai")
+        assert prov_1 is prov_2
+        assert prov_1.provider_name == "xai"
+
+    def test_create_client_defaults_to_xai_base_url(self) -> None:
+        # Without an explicit base_url, the factory should inject
+        # XAI_DEFAULT_BASE_URL so callers don't have to know it.
+        client = create_client("xai", base_url="", api_key="xai-test-key")
+        # The openai-python SDK exposes `base_url` as a string-y attribute.
+        assert XAI_DEFAULT_BASE_URL.rstrip("/") in str(client.base_url)
+
+    def test_list_known_models_returns_documented_set(self) -> None:
+        known = list_known_models("xai")
+        assert "grok-4.3" in known
+        assert "grok-4.20-multi-agent-0309" in known
+        assert "grok-build-0.1" in known
+
+    def test_lookup_model_capabilities_resolves_known(self) -> None:
+        caps = lookup_model_capabilities("xai", "grok-4.3")
+        assert caps is not None
+        assert caps["context_window"] == 1_000_000
+
+    def test_lookup_model_capabilities_returns_none_for_unknown(self) -> None:
+        assert lookup_model_capabilities("xai", "grok-x-unreleased") is None

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9832,7 +9832,7 @@ async def admin_import_mcp_config(request: Request) -> JSONResponse:
 # ---------------------------------------------------------------------------
 
 _MODEL_ALIAS_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
-_MODEL_PROVIDERS = frozenset({"openai", "anthropic", "openai-compatible", "google"})
+_MODEL_PROVIDERS = frozenset({"openai", "anthropic", "openai-compatible", "google", "xai"})
 _REASONING_EFFORT_CHOICES = frozenset(
     {"", "none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -629,6 +629,22 @@ def _select_best_model(model_ids: list[str], provider: str) -> str:
             return sonnet[0]
         return model_ids[0]
 
+    if provider == "xai":
+        # Prefer base grok-N.N reasoning models (skip image/voice/video
+        # variants and dated multi-agent snapshots when a base flagship
+        # is available).
+        grok_base_pattern = re.compile(r"^grok-(\d+(?:\.\d+)?)$")
+        grok_base_models: list[tuple[float, str]] = []
+        for m in model_ids:
+            match = grok_base_pattern.match(m)
+            if match:
+                version = float(match.group(1))
+                grok_base_models.append((version, m))
+        if grok_base_models:
+            grok_base_models.sort(key=lambda x: x[0], reverse=True)
+            return grok_base_models[0][1]
+        return model_ids[0]
+
     if provider == "openai":
         # Prefer base gpt-N.N (not mini/nano/pro/codex/chat variants)
         base_pattern = re.compile(r"^gpt-(\d+(?:\.\d+)?)(?:-\d+)?$")
@@ -649,13 +665,18 @@ def _select_best_model(model_ids: list[str], provider: str) -> str:
 def _extract_context_window(model_obj: Any, provider: str) -> int | None:
     """Extract context window from a model object returned by ``/v1/models``.
 
-    Handles Anthropic (static capability table), vLLM (``max_model_len``),
-    and llama.cpp (``meta.n_ctx_train``).  Returns ``None`` when not available.
+    Handles Anthropic and xAI (static capability tables), vLLM
+    (``max_model_len``), and llama.cpp (``meta.n_ctx_train``).
+    Returns ``None`` when not available.
     """
     if provider == "anthropic":
         from turnstone.core.providers._anthropic import AnthropicProvider
 
         return AnthropicProvider().get_capabilities(model_obj.id).context_window
+    if provider == "xai":
+        from turnstone.core.providers._xai import lookup_grok_capabilities
+
+        return lookup_grok_capabilities(model_obj.id).context_window
     model_data = model_obj.model_dump()
     max_len = model_data.get("max_model_len")
     if isinstance(max_len, int) and max_len > 0:
@@ -781,6 +802,13 @@ def probe_model_endpoint(
             if known is not None:
                 result["context_window"] = known["context_window"]
             result["server_type"] = "anthropic"
+        elif provider == "xai":
+            from turnstone.core.providers import lookup_model_capabilities
+
+            known = lookup_model_capabilities("xai", inspect_id)
+            if known is not None:
+                result["context_window"] = known["context_window"]
+            result["server_type"] = "xai"
         else:
             # OpenAI-compatible path
             _detect_openai_compat(result, inspect_obj, inspect_id, base_url)
@@ -832,6 +860,8 @@ def _detect_openai_compat(
     _hostname = urlparse(_normalized).hostname or "" if _normalized else ""
     if base_url and (_hostname == "api.openai.com" or _hostname.endswith(".openai.com")):
         result["server_type"] = "openai"
+    elif base_url and (_hostname == "api.x.ai" or _hostname.endswith(".x.ai")):
+        result["server_type"] = "xai"
     elif meta is not None and "n_ctx_train" in meta:
         result["server_type"] = "llama.cpp"
     elif "sglang" in owned_by.lower():

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -632,34 +632,48 @@ def _select_best_model(model_ids: list[str], provider: str) -> str:
     if provider == "xai":
         # Prefer base grok-N.N reasoning models (skip image/voice/video
         # variants and dated multi-agent snapshots when a base flagship
-        # is available).
+        # is available).  Use tuple-of-ints version ordering so
+        # ``grok-4.20`` sorts after ``grok-4.3`` — ``float`` would
+        # mis-order them (``float("4.20") == 4.2``).
         grok_base_pattern = re.compile(r"^grok-(\d+(?:\.\d+)?)$")
-        grok_base_models: list[tuple[float, str]] = []
+        grok_base_models: list[tuple[tuple[int, ...], str]] = []
         for m in model_ids:
             match = grok_base_pattern.match(m)
             if match:
-                version = float(match.group(1))
-                grok_base_models.append((version, m))
+                grok_base_models.append((_version_tuple(match.group(1)), m))
         if grok_base_models:
             grok_base_models.sort(key=lambda x: x[0], reverse=True)
             return grok_base_models[0][1]
         return model_ids[0]
 
     if provider == "openai":
-        # Prefer base gpt-N.N (not mini/nano/pro/codex/chat variants)
+        # Prefer base gpt-N.N (not mini/nano/pro/codex/chat variants).
+        # Same tuple-of-ints rationale as the xai branch — guards
+        # against future ``gpt-5.10`` mis-sorting under ``gpt-5.2``.
         base_pattern = re.compile(r"^gpt-(\d+(?:\.\d+)?)(?:-\d+)?$")
-        base_models: list[tuple[float, str]] = []
+        base_models: list[tuple[tuple[int, ...], str]] = []
         for m in model_ids:
             match = base_pattern.match(m)
             if match:
-                version = float(match.group(1))
-                base_models.append((version, m))
+                base_models.append((_version_tuple(match.group(1)), m))
         if base_models:
             base_models.sort(key=lambda x: x[0], reverse=True)
             return base_models[0][1]
         return model_ids[0]
 
     return model_ids[0]
+
+
+def _version_tuple(version_str: str) -> tuple[int, ...]:
+    """Parse a dotted version like ``"4.20"`` into ``(4, 20)`` for
+    correct numeric ordering.
+
+    ``float`` parsing collapses ``"4.20"`` and ``"4.2"`` to the same
+    value, mis-ordering minor-version-20 releases under minor-version-3.
+    Tuple comparison treats each component as an integer so
+    ``(4, 20) > (4, 3)`` as intended.
+    """
+    return tuple(int(p) for p in version_str.split("."))
 
 
 def _extract_context_window(model_obj: Any, provider: str) -> int | None:

--- a/turnstone/core/providers/__init__.py
+++ b/turnstone/core/providers/__init__.py
@@ -16,6 +16,7 @@ from turnstone.core.providers._protocol import (
     ToolCallDelta,
     UsageInfo,
 )
+from turnstone.core.providers._xai import XAI_DEFAULT_BASE_URL, XAIProvider
 
 __all__ = [
     "CompletionResult",
@@ -27,6 +28,7 @@ __all__ = [
     "StreamChunk",
     "ToolCallDelta",
     "UsageInfo",
+    "XAIProvider",
     "create_client",
     "create_provider",
     "list_known_models",
@@ -36,9 +38,13 @@ __all__ = [
 # Singleton instances (stateless, safe to share).  ``_openai_provider``
 # is reused for both cloud OpenAI and ``openai-compatible`` with
 # ``api_surface="responses"`` — see the ``create_provider`` docstring.
+# ``_xai_provider`` is its own singleton because it overrides
+# ``_build_kwargs`` to add ``*_call_output`` includes for xAI's hidden
+# server-tool outputs.
 _provider_lock = threading.Lock()
 _openai_provider = OpenAIResponsesProvider()
 _openai_compat_provider = OpenAIChatCompletionsProvider()
+_xai_provider = XAIProvider()
 _anthropic_provider: LLMProvider | None = None
 _google_provider: LLMProvider | None = None
 
@@ -83,6 +89,8 @@ def create_provider(
         if normalised == "responses":
             return _openai_provider
         return _openai_compat_provider
+    if provider_name == "xai":
+        return _xai_provider
     if provider_name == "anthropic":
         with _provider_lock:
             if _anthropic_provider is None:
@@ -99,19 +107,21 @@ def create_provider(
             return _google_provider
     raise ValueError(
         f"Unknown provider: {provider_name!r}. "
-        "Supported: openai, anthropic, google, openai-compatible"
+        "Supported: openai, anthropic, google, openai-compatible, xai"
     )
 
 
 def create_client(provider_name: str, *, base_url: str, api_key: str) -> Any:
     """Create an SDK client for the given provider."""
-    if provider_name in ("openai", "openai-compatible", "google"):
+    if provider_name in ("openai", "openai-compatible", "google", "xai"):
         from openai import OpenAI
 
         if not base_url and provider_name == "google":
             from turnstone.core.providers._google import GOOGLE_DEFAULT_BASE_URL
 
             base_url = GOOGLE_DEFAULT_BASE_URL
+        elif not base_url and provider_name == "xai":
+            base_url = XAI_DEFAULT_BASE_URL
         if base_url:
             return OpenAI(base_url=base_url, api_key=api_key)
         return OpenAI(api_key=api_key)
@@ -125,7 +135,7 @@ def create_client(provider_name: str, *, base_url: str, api_key: str) -> Any:
         return anthropic.Anthropic(**kwargs)
     raise ValueError(
         f"Unknown provider: {provider_name!r}. "
-        "Supported: openai, anthropic, google, openai-compatible"
+        "Supported: openai, anthropic, google, openai-compatible, xai"
     )
 
 
@@ -162,5 +172,9 @@ def list_known_models(provider: str) -> list[str]:
         from turnstone.core.providers._anthropic import _ANTHROPIC_CAPABILITIES
 
         return sorted(_ANTHROPIC_CAPABILITIES.keys())
+    if provider == "xai":
+        from turnstone.core.providers._xai import GROK_CAPABILITIES
+
+        return sorted(GROK_CAPABILITIES.keys())
     # Google models change frequently — no static table.
     return []

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -728,6 +728,7 @@ class AnthropicProvider:
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> Iterator[StreamChunk]:
         _ensure_anthropic()
         caps = capabilities or self.get_capabilities(model)
@@ -746,6 +747,8 @@ class AnthropicProvider:
             tools,
             deferred_names,
         )
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         manager = client.messages.stream(**kwargs)
         try:
@@ -935,6 +938,7 @@ class AnthropicProvider:
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> CompletionResult:
         _ensure_anthropic()
         caps = capabilities or self.get_capabilities(model)
@@ -953,6 +957,8 @@ class AnthropicProvider:
             tools,
             deferred_names,
         )
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         # Use streaming internally to avoid the Anthropic SDK's 10-minute
         # timeout on non-streaming requests.  get_final_message() returns the

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -178,6 +178,7 @@ class OpenAIChatCompletionsProvider:
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> Iterator[StreamChunk]:
         caps = capabilities or self.get_capabilities(model)
         messages = self._prepare_messages(messages)
@@ -197,6 +198,8 @@ class OpenAIChatCompletionsProvider:
         extra_body = self._finalize_extra_body(extra_params, caps)
         if extra_body:
             kwargs["extra_body"] = extra_body
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         log.debug(
             "openai.chat.request",
@@ -309,6 +312,7 @@ class OpenAIChatCompletionsProvider:
         capabilities: ModelCapabilities | None = None,
         # See create_streaming above for the Phase 2 reasoning-persistence rationale.
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> CompletionResult:
         caps = capabilities or self.get_capabilities(model)
         messages = self._prepare_messages(messages)
@@ -327,6 +331,8 @@ class OpenAIChatCompletionsProvider:
         extra_body = self._finalize_extra_body(extra_params, caps)
         if extra_body:
             kwargs["extra_body"] = extra_body
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         log.debug(
             "openai.chat.request",

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -285,6 +285,22 @@ def apply_cache_retention(kwargs: dict[str, Any], model: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def resolve_server_side_tools(caps: ModelCapabilities) -> list[str]:
+    """Return the effective server-side tool list for *caps*.
+
+    Merges the explicit ``server_side_tools`` tuple with the legacy
+    ``supports_web_search`` boolean so existing capability rows that
+    only set the flag continue to inject ``{"type": "web_search"}``
+    on the Responses surface without an explicit tuple entry.
+
+    Returns a fresh list; callers are free to mutate it.
+    """
+    effective: list[str] = list(caps.server_side_tools)
+    if caps.supports_web_search and "web_search" not in effective:
+        effective.append("web_search")
+    return effective
+
+
 def apply_tool_search(
     caps: ModelCapabilities,
     tools: list[dict[str, Any]] | None,

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -25,6 +25,7 @@ from turnstone.core.providers._openai_common import (
     format_document_wrapper,
     lookup_openai_capabilities,
     resolve_reasoning_effort,
+    resolve_server_side_tools,
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
@@ -336,12 +337,17 @@ class OpenAIResponsesProvider:
         tools = apply_tool_search(caps, tools, deferred_names)
         converted_tools = self._convert_tools(tools, caps)
 
-        # Ensure web search is always injected for search-capable models,
-        # even when no function tools are registered (e.g. creative mode).
-        if caps.supports_web_search:
+        # Auto-inject server-side tools declared on the capability row.
+        # ``resolve_server_side_tools`` merges the legacy
+        # ``supports_web_search`` flag, so search-capable models that
+        # haven't been migrated to the explicit tuple still get
+        # ``{"type": "web_search"}`` appended.  Subclasses (e.g.
+        # ``XAIProvider``) opt their own provider-specific server tools
+        # into ``caps.server_side_tools`` and inherit this injection.
+        for tool_type in resolve_server_side_tools(caps):
             converted_tools = converted_tools or []
-            if not any(t.get("type") == "web_search" for t in converted_tools):
-                converted_tools.append({"type": "web_search"})
+            if not any(t.get("type") == tool_type for t in converted_tools):
+                converted_tools.append({"type": tool_type})
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -397,6 +403,7 @@ class OpenAIResponsesProvider:
         # ``ChatSession._resolve_replay_reasoning_to_model`` — single
         # source of truth across providers.
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> Iterator[StreamChunk]:
         if extra_params:
             log.debug("openai.responses: extra_params ignored (not supported by Responses API)")
@@ -412,6 +419,8 @@ class OpenAIResponsesProvider:
             replay_reasoning_to_model=replay_reasoning_to_model,
         )
         kwargs["stream"] = True
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         log.debug(
             "openai.responses.request",
@@ -581,6 +590,7 @@ class OpenAIResponsesProvider:
         capabilities: ModelCapabilities | None = None,
         # See create_streaming above for the Phase 3 reasoning-persistence rationale.
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> CompletionResult:
         if extra_params:
             log.debug("openai.responses: extra_params ignored (not supported by Responses API)")
@@ -595,6 +605,8 @@ class OpenAIResponsesProvider:
             capabilities=capabilities,
             replay_reasoning_to_model=replay_reasoning_to_model,
         )
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         log.debug(
             "openai.responses.request",

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -86,6 +86,13 @@ class ModelCapabilities:
     supports_web_search: bool = False
     supports_tool_search: bool = False
     supports_vision: bool = False
+    # Server-side tool types to auto-inject into Responses-API ``tools[]``
+    # for this model (e.g. ``("web_search",)`` for OpenAI search models,
+    # ``("web_search", "x_search")`` for Grok variants).  The
+    # OpenAI-facing flag ``supports_web_search`` is implicitly merged in
+    # by ``resolve_server_side_tools`` so legacy capability rows
+    # continue to work without an explicit entry here.
+    server_side_tools: tuple[str, ...] = ()
     thinking_display: str = ""  # "summarized" for models that omit thinking by default
     # Phase 3 reasoning-persistence: gate the per-model
     # ``replay_reasoning_to_model`` flag.  When False, the wire-build
@@ -181,6 +188,7 @@ class LLMProvider(Protocol):
         cancel_ref: list[Any] | None = None,
         capabilities: ModelCapabilities | None = None,
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> Iterator[StreamChunk]:
         """Create a streaming request, yielding normalized StreamChunks.
 
@@ -226,6 +234,7 @@ class LLMProvider(Protocol):
         deferred_names: frozenset[str] | None = None,
         capabilities: ModelCapabilities | None = None,
         replay_reasoning_to_model: bool = True,
+        extra_headers: dict[str, str] | None = None,
     ) -> CompletionResult:
         """Create a non-streaming request, returning a normalized result.
 

--- a/turnstone/core/providers/_xai.py
+++ b/turnstone/core/providers/_xai.py
@@ -1,0 +1,195 @@
+"""xAI / Grok provider — wraps the OpenAI-compatible Responses surface.
+
+xAI exposes ``/v1/responses`` and ``/v1/chat/completions`` at
+``https://api.x.ai/v1`` with OpenAI-compatible wire shapes; the
+comparison page on docs.x.ai marks Chat Completions as deprecated, so
+this adapter targets Responses only.
+
+The class is a thin subclass of :class:`OpenAIResponsesProvider`:
+
+* No tool-call fidelity-lane override is required.  xAI's ``ToolCall``
+  proto carries no analog to Gemini's ``thought_signature`` — only
+  ``id`` / ``type`` / ``status`` / ``error_message`` / ``function``
+  round-trip through tool calls.
+* Encrypted reasoning replay (``include=["reasoning.encrypted_content"]``)
+  inherits unchanged from the base class — the wire shape mirrors
+  OpenAI o-series.
+* ``parallel_tool_calls`` and ``tool_choice`` shapes match OpenAI
+  exactly, so no per-request rewriting.
+
+Two xAI-specific extensions over the inherited Responses behaviour:
+
+1. **Hidden server-side tool outputs.**  xAI executes ``web_search`` /
+   ``x_search`` / ``code_execution`` / ``collections_search`` on its
+   servers but omits their outputs from the response body by default;
+   callers must opt in via ``include=["<tool>_call_output"]``.  We
+   inject the appropriate ``*_call_output`` strings whenever the
+   capability row declares matching ``server_side_tools``.
+2. **Prompt-cache hinting.**  The ``x-grok-conv-id`` request header
+   maximises cache-hit rate on multi-turn conversations.  This module
+   does not populate it; callers thread it via ``extra_headers`` on
+   :meth:`create_streaming` / :meth:`create_completion` once they
+   know the workstream id.
+
+A static :data:`GROK_CAPABILITIES` table covers the five chat models
+listed at docs.x.ai/developers/models (May 2026).  Aliases such as
+``grok-4.3-latest`` resolve via the existing longest-prefix lookup.
+Bare family aliases (``grok-4``, ``grok-3``) fall through to a
+conservative default so undocumented IDs do not silently inherit
+reasoning-replay behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from turnstone.core.providers._openai_common import resolve_server_side_tools
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.providers._protocol import ModelCapabilities, _lookup_capabilities
+
+# Default endpoint used when no base_url is configured.
+XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
+
+
+# ---------------------------------------------------------------------------
+# Capability table — chat models from docs.x.ai/developers/models (May 2026).
+# ---------------------------------------------------------------------------
+
+GROK_CAPABILITIES: dict[str, ModelCapabilities] = {
+    # grok-4.3 — flagship reasoning model.  Default effort is "low" per
+    # docs.x.ai/developers/model-capabilities/text/reasoning; "none"
+    # disables reasoning entirely (zero thinking tokens).
+    "grok-4.3": ModelCapabilities(
+        context_window=1_000_000,
+        max_output_tokens=64_000,
+        reasoning_effort_values=("none", "low", "medium", "high"),
+        default_reasoning_effort="low",
+        supports_web_search=True,
+        supports_vision=True,
+        supports_reasoning_replay=True,
+        server_side_tools=("web_search",),
+    ),
+    # grok-4.20 reasoning variant — dated snapshot, always reasons.
+    "grok-4.20-0309-reasoning": ModelCapabilities(
+        context_window=1_000_000,
+        max_output_tokens=64_000,
+        supports_web_search=True,
+        supports_vision=True,
+        supports_reasoning_replay=True,
+        server_side_tools=("web_search",),
+    ),
+    # grok-4.20 non-reasoning variant — dated snapshot, never reasons.
+    "grok-4.20-0309-non-reasoning": ModelCapabilities(
+        context_window=1_000_000,
+        max_output_tokens=64_000,
+        supports_web_search=True,
+        supports_vision=True,
+        server_side_tools=("web_search",),
+    ),
+    # grok-4.20 multi-agent — effort controls *agent count*, not depth.
+    "grok-4.20-multi-agent-0309": ModelCapabilities(
+        context_window=1_000_000,
+        max_output_tokens=64_000,
+        reasoning_effort_values=("low", "medium", "high", "xhigh"),
+        default_reasoning_effort="low",
+        supports_web_search=True,
+        supports_vision=True,
+        supports_reasoning_replay=True,
+        server_side_tools=("web_search",),
+    ),
+    # grok-build — coding-focused, smaller context, no reasoning.
+    "grok-build-0.1": ModelCapabilities(
+        context_window=256_000,
+        max_output_tokens=64_000,
+        supports_web_search=True,
+        server_side_tools=("web_search",),
+    ),
+}
+
+# Conservative default for unknown / family-alias model IDs (grok-4,
+# grok-3, grok-4-fast, etc.).  Capabilities the caller cannot verify
+# without a live call (vision, reasoning replay) stay off; web search
+# stays on because it is the only documented xAI server-side tool we
+# inject today and undocumented IDs are likely future grok variants
+# that still support it.  If the API rejects the request, the error
+# surfaces to the caller directly.
+_GROK_DEFAULT = ModelCapabilities(
+    context_window=256_000,
+    max_output_tokens=64_000,
+    supports_web_search=True,
+    server_side_tools=("web_search",),
+)
+
+
+def lookup_grok_capabilities(model: str) -> ModelCapabilities:
+    """Find capabilities for *model* by longest prefix match."""
+    return _lookup_capabilities(model, GROK_CAPABILITIES, _GROK_DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class XAIProvider(OpenAIResponsesProvider):
+    """Provider for xAI / Grok models via the OpenAI-compatible Responses API.
+
+    Subclasses :class:`OpenAIResponsesProvider` and adds two narrow
+    behaviours specific to xAI's surface; see the module docstring.
+    """
+
+    @property
+    def provider_name(self) -> str:
+        return "xai"
+
+    def get_capabilities(self, model: str) -> ModelCapabilities:
+        return lookup_grok_capabilities(model)
+
+    # -- request kwargs ------------------------------------------------------
+
+    def _build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+        temperature: float,
+        reasoning_effort: str,
+        deferred_names: frozenset[str] | None,
+        capabilities: ModelCapabilities | None = None,
+        replay_reasoning_to_model: bool = True,
+    ) -> dict[str, Any]:
+        """Add ``include=["<tool>_call_output"]`` entries on top of the
+        base Responses kwargs.
+
+        xAI omits server-side tool outputs from the response body by
+        default; the matching ``*_call_output`` include string must be
+        sent for the caller to see what the tool actually did.  The
+        base ``OpenAIResponsesProvider`` already adds
+        ``reasoning.encrypted_content`` to ``include[]`` when
+        replay is enabled, so we merge into the existing list rather
+        than replace it.
+        """
+        kwargs = super()._build_kwargs(
+            model,
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            reasoning_effort,
+            deferred_names,
+            capabilities=capabilities,
+            replay_reasoning_to_model=replay_reasoning_to_model,
+        )
+        caps = capabilities or self.get_capabilities(model)
+        effective_tools = resolve_server_side_tools(caps)
+        if not effective_tools:
+            return kwargs
+        includes = list(kwargs.get("include") or [])
+        for tool_type in effective_tools:
+            output_include = f"{tool_type}_call_output"
+            if output_include not in includes:
+                includes.append(output_include)
+        if includes:
+            kwargs["include"] = includes
+        return kwargs


### PR DESCRIPTION
## Summary

Adds xAI as a first-class commercial provider through the officially-documented server-to-server API-key path against `https://api.x.ai/v1`. No OAuth / SuperGrok / X-Premium+ paths.

`XAIProvider` is a thin subclass of `OpenAIResponsesProvider`; xAI's Responses surface is OpenAI-shaped, so the only override needed is `_build_kwargs`, which merges `<tool>_call_output` strings into `include[]` so xAI's server-side tool outputs (hidden by default) become visible. `GROK_CAPABILITIES` covers the five documented chat models; aliases like `grok-4.3-latest` resolve via the existing longest-prefix lookup.

Two narrow base-class generalisations earn their keep beyond Grok:

- `ModelCapabilities.server_side_tools: tuple[str, ...]` drives the Responses-surface tool injection (previously a hardcoded `web_search` block). `resolve_server_side_tools` folds in the legacy `supports_web_search` boolean for backward compat — no migration churn on the existing OpenAI search-capable entries.
- `extra_headers: dict[str, str] | None` threaded through `LLMProvider.create_streaming` / `create_completion` so callers can pass `x-grok-conv-id: <ws_id>` for prompt-cache hit-rate. Session-side population is a follow-up; the plumbing lands here.

## Out of scope

- OAuth (SuperGrok / X-Premium+) — not officially documented.
- Chat Completions surface — marked Deprecated on xAI's surface comparison page.
- Image / voice / video models (`grok-imagine-*`, Voice API).
- argparse `--provider xai` in `cli.py` / `server.py` — Google isn't there either; both providers configure via `config.toml`.
- Server-side `x_search` / `code_execution` / `collections_search` / `mcp` / `attachment_search` enablement — capability hooks land here but operator-facing wiring is a follow-on PR.

## Test plan

- [x] Unit tests at `tests/test_provider_xai.py` — 27 cases covering capability-table prefix-match, `server_side_tools` injection, `*_call_output` include merge, `extra_headers` forwarding through Responses + Chat providers, hostname detection, and end-to-end wiring (`create_provider` / `create_client` / `list_known_models` / `lookup_model_capabilities`).
- [x] Full provider regression suite — 291 existing provider tests pass.
- [x] Full test suite — 6668 passed, 7 skipped (live-API gated), 0 failures.
- [x] `ruff check turnstone/ tests/` clean.
- [x] `mypy turnstone/ tests/test_provider_xai.py` clean.
- [ ] Live smoke test against a paid `XAI_API_KEY` — gated by the env var; would clear three still-`UNCERTAIN` items from the boundary spike (mid-conversation `reasoning_effort` switching, 429 retry-after header format, unknown-model-ID error shape). Not blocking — conservative defaults handle all three.

Closes #583.