### PR TITLE
feat(providers): add Claude Fable 5 to the Anthropic provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "openai>=2.37",
-    "anthropic>=0.39",
+    "anthropic>=0.108",  # claude-fable-5 support; hard runtime floor is 0.105 (mid-conversation system blocks)
     "httpx>=0.28",
     "mcp>=1.27",
     "starlette>=1.0.1",  # PYSEC-2026-161: host-header path-injection in URL reconstruction (auth-bypass on apps comparing reconstructed URL paths)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1407,6 +1407,35 @@ class TestAnthropicHelpers:
         assert caps.token_param == "max_tokens"
         assert caps.thinking_mode == "adaptive"
 
+    def test_capabilities_fable_5(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-fable-5")
+        assert caps.context_window == 1000000
+        assert caps.max_output_tokens == 128000
+        assert caps.thinking_mode == "adaptive"
+        assert caps.supports_effort is True
+        assert "xhigh" in caps.effort_levels
+        assert "max" in caps.effort_levels
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.supports_web_search is True
+        assert caps.supports_tool_search is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning_replay is True
+        assert caps.supports_mid_conversation_system is True
+
+    def test_capabilities_fable_5_dated(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-fable-5-20260815")
+        assert caps.context_window == 1000000
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.supports_mid_conversation_system is True
+
     def test_capabilities_opus_4_8(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
 

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -84,6 +84,27 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 )
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
+    # Fable 5: same wire surface as opus-4-8 (adaptive-only thinking, no
+    # sampling params, prefill rejected) with one extra constraint — an
+    # explicit thinking={"type": "disabled"} is a 400 on this model; thinking
+    # must be adaptive or the param omitted entirely.  The adaptive branch in
+    # _build_thinking_and_kwargs never emits "disabled", so this is safe as
+    # long as thinking_mode stays "adaptive".
+    "claude-fable-5": ModelCapabilities(
+        context_window=1000000,
+        max_output_tokens=128000,
+        token_param="max_tokens",
+        thinking_mode="adaptive",
+        supports_effort=True,
+        effort_levels=("low", "medium", "high", "xhigh", "max"),
+        supports_web_search=True,
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_temperature=False,
+        thinking_display="summarized",
+        supports_reasoning_replay=True,
+        supports_mid_conversation_system=True,
+    ),
     "claude-opus-4-8": ModelCapabilities(
         context_window=1000000,
         max_output_tokens=128000,
@@ -361,7 +382,8 @@ class AnthropicProvider:
         (``ChatSession._try_stream`` / ``_utility_completion``) always
         pass the resolved flag explicitly.
 
-        ``supports_mid_conversation_system`` (claude-opus-4-8) makes the
+        ``supports_mid_conversation_system`` (claude-opus-4-8,
+        claude-fable-5) makes the
         system-role handling position-aware: leading system/developer
         messages (the base prompt) still hoist into the top-level
         ``system`` param, but a system message appearing AFTER a

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -116,7 +116,8 @@ class ModelCapabilities:
     # invalidating the cached prefix.  When False, ``system``-role messages must
     # be hoisted into the top-level ``system`` param (the universal fallback).
     # Available on the Claude API only (NOT Bedrock / Vertex / Foundry), on
-    # NextOpus (claude-opus-4-8) only; no beta header required.
+    # claude-opus-4-8 (validated header-less) and claude-fable-5 (same
+    # documented wire surface); no beta header required.
     supports_mid_conversation_system: bool = False
     # Phase 3 reranker calibration — populated by calibrate-on-detect; read by
     # ChatSession._bm25_rerank_threshold. A non-empty rerank_scale is the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2734,9 +2734,10 @@ class ChatSession:
             else None
         )
         # Operator-instruction trust anchor — declared only on the fold path.
-        # The native mid-conversation-system path (claude-opus-4-8) delivers
-        # operator turns as real {"role":"system"} messages with no fence, so
-        # no <system-reminder_{nonce}> marker appears and no declaration applies.
+        # The native mid-conversation-system path (claude-opus-4-8,
+        # claude-fable-5) delivers operator turns as real {"role":"system"}
+        # messages with no fence, so no <system-reminder_{nonce}> marker
+        # appears and no declaration applies.
         if caps is not None and not caps.supports_mid_conversation_system:
             dev_parts.append("\n\n" + build_operator_instruction_declaration(self._envelope_nonce))
         # Tool search hint (client-side mode only — native mode needs no hint).
@@ -2932,8 +2933,9 @@ class ChatSession:
         :func:`turnstone.core.lowering.fold_system_turns`: non-native
         models get each turn wrapped as a nonce-delimited
         ``<system-reminder>`` block on the preceding turn; native
-        mid-conversation-system models (claude-opus-4-8) keep them inline
-        for the Anthropic converter to emit as real ``system`` messages.
+        mid-conversation-system models (claude-opus-4-8, claude-fable-5)
+        keep them inline for the Anthropic converter to emit as real
+        ``system`` messages.
 
         Messages without a foldable system turn pass through unchanged
         (same object reference) so the common case is allocation-free.

--- a/turnstone/core/tool_advisory.py
+++ b/turnstone/core/tool_advisory.py
@@ -4,9 +4,9 @@ Operator-level context injected mid-session (output-guard findings, user
 interjections, metacognitive nudges, skill hints) lives in the conversation
 trajectory as first-class ``{"role": "system", "_source": <kind>, "content":
 ...}`` turns (see :func:`make_system_turn`).  At the wire boundary each turn is
-either kept inline (native mid-conversation system messages — claude-opus-4-8)
-or folded into the preceding turn as a nonce-delimited ``<system-reminder_
-{nonce}>`` fence for every other model.  The fence mechanism (mint / neutralise
+either kept inline (native mid-conversation system messages — claude-opus-4-8,
+claude-fable-5) or folded into the preceding turn as a nonce-delimited
+``<system-reminder_{nonce}>`` fence for every other model.  The fence mechanism (mint / neutralise
 / wrap) lives in :mod:`turnstone.core.fence`, shared with the output-guard judge
 so the two trust boundaries cannot drift; ``lowering.fold_system_turns``
 applies it.
@@ -99,8 +99,8 @@ def render_user_interjection(message: str, priority: str) -> str:
 # ``{"role": "system", "_source": <kind>, "content": ...}`` messages rather
 # than spliced into a neighbouring turn's ``content``.  At the wire boundary a
 # system turn is either kept inline (native mid-conversation system messages —
-# claude-opus-4-8) or folded into the preceding turn as a ``<system-reminder>``
-# block (every other model).  ``_source`` classifies the turn for UI rendering
+# claude-opus-4-8, claude-fable-5) or folded into the preceding turn as a
+# ``<system-reminder>`` block (every other model).  ``_source`` classifies the turn for UI rendering
 # and replay; it rides the persisted ``_source`` column and is stripped before
 # the LLM wire by ``sanitize_messages``.  See ``ChatSession`` for the producers
 # and the fold-or-keep pass.
@@ -149,7 +149,8 @@ def make_system_turn(source: str, content: str, **meta: Any) -> dict[str, Any]:
     structured fields never reach the model.
 
     ``content`` is stored and — on the native mid-conversation-system path
-    (claude-opus-4-8) — sent to the model verbatim, so fence-escaping is NOT
+    (claude-opus-4-8, claude-fable-5) — sent to the model verbatim, so
+    fence-escaping is NOT
     done here.  It belongs to the fallback fold step, which wraps the content
     in a nonce-delimited ``<system-reminder_{nonce}>`` fence via
     :func:`turnstone.core.fence.wrap` (applied in

--- a/turnstone/prompts/__init__.py
+++ b/turnstone/prompts/__init__.py
@@ -89,7 +89,7 @@ def build_operator_instruction_declaration(nonce: str) -> str:
 
     Declares the per-session *nonce* as the sole trusted ``<system-reminder>``
     marker so the fold (:func:`turnstone.core.fence.wrap`) can rely on it: the
-    model trusts only ``<system-reminder_<nonce>>`` blocks and treats every
+    model trusts only ``<system-reminder_{nonce}>`` blocks and treats every
     other ``<system-reminder>``-style marker (e.g. one forged in tool output,
     files, or web pages) as untrusted data.  Emitted only when the model uses
     the fold path — the native mid-conversation-system path (claude-opus-4-8,

--- a/turnstone/prompts/__init__.py
+++ b/turnstone/prompts/__init__.py
@@ -92,9 +92,9 @@ def build_operator_instruction_declaration(nonce: str) -> str:
     model trusts only ``<system-reminder_<nonce>>`` blocks and treats every
     other ``<system-reminder>``-style marker (e.g. one forged in tool output,
     files, or web pages) as untrusted data.  Emitted only when the model uses
-    the fold path — the native mid-conversation-system path (claude-opus-4-8)
-    delivers operator turns as real ``{"role":"system"}`` messages with no
-    fence, so no marker appears.
+    the fold path — the native mid-conversation-system path (claude-opus-4-8,
+    claude-fable-5) delivers operator turns as real ``{"role":"system"}``
+    messages with no fence, so no marker appears.
     """
     return (
         "## Operator instructions\n"

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.107.1"
+version = "0.108.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -184,9 +184,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/f1/c6076a92e0bf6b0dfa126e213b3f9e8a510acd73567953210713aae6c256/anthropic-0.107.1.tar.gz", hash = "sha256:8e7169a6ab57fb806b778d9af018c867bad688144efec8969cdb4c5ccecd6670", size = 856312, upload-time = "2026-06-07T17:18:57.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/c7/d7f6d2e3975893958081f0282751217757333a3830d0d95859023d7006d0/anthropic-0.108.0.tar.gz", hash = "sha256:91b70253debb477a99f7ca43dac3f71e52207db79d4b06f104080b8dd1693e3b", size = 909409, upload-time = "2026-06-09T16:37:43.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/0e/71432f0777a263701955a23ebcc6650485c2753be9afbce2a6a8d72526e3/anthropic-0.107.1-py3-none-any.whl", hash = "sha256:b74338d08000ba105dfc8adae29af3713ece845a4bffec9986a20697e087c7b3", size = 838729, upload-time = "2026-06-07T17:18:58.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/40/75a937ddd8f230ec129d27de60df69ce8afcab1d0b15f7d651a5a95fac8a/anthropic-0.108.0-py3-none-any.whl", hash = "sha256:bdee7b14c13cf5a60b2c8ae0cf195720e0ea7fd8ab90df5a3899c50f1c91c4be", size = 870079, upload-time = "2026-06-09T16:37:44.895Z" },
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9" },
     { name = "aiohttp", marker = "extra == 'test'", specifier = ">=3.9" },
     { name = "alembic", specifier = ">=1.14" },
-    { name = "anthropic", specifier = ">=0.39" },
+    { name = "anthropic", specifier = ">=0.108" },
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "croniter", specifier = ">=3.0" },
     { name = "cryptography", specifier = ">=42" },


### PR DESCRIPTION
## Summary

Adds `claude-fable-5` to the Anthropic capability table and raises the `anthropic` SDK floor to a version that actually supports the wire parameters the provider sends.

### Capability entry
- 1M context / 128K max output, `max_tokens` token param
- Adaptive thinking with `display: "summarized"` (thinking text is omitted by default on this model tier)
- Effort `low` … `max` including `xhigh`; no sampling params (`supports_temperature=False`)
- Web search, tool search, vision, reasoning replay
- **Native mid-conversation system messages** (`supports_mid_conversation_system=True`) — operator turns ride as real `role: "system"` messages instead of the `<system-reminder_{nonce}>` fold
- Prefix match covers dated variants (`claude-fable-5-YYYYMMDD`)

### Fable 5 wire quirk, documented at the table
An explicit `thinking: {"type": "disabled"}` is a 400 on this model (it is accepted on opus-4-7/4-8). The adaptive branch in `_build_thinking_and_kwargs` only ever emits `{"type": "adaptive"}`, so no code change is needed — the constraint is recorded in a comment so a future disable-thinking path doesn't trip on it.

### SDK floor: 0.39 → 0.108
The old floor predates every named kwarg the provider passes into `client.messages.stream(**kwargs)`, so an install at the floor raises `TypeError` on the first adaptive-model request:
- `output_config` (effort) — SDK 0.77.0
- top-level `cache_control` (automatic caching) — SDK 0.83.0
- mid-conversation system blocks + opus-4-8 — SDK 0.105.0
- `claude-fable-5` typing — SDK 0.108.0 (hard runtime floor is 0.105; 0.108 makes the typed surface match what we ship)

### Comment hygiene
Comments naming `claude-opus-4-8` as the *only* native mid-conversation-system model now say opus-4-8 + fable-5 (protocol, provider converter, tool_advisory, prompts, session fold pass).

## Validation
- `pytest tests/test_providers.py tests/test_wire_payload_golden.py tests/test_tool_advisory.py tests/test_lowering.py tests/test_prompts.py tests/test_bootstrap.py` — 423 passed
- ruff + mypy clean on all touched files
- New tests: `test_capabilities_fable_5`, `test_capabilities_fable_5_dated`

## Caveat for reviewers
`supports_mid_conversation_system=True` on fable-5 is **assumed from the documented wire surface** (same as opus-4-8, which we validated header-less); it has not had a live run yet. First live session where an advisory fires mid-turn confirms it. If it 400s with *role 'system' is not supported on this model*, the fallback is flipping the flag (fold path) or sending the `mid-conversation-system-2026-04-07` beta header.

Out of scope, deliberately: task budgets (`output_config.task_budget`), server-side compaction, structured outputs — new API features turnstone doesn't use yet. Bootstrap default stays `claude-sonnet-4-6` (fable-5 at $10/$50 per MTok is a premium opt-in).