### PR TITLE
Rerank models as per-model definitions; fix proactive-memory relevance

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -314,12 +314,9 @@ Search the web using a text query.
 
 `web_search` can use an external **reranker** to re-order the backend's result pool by relevance to the query before returning the top hits. Turnstone runs no reranker model itself; it POSTs to a Cohere/Jina-compatible `/rerank` endpoint (self-hosted [vLLM](https://docs.vllm.ai) / [TEI](https://github.com/huggingface/text-embeddings-inference) / llama.cpp, or hosted Cohere/Jina/Voyage).
 
-**Disabled by default.** Two ways to point at an endpoint:
+**Disabled by default.** In the console **Models** tab, add a model definition whose `base_url` is a Cohere/Jina-compatible `/rerank` endpoint and whose capabilities include `{"supports_rerank": true}`, then select it under **Models → Roles → Reranker**. It's managed like every other model (write-only key, enable/disable, calibration). The reranker is purely this per-model definition — there is no global `rerank_url`-style endpoint setting.
 
-- **A reranker model (recommended, admin UI):** in the console **Models** tab, add a model definition whose `base_url` is a Cohere/Jina-compatible `/rerank` endpoint and whose capabilities include `{"supports_rerank": true}`, then select it under **Models → Roles → Reranker**. Managed like every other model (write-only key, enable/disable).
-- **Config settings:** set `rerank_url` (full endpoint URL including path) in `config.toml` `[tools]`, the admin Settings tab, or `$TURNSTONE_RERANK_URL`; optionally `rerank_model` and `rerank_api_key` (write-only). The reranker model role, if set, takes precedence over these.
-
-The `rerank_web_search` toggle defaults on once an endpoint is configured. If the endpoint is unreachable or errors, web_search falls back silently to the backend's native result order — reranking never makes a search fail.
+The `rerank_web_search` toggle defaults on once a reranker is selected. If the endpoint is unreachable or errors, web_search falls back silently to the backend's native result order — reranking never makes a search fail.
 
 When `rerank_bm25` is enabled, the candidate text for memory, tool, and skill retrieval (memory name/description/content and tool/skill names + descriptions) is also sent to the rerank endpoint — a self-hosted endpoint (vLLM/TEI/llama.cpp) keeps it on your infrastructure, a hosted provider (Cohere/Jina/Voyage) sends it off-box.
 
@@ -333,11 +330,7 @@ vllm serve /models/Qwen3-Reranker-0.6B \
   --served-model-name qwen3-reranker --port 8000
 ```
 
-```toml
-[tools]
-rerank_url = "http://vllm:8000/rerank"
-rerank_model = "qwen3-reranker"
-```
+Then add a reranker model in the **Models** tab with `base_url` `http://vllm:8000/rerank` (model name `qwen3-reranker`) and select it under **Models → Roles → Reranker**.
 
 For an endpoint that does *not* apply the model's template, set `rerank_instruction` instead — Turnstone then wraps each query as `<Instruct>: {instruction}` / `<Query>: {query}` (Qwen3's own default is `Given a web search query, retrieve relevant passages that answer the query`). Use the chat template **or** the instruction, not both (they double-wrap).
 

--- a/tests/test_admin_calibrate_endpoint.py
+++ b/tests/test_admin_calibrate_endpoint.py
@@ -6,9 +6,12 @@ Covers the two server paths added in Phase 3:
   reranker, persists the three calibration fields onto its capabilities, and
   returns a verdict; a calibration failure is graceful (no 500, nothing
   persisted).
-- ``POST /api/admin/model-definitions/detect`` with ``supports_rerank`` — merges
-  the calibration fields into the returned capabilities so the client
-  autopopulates them; a non-rerank detect takes no calibration path.
+- ``POST /api/admin/model-definitions/detect`` with ``supports_rerank`` —
+  calibrates the /rerank endpoint *directly* (a reranker's base_url is its full
+  /rerank path, which the ``/v1/models`` probe can't reach), so the probe is
+  skipped and the calibration round-trip IS the reachability check: success
+  autopopulates the three fields, failure reports ``reachable: False``. A
+  non-rerank detect still probes ``/v1/models`` and takes no calibration path.
 
 ``calibrate_model`` is monkeypatched (it needs a live /rerank endpoint).
 Mirrors the TestClient wiring in test_admin_model_registry_refresh.py.
@@ -238,12 +241,15 @@ def _stub_probe(monkeypatch: pytest.MonkeyPatch, result: dict[str, Any]) -> None
     )
 
 
-def test_detect_autopopulates_calibration_for_reranker(
+def test_detect_reranker_calibrates_directly_skipping_probe(
     storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _stub_probe(
-        monkeypatch,
-        {"reachable": True, "available_models": ["bge-reranker"], "error": None},
+    """A reranker detect must NOT touch /v1/models (its base_url is the full
+    /rerank path) — it calibrates directly and autopopulates the three fields."""
+    probe_called: list[Any] = []
+    monkeypatch.setattr(
+        "turnstone.core.model_registry.probe_model_endpoint",
+        lambda *a, **kw: probe_called.append(a) or {"reachable": True},
     )
     _stub_calibrate(monkeypatch, _result(separated=True, threshold=0.33))
     client = _make_client(storage, None)
@@ -258,19 +264,48 @@ def test_detect_autopopulates_calibration_for_reranker(
         },
     )
     assert resp.status_code == 200, resp.text
-    caps = resp.json().get("capabilities", {})
+    assert probe_called == []  # /v1/models never probed for a reranker
+    body = resp.json()
+    assert body["reachable"] is True
+    assert body["available_models"] == []
+    caps = body.get("capabilities", {})
+    assert caps["supports_rerank"] is True
     assert caps["rerank_threshold"] == 0.33
     assert caps["rerank_scale"] == "logit (sigmoid-normalised)"
     assert caps["rerank_separated"] is True
 
 
-def test_detect_reranker_calibration_failure_is_noted(
+def test_detect_reranker_no_separation_notes_but_reachable(
     storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _stub_probe(
-        monkeypatch,
-        {"reachable": True, "available_models": ["bge-reranker"], "error": None},
+    """Reachable reranker with no clean split: fields still populate (scale
+    marker + separated=False, threshold 0) and a note warns; still reachable."""
+    _stub_calibrate(monkeypatch, _result(separated=False, threshold=None))
+    client = _make_client(storage, None)
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions/detect",
+        json={
+            "provider": "openai-compatible",
+            "base_url": "http://localhost:9999/rerank",
+            "model": "bge-reranker",
+            "supports_rerank": True,
+        },
     )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["reachable"] is True
+    caps = body["capabilities"]
+    assert caps["rerank_separated"] is False
+    assert caps["rerank_threshold"] == 0.0
+    assert "no clean separation" in body["rerank_calibration_note"]
+
+
+def test_detect_reranker_calibration_failure_is_unreachable(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Can't calibrate -> it isn't a working reranker: reachable False + error,
+    no capabilities (there is no independent /v1/models reachability signal)."""
 
     def _boom(base_url, model, api_key, *, instruction="", timeout=60.0):
         raise RuntimeError("not a reranker")
@@ -289,8 +324,35 @@ def test_detect_reranker_calibration_failure_is_noted(
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert not body.get("capabilities")  # fields omitted on failure
-    assert "not a reranker" in body["rerank_calibration_note"]
+    assert body["reachable"] is False
+    assert not body.get("capabilities")
+    assert "not a reranker" in body["error"]
+
+
+def test_detect_reranker_requires_base_url(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reranker has no provider-default URL — an empty base_url is a clear 400
+    (not a probe against some default host) and never attempts calibration."""
+    called: list[Any] = []
+    monkeypatch.setattr(
+        "turnstone.core.rerank_calibrate.calibrate_model",
+        lambda *a, **kw: called.append(a) or _result(separated=True, threshold=0.5),
+    )
+    client = _make_client(storage, None)
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions/detect",
+        json={
+            "provider": "openai-compatible",
+            "base_url": "",
+            "model": "bge-reranker",
+            "supports_rerank": True,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "/rerank" in resp.json()["error"]
+    assert called == []  # never attempted calibration with an empty url
 
 
 def test_detect_non_reranker_skips_calibration(

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -215,41 +215,20 @@ class _FakeConfigStore:
         return self._values.get(key)
 
 
-def _patch_getters_empty(monkeypatch):
-    for name in ("get_rerank_url", "get_rerank_model", "get_rerank_api_key"):
-        monkeypatch.setattr(f"turnstone.core.config.{name}", lambda: "")
-
-
 class TestSessionRerankWiring:
-    def test_disabled_by_default_when_no_endpoint(self, monkeypatch):
-        _patch_getters_empty(monkeypatch)
-        stub = SimpleNamespace(_config_store=None, tool_timeout=30)
+    def test_disabled_when_no_config_store(self):
+        stub = SimpleNamespace(_config_store=None, _registry=None, tool_timeout=30)
         assert ChatSession._resolve_rerank_client(stub) is None
 
-    def test_resolves_client_from_config_store(self, monkeypatch):
-        _patch_getters_empty(monkeypatch)
-        cs = _FakeConfigStore(
-            {
-                "tools.rerank_url": "http://h/rerank",
-                "tools.rerank_model": "m",
-                "tools.rerank_api_key": "k",
-            }
+    def test_disabled_when_no_reranker_alias(self):
+        # No Reranker role selected -> reranking off. There is no global endpoint
+        # fallback: the reranker is purely a per-model definition.
+        cs = _FakeConfigStore({"tools.reranker_alias": ""})
+        stub = SimpleNamespace(
+            _config_store=cs,
+            tool_timeout=30,
+            _registry=SimpleNamespace(get_config=lambda a: None),
         )
-        stub = SimpleNamespace(_config_store=cs, tool_timeout=15)
-        client = ChatSession._resolve_rerank_client(stub)
-        assert isinstance(client, CohereJinaRerankClient)
-        assert client._url == "http://h/rerank"
-        assert client._model == "m"
-        assert client._api_key == "k"
-
-    def test_explicit_empty_url_stays_disabled(self, monkeypatch):
-        # An admin who clears the URL (explicit "") must NOT fall back to a
-        # config.toml/env value — explicit-empty means "off".
-        monkeypatch.setattr("turnstone.core.config.get_rerank_url", lambda: "http://env/rerank")
-        monkeypatch.setattr("turnstone.core.config.get_rerank_model", lambda: "")
-        monkeypatch.setattr("turnstone.core.config.get_rerank_api_key", lambda: "")
-        cs = _FakeConfigStore({"tools.rerank_url": ""}, stored={"tools.rerank_url"})
-        stub = SimpleNamespace(_config_store=cs, tool_timeout=30)
         assert ChatSession._resolve_rerank_client(stub) is None
 
     def test_enabled_for_defaults_true_without_store(self):
@@ -261,10 +240,9 @@ class TestSessionRerankWiring:
         stub = SimpleNamespace(_config_store=cs)
         assert ChatSession._rerank_enabled_for(stub, "web_search") is False
 
-    def test_prefers_reranker_model_definition(self, monkeypatch):
-        # A model definition with supports_rerank, selected via the Reranker
-        # role, wins over the raw tools.rerank_url settings.
-        _patch_getters_empty(monkeypatch)
+    def test_resolves_reranker_model_definition(self):
+        # The reranker is a model definition (supports_rerank) selected via the
+        # Reranker role; its base_url is the full /rerank endpoint.
         from turnstone.core.model_registry import ModelConfig
 
         cfg = ModelConfig(
@@ -286,10 +264,9 @@ class TestSessionRerankWiring:
         assert client._model == "bge"
         assert client._api_key == "k"
 
-    def test_ignores_alias_without_rerank_capability(self, monkeypatch):
+    def test_ignores_alias_without_rerank_capability(self):
         # A non-reranker model (no supports_rerank) must NOT be used as a reranker,
-        # even if the alias is set — guards against a stale/wrong alias misrouting.
-        _patch_getters_empty(monkeypatch)
+        # even if the alias is set -> reranking off (no fallback).
         from turnstone.core.model_registry import ModelConfig
 
         cfg = ModelConfig(
@@ -301,7 +278,7 @@ class TestSessionRerankWiring:
             tool_timeout=30,
             _registry=SimpleNamespace(get_config=lambda a: cfg),
         )
-        assert ChatSession._resolve_rerank_client(stub) is None  # falls through, no rerank_url
+        assert ChatSession._resolve_rerank_client(stub) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2785,6 +2785,26 @@ class TestMemoryCompositionDeferral:
         assert any("kubernetes" in q for q in seen_queries)
         assert session._system_composed_with_context is True
 
+    def test_whitespace_send_does_not_recompose(self, tmp_db):
+        """A whitespace-only / wake send carries no query, so the deferred
+        recompose must NOT fire -- and the flag stays False so a later real
+        turn still triggers it."""
+        session = _make_session()
+        session._title_generated = True
+        init_calls = 0
+
+        def spy_init():
+            nonlocal init_calls
+            init_calls += 1
+
+        responses = [{"role": "assistant", "content": "ok"}]
+        with _send_with_mocks(
+            session, responses, lambda _tc: ([], None), _init_system_messages=spy_init
+        ):
+            session.send("   ")
+        assert init_calls == 0
+        assert session._system_composed_with_context is False
+
 
 class TestMetacognitiveBuffers:
     """Nudges drain through advisory channels, not the system message."""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2741,6 +2741,51 @@ class TestPerKindToolVariants:
             assert coord_t is union_t, f"{name} should pass through unchanged"
 
 
+class TestMemoryCompositionDeferral:
+    """The memory block is selected from the recent-user-message query, so a
+    fresh session (no messages at __init__) must NOT freeze a recency-only,
+    un-reranked block — the memory-bearing compose defers to the first real
+    user turn, where the query is non-empty.
+    """
+
+    def test_flag_false_until_real_user_query(self, tmp_db):
+        session = _make_session()
+        # __init__ composed against an empty history -> no query yet.
+        assert session._system_composed_with_context is False
+        # A whitespace-only "turn" (e.g. a wake send("")) is not a real query.
+        session.messages.append({"role": "user", "content": "   "})
+        session._init_system_messages()
+        assert session._system_composed_with_context is False
+        # A real user message flips it (one-shot).
+        session.messages.append({"role": "user", "content": "what is the weather"})
+        session._init_system_messages()
+        assert session._system_composed_with_context is True
+
+    def test_send_recomposes_memory_block_on_first_user_turn(self, tmp_db):
+        from turnstone.core.memory_relevance import extract_recent_context
+
+        session = _make_session()
+        session._title_generated = True  # suppress the auto-title daemon thread
+        assert session._system_composed_with_context is False
+        seen_queries: list[str] = []
+        real_init = session._init_system_messages
+
+        def spy_init():
+            seen_queries.append(extract_recent_context(session.messages))
+            real_init()
+
+        responses = [{"role": "assistant", "content": "ok"}]
+        with _send_with_mocks(
+            session, responses, lambda _tc: ([], None), _init_system_messages=spy_init
+        ):
+            session.send("debug my kubernetes pods")
+
+        # send() ran the deferred recompose AFTER appending the user turn, so the
+        # memory query saw the real message instead of the empty __init__ history.
+        assert any("kubernetes" in q for q in seen_queries)
+        assert session._system_composed_with_context is True
+
+
 class TestMetacognitiveBuffers:
     """Nudges drain through advisory channels, not the system message."""
 

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -112,18 +112,11 @@
 #
 # Reranking (optional, disabled by default). Turnstone runs no reranker itself —
 # it POSTs to an external Cohere/Jina-compatible /rerank endpoint (self-hosted
-# vLLM/TEI/llama.cpp, or hosted Cohere/Jina/Voyage) to reorder web_search results
-# by query relevance. Set rerank_url to enable; leave empty to disable. (Alternatively,
-# add a reranker model in the admin Models tab and pick it under Models -> Roles
-# -> Reranker; that selection takes precedence over rerank_url.)
-# rerank_url = ""              # full endpoint URL incl. path, e.g.
-                               # "http://vllm:8000/rerank" or
-                               # "https://api.cohere.com/v2/rerank";
-                               # env: TURNSTONE_RERANK_URL
-# rerank_model = ""            # model name sent in the request; empty = the
-                               # endpoint's default; env: TURNSTONE_RERANK_MODEL
-# rerank_api_key = ""          # bearer token for hosted providers; usually empty
-                               # for self-hosted. config.toml only (never env)
+# vLLM/TEI/llama.cpp, or hosted Cohere/Jina/Voyage) to reorder results by query
+# relevance. The endpoint is a per-model definition: add a model in the admin
+# Models tab with capability {"supports_rerank": true} and base_url set to the
+# full /rerank endpoint, then pick it under Models -> Roles -> Reranker. The
+# settings below are global knobs — there is no rerank_url-style endpoint setting.
 # rerank_web_search = true     # rerank web_search results (when an endpoint is set)
 # rerank_bm25 = true           # rerank BM25 retrieval: tool search, skill search, memory
 # rerank_bm25_threshold = 0.0  # 0-1 relevance floor for proactive memory; 0 = off (reorder

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -10943,6 +10943,64 @@ async def admin_detect_model(request: Request) -> JSONResponse:
             if not base_url:
                 base_url = row.get("base_url", "")
 
+    # Reranker endpoints speak the Cohere/Jina ``POST <url>`` protocol, not
+    # ``/v1/models`` — their base_url is the full rerank path, which the OpenAI
+    # probe below can't reach (that mismatch is why adding a reranker failed:
+    # ``$host/v1`` made the probe pass but calibration POST to the wrong path,
+    # ``$host/rerank`` made the probe fail outright). Calibrate directly instead
+    # and let that round-trip be the reachability check; the three calibration
+    # fields then autopopulate the way context_window does for a chat model.
+    if bool(body.get("supports_rerank")):
+        if not base_url:
+            return JSONResponse(
+                {
+                    "reachable": False,
+                    "error": "A reranker's base_url must be its full /rerank "
+                    "endpoint (e.g. http://host:8000/rerank).",
+                },
+                status_code=400,
+            )
+        from turnstone.core.rerank_calibrate import calibration_caps_fields
+
+        loop = asyncio.get_running_loop()
+        instruction = _global_rerank_instruction(request.app.state)
+        try:
+            async with asyncio.timeout(90):
+                cal, cal_err = await loop.run_in_executor(
+                    None, _run_rerank_calibration, base_url, model, api_key, instruction
+                )
+        except TimeoutError:
+            cal, cal_err = None, "calibration timed out"
+        if cal is None:
+            # Can't calibrate it -> it isn't a working reranker endpoint. There
+            # is no independent /v1/models reachability signal to fall back on.
+            return JSONResponse(
+                {
+                    "reachable": False,
+                    "model_found": None,
+                    "available_models": [],
+                    "context_window": None,
+                    "server_type": None,
+                    "error": cal_err,
+                }
+            )
+        payload: dict[str, Any] = {
+            "reachable": True,
+            "model_found": None,
+            "available_models": [],
+            "context_window": None,
+            "server_type": None,
+            "error": None,
+            "capabilities": {"supports_rerank": True, **calibration_caps_fields(cal)},
+        }
+        if not cal.separated:
+            payload["rerank_calibration_note"] = (
+                "Calibrated, but no clean separation between relevant and "
+                "irrelevant probes — check the model name and that this endpoint "
+                "is a real reranker."
+            )
+        return JSONResponse(payload)
+
     # Apply provider default URL if still empty
     if not base_url:
         base_url = _PROVIDER_DEFAULT_URLS.get(provider, "")
@@ -10964,33 +11022,6 @@ async def admin_detect_model(request: Request) -> JSONResponse:
     result = await loop.run_in_executor(
         None, probe_model_endpoint, provider, base_url, api_key, model
     )
-
-    # Calibrate-on-detect: when the target is a reranker (the UI flags it from
-    # the capabilities being edited), ALSO probe the /rerank endpoint with the
-    # labelled set and merge the calibration fields so the client autopopulates
-    # them like context_window. Best-effort — a failure adds a non-fatal note
-    # and omits the fields ("not calibrated"); non-rerank detect is untouched
-    # (no extra round-trip, no slowdown).
-    if bool(body.get("supports_rerank")) and result.get("reachable") and base_url:
-        from turnstone.core.rerank_calibrate import calibration_caps_fields
-
-        instruction = _global_rerank_instruction(request.app.state)
-        try:
-            async with asyncio.timeout(90):
-                cal, cal_err = await loop.run_in_executor(
-                    None, _run_rerank_calibration, base_url, model, api_key, instruction
-                )
-        except TimeoutError:
-            cal, cal_err = None, "calibration timed out"
-        if cal is not None:
-            caps_out = result.get("capabilities")
-            if not isinstance(caps_out, dict):
-                caps_out = {}
-            caps_out.update(calibration_caps_fields(cal))
-            result["capabilities"] = caps_out
-        else:
-            result["rerank_calibration_note"] = f"Reranker not calibrated: {cal_err}"
-
     return JSONResponse(result)
 
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5209,7 +5209,7 @@ const MODEL_ROLES = [
   {
     label: "Reranker",
     description:
-      "Reranks web_search results. Point at a model whose base_url is a Cohere/Jina-compatible /rerank endpoint and whose capabilities include supports_rerank. Empty falls back to the tools.rerank_url setting (if set). Enabling a reranker sends web_search results AND BM25 retrieval candidates (tool/skill descriptions and memory content) to this endpoint; self-hosted endpoints keep it on your infrastructure.",
+      "Reranks web_search results. Point at a model whose base_url is a Cohere/Jina-compatible /rerank endpoint and whose capabilities include supports_rerank. Empty disables reranking. Enabling a reranker sends web_search results AND BM25 retrieval candidates (tool/skill descriptions and memory content) to this endpoint; self-hosted endpoints keep it on your infrastructure.",
     aliasKey: "tools.reranker_alias",
     fallbackKind: "disabled",
     mediaCapability: "supports_rerank",

--- a/turnstone/core/config.py
+++ b/turnstone/core/config.py
@@ -229,57 +229,12 @@ def get_searxng_engines() -> str:
     return _searxng_engines
 
 
-# -- Rerank endpoint (cached) -------------------------------------------------
+# -- Rerank query instruction (cached) ----------------------------------------
+# The reranker endpoint itself is a per-model definition (admin Models tab ->
+# Reranker role); only the query instruction is a global knob.
 
-_rerank_url: str | None = None
-_rerank_url_loaded: bool = False
-_rerank_model: str | None = None
-_rerank_model_loaded: bool = False
-_rerank_api_key: str | None = None
-_rerank_api_key_loaded: bool = False
 _rerank_instruction: str | None = None
 _rerank_instruction_loaded: bool = False
-
-
-def get_rerank_url() -> str:
-    """Load the rerank endpoint URL (cached after first call).
-
-    Precedence: config.toml [tools] rerank_url -> $TURNSTONE_RERANK_URL -> ""
-    ("" disables reranking — there is no bundled rerank endpoint).
-    """
-    global _rerank_url, _rerank_url_loaded
-    if not _rerank_url_loaded:
-        _rerank_url_loaded = True
-        cfg = load_config("tools").get("rerank_url", "").strip()
-        _rerank_url = cfg or os.environ.get("TURNSTONE_RERANK_URL", "").strip()
-    return _rerank_url or ""
-
-
-def get_rerank_model() -> str:
-    """Load the rerank model name (cached after first call).
-
-    Precedence: config.toml [tools] rerank_model -> $TURNSTONE_RERANK_MODEL -> ""
-    (use the endpoint's default model).
-    """
-    global _rerank_model, _rerank_model_loaded
-    if not _rerank_model_loaded:
-        _rerank_model_loaded = True
-        cfg = load_config("tools").get("rerank_model", "").strip()
-        _rerank_model = cfg or os.environ.get("TURNSTONE_RERANK_MODEL", "").strip()
-    return _rerank_model or ""
-
-
-def get_rerank_api_key() -> str:
-    """Load the rerank endpoint bearer token (cached after first call).
-
-    Read from config.toml [tools] rerank_api_key only — secrets are never read
-    from the environment.
-    """
-    global _rerank_api_key, _rerank_api_key_loaded
-    if not _rerank_api_key_loaded:
-        _rerank_api_key_loaded = True
-        _rerank_api_key = load_config("tools").get("rerank_api_key", "").strip()
-    return _rerank_api_key or ""
 
 
 def get_rerank_instruction() -> str:

--- a/turnstone/core/rerank_config.py
+++ b/turnstone/core/rerank_config.py
@@ -1,9 +1,10 @@
 """Resolve a rerank client from configuration.
 
-Shared by ``ChatSession`` and the ``turnstone-admin rerank-calibrate`` CLI (and,
-later, an admin "Calibrate" endpoint) so the precedence — a Reranker model role
-(``tools.reranker_alias`` -> a model with ``supports_rerank``) over the
-``tools.rerank_url`` settings (storage -> config.toml/env) — lives in one place.
+Shared by ``ChatSession`` and the ``turnstone-admin rerank-calibrate`` CLI (and
+the admin "Calibrate" endpoint) so the resolution lives in one place: the
+reranker is the model definition (capability ``supports_rerank``) selected via
+the Reranker role (``tools.reranker_alias``). There is no global endpoint
+fallback — the reranker is a per-model definition, nothing else.
 """
 
 from __future__ import annotations
@@ -20,60 +21,46 @@ def resolve_rerank_client_from(
     *,
     timeout: float,
 ) -> RerankClient | None:
-    """Return a rerank client from settings, or ``None`` when unconfigured.
+    """Return a rerank client from the selected Reranker model, or ``None``.
 
-    A reranker model definition selected via the Reranker role
-    (``tools.reranker_alias`` -> a model with ``supports_rerank``) takes
-    precedence; otherwise the ``tools.rerank_url`` settings (explicit stored
-    value -> config.toml/env -> registry default). There is no bundled rerank
-    endpoint, so this returns ``None`` until one is configured.
+    The reranker is the model definition (capability ``supports_rerank``) picked
+    via the Reranker role (``tools.reranker_alias``) — managed like every other
+    model, its ``base_url`` the full Cohere/Jina-compatible /rerank endpoint.
+    Returns ``None`` until such a model is selected (there is no bundled rerank
+    endpoint and no global URL fallback).
     """
-    from turnstone.core.config import (
-        get_rerank_api_key,
-        get_rerank_instruction,
-        get_rerank_model,
-        get_rerank_url,
-    )
-    from turnstone.core.rerank import resolve_rerank_client
+    if config_store is None or registry is None:
+        return None
 
     cs = config_store
-    stored = cs.stored_keys() if cs is not None else frozenset()
+    alias = str(cs.get("tools.reranker_alias") or "").strip()
+    if not alias:
+        return None
+    try:
+        cfg = registry.get_config(alias)
+    except Exception:
+        cfg = None
+    if cfg is None or not cfg.base_url or not cfg.capabilities.get("supports_rerank"):
+        return None
 
-    def _setting(key: str, env_value: str) -> str:
-        if cs is not None and key in stored:  # explicit admin value wins
-            return str(cs.get(key) or "").strip()
-        if env_value:  # config.toml / env var
-            return env_value
-        if cs is not None:  # registry default, surfaced by the store
-            return str(cs.get(key) or "").strip()
-        return ""
+    from turnstone.core.config import get_rerank_instruction
+    from turnstone.core.rerank import resolve_rerank_client
 
-    # The query instruction is global — it applies to whichever endpoint resolves.
-    instruction = _setting("tools.rerank_instruction", get_rerank_instruction())
-
-    # A reranker model definition (capability ``supports_rerank``), picked via
-    # the Reranker role, wins — managed like every other model; its base_url is
-    # the full Cohere/Jina-compatible rerank endpoint.
-    if cs is not None and registry is not None:
-        alias = str(cs.get("tools.reranker_alias") or "").strip()
-        if alias:
-            try:
-                cfg = registry.get_config(alias)
-            except Exception:
-                cfg = None
-            if cfg is not None and cfg.base_url and cfg.capabilities.get("supports_rerank"):
-                return resolve_rerank_client(
-                    url=cfg.base_url,
-                    model=cfg.model or "",
-                    api_key=cfg.api_key,
-                    timeout=timeout,
-                    instruction=instruction,
-                )
+    # The query instruction is a global task knob (instruction-aware rerankers
+    # like Qwen3); it applies to whichever reranker model is active. Explicit
+    # stored value wins, then config.toml/env, then the registry default.
+    stored = cs.stored_keys()
+    if "tools.rerank_instruction" in stored:
+        instruction = str(cs.get("tools.rerank_instruction") or "").strip()
+    else:
+        instruction = (
+            get_rerank_instruction() or str(cs.get("tools.rerank_instruction") or "").strip()
+        )
 
     return resolve_rerank_client(
-        url=_setting("tools.rerank_url", get_rerank_url()),
-        model=_setting("tools.rerank_model", get_rerank_model()),
-        api_key=_setting("tools.rerank_api_key", get_rerank_api_key()),
+        url=cfg.base_url,
+        model=cfg.model or "",
+        api_key=cfg.api_key,
         timeout=timeout,
         instruction=instruction,
     )

--- a/turnstone/core/rerank_config.py
+++ b/turnstone/core/rerank_config.py
@@ -1,10 +1,11 @@
-"""Resolve a rerank client from configuration.
+"""Resolve the runtime rerank client from configuration.
 
-Shared by ``ChatSession`` and the ``turnstone-admin rerank-calibrate`` CLI (and
-the admin "Calibrate" endpoint) so the resolution lives in one place: the
-reranker is the model definition (capability ``supports_rerank``) selected via
-the Reranker role (``tools.reranker_alias``). There is no global endpoint
-fallback — the reranker is a per-model definition, nothing else.
+Sole caller is ``ChatSession._resolve_rerank_client``: the reranker is the model
+definition (capability ``supports_rerank``) selected via the Reranker role
+(``tools.reranker_alias``); there is no global endpoint fallback. The calibrate
+CLI (``admin.py``) and the calibrate endpoint (``_global_rerank_instruction`` in
+console/server.py) resolve the endpoint themselves via ``calibrate_model`` and
+only share the instruction precedence below, not this function.
 """
 
 from __future__ import annotations
@@ -47,15 +48,11 @@ def resolve_rerank_client_from(
     from turnstone.core.rerank import resolve_rerank_client
 
     # The query instruction is a global task knob (instruction-aware rerankers
-    # like Qwen3); it applies to whichever reranker model is active. Explicit
-    # stored value wins, then config.toml/env, then the registry default.
-    stored = cs.stored_keys()
-    if "tools.rerank_instruction" in stored:
-        instruction = str(cs.get("tools.rerank_instruction") or "").strip()
-    else:
-        instruction = (
-            get_rerank_instruction() or str(cs.get("tools.rerank_instruction") or "").strip()
-        )
+    # like Qwen3); it applies to whichever reranker model is active. Stored admin
+    # value wins, else config.toml/env -- the same precedence the calibrate CLI
+    # (admin.py) and the calibrate endpoint (_global_rerank_instruction) use, so
+    # the instruction used at calibration time matches the one used at runtime.
+    instruction = str(cs.get("tools.rerank_instruction") or "").strip() or get_rerank_instruction()
 
     return resolve_rerank_client(
         url=cfg.base_url,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1312,11 +1312,11 @@ class ChatSession:
     def _resolve_rerank_client(self) -> RerankClient | None:
         """Return a rerank client, or None when reranking is unconfigured.
 
-        Precedence: a reranker **model definition** selected via the Reranker
-        role (``tools.reranker_alias`` → a model with ``supports_rerank``) wins;
-        otherwise the ``tools.rerank_url`` settings (storage → config.toml/env).
-        There is no bundled rerank endpoint, so reranking stays disabled until
-        one is configured.
+        The reranker is a **model definition** (capability ``supports_rerank``)
+        selected via the Reranker role (``tools.reranker_alias``); its base_url
+        is the full /rerank endpoint. There is no bundled rerank endpoint and no
+        global URL fallback, so reranking stays disabled until such a model is
+        selected.
         """
         from turnstone.core.rerank_config import resolve_rerank_client_from
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3789,11 +3789,14 @@ class ChatSession:
 
         # A fresh session composed its system prefix at __init__ with an empty
         # history, so memory selection fell back to recency (no query, no rerank).
-        # Now that the first real user message exists, recompose so the opening
-        # turn gets a query-relevant memory set. The flag flips True once composed
-        # against real context, so this fires once and the prefix stays cache-
-        # stable after -- per-turn refresh is the larger redesign on another branch.
-        if not self._system_composed_with_context:
+        # Recompose once the first real user message exists so the opening turn
+        # gets a query-relevant memory set. Gate on a non-empty query (not just
+        # the flag) so synthetic wake sends -- which carry no user content and
+        # leave the flag False -- don't re-pay the compose every wake; the flag
+        # flips True inside the recompose, so this fires once and the prefix
+        # stays cache-stable after. Per-turn refresh is the larger redesign on
+        # another branch.
+        if not self._system_composed_with_context and extract_recent_context(self.messages).strip():
             self._init_system_messages()
 
         try:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1193,6 +1193,12 @@ class ChatSession:
         self._skill_resources: dict[str, str] = {}
         self._skill_resources_dir: str | None = None
         self._load_skills()
+        # Memory selection keys off the recent-user-message query, but a fresh
+        # session has no messages yet here -> the first compose would inject
+        # recency-only memories with no relevance/rerank. Track whether we've
+        # composed against a real query so send() can defer the memory-bearing
+        # recompose to the first user turn (keeps the cached prefix stable).
+        self._system_composed_with_context: bool = False
         self._init_system_messages()
         # Skip on rehydrate — ``_save_config`` is ``INSERT OR
         # REPLACE`` per-key, and the persisted row is what
@@ -2806,6 +2812,10 @@ class ChatSession:
             dev_parts.append("")
             dev_parts.append(self.instructions)
         context = extract_recent_context(self.messages)
+        if context.strip():
+            # Composed against a real user-message query at least once; send()
+            # uses this to know the deferred first-turn recompose is done.
+            self._system_composed_with_context = True
         visible_mems, candidate_source = self._select_memory_candidates(context)
         if visible_mems:
             thr = self._bm25_rerank_threshold()
@@ -3776,6 +3786,15 @@ class ChatSession:
             self._queue_user_advisory(*nudge)
 
         self._append_user_turn(user_input, attachments or (), send_id=send_id, from_wake=from_wake)
+
+        # A fresh session composed its system prefix at __init__ with an empty
+        # history, so memory selection fell back to recency (no query, no rerank).
+        # Now that the first real user message exists, recompose so the opening
+        # turn gets a query-relevant memory set. The flag flips True once composed
+        # against real context, so this fires once and the prefix stays cache-
+        # stable after -- per-turn refresh is the larger redesign on another branch.
+        if not self._system_composed_with_context:
+            self._init_system_messages()
 
         try:
             while True:

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -251,41 +251,6 @@ def _build_registry() -> dict[str, SettingDef]:
             "(e.g. 'mcp:search:web_search').",
         ),
         SettingDef(
-            "tools.rerank_url",
-            "str",
-            "",
-            "Full rerank endpoint URL (empty = reranking disabled)",
-            "tools",
-            help="Full URL of a Cohere/Jina-compatible rerank endpoint, including the path "
-            "(e.g. 'http://vllm:8000/rerank', 'http://tei:8080/rerank', or "
-            "'https://api.cohere.com/v2/rerank'). Turnstone runs no rerank model itself: "
-            "web_search results are reranked by POSTing to this endpoint. Empty disables "
-            "reranking entirely. Overrides config.toml [tools] rerank_url and "
-            "$TURNSTONE_RERANK_URL.",
-        ),
-        SettingDef(
-            "tools.rerank_model",
-            "str",
-            "",
-            "Reranker model name sent to the endpoint (empty = endpoint default)",
-            "tools",
-            help="Model identifier passed in the rerank request body (e.g. "
-            "'BAAI/bge-reranker-v2-m3', 'rerank-v3.5'). Empty uses the endpoint's default "
-            "model. Overrides config.toml [tools] rerank_model.",
-        ),
-        SettingDef(
-            "tools.rerank_api_key",
-            "str",
-            "",
-            "Bearer token for the rerank endpoint (write-only)",
-            "tools",
-            is_secret=True,
-            help="Sent as 'Authorization: Bearer <key>' to the rerank endpoint. Required for "
-            "hosted providers (Cohere/Jina/Voyage); usually empty for a self-hosted vLLM/TEI "
-            "instance. Write-only: never returned by the API. For non-console deployments set "
-            "it in config.toml [tools] rerank_api_key (secrets belong in config.toml, not env).",
-        ),
-        SettingDef(
             "tools.rerank_instruction",
             "str",
             "",
@@ -303,10 +268,9 @@ def _build_registry() -> dict[str, SettingDef]:
             True,
             "Rerank web_search results when a rerank endpoint is configured",
             "tools",
-            help="When a rerank endpoint is configured (via tools.reranker_alias or "
-            "tools.rerank_url), re-order web_search results by query relevance before "
-            "returning the top hits. No effect when no endpoint is configured. Disable to "
-            "keep the search backend's native ranking.",
+            help="When a reranker model is selected (Models -> Roles -> Reranker), re-order "
+            "web_search results by query relevance before returning the top hits. No effect "
+            "when no reranker is selected. Disable to keep the search backend's native ranking.",
         ),
         SettingDef(
             "tools.reranker_alias",
@@ -316,8 +280,8 @@ def _build_registry() -> dict[str, SettingDef]:
             "tools",
             help="Selects a reranker added in the admin Models tab: create a model definition "
             'with capability {"supports_rerank": true} and its base_url set to a Cohere/Jina-'
-            "compatible /rerank endpoint, then pick it under Models -> Roles -> Reranker. Takes "
-            "precedence over tools.rerank_url; empty falls back to tools.rerank_url (if set).",
+            "compatible /rerank endpoint, then pick it under Models -> Roles -> Reranker. "
+            "Empty disables reranking (there is no global endpoint fallback).",
         ),
         SettingDef(
             "tools.rerank_bm25",


### PR DESCRIPTION
Stack of 4 commits cleaning up reranking configuration and fixing proactive-memory relevance — found while running a live instance with the #626–#629 reranking stack.

## Commits

1. **fix(rerank): calibrate-as-probe for reranker detect** — the admin *Add model → Detect* flow couldn't add a reranker: it always ran the OpenAI `/v1/models` probe first and gated calibration on it, so a Cohere/Jina `/rerank` endpoint failed either way (`$host/v1` passed the probe but calibration POSTed the wrong path; `$host/rerank` 404'd the probe). Now `supports_rerank` requests skip the probe and calibrate the endpoint directly — that round-trip *is* the reachability check. Empty base_url → 400; calibration failure → `reachable:False`; no clean separation → reachable + note.

2. **refactor(rerank): reranker is a per-model definition only** — **BREAKING.** Removes the legacy global endpoint settings `tools.rerank_url` / `rerank_model` / `rerank_api_key` (+ their `config.py` getters, `$TURNSTONE_RERANK_URL`/`$TURNSTONE_RERANK_MODEL` env vars, module caches, and the global-fallback branch in `resolve_rerank_client_from`). Reranking now resolves **only** via the Reranker role (`tools.reranker_alias` → a model with `supports_rerank`). Kept as global knobs: `reranker_alias`, `rerank_web_search`, `rerank_bm25`, `rerank_bm25_threshold`, `rerank_instruction`. The Settings tab is registry-driven so the fields drop with the `SettingDef`s; docs / `turnstone.example.toml` / role help updated.
   **Migration:** anyone who configured a reranker via `[tools] rerank_url` must re-add it in the **Models** tab and pick it under **Models → Roles → Reranker**. No data migration (feature is days old + off by default; orphaned `tools.rerank_*` rows are inert).

3. **fix(memory): defer system-message compose to the first user turn** — proactive memory selection scores candidates against the recent-user-message query, but a fresh session composed the system prefix once at `__init__` with an empty history → the no-context path returned recency-only memories (5 most recently *updated*, BM25/reranker never invoked), and `send()` never recomposed, so unrelated memories were frozen for the whole session. A one-shot `_system_composed_with_context` flag now defers the memory-bearing compose to the first real user turn, so the opening turn's memories are query-relevant. Composed once with a real query then frozen → prompt-cache-stable, no per-turn churn. Per-turn refresh (later topic shifts) is the larger tail-injection redesign tracked separately.

4. **fix(review): address review findings** — from the multi-stage review of this stack. Fixed: a dead instruction-fallback tail + a stale "shared / one place" docstring in `rerank_config.py`, and tightened the deferred-recompose gate so synthetic wake sends (empty content) don't re-pay the compose before the first real turn (+ test).

## Review

Ran the multi-stage review pipeline (bug / security / performance / quality finders) over `main..HEAD`. Bug finder: clean. 5 minor findings — 3 fixed (commit 4), 2 accepted with rationale:

- **Orphaned `tools.rerank_api_key` row** after the settings removal — inert (no read path, never listed/redacted by the registry-keyed settings API), negligible population, and a purge migration would collide with the `060` currently in flight on another branch.
- **One extra prefix compose per fresh session** (`__init__` then first-send) — kept deliberately so `system_messages` / `_agent_system_messages` are valid for early readers (title-gen, token table); sub-perception, per-session not per-turn.

## Tests

`ruff` + `mypy` + `ruff format` clean. **442 tests pass** across rerank / calibrate / settings / config-store / session / memory suites, including the rewritten detect/calibrate tests (probe-skip, no-separation, unreachable-on-failure, empty-base_url-400) and new memory-deferral tests (flag semantics, wake/empty-turn guard, `send()` drives the recompose).

## Known-deferred (not in this PR)

Two memory-pipeline quality gaps remain (acknowledged in commit 3's body): the reranker/BM25 only see `content[:200]`, and injected memories are flat-truncated to 500 chars (`max_content` is the per-memory *save* cap, not an injection budget). Both are independent follow-ups ahead of the per-turn tail-injection redesign.
