### PR TITLE
fix(history): gate /history pending flag on live awaiting-approval

### DIFF
--- a/tests/test_history_projection.py
+++ b/tests/test_history_projection.py
@@ -285,7 +285,54 @@ class TestProjectHistoryMessages:
         assert out[4]["denied"] is True  # tool deny derived from content prefix
         assert out[3]["denied"] is True  # propagated to the parent assistant turn
         assert out[5]["is_error"] is True  # tool error derived from content prefix
-        # pending ONLY on the last orphan turn
-        assert out[7].get("pending") is True  # trailing orphan c3 awaiting
+        # ``pending`` is a LIVE-state decision gated on ``awaiting_approval``
+        # (default False here) — NOT orphan-detection.  So even the trailing
+        # orphan renders its tool block by default; see
+        # ``test_pending_gated_on_awaiting_approval`` for the gate.
+        assert out[7].get("pending") is not True  # trailing orphan c3 — not awaiting → renders
         assert out[6].get("pending") is not True  # mid-conversation orphan c_mid renders
         assert out[1].get("pending") is not True  # resolved c1
+
+    def test_pending_gated_on_awaiting_approval(self) -> None:
+        """``pending`` marks the LAST orphan tool-call turn only when the
+        caller passes ``awaiting_approval=True`` (the live ``_pending_approval``
+        read).  This is the regression guard for the fresh-connect bug: an
+        orphan tool call mid-execution is NOT awaiting approval, so it must
+        render its tool block (``pending`` absent) rather than vanish until a
+        reconnect replays the buffered events.
+        """
+        raw: list[dict[str, Any]] = [
+            # resolved turn (has a tool result)
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "res"},
+            # mid-conversation orphan (NOT the last tool turn)
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c_mid", "function": {"name": "g", "arguments": "{}"}}],
+            },
+            {"role": "user", "content": "carry on"},
+            # trailing orphan (last tool turn, no result)
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c_last", "function": {"name": "h", "arguments": "{}"}}],
+            },
+        ]
+
+        # Awaiting approval: ONLY the trailing orphan turn is pending.
+        awaiting = project_history_messages(raw, awaiting_approval=True)
+        assert awaiting[4].get("pending") is True  # trailing orphan → skip static, live prompt
+        assert awaiting[2].get("pending") is not True  # mid-conversation orphan still renders
+        assert awaiting[0].get("pending") is not True  # resolved turn
+
+        # Executing / not awaiting: NOTHING is pending — the trailing orphan
+        # (a tool mid-execution) renders its tool block on a fresh connect.
+        executing = project_history_messages(raw, awaiting_approval=False)
+        executing_pending = [entry.get("pending") for entry in executing]
+        assert executing_pending == [None, None, None, None, None]
+        # Default matches awaiting_approval=False.
+        default_pending = [entry.get("pending") for entry in project_history_messages(raw)]
+        assert default_pending == [None, None, None, None, None]

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1108,22 +1108,70 @@ class TestHistoryInteractive:
         # call_2 result not yet persisted — operator refreshes here.
         mock_ws = MagicMock()
         mock_ws.id = ws_id
+        # Mid-EXECUTION, not awaiting approval: any approval already
+        # resolved, so ``_pending_approval`` is None.  The trailing orphan
+        # tool turn must therefore RENDER (``pending`` absent) — marking it
+        # pending is the fresh-connect-during-execution bug (the renderer
+        # skips pending turns, so the tool call vanishes until a reconnect
+        # replays the buffered events).
+        mock_ws.ui._pending_approval = None
         mock_mgr = MagicMock()
         mock_mgr.get.return_value = mock_ws
         client = _build_history_app(mock_mgr, _inject_storage)
 
         r = client.get(f"/v1/api/workstreams/{ws_id}/history")
         assert r.status_code == 200
-        roles = [m.get("role") for m in r.json()["messages"]]
+        messages = r.json()["messages"]
+        roles = [m.get("role") for m in messages]
         # All three rows survive — the trailing assistant + partial
         # tool result are what the operator was watching live.  The
         # default-repair shape would have been just ``["user"]``.
         assert roles == ["user", "assistant", "tool"]
+        # And the trailing tool-call turn is NOT pending → renders.
+        assistant_turn = next(m for m in messages if m.get("role") == "assistant")
+        assert assistant_turn.get("pending") is not True
 
         # Confirm the default-repair path collapses this to just the
         # user message — locks in the regression contract.
         with_repair = _inject_storage.load_messages(ws_id, repair=True)
         assert [m.get("role") for m in with_repair] == ["user"]
+
+    def test_trailing_tool_turn_pending_when_awaiting_approval(self, _inject_storage):
+        """Counterpart to the execution case: when the live session IS
+        awaiting approval (``_pending_approval`` set), the trailing orphan
+        tool-call turn is marked ``pending`` so the renderer skips the static
+        block — the SSE replay re-emits the interactive approve_request prompt
+        to render it instead.  Keeps the ``/history`` ``pending`` flag in
+        lockstep with the live approval signal (``_interactive_events_replay``).
+        """
+        import json
+
+        ws_id = "ws-awaiting"
+        _inject_storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        _inject_storage.save_message(ws_id, "user", "kick off")
+        tc_json = json.dumps(
+            [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ]
+        )
+        _inject_storage.save_message(ws_id, "assistant", "Working", tool_calls=tc_json)
+        # No tool result yet AND the session is parked awaiting approval.
+        mock_ws = MagicMock()
+        mock_ws.id = ws_id
+        mock_ws.ui._pending_approval = {"type": "approve_request", "items": []}
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = mock_ws
+        client = _build_history_app(mock_mgr, _inject_storage)
+
+        r = client.get(f"/v1/api/workstreams/{ws_id}/history")
+        assert r.status_code == 200
+        messages = r.json()["messages"]
+        assistant_turn = next(m for m in messages if m.get("role") == "assistant")
+        assert assistant_turn.get("pending") is True
 
     def test_history_does_not_synthesize_orphan_results(self, _inject_storage):
         """``repair=False`` via ``/history`` must NOT splice synthetic
@@ -1152,6 +1200,7 @@ class TestHistoryInteractive:
         _inject_storage.save_message(ws_id, "assistant", "ok")
         mock_ws = MagicMock()
         mock_ws.id = ws_id
+        mock_ws.ui._pending_approval = None  # cancelled, not awaiting approval
         mock_mgr = MagicMock()
         mock_mgr.get.return_value = mock_ws
         client = _build_history_app(mock_mgr, _inject_storage)

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -565,7 +565,9 @@ def decorate_history_messages(
                 msg["advisories"] = advisories
 
 
-def project_history_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def project_history_messages(
+    messages: list[dict[str, Any]], awaiting_approval: bool = False
+) -> list[dict[str, Any]]:
     """Project decorated storage messages into the canonical wire shape.
 
     This is the SINGLE server-side projection that both the interactive
@@ -589,8 +591,24 @@ def project_history_messages(messages: list[dict[str, Any]]) -> list[dict[str, A
     - tool results: surface ``advisories``, coerce list content to a
       string, derive ``denied`` / ``is_error`` from the content prefix;
     - ``denied`` propagates from a tool result to its parent assistant
-      turn; ``pending`` marks ONLY the last assistant tool-call turn that
-      still has an orphan (a tool_call with no result in the window).
+      turn; ``pending`` marks the last assistant tool-call turn ONLY when
+      the workstream is genuinely awaiting approval for it
+      (*awaiting_approval*) — driven by the live ``_pending_approval``
+      signal, NOT orphan-detection.  An orphan that is executing or was
+      interrupted is not awaiting approval and must still render its tool
+      block.
+
+    *awaiting_approval* is the caller's live read of the workstream's
+    ``_pending_approval`` (``make_history_handler`` reads it off the
+    loaded session; ``False`` for a storage-only / closed ws).  It must
+    track the SAME signal that the SSE replay uses to re-emit the
+    interactive approve_request prompt (``_interactive_events_replay`` /
+    the coord replay): ``pending=True`` tells the renderer to SKIP the
+    static tool block precisely because that live prompt will render it
+    instead.  Deriving ``pending`` from orphan-detection alone desynced
+    the two — a tool call mid-execution (orphan, but not awaiting) was
+    marked pending, so it rendered from neither source on a fresh connect
+    and only reappeared on reconnect (ring-buffer event replay).
 
     Two projection responsibilities live HERE and nowhere else:
 
@@ -832,17 +850,24 @@ def project_history_messages(messages: list[dict[str, Any]]) -> list[dict[str, A
             history[last_assistant_idx]["denied"] = True
 
     # (9) Mark ``pending`` ONLY on the LAST assistant tool-call turn, and
-    #     only when it has an orphan (a tool_call with no result in the
-    #     loaded window) — the proxy for "awaiting approval".  A
-    #     mid-conversation cancelled/interrupted tool call is also an
-    #     orphan but must still render its tool block (not vanish), so it
-    #     is NOT marked pending.
-    for entry in reversed(history):
-        tcs = entry.get("tool_calls")
-        if tcs:
-            has_orphan = any(tc.get("id") and str(tc["id"]) not in resulted_call_ids for tc in tcs)
-            if has_orphan:
-                entry["pending"] = True
-            break
+    #     only when the workstream is genuinely awaiting approval for it
+    #     (``awaiting_approval`` — the live ``_pending_approval`` read)
+    #     AND it still has an orphan (a tool_call with no result in the
+    #     loaded window).  ``pending`` tells the renderer to skip the
+    #     static tool block because the SSE replay re-emits the live
+    #     approve_request prompt instead, so this must track the same
+    #     signal as that re-emit.  An orphan that is executing or was
+    #     interrupted is NOT awaiting approval, so it stays unmarked and
+    #     renders its tool block (the fresh-connect-during-execution gap).
+    if awaiting_approval:
+        for entry in reversed(history):
+            tcs = entry.get("tool_calls")
+            if tcs:
+                has_orphan = any(
+                    tc.get("id") and str(tc["id"]) not in resulted_call_ids for tc in tcs
+                )
+                if has_orphan:
+                    entry["pending"] = True
+                break
 
     return history

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2829,6 +2829,22 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 await asyncio.to_thread(
                     extract_reasoning_for_history, messages, surface_persisted_reasoning
                 )
+                # ``pending`` on the trailing tool-call turn must track the
+                # LIVE awaiting-approval signal, not orphan-detection — an
+                # executing or interrupted orphan is not awaiting approval
+                # and must render its tool block on a fresh connect (else it
+                # vanishes until a reconnect replays the buffered events).
+                # Read ``_pending_approval`` off the loaded session; a
+                # storage-only / closed ws has no live session → never
+                # pending.  Stays in lockstep with the approve_request
+                # re-emit in the SSE replay (``_interactive_events_replay``).
+                # Asserted as ``dict`` (its only real production shape) to
+                # match the detail handler below, so a MagicMock-based unit
+                # test's auto-vivified attribute doesn't trip the path.
+                awaiting_approval = isinstance(
+                    getattr(getattr(live_session, "ui", None), "_pending_approval", None),
+                    dict,
+                )
                 # Final structural projection: flatten nested tool_calls,
                 # collapse multipart content, surface the
                 # ``_source`` / ``_reminders`` / ``_attachments_meta``
@@ -2839,7 +2855,9 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 # wire payload is the canonical render shape both the
                 # interactive ``replayHistory`` and the coordinator history
                 # rebuild consume directly — no client-side normaliser.
-                messages = await asyncio.to_thread(project_history_messages, messages)
+                messages = await asyncio.to_thread(
+                    project_history_messages, messages, awaiting_approval
+                )
             except Exception:
                 # Operationally interesting: a persistent decoration
                 # failure (missing migration, driver mismatch, schema


### PR DESCRIPTION
## Summary

In-flight tool calls did not render when a browser connected **fresh** to an in-progress workstream mid-tool-execution — they only reappeared after the SSE dropped and reconnected.

**Root cause.** `project_history_messages` marked the trailing tool-call turn `pending` from orphan-detection (a `tool_call` with no result) as a proxy for "awaiting approval". But an orphan that is *executing* (already approved, running) is orphan-but-**not**-awaiting. The renderer skips `pending` turns because the SSE replay re-emits the interactive approve_request prompt instead — and during execution `_pending_approval` is `None`, so nothing re-emits. The tool call rendered from **neither** source on a fresh connect, recovering only on reconnect (ring-buffer replay carries the `tool_info` / `tool_result` events).

**Regression origin.** The REST-first history convergence (`0ad1ab7f`), inherited by the wire-shape unification (#596) — both swapped the `pending` predicate from the live `_pending_approval` signal to storage orphan-detection, which diverge exactly during tool execution.

## Fix

Thread the live awaiting-approval signal from `make_history_handler` into `project_history_messages` (new `awaiting_approval` param) and gate the `pending` mark on it, re-syncing `pending` with the same `_pending_approval` signal that drives the SSE prompt re-emit. A storage-only / closed ws has no live session → never `pending` → trailing orphans render as historical. Asserted as `dict` to match the sibling detail handler's MagicMock-safe guard.

The projection is the single shared server-side wire shape, so both the interactive `replayHistory` renderer and the coordinator history rebuild get the corrected `pending` semantics.

## Tests

- New projection-level gate test (`test_pending_gated_on_awaiting_approval`): awaiting → only the trailing orphan turn `pending`; not-awaiting → nothing `pending`.
- New handler boundary test (`test_trailing_tool_turn_pending_when_awaiting_approval`).
- The existing `test_returns_partial_trailing_turn_during_tool_execution` now asserts the turn **renders** (not `pending`), not just that the row survives — the parity gap that let this regression through.
- `ruff` + `mypy` clean; history, endpoint, coordinator, session, SSE-replay, and JS-guard suites all pass. `/review` multi-stage pipeline run (bug/security/performance/quality) — clean after one fix (matched the detail handler's `isinstance(dict)` guard).

## Out of scope (follow-ups)

Tracked for the broader fresh-connect-replay-robustness work alongside the fan-in design:
- A residual sub-millisecond race if approval resolves in the gap between the client's `/history` fetch and its SSE connect.
- Client-side `appendToolOutput` silently drops a `tool_result` for an unknown `call_id` (anchor hardening).

Refs #540.
