### PR TITLE
feat(ui): re-add saved-list pagination (cap 20) and align coordinator dashboard

### DIFF
--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -2066,23 +2066,47 @@ function _renderHomeView() {
   }
   if (coordsFp !== _homeCoordsFingerprint) {
     _homeCoordsFingerprint = coordsFp;
-    const countEl = document.getElementById("active-coord-count");
-    if (countEl) {
-      countEl.textContent = coords.length ? "(" + coords.length + ")" : "";
+    // Header summary mirrors the server dashboard's wording exactly
+    // ("N active · M total"; active = non-idle) so the two surfaces read
+    // the same.
+    const total = coords.length;
+    let active = 0;
+    for (let i = 0; i < coords.length; i++) {
+      if ((coords[i].state || "idle") !== "idle") active++;
     }
-    const listEl = document.getElementById("active-coord-list");
-    if (listEl) {
-      listEl.replaceChildren();
-      if (!coords.length) {
+    const summaryEl = document.getElementById("active-coord-summary");
+    if (summaryEl) {
+      summaryEl.textContent = active + " active · " + total + " total";
+    }
+    const rowsEl = document.getElementById("active-coord-rows");
+    const colHeadersEl = document.getElementById("active-coord-colheaders");
+    const footerEl = document.getElementById("active-coord-footer");
+    const footerCountEl = document.getElementById("active-coord-footer-count");
+    if (rowsEl) {
+      if (!total) {
+        // Empty: hide the column-header band (no columns to label) but keep
+        // the footer so the card retains its rounded, bordered bottom edge
+        // rather than an open-bottomed header over the empty-state copy.
+        if (colHeadersEl) colHeadersEl.style.display = "none";
+        if (footerEl) footerEl.style.display = "";
+        if (footerCountEl) footerCountEl.textContent = "0 coordinators";
         const empty = document.createElement("div");
         empty.className = "dashboard-empty";
         empty.textContent = "No active coordinator sessions. Start one above.";
-        listEl.appendChild(empty);
+        rowsEl.replaceChildren(empty);
       } else {
-        // Reuse the shared tree-grouped renderer so coordinators on
-        // the landing page get the same glyphs, child-count badges,
-        // and row treatment as the legacy dashboard.
-        renderWsTable(listEl, coords);
+        // Reveal the column-header band + footer (static siblings of the
+        // rows container, so renderWsTable's replaceChildren leaves them
+        // intact), then reuse the shared tree-grouped renderer so the rows
+        // get the same labelled columns, glyphs, child-count badges, and
+        // treatment as the Nodes table and the server's Workstreams card.
+        if (colHeadersEl) colHeadersEl.style.display = "";
+        if (footerEl) footerEl.style.display = "";
+        if (footerCountEl) {
+          footerCountEl.textContent =
+            total + (total === 1 ? " coordinator" : " coordinators");
+        }
+        renderWsTable(rowsEl, coords);
       }
     }
   }
@@ -2172,6 +2196,7 @@ const _coordTable = createSavedTable({
   bodyEl: document.getElementById("saved-coord-cards"),
   filterEl: document.getElementById("coord-filter"),
   footerEl: document.getElementById("coord-saved-footer"),
+  paginationEl: document.getElementById("coord-pagination"),
   columns: COORD_COLUMNS,
   noun: "coordinator",
   emptyText: "No saved coordinators",

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -110,25 +110,47 @@
           ></div>
         </section>
 
-        <!-- Active coordinators list — SSE-driven.  Rows render via the shared
-         _renderWsRow helper so state glyph + name + child-count badge +
-         last-activity match the existing dashboard tree. -->
-        <section
-          id="active-coordinators"
-          class="home-section"
-          aria-label="Coordinators"
-        >
-          <h2 class="home-section-title">
-            <span>Coordinators</span>
-            <span id="active-coord-count" class="home-section-count"></span>
-          </h2>
+        <!-- Active coordinators — SSE-driven, contiguous card matching the
+             server's Workstreams block: a dash-header bar (title +
+             active/total summary), the column-header band, the rows
+             (rendered via the shared _renderWsRow tree helper so glyphs /
+             child-count badges / last-activity match the dashboard), and a
+             dash-footer count line.  The band + footer are static siblings of
+             the rows container so renderWsTable's replaceChildren leaves them
+             intact; the renderer reveals them with rows, hides them empty. -->
+        <section id="active-coordinators" aria-label="Coordinators">
+          <div class="dash-header">
+            <span class="dash-header-title">COORDINATORS</span>
+            <span class="dash-header-summary" id="active-coord-summary"></span>
+          </div>
           <div
-            id="active-coord-list"
-            class="dash-table home-coord-list"
+            class="dash-colheaders"
+            id="active-coord-colheaders"
+            aria-hidden="true"
+            style="display: none"
+          >
+            <span class="dash-col dash-col-state">STATE</span>
+            <span class="dash-col dash-col-name">NAME</span>
+            <span class="dash-col dash-col-model">MODEL</span>
+            <span class="dash-col dash-col-node">NODE</span>
+            <span class="dash-col dash-col-task">TASK</span>
+            <span class="dash-col dash-col-tokens">TOKENS</span>
+            <span class="dash-col dash-col-ctx">CTX</span>
+          </div>
+          <div
+            id="active-coord-rows"
+            class="dash-table"
             role="list"
             aria-live="polite"
           >
             <div class="dashboard-empty">Loading…</div>
+          </div>
+          <div
+            class="dash-footer"
+            id="active-coord-footer"
+            style="display: none"
+          >
+            <span class="dash-footer-count" id="active-coord-footer-count"></span>
           </div>
         </section>
 
@@ -140,7 +162,6 @@
          from storage.  Hidden until at least one saved coordinator loads. -->
         <section
           id="saved-coordinators"
-          class="home-section"
           style="display: none"
           aria-label="Saved coordinators"
         >
@@ -172,13 +193,20 @@
             role="group"
             aria-label="Saved coordinators"
           ></div>
-          <div
-            class="saved-footer"
-            id="coord-saved-footer"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          ></div>
+          <div class="saved-pager-row">
+            <div
+              class="saved-footer"
+              id="coord-saved-footer"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            ></div>
+            <div
+              class="pagination"
+              id="coord-pagination"
+              style="display: none"
+            ></div>
+          </div>
           <div id="coord-delete-bar" class="ws-delete-bar">
             <span
               class="ws-delete-count-label"

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -127,48 +127,6 @@
   white-space: nowrap;
 }
 
-.home-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-/* Mirrors .section-header (the 'NODES' heading below) so coordinators
-   and nodes read as peer sections instead of one looking demoted. */
-.home-section-title {
-  margin: 0;
-  font-family: var(--font-ui);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.home-section-count {
-  color: var(--fg-dim);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-}
-/* Right-align action buttons (e.g. Saved Coordinators "Delete") inside
-   .home-section-title without breaking the count's natural left position. */
-.home-section-title .home-section-action {
-  margin-left: auto;
-}
-
-/* Saved Coordinators scroll-all (no pagination); the shared createSavedTable
-   in /shared/cards.js owns filter + sort + render. */
-
-.home-coord-list {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-.home-coord-list .dashboard-empty {
-  padding: 18px 0;
-}
-
 /* Sub-700px: collapse the composer row and tighten padding.  The
    phase-4 designer-review "composer wrap 340-699px" observation is
    fully covered by this full-stack rule — the flex math at ≥701px

--- a/turnstone/shared_static/base.css
+++ b/turnstone/shared_static/base.css
@@ -279,7 +279,24 @@ body {
   font-weight: 600;
   letter-spacing: 0.1em;
 }
-.dash-header-summary { color: var(--fg-dim); font-size: 11px; }
+.dash-header-summary { color: var(--fg-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
+
+/* Footer bar — the bottom counterpart to .dash-header.  Shared so the
+   server's Workstreams card and the console's active-Coordinators card read
+   the same; per-surface spacing (e.g. the server's bottom margin) is layered
+   on in each app's stylesheet. */
+.dash-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  background: var(--code-bg);
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 var(--radius) var(--radius);
+  font-size: 11px;
+  color: var(--fg-dim);
+}
+.dash-footer-count { font-variant-numeric: tabular-nums; }
 
 .dash-colheaders {
   display: grid;

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -259,10 +259,10 @@
    for DOM inspection and as a future hook. */
 
 /* ==========================================================================
-   Pagination — used by the console's filtered admin lists.  The saved
-   workstream / coordinator lists scroll-all now (see createSavedTable), so
-   this control is no longer wired to them; it lives in /shared so the
-   remaining admin surfaces can't drift apart.
+   Pagination — shared by the console's filtered admin lists and the saved
+   workstream / coordinator tables (createSavedTable fills the container with
+   Prev / “page X / Y” / Next, 20 rows per page).  Lives in /shared so the
+   surfaces that use it can't drift apart.
    ========================================================================== */
 .pagination {
   display: flex;
@@ -364,6 +364,15 @@
    near-zero --row-alt vanishes on a long list) and full-opacity muted text
    (AA-legible colours, no opacity hacks).  Idle-dimming is avoided at the
    source — renderSessionRow only sets data-state for `error`. */
+/* Saved rows are always interactive — resume on click, or toggle a checkbox
+   in delete mode — so they own the pointer cursor here rather than relying on
+   each app's `.dash-row` convention.  The server sets `cursor: pointer` on
+   every `.dash-row`; the console scopes it to `.dash-row.has-link` (a class
+   the shared row builder doesn't set), so without this the console's saved
+   rows fell back to the base `cursor: default`. */
+.saved-row {
+  cursor: pointer;
+}
 .saved-row .dash-row-main {
   padding: 8px 16px;
   /* one CSS var, set per render by createSavedTable (responsive-aware) */
@@ -455,6 +464,32 @@
   padding: 9px 16px;
   font-size: 11px;
   color: var(--fg-dim);
+}
+
+/* Footer + pager share one justified row: the dim range readout anchors the
+   left edge, the Prev/Next control docks to the right gutter on the same
+   baseline, so the count and the navigation that moves it read as one region
+   instead of a left-aligned count floating above a centred pager.  Scoped to
+   the saved table — the standalone `.pagination` the console's filtered admin
+   lists use keeps its own centred block layout. */
+.saved-pager-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.saved-pager-row .pagination {
+  padding: 6px 16px;
+}
+@media (max-width: 760px) {
+  .saved-pager-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+  }
+  .saved-pager-row .pagination {
+    justify-content: center;
+  }
 }
 
 /* Delete mode on rows: the shared controller inserts an absolute checkbox

--- a/turnstone/shared_static/cards.js
+++ b/turnstone/shared_static/cards.js
@@ -223,6 +223,10 @@ function renderSessionRow(sess, opts) {
      headerEl, bodyEl  — the .dash-colheaders + .dash-table elements
      filterEl          — optional <input> for the client-side name filter
      footerEl          — optional element for the count line
+     paginationEl      — optional .pagination container; the table fills it
+                         with Prev / “page X / Y” / Next and hides it when
+                         the list fits on one page or delete mode is active
+     pageSize          — rows per page (default 20)
      columns           — array from SavedColumns
      noun              — "workstream" / "coordinator"
      onActivate        — sess => void (resume); gated by delete mode
@@ -237,7 +241,12 @@ function createSavedTable(opts) {
     sortKey: "updated",
     sortDir: -1,
     compact: false,
+    page: 0,
   };
+  /* Client-side page size — the list is fetched whole and sliced here, so
+     the visible page (and therefore the delete controller's Select-All
+     fan-out) is capped at this many rows. */
+  var pageSize = opts.pageSize || 20;
 
   var controller = createSavedCardsController({
     idPrefix: opts.delete.idPrefix,
@@ -347,6 +356,9 @@ function createSavedTable(opts) {
           /* text columns default A→Z, everything else newest/highest-first */
           state.sortDir = col.key === "name" || col.key === "model" ? 1 : -1;
         }
+        /* Re-sorting reshuffles which rows land on which page; jump back to
+           the first page so the user isn't stranded mid-list. */
+        state.page = 0;
         render();
       }
       h.onclick = doSort;
@@ -360,15 +372,40 @@ function createSavedTable(opts) {
     });
   }
 
-  function renderFooter(visibleCount) {
+  /* footer copy:
+       filteredCount — rows after the name filter (the paginated population)
+       start         — index of the first visible row within filteredCount
+       shown         — rows actually painted this page
+       pages         — total page count for filteredCount
+     When the list spans more than one page the footer leads with the
+     visible range so the Prev/Next control reads as intentional paging, not
+     a silent truncation. */
+  function renderFooter(filteredCount, start, shown, pages) {
     if (!opts.footerEl) return;
     var total = state.items.length;
     var noun = opts.noun + (total === 1 ? "" : "s");
-    /* The empty/filtered body message owns the "no match" copy; the footer
-       stays a plain total so the two don't say the same thing twice. */
-    if (state.filter && visibleCount > 0 && visibleCount !== total) {
+    if (pages > 1 && filteredCount > 0) {
+      var rangeNoun = opts.noun + (filteredCount === 1 ? "" : "s");
+      var range =
+        "Showing " +
+        (start + 1) +
+        "–" +
+        (start + shown) +
+        " of " +
+        filteredCount +
+        " " +
+        rangeNoun;
+      opts.footerEl.textContent = state.filter
+        ? range + " matching “" + state.filter + "”"
+        : range;
+      return;
+    }
+    /* Single page: the empty/filtered body message owns the "no match" copy,
+       so the footer stays a plain total — the two don't say the same thing
+       twice. */
+    if (state.filter && filteredCount > 0 && filteredCount !== total) {
       opts.footerEl.textContent =
-        visibleCount +
+        filteredCount +
         " of " +
         total +
         " " +
@@ -381,16 +418,81 @@ function createSavedTable(opts) {
     }
   }
 
+  /* Fill the optional .pagination container with Prev / “page X / Y” / Next.
+     Hidden when the list fits on one page or while multi-selecting: paging
+     in delete mode would orphan the user's checkbox selections, which live
+     on the visible page only.  Buttons are rebuilt each render so their
+     onclick closures always page over the current filtered/sorted list.
+     The page label is intentionally NOT a live region — the footer (already
+     aria-live) announces the resulting "Showing X–Y of Z" range. */
+  function renderPagination(pages) {
+    if (!opts.paginationEl) return;
+    var pag = opts.paginationEl;
+    if (pages <= 1 || controller.inMode()) {
+      pag.style.display = "none";
+      pag.replaceChildren();
+      /* Don't leave an empty navigation landmark (or a stale label) behind
+         when the pager isn't shown — the visible branch re-applies both. */
+      pag.removeAttribute("role");
+      pag.removeAttribute("aria-label");
+      return;
+    }
+    pag.style.display = "";
+    pag.setAttribute("role", "navigation");
+    /* state.page is 0-based here; the legacy console pager
+       (console/static/app.js renderPagination) is 1-based.  The rendered
+       "X / Y" is identical — only the internal index differs — so don't
+       assume a shared base if the two are ever unified. */
+    var prev = document.createElement("button");
+    prev.type = "button";
+    prev.setAttribute("aria-label", "Previous page");
+    prev.textContent = "◄ Prev";
+    prev.disabled = state.page <= 0;
+    prev.onclick = function () {
+      if (state.page > 0) {
+        state.page--;
+        render();
+      }
+    };
+    var label = document.createElement("span");
+    label.textContent = state.page + 1 + " / " + pages;
+    var next = document.createElement("button");
+    next.type = "button";
+    next.setAttribute("aria-label", "Next page");
+    next.textContent = "Next ►";
+    next.disabled = state.page >= pages - 1;
+    next.onclick = function () {
+      if (state.page < pages - 1) {
+        state.page++;
+        render();
+      }
+    };
+    pag.replaceChildren(prev, label, next);
+    pag.setAttribute(
+      "aria-label",
+      "Saved " + opts.noun + "s — page " + (state.page + 1) + " of " + pages,
+    );
+  }
+
   function render() {
     var cols = visibleColumns();
-    var rows = sorted();
+    var all = sorted();
+    var filteredCount = all.length;
+    /* Clamp the page after a delete / filter / upstream churn shrinks the
+       list, then slice to it.  The delete controller only ever sees the
+       visible page, so its Select-All / count can't reach off-page rows. */
+    var pages = Math.max(1, Math.ceil(filteredCount / pageSize));
+    if (state.page > pages - 1) state.page = pages - 1;
+    if (state.page < 0) state.page = 0;
+    var start = state.page * pageSize;
+    var rows = all.slice(start, start + pageSize);
     controller.setItems(rows);
     /* One grid write per render: rows read it from the inherited CSS var. */
     if (opts.bodyEl) {
       opts.bodyEl.style.setProperty("--saved-grid", gridTemplate(cols));
       opts.bodyEl.replaceChildren();
     }
-    if (!rows.length) {
+    if (!filteredCount) {
       /* Empty state owns the space — hide the column headers so it doesn't
          read as a broken grid. */
       if (opts.headerEl) opts.headerEl.style.display = "none";
@@ -417,7 +519,8 @@ function createSavedTable(opts) {
       });
     }
     if (controller.inMode()) controller.refreshBar();
-    renderFooter(rows.length);
+    renderPagination(pages);
+    renderFooter(filteredCount, start, rows.length, pages);
   }
 
   /* Debounce only the filter keystrokes; setItems / sort / delete render
@@ -428,6 +531,9 @@ function createSavedTable(opts) {
       if (filterTimer) clearTimeout(filterTimer);
       filterTimer = setTimeout(function () {
         state.filter = opts.filterEl.value.trim().toLowerCase();
+        /* A narrower filter usually means fewer pages; restart at page 1 so
+           the user lands on matches rather than an out-of-range page. */
+        state.page = 0;
         render();
       }, 120);
     });

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -4111,11 +4111,15 @@ function toggleDashboard() {
 // area.  Clears any cards AND hides the pagination control \u2014 it's a sibling
 // of the cards container, so a bare replaceChildren on the cards alone would
 // leave stale Prev/Next visible and still wired to the previous list cache.
-// A successful load re-shows both via _wsTable.setItems.
+// A successful load re-shows it (and the footer) via _wsTable.setItems.
 function _setSavedWsMessage(text) {
   document
     .getElementById("dashboard-saved-cards")
     .replaceChildren(makeEmptyState(text));
+  const pag = document.getElementById("ws-pagination");
+  if (pag) pag.style.display = "none";
+  const footer = document.getElementById("ws-saved-footer");
+  if (footer) footer.textContent = "";
 }
 
 function loadDashboard() {
@@ -4308,6 +4312,7 @@ const _wsTable = createSavedTable({
   bodyEl: document.getElementById("dashboard-saved-cards"),
   filterEl: document.getElementById("ws-filter"),
   footerEl: document.getElementById("ws-saved-footer"),
+  paginationEl: document.getElementById("ws-pagination"),
   columns: WS_COLUMNS,
   noun: "workstream",
   emptyText: "No saved workstreams",

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -231,13 +231,20 @@
             role="group"
             aria-label="Saved workstreams"
           ></div>
-          <div
-            class="saved-footer"
-            id="ws-saved-footer"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          ></div>
+          <div class="saved-pager-row">
+            <div
+              class="saved-footer"
+              id="ws-saved-footer"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            ></div>
+            <div
+              class="pagination"
+              id="ws-pagination"
+              style="display: none"
+            ></div>
+          </div>
           <div id="ws-delete-bar" class="ws-delete-bar">
             <span
               class="ws-delete-count-label"

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -2266,16 +2266,10 @@ audio.media-player {
   cursor: pointer;
 }
 
-/* Dashboard footer */
+/* Dashboard footer — the bar styling now lives in /shared/base.css; the
+   server keeps its own bottom margin to space the footer from the saved-
+   workstreams section below. */
 .dash-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 16px;
-  background: var(--code-bg);
-  border-top: 1px solid var(--border);
-  border-radius: 0 0 var(--radius) var(--radius);
-  font-size: 11px;
   margin-bottom: 24px;
 }
 .dash-footer-nodes {


### PR DESCRIPTION
Re-adds the saved-list pagination retired by #611, and brings the console's active-coordinators dashboard into visual parity with the server's Workstreams block. Frontend only — no API, DTO, or migration changes.

## Saved Workstreams / Saved Coordinators (shared `createSavedTable`)
- **Pagination re-added, capped at 20 rows/page**, in the shared component so both surfaces stay consistent. The list is fetched whole and sliced client-side; the delete controller only ever sees the visible page, so Select-All / delete fan-out stays bounded. Page resets on filter/sort, clamps on shrink, and hides on a single page or in delete mode (paging would orphan checkbox selections).
- **Range-aware footer** (`Showing 1–20 of N …`); the footer + pager share one justified row (range left, pager right) so they read as one region instead of a left-aligned count floating above a centred pager.
- **Pointer cursor on saved rows**, owned in the shared `cards.css`. The console only set `cursor: pointer` on `.dash-row.has-link` (a class the shared row builder never adds), so saved-coordinator rows had fallen back to the default cursor while saved-workstream rows showed the link cursor.

## Active Coordinators (console home)
- Gives the active-coordinators block the **full card chrome matching the server's Workstreams block**: a `dash-header` bar with an `N active · M total` summary, the shared `dash-colheaders` band (previously **missing entirely**, so the rows read as unlabelled), the rows, and a `dash-footer` count line.
- Promotes `.dash-footer` into shared `base.css` (was server-only); the server keeps its bottom-margin override.
- Makes **both** coordinator cards contiguous by dropping the console-only `home-section` gap — matching the server, which ships both its active and saved cards contiguous (`.dashboard-section` is margin-only, not a gap container).

## Testing / review
- Pagination logic (slice, page clamp, footer range, prev/next disabled states, hide-on-single-page, hide-in-delete-mode, dynamic `role`/`aria-label`) verified via a DOM-stub harness.
- Two `designer` passes applied: the first added the pager-row consolidation; the second settled the active-vs-saved card consistency (both made contiguous to match the server) and kept the footer in the empty state to preserve the card frame.
- Built with safe DOM APIs (`createElement` / `textContent`); no `innerHTML`.