### PR TITLE
fix(sse): surface persisted last_error on fresh-connect replay

### DIFF
--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -671,16 +671,32 @@ def test_handler_fresh_connect_in_error_state_surfaces_last_error(monkeypatch: A
     can't rebuild it — the ``last_error`` config row is the only durable
     source.  Gated on the error state: a healthy (idle) ws skips the
     storage read and surfaces nothing (no stale error on every load).
+
+    The surfaced event carries the SSE ``id:`` (registration-time buffer
+    cursor ``snap_seq``) so a native EventSource reconnect advances
+    ``lastEventId`` and resumes via ``replay_ok`` instead of re-running
+    this fresh path and APPENDING a duplicate bubble — the client's
+    ``error`` handler is append-only (not idempotent like
+    ``state_change`` / ``in_progress_snapshot``).  The reconnect half is
+    pinned by ``test_handler_replay_ok_does_not_resurface_last_error``.
     """
     import turnstone.core.memory as memory_mod
 
     monkeypatch.setattr(memory_mod, "load_last_error", lambda _ws: "boom: kaboom")
 
-    # Error state → surfaced.
+    # Error state → surfaced.  A prior buffered event gives a non-zero
+    # cursor (snap_seq == 1) for the id assertion below.
     err_ui = _make_ui()
-    _, err_blob = _drain_handler_yields(err_ui, state="error", max_yields=8)
+    err_ui.on_content_token("x")  # _event_id -> 1
+    err_yields, err_blob = _drain_handler_yields(err_ui, state="error", max_yields=8)
     assert '"type": "error"' in err_blob
     assert "boom: kaboom" in err_blob
+    # The surfaced error advances the reconnect cursor (carries id: snap_seq).
+    err_events = [
+        y for y in err_yields if isinstance(y, dict) and "boom: kaboom" in y.get("data", "")
+    ]
+    assert len(err_events) == 1
+    assert err_events[0].get("id") == "1"
 
     # Idle state → the gate skips it.
     idle_ui = _make_ui()

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -471,14 +471,18 @@ def test_snap_seq_high_water_mark_holds_under_writer_race() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _wire_events_handler(ui: _ConcreteUI) -> Any:
+def _wire_events_handler(ui: _ConcreteUI, *, state: str = "idle") -> Any:
     """Build a minimal ``make_events_handler`` closure that returns
     yields suitable for the EventSourceResponse generator.
 
     Calls the closure with a fake request; returns the inner generator
     AFTER it has been started so the test can iterate yields directly.
+
+    ``state`` sets the workstream's ``ws.state.value`` so a test can
+    exercise the error-state branch (the persisted ``last_error``
+    surface) without a real session.
     """
-    ws = SimpleNS(id=ui.ws_id, ui=ui, state=SimpleNS(value="idle"))
+    ws = SimpleNS(id=ui.ws_id, ui=ui, state=SimpleNS(value=state))
     mgr = MagicMock()
     mgr.get.return_value = ws
 
@@ -499,6 +503,7 @@ def _drain_handler_yields(
     headers: dict[str, str] | None = None,
     query: dict[str, str] | None = None,
     max_yields: int = 10,
+    state: str = "idle",
 ) -> tuple[list[Any], str]:
     """Synchronous helper: spin up the handler, drain up to N yields,
     return ``(raw_yields, decoded_blob)``.  Uses ``asyncio.run`` so
@@ -509,7 +514,7 @@ def _drain_handler_yields(
     returned for shape-level assertions (e.g. the first-yield
     ``retry`` check).
     """
-    handler = _wire_events_handler(ui)
+    handler = _wire_events_handler(ui, state=state)
     req = _fake_request(headers=headers, query=query, path_params={"ws_id": ui.ws_id})
 
     async def _run() -> list[Any]:
@@ -648,3 +653,51 @@ def test_handler_query_param_fallback_is_honoured() -> None:
     # Replay path: in_progress_snapshot SKIPPED, id:1 present.
     assert "in_progress_snapshot" not in blob
     assert "id: 1" in blob
+
+
+# ---------------------------------------------------------------------------
+# Fresh-connect replay completeness — persisted last_error surface
+# (sibling to the tool-call ``pending`` fix; the fresh-connect synthetic
+# path must reconstruct the same render state a reconnect's ring-buffer
+# replay would carry).
+# ---------------------------------------------------------------------------
+
+
+def test_handler_fresh_connect_in_error_state_surfaces_last_error(monkeypatch: Any) -> None:
+    """Fresh connect to a workstream sitting in the error state must
+    surface the persisted ``last_error`` so the operator sees WHY it
+    failed (the ``error`` text bubble), not just the bare error state +
+    retry.  ``on_error`` is never persisted as a message, so ``/history``
+    can't rebuild it — the ``last_error`` config row is the only durable
+    source.  Gated on the error state: a healthy (idle) ws skips the
+    storage read and surfaces nothing (no stale error on every load).
+    """
+    import turnstone.core.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "load_last_error", lambda _ws: "boom: kaboom")
+
+    # Error state → surfaced.
+    err_ui = _make_ui()
+    _, err_blob = _drain_handler_yields(err_ui, state="error", max_yields=8)
+    assert '"type": "error"' in err_blob
+    assert "boom: kaboom" in err_blob
+
+    # Idle state → the gate skips it.
+    idle_ui = _make_ui()
+    _, idle_blob = _drain_handler_yields(idle_ui, state="idle", max_yields=8)
+    assert "boom: kaboom" not in idle_blob
+
+
+def test_handler_replay_ok_does_not_resurface_last_error(monkeypatch: Any) -> None:
+    """On the ``replay_ok`` (reconnect) path the ring buffer already
+    carries the original ``error`` event, so the synthetic last_error
+    surface must NOT fire — otherwise a reconnect to an errored ws would
+    double the error bubble.  The surface is fresh/truncated-only."""
+    import turnstone.core.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "load_last_error", lambda _ws: "boom")
+
+    ui = _make_ui()
+    ui.on_content_token("hi")  # one buffered event so Last-Event-ID=0 → replay_ok
+    _, blob = _drain_handler_yields(ui, headers={"Last-Event-ID": "0"}, state="error", max_yields=8)
+    assert "boom" not in blob

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1939,14 +1939,30 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
 
                             last_err = await asyncio.to_thread(load_last_error, ws_id)
                             if last_err:
+                                # Carry the SSE ``id:`` (registration-time
+                                # buffer position) so the client's
+                                # ``lastEventId`` advances past this surface.
+                                # Unlike the idempotent ``state_change`` /
+                                # ``in_progress_snapshot`` above, the client
+                                # APPENDS this ``error`` bubble (non-idempotent),
+                                # and a terminal-errored idle ws emits no live
+                                # event to set a cursor — so without an ``id:``
+                                # a native EventSource reconnect would send no
+                                # ``Last-Event-ID``, re-run this fresh path, and
+                                # append a DUPLICATE bubble on every reconnect
+                                # cycle.  With it, the reconnect resumes via
+                                # ``replay_ok`` (nothing buffered past
+                                # ``snap_seq`` on an idle ws) and skips this
+                                # surface.
                                 yield {
+                                    "id": str(snap_seq),
                                     "data": json.dumps(
                                         {
                                             "type": "error",
                                             "message": last_err,
                                             "ws_id": ws_id,
                                         }
-                                    )
+                                    ),
                                 }
                     except Exception:
                         log.debug(

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1921,6 +1921,39 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
                                 }
                             )
                         }
+                    # Surface the persisted ``last_error`` so a fresh
+                    # connect to a workstream sitting in the error state
+                    # shows WHY it failed (the ``error`` text bubble), not
+                    # just the bare error state + retry affordance.
+                    # ``on_error`` is never persisted as a message, so
+                    # ``/history`` can't rebuild it — the ``last_error``
+                    # config row (set by ``_record_fatal_error``, cleared
+                    # on recovery) is the only durable source.  Gated on
+                    # the error state so a healthy ws skips the storage
+                    # read, and confined to this fresh/truncated path —
+                    # the ``replay_ok`` branch's ring buffer already
+                    # carries the original ``error`` event.
+                    try:
+                        if getattr(ws.state, "value", None) == "error":
+                            from turnstone.core.memory import load_last_error
+
+                            last_err = await asyncio.to_thread(load_last_error, ws_id)
+                            if last_err:
+                                yield {
+                                    "data": json.dumps(
+                                        {
+                                            "type": "error",
+                                            "message": last_err,
+                                            "ws_id": ws_id,
+                                        }
+                                    )
+                                }
+                    except Exception:
+                        log.debug(
+                            "ws.events.last_error_replay_failed ws=%s",
+                            ws_id[:8],
+                            exc_info=True,
+                        )
                 # Live phase — drain the per-UI listener queue
                 # until either the workstream closes or the client
                 # disconnects. 5s poll matches pre-lift interactive


### PR DESCRIPTION
## Summary

Second of the fresh-connect SSE replay-completeness fixes (sibling to the now-merged tool-call `pending` fix, #610). A browser connecting **fresh** to a workstream sitting in the **error** state saw the error STATE (composer unlock + retry, via the replayed `state_change`) but **not the error TEXT** explaining why — on a fresh connect there was no source for it. `on_error` is never persisted as a message, so `/history` can't rebuild it; only the reconnect path (ring buffer) carried the original `error` event.

## Fix

Surface the persisted `last_error` in `make_events_handler`'s fresh/truncated synthetic-replay branch when the workstream is in the error state:
- **Gated on the error state** → a healthy ws skips the storage read.
- **Confined to the fresh/truncated path** → the `replay_ok` (reconnect) branch's ring buffer already replays the original `error` event, so surfacing here would double it.
- The persist (`_record_fatal_error`, sanitized) / clear (on recovery) lifecycle **already exists** — this only reconstructs the event on a fresh connect, reaching parity with reconnect. No client change (the `error` handler already appends the bubble).

## Tests

Two parity tests in `tests/test_sse_reconnect_replay.py`: fresh + error → surfaced / fresh + idle → gate skips, and `replay_ok` → not double-emitted. The shared `_wire_events_handler` / `_drain_handler_yields` helpers gained a backward-compatible `state` param.

`ruff` + `mypy` clean; SSE-replay, workstream-endpoint, history-projection, coordinator and session suites pass. `/review` pipeline (bug / security / quality) — clean, no findings.

## Scope notes

From a fresh-connect replay-completeness audit of all 27 interactive event types. Deliberately **out of scope** here:
- **Non-terminal mid-turn errors** (tool parse failures, truncation — they don't set `state=error` and aren't persisted) stay an accepted gap; there's no durable source to reconstruct them.
- **The queued-message indicator gap** is deferred — it needs client-side render-on-replay + dedup against the optimistic render.

Both are documented for the eventual console-side fan-in work, where fresh-connect completeness is load-bearing (fan-in opens each upstream fresh per pane).

Refs #540.
