### PR TITLE
feat(admin): surface output-guard judge model in Models → Roles

### DIFF
--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5163,6 +5163,13 @@ const MODEL_ROLES = [
     fallbackKind: "default",
   },
   {
+    label: "Output guard judge",
+    description:
+      "Output-guard judge that semantically evaluates tool results for camouflaged prompt injection (active when judge.output_guard_llm is enabled).",
+    aliasKey: "judge.output_guard_model",
+    fallbackKind: "default",
+  },
+  {
     label: "Plan agent",
     description:
       "plan_agent sub-agent — produces high-level plans before task dispatch.",

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -3708,7 +3708,10 @@ function renderJudgeSettings() {
   let html = "";
   for (let i = 0; i < _judgeSettings.length; i++) {
     const s = _judgeSettings[i];
-    if (s.key === "judge.model") continue;
+    // Model-role pickers live in Models → Roles, not here, so the judge
+    // model and the output-guard judge model are skipped on this tab.
+    if (s.key === "judge.model" || s.key === "judge.output_guard_model")
+      continue;
     const shortKey = s.key.replace("judge.", "");
     let inputHtml = "";
     const currentVal = s.value;


### PR DESCRIPTION
## Summary

Surface the output-guard judge's model in **Models → Roles**, where every other
model role is configured. Previously `judge.output_guard_model` was only
settable on the **Judge** settings tab — inconsistent with the coordinator,
intent judge, plan/task agents, and channel adapter, which all live in
Models → Roles.

## Change

- Add an **"Output guard judge"** entry to `MODEL_ROLES` (`admin.js`), right
  under the existing intent **Judge** role it mirrors.
- Skip `judge.output_guard_model` on the Judge tab (`governance.js`,
  `renderJudgeSettings`) — same treatment `judge.model` already gets — so it
  renders in exactly one place.

The intent-judge model (`judge.model`) was already a role here; this brings the
output-guard judge into line with it.

## No backend change

The role read/write path goes through the generic `/v1/api/admin/settings`
endpoints — the same path the intent-judge model role already uses. The role
has no reasoning-effort control (the output-guard judge runs at a fixed effort),
which the roles renderer already handles (the intent Judge role is also
effort-less).

## Verification

`node --check` passes on both files; the new role reuses the proven
`judge.model` render/save path (no-effort branch, generic settings PUT).
