### PR TITLE
feat(providers): add Claude Opus 4.8 model support

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1265,6 +1265,33 @@ class TestAnthropicHelpers:
         assert caps.token_param == "max_tokens"
         assert caps.thinking_mode == "adaptive"
 
+    def test_capabilities_opus_4_8(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-opus-4-8")
+        assert caps.context_window == 1000000
+        assert caps.max_output_tokens == 128000
+        assert caps.thinking_mode == "adaptive"
+        assert caps.supports_effort is True
+        assert "xhigh" in caps.effort_levels
+        assert "max" in caps.effort_levels
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.supports_web_search is True
+        assert caps.supports_tool_search is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning_replay is True
+
+    def test_capabilities_opus_4_8_dated(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-opus-4-8-20260601")
+        assert caps.context_window == 1000000
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+
     def test_capabilities_opus_4_7(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
 

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -54,7 +54,7 @@
 # supports_web_search = false
 #
 # [models.claude]
-# name = "claude-opus-4-7"
+# name = "claude-opus-4-8"
 # provider = "anthropic"
 
 # --- Database (turnstone, node, console) ---

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -85,6 +85,20 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 )
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
+    "claude-opus-4-8": ModelCapabilities(
+        context_window=1000000,
+        max_output_tokens=128000,
+        token_param="max_tokens",
+        thinking_mode="adaptive",
+        supports_effort=True,
+        effort_levels=("low", "medium", "high", "xhigh", "max"),
+        supports_web_search=True,
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_temperature=False,
+        thinking_display="summarized",
+        supports_reasoning_replay=True,
+    ),
     "claude-opus-4-7": ModelCapabilities(
         context_window=1000000,
         max_output_tokens=128000,
@@ -311,7 +325,7 @@ class AnthropicProvider:
             kwargs["tools"] = anthropic_tools
         kwargs.update(thinking_params)
 
-        # Effort param for models that support it (Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5)
+        # Effort param for models that support it (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5)
         if caps.supports_effort and reasoning_effort:
             effort = _map_reasoning_to_effort(reasoning_effort, caps.effort_levels)
             if effort:


### PR DESCRIPTION
Registers `claude-opus-4-8` in the Anthropic capability table.

## Investigation: Opus 4.7 → 4.8 API differences

**None that turnstone needs to handle.** Opus 4.8 keeps Opus 4.7's request/response surface exactly:

| Property | Opus 4.7 | Opus 4.8 |
|---|---|---|
| Context window | 1M | 1M |
| Max output | 128K | 128K |
| Thinking | adaptive only (`budget_tokens` → 400) | same |
| Sampling (`temperature`/`top_p`/`top_k`) | removed → 400 | same |
| Effort levels | `low/medium/high/xhigh/max` | same |
| `thinking.display` | defaults `omitted` | same |
| Prompt-cache minimum | 4096 tokens | same |
| Pricing | $5/$25 per 1M | same |

The only deltas are behavioral (4.8 narrates more, asks more, warmer prose) — prompt-tuning, not provider code. The existing 4.7 handling in `AnthropicProvider` already covers every API aspect of 4.8 (adaptive thinking, `supports_temperature=False`, `thinking_display="summarized"`, the `xhigh`/`max` effort mapping).

## Changes

- **`_anthropic.py`** — new `claude-opus-4-8` capability entry (verbatim copy of the 4.7 row). `_lookup_capabilities` longest-prefix matching resolves date-suffixed ids (`claude-opus-4-8-20260601`) without colliding with the 4.7 key. Updated the effort comment.
- **`tests/test_providers.py`** — `test_capabilities_opus_4_8` + `_dated`, mirroring the 4.7 tests.
- **`turnstone.example.toml`** — bumped the showcased model example to `claude-opus-4-8`.

## Out of scope (intentional)

- **Bootstrap default unchanged** — the `anthropic` provider still defaults to `claude-sonnet-4-6` (deliberate cost/speed choice). Can flip to 4.8 separately if desired.
- **No catalog/dropdown** — models are added via `config.toml` / admin ConfigStore UI; the capability table is the only code-side registry.
- **CHANGELOG** — deferred; reconcile at stable cut.

## Verification

- ruff + mypy clean
- 91/91 Anthropic provider tests pass (incl. the 2 new ones)
- `/review` pipeline (bug + quality finders): zero findings