### PR TITLE
fix(admin): replace clipped action-button strips with an overflow menu

### DIFF
--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -315,6 +315,200 @@ function switchAdminTab(tab) {
 }
 
 // ---------------------------------------------------------------------------
+// Row action overflow menu (kebab)
+// ---------------------------------------------------------------------------
+// Shared affordance for every admin table's ACTIONS column.  _kebabMenu()
+// returns the markup string; _kebabMenuEl() the equivalent DOM node for the
+// few tables that build rows with createElement.  Each menu item carries the
+// SAME data-* attribute its inline-button predecessor had, so every existing
+// click binding (querySelectorAll('[data-...]')) keeps working untouched —
+// only the markup generation changes.  _initKebabMenus() wires open/close,
+// outside-click, Escape, scroll/resize dismissal, viewport-aware flip-up, and
+// arrow-key navigation once, via document-level delegation, so it covers rows
+// rendered by both admin.js and governance.js.
+
+let _kebabInit = false;
+// Tracks whether any menu is open, so the high-frequency scroll/resize
+// dismiss listeners can skip the DOM query in the common (nothing-open) case.
+let _anyKebabOpen = false;
+
+function _kebabBtnClass(kind) {
+  if (kind === "danger") return "admin-btn-danger";
+  if (kind === "caution") return "admin-btn-caution";
+  return "admin-btn-action";
+}
+
+function _kebabAttrString(attrs) {
+  let out = "";
+  if (attrs) {
+    const keys = Object.keys(attrs);
+    for (let k = 0; k < keys.length; k++) {
+      out += " " + keys[k] + '="' + escapeHtml(String(attrs[keys[k]])) + '"';
+    }
+  }
+  return out;
+}
+
+function _kebabMenu(items) {
+  // items: array of { label, kind?: "danger" | "caution", title?, attrs? }.
+  // Falsy entries are dropped so callers can inline conditionals; an empty
+  // list yields "" so a row with no applicable actions renders no kebab.
+  const real = (items || []).filter(Boolean);
+  if (!real.length) return "";
+  if (real.length === 1) {
+    // A lone action doesn't earn the open-the-menu click — render it as a
+    // direct inline button.  Keeps the same data-* attrs (so existing
+    // bindings still match) and the familiar bordered button look.
+    const it = real[0];
+    const title = it.title ? ' title="' + escapeHtml(it.title) + '"' : "";
+    return (
+      '<button type="button" class="' +
+      _kebabBtnClass(it.kind) +
+      '"' +
+      _kebabAttrString(it.attrs) +
+      title +
+      ">" +
+      escapeHtml(it.label) +
+      "</button>"
+    );
+  }
+  let inner = "";
+  for (let i = 0; i < real.length; i++) {
+    const it = real[i];
+    let cls = "admin-kebab-item";
+    if (it.kind === "danger") cls += " admin-kebab-item--danger";
+    else if (it.kind === "caution") cls += " admin-kebab-item--caution";
+    const title = it.title ? ' title="' + escapeHtml(it.title) + '"' : "";
+    inner +=
+      '<button type="button" class="' +
+      cls +
+      '" role="menuitem"' +
+      _kebabAttrString(it.attrs) +
+      title +
+      ">" +
+      escapeHtml(it.label) +
+      "</button>";
+  }
+  return (
+    '<div class="admin-kebab">' +
+    '<button type="button" class="admin-kebab-btn" aria-haspopup="true" ' +
+    'aria-expanded="false" aria-label="Row actions" title="Row actions">' +
+    "⋯" +
+    "</button>" +
+    '<div class="admin-kebab-menu" role="menu">' +
+    inner +
+    "</div>" +
+    "</div>"
+  );
+}
+
+function _kebabMenuEl(items) {
+  // DOM-node variant for createElement-built rows.  Parsed via DOMParser
+  // (same as setSafeHtml) rather than innerHTML; _kebabMenu() has already
+  // escaped every interpolated value.
+  const html = _kebabMenu(items);
+  if (!html) return null;
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  return parsed.body.firstElementChild;
+}
+
+function _closeAllKebabs() {
+  if (!_anyKebabOpen) return;
+  _anyKebabOpen = false;
+  const open = document.querySelectorAll(".admin-kebab.is-open");
+  for (let i = 0; i < open.length; i++) {
+    open[i].classList.remove("is-open");
+    const menu = open[i].querySelector(".admin-kebab-menu");
+    if (menu) menu.classList.remove("flip-up", "flip-left");
+    const btn = open[i].querySelector(".admin-kebab-btn");
+    if (btn) btn.setAttribute("aria-expanded", "false");
+  }
+}
+
+function _openKebab(kebab) {
+  _closeAllKebabs();
+  kebab.classList.add("is-open");
+  _anyKebabOpen = true;
+  const btn = kebab.querySelector(".admin-kebab-btn");
+  const menu = kebab.querySelector(".admin-kebab-menu");
+  if (btn) btn.setAttribute("aria-expanded", "true");
+  if (!menu) return;
+  // Steer the menu back into the viewport: flip above the trigger if a
+  // downward menu would pass the bottom edge, and open rightward if a
+  // right-anchored menu would run off the left edge (narrow viewports where
+  // the actions column isn't flush against the right of the screen).
+  menu.classList.remove("flip-up", "flip-left");
+  const rect = menu.getBoundingClientRect();
+  if (rect.bottom > window.innerHeight - 8) menu.classList.add("flip-up");
+  if (rect.left < 8) menu.classList.add("flip-left");
+  // Move focus into the menu (WAI-ARIA menu-button pattern).  preventScroll
+  // stops the scroll-dismiss listener from firing as the menu opens.
+  const first = menu.querySelector(".admin-kebab-item");
+  if (first) first.focus({ preventScroll: true });
+}
+
+function _initKebabMenus() {
+  if (_kebabInit) return;
+  _kebabInit = true;
+
+  document.addEventListener("click", function (e) {
+    const trigger = e.target.closest(".admin-kebab-btn");
+    if (trigger) {
+      const kebab = trigger.closest(".admin-kebab");
+      if (kebab.classList.contains("is-open")) _closeAllKebabs();
+      else _openKebab(kebab);
+      return;
+    }
+    // A menu item's own data-* handler runs first (target phase); we just
+    // dismiss the menu afterwards as the click bubbles to the document.
+    if (e.target.closest(".admin-kebab-item")) {
+      _closeAllKebabs();
+      return;
+    }
+    // Any other click closes an open menu.
+    _closeAllKebabs();
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      const open = document.querySelector(".admin-kebab.is-open");
+      if (open) {
+        const btn = open.querySelector(".admin-kebab-btn");
+        _closeAllKebabs();
+        if (btn) btn.focus();
+      }
+      return;
+    }
+    const trigger = e.target.closest(".admin-kebab-btn");
+    if (trigger && e.key === "ArrowDown") {
+      e.preventDefault();
+      _openKebab(trigger.closest(".admin-kebab"));
+      return;
+    }
+    const menu = e.target.closest(".admin-kebab-menu");
+    if (!menu) return;
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const items = Array.prototype.slice.call(
+        menu.querySelectorAll(".admin-kebab-item"),
+      );
+      const cur = items.indexOf(document.activeElement);
+      const delta = e.key === "ArrowDown" ? 1 : -1;
+      const next = items[(cur + delta + items.length) % items.length];
+      if (next) next.focus();
+    } else if (e.key === "Tab") {
+      // Don't let Tab walk focus into the page behind an open menu.
+      _closeAllKebabs();
+    }
+  });
+
+  // The menu is anchored to its cell and rides document scroll, but an
+  // independent scroll or a resize can leave it mispositioned — dismiss.
+  window.addEventListener("scroll", _closeAllKebabs, true);
+  window.addEventListener("resize", _closeAllKebabs);
+}
+
+// ---------------------------------------------------------------------------
 // Users
 // ---------------------------------------------------------------------------
 
@@ -366,14 +560,19 @@ function _renderUsers(users) {
       escapeHtml(u.created || "").slice(0, 10) +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-action" data-user-roles="' +
-      escapeHtml(u.user_id) +
-      '" title="Manage roles">roles</button>' +
-      '<button class="admin-btn-danger" data-delete-user="' +
-      escapeHtml(u.user_id) +
-      '" data-username="' +
-      escapeHtml(u.username) +
-      '" title="Delete user">delete</button>' +
+      _kebabMenu([
+        {
+          label: "roles",
+          title: "Manage roles",
+          attrs: { "data-user-roles": u.user_id },
+        },
+        {
+          label: "delete",
+          kind: "danger",
+          title: "Delete user",
+          attrs: { "data-delete-user": u.user_id, "data-username": u.username },
+        },
+      ]) +
       "</span>" +
       "</div>";
   }
@@ -405,7 +604,10 @@ function _renderUsers(users) {
         _toggleOidcPanel(uid, uname, row);
       };
       row.addEventListener("click", function (e) {
+        // Clicks on the row's action menu (kebab trigger or any item) must
+        // not also toggle the OIDC detail panel.
         if (
+          e.target.closest(".admin-kebab") ||
           e.target.closest(".admin-btn-danger") ||
           e.target.closest(".admin-btn-action")
         )
@@ -781,9 +983,14 @@ function _renderTokens(tokens) {
       expires +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-danger" data-revoke-token="' +
-      escapeHtml(t.token_id) +
-      '" title="Revoke token">revoke</button>' +
+      _kebabMenu([
+        {
+          label: "revoke",
+          kind: "danger",
+          title: "Revoke token",
+          attrs: { "data-revoke-token": t.token_id },
+        },
+      ]) +
       "</span>" +
       "</div>";
   }
@@ -918,11 +1125,17 @@ function _renderChannels(channels) {
       escapeHtml(c.created || "").slice(0, 10) +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-danger" data-unlink-type="' +
-      escapeHtml(c.channel_type) +
-      '" data-unlink-uid="' +
-      escapeHtml(c.channel_user_id) +
-      '" title="Unlink channel account">unlink</button>' +
+      _kebabMenu([
+        {
+          label: "unlink",
+          kind: "danger",
+          title: "Unlink channel account",
+          attrs: {
+            "data-unlink-type": c.channel_type,
+            "data-unlink-uid": c.channel_user_id,
+          },
+        },
+      ]) +
       "</span>" +
       "</div>";
   }
@@ -1052,26 +1265,32 @@ function _renderSchedules(schedules) {
       statusLabel +
       "</span></span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-action" data-edit-sched="' +
-      escapeHtml(s.task_id) +
-      '" title="Edit">edit</button>' +
-      '<button class="admin-btn-action" data-runs-sched="' +
-      escapeHtml(s.task_id) +
-      '" title="Run history">runs</button>' +
-      '<button class="admin-btn-action" data-toggle-sched="' +
-      escapeHtml(s.task_id) +
-      '" data-enabled="' +
-      (enabled ? "1" : "0") +
-      '" title="' +
-      (enabled ? "Disable" : "Enable") +
-      '">' +
-      (enabled ? "disable" : "enable") +
-      "</button>" +
-      '<button class="admin-btn-danger" data-delete-sched="' +
-      escapeHtml(s.task_id) +
-      '" data-sname="' +
-      escapeHtml(s.name) +
-      '" title="Delete">delete</button>' +
+      _kebabMenu([
+        {
+          label: "edit",
+          title: "Edit",
+          attrs: { "data-edit-sched": s.task_id },
+        },
+        {
+          label: "runs",
+          title: "Run history",
+          attrs: { "data-runs-sched": s.task_id },
+        },
+        {
+          label: enabled ? "disable" : "enable",
+          title: enabled ? "Disable" : "Enable",
+          attrs: {
+            "data-toggle-sched": s.task_id,
+            "data-enabled": enabled ? "1" : "0",
+          },
+        },
+        {
+          label: "delete",
+          kind: "danger",
+          title: "Delete",
+          attrs: { "data-delete-sched": s.task_id, "data-sname": s.name },
+        },
+      ]) +
       "</span></div>";
   }
   setSafeHtml(container, html);
@@ -1842,15 +2061,21 @@ function _renderWatches(watches) {
     const statusCls = active ? "watch-active" : "watch-completed";
     const statusLabel = active ? "active" : "done";
     const statusDot = active ? "\u25cf " : "\u25cb ";
-    const cancelBtn = active
-      ? '<button class="admin-btn-danger" data-cancel-watch="' +
-        escapeHtml(w.watch_id) +
-        '" data-watch-node="' +
-        escapeHtml(w.node_id || "") +
-        '" data-watch-name="' +
-        escapeHtml(name) +
-        '" title="Cancel watch">cancel</button>'
-      : "";
+    // Only active watches can be cancelled; completed rows render no menu.
+    const cancelBtn = _kebabMenu([
+      active
+        ? {
+            label: "cancel",
+            kind: "danger",
+            title: "Cancel watch",
+            attrs: {
+              "data-cancel-watch": w.watch_id,
+              "data-watch-node": w.node_id || "",
+              "data-watch-name": name,
+            },
+          }
+        : null,
+    ]);
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col admin-col-wname">' +
@@ -2607,28 +2832,24 @@ function loadTlsCerts() {
 
         const colActions = document.createElement("span");
         colActions.className = "admin-col admin-col-actions";
-        const renewBtn = document.createElement("button");
-        renewBtn.className = "admin-btn-action";
-        renewBtn.textContent = "Renew";
-        renewBtn.setAttribute(
-          "aria-label",
-          "Renew certificate for " + c.domain,
-        );
-        renewBtn.onclick = function () {
-          tlsRenewCert(c.domain);
-        };
-        const deleteBtn = document.createElement("button");
-        deleteBtn.className = "admin-btn-danger";
-        deleteBtn.textContent = "Delete";
-        deleteBtn.setAttribute(
-          "aria-label",
-          "Delete certificate for " + c.domain,
-        );
-        deleteBtn.onclick = function () {
-          tlsDeleteCert(c.domain);
-        };
-        colActions.appendChild(renewBtn);
-        colActions.appendChild(deleteBtn);
+        const kebab = _kebabMenuEl([
+          {
+            label: "Renew",
+            attrs: {
+              "data-tls-renew": c.domain,
+              "aria-label": "Renew certificate for " + c.domain,
+            },
+          },
+          {
+            label: "Delete",
+            kind: "danger",
+            attrs: {
+              "data-tls-delete": c.domain,
+              "aria-label": "Delete certificate for " + c.domain,
+            },
+          },
+        ]);
+        colActions.appendChild(kebab);
 
         row.appendChild(colDomain);
         row.appendChild(colSans);
@@ -2636,6 +2857,19 @@ function loadTlsCerts() {
         row.appendChild(colExpires);
         row.appendChild(colActions);
         listEl.appendChild(row);
+      });
+      // Bind by attribute (matching the Models call site) rather than by
+      // positional index into the kebab items, so this survives any future
+      // single-item degrade (where _kebabMenu returns a bare button).
+      listEl.querySelectorAll("[data-tls-renew]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          tlsRenewCert(this.getAttribute("data-tls-renew"));
+        });
+      });
+      listEl.querySelectorAll("[data-tls-delete]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          tlsDeleteCert(this.getAttribute("data-tls-delete"));
+        });
       });
     })
     .catch(function () {
@@ -3522,48 +3756,44 @@ function _renderMcpServers(items) {
     const detailAttr = isConfig
       ? 'data-mcp-detail-name="' + escapeHtml(s.name) + '"'
       : 'data-mcp-detail="' + escapeHtml(s.server_id) + '"';
-    let actionBtns =
-      '<button class="admin-btn-action" data-mcp-refresh="' +
-      escapeHtml(s.name) +
-      '">refresh</button>' +
-      '<button class="admin-btn-action" data-mcp-reconnect="' +
-      escapeHtml(s.name) +
-      '">reconnect</button>';
-    if (s.auth_type === "oauth_user") {
-      actionBtns +=
-        '<button class="admin-btn-action" data-mcp-oauth-connect="' +
-        escapeHtml(s.name) +
-        '">connect</button>';
-      // Phase 9: surface the consented-users count + bulk-revoke
-      // affordance only when at least one user has consented.
-      const consentCount =
-        typeof s.consented_users_count === "number"
-          ? s.consented_users_count
-          : 0;
-      if (consentCount > 0) {
-        actionBtns +=
-          '<button class="admin-btn-danger" data-mcp-bulk-revoke="' +
-          escapeHtml(s.name) +
-          '" data-mcp-consent-count="' +
-          consentCount +
-          '" title="Drop all ' +
-          consentCount +
-          ' user consents for this server">bulk-revoke (' +
-          consentCount +
-          ")</button>";
-      }
-    }
-    const actions = isConfig
-      ? actionBtns
-      : actionBtns +
-        '<button class="admin-btn-action" data-mcp-edit="' +
-        escapeHtml(s.server_id) +
-        '">edit</button>' +
-        '<button class="admin-btn-danger" data-mcp-delete="' +
-        escapeHtml(s.server_id) +
-        '" data-mcp-name="' +
-        escapeHtml(s.name) +
-        '">del</button>';
+    // Phase 9: surface the connect/bulk-revoke affordances only for
+    // user-OAuth servers, and bulk-revoke only once a user has consented.
+    const isOauth = s.auth_type === "oauth_user";
+    const consentCount =
+      typeof s.consented_users_count === "number" ? s.consented_users_count : 0;
+    const actions = _kebabMenu([
+      { label: "refresh", attrs: { "data-mcp-refresh": s.name } },
+      { label: "reconnect", attrs: { "data-mcp-reconnect": s.name } },
+      isOauth
+        ? { label: "connect", attrs: { "data-mcp-oauth-connect": s.name } }
+        : null,
+      isOauth && consentCount > 0
+        ? {
+            label: "bulk-revoke (" + consentCount + ")",
+            kind: "danger",
+            title:
+              "Drop all " + consentCount + " user consents for this server",
+            attrs: {
+              "data-mcp-bulk-revoke": s.name,
+              "data-mcp-consent-count": consentCount,
+            },
+          }
+        : null,
+      // Config-sourced servers are read-only here (edited via config.toml).
+      isConfig
+        ? null
+        : { label: "edit", attrs: { "data-mcp-edit": s.server_id } },
+      isConfig
+        ? null
+        : {
+            label: "delete",
+            kind: "danger",
+            attrs: {
+              "data-mcp-delete": s.server_id,
+              "data-mcp-name": s.name,
+            },
+          },
+    ]);
 
     html +=
       '<div class="admin-row mcp-grid ' +
@@ -5372,32 +5602,40 @@ function _renderModels(items) {
 
     // Actions
     const colActions = document.createElement("span");
-    colActions.className = "admin-col";
-    if (!isDefault && m.enabled) {
-      const defBtn = document.createElement("button");
-      defBtn.className = "admin-btn-action";
-      defBtn.textContent = "set default";
-      defBtn.setAttribute("data-model-set-default", m.alias);
-      defBtn.setAttribute("aria-label", "Set " + m.alias + " as default model");
-      defBtn.setAttribute("title", "Set " + m.alias + " as default model");
-      colActions.appendChild(defBtn);
-    }
-    if (!isConfig) {
-      const editBtn = document.createElement("button");
-      editBtn.className = "admin-btn-action";
-      editBtn.textContent = "edit";
-      editBtn.setAttribute("data-model-edit", m.definition_id);
-      editBtn.setAttribute("title", "Edit " + m.alias);
-      colActions.appendChild(editBtn);
-
-      const delBtn = document.createElement("button");
-      delBtn.className = "admin-btn-danger";
-      delBtn.textContent = "del";
-      delBtn.setAttribute("data-model-delete", m.definition_id);
-      delBtn.setAttribute("data-model-alias", m.alias);
-      delBtn.setAttribute("title", "Delete " + m.alias);
-      colActions.appendChild(delBtn);
-    }
+    colActions.className = "admin-col admin-col-actions";
+    const modelKebab = _kebabMenuEl([
+      // Config-sourced models are read-only here; only the live default may
+      // be changed.  Hide "set default" on the row that already is default.
+      !isDefault && m.enabled
+        ? {
+            label: "set default",
+            title: "Set " + m.alias + " as default model",
+            attrs: {
+              "data-model-set-default": m.alias,
+              "aria-label": "Set " + m.alias + " as default model",
+            },
+          }
+        : null,
+      isConfig
+        ? null
+        : {
+            label: "edit",
+            title: "Edit " + m.alias,
+            attrs: { "data-model-edit": m.definition_id },
+          },
+      isConfig
+        ? null
+        : {
+            label: "delete",
+            kind: "danger",
+            title: "Delete " + m.alias,
+            attrs: {
+              "data-model-delete": m.definition_id,
+              "data-model-alias": m.alias,
+            },
+          },
+    ]);
+    if (modelKebab) colActions.appendChild(modelKebab);
     row.appendChild(colActions);
 
     el.appendChild(row);
@@ -6377,3 +6615,8 @@ function _deleteNodeMeta(nodeId, key) {
     },
   );
 }
+
+// Wire the shared row-action menu once.  admin.js loads at the end of the
+// console <body>, so the document-level delegation below covers every admin
+// table (including those rendered by governance.js, which loads after).
+_initKebabMenus();

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -503,8 +503,19 @@ function _initKebabMenus() {
   });
 
   // The menu is anchored to its cell and rides document scroll, but an
-  // independent scroll or a resize can leave it mispositioned — dismiss.
-  window.addEventListener("scroll", _closeAllKebabs, true);
+  // independent page/ancestor scroll or a resize can leave it mispositioned —
+  // dismiss.  Capture phase catches descendant scrolls too, so skip scrolls
+  // originating INSIDE the menu (it can overflow-y:auto at high zoom / short
+  // viewports) — those must scroll the menu, not close it.
+  window.addEventListener(
+    "scroll",
+    function (e) {
+      const t = e.target;
+      if (t && t.closest && t.closest(".admin-kebab-menu")) return;
+      _closeAllKebabs();
+    },
+    true,
+  );
   window.addEventListener("resize", _closeAllKebabs);
 }
 

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -192,18 +192,19 @@ function _renderGovRoles(items) {
 
     // Builtin rows always get Edit (lands in the overrides editor).
     // Custom rows get Edit + Delete (existing behavior).
-    let actions =
-      '<button class="admin-btn-action" data-edit-role="' +
-      escapeHtml(r.role_id) +
-      '">edit</button>';
-    if (!r.builtin) {
-      actions +=
-        '<button class="admin-btn-danger" data-delete-role="' +
-        escapeHtml(r.role_id) +
-        '" data-role-name="' +
-        escapeHtml(r.name) +
-        '">delete</button>';
-    }
+    const actions = _kebabMenu([
+      { label: "edit", attrs: { "data-edit-role": r.role_id } },
+      r.builtin
+        ? null
+        : {
+            label: "delete",
+            kind: "danger",
+            attrs: {
+              "data-delete-role": r.role_id,
+              "data-role-name": r.name,
+            },
+          },
+    ]);
 
     const chevron = expanded ? "▾" : "▸";
     html +=
@@ -240,6 +241,9 @@ function _renderGovRoles(items) {
   const expandBtns = el.querySelectorAll("[data-expand-role]");
   for (let k = 0; k < expandBtns.length; k++) {
     expandBtns[k].addEventListener("click", function (ev) {
+      // The row carries data-expand-role too, so a click on its action menu
+      // would otherwise toggle the drawer — let the kebab handle its own.
+      if (ev.target.closest(".admin-kebab")) return;
       ev.stopPropagation();
       const rid = this.getAttribute("data-expand-role");
       if (_govRoleExpanded.has(rid)) _govRoleExpanded.delete(rid);
@@ -251,7 +255,11 @@ function _renderGovRoles(items) {
   const editBtns = el.querySelectorAll("[data-edit-role]");
   for (let k = 0; k < editBtns.length; k++) {
     editBtns[k].addEventListener("click", function (ev) {
+      // stopPropagation keeps the builtin single-action inline button from
+      // toggling the row drawer; it also blocks the document-level kebab
+      // close, so dismiss the menu explicitly here.
       ev.stopPropagation();
+      _closeAllKebabs();
       showEditRoleModal(this.getAttribute("data-edit-role"));
     });
   }
@@ -259,7 +267,10 @@ function _renderGovRoles(items) {
   const delBtns = el.querySelectorAll("[data-delete-role]");
   for (let k = 0; k < delBtns.length; k++) {
     delBtns[k].addEventListener("click", function (ev) {
+      // See edit handler: stopPropagation also blocks the document-level
+      // kebab close, so dismiss the menu explicitly.
       ev.stopPropagation();
+      _closeAllKebabs();
       const rid = this.getAttribute("data-delete-role");
       const rname = this.getAttribute("data-role-name");
       showConfirmModal(
@@ -847,14 +858,17 @@ function _renderGovPolicies(items) {
       statusDot +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-action" data-edit-policy="' +
-      escapeHtml(p.policy_id) +
-      '">edit</button>' +
-      '<button class="admin-btn-danger" data-delete-policy="' +
-      escapeHtml(p.policy_id) +
-      '" data-policy-name="' +
-      escapeHtml(p.name) +
-      '">delete</button>' +
+      _kebabMenu([
+        { label: "edit", attrs: { "data-edit-policy": p.policy_id } },
+        {
+          label: "delete",
+          kind: "danger",
+          attrs: {
+            "data-delete-policy": p.policy_id,
+            "data-policy-name": p.name,
+          },
+        },
+      ]) +
       "</span></div>";
   }
   setSafeHtml(el, html);
@@ -1136,7 +1150,6 @@ function _renderGovSkills(items) {
         " res</span>";
     }
     const editLabel = t.readonly ? "view" : "edit";
-    const deleteDisabled = "";
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col admin-col-tmcat">' +
@@ -1159,18 +1172,17 @@ function _renderGovSkills(items) {
       riskCell +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-action" data-edit-tmpl="' +
-      escapeHtml(t.template_id) +
-      '">' +
-      editLabel +
-      "</button>" +
-      '<button class="admin-btn-danger" data-delete-tmpl="' +
-      escapeHtml(t.template_id) +
-      '" data-tmpl-name="' +
-      escapeHtml(t.name) +
-      '"' +
-      deleteDisabled +
-      ">delete</button>" +
+      _kebabMenu([
+        { label: editLabel, attrs: { "data-edit-tmpl": t.template_id } },
+        {
+          label: "delete",
+          kind: "danger",
+          attrs: {
+            "data-delete-tmpl": t.template_id,
+            "data-tmpl-name": t.name,
+          },
+        },
+      ]) +
       "</span></div>";
   }
   setSafeHtml(el, html);
@@ -2835,14 +2847,17 @@ function _renderAdminMemories(items, total) {
       _relativeTime(m.updated) +
       "</span>" +
       '<span class="admin-col admin-col-actions">' +
-      '<button class="admin-btn-action" data-view-memory="' +
-      escapeHtml(m.memory_id) +
-      '">view</button>' +
-      '<button class="admin-btn-danger" data-delete-memory="' +
-      escapeHtml(m.memory_id) +
-      '" data-delete-name="' +
-      escapeHtml(m.name) +
-      '">delete</button>' +
+      _kebabMenu([
+        { label: "view", attrs: { "data-view-memory": m.memory_id } },
+        {
+          label: "delete",
+          kind: "danger",
+          attrs: {
+            "data-delete-memory": m.memory_id,
+            "data-delete-name": m.name,
+          },
+        },
+      ]) +
       "</span>" +
       "</div>";
   }
@@ -3376,19 +3391,25 @@ function _renderPromptPolicies(items) {
 
     const colActions = document.createElement("span");
     colActions.className = "admin-col admin-col-actions";
-    const editBtn = document.createElement("button");
-    editBtn.className = "admin-btn-action";
-    editBtn.textContent = "edit";
-    editBtn.setAttribute("data-edit-ppolicy", p.policy_id);
-    editBtn.setAttribute("aria-label", "Edit prompt " + p.name);
-    colActions.appendChild(editBtn);
-    const delBtn = document.createElement("button");
-    delBtn.className = "admin-btn-danger";
-    delBtn.textContent = "delete";
-    delBtn.setAttribute("data-delete-ppolicy", p.policy_id);
-    delBtn.setAttribute("data-ppolicy-name", p.name);
-    delBtn.setAttribute("aria-label", "Delete prompt " + p.name);
-    colActions.appendChild(delBtn);
+    const ppKebab = _kebabMenuEl([
+      {
+        label: "edit",
+        attrs: {
+          "data-edit-ppolicy": p.policy_id,
+          "aria-label": "Edit prompt " + p.name,
+        },
+      },
+      {
+        label: "delete",
+        kind: "danger",
+        attrs: {
+          "data-delete-ppolicy": p.policy_id,
+          "data-ppolicy-name": p.name,
+          "aria-label": "Delete prompt " + p.name,
+        },
+      },
+    ]);
+    if (ppKebab) colActions.appendChild(ppKebab);
     row.appendChild(colActions);
 
     el.appendChild(row);
@@ -3942,70 +3963,71 @@ function renderHeuristicRules() {
     const statusBadge = r.enabled
       ? '<span class="scope-badge scope-scan-safe">active</span>'
       : '<span class="scope-badge scope-deny">disabled</span>';
-    let actions = "";
-    const eName = escapeHtml(r.name);
+    // Enable/Disable toggle, shared by the two DB-backed branches.  The
+    // data-enabled attr carries the NEXT state (!r.enabled).
+    const toggleHrItem = {
+      label: r.enabled ? "Disable" : "Enable",
+      attrs: {
+        "data-toggle-hr": r.rule_id,
+        "data-enabled": !r.enabled,
+        "aria-label": (r.enabled ? "Disable " : "Enable ") + r.name,
+      },
+    };
+    let actionItems;
     if (!r.rule_id) {
       // Pure built-in: Disable + Edit
-      actions =
-        '<button class="admin-btn-action" data-disable-builtin-hr="' +
-        eName +
-        '" aria-label="Disable ' +
-        eName +
-        '">Disable</button> ' +
-        '<button class="admin-btn-action" data-edit-hr-builtin="' +
-        eName +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button>';
+      actionItems = [
+        {
+          label: "Disable",
+          attrs: {
+            "data-disable-builtin-hr": r.name,
+            "aria-label": "Disable " + r.name,
+          },
+        },
+        {
+          label: "Edit",
+          attrs: {
+            "data-edit-hr-builtin": r.name,
+            "aria-label": "Edit " + r.name,
+          },
+        },
+      ];
     } else if (r.builtin) {
       // Overridden or disabled built-in: Enable/Disable + Edit + Reset
-      actions =
-        '<button class="admin-btn-action" data-toggle-hr="' +
-        r.rule_id +
-        '" data-enabled="' +
-        !r.enabled +
-        '" aria-label="' +
-        (r.enabled ? "Disable" : "Enable") +
-        " " +
-        eName +
-        '">' +
-        (r.enabled ? "Disable" : "Enable") +
-        "</button> " +
-        '<button class="admin-btn-action" data-edit-hr="' +
-        r.rule_id +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button> ' +
-        '<button class="admin-btn-caution" data-reset-hr="' +
-        r.rule_id +
-        '" aria-label="Reset ' +
-        eName +
-        '">Reset</button>';
+      actionItems = [
+        toggleHrItem,
+        {
+          label: "Edit",
+          attrs: { "data-edit-hr": r.rule_id, "aria-label": "Edit " + r.name },
+        },
+        {
+          label: "Reset",
+          kind: "caution",
+          attrs: {
+            "data-reset-hr": r.rule_id,
+            "aria-label": "Reset " + r.name,
+          },
+        },
+      ];
     } else {
       // Custom rule: Enable/Disable + Edit + Delete
-      actions =
-        '<button class="admin-btn-action" data-toggle-hr="' +
-        r.rule_id +
-        '" data-enabled="' +
-        !r.enabled +
-        '" aria-label="' +
-        (r.enabled ? "Disable" : "Enable") +
-        " " +
-        eName +
-        '">' +
-        (r.enabled ? "Disable" : "Enable") +
-        "</button> " +
-        '<button class="admin-btn-action" data-edit-hr="' +
-        r.rule_id +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button> ' +
-        '<button class="admin-btn-danger" data-delete-hr="' +
-        r.rule_id +
-        '" aria-label="Delete ' +
-        eName +
-        '">Delete</button>';
+      actionItems = [
+        toggleHrItem,
+        {
+          label: "Edit",
+          attrs: { "data-edit-hr": r.rule_id, "aria-label": "Edit " + r.name },
+        },
+        {
+          label: "Delete",
+          kind: "danger",
+          attrs: {
+            "data-delete-hr": r.rule_id,
+            "aria-label": "Delete " + r.name,
+          },
+        },
+      ];
     }
+    const actions = _kebabMenu(actionItems);
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col"><code>' +
@@ -4029,7 +4051,7 @@ function renderHeuristicRules() {
       '<span class="admin-col">' +
       statusBadge +
       "</span>" +
-      '<span class="admin-col">' +
+      '<span class="admin-col admin-col-actions">' +
       actions +
       "</span></div>";
   }
@@ -4459,70 +4481,77 @@ function renderOGPatterns() {
     const statusBadge = p.enabled
       ? '<span class="scope-badge scope-scan-safe">active</span>'
       : '<span class="scope-badge scope-deny">disabled</span>';
-    let actions = "";
-    const eName = escapeHtml(p.name);
+    // Enable/Disable toggle, shared by the two DB-backed branches.  The
+    // data-enabled attr carries the NEXT state (!p.enabled).
+    const toggleOgpItem = {
+      label: p.enabled ? "Disable" : "Enable",
+      attrs: {
+        "data-toggle-ogp": p.pattern_id,
+        "data-enabled": !p.enabled,
+        "aria-label": (p.enabled ? "Disable " : "Enable ") + p.name,
+      },
+    };
+    let actionItems;
     if (!p.pattern_id) {
       // Pure built-in: Disable + Edit
-      actions =
-        '<button class="admin-btn-action" data-disable-builtin-ogp="' +
-        eName +
-        '" aria-label="Disable ' +
-        eName +
-        '">Disable</button> ' +
-        '<button class="admin-btn-action" data-edit-ogp-builtin="' +
-        eName +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button>';
+      actionItems = [
+        {
+          label: "Disable",
+          attrs: {
+            "data-disable-builtin-ogp": p.name,
+            "aria-label": "Disable " + p.name,
+          },
+        },
+        {
+          label: "Edit",
+          attrs: {
+            "data-edit-ogp-builtin": p.name,
+            "aria-label": "Edit " + p.name,
+          },
+        },
+      ];
     } else if (p.builtin) {
       // Overridden or disabled built-in: Enable/Disable + Edit + Reset
-      actions =
-        '<button class="admin-btn-action" data-toggle-ogp="' +
-        p.pattern_id +
-        '" data-enabled="' +
-        !p.enabled +
-        '" aria-label="' +
-        (p.enabled ? "Disable" : "Enable") +
-        " " +
-        eName +
-        '">' +
-        (p.enabled ? "Disable" : "Enable") +
-        "</button> " +
-        '<button class="admin-btn-action" data-edit-ogp="' +
-        p.pattern_id +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button> ' +
-        '<button class="admin-btn-caution" data-reset-ogp="' +
-        p.pattern_id +
-        '" aria-label="Reset ' +
-        eName +
-        '">Reset</button>';
+      actionItems = [
+        toggleOgpItem,
+        {
+          label: "Edit",
+          attrs: {
+            "data-edit-ogp": p.pattern_id,
+            "aria-label": "Edit " + p.name,
+          },
+        },
+        {
+          label: "Reset",
+          kind: "caution",
+          attrs: {
+            "data-reset-ogp": p.pattern_id,
+            "aria-label": "Reset " + p.name,
+          },
+        },
+      ];
     } else {
       // Custom rule: Enable/Disable + Edit + Delete
-      actions =
-        '<button class="admin-btn-action" data-toggle-ogp="' +
-        p.pattern_id +
-        '" data-enabled="' +
-        !p.enabled +
-        '" aria-label="' +
-        (p.enabled ? "Disable" : "Enable") +
-        " " +
-        eName +
-        '">' +
-        (p.enabled ? "Disable" : "Enable") +
-        "</button> " +
-        '<button class="admin-btn-action" data-edit-ogp="' +
-        p.pattern_id +
-        '" aria-label="Edit ' +
-        eName +
-        '">Edit</button> ' +
-        '<button class="admin-btn-danger" data-delete-ogp="' +
-        p.pattern_id +
-        '" aria-label="Delete ' +
-        eName +
-        '">Delete</button>';
+      actionItems = [
+        toggleOgpItem,
+        {
+          label: "Edit",
+          attrs: {
+            "data-edit-ogp": p.pattern_id,
+            "aria-label": "Edit " + p.name,
+          },
+        },
+        {
+          label: "Delete",
+          kind: "danger",
+          attrs: {
+            "data-delete-ogp": p.pattern_id,
+            "aria-label": "Delete " + p.name,
+          },
+        },
+      ];
     }
+    const actions = _kebabMenu(actionItems);
     html +=
       '<div class="admin-row" role="listitem">' +
       '<span class="admin-col"><code>' +
@@ -4543,7 +4572,7 @@ function renderOGPatterns() {
       '<span class="admin-col">' +
       statusBadge +
       "</span>" +
-      '<span class="admin-col">' +
+      '<span class="admin-col admin-col-actions">' +
       actions +
       "</span></div>";
   }

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -1507,6 +1507,141 @@
   outline-offset: 2px;
 }
 
+/* Row action overflow menu (kebab) — shared affordance for every admin
+   table's ACTIONS column.  Replaces the inline button strips that
+   overflowed narrow action tracks and rendered a misleading
+   text-overflow "…".  The actions cell inherits `.admin-col`'s
+   `overflow: hidden`, which would re-clip a dropdown, so we override it
+   to `visible` and anchor an absolutely-positioned menu to the kebab
+   container.  `.admin-content` does not scroll (the document does), so
+   the menu — glued to its cell — overlays the page without being
+   clipped by any ancestor. */
+.admin-col-actions,
+.admin-col-mactions {
+  overflow: visible;
+  /* Pin the trigger to the right of its (over-wide) track so it shares an
+     edge with the right-anchored menu — and right-align the "ACTIONS"
+     header label to match. */
+  text-align: right;
+}
+
+.admin-kebab {
+  position: relative;
+  display: inline-block;
+}
+.admin-kebab.is-open {
+  z-index: 60;
+}
+
+.admin-kebab-btn {
+  background: none;
+  border: 1px solid var(--border-strong);
+  color: var(--fg-dim);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 7px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0.8;
+  transition:
+    opacity 0.15s,
+    background 0.15s,
+    color 0.15s;
+}
+.admin-kebab-btn:hover,
+.admin-kebab.is-open .admin-kebab-btn {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--fg);
+}
+.admin-kebab-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.admin-kebab-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 1;
+  min-width: 148px;
+  /* Never exceed the viewport on either axis (narrow screens / tall menus);
+     _openKebab() flips side/up when an edge would be crossed. */
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  padding: 4px;
+  display: none;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+.admin-kebab.is-open .admin-kebab-menu {
+  display: flex;
+}
+.admin-kebab-menu.flip-up {
+  top: auto;
+  bottom: calc(100% + 4px);
+}
+.admin-kebab-menu.flip-left {
+  right: auto;
+  left: 0;
+}
+
+.admin-kebab-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.admin-kebab-item:hover {
+  background: var(--bg-highlight);
+}
+.admin-kebab-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.admin-kebab-item--danger {
+  color: var(--red);
+}
+/* Pair the colour with a glyph so destructive/caution items don't rely on
+   hue alone.  \FE0E forces the text (non-emoji) presentation of the sign. */
+.admin-kebab-item--danger::before {
+  content: "⚠\FE0E";
+  margin-right: 7px;
+  opacity: 0.9;
+}
+.admin-kebab-item--danger:hover {
+  background: var(--red-glow);
+}
+.admin-kebab-item--caution {
+  color: var(--yellow);
+}
+.admin-kebab-item--caution::before {
+  content: "△";
+  margin-right: 7px;
+  opacity: 0.9;
+}
+.admin-kebab-item--caution:hover {
+  background: var(--yellow-glow);
+}
+
 /* Schedules grid: NAME | TYPE | SCHEDULE | TARGET | NEXT RUN | STATUS | ACTIONS */
 #admin-schedules .admin-colheaders,
 #admin-schedules .admin-row {
@@ -4511,6 +4646,8 @@ textarea.skill-content-area {
   .admin-btn-danger,
   .admin-btn-caution,
   .admin-btn-action,
+  .admin-kebab-btn,
+  .admin-kebab-item,
   .admin-subtab-btn {
     transition: none;
   }


### PR DESCRIPTION
## Problem

Admin tables render their per-row actions in an ACTIONS column whose grid track is fixed-width and inherits `.admin-col`'s `overflow: hidden` + `text-overflow: ellipsis`. Rows with several actions (MCP servers: `refresh`/`reconnect`/`edit`/`del`) overflowed the track, so only the first button showed and the rest were clipped behind a misleading text-overflow `…`. The edit button was unreachable — the only way to change an MCP server was editing the DB by hand.

Fixes #593.

## Change

Replace the inline button strips across all 15 admin tables (`admin.js` + `governance.js`) with a shared kebab (`⋯`) overflow menu:

- `_kebabMenu()` / `_kebabMenuEl()` build the menu; a single action degrades to an inline button. `_initKebabMenus()` wires open/close, outside-click, `Escape`, arrow-key nav and viewport-aware flip-up/flip-left through **one** document-level delegated listener. Menu items keep the **same `data-*` attributes**, so the existing per-table click bindings are unchanged.
- Right-align the actions column so the trigger shares an edge with its menu; pair danger/caution items with warning glyphs (not colour alone); theme-aware `--red-glow` / `--yellow-glow` hover tints.

Tables migrated: Users, API Tokens, Channels, Schedules, Watches, MCP Servers, Models, TLS (`admin.js`); Roles, Policies, Skills/Prompts, Memories, Prompt Policies, Judge Heuristic Rules, Output Guard Patterns (`governance.js`).

## Verification

- `node --check` + `prettier --check` clean on both JS files.
- Interactive self-test 15/15 — open/close, outside-click, `Escape`+refocus, item-dismiss, single-open-at-a-time, `ArrowDown`, `aria-expanded` state.
- Real-render checks for the MCP and Judge-heuristic-rules tables: items, `data-*` attrs, and per-row conditionals preserved (oauth/config/builtin branches; toggle carries the next state).
- XSS: labels/attrs route through `escapeHtml`; `_kebabMenuEl` parses via `DOMParser`, not `innerHTML`.
- Renders in dark + light themes; flip-left keeps the menu on-screen on narrow viewports.
- Reviewed for correctness/security/performance/quality; folded in fixes for the Roles menu-close, TLS binding robustness (attribute lookup instead of positional index), and a scroll-listener early-out.

## Not included (intentionally)

- Per-row `aria-controls` / `aria-label` and per-row `DOMParser` reuse — flagged as optional / sub-perceptual.
- Kebab trigger border contrast — pre-existing (shared `--border-strong` across all admin buttons); out of scope for this fix.

## Screenshots

Before: a single MCP row showed `refresh …` with the rest of the actions clipped and unclickable. After: each row shows a single `⋯` that opens the full action set (`edit` included), with destructive items marked by colour + a warning glyph.
