### PR TITLE
feat(console): replace NODES table with a bottom-bar node picker

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1105,15 +1105,20 @@ class TestConsoleHTTPEndpoints:
     def test_index_landing_surfaces(self, client):
         status, body, ct = self._get_raw(client, "/")
         assert status == 200
-        # Coordinator-first landing keeps the node list always-visible.
-        assert 'id="view-overview"' in body
-        assert 'id="node-table"' in body
+        # Nodes are reached through the bottom-bar node picker; the old
+        # always-visible NODES table was replaced by it.
+        assert 'id="csb-node-picker"' in body
+        assert 'id="csb-np-trigger"' in body
+        assert 'id="csb-np-menu"' in body
         # Removed in the 1.5.0 landing-page cleanup — guard against
         # accidental reintroduction.
         assert 'id="new-ws-overlay"' not in body
         assert 'id="new-ws-btn"' not in body
         assert 'id="cluster-summary-compact"' not in body
         assert 'id="view-node"' not in body
+        # Replaced by the node picker — guard against reintroduction.
+        assert 'id="view-overview"' not in body
+        assert 'id="node-table"' not in body
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -699,7 +699,10 @@ function renderNodePicker() {
     // Status is dot colour + shape, but colour/shape alone fails for
     // color-blind users at 7px — spell out the non-healthy states.
     const degraded = !!(node.health && node.health.status === "degraded");
-    if (!node.reachable || degraded) {
+    let stateSuffix = "";
+    if (!node.reachable) stateSuffix = " (unreachable)";
+    else if (degraded) stateSuffix = " (degraded)";
+    if (stateSuffix) {
       const tag = document.createElement("span");
       tag.className = "csb-np-state" + (node.reachable ? "" : " down");
       tag.textContent = node.reachable ? "degraded" : "down";
@@ -709,11 +712,7 @@ function renderNodePicker() {
     }
     item.setAttribute(
       "aria-label",
-      node.node_id +
-        ", " +
-        node.ws_total +
-        " workstreams" +
-        (node.reachable ? "" : " (unreachable)"),
+      node.node_id + ", " + node.ws_total + " workstreams" + stateSuffix,
     );
     const nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
     item.onclick = function () {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -65,9 +65,8 @@ window.onThemeChange = function (next) {
 // --- State ---
 let currentView = "home"; // "home" | "overview" | "filtered" | "admin"
 let currentFilter = { state: null, node: null, page: 1, per_page: 50 };
-const expandedGroups = {};
 let _lastOverviewJson = "";
-let _lastNodesJson = "";
+let _lastNodePickerJson = "";
 let evtSource = null;
 let retryDelay = 1000;
 let clusterState = null;
@@ -293,24 +292,9 @@ function buildNodeInfoFromSnapshot(node) {
 function renderFromState() {
   if (!clusterState) return;
   renderStatusBar(clusterState.overview);
+  renderNodePicker();
   if (currentView === "home") {
     _renderHomeView();
-    // Home view also hosts the inline node-list (cluster details);
-    // render it so the next SSE tick doesn't leave it stale.
-    const nodesList = Object.keys(clusterState.nodes)
-      .filter(function (nid) {
-        // Exclude the "console" pseudo-node from the nodes list — it's
-        // a synthetic carrier for coordinators, not a compute node.
-        return nid !== "console";
-      })
-      .map(function (nid) {
-        return buildNodeInfoFromSnapshot(clusterState.nodes[nid]);
-      });
-    nodesList.sort(function (a, b) {
-      const d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
-      return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
-    });
-    renderNodeGroups(nodesList, nodesList.length);
   } else if (currentView === "filtered") {
     let allWs = [];
     Object.keys(clusterState.nodes).forEach(function (nid) {
@@ -487,9 +471,7 @@ function loadOverview() {
       applySnapshot(data);
     })
     .catch(function () {
-      document
-        .getElementById("node-table")
-        .replaceChildren(makeEmptyState("Failed to load"));
+      showToast("Failed to load cluster data");
     });
 }
 
@@ -538,13 +520,12 @@ function renderStatusBar(overview) {
   const metricsContainer = document.getElementById("csb-metrics");
   metricsContainer.replaceChildren();
   const metrics = [
-    { value: overview.nodes || 0, label: "nodes", format: formatCount },
     { value: overview.workstreams || 0, label: "ws", format: formatCount },
     { value: agg.total_tokens || 0, label: "tokens", format: formatTokens },
     { value: agg.total_tool_calls || 0, label: "calls", format: formatCount },
   ];
   metrics.forEach(function (m) {
-    if (m.value === 0 && m.label !== "nodes" && m.label !== "ws") return;
+    if (m.value === 0 && m.label !== "ws") return;
     const el = document.createElement("span");
     el.className = "csb-metric";
     const valSpan = document.createElement("span");
@@ -557,36 +538,6 @@ function renderStatusBar(overview) {
     el.appendChild(labelSpan);
     metricsContainer.appendChild(el);
   });
-  if (
-    overview.version_drift &&
-    overview.versions &&
-    overview.versions.length > 1
-  ) {
-    const driftEl = document.createElement("span");
-    driftEl.className = "csb-metric csb-version-drift";
-    driftEl.title = "Versions detected: " + overview.versions.join(", ");
-    const warnSpan = document.createElement("span");
-    warnSpan.className = "csb-metric-value drift-warn";
-    warnSpan.textContent = "DRIFT";
-    const verLabel = document.createElement("span");
-    verLabel.className = "csb-metric-label";
-    verLabel.textContent = overview.versions.join(" / ");
-    driftEl.appendChild(warnSpan);
-    driftEl.appendChild(verLabel);
-    metricsContainer.appendChild(driftEl);
-  } else if (overview.versions && overview.versions.length === 1) {
-    const verEl = document.createElement("span");
-    verEl.className = "csb-metric";
-    const valSpan = document.createElement("span");
-    valSpan.className = "csb-metric-value";
-    valSpan.textContent = overview.versions[0];
-    const verLbl = document.createElement("span");
-    verLbl.className = "csb-metric-label";
-    verLbl.textContent = "ver";
-    verEl.appendChild(valSpan);
-    verEl.appendChild(verLbl);
-    metricsContainer.appendChild(verEl);
-  }
   // MCP aggregate metrics
   if (overview.mcp_servers && overview.mcp_servers > 0) {
     const mcpDivider = document.createElement("span");
@@ -626,435 +577,214 @@ function renderStatusBar(overview) {
   }
 }
 
-// --- Node Grouping ---
-function extractNodePrefix(nodeId) {
-  let stripped = nodeId.replace(/[-_][a-z0-9]*\d[a-z0-9]*$/i, "");
-  if (!stripped || stripped === nodeId) {
-    stripped = nodeId.replace(/[-_]?\d+$/, "");
-  }
-  // Clean trailing separators (e.g., FQDN-style "node.prod.01" → "node.prod")
-  stripped = stripped.replace(/[-_.]$/, "");
-  return stripped || nodeId;
-}
-
-function groupNodes(nodes) {
-  const groupMap = {};
-  const groupOrder = [];
-  nodes.forEach(function (node) {
-    const prefix = extractNodePrefix(node.node_id);
-    if (!groupMap[prefix]) {
-      groupMap[prefix] = {
-        prefix: prefix,
-        nodes: [],
-        ws_total: 0,
-        ws_running: 0,
-        ws_thinking: 0,
-        ws_attention: 0,
-        ws_error: 0,
-        ws_idle: 0,
-        total_tokens: 0,
-        all_reachable: true,
-        any_degraded: false,
-        versions: new Set(),
-      };
-      groupOrder.push(prefix);
-    }
-    const g = groupMap[prefix];
-    g.nodes.push(node);
-    g.ws_total += node.ws_total || 0;
-    g.ws_running += node.ws_running || 0;
-    g.ws_thinking += node.ws_thinking || 0;
-    g.ws_attention += node.ws_attention || 0;
-    g.ws_error += node.ws_error || 0;
-    g.ws_idle += node.ws_idle || 0;
-    g.total_tokens += node.total_tokens || 0;
-    if (!node.reachable) g.all_reachable = false;
-    if (node.health && node.health.status === "degraded") g.any_degraded = true;
-    const nodeVer = node.version || "";
-    if (nodeVer) g.versions.add(nodeVer);
-  });
-  groupOrder.forEach(function (prefix) {
-    groupMap[prefix].nodes.sort(function (a, b) {
-      const d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
-      return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
+// --- Node Picker ---
+//
+// Replaces the old NODES table.  The bottom status bar carries a compact
+// trigger ("N NODES · <version>", or a DRIFT badge when the cluster runs
+// mixed versions); clicking it opens a popup list of every compute node
+// with its live workstream count.  Selecting a node navigates to that
+// node's own dashboard (/node/<id>/) — the same destination the table
+// rows used to link to.
+function _nodePickerList() {
+  // Real compute nodes only — the "console" pseudo-node is a synthetic
+  // carrier for coordinators, not a node you can open.
+  const list = Object.keys(clusterState.nodes)
+    .filter(function (nid) {
+      return nid !== "console";
+    })
+    .map(function (nid) {
+      return buildNodeInfoFromSnapshot(clusterState.nodes[nid]);
     });
+  list.sort(function (a, b) {
+    const d = b.ws_running + b.ws_attention - (a.ws_running + a.ws_attention);
+    return d !== 0 ? d : a.node_id.localeCompare(b.node_id);
   });
-  const groups = groupOrder.map(function (p) {
-    return groupMap[p];
+  return list;
+}
+
+function _nodeDotClass(node) {
+  if (!node.reachable) return "csb-np-dot unreachable";
+  if (node.health && node.health.status === "degraded")
+    return "csb-np-dot degraded";
+  return "csb-np-dot";
+}
+
+function renderNodePicker() {
+  if (!clusterState) return;
+  const overview = clusterState.overview || {};
+  const nodes = _nodePickerList();
+  const versions = overview.versions || [];
+  const drift = !!(overview.version_drift && versions.length > 1);
+
+  // Skip the rebuild when nothing the picker shows has changed — node
+  // count, per-node ws count/reachability/health, and the version set.
+  const sig = JSON.stringify({
+    n: nodes.map(function (x) {
+      return [x.node_id, x.ws_total, x.reachable, (x.health || {}).status];
+    }),
+    v: versions,
+    d: drift,
   });
-  groups.sort(function (a, b) {
-    const aAct = a.ws_running + a.ws_attention;
-    const bAct = b.ws_running + b.ws_attention;
-    if (bAct !== aAct) return bAct - aAct;
-    return a.prefix.localeCompare(b.prefix);
-  });
-  return groups;
-}
+  if (sig === _lastNodePickerJson) return;
+  _lastNodePickerJson = sig;
 
-// 7-span node-table column header — used at the top of the table and
-// inside each multi-node group body.  Returns a DocumentFragment built
-// via createElement so the static label list is constructed once with
-// no HTML parsing / string interpolation per render.
-const _NODE_COLHEADER_LABELS = [
-  ["ncol ncol-node", "NODE"],
-  ["ncol ncol-ws", "WS"],
-  ["ncol ncol-run", "RUN"],
-  ["ncol ncol-attn", "ATTN"],
-  ["ncol ncol-tokens", "TOKENS"],
-  ["ncol ncol-version", "VER"],
-  ["ncol ncol-health", "LOAD"],
-];
+  // --- Trigger ---
+  const trigger = document.getElementById("csb-np-trigger");
+  if (!trigger) return;
+  trigger.onclick = toggleNodePicker;
+  trigger.replaceChildren();
+  const caret = document.createElement("span");
+  caret.className = "csb-np-caret";
+  caret.setAttribute("aria-hidden", "true");
+  caret.textContent = "▾";
+  const countVal = document.createElement("span");
+  countVal.className = "csb-metric-value";
+  countVal.textContent = formatCount(nodes.length);
+  const countLbl = document.createElement("span");
+  countLbl.className = "csb-metric-label";
+  countLbl.textContent = nodes.length === 1 ? "node" : "nodes";
+  trigger.append(caret, countVal, countLbl);
 
-function buildColHeaders() {
-  const frag = document.createDocumentFragment();
-  for (let i = 0; i < _NODE_COLHEADER_LABELS.length; i++) {
-    const span = document.createElement("span");
-    span.className = _NODE_COLHEADER_LABELS[i][0];
-    span.textContent = _NODE_COLHEADER_LABELS[i][1];
-    frag.appendChild(span);
-  }
-  return frag;
-}
-
-// Build a numeric cell for the node table.  ``highlighted`` adds
-// ``has-value`` so non-zero counts get the CSS treatment.
-function _buildNodeNumCell(value, highlighted, cellClass) {
-  const cell = document.createElement("span");
-  cell.className = cellClass + (highlighted ? " has-value" : "");
-  cell.textContent = String(value);
-  return cell;
-}
-
-// Build the health-bar trailing cell ("[bar] [pct]%") for either a
-// node row or a group header — the structure is identical, only the
-// outer cell class differs.
-function _buildHealthCell(cellClass, healthPct, healthFillClass) {
-  const cell = document.createElement("span");
-  cell.className = cellClass;
-  const bar = document.createElement("span");
-  bar.className = "health-bar";
-  if (healthPct > 0) {
-    const fill = document.createElement("span");
-    fill.className = "health-bar-fill " + healthFillClass;
-    fill.style.width = healthPct + "%";
-    bar.appendChild(fill);
-  }
-  cell.append(bar, " " + healthPct + "%");
-  return cell;
-}
-
-function buildNodeRow(node) {
-  const row = document.createElement("div");
-  row.className = "node-row";
-  if (node.ws_attention > 0) row.classList.add("has-attention");
-  else if (node.ws_running > 0) row.classList.add("has-running");
-  else if (node.ws_thinking > 0) row.classList.add("has-thinking");
-  else if (node.ws_error > 0) row.classList.add("has-error");
-  row.setAttribute("role", "button");
-  row.setAttribute("tabindex", "0");
-  row.setAttribute(
-    "aria-label",
-    node.node_id +
-      ": " +
-      node.ws_total +
-      " workstreams, " +
-      node.ws_running +
-      " running, " +
-      node.ws_attention +
-      " attention, " +
-      formatTokens(node.total_tokens) +
-      " tokens" +
-      (node.version ? ", version " + node.version : ""),
-  );
-
-  const isDegraded = node.health && node.health.status === "degraded";
-  const dotClass = node.reachable
-    ? isDegraded
-      ? "node-dot degraded"
-      : "node-dot"
-    : "node-dot unreachable";
-  const displayTokens = node.total_tokens || node.ws_tokens || 0;
-  const maxWs = node.max_ws || 10;
-  const healthPct =
-    maxWs > 0 ? Math.min(Math.round((node.ws_total / maxWs) * 100), 100) : 0;
-  const healthFillClass =
-    healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
-
-  let healthTitle = "";
-  if (node.health && node.health.backend) {
-    healthTitle = "backend: " + node.health.backend.status;
+  if (drift) {
+    const driftBadge = document.createElement("span");
+    driftBadge.className = "csb-np-drift";
+    driftBadge.textContent = "DRIFT";
+    driftBadge.title = "Versions detected: " + versions.join(", ");
+    trigger.appendChild(driftBadge);
+    trigger.setAttribute(
+      "aria-label",
+      nodes.length + " nodes, version drift: " + versions.join(", "),
+    );
+  } else if (versions.length === 1) {
+    const verVal = document.createElement("span");
+    verVal.className = "csb-np-ver";
+    verVal.textContent = versions[0];
+    trigger.appendChild(verVal);
+    trigger.setAttribute(
+      "aria-label",
+      nodes.length + " nodes, version " + versions[0],
+    );
+  } else {
+    trigger.setAttribute("aria-label", nodes.length + " nodes");
   }
 
-  // Name cell — dot, node id, optional degraded badge.
-  const nameCell = document.createElement("span");
-  nameCell.className = "node-cell node-cell-name";
-  if (healthTitle) nameCell.setAttribute("title", healthTitle);
-  const dot = document.createElement("span");
-  dot.className = dotClass;
-  nameCell.append(dot, node.node_id);
-  if (isDegraded) {
-    const degradedEl = document.createElement("span");
-    degradedEl.className = "node-degraded-badge";
-    // Only attach the descriptive title / aria-label when there's a
-    // backend-status string to surface.  An empty aria-label would
-    // suppress the badge's textContent ("degraded") for screen
-    // readers — strictly worse than leaving the attribute off.
-    if (healthTitle) {
-      degradedEl.setAttribute("title", healthTitle);
-      degradedEl.setAttribute("aria-label", healthTitle);
-    }
-    degradedEl.textContent = "degraded";
-    nameCell.appendChild(degradedEl);
-  }
-  row.appendChild(nameCell);
-
-  row.appendChild(
-    _buildNodeNumCell(
-      node.ws_total,
-      node.ws_total > 0,
-      "node-cell node-cell-num",
-    ),
-  );
-  row.appendChild(
-    _buildNodeNumCell(
-      node.ws_running,
-      node.ws_running > 0,
-      "node-cell node-cell-num",
-    ),
-  );
-  row.appendChild(
-    _buildNodeNumCell(
-      node.ws_attention,
-      node.ws_attention > 0,
-      "node-cell node-cell-num",
-    ),
-  );
-
-  const tokensCell = document.createElement("span");
-  tokensCell.className = "node-cell node-cell-num";
-  tokensCell.textContent = formatTokens(displayTokens);
-  row.appendChild(tokensCell);
-
-  const versionCell = document.createElement("span");
-  versionCell.className = "node-cell node-cell-version";
-  versionCell.textContent = node.version || "";
-  row.appendChild(versionCell);
-
-  row.appendChild(
-    _buildHealthCell("node-cell node-cell-health", healthPct, healthFillClass),
-  );
-
-  const nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
-  row.onclick = function () {
-    window.location.href = nodeUrl;
-  };
-  row.onkeydown = function (e) {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      window.location.href = nodeUrl;
-    }
-  };
-  return row;
-}
-
-function toggleGroup(prefix) {
-  expandedGroups[prefix] = !expandedGroups[prefix];
-  const body = document.querySelector(
-    '.node-group-body[data-prefix="' +
-      prefix.replace(/\\/g, "\\\\").replace(/"/g, '\\"') +
-      '"]',
-  );
-  if (!body) return;
-  const isExpanded = expandedGroups[prefix];
-  if (isExpanded) body.classList.remove("collapsed");
-  else body.classList.add("collapsed");
-  const groupEl = body.parentElement;
-  if (groupEl) groupEl.setAttribute("aria-expanded", String(isExpanded));
-  const chevron = groupEl ? groupEl.querySelector(".node-group-chevron") : null;
-  if (chevron) {
-    if (isExpanded) chevron.classList.add("expanded");
-    else chevron.classList.remove("expanded");
-  }
-}
-
-function renderNodeGroups(nodes, total) {
-  const json = JSON.stringify(nodes);
-  if (json === _lastNodesJson) return;
-  _lastNodesJson = json;
-
-  const table = document.getElementById("node-table");
-  table.replaceChildren();
+  // --- Menu ---
+  const menu = document.getElementById("csb-np-menu");
+  if (!menu) return;
+  menu.replaceChildren();
   if (!nodes.length) {
-    table.appendChild(makeEmptyState("No nodes discovered"));
+    const empty = document.createElement("div");
+    empty.className = "csb-np-empty";
+    empty.textContent = "No nodes discovered";
+    menu.appendChild(empty);
     return;
   }
-
-  const topHeaders = document.createElement("div");
-  topHeaders.className = "node-colheaders";
-  topHeaders.setAttribute("aria-hidden", "true");
-  topHeaders.appendChild(buildColHeaders());
-  table.appendChild(topHeaders);
-
-  const groups = groupNodes(nodes);
-
-  groups.forEach(function (group) {
-    // Single-node group — render as plain row
-    if (group.nodes.length === 1) {
-      const wrapper = document.createElement("div");
-      wrapper.className = "node-group node-group-single";
-      wrapper.appendChild(buildNodeRow(group.nodes[0]));
-      table.appendChild(wrapper);
-      return;
+  nodes.forEach(function (node) {
+    // Navigation popup, not a selection control — menuitem, not option.
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "csb-np-item";
+    item.setAttribute("role", "menuitem");
+    const dot = document.createElement("span");
+    dot.className = _nodeDotClass(node);
+    dot.setAttribute("aria-hidden", "true");
+    const name = document.createElement("span");
+    name.className = "csb-np-name";
+    name.textContent = node.node_id;
+    // Full id on hover for when the name ellipsizes.
+    name.title = node.node_id;
+    const ws = document.createElement("span");
+    ws.className = "csb-np-ws" + (node.ws_total > 0 ? " has-value" : "");
+    ws.textContent = formatCount(node.ws_total) + " ws";
+    // Status is dot colour + shape, but colour/shape alone fails for
+    // color-blind users at 7px — spell out the non-healthy states.
+    const degraded = !!(node.health && node.health.status === "degraded");
+    if (!node.reachable || degraded) {
+      const tag = document.createElement("span");
+      tag.className = "csb-np-state" + (node.reachable ? "" : " down");
+      tag.textContent = node.reachable ? "degraded" : "down";
+      item.append(dot, name, tag, ws);
+    } else {
+      item.append(dot, name, ws);
     }
-
-    const groupEl = document.createElement("div");
-    groupEl.className = "node-group";
-    const isExpanded = !!expandedGroups[group.prefix];
-    groupEl.setAttribute("role", "listitem");
-    groupEl.setAttribute("aria-expanded", String(isExpanded));
-
-    // Group header
-    const header = document.createElement("div");
-    header.className = "node-group-header";
-    if (group.ws_attention > 0) header.classList.add("has-attention");
-    else if (group.ws_running > 0) header.classList.add("has-running");
-    else if (group.ws_thinking > 0) header.classList.add("has-thinking");
-    else if (group.ws_error > 0) header.classList.add("has-error");
-    header.setAttribute("role", "button");
-    header.setAttribute("tabindex", "0");
-    header.setAttribute(
+    item.setAttribute(
       "aria-label",
-      group.prefix +
-        " group: " +
-        group.nodes.length +
-        " nodes, " +
-        group.ws_total +
-        " workstreams, " +
-        group.ws_running +
-        " running, " +
-        group.ws_attention +
-        " attention, " +
-        formatTokens(group.total_tokens) +
-        " tokens" +
-        (group.versions.size > 1 ? ", version drift detected" : ""),
+      node.node_id +
+        ", " +
+        node.ws_total +
+        " workstreams" +
+        (node.reachable ? "" : " (unreachable)"),
     );
-
-    const chevronClass = "node-group-chevron" + (isExpanded ? " expanded" : "");
-    let totalMaxWs = 0;
-    group.nodes.forEach(function (n) {
-      totalMaxWs += n.max_ws || 10;
-    });
-    const healthPct =
-      totalMaxWs > 0
-        ? Math.min(Math.round((group.ws_total / totalMaxWs) * 100), 100)
-        : 0;
-    const healthFillClass =
-      healthPct < 50 ? "low" : healthPct < 80 ? "mid" : "high";
-    let groupVersionText = "";
-    let groupVersionDrift = false;
-    if (group.versions.size === 1) {
-      groupVersionText = Array.from(group.versions)[0];
-    } else if (group.versions.size > 1) {
-      groupVersionText = "mixed";
-      groupVersionDrift = true;
-    }
-
-    // Group-name cell: chevron + prefix + node count + optional degraded badge.
-    const nameCell = document.createElement("span");
-    nameCell.className = "node-group-name";
-    const chevron = document.createElement("span");
-    chevron.className = chevronClass;
-    chevron.setAttribute("aria-hidden", "true");
-    chevron.textContent = "▸";
-    const badge = document.createElement("span");
-    badge.className = "node-group-badge";
-    badge.textContent = group.nodes.length + " nodes";
-    nameCell.append(chevron, group.prefix, badge);
-    if (group.any_degraded) {
-      const degradedEl = document.createElement("span");
-      degradedEl.className = "node-degraded-badge";
-      degradedEl.textContent = "degraded";
-      nameCell.appendChild(degradedEl);
-    }
-    header.appendChild(nameCell);
-
-    header.appendChild(
-      _buildNodeNumCell(
-        group.ws_total,
-        group.ws_total > 0,
-        "node-group-cell num",
-      ),
-    );
-    header.appendChild(
-      _buildNodeNumCell(
-        group.ws_running,
-        group.ws_running > 0,
-        "node-group-cell num",
-      ),
-    );
-    header.appendChild(
-      _buildNodeNumCell(
-        group.ws_attention,
-        group.ws_attention > 0,
-        "node-group-cell num",
-      ),
-    );
-
-    const groupTokensCell = document.createElement("span");
-    groupTokensCell.className = "node-group-cell num";
-    groupTokensCell.textContent = formatTokens(group.total_tokens);
-    header.appendChild(groupTokensCell);
-
-    const groupVersionCell = document.createElement("span");
-    groupVersionCell.className =
-      "node-group-cell node-cell-version" + (groupVersionDrift ? " drift" : "");
-    groupVersionCell.textContent = groupVersionText;
-    if (groupVersionDrift) {
-      const driftBadge = document.createElement("span");
-      driftBadge.className = "node-version-drift-badge";
-      driftBadge.textContent = "drift";
-      groupVersionCell.appendChild(driftBadge);
-    }
-    header.appendChild(groupVersionCell);
-
-    header.appendChild(
-      _buildHealthCell(
-        "node-group-cell node-cell-health",
-        healthPct,
-        healthFillClass,
-      ),
-    );
-
-    const prefix = group.prefix;
-    header.onclick = function () {
-      toggleGroup(prefix);
+    const nodeUrl = "/node/" + encodeURIComponent(node.node_id) + "/";
+    item.onclick = function () {
+      window.location.href = nodeUrl;
     };
-    header.onkeydown = function (e) {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        toggleGroup(prefix);
-      }
-    };
-    groupEl.appendChild(header);
-
-    // Group body
-    const body = document.createElement("div");
-    body.className = "node-group-body" + (isExpanded ? "" : " collapsed");
-    body.dataset.prefix = group.prefix;
-
-    const colHeaders = document.createElement("div");
-    colHeaders.className = "node-colheaders";
-    colHeaders.setAttribute("aria-hidden", "true");
-    colHeaders.appendChild(buildColHeaders());
-    body.appendChild(colHeaders);
-
-    group.nodes.forEach(function (node) {
-      body.appendChild(buildNodeRow(node));
-    });
-
-    groupEl.appendChild(body);
-    table.appendChild(groupEl);
+    menu.appendChild(item);
   });
+}
+
+function _closeNodePicker() {
+  const menu = document.getElementById("csb-np-menu");
+  const trigger = document.getElementById("csb-np-trigger");
+  if (menu) menu.hidden = true;
+  if (trigger) trigger.setAttribute("aria-expanded", "false");
+  document.removeEventListener("click", _onNodePickerOutside, true);
+  document.removeEventListener("keydown", _onNodePickerKeydown, true);
+}
+
+function _onNodePickerOutside(e) {
+  const wrap = document.getElementById("csb-node-picker");
+  if (wrap && !wrap.contains(e.target)) _closeNodePicker();
+}
+
+function _onNodePickerKeydown(e) {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    _closeNodePicker();
+    const trigger = document.getElementById("csb-np-trigger");
+    if (trigger) trigger.focus();
+    return;
+  }
+  const menu = document.getElementById("csb-np-menu");
+  if (!menu || menu.hidden) return;
+  const items = Array.prototype.slice.call(
+    menu.querySelectorAll(".csb-np-item"),
+  );
+  if (!items.length) return;
+  const idx = items.indexOf(document.activeElement);
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    items[idx < 0 ? 0 : Math.min(idx + 1, items.length - 1)].focus();
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    items[idx <= 0 ? 0 : idx - 1].focus();
+  } else if (e.key === "Home") {
+    e.preventDefault();
+    items[0].focus();
+  } else if (e.key === "End") {
+    e.preventDefault();
+    items[items.length - 1].focus();
+  }
+}
+
+function toggleNodePicker() {
+  const menu = document.getElementById("csb-np-menu");
+  const trigger = document.getElementById("csb-np-trigger");
+  if (!menu || !trigger) return;
+  if (menu.hidden) {
+    menu.hidden = false;
+    trigger.setAttribute("aria-expanded", "true");
+    // Capture-phase listeners so a click/keypress is caught before it
+    // bubbles back up.  Registering them here (during the trigger's own
+    // bubble-phase click) means this same click won't re-trigger them.
+    document.addEventListener("click", _onNodePickerOutside, true);
+    document.addEventListener("keydown", _onNodePickerKeydown, true);
+    const first = menu.querySelector(".csb-np-item");
+    if (first) first.focus();
+    else trigger.focus();
+  } else {
+    _closeNodePicker();
+  }
 }
 
 // --- Drill-down: Filtered ---
@@ -2303,6 +2033,10 @@ initLogin();
 // pipeline (#9); the console pseudo-node carries coordinator
 // ws_created / ws_closed / cluster_state events.
 loadOverview();
+(function () {
+  const npTrigger = document.getElementById("csb-np-trigger");
+  if (npTrigger) npTrigger.onclick = toggleNodePicker;
+})();
 _ensureHomeComposerInit();
 // Refresh the coord button visibility once auth.js has populated
 // sessionStorage from the initial whoami.  window.permissionsReady

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -2233,6 +2233,7 @@
           aria-haspopup="menu"
           aria-expanded="false"
           aria-controls="csb-np-menu"
+          aria-label="Nodes"
         ></button>
         <div
           class="csb-np-menu"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -80,10 +80,9 @@
 
     <div id="main">
       <!-- HOME — coordinator-first landing.  The console's primary
-       workflow on page load is "start / continue a coordinator task";
-       the cluster node list sits below as a sibling section.
-       #view-overview / #view-filtered remain for deep-link
-       compatibility. -->
+       workflow on page load is "start / continue a coordinator task".
+       Nodes are reached via the bottom-bar node picker; #view-filtered
+       remains for state/node drill-down deep-links. -->
       <div id="view-home">
         <!-- Persistent "start a new coordinator task" composer.  Visibility is
          gated on the admin.coordinator permission (same rule the existing
@@ -240,21 +239,6 @@
           </div>
         </section>
 
-        <!-- Cluster details — node list, always visible.  The list is
-         self-collapsing (consecutive same-prefix nodes group into a
-         single expandable row) so a separate summary toggle would be
-         redundant. -->
-        <div id="view-overview">
-          <div class="section-header">NODES</div>
-          <div
-            id="node-table"
-            role="list"
-            aria-label="Nodes"
-            aria-live="polite"
-          >
-            <div class="dashboard-empty">Loading cluster data...</div>
-          </div>
-        </div>
       </div>
 
       <!-- FILTERED WORKSTREAMS -->
@@ -2240,6 +2224,24 @@
       </div>
       <div class="csb-divider" aria-hidden="true"></div>
       <div class="csb-metrics" id="csb-metrics"></div>
+      <div class="csb-divider" aria-hidden="true"></div>
+      <div class="csb-node-picker" id="csb-node-picker">
+        <button
+          type="button"
+          class="csb-np-trigger"
+          id="csb-np-trigger"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          aria-controls="csb-np-menu"
+        ></button>
+        <div
+          class="csb-np-menu"
+          id="csb-np-menu"
+          role="menu"
+          aria-label="Switch node"
+          hidden
+        ></div>
+      </div>
     </div>
 
     <div id="toast" role="status" aria-live="polite"></div>

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -366,8 +366,10 @@
   gap: 6px;
   padding: 5px 10px;
   border-radius: var(--radius-sm);
-  border: 1px solid transparent;
-  background: none;
+  /* Persistent recessed box so the picker reads as clickable at rest —
+     the one interactive control on the metrics side of the bar. */
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
   color: var(--fg-dim);
   font: inherit;
   font-family: var(--font-mono);
@@ -381,7 +383,7 @@
 }
 .csb-np-trigger:hover {
   background: var(--bg-highlight);
-  border-color: var(--border-strong);
+  border-color: var(--accent);
   color: var(--fg-bright);
 }
 .csb-np-trigger:focus-visible {
@@ -390,7 +392,8 @@
 }
 .csb-np-trigger[aria-expanded="true"] {
   background: var(--bg-highlight);
-  border-color: var(--border-strong);
+  border-color: var(--accent);
+  color: var(--fg-bright);
 }
 .csb-np-caret {
   font-size: 9px;

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -353,6 +353,179 @@
   flex-shrink: 0;
 }
 
+/* ==========================================================================
+   Node picker — bottom-bar dropdown that replaced the NODES table
+   ========================================================================== */
+.csb-node-picker {
+  position: relative;
+  flex-shrink: 0;
+}
+.csb-np-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: none;
+  color: var(--fg-dim);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+.csb-np-trigger:hover {
+  background: var(--bg-highlight);
+  border-color: var(--border-strong);
+  color: var(--fg-bright);
+}
+.csb-np-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.csb-np-trigger[aria-expanded="true"] {
+  background: var(--bg-highlight);
+  border-color: var(--border-strong);
+}
+.csb-np-caret {
+  font-size: 9px;
+  color: var(--fg-dim);
+  transition: transform 0.18s ease;
+}
+.csb-np-trigger[aria-expanded="true"] .csb-np-caret {
+  transform: rotate(180deg);
+}
+.csb-np-ver {
+  color: var(--fg-dim);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  margin-left: 2px;
+}
+.csb-np-drift {
+  font-size: 9px;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  /* Solid amber chip — dark text on fill so it reads as a true alert,
+     not a faint yellow-on-yellow smudge at 9px. */
+  color: var(--bg);
+  background: var(--yellow);
+  border: 1px solid var(--yellow);
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+  margin-left: 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Popup list — anchored to the trigger, opens upward over the bar */
+.csb-np-menu {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 0;
+  min-width: 220px;
+  /* Cap by viewport too so a tall list never touches the top edge on a
+     short window; the bar + a margin reserve the trailing 64px. */
+  max-height: min(60vh, calc(100vh - 64px), 420px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  padding: 4px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow:
+    0 8px 28px -6px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  z-index: 200;
+}
+.csb-np-menu[hidden] {
+  display: none;
+}
+.csb-np-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--fg-bright);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.csb-np-item:hover,
+.csb-np-item:focus-visible {
+  background: var(--bg-highlight);
+  outline: none;
+}
+.csb-np-item:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+/* Status by shape AND colour (color-blind-safe) — mirrors the
+   .csb-state-dot vocabulary: round = healthy, diamond = degraded,
+   sharp square = unreachable. */
+.csb-np-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--green);
+  box-shadow: 0 0 4px var(--green-glow);
+}
+.csb-np-dot.degraded {
+  background: var(--accent);
+  box-shadow: 0 0 4px var(--accent-glow-strong);
+  border-radius: 1px;
+  transform: rotate(45deg);
+}
+.csb-np-dot.unreachable {
+  background: var(--red);
+  box-shadow: 0 0 4px var(--red-glow);
+  border-radius: 0;
+}
+.csb-np-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.csb-np-state {
+  font-size: 9px;
+  font-family: var(--font-ui);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.csb-np-state.down {
+  color: var(--red);
+}
+.csb-np-ws {
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.csb-np-ws.has-value {
+  color: var(--fg-bright);
+}
+.csb-np-empty {
+  padding: 10px 12px;
+  color: var(--fg-dim);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
 .csb-loading {
   color: var(--fg-dim);
   font-size: 11px;
@@ -390,335 +563,6 @@
   letter-spacing: 0.1em;
   margin-bottom: 12px;
   text-transform: uppercase;
-}
-
-/* ==========================================================================
-   Node table — column headers
-   ========================================================================== */
-.node-colheaders {
-  display: grid;
-  grid-template-columns: 1fr 50px 50px 50px 70px 60px 140px;
-  padding: 6px 16px;
-  background: var(--bg-surface);
-  border-bottom: 1px solid var(--border-strong);
-  font-size: 10px;
-  font-family: var(--font-ui);
-  font-weight: 600;
-  color: var(--fg-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-.ncol-ws,
-.ncol-run,
-.ncol-attn,
-.ncol-tokens {
-  text-align: right;
-}
-.ncol-health,
-.node-cell-health {
-  padding-left: 10px;
-}
-
-/* ==========================================================================
-   Node rows — individual instrument readouts
-   ========================================================================== */
-.node-row {
-  display: grid;
-  grid-template-columns: 1fr 50px 50px 50px 70px 60px 140px;
-  padding: 9px 16px;
-  cursor: pointer;
-  transition:
-    background 0.12s ease,
-    border-color 0.12s ease,
-    box-shadow 0.12s ease;
-  border-left: 3px solid transparent;
-  position: relative;
-}
-.node-row:nth-child(odd) {
-  background: var(--bg);
-}
-.node-row:nth-child(even) {
-  background: var(--row-alt);
-}
-.node-row:hover {
-  background: var(--bg-highlight);
-  box-shadow: inset 0 0 0 1px var(--border);
-}
-.node-row:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-.node-row.has-attention {
-  border-left-color: var(--yellow);
-  background: linear-gradient(90deg, var(--yellow-glow), transparent 30%);
-}
-.node-row.has-running {
-  border-left-color: var(--green);
-  background: linear-gradient(90deg, var(--green-glow), transparent 30%);
-}
-.node-row.has-thinking {
-  border-left-color: var(--cyan);
-  background: linear-gradient(90deg, var(--cyan-glow), transparent 30%);
-}
-.node-row.has-error {
-  border-left-color: var(--red);
-  background: linear-gradient(90deg, var(--red-glow), transparent 30%);
-}
-.node-row.has-attention:hover,
-.node-row.has-running:hover,
-.node-row.has-thinking:hover,
-.node-row.has-error:hover {
-  background: var(--bg-highlight);
-}
-
-.node-cell {
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-}
-.node-cell-name {
-  color: var(--fg-bright);
-  font-weight: 500;
-  gap: 8px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.node-cell-name .node-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--green);
-  flex-shrink: 0;
-  box-shadow: 0 0 4px var(--green-glow);
-}
-.node-cell-name .node-dot.unreachable {
-  background: var(--red);
-  box-shadow: 0 0 4px var(--red-glow);
-}
-.node-cell-name .node-dot.degraded {
-  background: var(--accent);
-  box-shadow: 0 0 4px var(--accent-glow-strong);
-}
-.node-degraded-badge {
-  font-size: 9px;
-  font-family: var(--font-ui);
-  font-weight: 600;
-  color: var(--accent);
-  background: var(--accent-dim);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-sm);
-  padding: 0 5px;
-  margin-left: 6px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  line-height: 1.6;
-  flex-shrink: 0;
-}
-
-/* Version drift */
-.node-cell-version {
-  font-size: 11px;
-  color: var(--fg-dim);
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
-  font-variant-numeric: tabular-nums;
-}
-.node-cell-version.drift {
-  color: var(--yellow);
-}
-.ncol-version {
-  text-align: right;
-}
-.node-version-drift-badge {
-  font-size: 9px;
-  font-family: var(--font-ui);
-  font-weight: 600;
-  color: var(--yellow);
-  background: var(--yellow-glow);
-  border: 1px solid var(--yellow);
-  border-radius: var(--radius-sm);
-  padding: 0 5px;
-  margin-left: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  line-height: 1.6;
-  flex-shrink: 0;
-}
-.csb-version-drift .drift-warn {
-  color: var(--yellow);
-  font-weight: 600;
-  font-size: 11px;
-  letter-spacing: 0.06em;
-}
-
-.node-cell-num {
-  color: var(--fg-dim);
-  font-size: 11px;
-  justify-content: flex-end;
-  font-variant-numeric: tabular-nums;
-}
-.node-cell-num.has-value {
-  color: var(--fg-bright);
-}
-.node-cell-health {
-  gap: 8px;
-  font-size: 11px;
-  color: var(--fg-dim);
-  font-variant-numeric: tabular-nums;
-}
-
-/* Health bar — precision gauge */
-.health-bar {
-  width: 80px;
-  height: 4px;
-  background: var(--bg-highlight);
-  border-radius: 2px;
-  overflow: hidden;
-  position: relative;
-}
-.health-bar-fill {
-  display: block;
-  height: 100%;
-  min-width: 3px;
-  border-radius: 2px;
-  transition: width 0.3s ease;
-}
-.health-bar-fill.low {
-  background: var(--green);
-  box-shadow: 0 0 4px var(--green-glow);
-}
-.health-bar-fill.mid {
-  background: var(--yellow);
-  box-shadow: 0 0 4px var(--yellow-glow);
-}
-.health-bar-fill.high {
-  background: var(--red);
-  box-shadow: 0 0 4px var(--red-glow);
-}
-
-/* ==========================================================================
-   Node groups — rack panel sections
-   ========================================================================== */
-.node-group {
-  margin-bottom: 1px;
-}
-
-.node-group-header {
-  display: grid;
-  grid-template-columns: 1fr 50px 50px 50px 70px 60px 140px;
-  padding: 10px 16px;
-  cursor: pointer;
-  transition:
-    background 0.12s ease,
-    border-color 0.12s ease,
-    box-shadow 0.12s ease;
-  background: var(--bg-surface);
-  border-left: 3px solid transparent;
-  border-bottom: 1px solid var(--border);
-  position: relative;
-}
-.node-group-header::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  transition: opacity 0.15s;
-  pointer-events: none;
-}
-.node-group-header:hover {
-  background: var(--bg-highlight);
-}
-.node-group-header:hover::before {
-  opacity: 1;
-}
-.node-group-header:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-.node-group-header.has-attention {
-  border-left-color: var(--yellow);
-}
-.node-group-header.has-running {
-  border-left-color: var(--green);
-}
-.node-group-header.has-thinking {
-  border-left-color: var(--cyan);
-}
-.node-group-header.has-error {
-  border-left-color: var(--red);
-}
-
-.node-group-name {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--fg-bright);
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.node-group-chevron {
-  font-size: 10px;
-  color: var(--fg);
-  transition: transform 0.2s ease;
-  flex-shrink: 0;
-  width: 14px;
-  display: inline-block;
-  text-align: center;
-}
-.node-group-chevron.expanded {
-  transform: rotate(90deg);
-}
-.node-group-badge {
-  font-size: 10px;
-  font-family: var(--font-ui);
-  color: var(--fg-dim);
-  background: var(--bg-highlight);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 1px 6px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-}
-.node-group-cell {
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-}
-.node-group-cell.num {
-  color: var(--fg-dim);
-  font-size: 11px;
-  justify-content: flex-end;
-  font-variant-numeric: tabular-nums;
-}
-.node-group-cell.num.has-value {
-  color: var(--fg-bright);
-}
-
-.node-group-body {
-  overflow: hidden;
-}
-.node-group-body.collapsed {
-  display: none;
-}
-.node-group-body .node-colheaders {
-  position: static;
-  z-index: auto;
-  opacity: 0.85;
-}
-.node-group-body .node-row {
-  padding-left: 32px;
-}
-.node-group-single .node-row {
-  padding-left: 16px;
 }
 
 /* ==========================================================================
@@ -880,24 +724,6 @@
   .dash-cell-model,
   .dash-col-node,
   .dash-cell-node {
-    display: none;
-  }
-  .node-colheaders,
-  .node-row {
-    grid-template-columns: 1fr 40px 40px 40px 60px;
-  }
-  .node-group-header {
-    grid-template-columns: 1fr 40px 40px 40px 60px;
-  }
-  .node-group-header .node-group-cell:last-child {
-    display: none;
-  }
-  .ncol-version,
-  .node-cell-version {
-    display: none;
-  }
-  .ncol-health,
-  .node-cell-health {
     display: none;
   }
   #main {
@@ -4544,22 +4370,18 @@ textarea.skill-content-area {
    Reduced motion — console-specific
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {
-  .node-group-chevron {
-    transition: none;
-  }
-  .health-bar-fill {
+  .csb-np-caret {
     transition: none;
   }
   .csb-state,
-  .node-row,
-  .node-group-header {
+  .csb-np-trigger,
+  .csb-np-item {
     transition: none;
   }
   .dash-cell-node {
     transition: none;
   }
-  .dash-row.has-link::after,
-  .node-group-header::before {
+  .dash-row.has-link::after {
     transition: none;
   }
   .admin-nav,


### PR DESCRIPTION
## What

Replaces the always-visible **NODES table** on the coordinator landing page with a compact **node picker** in the cluster status bar.

- The rightmost status-bar segment shows `▾ N nodes` + the cluster version, or a solid amber **DRIFT** chip when nodes run mixed versions.
- Clicking it opens a dropdown of every compute node — status dot + node id + live `N ws` count. Selecting a node navigates to `/node/{id}/` (the same destination the table rows linked to).

## Why

The table dominated a page whose primary workflow is "start/continue a coordinator task"; per-node detail is something most users glance at rarely. The picker keeps nodes one click away without the visual weight, and folds the old `N nodes` / version status-bar metrics into the trigger.

## Backend impact: none

The picker reads the same `/v1/api/cluster/snapshot` + SSE stream the table did (via the retained `buildNodeInfoFromSnapshot`). The table was a pure client-side render, so no endpoint, DTO, or collector logic changed. The node-grouping/prefix-collapsing JS and all the table CSS are deleted. (The separate node switcher in the proxied per-node UI — the header pill backed by `/v1/api/cluster/nodes` — is untouched.)

## Accessibility & design

Reviewed with the designer agent; fixes applied:

- **Color-blind-safe status**: shape + colour — round = healthy, **diamond** = degraded, **square** = unreachable, mirroring the existing `.csb-state-dot` vocabulary, plus a spelled-out `DEGRADED` / `DOWN` word. (`degraded` is a real backend state — `collector.py` sets `health.status` to `ok`/`degraded` on `health_changed`.)
- **DRIFT** is a solid amber chip (dark text on fill), not yellow-on-yellow.
- `role="menu"`/`menuitem` (navigation, not a selection listbox), `aria-haspopup` + `aria-expanded`; Escape / outside-click / Arrow / Home / End handling; full node id via `title` when the name ellipsizes; menu height clamped to the viewport so long lists never touch the top edge.

## Tests

`tests/test_console.py` now asserts the picker markup is served and the old table markup (`#view-overview` / `#node-table`) stays gone. All 149 console tests pass; ruff + `node --check` clean. Verified rendered states (healthy/degraded/unreachable, DRIFT, long ids, 100-node scroll, single node, empty) via a headless-Chrome harness.