### PR TITLE
feat(ui): backport coordinator selector + pagination UX to interactive dashboard

### DIFF
--- a/tests/test_server_available_models.py
+++ b/tests/test_server_available_models.py
@@ -1,0 +1,161 @@
+"""``GET /v1/api/models`` (server) default-alias resolution.
+
+The server handler surfaces effective defaults for the web UI's dashboard
+composer + the channel gateway.  The dashboard's Options panel renders
+each one as a "Default — alias (model)" placeholder, so the resolution
+chain has to stay honest:
+
+* ``default_alias``        ← ``model.default_alias``, falling back to the
+  registry default; blanked when it points at a disabled/removed alias.
+* ``channel_default_alias`` ← ``channels.default_model_alias``.
+* ``judge_default_alias``   ← ``judge.model``, but *only* when it names an
+  enabled alias.  An unset / whitespace / unknown / disabled value stays
+  blank: at runtime the judge then inherits the per-workstream agent model
+  (``session_factory``: ``judge_config.model or model``), which the UI
+  renders as "Default (agent model)".  Surfacing a fixed alias there would
+  mislabel the common follow-the-agent case.
+
+These tests pin the judge branch (added so the server dashboard matches
+the coordinator launcher) alongside the pre-existing model default.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tests._coord_test_helpers import _AuthMiddleware, _FakeConfigStore
+from turnstone.server import list_available_models
+
+
+class _StubRegistry:
+    """Mimics the ``ModelRegistry`` surface ``list_available_models``
+    reads: ``list_aliases()`` / ``get_config(alias)`` / ``.default``."""
+
+    def __init__(self, *, aliases: dict[str, str], default: str = "") -> None:
+        # alias -> underlying model id
+        self._aliases = aliases
+        self.default = default
+
+    def list_aliases(self) -> list[str]:
+        return list(self._aliases)
+
+    def get_config(self, alias: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            alias=alias,
+            model=self._aliases[alias],
+            provider="openai-compatible",
+        )
+
+
+def _make_client(
+    *,
+    aliases: dict[str, str] | None = None,
+    settings: dict[str, str] | None = None,
+    registry_default: str = "",
+) -> TestClient:
+    app = Starlette(
+        routes=[Route("/v1/api/models", list_available_models)],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    app.state.registry = _StubRegistry(aliases=aliases or {}, default=registry_default)
+    app.state.config_store = _FakeConfigStore(dict(settings or {}))
+    client = TestClient(app)
+    client.headers.update({"X-Test-User": "admin", "X-Test-Perms": ""})
+    return client
+
+
+def _get_models(client: TestClient) -> dict[str, Any]:
+    resp = client.get("/v1/api/models")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Judge resolution (new — drives the dashboard "Judge Model" placeholder)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_unset_stays_blank_for_agent_model_fallback() -> None:
+    """No ``judge.model`` configured → blank, so the dashboard keeps the
+    "Default (agent model)" wording rather than advertising a fixed alias
+    the judge won't actually use."""
+    body = _get_models(
+        _make_client(
+            aliases={"primary": "vendor/primary"},
+            settings={"model.default_alias": "primary"},
+        )
+    )
+    assert body["default_alias"] == "primary"
+    assert body["judge_default_alias"] == ""
+
+
+def test_judge_explicit_enabled_alias_passes_through() -> None:
+    body = _get_models(
+        _make_client(
+            aliases={"primary": "vendor/primary", "judge-fast": "vendor/judge-fast"},
+            settings={
+                "model.default_alias": "primary",
+                "judge.model": "judge-fast",
+            },
+        )
+    )
+    assert body["judge_default_alias"] == "judge-fast"
+
+
+def test_judge_set_to_unknown_alias_stays_blank() -> None:
+    """``judge.model`` naming a non-enabled alias falls back to the agent
+    model at runtime, so the field is blanked rather than echoing a value
+    workstream creation can't honour."""
+    body = _get_models(
+        _make_client(
+            aliases={"primary": "vendor/primary"},
+            settings={
+                "model.default_alias": "primary",
+                "judge.model": "ghost",
+            },
+        )
+    )
+    assert body["judge_default_alias"] == ""
+
+
+def test_judge_whitespace_only_value_stays_blank() -> None:
+    """``judge.model`` is ``.strip()``-ed — a whitespace-only setting is
+    treated as unset, not as an (always-unknown) alias."""
+    body = _get_models(
+        _make_client(
+            aliases={"primary": "vendor/primary"},
+            settings={"model.default_alias": "primary", "judge.model": "   "},
+        )
+    )
+    assert body["judge_default_alias"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing model default stays correct under the new resolution code
+# ---------------------------------------------------------------------------
+
+
+def test_model_default_falls_back_to_registry_default() -> None:
+    """Unset ``model.default_alias`` → the registry default is surfaced so
+    the placeholder reports the alias sessions actually launch on."""
+    body = _get_models(
+        _make_client(aliases={"primary": "vendor/primary"}, registry_default="primary")
+    )
+    assert body["default_alias"] == "primary"
+    assert body["judge_default_alias"] == ""
+
+
+def test_model_default_blanked_when_pointing_at_unknown_alias() -> None:
+    body = _get_models(
+        _make_client(
+            aliases={"primary": "vendor/primary"},
+            settings={"model.default_alias": "ghost"},
+        )
+    )
+    assert body["default_alias"] == ""

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -611,3 +611,4 @@ class ListAvailableModelsResponse(BaseModel):
     models: list[AvailableModelInfo] = Field(default_factory=list)
     default_alias: str = ""
     channel_default_alias: str = ""
+    judge_default_alias: str = ""

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -157,11 +157,10 @@
   margin-left: auto;
 }
 
-/* Saved Coordinators reuses the existing .pagination control (see the
-   "Pagination" block below) — the visible page is capped at
-   COORD_PAGE_SIZE so Select-All fan-out is bounded.  Pagination is
-   hidden in delete mode and when there's only one page (see
-   _renderCoordPagination). */
+/* Saved Coordinators reuses the shared .pagination control (defined in
+   /shared/cards.css) — the visible page is capped at COORD_PAGE_SIZE so
+   Select-All fan-out is bounded.  Pagination is hidden in delete mode and
+   when there's only one page (see _renderCoordPagination). */
 
 .home-coord-list {
   border: 1px solid var(--border);
@@ -870,42 +869,9 @@
   border-radius: 2px;
 }
 
-/* ==========================================================================
-   Pagination
-   ========================================================================== */
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 16px 0;
-  font-size: 12px;
-  color: var(--fg-dim);
-}
-.pagination button {
-  background: var(--bg-surface);
-  border: 1px solid var(--border-strong);
-  color: var(--fg-bright);
-  border-radius: var(--radius-sm);
-  padding: 5px 14px;
-  font: inherit;
-  font-size: 11px;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    border-color 0.15s,
-    color 0.15s;
-  font-family: var(--font-ui);
-  font-weight: 500;
-}
-.pagination button:hover {
-  background: var(--bg-highlight);
-  border-color: var(--accent-dim);
-}
-.pagination button:disabled {
-  opacity: 0.25;
-  cursor: not-allowed;
-}
+/* The ``.pagination`` control (Saved Coordinators + the filtered admin
+   lists, and the server UI's Saved Workstreams) lives in /shared/cards.css
+   so the two dashboards share one source of truth. */
 
 /* ==========================================================================
    Toast override — position above cluster status bar AND above admin modal
@@ -4633,8 +4599,7 @@ textarea.skill-content-area {
   .node-group-header {
     transition: none;
   }
-  .dash-cell-node,
-  .pagination button {
+  .dash-cell-node {
     transition: none;
   }
   .dash-row.has-link::after,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1165,9 +1165,11 @@ async def list_available_models(request: Request) -> JSONResponse:
     cs = getattr(request.app.state, "config_store", None)
     default_alias = ""
     channel_default_alias = ""
+    judge_default_alias = ""
     if cs is not None:
         default_alias = cs.get("model.default_alias") or ""
         channel_default_alias = cs.get("channels.default_model_alias") or ""
+        judge_default_alias = (cs.get("judge.model") or "").strip()
     if not default_alias:
         default_alias = registry.default
     # Clear defaults that point to unknown/disabled aliases.
@@ -1176,11 +1178,20 @@ async def list_available_models(request: Request) -> JSONResponse:
         default_alias = ""
     if channel_default_alias and channel_default_alias not in enabled_aliases:
         channel_default_alias = ""
+    # ``judge.model`` is alias-only.  When unset — or pointing at a
+    # disabled/removed alias — the judge inherits the per-workstream agent
+    # model at runtime (see session_factory: ``judge_config.model or
+    # model``).  Leave the field blank in that case so the UI renders
+    # "Default (agent model)" rather than a misleading fixed alias; only
+    # an explicitly-configured, enabled alias surfaces a concrete default.
+    if judge_default_alias and judge_default_alias not in enabled_aliases:
+        judge_default_alias = ""
     return JSONResponse(
         {
             "models": models,
             "default_alias": default_alias,
             "channel_default_alias": channel_default_alias,
+            "judge_default_alias": judge_default_alias,
         }
     )
 

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -185,6 +185,9 @@
   .ws-delete-bar.visible {
     animation: none;
   }
+  .pagination button {
+    transition: none;
+  }
 }
 /* Below ~700px the four-pill bar's preferred width (~480-520px) starts
    eating into hit-targets and risking horizontal overflow.  Wrap onto
@@ -356,3 +359,44 @@
    `.ws-delete-modal-buttons button` rule above already provides the
    transparent / fg-bright / border styling.  The class itself is useful
    for DOM inspection and as a future hook. */
+
+/* ==========================================================================
+   Pagination — shared by the console (Saved Coordinators + the filtered
+   admin lists) and the server UI (Saved Workstreams).  Lives in /shared so
+   the two dashboards can't drift apart; the per-app render helpers
+   (_renderCoordPagination / _renderWsPagination) own the show/hide + page-
+   clamp logic.
+   ========================================================================== */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px 0;
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.pagination button {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  color: var(--fg-bright);
+  border-radius: var(--radius-sm);
+  padding: 5px 14px;
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+  font-family: var(--font-ui);
+  font-weight: 500;
+}
+.pagination button:hover {
+  background: var(--bg-highlight);
+  border-color: var(--accent-dim);
+}
+.pagination button:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -4250,7 +4250,12 @@ function updateDashFooter(agg) {
 // Saved Workstreams cache + multi-select delete controller.  The
 // controller (from /shared/cards.js) owns mode state, checkbox
 // decoration, the toolbar wiring, and the confirmation modal — see
-// createSavedCardsController for the shared bits.
+// createSavedCardsController for the shared bits.  Page size + clamp
+// logic mirror the coordinator launcher (console/static) so the two
+// dashboards stay consistent; the controller only ever sees the visible
+// page, bounding Select-All fan-out to WS_PAGE_SIZE.
+const WS_PAGE_SIZE = 24;
+let _wsPage = 0;
 let _wsSavedItems = [];
 const _wsDeleteController = createSavedCardsController({
   idPrefix: "ws-delete",
@@ -4275,17 +4280,42 @@ const _wsDeleteController = createSavedCardsController({
 
 function renderSavedWorkstreams(items) {
   _wsSavedItems = items;
-  _wsDeleteController.setItems(items);
   const c = document.getElementById("dashboard-saved-cards");
   c.replaceChildren();
   if (!items.length) {
+    _wsPage = 0;
+    // If the list empties while delete mode is open (e.g. external churn
+    // removes the last card), drop out of delete mode so the toolbar
+    // doesn't linger over an empty grid — matches the coordinator
+    // launcher.  cancel() re-renders via the controller's callback, which
+    // re-enters here with the mode off and paints the empty state, so
+    // return and let that pass own the DOM (re-appending here would
+    // double the empty-state row, since — unlike the console, which hides
+    // a section — this dashboard appends an empty node).
+    if (_wsDeleteController.inMode()) {
+      _wsDeleteController.cancel();
+      return;
+    }
+    _wsDeleteController.setItems(items);
     const empty = document.createElement("div");
     empty.className = "dashboard-empty";
     empty.textContent = "No saved workstreams";
     c.appendChild(empty);
+    _renderWsPagination();
     return;
   }
-  items.forEach(function (sess) {
+  // Clamp the page index after deletes (or upstream churn) shrink the list.
+  const pages = Math.max(1, Math.ceil(items.length / WS_PAGE_SIZE));
+  if (_wsPage > pages - 1) _wsPage = pages - 1;
+  if (_wsPage < 0) _wsPage = 0;
+  const visible = items.slice(
+    _wsPage * WS_PAGE_SIZE,
+    (_wsPage + 1) * WS_PAGE_SIZE,
+  );
+  // The controller only sees the visible page so its Select-All / count
+  // can't reach off-page cards that aren't in the DOM.
+  _wsDeleteController.setItems(visible);
+  visible.forEach(function (sess) {
     const card = renderSessionCard(sess, {
       ariaLabel: _wsDeleteController.ariaLabel,
       onActivate: function (s) {
@@ -4297,6 +4327,55 @@ function renderSavedWorkstreams(items) {
     c.appendChild(card);
   });
   if (_wsDeleteController.inMode()) _wsDeleteController.refreshBar();
+  _renderWsPagination();
+}
+
+// Twin of the console launcher's _renderCoordPagination / coordPagePrev /
+// coordPageNext (console/static/app.js) — keep the two in sync when the
+// paging behaviour changes.  Only the shared .pagination CSS is de-duped;
+// the render wiring stays per-app because it binds per-app DOM ids and
+// controller instances.
+function _renderWsPagination() {
+  const pag = document.getElementById("ws-pagination");
+  if (!pag) return;
+  const total = _wsSavedItems.length;
+  const pages = Math.max(1, Math.ceil(total / WS_PAGE_SIZE));
+  // Single-page lists and delete-mode hide the controls — paging would
+  // invalidate the user's checkbox selections, so we lock them out.
+  if (pages <= 1 || _wsDeleteController.inMode()) {
+    pag.style.display = "none";
+    return;
+  }
+  pag.style.display = "";
+  const label = document.getElementById("ws-page-label");
+  if (label) {
+    /* Visible text uses the terse "X / Y" form; the long form sits on the
+       parent's aria-label so screen readers get a full sentence. */
+    label.textContent = _wsPage + 1 + " / " + pages;
+    pag.setAttribute(
+      "aria-label",
+      "Saved workstreams pagination — page " + (_wsPage + 1) + " of " + pages,
+    );
+  }
+  const prev = document.getElementById("ws-page-prev");
+  if (prev) prev.disabled = _wsPage <= 0;
+  const next = document.getElementById("ws-page-next");
+  if (next) next.disabled = _wsPage >= pages - 1;
+}
+
+function wsPagePrev() {
+  if (_wsPage > 0) {
+    _wsPage--;
+    renderSavedWorkstreams(_wsSavedItems);
+  }
+}
+
+function wsPageNext() {
+  const pages = Math.max(1, Math.ceil(_wsSavedItems.length / WS_PAGE_SIZE));
+  if (_wsPage < pages - 1) {
+    _wsPage++;
+    renderSavedWorkstreams(_wsSavedItems);
+  }
 }
 
 // HTML inline-onclick wrappers — keep the global names the existing
@@ -4687,6 +4766,21 @@ function _refreshDashboardSubmitLabel() {
   btn.textContent = hasText || hasFiles ? "Send" : "Create";
 }
 
+// Format a resolved alias with its model suffix the same way as the
+// dropdown rows ("alias (model)", or just "alias" when they coincide).
+// Returns "" when alias is empty or unknown so callers fall back to a
+// neutral placeholder.
+function _resolveModelLabel(alias, models) {
+  if (!alias) return "";
+  for (let i = 0; i < (models || []).length; i++) {
+    const m = models[i];
+    if (m.alias === alias) {
+      return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
+    }
+  }
+  return "";
+}
+
 function _loadDashboardOptionsLists() {
   // Models
   const modelSel = document.getElementById("dashboard-model");
@@ -4710,6 +4804,28 @@ function _loadDashboardOptionsLists() {
             judgeSel.appendChild(jOpt);
           }
         });
+        // Surface the resolved defaults in the placeholder rows so the
+        // panel shows which model actually runs when left untouched —
+        // mirrors the coordinator launcher.  The judge tracks the
+        // per-workstream agent model unless judge.model is explicitly
+        // configured, so keep the "(agent model)" wording in that case
+        // rather than advertising a fixed alias the judge won't use.
+        const modelDefault = _resolveModelLabel(
+          data.default_alias || "",
+          data.models || [],
+        );
+        modelSel.options[0].textContent = modelDefault
+          ? "Default — " + modelDefault
+          : "Default model";
+        if (judgeSel) {
+          const judgeDefault = _resolveModelLabel(
+            data.judge_default_alias || "",
+            data.models || [],
+          );
+          judgeSel.options[0].textContent = judgeDefault
+            ? "Default — " + judgeDefault
+            : "Default (agent model)";
+        }
       })
       .catch(function () {
         /* default model still works */

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -4071,12 +4071,23 @@ function toggleDashboard() {
   else showDashboard();
 }
 
+// Paint a transient message (loading / error) into the saved-workstreams
+// area.  Clears any cards AND hides the pagination control \u2014 it's a sibling
+// of the cards container, so a bare replaceChildren on the cards alone would
+// leave stale Prev/Next visible and still wired to the previous list cache.
+// A successful load re-shows both via renderSavedWorkstreams.
+function _setSavedWsMessage(text) {
+  document
+    .getElementById("dashboard-saved-cards")
+    .replaceChildren(makeEmptyState(text));
+  const pag = document.getElementById("ws-pagination");
+  if (pag) pag.style.display = "none";
+}
+
 function loadDashboard() {
   const tableEl = document.getElementById("dash-ws-table");
   tableEl.replaceChildren(makeEmptyState("Loading\u2026"));
-  document
-    .getElementById("dashboard-saved-cards")
-    .replaceChildren(makeEmptyState("Loading\u2026"));
+  _setSavedWsMessage("Loading\u2026");
   const dashP = authFetch("/v1/api/dashboard").then(function (r) {
     return r.json();
   });
@@ -4100,9 +4111,7 @@ function loadDashboard() {
     })
     .catch(function () {
       tableEl.replaceChildren(makeEmptyState("Failed to load"));
-      document
-        .getElementById("dashboard-saved-cards")
-        .replaceChildren(makeEmptyState("Failed to load"));
+      _setSavedWsMessage("Failed to load");
     });
 }
 

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -215,6 +215,22 @@
             </button>
           </div>
           <div class="dashboard-cards" id="dashboard-saved-cards"></div>
+          <div
+            id="ws-pagination"
+            class="pagination"
+            style="display: none"
+            role="navigation"
+            aria-label="Saved workstreams pagination"
+          >
+            <button id="ws-page-prev" type="button" onclick="wsPagePrev()">
+              &#x25c4; Prev
+            </button>
+            <span id="ws-page-label" aria-live="polite" aria-atomic="true">
+            </span>
+            <button id="ws-page-next" type="button" onclick="wsPageNext()">
+              Next &#x25ba;
+            </button>
+          </div>
           <div id="ws-delete-bar" class="ws-delete-bar">
             <span
               class="ws-delete-count-label"


### PR DESCRIPTION
## What & why

The interactive dashboard ("What are you working on?") had drifted from the coordinator launcher in two ways. This backports both for consistency.

### Selectors
The **Model** / **Judge Model** dropdowns now show the resolved default model in the placeholder (e.g. `Default — primary (vendor/primary)`) instead of a generic `Default model` / `Default (agent model)`.

`GET /v1/api/models` now returns `judge_default_alias` (mirroring the console endpoint), sourced from the `judge.model` setting. It is intentionally **blank** when `judge.model` is unset or points at a disabled/removed alias, because the judge then follows the per-workstream agent model at runtime (`session_factory`: `judge_config.model or model`) — so the UI keeps the honest `Default (agent model)` wording in that case. This also fixes a latent mislabel: the judge row previously read "agent model" even when an operator had configured `judge.model`.

### Pagination
**Saved Workstreams** now paginates at 24/page (`◄ Prev · X / Y · Next ►`), matching Saved Coordinators — page clamp after deletes, hidden on a single page and in delete mode, Select-All bounded to the visible page. The empty branch drops out of delete mode (matching the launcher) so the toolbar can't linger over an empty grid.

### Anti-drift
The shared `.pagination` CSS is **lifted** from `console/static/style.css` into `shared/cards.css` (loaded by both apps) so the two dashboards keep one source of truth instead of gaining a third copy. The pagination JS render wiring stays per-app (it binds per-app DOM ids + controller instances) with a cross-reference comment to its console twin.

## Test plan
- `ruff` + `mypy` clean.
- `pytest` — new `tests/test_server_available_models.py` (6 cases) pins the judge/model resolution chain (unset / configured / unknown / whitespace / registry-default fallback); full sweep incl. `test_openapi`, `test_output_guard`, console models, channel/discord green (90 passed).
- Headless-Chrome verification of both features against the real `app.js` + shared CSS: resolved/unset/configured/unknown selector labels; pagination nav (24→6, label, disabled states); single-page hide; empty state; the CSS lift resolving to `display:flex`; and the delete-mode-empties path (exactly one empty-state row, mode exits, no double-append).
