### PR TITLE
feat(rerank): calibration CLI, 0-1 normalization, instruction support

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -323,13 +323,32 @@ The `rerank_web_search` toggle defaults on once an endpoint is configured. If th
 
 When `rerank_bm25` is enabled, the candidate text for memory, tool, and skill retrieval (memory name/description/content and tool/skill names + descriptions) is also sent to the rerank endpoint — a self-hosted endpoint (vLLM/TEI/llama.cpp) keeps it on your infrastructure, a hosted provider (Cohere/Jina/Voyage) sends it off-box.
 
-Example (vLLM serving a Qwen3 reranker):
+**Serving a Qwen3-Reranker with vLLM.** The model is instruction-aware, so vLLM **must** apply its chat template — pass `--chat-template` explicitly. Without it the bare query produces near-random scores and reranking actively *hurts* retrieval (verified: an irrelevant passage outscored the correct one):
+
+```bash
+vllm serve /models/Qwen3-Reranker-0.6B \
+  --runner pooling \
+  --hf-overrides '{"architectures":["Qwen3ForSequenceClassification"],"classifier_from_token":["no","yes"],"is_original_qwen3_reranker":true}' \
+  --chat-template /models/Qwen3-Reranker-0.6B/chat_template.jinja \
+  --served-model-name qwen3-reranker --port 8000
+```
 
 ```toml
 [tools]
 rerank_url = "http://vllm:8000/rerank"
 rerank_model = "qwen3-reranker"
 ```
+
+For an endpoint that does *not* apply the model's template, set `rerank_instruction` instead — Turnstone then wraps each query as `<Instruct>: {instruction}` / `<Query>: {query}` (Qwen3's own default is `Given a web search query, retrieve relevant passages that answer the query`). Use the chat template **or** the instruction, not both (they double-wrap).
+
+**Picking `rerank_bm25_threshold`.** The relevance floor that gates proactive memory injection is a probability in `[0, 1]`, but the right value differs per model (a sharp 0.6B reranker may want ~0.95; a broader 4B ~0.33). Calibrate it against your endpoint:
+
+```bash
+turnstone-admin rerank-calibrate           # probe the endpoint, recommend a floor
+turnstone-admin rerank-calibrate --apply   # ...and write tools.rerank_bm25_threshold
+```
+
+It reports the score scale, whether the endpoint cleanly separates relevant from irrelevant probes (a **"no clean separation"** result flags a mis-served or weak reranker), and the suggested floor. Leave the threshold at `0` to rerank-without-filtering.
 
 ---
 

--- a/tests/test_admin_rerank_calibrate.py
+++ b/tests/test_admin_rerank_calibrate.py
@@ -1,0 +1,114 @@
+"""Tests for ``turnstone-admin rerank-calibrate`` (Phase 2 calibration CLI).
+
+Drives the real ``_cmd_rerank_calibrate`` through a real sqlite ConfigStore.
+``calibrate`` itself is stubbed (it needs a live endpoint); the rerank endpoint
+is configured via ``tools.rerank_url`` so resolution returns a real client
+object (no network until calibrate, which is stubbed). Mirrors the storage
+setup in test_admin_export.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turnstone.admin import _cmd_rerank_calibrate
+from turnstone.core.config_store import ConfigStore
+from turnstone.core.rerank_calibrate import CalibrationResult
+from turnstone.core.storage import init_storage, reset_storage
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_storage_singleton() -> Iterator[None]:
+    reset_storage()
+    yield
+    reset_storage()
+
+
+def _args(db_path: str, *, apply: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        apply=apply,
+        db_backend="sqlite",
+        db_url="",
+        db_path=db_path,
+        db_pool_size=None,
+        db_sslmode="",
+        db_sslrootcert="",
+        db_sslcert="",
+        db_sslkey="",
+    )
+
+
+def _result(*, separated: bool, threshold: float | None) -> CalibrationResult:
+    return CalibrationResult(
+        model="m",
+        raw_scale="probability (0-1)",
+        separated=separated,
+        suggested_threshold=threshold,
+        relevant_min=0.8,
+        relevant_max=0.9,
+        irrelevant_min=0.1,
+        irrelevant_max=0.2,
+        n_relevant=7,
+        n_irrelevant=42,
+    )
+
+
+def _seed_endpoint(db_path: str) -> None:
+    ConfigStore(init_storage("sqlite", path=db_path)).set(
+        "tools.rerank_url", "http://localhost:9999/rerank"
+    )
+
+
+def _stub_calibrate(monkeypatch, result: CalibrationResult) -> None:
+    monkeypatch.setattr(
+        "turnstone.core.rerank_calibrate.calibrate", lambda client, model="": result
+    )
+
+
+def _read_threshold(db_path: str) -> float:
+    return ConfigStore(init_storage("sqlite", path=db_path)).get("tools.rerank_bm25_threshold")
+
+
+def test_apply_writes_threshold(tmp_path, monkeypatch, capsys):
+    db = str(tmp_path / "t.db")
+    _seed_endpoint(db)
+    _stub_calibrate(monkeypatch, _result(separated=True, threshold=0.37))
+    _cmd_rerank_calibrate(_args(db, apply=True))
+    assert _read_threshold(db) == 0.37
+    assert "Applied" in capsys.readouterr().out
+
+
+def test_no_apply_recommends_only(tmp_path, monkeypatch, capsys):
+    db = str(tmp_path / "t.db")
+    _seed_endpoint(db)
+    _stub_calibrate(monkeypatch, _result(separated=True, threshold=0.37))
+    _cmd_rerank_calibrate(_args(db, apply=False))
+    assert _read_threshold(db) == 0.0  # not written
+    out = capsys.readouterr().out
+    assert "0.37" in out and "--apply" in out
+
+
+def test_no_separation_does_not_apply(tmp_path, monkeypatch):
+    db = str(tmp_path / "t.db")
+    _seed_endpoint(db)
+    _stub_calibrate(monkeypatch, _result(separated=False, threshold=None))
+    with pytest.raises(SystemExit) as ei:
+        _cmd_rerank_calibrate(_args(db, apply=True))
+    assert ei.value.code == 1
+    assert _read_threshold(db) == 0.0  # nothing written on no-separation
+
+
+def test_no_endpoint_errors(tmp_path, monkeypatch):
+    db = str(tmp_path / "t.db")
+    init_storage("sqlite", path=db)  # schema only, no rerank_url configured
+    for getter in ("get_rerank_url", "get_rerank_model", "get_rerank_api_key"):
+        monkeypatch.setattr(f"turnstone.core.config.{getter}", lambda: "")
+    with pytest.raises(SystemExit) as ei:
+        _cmd_rerank_calibrate(_args(db, apply=False))
+    assert ei.value.code == 1

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -12,6 +12,7 @@ from turnstone.core.rerank import (
     CohereJinaRerankClient,
     RerankHit,
     _parse_hits,
+    normalize_scores,
     resolve_rerank_client,
 )
 from turnstone.core.session import ChatSession
@@ -320,6 +321,78 @@ class _FakeRerankClient:
         return self._hits
 
 
+class TestRerankInstruction:
+    """`rerank_instruction` wraps the query for instruction-aware rerankers.
+
+    Drives through the real httpx boundary (MockTransport) and inspects the sent
+    body — for endpoints that don't apply the model's own chat template; vLLM
+    should use --chat-template instead (combining both double-wraps).
+    """
+
+    def _capture(self):
+        sent: dict = {}
+
+        def handler(request):
+            sent["body"] = json.loads(request.content)
+            return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+        return sent, handler
+
+    def test_no_instruction_sends_bare_query(self, monkeypatch):
+        sent, handler = self._capture()
+        monkeypatch.setattr("turnstone.core.rerank.httpx.post", _mock_httpx_post(handler))
+        CohereJinaRerankClient("http://x/rerank").rerank("capital of France", ["d0"])
+        assert sent["body"]["query"] == "capital of France"
+
+    def test_instruction_wraps_query(self, monkeypatch):
+        sent, handler = self._capture()
+        monkeypatch.setattr("turnstone.core.rerank.httpx.post", _mock_httpx_post(handler))
+        CohereJinaRerankClient("http://x/rerank", instruction="Find relevant passages").rerank(
+            "capital of France", ["d0"]
+        )
+        assert (
+            sent["body"]["query"]
+            == "<Instruct>: Find relevant passages\n<Query>: capital of France"
+        )
+
+    def test_resolve_threads_instruction(self):
+        client = resolve_rerank_client("http://x/rerank", instruction="X")
+        assert client is not None and client._instruction == "X"
+
+
+class TestNormalizeScores:
+    """`normalize_scores` — per-batch 0-1 mapping (sigmoid for logit batches)."""
+
+    def test_empty(self):
+        assert normalize_scores([]) == []
+
+    def test_all_in_range_pass_through(self):
+        # Probability-scale batch (Cohere/Jina/Qwen) -> identity, no transform.
+        assert normalize_scores([0.9, 0.1, 0.5, 0.0, 1.0]) == [0.9, 0.1, 0.5, 0.0, 1.0]
+
+    def test_negative_triggers_sigmoid(self):
+        out = normalize_scores([2.0, -2.0])
+        assert all(0.0 < s < 1.0 for s in out)
+        assert out[0] > 0.8 and out[1] < 0.2  # sigmoid(2)=0.88, sigmoid(-2)=0.12
+
+    def test_above_one_triggers_sigmoid(self):
+        out = normalize_scores([5.0, 0.5])  # 5.0 > 1 -> the whole batch is sigmoided
+        assert out != [5.0, 0.5]
+        assert all(0.0 < s < 1.0 for s in out)
+
+    def test_sigmoid_is_monotonic(self):
+        # Ranking must be preserved by normalisation (only the scale changes).
+        raw = [3.0, -1.0, 0.0, -5.0, 2.0]
+        out = normalize_scores(raw)
+        assert sorted(range(len(raw)), key=lambda i: out[i]) == sorted(
+            range(len(raw)), key=lambda i: raw[i]
+        )
+
+    def test_extreme_values_do_not_overflow(self):
+        out = normalize_scores([1000.0, -1000.0])
+        assert out[0] == pytest.approx(1.0) and out[1] == pytest.approx(0.0)
+
+
 class TestSessionBM25Reranker:
     """``_bm25_reranker`` / ``_bm25_rerank_threshold`` — the BM25 seam adapters.
 
@@ -399,6 +472,16 @@ class TestSessionBM25Reranker:
         rank = ChatSession._bm25_reranker(self._enabled_stub([]), 0.0)
         assert rank is not None
         assert rank("q", []) == []
+
+    def test_logit_scores_are_normalized_before_floor(self):
+        # Batch has a score outside [0,1] -> treated as logits -> sigmoid. raw
+        # 0.3 fails a 0.5 floor, but sigmoid(0.3)=0.574 clears it; the negative
+        # sibling sigmoid(-2)=0.12 does not. Without normalisation BOTH raw
+        # values fail 0.5 -> []; this proves the closure normalises the batch.
+        hits = [RerankHit(index=0, score=0.3), RerankHit(index=1, score=-2.0)]
+        rank = ChatSession._bm25_reranker(self._enabled_stub(hits), 0.5)
+        assert rank is not None
+        assert rank("q", ["d0", "d1"]) == [0]
 
     def test_threshold_reads_setting(self):
         cs = _FakeConfigStore({"tools.rerank_bm25_threshold": 0.42})

--- a/tests/test_rerank_calibrate.py
+++ b/tests/test_rerank_calibrate.py
@@ -1,0 +1,95 @@
+"""Calibration core — probe a fake reranker and recommend a 0-1 floor."""
+
+from __future__ import annotations
+
+from turnstone.core.rerank import RerankHit
+from turnstone.core.rerank_calibrate import _GAP_FRACTION, _PROBE_SET, _build_result, calibrate
+
+
+class _ScriptedClient:
+    """RerankClient stub: scores doc 0 (the relevant one) at ``r``, the rest ``i``.
+
+    Drives the real ``calibrate`` loop through the ``RerankClient`` seam — the
+    relevant doc is always position 0 of the documents calibrate sends.
+    """
+
+    def __init__(self, r: float, i: float) -> None:
+        self._r, self._i = r, i
+
+    def rerank(
+        self, query: str, documents: list[str], *, top_n: int | None = None
+    ) -> list[RerankHit]:
+        assert top_n is None  # calibration must request every doc's score
+        return [RerankHit(index=0, score=self._r)] + [
+            RerankHit(index=idx, score=self._i) for idx in range(1, len(documents))
+        ]
+
+
+class _FlakyClient:
+    """Fails the first ``cold`` calls (cold-start compile), then scores normally."""
+
+    def __init__(self, cold: int, r: float, i: float) -> None:
+        self.calls = 0
+        self.cold = cold
+        self._r, self._i = r, i
+
+    def rerank(
+        self, query: str, documents: list[str], *, top_n: int | None = None
+    ) -> list[RerankHit]:
+        self.calls += 1
+        if self.calls <= self.cold:
+            raise RuntimeError("cold endpoint (compiling)")
+        return [RerankHit(index=0, score=self._r)] + [
+            RerankHit(index=idx, score=self._i) for idx in range(1, len(documents))
+        ]
+
+
+class TestCalibrate:
+    def test_warmup_absorbs_cold_start(self):
+        # First 2 calls fail (compile); warmup consumes them so the probe loop is
+        # warm and calibration still succeeds.
+        c = _FlakyClient(cold=2, r=0.9, i=0.1)
+        res = calibrate(c, model="m")
+        assert res.separated
+        assert c.calls > 2  # warmup absorbed the cold calls before the probes ran
+
+    def test_probability_scale_clean_separation(self):
+        res = calibrate(_ScriptedClient(0.9, 0.1), model="m")
+        assert res.raw_scale == "probability (0-1)"  # already 0-1 -> identity
+        assert res.separated
+        # gap (0.1, 0.9); _GAP_FRACTION in from the irrelevant edge.
+        assert res.suggested_threshold == round(0.1 + _GAP_FRACTION * 0.8, 4)
+        assert res.irrelevant_max < res.suggested_threshold < res.relevant_min
+        assert res.n_relevant == len(_PROBE_SET)
+        assert res.n_irrelevant == len(_PROBE_SET) * (len(_PROBE_SET) - 1)
+
+    def test_logit_scale_normalized_then_separated(self):
+        # Out-of-[0,1] raw scores -> sigmoid -> a 0-1 floor regardless of scale.
+        res = calibrate(_ScriptedClient(5.0, -2.0), model="m")
+        assert "logit" in res.raw_scale
+        assert res.separated
+        assert res.suggested_threshold is not None
+        assert 0.0 < res.suggested_threshold < 1.0
+        assert res.irrelevant_max < res.suggested_threshold < res.relevant_min
+        # all reported score fields live in the normalised 0-1 space
+        assert 0.0 <= res.irrelevant_min <= res.relevant_max <= 1.0
+
+    def test_overlap_reports_no_separation(self):
+        # relevant 0.4 <= irrelevant 0.6 -> not separable, no recommendation.
+        res = calibrate(_ScriptedClient(0.4, 0.6), model="m")
+        assert not res.separated
+        assert res.suggested_threshold is None
+
+    def test_recall_bias_floor_below_lowest_relevant(self):
+        # The floor must never exceed the lowest relevant score (no false drops).
+        res = calibrate(_ScriptedClient(0.55, 0.45), model="m")
+        assert res.separated
+        assert res.suggested_threshold is not None
+        assert res.suggested_threshold < res.relevant_min
+
+    def test_empty_scores_is_no_separation(self):
+        # A broken endpoint that scores nothing -> health-check fail, no floor.
+        res = _build_result("m", "unknown (no scores)", [], [])
+        assert not res.separated
+        assert res.suggested_threshold is None
+        assert res.raw_scale == "unknown (no scores)"

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -125,6 +125,15 @@
 # rerank_api_key = ""          # bearer token for hosted providers; usually empty
                                # for self-hosted. config.toml only (never env)
 # rerank_web_search = true     # rerank web_search results (when an endpoint is set)
+# rerank_bm25 = true           # rerank BM25 retrieval: tool search, skill search, memory
+# rerank_bm25_threshold = 0.0  # 0-1 relevance floor for proactive memory; 0 = off (reorder
+                               # only). Per-model: set via `turnstone-admin rerank-calibrate`.
+# rerank_instruction = ""      # for instruction-aware rerankers (Qwen3) when the endpoint
+                               # does NOT apply the model's chat template, e.g. "Given a web
+                               # search query, retrieve relevant passages that answer the
+                               # query". Prefer vLLM's --chat-template; don't use both.
+                               # NB: serving Qwen3-Reranker via vLLM REQUIRES --chat-template
+                               # (the model's chat_template.jinja) or scores are near-random.
 
 # --- Judge (turnstone, node) ---
 

--- a/turnstone/admin.py
+++ b/turnstone/admin.py
@@ -439,6 +439,66 @@ def _discover_console_url() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _cmd_rerank_calibrate(args: argparse.Namespace) -> None:
+    from turnstone.core.config_store import ConfigStore
+    from turnstone.core.model_registry import load_model_registry
+    from turnstone.core.rerank_calibrate import calibrate
+    from turnstone.core.rerank_config import resolve_rerank_client_from
+
+    storage = _get_storage(args)
+    config_store = ConfigStore(storage)
+    try:
+        registry: Any = load_model_registry(storage=storage, allow_empty=True)
+    except Exception:
+        registry = None
+    # Calibration is a manual, one-shot op against a possibly-cold endpoint, so a
+    # generous timeout (vs the per-turn 15s cap) keeps a first-request compile
+    # from failing it; calibrate() also warms the endpoint up first.
+    client = resolve_rerank_client_from(config_store, registry, timeout=60.0)
+    if client is None:
+        print(
+            "No rerank endpoint configured. Set tools.rerank_url (config.toml [tools] or the "
+            "Settings tab) or select a Reranker model role.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    alias = str(config_store.get("tools.reranker_alias") or "").strip()
+    label = alias or str(config_store.get("tools.rerank_model") or "") or "(endpoint default)"
+    try:
+        result = calibrate(client, model=label)
+    except Exception as e:  # network / endpoint failure surfaces to the operator
+        print(f"Calibration failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Reranker:        {result.model}")
+    print(f"Raw score scale: {result.raw_scale}")
+    print(
+        f"Relevant   (n={result.n_relevant}): "
+        f"{result.relevant_min:.4f} .. {result.relevant_max:.4f}"
+    )
+    print(
+        f"Irrelevant (n={result.n_irrelevant}): "
+        f"{result.irrelevant_min:.4f} .. {result.irrelevant_max:.4f}"
+    )
+    if not result.separated:
+        print(
+            "\nNo clean separation between relevant and irrelevant probes: this endpoint can't "
+            "be thresholded reliably (is it a real reranker, and is the model name right?). "
+            "Not recommending a floor."
+        )
+        sys.exit(1 if args.apply else 0)
+
+    print(f"\nSuggested tools.rerank_bm25_threshold = {result.suggested_threshold}")
+    if args.apply:
+        config_store.set(
+            "tools.rerank_bm25_threshold", result.suggested_threshold, changed_by="rerank-calibrate"
+        )
+        print(f"Applied: tools.rerank_bm25_threshold = {result.suggested_threshold}")
+    else:
+        print("Re-run with --apply to write it.")
+
+
 def main() -> None:
     """Entry point for turnstone-admin CLI."""
     parser = argparse.ArgumentParser(
@@ -523,6 +583,14 @@ def main() -> None:
     )
     p_export.add_argument("--output", "-o", default="-", help="Output file path, or - for stdout")
 
+    p_cal = sub.add_parser(
+        "rerank-calibrate",
+        help="Probe the configured reranker and recommend tools.rerank_bm25_threshold",
+    )
+    p_cal.add_argument(
+        "--apply", action="store_true", help="Write the suggested threshold to settings"
+    )
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -542,5 +610,6 @@ def main() -> None:
         "set-node-metadata": _cmd_set_node_metadata,
         "delete-node-metadata": _cmd_delete_node_metadata,
         "export": _cmd_export,
+        "rerank-calibrate": _cmd_rerank_calibrate,
     }
     dispatch[args.command](args)

--- a/turnstone/core/config.py
+++ b/turnstone/core/config.py
@@ -237,6 +237,8 @@ _rerank_model: str | None = None
 _rerank_model_loaded: bool = False
 _rerank_api_key: str | None = None
 _rerank_api_key_loaded: bool = False
+_rerank_instruction: str | None = None
+_rerank_instruction_loaded: bool = False
 
 
 def get_rerank_url() -> str:
@@ -278,6 +280,22 @@ def get_rerank_api_key() -> str:
         _rerank_api_key_loaded = True
         _rerank_api_key = load_config("tools").get("rerank_api_key", "").strip()
     return _rerank_api_key or ""
+
+
+def get_rerank_instruction() -> str:
+    """Load the rerank query instruction (cached after first call).
+
+    Precedence: config.toml [tools] rerank_instruction -> $TURNSTONE_RERANK_INSTRUCTION
+    -> "" (no instruction; a bare query, correct for Cohere/Jina/bge cross-encoders).
+    Instruction-aware rerankers (the Qwen3-Reranker family) need it; the client
+    then wraps the query with the model's ``<Instruct>:`` / ``<Query>:`` framing.
+    """
+    global _rerank_instruction, _rerank_instruction_loaded
+    if not _rerank_instruction_loaded:
+        _rerank_instruction_loaded = True
+        cfg = load_config("tools").get("rerank_instruction", "").strip()
+        _rerank_instruction = cfg or os.environ.get("TURNSTONE_RERANK_INSTRUCTION", "").strip()
+    return _rerank_instruction or ""
 
 
 def nonneg_float(val: str) -> float:

--- a/turnstone/core/rerank.py
+++ b/turnstone/core/rerank.py
@@ -21,6 +21,7 @@ default and no fall back to a local model.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -46,6 +47,34 @@ class RerankError(RuntimeError):
     Callers raise this so retrieval falls back to BM25 order rather than
     treating the failure as "nothing relevant".
     """
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically-stable logistic sigmoid (maps a logit to a probability)."""
+    if x >= 0.0:
+        return 1.0 / (1.0 + math.exp(-x))
+    e = math.exp(x)
+    return e / (1.0 + e)
+
+
+def normalize_scores(scores: list[float]) -> list[float]:
+    """Map a batch of raw rerank scores into a 0-1 relevance space.
+
+    Cohere/Jina/Qwen endpoints already return 0-1 relevance; cross-encoders
+    (bge, TEI) return raw logits. If ANY score in the batch falls outside
+    ``[0, 1]`` the batch is treated as logits and squashed with the logistic
+    sigmoid (the canonical logit -> P(relevant) map); otherwise the scores are
+    already probabilities and pass through unchanged. Detection is per-batch
+    because one rerank response comes from one model, and a real batch mixes
+    relevant and irrelevant docs so a logit model reveals out-of-range (often
+    negative) scores. Sigmoid is monotonic, so ranking ORDER is never affected
+    -- only a threshold comparison gains a consistent 0-1 meaning.
+    """
+    if not scores:
+        return []
+    if all(0.0 <= s <= 1.0 for s in scores):
+        return list(scores)
+    return [_sigmoid(s) for s in scores]
 
 
 @dataclass(frozen=True)
@@ -75,18 +104,32 @@ class CohereJinaRerankClient:
     ``relevance_score`` response are shared across all of them.
     """
 
-    def __init__(self, url: str, model: str = "", api_key: str = "", timeout: float = 30) -> None:
+    def __init__(
+        self,
+        url: str,
+        model: str = "",
+        api_key: str = "",
+        timeout: float = 30,
+        instruction: str = "",
+    ) -> None:
         self._url = url
         self._model = model
         self._api_key = api_key
         self._timeout = timeout
+        self._instruction = instruction
 
     def rerank(
         self, query: str, documents: list[str], *, top_n: int | None = None
     ) -> list[RerankHit]:
         if not documents:
             return []
-        payload: dict[str, Any] = {"query": query, "documents": list(documents)}
+        # Instruction-aware rerankers (Qwen3-Reranker) need the instruction in the
+        # query; vLLM's /rerank does not inject it (a bare query can even invert
+        # relevance). Wrap with the model's <Instruct>/<Query> framing — it frames
+        # the <Document> side itself. Empty instruction -> bare query, which is
+        # correct for Cohere/Jina/bge cross-encoders.
+        q = f"<Instruct>: {self._instruction}\n<Query>: {query}" if self._instruction else query
+        payload: dict[str, Any] = {"query": q, "documents": list(documents)}
         if self._model:
             payload["model"] = self._model
         if top_n is not None:
@@ -128,12 +171,13 @@ def _parse_hits(data: Any, n_docs: int) -> list[RerankHit]:
 
 
 def resolve_rerank_client(
-    url: str, model: str = "", api_key: str = "", timeout: float = 30
+    url: str, model: str = "", api_key: str = "", timeout: float = 30, instruction: str = ""
 ) -> RerankClient | None:
     """Return a rerank client, or ``None`` when no endpoint URL is configured.
 
     A missing URL is the "reranking disabled" state (the default) — there is no
-    bundled endpoint and no local-inference fallback.
+    bundled endpoint and no local-inference fallback. ``instruction`` is the
+    optional query instruction for instruction-aware rerankers (Qwen3-Reranker).
     """
     url = (url or "").strip()
     if not url:
@@ -143,4 +187,5 @@ def resolve_rerank_client(
         model=(model or "").strip(),
         api_key=(api_key or "").strip(),
         timeout=timeout,
+        instruction=(instruction or "").strip(),
     )

--- a/turnstone/core/rerank_calibrate.py
+++ b/turnstone/core/rerank_calibrate.py
@@ -1,0 +1,198 @@
+"""Reranker threshold calibration (Phase 2 core).
+
+Probes a configured rerank endpoint with a small bundled set of labelled
+relevant/irrelevant query groups and recommends a ``tools.rerank_bm25_threshold``
+floor that separates the two — or reports that the endpoint cannot cleanly
+separate them (which doubles as a mis-served-reranker health check).
+
+Scores are normalised to a 0-1 relevance probability via
+``rerank.normalize_scores`` (sigmoid for logit endpoints) — the SAME transform
+the ``_bm25_reranker`` closure applies — so the recommended floor is in the
+exact space the production comparison uses. The raw score scale is detected and
+reported separately for diagnostics. ``scripts/bench_bm25_rerank.py`` is the
+manual prototype of this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from turnstone.core.rerank import normalize_scores
+
+if TYPE_CHECKING:
+    from turnstone.core.rerank import RerankClient
+
+# Labelled probe groups: each doc is clearly relevant to its own query and
+# irrelevant to every other query (distinct topics, with a few technical ones to
+# approximate the tool/skill/memory domain). For each query we send its own doc
+# plus all the others; the own-doc score is "relevant", the rest "irrelevant".
+_PROBE_SET: list[tuple[str, str]] = [
+    ("capital of France", "Paris is the capital and largest city of France."),
+    ("sort a list in Python", "Use sorted() or the list.sort() method to order a Python list."),
+    ("symptoms of dehydration", "Dehydration causes thirst, dry mouth, fatigue, and dark urine."),
+    (
+        "how photosynthesis works",
+        "Photosynthesis turns sunlight, water, and CO2 into glucose and oxygen in chloroplasts.",
+    ),
+    (
+        "rotate a JWT signing secret",
+        "Rotate a JWT secret by signing new tokens with a new key while still accepting the old "
+        "key until previously issued tokens expire.",
+    ),
+    (
+        "Dockerfile layer cache best practice",
+        "Order Dockerfile instructions from least- to most-frequently changing to maximise build "
+        "cache reuse.",
+    ),
+    ("treat a sprained ankle", "For a sprained ankle use RICE: rest, ice, compression, elevation."),
+    (
+        "boiling point of water at sea level",
+        "Water boils at 100 degrees Celsius (212 Fahrenheit) at sea-level pressure.",
+    ),
+    (
+        "what causes ocean tides",
+        "Ocean tides are caused mainly by the Moon's gravitational pull on Earth's oceans.",
+    ),
+    (
+        "reverse a string in JavaScript",
+        "Reverse a JavaScript string with str.split('').reverse().join('').",
+    ),
+    (
+        "difference between TCP and UDP",
+        "TCP is connection-oriented and reliable; UDP is connectionless and best-effort.",
+    ),
+    ("who painted the Mona Lisa", "The Mona Lisa was painted by Leonardo da Vinci."),
+    (
+        "set up SSH key-based login",
+        "Append your public key to ~/.ssh/authorized_keys to enable key-based SSH login.",
+    ),
+    (
+        "what is compound interest",
+        "Compound interest is interest on the principal plus all previously accrued interest.",
+    ),
+    ("largest planet in the solar system", "Jupiter is the largest planet in the solar system."),
+    (
+        "prevent SQL injection",
+        "Prevent SQL injection by using parameterised queries or prepared statements rather than "
+        "string concatenation.",
+    ),
+    (
+        "how to brew espresso",
+        "Espresso is made by forcing hot water at high pressure through finely-ground coffee.",
+    ),
+    (
+        "convert Celsius to Fahrenheit",
+        "To convert Celsius to Fahrenheit, multiply by 9/5 and add 32.",
+    ),
+]
+
+# How far into the relevant/irrelevant gap to place the floor, measured from the
+# irrelevant (high) edge. 0.25 biases toward RECALL: the bundled probes are
+# generic, so the real tool/skill/memory domain may separate slightly
+# differently — under-drop rather than over-drop.
+_GAP_FRACTION = 0.25
+
+
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Outcome of probing a rerank endpoint with the labelled set.
+
+    Score fields are in the NORMALISED 0-1 space (the space the floor compares
+    in); ``raw_scale`` describes the endpoint's untransformed output.
+    """
+
+    model: str
+    raw_scale: str  # "probability (0-1)" | "logit (sigmoid-normalised)" | "unknown (no scores)"
+    separated: bool
+    suggested_threshold: float | None  # 0-1, None when the classes overlap
+    relevant_min: float
+    relevant_max: float
+    irrelevant_min: float
+    irrelevant_max: float
+    n_relevant: int
+    n_irrelevant: int
+
+
+def _warmup(client: RerankClient, rounds: int = 3) -> None:
+    """Prime a cold rerank endpoint before measuring.
+
+    A freshly-booted vLLM endpoint compiles / captures CUDA graphs on the first
+    request of a new batch shape, which can exceed the per-call timeout. Send
+    throwaway calls (of the probe batch shape) until one succeeds, so the real
+    loop below doesn't time out on the cold start. Best-effort — give up after
+    ``rounds`` and let calibration surface any persistent failure.
+    """
+    docs = [doc for _, doc in _PROBE_SET]
+    for _ in range(rounds):
+        try:
+            client.rerank("warmup", docs)
+            return
+        except Exception:
+            continue
+
+
+def calibrate(client: RerankClient, *, model: str = "") -> CalibrationResult:
+    """Probe ``client`` with the labelled set and recommend a 0-1 floor.
+
+    For each query, send its own doc plus every other probe doc (no ``top_n`` so
+    all are scored), normalise each response to 0-1, pool the own-doc scores as
+    "relevant" and the rest as "irrelevant", then place a recall-biased floor in
+    the gap — or report ``separated=False`` (no recommendation) when the pooled
+    classes overlap.
+    """
+    _warmup(client)  # absorb cold-start compile latency before measuring
+    docs_all = [doc for _, doc in _PROBE_SET]
+    relevant: list[float] = []
+    irrelevant: list[float] = []
+    raw_all: list[float] = []
+    for i, (query, _) in enumerate(_PROBE_SET):
+        docs = [docs_all[i]] + [d for j, d in enumerate(docs_all) if j != i]
+        hits = client.rerank(query, docs)
+        raw_all.extend(h.score for h in hits)
+        norm = normalize_scores([h.score for h in hits])
+        by_index = {h.index: s for h, s in zip(hits, norm, strict=True)}
+        if 0 in by_index:
+            relevant.append(by_index[0])
+        irrelevant.extend(by_index[idx] for idx in range(1, len(docs)) if idx in by_index)
+    return _build_result(model, _raw_scale(raw_all), relevant, irrelevant)
+
+
+def _raw_scale(raw: list[float]) -> str:
+    if not raw:
+        return "unknown (no scores)"
+    if all(0.0 <= s <= 1.0 for s in raw):
+        return "probability (0-1)"
+    return "logit (sigmoid-normalised)"
+
+
+def _build_result(
+    model: str, raw_scale: str, relevant: list[float], irrelevant: list[float]
+) -> CalibrationResult:
+    """Pool the labelled (normalised) scores, detect separation, place a floor.
+
+    Separation is judged on the POOLED classes (lowest relevant vs highest
+    irrelevant across all queries) because the production floor is a single
+    global value — if the pooled classes overlap, no single threshold cleanly
+    works, which is exactly the signal an operator needs.
+    """
+    if not relevant or not irrelevant:
+        return CalibrationResult(
+            model, raw_scale, False, None, 0.0, 0.0, 0.0, 0.0, len(relevant), len(irrelevant)
+        )
+    r_min, r_max = min(relevant), max(relevant)
+    i_min, i_max = min(irrelevant), max(irrelevant)
+    separated = r_min > i_max
+    suggested = round(i_max + _GAP_FRACTION * (r_min - i_max), 4) if separated else None
+    return CalibrationResult(
+        model,
+        raw_scale,
+        separated,
+        suggested,
+        r_min,
+        r_max,
+        i_min,
+        i_max,
+        len(relevant),
+        len(irrelevant),
+    )

--- a/turnstone/core/rerank_config.py
+++ b/turnstone/core/rerank_config.py
@@ -1,0 +1,79 @@
+"""Resolve a rerank client from configuration.
+
+Shared by ``ChatSession`` and the ``turnstone-admin rerank-calibrate`` CLI (and,
+later, an admin "Calibrate" endpoint) so the precedence — a Reranker model role
+(``tools.reranker_alias`` -> a model with ``supports_rerank``) over the
+``tools.rerank_url`` settings (storage -> config.toml/env) — lives in one place.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from turnstone.core.rerank import RerankClient
+
+
+def resolve_rerank_client_from(
+    config_store: Any | None,
+    registry: Any | None,
+    *,
+    timeout: float,
+) -> RerankClient | None:
+    """Return a rerank client from settings, or ``None`` when unconfigured.
+
+    A reranker model definition selected via the Reranker role
+    (``tools.reranker_alias`` -> a model with ``supports_rerank``) takes
+    precedence; otherwise the ``tools.rerank_url`` settings (explicit stored
+    value -> config.toml/env -> registry default). There is no bundled rerank
+    endpoint, so this returns ``None`` until one is configured.
+    """
+    from turnstone.core.config import (
+        get_rerank_api_key,
+        get_rerank_instruction,
+        get_rerank_model,
+        get_rerank_url,
+    )
+    from turnstone.core.rerank import resolve_rerank_client
+
+    cs = config_store
+    stored = cs.stored_keys() if cs is not None else frozenset()
+
+    def _setting(key: str, env_value: str) -> str:
+        if cs is not None and key in stored:  # explicit admin value wins
+            return str(cs.get(key) or "").strip()
+        if env_value:  # config.toml / env var
+            return env_value
+        if cs is not None:  # registry default, surfaced by the store
+            return str(cs.get(key) or "").strip()
+        return ""
+
+    # The query instruction is global — it applies to whichever endpoint resolves.
+    instruction = _setting("tools.rerank_instruction", get_rerank_instruction())
+
+    # A reranker model definition (capability ``supports_rerank``), picked via
+    # the Reranker role, wins — managed like every other model; its base_url is
+    # the full Cohere/Jina-compatible rerank endpoint.
+    if cs is not None and registry is not None:
+        alias = str(cs.get("tools.reranker_alias") or "").strip()
+        if alias:
+            try:
+                cfg = registry.get_config(alias)
+            except Exception:
+                cfg = None
+            if cfg is not None and cfg.base_url and cfg.capabilities.get("supports_rerank"):
+                return resolve_rerank_client(
+                    url=cfg.base_url,
+                    model=cfg.model or "",
+                    api_key=cfg.api_key,
+                    timeout=timeout,
+                    instruction=instruction,
+                )
+
+    return resolve_rerank_client(
+        url=_setting("tools.rerank_url", get_rerank_url()),
+        model=_setting("tools.rerank_model", get_rerank_model()),
+        api_key=_setting("tools.rerank_api_key", get_rerank_api_key()),
+        timeout=timeout,
+        instruction=instruction,
+    )

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1318,48 +1318,11 @@ class ChatSession:
         There is no bundled rerank endpoint, so reranking stays disabled until
         one is configured.
         """
-        from turnstone.core.config import (
-            get_rerank_api_key,
-            get_rerank_model,
-            get_rerank_url,
-        )
-        from turnstone.core.rerank import resolve_rerank_client
+        from turnstone.core.rerank_config import resolve_rerank_client_from
 
-        cs = getattr(self, "_config_store", None)
-        stored = cs.stored_keys() if cs is not None else frozenset()
-
-        # A reranker model definition (capability ``supports_rerank``), picked
-        # via the Reranker role, takes precedence — managed like every other
-        # model. Its base_url is the full Cohere/Jina-compatible rerank endpoint.
-        registry = getattr(self, "_registry", None)
-        if cs is not None and registry is not None:
-            alias = str(cs.get("tools.reranker_alias") or "").strip()
-            if alias:
-                try:
-                    cfg = registry.get_config(alias)
-                except Exception:
-                    cfg = None
-                if cfg is not None and cfg.base_url and cfg.capabilities.get("supports_rerank"):
-                    return resolve_rerank_client(
-                        url=cfg.base_url,
-                        model=cfg.model or "",
-                        api_key=cfg.api_key,
-                        timeout=min(self.tool_timeout, _RERANK_TIMEOUT_CAP_S),
-                    )
-
-        def _setting(key: str, env_value: str) -> str:
-            if cs is not None and key in stored:  # explicit admin value wins
-                return str(cs.get(key) or "").strip()
-            if env_value:  # config.toml / env var
-                return env_value
-            if cs is not None:  # registry default, surfaced by the store
-                return str(cs.get(key) or "").strip()
-            return ""
-
-        return resolve_rerank_client(
-            url=_setting("tools.rerank_url", get_rerank_url()),
-            model=_setting("tools.rerank_model", get_rerank_model()),
-            api_key=_setting("tools.rerank_api_key", get_rerank_api_key()),
+        return resolve_rerank_client_from(
+            getattr(self, "_config_store", None),
+            getattr(self, "_registry", None),
             timeout=min(self.tool_timeout, _RERANK_TIMEOUT_CAP_S),
         )
 
@@ -1410,7 +1373,7 @@ class ChatSession:
         if rc is None:
             return None
 
-        from turnstone.core.rerank import RerankError
+        from turnstone.core.rerank import RerankError, normalize_scores
 
         def _rank(query: str, docs: list[str]) -> list[int]:
             hits = rc.rerank(query, docs)
@@ -1423,7 +1386,15 @@ class ChatSession:
                 # fall back to BM25 order in BOTH modes, instead of the
                 # filter-mode floor honoring it as "nothing relevant".
                 raise RerankError("rerank endpoint returned no scores for non-empty input")
-            return [h.index for h in hits if threshold <= 0 or h.score >= threshold]
+            # Normalise to a 0-1 relevance space (sigmoid for logit endpoints) so
+            # ``threshold`` means the same on every reranker. Sigmoid is monotonic
+            # -> ordering is unchanged; only the floor compare gains a uniform scale.
+            scores = normalize_scores([h.score for h in hits])
+            return [
+                h.index
+                for h, score in zip(hits, scores, strict=True)
+                if threshold <= 0 or score >= threshold
+            ]
 
         return _rank
 

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -286,6 +286,18 @@ def _build_registry() -> dict[str, SettingDef]:
             "it in config.toml [tools] rerank_api_key (secrets belong in config.toml, not env).",
         ),
         SettingDef(
+            "tools.rerank_instruction",
+            "str",
+            "",
+            "Query instruction for instruction-aware rerankers (e.g. Qwen3-Reranker)",
+            "tools",
+            help="Instruction-aware rerankers (the Qwen3-Reranker family) need a task "
+            "instruction; when set, the client wraps the query with the model's "
+            "<Instruct>:/<Query>: framing. Qwen3's own default is 'Given a web search query, "
+            "retrieve relevant passages that answer the query'. Empty = bare query, correct for "
+            "Cohere/Jina/bge cross-encoders.",
+        ),
+        SettingDef(
             "tools.rerank_web_search",
             "bool",
             True,
@@ -327,9 +339,9 @@ def _build_registry() -> dict[str, SettingDef]:
             0.0,
             "Relevance floor (0-1) for proactive memory surfacing; 0 disables",
             "tools",
-            help="0-1 relevance floor for PROACTIVE memory surfacing; 0 disables it. On "
-            "your reranker's score scale -- calibrated 0-1 on Cohere/Jina/Qwen endpoints, "
-            "raw logits on bge/TEI.",
+            help="0-1 relevance-probability floor for PROACTIVE memory surfacing; 0 disables "
+            "it. Reranker scores are normalised to 0-1 first (logit rerankers like bge/TEI are "
+            "sigmoid-mapped), so the scale is uniform across endpoints. Calibrate to pick a value.",
         ),
         # -- server ---------------------------------------------------------
         SettingDef(


### PR DESCRIPTION
Follows #627 (BM25 reranking, now merged to main). Phase 2: making the `rerank_bm25_threshold` floor usable across reranker models, with tooling to pick it.

## What's here

**0–1 normalization** (`normalize_scores`) — maps a rerank batch into a relevance probability: sigmoid when any score is outside `[0,1]` (logit endpoints like bge/TEI), identity otherwise (Cohere/Jina/Qwen). Applied in both the `_bm25_reranker` closure and calibration, so a threshold means the same thing on every endpoint. Monotonic → ranking order never changes.

**Calibration** — `turnstone-admin rerank-calibrate [--apply]` probes the configured endpoint with labelled relevant/irrelevant groups, normalises, and recommends a recall-biased floor — or reports **"no clean separation"** (a mis-served or weak reranker). A warmup loop absorbs a cold endpoint's first-request compile so calibration doesn't time out.

**`resolve_rerank_client_from`** — the alias→url precedence is extracted into one shared function; `ChatSession` delegates to it, and so does the CLI (and the future admin button).

**`tools.rerank_instruction`** — wraps the query as `<Instruct>:` / `<Query>:` for instruction-aware rerankers (Qwen3) on endpoints that don't apply the model's own chat template (use this *or* `--chat-template`, not both).

## Live validation (Qwen3-Reranker on vLLM, RTX PRO 6000)

Validated end-to-end against the 0.6B and 4B. The headline finding, now documented: **Qwen3-Reranker via vLLM requires `--chat-template`** — without it the bare query produces near-random scores and reranking actively *hurts* retrieval (tool-search MRR 0.69 → 0.45); with it, the right answer ranks #1 every time (MRR 0.69 → **1.0**) with clean separation. The calibrated floor came out **0.95 for the 0.6B vs 0.33 for the 4B** on the identical task — concrete proof that a fixed default can't work and per-endpoint calibration is the point.

## Testing

Negative-tested each guard (revert the production line → confirm the test fails → restore): the normalize sigmoid/identity branches, closure-normalises-before-floor, calibration separation + recall-bias + warmup-absorbs-cold-start, the CLI apply / no-apply / no-separation paths, and instruction query-wrapping through the real httpx boundary. Full touched suite green (579), ruff + mypy clean.

## Follow-up

Phase 2b: an admin-console "Calibrate" button wrapping the CLI's `calibrate()`.
