### PR TITLE
fix(ui): clear browser-console warnings (invalid pattern regex + favicon 404)

### DIFF
--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>coordinator · turnstone</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>turnstone console</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -3675,7 +3679,7 @@
           id="mcp-name"
           placeholder="e.g. filesystem"
           maxlength="64"
-          pattern="[a-zA-Z0-9._-]+"
+          pattern="[a-zA-Z0-9._\-]+"
         />
         <label for="mcp-transport">Transport</label>
         <select id="mcp-transport" onchange="toggleMcpTransport()">
@@ -3990,7 +3994,7 @@
           id="model-alias"
           placeholder="e.g. gpt5-prod"
           maxlength="64"
-          pattern="[a-zA-Z0-9._-]+"
+          pattern="[a-zA-Z0-9._\-]+"
         />
         <label for="model-name"
           >Model ID

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>turnstone</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Small polish pass clearing browser-console noise spotted during alpha live-testing.

## Invalid `pattern` regex (functional, Firefox)
The MCP server-name and model-alias inputs used `pattern="[a-zA-Z0-9._-]+"`. Browsers compile the HTML `pattern` attribute with the RegExp `v` flag, under which an unescaped `-` in a character class is a syntax error. The pattern failed to compile and the browser **silently dropped the constraint** — disabling client-side validation in Firefox (the server-side `^[a-zA-Z0-9._-]+$` checks still hold, so no security gap). Escaped the hyphen; the matched set is unchanged and stays consistent with the server validators.

## favicon 404
No favicon link or route existed, so every page load 404'd on `/favicon.ico` across all three entry points (console, coordinator, ui). Added an inline-SVG `data:` URI favicon (an amber gauge on the dark theme) to each `<head>`. A data URI needs no new static route and survives the `/node/{id}` proxy path rewrite; its presence also stops the automatic `/favicon.ico` request.
