### PR TITLE
feat(tools): make notify dual-kind, expose to coordinator sessions (#559)

### DIFF
--- a/docs/coordinator-skills.md
+++ b/docs/coordinator-skills.md
@@ -77,6 +77,8 @@ or MCP config can do adds to it.  Current members:
 | `delete_workstream`       | wind-down       | Hard-delete one child.  Requires approval.                          |
 | `list_nodes`              | discover        | Enumerate live cluster nodes + capabilities.                        |
 | `skills` (action=find)    | discover        | Browse the skill catalog; opt-in `kind` filter narrows by audience. |
+| `memory`                  | persist         | Orchestration scratchpad keyed by the `coordinator` scope.          |
+| `notify`                  | broadcast       | Post a status update to a human channel at a narrative beat.        |
 | `tasks`                   | plan            | Orchestrator-only scratchpad.  Children don't see it.               |
 
 Explicitly **not** in the coordinator set:
@@ -85,7 +87,7 @@ Explicitly **not** in the coordinator set:
 - `read_file` / `search` — no local FS reads.
 - `web_fetch` / `web_search` — no direct web access.
 - `task_agent` / `plan_agent` — sub-agent tools are zeroed on coord sessions.
-- `memory` / `recall` / `notify` / `watch` / `read_resource` / `use_prompt` / `skill` — the orchestrator's "memory" is its children's outputs; these UX / persistence tools belong to interactive sessions.
+- `recall` / `watch` / `read_resource` / `use_prompt` — UX / persistence tools that belong to interactive sessions.  The dual-kind `memory` / `skills` / `notify` tools are available on both kinds (see the table above).
 
 If your skill needs a coordinator to "run a command" or "read a
 file", write the delegate pattern instead: spawn a child with an

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from turnstone.core.session import ChatSession
+from turnstone.core.storage._sqlite import SQLiteBackend
 from turnstone.prompts import ClientType
 
 
@@ -149,6 +150,11 @@ def test_coordinator_session_uses_coordinator_tools(coord_session):
         # Dual-kind (interactive + coordinator) — read actions auto-approve
         # on both; writes gate on ``model.skills.write``.
         "skills",
+        # ``notify`` joined the coord set in 1.6.0 — orchestrators have
+        # natural "fan-out complete" / "batch failed" beats worth
+        # surfacing to a human channel without spawning a child purely
+        # to ship the message.  Routing is session-kind-agnostic.
+        "notify",
     }
     # Sub-agent tool sets are zeroed on coordinator sessions.
     assert sess._task_tools == []
@@ -1683,3 +1689,68 @@ def test_close_all_children_prepare_errors_when_coord_client_unavailable(coord_s
     item = sess._prepare_tool(_tc("close_all_children", {}))
     assert "error" in item
     assert "unavailable" in item["error"]
+
+
+# ---------------------------------------------------------------------------
+# notify — dual-kind invocability on coordinator sessions
+# ---------------------------------------------------------------------------
+#
+# notify joined the coord toolset so orchestrators can post status updates
+# at narrative beats (fan-out complete, batch failed, phase done) without
+# spawning a child purely to ship a message. _prepare_notify / _exec_notify
+# are session-kind-agnostic — the routing logic is identical to interactive
+# sessions; these tests pin the coord-side dispatch wiring.
+
+
+def test_notify_prepare_on_coord_session_dispatches_cleanly(coord_session):
+    """A coord session can reach _prepare_notify via the standard
+    dispatcher and produce a well-formed execute item."""
+    sess, _coord, _ui = coord_session
+    item = sess._prepare_tool(
+        _tc(
+            "notify",
+            {"message": "fan-out of 3 children complete", "username": "admin"},
+        )
+    )
+    assert "error" not in item
+    assert item["func_name"] == "notify"
+    assert item["execute"].__func__ is ChatSession._exec_notify
+    assert item["message"] == "fan-out of 3 children complete"
+    assert item["username"] == "admin"
+    # notify carries ``auto_approve: true`` in notify.json and
+    # ``_prepare_notify`` hardcodes ``needs_approval: False`` — pin the
+    # auto-approve contract on the coord surface so a future change that
+    # tightens approval semantics has to update this test deliberately.
+    assert item["needs_approval"] is False
+
+
+def test_notify_exec_on_coord_session_sends_via_channel_gateway(coord_session, tmp_path):
+    """End-to-end: coord-session notify reaches the channel gateway path
+    with the same payload shape an interactive session would emit."""
+    sess, _coord, _ui = coord_session
+    storage = SQLiteBackend(str(tmp_path / "test.db"))
+    storage.register_service("channel", "ch-1", "http://localhost:8091")
+
+    item = sess._prepare_tool(
+        _tc(
+            "notify",
+            {"message": "batch failed on child-x", "username": "admin"},
+        )
+    )
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "results": [{"channel_type": "discord", "channel_id": "123", "status": "sent"}]
+    }
+    with (
+        patch("turnstone.core.session.get_storage", return_value=storage),
+        patch("turnstone.core.session.httpx.post", return_value=mock_resp) as mock_post,
+    ):
+        call_id, msg = sess._exec_notify(item)
+
+    assert call_id == "call-1"
+    assert "sent successfully" in msg.lower()
+    post_kwargs = mock_post.call_args.kwargs
+    assert post_kwargs["json"]["target"] == {"username": "admin"}
+    assert post_kwargs["json"]["message"] == "batch failed on child-x"
+    assert post_kwargs["json"]["ws_id"] == "coord-1"

--- a/tests/test_tools_schema.py
+++ b/tests/test_tools_schema.py
@@ -86,7 +86,7 @@ class TestToolsMetadata:
     def test_coordinator_tools_count(self):
         from turnstone.core.tools import COORDINATOR_TOOLS
 
-        assert len(COORDINATOR_TOOLS) == 14
+        assert len(COORDINATOR_TOOLS) == 15
         assert {t["function"]["name"] for t in COORDINATOR_TOOLS} == {
             "spawn_workstream",
             "spawn_batch",
@@ -111,6 +111,11 @@ class TestToolsMetadata:
             # coord sessions — coords delegate skill assignment via
             # ``spawn_workstream(skill=...)``.
             "skills",
+            # ``notify`` is dual-kind so coordinators can post status
+            # updates at narrative beats (fan-out complete, batch
+            # failed, phase done) without spawning a child purely to
+            # ship a message.  Routing logic is session-kind-agnostic.
+            "notify",
         }
 
     def test_auto_approve_sets_match(self):

--- a/tests/test_workstream_kind.py
+++ b/tests/test_workstream_kind.py
@@ -281,8 +281,10 @@ def test_interactive_and_coordinator_tool_sets_overlap_only_on_dual_kind():
     # joined in 1.6.0 (replaces legacy ``skill`` + ``list_skills``) — read
     # actions auto-approve on both kinds, write actions gate on
     # ``model.skills.write`` permission, and ``load`` errors on coord
-    # sessions where it doesn't apply.
-    dual_kind = {"memory", "skills"}
+    # sessions where it doesn't apply.  ``notify`` joined in 1.6.0 so
+    # coords can post status updates at narrative beats without spawning
+    # a child purely to ship a message.
+    dual_kind = {"memory", "skills", "notify"}
 
     overlap = interactive_names & coord_names
     assert overlap == dual_kind, (

--- a/turnstone/prompts/tools_coordinator.md
+++ b/turnstone/prompts/tools_coordinator.md
@@ -45,3 +45,6 @@ Plan and track work → tasks (your scratchpad; children don't see it):
    tasks(action='add', title='audit auth.py for CSRF')
    tasks(action='update', task_id='t_03', status='in_progress')
    tasks(action='remove', task_id='t_03')
+
+Post a status update to a human channel at a narrative beat → notify (after close_all_children, on batch failure, on phase done):
+   notify(username='admin', message='fan-out of 5 children complete — synthesis attached')

--- a/turnstone/tools/notify.json
+++ b/turnstone/tools/notify.json
@@ -30,6 +30,8 @@
   },
   "agent": true,
   "task_agent": true,
+  "coordinator": true,
+  "interactive": true,
   "auto_approve": true,
   "primary_key": "message"
 }


### PR DESCRIPTION
Closes #559.

## Summary

- `notify` was interactive-only. A coordinator session with a natural "fan-out complete" / "batch failed" beat had no path to post other than spawning a child for the single message — a lot of ceremony for one line of status.
- `_prepare_notify` / `_exec_notify` in `turnstone/core/session.py` are session-kind-agnostic; this is a metadata flip plus test + doc updates, no runtime changes.
- Establishes notify alongside `memory` and `skills` as a dual-kind tool — both `coordinator: true` and `interactive: true` flags set explicitly so the tools.py loader keeps it on both surfaces.

## Changes

- `turnstone/tools/notify.json` — add `coordinator: true` + `interactive: true`
- `tests/test_tools_schema.py` — bump `COORDINATOR_TOOLS` count 14 → 15, add `notify` to expected set
- `tests/test_workstream_kind.py` — add `notify` to the `dual_kind` whitelist for the interactive ∩ coordinator overlap check
- `tests/test_coordinator_tools.py` — add `notify` to the coord tool-set assertion; two new tests:
  - `test_notify_prepare_on_coord_session_dispatches_cleanly` — pins `needs_approval=False` (matches notify.json's `auto_approve: true`, intentionally diverges from the issue's acceptance text which misstates the contract)
  - `test_notify_exec_on_coord_session_sends_via_channel_gateway` — end-to-end from prepare through channel-gateway HTTP, asserting payload shape matches the interactive path
- `docs/coordinator-skills.md` — add `memory` + `notify` rows to the coord tool table; drop `memory` / `notify` / `skill` from the "Explicitly not in coord" exclusion list (the old list was stale post-#555/#557 for memory + skills and now picks up notify too)
- `turnstone/prompts/tools_coordinator.md` — one-line `notify(...)` example for the orchestrator persona

## Test plan

- [x] `pytest tests/test_tools_schema.py tests/test_workstream_kind.py tests/test_coordinator_tools.py tests/test_notify_tool.py tests/test_coordinator_end_to_end.py` — 171 pass
- [x] `pytest tests/test_session.py tests/test_skills_tool.py tests/test_tool_search.py tests/test_tool_policy.py tests/test_tool_advisory.py` — 405 pass (broader sanity)
- [x] `ruff check turnstone/ tests/` — clean
- [x] Reviewed via 2-channel `/review` pipeline (bug + quality finders); 3 minor/nit findings surfaced and addressed in this PR (assertion convention, doc clause split, inline-import lift)

## Acceptance criteria (from issue)

- [x] `len(COORDINATOR_TOOLS) == 15`
- [x] Coord-session test confirms notify is invokable + executes (mocks channel-send path); approval-prompt language in the issue was contradicted by the implementation — test pins the actual `needs_approval=False` contract with a comment explaining the divergence
- [x] `docs/coordinator-skills.md` exclusion list no longer lies — drops `notify` + `memory` + `skill`