### PR TITLE
fix(console-ui): converge settings-help-btn on data-help-target (#582)

### DIFF
--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2867,12 +2867,9 @@ function _renderSettings(container, grouped) {
       _onSettingsHeaderKey(e, this);
     });
   }
-  const helpBtns = container.querySelectorAll(".settings-help-btn");
-  for (let hb = 0; hb < helpBtns.length; hb++) {
-    helpBtns[hb].addEventListener("click", function (e) {
-      _toggleSettingsHelp(e, this);
-    });
-  }
+  // Help-button clicks are handled by the document-delegated listener
+  // below; no per-button binding is needed here (and re-binding on each
+  // render would leak listeners onto reused DOM).
 
   // Store original values for dirty detection + wire per-key change
   // handlers off data-setting-key (no key interpolation into JS).
@@ -2914,27 +2911,39 @@ function _renderSettingRow(item) {
   const escapedShort = escapeHtml(shortKey);
   const escapedDesc = escapeHtml(item.description);
 
+  // Description (short TLDR) renders inline below the key.  The ? button
+  // gates the long-form help paragraph + any reference_url link.
+  const hasHelp = !!(item.help || item.reference_url);
+  const helpId = escapedKey + "-help";
+
   let html = '<div class="settings-row" data-row-key="' + escapedKey + '">';
 
   // Label column
   html += '<div class="settings-label-col">';
   html += '<div class="settings-label">';
   html += escapeHtml(shortKey);
-  if (item.help) {
+  if (hasHelp) {
     html +=
-      ' <button class="settings-help-btn" ' +
-      'aria-label="Help for ' +
+      ' <button type="button" class="settings-help-btn" ' +
+      'data-help-target="' +
+      helpId +
+      '" aria-label="Help for ' +
       escapedShort +
-      '" aria-expanded="false" title="More info">?</button>';
+      '" aria-expanded="false" title="More info"></button>';
   }
   html += "</div>";
   if (item.description) {
     html += '<div class="settings-desc">' + escapedDesc + "</div>";
   }
-  if (item.help) {
-    html += '<div class="settings-help-popover" style="display:none">';
+  if (hasHelp) {
     html +=
-      '<span class="settings-help-text">' + escapeHtml(item.help) + "</span>";
+      '<div id="' +
+      helpId +
+      '" class="settings-help-popover" style="display:none">';
+    if (item.help) {
+      html +=
+        '<span class="settings-help-text">' + escapeHtml(item.help) + "</span>";
+    }
     if (item.reference_url) {
       html +=
         ' <a href="' +
@@ -3075,19 +3084,9 @@ function _toggleSettingsHelp(e, btn) {
   // the button click itself (irrelevant for type="button" but cheap insurance).
   e.stopPropagation();
   e.preventDefault();
-  // Two lookup paths:
-  //   (a) data-help-target="popover-id" — used by the skill modals where
-  //       the popover is a sibling of the label, not wrapped in a column.
-  //   (b) Ancestor .settings-label-col → child .settings-help-popover —
-  //       the original Settings-tab structure.
   const targetId = btn.getAttribute("data-help-target");
-  let popover = null;
-  if (targetId) {
-    popover = document.getElementById(targetId);
-  } else {
-    const col = btn.closest(".settings-label-col");
-    if (col) popover = col.querySelector(".settings-help-popover");
-  }
+  if (!targetId) return;
+  const popover = document.getElementById(targetId);
   if (!popover) return;
   const isVisible = popover.style.display !== "none";
   _closeAllSettingsHelp(popover);
@@ -3095,10 +3094,9 @@ function _toggleSettingsHelp(e, btn) {
   btn.setAttribute("aria-expanded", isVisible ? "false" : "true");
 }
 
-// Document-delegated click handler for help buttons that opt in via
-// ``data-help-target``.  Settings-tab buttons keep their per-button
-// listeners (bound at render time) so this only fires for the static-HTML
-// buttons in the skill modals.  Bound once at module load.
+// Single document-delegated handler for every .settings-help-btn — both the
+// settings-tab buttons emitted by _renderSettingRow and the static skill-modal
+// buttons in index.html.  Bound once at module load.
 document.addEventListener("click", function (e) {
   const btn = e.target.closest(".settings-help-btn[data-help-target]");
   if (btn) _toggleSettingsHelp(e, btn);
@@ -3110,21 +3108,10 @@ function _closeAllSettingsHelp(except) {
     if (allOpen[i] === except) continue;
     const popover = allOpen[i];
     popover.style.display = "none";
-    // Reverse-resolve the button so we can clear aria-expanded.  Two paths,
-    // mirroring _toggleSettingsHelp's lookup:
-    //   (a) Skill modals — button sits outside .settings-label-col but its
-    //       data-help-target attribute points at this popover's id.
-    //   (b) Settings tab — button is a sibling inside .settings-label-col.
-    let helpBtn = null;
-    if (popover.id) {
-      helpBtn = document.querySelector(
-        '.settings-help-btn[data-help-target="' + popover.id + '"]',
-      );
-    }
-    if (!helpBtn) {
-      const col = popover.closest(".settings-label-col");
-      if (col) helpBtn = col.querySelector(".settings-help-btn");
-    }
+    if (!popover.id) continue;
+    const helpBtn = document.querySelector(
+      '.settings-help-btn[data-help-target="' + popover.id + '"]',
+    );
     if (helpBtn) helpBtn.setAttribute("aria-expanded", "false");
   }
 }

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -3770,20 +3770,47 @@ function renderJudgeSettings() {
         '">Reset</button>'
       : "";
 
+    // Short description (TLDR) renders inline below the key.  The ? button
+    // gates the long-form help paragraph — mirrors the pattern in
+    // admin.js:_renderSettingRow so the document-delegated click handler
+    // picks it up automatically.
+    const helpId = eKey + "-help";
+    const helpBtn = s.help
+      ? ' <button type="button" class="settings-help-btn"' +
+        ' data-help-target="' +
+        helpId +
+        '" aria-label="Help for ' +
+        escapeHtml(shortKey) +
+        '" aria-expanded="false" title="More info"></button>'
+      : "";
+    const descBlock = s.description
+      ? '<div style="font-size:11px;color:var(--fg-dim);margin-bottom:5px">' +
+        escapeHtml(s.description) +
+        "</div>"
+      : "";
+    const helpPopover = s.help
+      ? '<div id="' +
+        helpId +
+        '" class="settings-help-popover" style="display:none;margin-bottom:5px">' +
+        '<span class="settings-help-text">' +
+        escapeHtml(s.help) +
+        "</span></div>"
+      : "";
+
     html +=
       '<div style="margin-bottom:12px;padding-bottom:10px;border-bottom:1px solid var(--border-strong)">' +
       '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">' +
       '<code style="font-size:12px;font-weight:600;color:var(--fg)">' +
       shortKey +
       "</code>" +
+      helpBtn +
       (isDefault
         ? '<span style="font-size:11px;color:var(--fg-dim)">default</span>'
         : '<span style="font-size:11px;color:var(--green)">customized</span>') +
       resetBtn +
       "</div>" +
-      '<div style="font-size:11px;color:var(--fg-dim);margin-bottom:5px">' +
-      escapeHtml(s.help || s.description || "") +
-      "</div>" +
+      descBlock +
+      helpPopover +
       inputHtml +
       "</div>";
   }

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1049,11 +1049,21 @@
                   </div>
                 </div>
                 <label for="hr-tool"
-                  >Tool Pattern
-                  <span class="label-hint"
-                    >fnmatch syntax: bash, write_file, mcp__*</span
-                  ></label
+                  >Tool Pattern<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="hr-tool-help"
+                    aria-label="Help for Tool Pattern"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="hr-tool-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  fnmatch syntax: bash, write_file, mcp__*
+                </div>
                 <input
                   id="hr-tool"
                   type="text"
@@ -1062,17 +1072,44 @@
                   spellcheck="false"
                 />
                 <label for="hr-args"
-                  >Arg Patterns
-                  <span class="label-hint">one regex per line</span></label
+                  >Arg Patterns<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="hr-args-help"
+                    aria-label="Help for Arg Patterns"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="hr-args-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  One regex per line. Each pattern is matched against the
+                  serialized tool arguments.
+                </div>
                 <textarea
                   id="hr-args"
                   rows="3"
                   style="font-family: var(--font-mono); font-size: 12px"
                 ></textarea>
                 <label for="hr-conf"
-                  >Confidence <span class="label-hint">0.0 – 1.0</span></label
+                  >Confidence<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="hr-conf-help"
+                    aria-label="Help for Confidence"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="hr-conf-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  Rule confidence between 0.0 and 1.0. Higher values mean the
+                  rule is more certain when it matches.
+                </div>
                 <input
                   id="hr-conf"
                   type="number"
@@ -1191,11 +1228,22 @@
                   autocomplete="off"
                 />
                 <label for="ogp-flags"
-                  >Pattern Flags
-                  <span class="label-hint"
-                    >comma-separated: IGNORECASE, MULTILINE, DOTALL</span
-                  ></label
+                  >Pattern Flags<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="ogp-flags-help"
+                    aria-label="Help for Pattern Flags"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="ogp-flags-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  Comma-separated regex compilation flags: IGNORECASE,
+                  MULTILINE, DOTALL.
+                </div>
                 <input id="ogp-flags" type="text" autocomplete="off" />
                 <div style="display: flex; gap: 16px; margin: 8px 0">
                   <label
@@ -1286,11 +1334,21 @@
                   </div>
                 </div>
                 <label for="ehr-tool"
-                  >Tool Pattern
-                  <span class="label-hint"
-                    >fnmatch syntax: bash, write_file, mcp__*</span
-                  ></label
+                  >Tool Pattern<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="ehr-tool-help"
+                    aria-label="Help for Tool Pattern"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="ehr-tool-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  fnmatch syntax: bash, write_file, mcp__*
+                </div>
                 <input
                   id="ehr-tool"
                   type="text"
@@ -1298,17 +1356,44 @@
                   spellcheck="false"
                 />
                 <label for="ehr-args"
-                  >Arg Patterns
-                  <span class="label-hint">one regex per line</span></label
+                  >Arg Patterns<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="ehr-args-help"
+                    aria-label="Help for Arg Patterns"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="ehr-args-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  One regex per line. Each pattern is matched against the
+                  serialized tool arguments.
+                </div>
                 <textarea
                   id="ehr-args"
                   rows="3"
                   style="font-family: var(--font-mono); font-size: 12px"
                 ></textarea>
                 <label for="ehr-conf"
-                  >Confidence <span class="label-hint">0.0 – 1.0</span></label
+                  >Confidence<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="ehr-conf-help"
+                    aria-label="Help for Confidence"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="ehr-conf-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  Rule confidence between 0.0 and 1.0. Higher values mean the
+                  rule is more certain when it matches.
+                </div>
                 <input
                   id="ehr-conf"
                   type="number"
@@ -1412,11 +1497,22 @@
                 <label for="eogp-ann">Annotation</label>
                 <input id="eogp-ann" type="text" autocomplete="off" />
                 <label for="eogp-flags"
-                  >Pattern Flags
-                  <span class="label-hint"
-                    >comma-separated: IGNORECASE, MULTILINE, DOTALL</span
-                  ></label
+                  >Pattern Flags<button
+                    type="button"
+                    class="settings-help-btn"
+                    data-help-target="eogp-flags-help"
+                    aria-label="Help for Pattern Flags"
+                    aria-expanded="false"
+                  ></button
+                ></label>
+                <div
+                  id="eogp-flags-help"
+                  class="settings-help-popover"
+                  style="display: none"
                 >
+                  Comma-separated regex compilation flags: IGNORECASE,
+                  MULTILINE, DOTALL.
+                </div>
                 <input id="eogp-flags" type="text" autocomplete="off" />
                 <div style="display: flex; gap: 16px; margin: 8px 0">
                   <label
@@ -3068,8 +3164,7 @@
                   data-help-target="skill-compatibility-help"
                   aria-label="Help for Compatibility"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3093,8 +3188,7 @@
                   data-help-target="skill-paths-help"
                   aria-label="Help for Paths"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3121,8 +3215,7 @@
                     data-help-target="skill-hidden-from-menu-help"
                     aria-label="Help for Hide from skill picker"
                     aria-expanded="false"
-                  >
-                    ?</button
+                  ></button
                   ></span
                 >
               </label>
@@ -3143,8 +3236,7 @@
                   data-help-target="skill-arguments-help"
                   aria-label="Help for Arguments"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3168,8 +3260,7 @@
                   data-help-target="skill-argument-hint-help"
                   aria-label="Help for Argument hint"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3197,8 +3288,7 @@
                   data-help-target="skill-activation-help"
                   aria-label="Help for Activation"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3513,8 +3603,7 @@
                   data-help-target="etm-compatibility-help"
                   aria-label="Help for Compatibility"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3538,8 +3627,7 @@
                   data-help-target="etm-paths-help"
                   aria-label="Help for Paths"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3566,8 +3654,7 @@
                     data-help-target="etm-hidden-from-menu-help"
                     aria-label="Help for Hide from skill picker"
                     aria-expanded="false"
-                  >
-                    ?</button
+                  ></button
                   ></span
                 >
               </label>
@@ -3588,8 +3675,7 @@
                   data-help-target="etm-arguments-help"
                   aria-label="Help for Arguments"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3613,8 +3699,7 @@
                   data-help-target="etm-argument-hint-help"
                   aria-label="Help for Argument hint"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div
@@ -3642,8 +3727,7 @@
                   data-help-target="etm-activation-help"
                   aria-label="Help for Activation"
                   aria-expanded="false"
-                >
-                  ?</button
+                ></button
                 ></label
               >
               <div

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -3548,13 +3548,7 @@ textarea.skill-content-area {
   background: var(--yellow-glow);
 }
 
-/* Help tooltip.  The glyph is painted by ``::after`` rather than HTML
-   text content so the button renders identically whether the markup
-   has literal ``>?</button>`` text (settings-tab buttons assembled in
-   admin.js) or prettier-introduced whitespace around the glyph (skill
-   modal buttons in index.html).  Any literal text content is hidden
-   via ``font-size: 0`` on the button; the pseudo restores its own
-   size so the glyph centers cleanly via flex. */
+/* Help tooltip.  Glyph painted via ``::after``; button content stays empty. */
 .settings-help-btn {
   display: inline-flex;
   align-items: center;
@@ -3565,7 +3559,6 @@ textarea.skill-content-area {
   border: 1px solid var(--accent);
   background: var(--accent-dim);
   color: var(--accent);
-  font-size: 0;
   font-weight: 600;
   font-family: var(--font-ui);
   cursor: pointer;


### PR DESCRIPTION
Closes #582.

Settings-tab buttons assembled in admin.js and the skill-modal buttons in index.html used two parallel rendering shapes with two binding mechanisms (per-button `addEventListener` vs. document delegation). Listeners stacked on the same DOM whenever the Settings tab re-rendered.

## Convergence

- `_renderSettingRow` emits empty `<button>` with `data-help-target` and gives the sibling popover a matching `id`. Per-button listener loop in `_renderSettings` removed.
- `_toggleSettingsHelp` and `_closeAllSettingsHelp` drop their `.settings-label-col` fallback branches; `data-help-target` reverse lookup is the only path.
- 12 skill-modal buttons in index.html lose their literal `?` text so every emitter produces empty content.
- `font-size: 0` on `.settings-help-btn` removed (workaround was load-bearing only while one emitter still had literal text).

## Judge admin polish

While in the area, 8 `.label-hint` spans in the Create/Edit Heuristic Rule and Create/Edit Output Guard Pattern modals (Tool Pattern, Arg Patterns, Confidence, Pattern Flags) become `?` + popover for consistency with the Settings tab. Short `.label-hint` strings elsewhere in the admin UI are unchanged.

## What didn't change

Description rows (the short TLDR under each key) stay inline. The `?` popover carries only the long-form `help` paragraph and any `reference_url` learn-more link — this keeps the at-a-glance TLDR available without forcing a click for short text.

## Test plan

- [ ] Settings tab: click `?` on a row with `help` (e.g. `model.temperature`) — popover opens; click again — closes; click another row's `?` — first closes, second opens.
- [ ] Settings tab: rows without `help` (e.g. `judge.timeout`) show no `?` button and keep their inline description.
- [ ] Skill modals (Create + Edit): all 6 `?` buttons per modal still toggle their popovers.
- [ ] Judge → Heuristic Rules → + Add rule: Tool Pattern / Arg Patterns / Confidence each toggle help.
- [ ] Judge → Output Guard → + Add pattern: Pattern Flags toggles help.
- [ ] Escape closes any open popover.
- [ ] No stacked listeners after switching off and back to the Settings tab (open DevTools elements panel, inspect a `.settings-help-btn` — only delegated listeners should be present).