### PR TITLE
L-shell polish: collapsible glyph rail, mobile drawer, shared_static ESM migration, dead-code retirement

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -795,19 +795,33 @@ def _slice_function_body(body: str, fn_name: str) -> str | None:
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-# Bundles that completed the var → const/let sweep.  Add a new JS file
-# here only after it has itself been swept — the var-free + const-reassign
-# guards below will otherwise fail loudly on any pre-sweep `var` it
-# contains.  coordinator.js is intentionally excluded (already modern;
-# 3 surviving `var` are by design per the sweep briefing).
+# CLASSIC bundles that completed the var → const/let sweep.  Add a new JS
+# file here only after it has itself been swept — the var-free +
+# const-reassign guards below will otherwise fail loudly on any pre-sweep
+# `var` it contains.  coordinator.js is intentionally excluded (already
+# modern; 3 surviving `var` are by design per the sweep briefing).  The
+# shared_static files that used to sit here (auth/kb/utils) are ES modules
+# now — test_shell_js.py sweeps them with module semantics.
 _SWEPT_BUNDLES = [
     _REPO_ROOT / "turnstone/ui/static/app.js",
     _REPO_ROOT / "turnstone/console/static/admin.js",
     _REPO_ROOT / "turnstone/console/static/governance.js",
     _REPO_ROOT / "turnstone/console/static/app.js",
+]
+
+# The const-reassign analysis below is pure text — module vs script semantics
+# is irrelevant — so the var-free ES modules ride the same guard (their parse
+# + var + sink guards live in test_shell_js.py).
+_CONST_GUARD_BUNDLES = _SWEPT_BUNDLES + [
     _REPO_ROOT / "turnstone/shared_static/auth.js",
     _REPO_ROOT / "turnstone/shared_static/kb.js",
     _REPO_ROOT / "turnstone/shared_static/utils.js",
+    _REPO_ROOT / "turnstone/shared_static/toast.js",
+    _REPO_ROOT / "turnstone/shared_static/shell.js",
+    _REPO_ROOT / "turnstone/shared_static/pane.js",
+    _REPO_ROOT / "turnstone/shared_static/rail.js",
+    _REPO_ROOT / "turnstone/shared_static/interactive.js",
+    _REPO_ROOT / "turnstone/shared_static/conversation.js",
 ]
 
 
@@ -1046,7 +1060,7 @@ def _enclosing_block(
     )
 
 
-@pytest.mark.parametrize("bundle", _SWEPT_BUNDLES, ids=lambda p: p.name)
+@pytest.mark.parametrize("bundle", _CONST_GUARD_BUNDLES, ids=lambda p: p.name)
 def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
     """For each ``const X = …`` declaration, fail if X is reassigned
     *within the same block scope* (``X = …``, ``X +=``, ``X++``, ``++X``,

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -42,18 +42,20 @@ def test_interactive_is_esm_imported_by_the_shell() -> None:
 
 
 def test_pane_constructor_takes_transport_and_host_seam() -> None:
-    """The constructor grew the ``(wsId, opts)`` seam: a transport ``base`` (the
-    node-proxy prefix), an ``embedded`` flag (drop the standalone split-pane
-    chrome), and a ``host`` adapter for the few things only the surrounding
-    shell knows."""
+    """The constructor takes the ``(wsId, opts)`` seam: a transport ``base``
+    (the node-proxy prefix) and a ``host`` adapter for the few things only the
+    surrounding shell knows.  The old ``embedded`` flag is gone — every pane is
+    L-shell-hosted since the step-6 fork collapse."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     assert "constructor(wsId, opts) {" in body
     for field in (
         "this._base = opts.base",
-        "this._embedded = !!opts.embedded",
         "this._host = opts.host || INTERACTIVE_DEFAULT_HOST",
     ):
         assert field in body, f"missing constructor seam: {field!r}"
+    assert "opts.embedded" not in body, (
+        "the embedded flag is retired — every pane is L-shell-hosted."
+    )
 
 
 def test_transport_urls_are_base_prefixed() -> None:
@@ -76,21 +78,33 @@ def test_transport_urls_are_base_prefixed() -> None:
     assert "new EventSource(evtUrl" in body
 
 
-def test_embedded_chrome_is_gated() -> None:
-    """The standalone split-pane affordances (focus tracking, context menu,
-    split/close buttons) AND the pane header are gated behind ``!this._embedded``:
-    the console (embedded) pane has NO header — name / persona / state live in
-    the tab + rail, and the conversation reclaims the full pane height."""
+def test_split_pane_chrome_is_retired() -> None:
+    """The standalone split-pane chrome is GONE, not gated: no pane header
+    (name / persona / state live in the tab + rail; the conversation owns the
+    full pane height), no focus tracking, no split/close buttons.  The dead
+    ``!this._embedded`` branches referenced shell globals (setFocusedPane,
+    splitPane, splitRoot…) that no longer exist anywhere — reaching them was a
+    guaranteed ReferenceError, so their removal is a bugfix too."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
-    assert "if (!this._embedded) {" in body, "standalone chrome must be gated"
-    assert 'this.el.classList.add("pane--embedded")' in body
-    # The embedded pane builds NO header — the persona tag is gone (the rail's
-    # INT/COORD vocabulary shows it instead).
+    assert "_embedded" not in body, "the embedded gate is retired (always-on)"
+    assert 'className = "pane pane--embedded"' in body, (
+        "the pane root must carry pane--embedded unconditionally — "
+        "interactive.css scopes the slim-chrome layout to it"
+    )
+    for gone in (
+        "setFocusedPane",
+        "showPaneContextMenu",
+        "splitPane(",
+        "splitRoot",
+        "this.headerEl",
+        '"pane-header"',
+        '"pane-action-btn"',
+        "updateWsName",
+    ):
+        assert gone not in body, f"retired split-pane symbol {gone!r} resurfaced"
+    # The persona tag stays gone (the rail's INT/COORD vocabulary shows it).
     assert '"pane-persona-tag"' not in body
     assert '"INTERACTIVE"' not in body
-    # The header (workstream name + split/close actions) builds for standalone
-    # only — gated, not unconditional.
-    assert 'this.headerEl = document.createElement("div")' in body
 
 
 def test_factory_returns_lifecycle_over_node_proxy() -> None:
@@ -114,13 +128,16 @@ def test_host_seam_routes_shell_couplings() -> None:
     badge reference survives in the module."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     for call in (
-        "this._host.getWsName(",
         "this._host.isFocused(this)",
         "this._host.onStreamError(this)",
         "this._host.warningTarget(this)",
         "this._host.onConsentDetected(",
     ):
         assert call in body, f"missing host seam call {call!r}"
+    assert "getWsName" not in body, (
+        "getWsName left the host seam with the pane header — the tab + rail "
+        "own the workstream name now."
+    )
     code = _strip_comments(body)
     # The classic split-pane shell globals must not leak into the module as
     # bare code references (URL path strings excepted, handled above).

--- a/tests/test_renderer_js.py
+++ b/tests/test_renderer_js.py
@@ -11,6 +11,14 @@ Each test invokes ``node -e`` with a small wrapper that loads
 the rendered HTML for a sample input. The assertions check the
 resulting markup contains the expected ``<span class="katex">…</span>``
 placeholder and not the raw delimiter.
+
+Both files are ES modules now; ``_demodulize`` strips the module syntax
+so the script-semantics harness keeps working.  That is DELIBERATE, not
+a shortcut: the mermaid harness pokes renderer-internal state
+(``_mermaidState``) that script evaluation exposes as a context global
+but a real module would encapsulate.  Module semantics themselves are
+covered elsewhere (``test_shell_js`` parses every shared module with
+``node --check`` as ``.mjs``); these tests pin renderer BEHAVIOR.
 """
 
 from __future__ import annotations
@@ -36,9 +44,24 @@ def _has_node() -> bool:
 pytestmark = pytest.mark.skipif(not _has_node(), reason="node not available")
 
 
+def _demodulize(path: Path) -> str:
+    """Strip ES-module syntax so ``vm.runInThisContext`` (script semantics)
+    can evaluate the file: imports drop (the harness loads the whole
+    dependency set into one shared context, so cross-file bindings resolve
+    as context globals, exactly like the pre-module classic scripts), and
+    ``export`` keywords peel off their declarations."""
+    src = path.read_text(encoding="utf-8")
+    src = re.sub(r"^import\s+\{[\s\S]*?\}\s+from\s+\"[^\"]+\";\s*$", "", src, flags=re.M)
+    src = re.sub(r"^import\s+[^;\n]+;\s*$", "", src, flags=re.M)
+    src = re.sub(
+        r"^export\s+(?=(?:async\s+)?(?:function|const|let|var|class)\b)", "", src, flags=re.M
+    )
+    src = re.sub(r"^export\s*\{[^}]*\};\s*$", "", src, flags=re.M)
+    return src
+
+
 _HARNESS_TEMPLATE = """
 const vm = require('vm');
-const fs = require('fs');
 global.document = {
   createElement: () => {
     let t = '';
@@ -60,8 +83,8 @@ global.katex = {
     ']</span>',
 };
 global.window = global;
-vm.runInThisContext(fs.readFileSync(%(utils)s, 'utf8'));
-vm.runInThisContext(fs.readFileSync(%(renderer)s, 'utf8'));
+vm.runInThisContext(%(utils_src)s);
+vm.runInThisContext(%(renderer_src)s);
 const input = %(input)s;
 process.stdout.write(renderMarkdown(input));
 """
@@ -70,8 +93,8 @@ process.stdout.write(renderMarkdown(input));
 def _render(markdown: str) -> str:
     """Render ``markdown`` through renderer.js + return the HTML."""
     harness = _HARNESS_TEMPLATE % {
-        "utils": json.dumps(str(_UTILS_JS)),
-        "renderer": json.dumps(str(_RENDERER_JS)),
+        "utils_src": json.dumps(_demodulize(_UTILS_JS)),
+        "renderer_src": json.dumps(_demodulize(_RENDERER_JS)),
         "input": json.dumps(markdown),
     }
     result = subprocess.run(
@@ -263,7 +286,6 @@ def test_dollar_signs_never_render_as_math_across_paragraphs() -> None:
 
 _MERMAID_HARNESS_TEMPLATE = """
 const vm = require('vm');
-const fs = require('fs');
 
 // Minimal DOM fake — enough surface for postRenderMermaid + the
 // mermaid render path. Each created element tracks its attributes,
@@ -431,12 +453,14 @@ global.hljs = {
   },
 };
 
-vm.runInThisContext(fs.readFileSync(%(utils)s, 'utf8'));
-vm.runInThisContext(fs.readFileSync(%(renderer)s, 'utf8'));
+vm.runInThisContext(%(utils_src)s);
+vm.runInThisContext(%(renderer_src)s);
 
 // Mermaid is normally lazy-loaded via _loadMermaid which fetches a
 // script tag. Force-mark it ready so postRenderMermaid invokes the
-// render path synchronously without trying to inject a script.
+// render path synchronously without trying to inject a script.  (This
+// poke is WHY the harness script-evaluates the demodulized source: a
+// real module would encapsulate _mermaidState.)
 _mermaidState = 'ready';
 
 %(scenario)s
@@ -446,8 +470,8 @@ _mermaidState = 'ready';
 def _run_mermaid_scenario(scenario_js: str) -> dict[str, Any]:
     """Run a JS snippet against the mermaid-aware harness, return JSON output."""
     harness = _MERMAID_HARNESS_TEMPLATE % {
-        "utils": json.dumps(str(_UTILS_JS)),
-        "renderer": json.dumps(str(_RENDERER_JS)),
+        "utils_src": json.dumps(_demodulize(_UTILS_JS)),
+        "renderer_src": json.dumps(_demodulize(_RENDERER_JS)),
         "scenario": scenario_js,
     }
     result = subprocess.run(

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -778,3 +778,84 @@ def test_coordinator_pane_reconnects_on_reopen() -> None:
         "reconnect must only act on a missing/CLOSED stream"
     )
     assert "reconnect: reconnect," in coord, "the factory must return reconnect"
+
+
+# ---------------------------------------------------------------------------
+# Polish round: rail collapse + mobile drawer + the shared popup-menu helper.
+# ---------------------------------------------------------------------------
+
+
+def test_rail_collapse_glyph_strip() -> None:
+    """Desktop rail collapse: a persisted preference (localStorage
+    ``turnstone_interface.rail``) shrinks the rail to a 52px glyph-only strip —
+    live state glyphs stay the navigation, the cluster pills keep glyph+count
+    (the label rides a hideable span), Manage gets a single gear stand-in that
+    opens the Admin pane, and the toggle mirrors its state through
+    aria-expanded/aria-controls."""
+    shell = _SHELL_JS.read_text(encoding="utf-8")
+    assert 'const RAIL_COLLAPSE_KEY = "turnstone_interface.rail"' in shell, (
+        "the collapse preference must persist under the turnstone_interface key"
+    )
+    assert 'make("button", "rail-collapse")' in shell, "the collapse toggle must exist"
+    assert 'collapseBtn.setAttribute("aria-controls", "shell-rail")' in shell, (
+        "the toggle must reference the rail it controls"
+    )
+    assert 'classList.toggle("rail-collapsed", collapsed)' in shell, (
+        "collapse must be a class flip on .app (CSS owns the layout change)"
+    )
+    rail = _RAIL_JS.read_text(encoding="utf-8")
+    assert '"cpill-label"' in rail, (
+        "cluster pill labels must ride a span so the collapsed strip can hide "
+        "them while keeping glyph + count"
+    )
+    assert "manage-glyph" in rail, (
+        "Manage needs its collapsed-strip gear stand-in (rail.js mountManage)"
+    )
+    css = _SHELL_CSS.read_text(encoding="utf-8")
+    assert "grid-template-columns: 52px 1fr" in css, "the collapsed rail is 52px"
+    assert ".app.rail-collapsed .manage-glyph" in css, (
+        "the gear stand-in must flip on while collapsed"
+    )
+    assert "@media (min-width: 769px)" in css, (
+        "the collapse block must be desktop-scoped (the drawer owns mobile)"
+    )
+
+
+def test_mobile_drawer_off_canvas() -> None:
+    """Mobile drawer: below the breakpoint the rail overlays off-canvas at full
+    width.  Burger in the tab bar opens it (focus moves into the rail);
+    Escape / scrim tap / any pane activation close it; the closed drawer is
+    visibility:hidden so its buttons leave the Tab order."""
+    shell = _SHELL_JS.read_text(encoding="utf-8")
+    assert 'make("button", "rail-burger"' in shell, "the drawer toggle must exist"
+    assert 'make("div", "rail-scrim")' in shell, "the backdrop scrim must exist"
+    assert 'classList.toggle("rail-open", open)' in shell, (
+        "drawer state must be a class flip on .app"
+    )
+    assert "pm.onActiveChange(() => setDrawer(false))" in shell, (
+        "opening/focusing a pane must close the drawer that did it"
+    )
+    css = _SHELL_CSS.read_text(encoding="utf-8")
+    assert "@media (max-width: 768px)" in css, "the drawer is mobile-scoped"
+    assert "translateX(-100%)" in css, "the closed drawer parks off-canvas"
+    assert "visibility: hidden" in css, (
+        "the closed drawer must leave the Tab order / a11y tree, not merely "
+        "translate off-screen"
+    )
+
+
+def test_popup_menu_shared_helper() -> None:
+    """One popup-menu chrome: pane.js exports openPopupMenu (items,
+    positioning with flip+clamp, dismissal, aria-expanded mirroring, arrow
+    roving) and BOTH consumers ride it — the tab-action dropdown and the
+    shell's footer user menu (which pops up from the viewport-bottom chip)."""
+    pane = _PANE_JS.read_text(encoding="utf-8")
+    assert "export function openPopupMenu(" in pane, "the shared helper must exist"
+    assert pane.count("openPopupMenu(") >= 2, (
+        "the tab-action dropdown must route through the helper"
+    )
+    shell = _SHELL_JS.read_text(encoding="utf-8")
+    assert "openPopupMenu(" in shell, "the user menu must ride the shared helper"
+    assert 'prefer: "up"' in shell, (
+        "the footer chip sits at the viewport bottom — the menu pops upward"
+    )

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -1,12 +1,12 @@
-"""Static smoke guards for the L-shell ES-module bundles.
+"""Static smoke guards for the shared_static ES-module bundles.
 
-``shell.js`` + ``pane.js`` are the first ES-module citizens in
-``shared_static`` (the rest are classic IIFE scripts loaded via ``<script
-src>``).  This mirrors ``test_app_js.py``'s posture — Python-side string /
-parse assertions that catch the silent one-line regression — adapted for
-module semantics: ``node --check`` only parses ``import`` / ``export`` when
-the file carries an ``.mjs`` extension, so the parse guard copies to a temp
-``.mjs`` first.
+The whole shared substrate is ES modules now (utils/toast/auth/composer/…
+followed shell.js + pane.js; only theme.js — FOUC-critical — and the vendored
+libs stay classic).  This mirrors ``test_app_js.py``'s posture — Python-side
+string / parse assertions that catch the silent one-line regression — adapted
+for module semantics: ``node --check`` only parses ``import`` / ``export``
+when the file carries an ``.mjs`` extension, so the parse guard copies to a
+temp ``.mjs`` first.
 """
 
 from __future__ import annotations
@@ -29,7 +29,45 @@ _CONSOLE_APP = _ROOT / "turnstone/console/static/app.js"
 _CONSOLE_ADMIN = _ROOT / "turnstone/console/static/admin.js"
 
 _RAIL_JS = _SHARED / "rail.js"
-_ESM_BUNDLES = [_SHELL_JS, _PANE_JS, _RAIL_JS]
+
+# Every shared ES module — parse-guarded with module semantics.  (auth/kb/
+# utils moved here from test_app_js's classic sweep when they were converted.)
+_ESM_BUNDLES = [
+    _SHELL_JS,
+    _PANE_JS,
+    _RAIL_JS,
+    _SHARED / "utils.js",
+    _SHARED / "toast.js",
+    _SHARED / "kb.js",
+    _SHARED / "cards.js",
+    _SHARED / "auth.js",
+    _SHARED / "renderer.js",
+    _SHARED / "status_bar.js",
+    _SHARED / "composer.js",
+    _SHARED / "composer_attachments.js",
+    _SHARED / "composer_queue.js",
+    _SHARED / "interactive.js",
+    _SHARED / "conversation.js",
+]
+
+# Sink scan: everything except renderer.js — the one sanctioned HTML-string
+# producer (its output is consumed via setSafeHtml; see utils.js docstring).
+_ESM_SINK_BUNDLES = [b for b in _ESM_BUNDLES if b.name != "renderer.js"]
+
+# Style ratchet: var-free modules only.  The lifted legacy bundles (cards/
+# renderer/status_bar/composer*) keep their pre-module `var` style — converting
+# them was a loader change, not a rewrite; don't grow NEW var use elsewhere.
+_ESM_NO_VAR_BUNDLES = [
+    _SHELL_JS,
+    _PANE_JS,
+    _RAIL_JS,
+    _SHARED / "utils.js",
+    _SHARED / "toast.js",
+    _SHARED / "kb.js",
+    _SHARED / "auth.js",
+    _SHARED / "interactive.js",
+    _SHARED / "conversation.js",
+]
 
 # The same unsafe DOM-write / dynamic-code sink set that ``test_app_js.py``
 # pins for the classic bundles — kept local so the two test files stay
@@ -65,7 +103,7 @@ def test_esm_bundle_parses(bundle: Path) -> None:
     assert proc.returncode == 0, f"node --check failed for {bundle.name}:\n{proc.stderr}"
 
 
-@pytest.mark.parametrize("bundle", _ESM_BUNDLES, ids=lambda p: p.name)
+@pytest.mark.parametrize("bundle", _ESM_SINK_BUNDLES, ids=lambda p: p.name)
 def test_esm_bundle_no_unsafe_sink(bundle: Path) -> None:
     """The shell builds DOM with createElement / textContent / append — never
     an HTML-string sink.  Keep it that way (XSS-free by construction once the
@@ -75,7 +113,7 @@ def test_esm_bundle_no_unsafe_sink(bundle: Path) -> None:
     assert not offenders, f"{bundle.name}: unsafe DOM/code sink at line(s) {offenders[:10]}"
 
 
-@pytest.mark.parametrize("bundle", _ESM_BUNDLES, ids=lambda p: p.name)
+@pytest.mark.parametrize("bundle", _ESM_NO_VAR_BUNDLES, ids=lambda p: p.name)
 def test_esm_bundle_has_no_var_decl(bundle: Path) -> None:
     """Match the modern-keyword posture of the swept classic bundles."""
     body = bundle.read_text(encoding="utf-8")

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -839,8 +839,7 @@ def test_mobile_drawer_off_canvas() -> None:
     assert "@media (max-width: 768px)" in css, "the drawer is mobile-scoped"
     assert "translateX(-100%)" in css, "the closed drawer parks off-canvas"
     assert "visibility: hidden" in css, (
-        "the closed drawer must leave the Tab order / a11y tree, not merely "
-        "translate off-screen"
+        "the closed drawer must leave the Tab order / a11y tree, not merely translate off-screen"
     )
 
 

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1723,7 +1723,7 @@ function loadSavedCoordinators() {
   // Freeze the list while the user is multi-selecting — re-rendering
   // mid-mode would shuffle the visible page out from under them.  The
   // delete-mode wrapper drains the retry flag on cancel/onClose.
-  if (typeof _coordTable !== "undefined" && _coordTable.controller.inMode()) {
+  if (_coordTable && _coordTable.controller.inMode()) {
     _savedCoordsRetry = true;
     return;
   }
@@ -1741,7 +1741,7 @@ function loadSavedCoordinators() {
       // fetch was already in flight, defer the render — re-rendering
       // mid-selection would shuffle visible cards and reshape selections.
       if (
-        typeof _coordTable !== "undefined" &&
+        _coordTable &&
         _coordTable.controller.inMode()
       ) {
         _savedCoordsRetry = true;
@@ -1771,6 +1771,12 @@ function loadSavedCoordinators() {
 // (/shared/cards.js), with a CHILDREN column instead of MSGS and the
 // body-keyed (router-proxied) delete.  Activation POSTs /open before
 // navigating so capacity limits surface as a toast, not a broken page.
+let _coordTable = null;
+
+// Built at boot, not parse: the saved-table substrate (/shared/cards.js) is a
+// deferred ES module now, so its bridged globals (SavedColumns,
+// createSavedTable) don't exist yet while this classic file parses.
+function _initSavedCoordTable() {
 const COORD_COLUMNS = [
   SavedColumns.name(),
   {
@@ -1794,7 +1800,7 @@ const COORD_COLUMNS = [
   SavedColumns.last(),
   SavedColumns.id(),
 ];
-const _coordTable = createSavedTable({
+_coordTable = createSavedTable({
   headerEl: document.getElementById("coord-saved-colheaders"),
   bodyEl: document.getElementById("saved-coord-cards"),
   filterEl: document.getElementById("coord-filter"),
@@ -1896,6 +1902,7 @@ const _coordTable = createSavedTable({
     },
   },
 });
+}
 
 // HTML inline-onclick wrappers — keep the global names the markup binds
 // to and forward to the shared controller.
@@ -2044,6 +2051,7 @@ window.TS_APP.resolveInteractiveNode = function (wsId, hintNodeId) {
 };
 window.TS_APP.boot = function () {
   history.replaceState({ view: "home" }, "");
+  _initSavedCoordTable(); // substrate modules have evaluated by boot time
   initLogin();
   // loadOverview fetches the cluster snapshot — both the node list AND
   // the active-coordinators list come from the same snapshot + SSE patch

--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -31,25 +31,24 @@
     </style>
   </head>
   <body>
-    <!-- Shared-static import order matches the console dashboard
-     (console/static/index.html) so global shortcuts (kb.js) and helpers
-     register in the expected sequence.  The renderer libs (katex, hljs,
-     renderer.js) match the server UI (ui/static/index.html) so the
-     coordinator page can call renderMarkdown / postRenderMarkdown on
-     streamed assistant content.  renderer.js is the single canonical
-     implementation shared across the two chat pages. -->
-    <script src="/shared/utils.js"></script>
-    <script src="/shared/toast.js"></script>
+    <!-- Shared-static set matches the console dashboard
+     (console/static/index.html), two lanes: classic theme.js (FOUC) +
+     vendored katex/hljs; everything else is the deferred shared module
+     substrate (renderer.js is the single canonical markdown implementation
+     shared across the chat pages).  The coordinator module below runs after
+     the substrate by document order. -->
     <script src="/shared/theme.js"></script>
-    <script src="/shared/auth.js"></script>
-    <script src="/shared/kb.js"></script>
-    <script src="/shared/composer.js"></script>
-    <script src="/shared/composer_attachments.js"></script>
-    <script src="/shared/composer_queue.js"></script>
-    <script src="/shared/status_bar.js"></script>
+    <script type="module" src="/shared/utils.js"></script>
+    <script type="module" src="/shared/toast.js"></script>
+    <script type="module" src="/shared/auth.js"></script>
+    <script type="module" src="/shared/kb.js"></script>
+    <script type="module" src="/shared/composer.js"></script>
+    <script type="module" src="/shared/composer_attachments.js"></script>
+    <script type="module" src="/shared/composer_queue.js"></script>
+    <script type="module" src="/shared/status_bar.js"></script>
     <script src="/shared/katex-0.17.0/katex.min.js"></script>
     <script src="/shared/hljs-11.11.1/highlight.min.js"></script>
-    <script src="/shared/renderer.js"></script>
+    <script type="module" src="/shared/renderer.js"></script>
     <script type="module">
       // Standalone coordinator page = one coordinator pane filling the body.
       // (The console shell instead creates panes on demand via the same imported

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1875,21 +1875,29 @@
         },
       ];
     </script>
-    <script src="/shared/utils.js"></script>
-    <script src="/shared/cards.js"></script>
-    <script src="/shared/toast.js"></script>
+    <!-- Two script lanes:
+         CLASSIC (parse-time): theme.js (must paint the stored theme before
+         first render — a deferred module would flash), the vendored libs
+         (katex/hljs — lazy typeof-guarded by renderer.js), and the legacy
+         admin/governance/app bundles at the end of the body.
+         MODULE (deferred): the shared substrate — each exports its API and
+         installs a transitional window bridge for the classic bundles, which
+         only touch the globals at boot/event time (after modules evaluate). -->
     <script src="/shared/theme.js"></script>
-    <script src="/shared/auth.js"></script>
-    <script src="/shared/kb.js"></script>
-    <script src="/shared/composer.js"></script>
+    <script type="module" src="/shared/utils.js"></script>
+    <script type="module" src="/shared/cards.js"></script>
+    <script type="module" src="/shared/toast.js"></script>
+    <script type="module" src="/shared/auth.js"></script>
+    <script type="module" src="/shared/kb.js"></script>
+    <script type="module" src="/shared/composer.js"></script>
     <!-- coordinator-pane deps (step 4): the controller builds its chrome + uses
-         the shared composer/renderer stack; load before app.js + the shell module -->
-    <script src="/shared/composer_attachments.js"></script>
-    <script src="/shared/composer_queue.js"></script>
-    <script src="/shared/status_bar.js"></script>
+         the shared composer/renderer stack; load before the shell module -->
+    <script type="module" src="/shared/composer_attachments.js"></script>
+    <script type="module" src="/shared/composer_queue.js"></script>
+    <script type="module" src="/shared/status_bar.js"></script>
     <script src="/shared/katex-0.17.0/katex.min.js"></script>
     <script src="/shared/hljs-11.11.1/highlight.min.js"></script>
-    <script src="/shared/renderer.js"></script>
+    <script type="module" src="/shared/renderer.js"></script>
 
     <!-- GitHub Import Modal -->
     <div

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -6,7 +6,18 @@
    1. Check /v1/api/auth/status — detect if setup is needed
    2. If setup_required → show first-time setup wizard (create admin user)
    3. If auth_enabled + has_users → show login (username:password)
-   4. Legacy: token-based login still supported via toggle */
+   4. Legacy: token-based login still supported via toggle
+
+   ES module (imports utils/toast).  The window bridge at the bottom keeps
+   the still-classic consumers working — app.js calls initLogin() from its
+   boot path and logout() rides an inline onclick.  Parse-time side effects
+   (BroadcastChannel wiring, the whoami refresh schedule, permissionsReady)
+   now run at module eval — after the classic scripts, before the shell
+   module calls TS_APP.boot(); every consumer reads them at boot time or
+   later, so the shift is observable only in ordering, not behaviour. */
+
+import { escapeHtml, setSafeHtml } from "./utils.js";
+import { showToast } from "./toast.js";
 
 const _AUTH_TITLE = window.TURNSTONE_AUTH_TITLE || "turnstone";
 let _loginTrapHandler = null;
@@ -36,7 +47,7 @@ if (_authChannel) {
   };
 }
 
-async function authFetch(url, opts) {
+export async function authFetch(url, opts) {
   const maxRetries = 2;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const r = await fetch(url, opts);
@@ -292,7 +303,7 @@ function _cancelRefreshTimer() {
   }
 }
 
-function initLogin() {
+export function initLogin() {
   const overlay = document.createElement("div");
   overlay.id = "login-overlay";
   overlay.style.display = "none";
@@ -484,7 +495,7 @@ function _showError(msg) {
   }
 }
 
-function showLogin(reason, oidcError) {
+export function showLogin(reason, oidcError) {
   const overlay = document.getElementById("login-overlay");
   if (!overlay) return;
   overlay.style.display = "flex";
@@ -554,7 +565,7 @@ function showLogin(reason, oidcError) {
   document.addEventListener("keydown", _loginTrapHandler);
 }
 
-function hideLogin() {
+export function hideLogin() {
   const overlay = document.getElementById("login-overlay");
   if (overlay) overlay.style.display = "none";
   document.body.style.overflow = "";
@@ -761,7 +772,7 @@ function _onSuccess() {
   _scheduleRefreshFromWhoami();
 }
 
-function logout() {
+export function logout() {
   // Set flag + abort in-flight fetches BEFORE the network call so any
   // concurrent _tryRefresh() / _scheduleRefreshFromWhoami() bails its
   // post-fetch effects (see _loggedOut handling above).  Without this,
@@ -792,3 +803,14 @@ function logout() {
 if (typeof window !== "undefined") {
   _scheduleRefreshFromWhoami();
 }
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach these as globals at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+Object.assign(window, {
+  authFetch,
+  showLogin,
+  hideLogin,
+  logout,
+  initLogin,
+});

--- a/turnstone/shared_static/cards.js
+++ b/turnstone/shared_static/cards.js
@@ -9,10 +9,17 @@
                                        multi-select delete controller
      - createSavedCardsController    — the delete-mode controller (below)
 
+   ES module (imports utils/toast/auth; window bridge below for the
+   still-classic app.js consumers).
+
    Built with safe DOM APIs (createElement + textContent), never innerHTML,
    so user-supplied alias/title/name/skill fields never reach the DOM as
    HTML.  Depends on formatRelativeTime (from /shared/utils.js).
 */
+
+import { formatRelativeTime } from "./utils.js";
+import { showToast } from "./toast.js";
+import { authFetch } from "./auth.js";
 
 /* ==========================================================================
    Saved-list TABLE primitives — the row builder (renderSessionRow) plus a
@@ -78,7 +85,7 @@ function _nameCell(sess) {
    cell(sess)->Node|string, sort(sess)->comparable}.  The only difference
    between the two surfaces is count("message_count","MSGS") vs
    count("child_count","CHILDREN"). */
-var SavedColumns = {
+export var SavedColumns = {
   name: function () {
     return {
       key: "name",
@@ -173,7 +180,7 @@ var SavedColumns = {
    list isn't dimmed by base.css's `[data-state="idle"]` rule.  The grid
    template comes from the `--saved-grid` CSS var that createSavedTable sets
    once per render (not rebuilt per row). */
-function renderSessionRow(sess, opts) {
+export function renderSessionRow(sess, opts) {
   opts = opts || {};
   var columns = opts.columns || [];
   var row = document.createElement("div");
@@ -234,7 +241,7 @@ function renderSessionRow(sess, opts) {
      emptyText         — empty-state copy
      delete            — {idPrefix, buttonId, buildDeleteRequest, onClose}
    returns { setItems(items), render(), controller }. */
-function createSavedTable(opts) {
+export function createSavedTable(opts) {
   var state = {
     items: [],
     filter: "",
@@ -601,7 +608,7 @@ function createSavedTable(opts) {
                          closes the post-delete results modal.  Typical
                          use: re-fetch the saved list.
 */
-function createSavedCardsController(opts) {
+export function createSavedCardsController(opts) {
   var state = { mode: false, selected: {}, items: [] };
   var batchTrap = null;
   /* Element that owned focus when the modal opened — restored in
@@ -991,3 +998,13 @@ function createSavedCardsController(opts) {
     confirm: confirm,
   };
 }
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach these as globals at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+Object.assign(window, {
+  SavedColumns,
+  renderSessionRow,
+  createSavedTable,
+  createSavedCardsController,
+});

--- a/turnstone/shared_static/composer.js
+++ b/turnstone/shared_static/composer.js
@@ -34,780 +34,780 @@
  * whole pane) — broader than the composer itself so users can drop
  * anywhere onto the pane to attach.
  */
-(function (root) {
-  "use strict";
+var ATTACH_DEFAULT_ACCEPT =
+  "image/png,image/jpeg,image/gif,image/webp,text/*," +
+  ".md,.py,.js,.ts,.tsx,.jsx,.json,.yaml,.yml,.toml,.html,.css,.sh," +
+  ".rs,.go,.java,.c,.cpp,.h,.hpp,.sql,.xml,.ini,.conf";
 
-  var ATTACH_DEFAULT_ACCEPT =
-    "image/png,image/jpeg,image/gif,image/webp,text/*," +
-    ".md,.py,.js,.ts,.tsx,.jsx,.json,.yaml,.yml,.toml,.html,.css,.sh," +
-    ".rs,.go,.java,.c,.cpp,.h,.hpp,.sql,.xml,.ini,.conf";
+var AUTO_RESIZE_MAX_PX = 200;
 
-  var AUTO_RESIZE_MAX_PX = 200;
+function isTouchDevice() {
+  return window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+}
 
-  function isTouchDevice() {
-    return window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+function makeButton(opts) {
+  var b = document.createElement("button");
+  b.type = "button";
+  if (opts.className) b.className = opts.className;
+  if (opts.text) b.textContent = opts.text;
+  if (opts.ariaLabel) b.setAttribute("aria-label", opts.ariaLabel);
+  if (opts.title) b.setAttribute("title", opts.title);
+  return b;
+}
+
+/**
+ * @param {HTMLElement} mount — container to receive the composer DOM
+ * @param {Object} opts — configuration:
+ *   onSend: (text) => void
+ *   onStop: () => void
+ *   attachments: { onAttach: (file) => void, accept?: string } | null
+ *   stopBtn: boolean (default false)
+ *   queueWhileBusy: boolean (default false) — busy state shows "Queue"
+ *     instead of disabling the send button
+ *   autoResize: boolean (default true)
+ *   placeholder: string | null (default touch-aware "Type a message…")
+ *   busyPlaceholder: string | null — shown on the textarea whenever
+ *     setBusy(true) is called.  Defaults to placeholder (no visible
+ *     swap) when omitted.
+ *   ariaLabel: string (default "Message input")
+ *   pasteFiles: boolean (default true if attachments enabled)
+ *   dragDrop: { targetEl: HTMLElement, dropClass: string } | null
+ *     — dropClass is the CSS class applied to targetEl during a
+ *       drag-over; the page must define the corresponding rule.
+ *   sendLabel: string (default "Send")
+ *   busyLabel: string — label shown on the send button whenever
+ *     setBusy(true) is called.  Default is context-sensitive:
+ *     "Queue" when queueWhileBusy=true, sendLabel otherwise (no
+ *     rotation for non-queue consumers that don't opt in).
+ *   stopLabel: string (default "■ Stop")
+ *   touchEnterSends: boolean (default false) — when true, Enter sends
+ *     even on touch devices (default makes Enter insert a newline on
+ *     touch so the on-screen keyboard's Return key behaves as the OS
+ *     expects).
+ *   rows: integer (default 1) — initial textarea row count; still
+ *     auto-resizes upward based on content.  Set to 3 for creation
+ *     forms where the user is expected to type a multi-line prompt.
+ *   layout: "inline" | "stacked" (default "inline") — "inline" puts
+ *     attach/input/send/stop on one row (chat-style composers).
+ *     "stacked" puts the textarea on its own row with the attach +
+ *     options + send row below (creation-form composers where the
+ *     input area is visually dominant).
+ *   options: {
+ *     fields: [{id, label, type, placeholder?, autocomplete?,
+ *               choices?, initial?}],
+ *     toggleLabel?: string (default "Options"),
+ *     summary?: (values) => string | null,
+ *     onChange?: (values) => void,
+ *     storageKey?: string,
+ *   } | null
+ *     — renders a collapsible "Options ▾" panel.  Fields support
+ *       type:"input" (text) and type:"select" (dropdown with
+ *       {choices: [{value, text}]}).  Any other type is rendered
+ *       as a text input.  toggleLabel sets the button text before
+ *       the caret; onChange fires whenever a field's change event
+ *       fires; summary returns an inline summary string shown beside
+ *       the toggle (return "" / null to hide).  getOptionValues()
+ *       returns the current {id: value} map; setOptionChoices(id,
+ *       choices) populates a select later (for async-loaded lists).
+ *       When storageKey is provided the open/closed state persists
+ *       to localStorage under that key.
+ *   externalDisable: boolean (default false) — when true, setBusy()
+ *     still rotates the send button's label / aria / placeholder
+ *     + toggles the stop button, but does NOT write sendBtn.disabled.
+ *     The caller owns the disabled flag and combines busy state
+ *     with any other disable inputs (e.g. a subsystem-down probe)
+ *     via its own reconciler function.
+ */
+export function Composer(mount, opts) {
+  if (!(this instanceof Composer)) return new Composer(mount, opts);
+  if (!mount) throw new Error("Composer: mount element required");
+  opts = opts || {};
+  this._opts = opts;
+  this._mount = mount;
+  this._busy = false;
+  this._destroyed = false;
+  this._listeners = []; // [{el, type, fn}, ...] for clean detach
+  this._autoResizeEnabled = opts.autoResize !== false;
+
+  this._isTouch = isTouchDevice();
+  this._buildDom();
+  this._wireEvents();
+}
+
+Composer.prototype._buildDom = function () {
+  var opts = this._opts;
+
+  var root = document.createElement("div");
+  root.className = "composer";
+  var layout = opts.layout === "stacked" ? "stacked" : "inline";
+  if (layout === "stacked") root.classList.add("composer--stacked");
+  // Chat composers (the model-chip hosts) get the mock's compact rounded
+  // composer box; the home launcher (no model chip) keeps its plain panel.
+  if (opts.modelChip) root.classList.add("composer--chat");
+  this.el = root;
+
+  // Attachment chips row — always present in the DOM when attachments
+  // are enabled (caller may append/remove chips at any time); hidden
+  // by CSS until populated.
+  if (opts.attachments) {
+    this.chipsEl = document.createElement("div");
+    this.chipsEl.className = "composer-chips";
+    this.chipsEl.setAttribute("role", "list");
+    this.chipsEl.setAttribute("aria-label", "Pending attachments");
+    root.appendChild(this.chipsEl);
+  } else {
+    this.chipsEl = null;
   }
 
-  function makeButton(opts) {
-    var b = document.createElement("button");
-    b.type = "button";
-    if (opts.className) b.className = opts.className;
-    if (opts.text) b.textContent = opts.text;
-    if (opts.ariaLabel) b.setAttribute("aria-label", opts.ariaLabel);
-    if (opts.title) b.setAttribute("title", opts.title);
-    return b;
+  // Stacked layout: textarea on its own row, action row below.
+  // Inline layout: textarea shares a row with buttons.
+  var textRow;
+  var actionRow;
+  if (layout === "stacked") {
+    textRow = document.createElement("div");
+    textRow.className = "composer-text";
+    root.appendChild(textRow);
+    actionRow = document.createElement("div");
+    actionRow.className = "composer-row";
+    root.appendChild(actionRow);
+  } else {
+    actionRow = document.createElement("div");
+    actionRow.className = "composer-row";
+    root.appendChild(actionRow);
+    textRow = actionRow;
   }
 
-  /**
-   * @param {HTMLElement} mount — container to receive the composer DOM
-   * @param {Object} opts — configuration:
-   *   onSend: (text) => void
-   *   onStop: () => void
-   *   attachments: { onAttach: (file) => void, accept?: string } | null
-   *   stopBtn: boolean (default false)
-   *   queueWhileBusy: boolean (default false) — busy state shows "Queue"
-   *     instead of disabling the send button
-   *   autoResize: boolean (default true)
-   *   placeholder: string | null (default touch-aware "Type a message…")
-   *   busyPlaceholder: string | null — shown on the textarea whenever
-   *     setBusy(true) is called.  Defaults to placeholder (no visible
-   *     swap) when omitted.
-   *   ariaLabel: string (default "Message input")
-   *   pasteFiles: boolean (default true if attachments enabled)
-   *   dragDrop: { targetEl: HTMLElement, dropClass: string } | null
-   *     — dropClass is the CSS class applied to targetEl during a
-   *       drag-over; the page must define the corresponding rule.
-   *   sendLabel: string (default "Send")
-   *   busyLabel: string — label shown on the send button whenever
-   *     setBusy(true) is called.  Default is context-sensitive:
-   *     "Queue" when queueWhileBusy=true, sendLabel otherwise (no
-   *     rotation for non-queue consumers that don't opt in).
-   *   stopLabel: string (default "■ Stop")
-   *   touchEnterSends: boolean (default false) — when true, Enter sends
-   *     even on touch devices (default makes Enter insert a newline on
-   *     touch so the on-screen keyboard's Return key behaves as the OS
-   *     expects).
-   *   rows: integer (default 1) — initial textarea row count; still
-   *     auto-resizes upward based on content.  Set to 3 for creation
-   *     forms where the user is expected to type a multi-line prompt.
-   *   layout: "inline" | "stacked" (default "inline") — "inline" puts
-   *     attach/input/send/stop on one row (chat-style composers).
-   *     "stacked" puts the textarea on its own row with the attach +
-   *     options + send row below (creation-form composers where the
-   *     input area is visually dominant).
-   *   options: {
-   *     fields: [{id, label, type, placeholder?, autocomplete?,
-   *               choices?, initial?}],
-   *     toggleLabel?: string (default "Options"),
-   *     summary?: (values) => string | null,
-   *     onChange?: (values) => void,
-   *     storageKey?: string,
-   *   } | null
-   *     — renders a collapsible "Options ▾" panel.  Fields support
-   *       type:"input" (text) and type:"select" (dropdown with
-   *       {choices: [{value, text}]}).  Any other type is rendered
-   *       as a text input.  toggleLabel sets the button text before
-   *       the caret; onChange fires whenever a field's change event
-   *       fires; summary returns an inline summary string shown beside
-   *       the toggle (return "" / null to hide).  getOptionValues()
-   *       returns the current {id: value} map; setOptionChoices(id,
-   *       choices) populates a select later (for async-loaded lists).
-   *       When storageKey is provided the open/closed state persists
-   *       to localStorage under that key.
-   *   externalDisable: boolean (default false) — when true, setBusy()
-   *     still rotates the send button's label / aria / placeholder
-   *     + toggles the stop button, but does NOT write sendBtn.disabled.
-   *     The caller owns the disabled flag and combines busy state
-   *     with any other disable inputs (e.g. a subsystem-down probe)
-   *     via its own reconciler function.
-   */
-  function Composer(mount, opts) {
-    if (!(this instanceof Composer)) return new Composer(mount, opts);
-    if (!mount) throw new Error("Composer: mount element required");
-    opts = opts || {};
-    this._opts = opts;
-    this._mount = mount;
-    this._busy = false;
-    this._destroyed = false;
-    this._listeners = []; // [{el, type, fn}, ...] for clean detach
-    this._autoResizeEnabled = opts.autoResize !== false;
+  // Supported surface for callers that need to add page-specific controls
+  // (e.g. a mic button) beside attach/send/stop.
+  this.actionsRowEl = actionRow;
 
-    this._isTouch = isTouchDevice();
-    this._buildDom();
-    this._wireEvents();
+  this._buildAttachButton(actionRow, opts);
+  this._buildModelChip(actionRow, opts);
+  this._buildInput(textRow, opts);
+  this._buildOptionsToggle(actionRow, opts);
+  this._buildSendButton(actionRow, opts);
+  this._buildStopButton(actionRow, opts);
+  this._buildOptionsPanel(root, opts);
+
+  this._mount.appendChild(root);
+};
+
+Composer.prototype._buildAttachButton = function (row, opts) {
+  if (!opts.attachments) {
+    this.attachBtn = null;
+    this.attachInput = null;
+    return;
   }
-
-  Composer.prototype._buildDom = function () {
-    var opts = this._opts;
-
-    var root = document.createElement("div");
-    root.className = "composer";
-    var layout = opts.layout === "stacked" ? "stacked" : "inline";
-    if (layout === "stacked") root.classList.add("composer--stacked");
-    // Chat composers (the model-chip hosts) get the mock's compact rounded
-    // composer box; the home launcher (no model chip) keeps its plain panel.
-    if (opts.modelChip) root.classList.add("composer--chat");
-    this.el = root;
-
-    // Attachment chips row — always present in the DOM when attachments
-    // are enabled (caller may append/remove chips at any time); hidden
-    // by CSS until populated.
-    if (opts.attachments) {
-      this.chipsEl = document.createElement("div");
-      this.chipsEl.className = "composer-chips";
-      this.chipsEl.setAttribute("role", "list");
-      this.chipsEl.setAttribute("aria-label", "Pending attachments");
-      root.appendChild(this.chipsEl);
-    } else {
-      this.chipsEl = null;
-    }
-
-    // Stacked layout: textarea on its own row, action row below.
-    // Inline layout: textarea shares a row with buttons.
-    var textRow;
-    var actionRow;
-    if (layout === "stacked") {
-      textRow = document.createElement("div");
-      textRow.className = "composer-text";
-      root.appendChild(textRow);
-      actionRow = document.createElement("div");
-      actionRow.className = "composer-row";
-      root.appendChild(actionRow);
-    } else {
-      actionRow = document.createElement("div");
-      actionRow.className = "composer-row";
-      root.appendChild(actionRow);
-      textRow = actionRow;
-    }
-
-    // Supported surface for callers that need to add page-specific controls
-    // (e.g. a mic button) beside attach/send/stop.
-    this.actionsRowEl = actionRow;
-
-    this._buildAttachButton(actionRow, opts);
-    this._buildModelChip(actionRow, opts);
-    this._buildInput(textRow, opts);
-    this._buildOptionsToggle(actionRow, opts);
-    this._buildSendButton(actionRow, opts);
-    this._buildStopButton(actionRow, opts);
-    this._buildOptionsPanel(root, opts);
-
-    this._mount.appendChild(root);
-  };
-
-  Composer.prototype._buildAttachButton = function (row, opts) {
-    if (!opts.attachments) {
-      this.attachBtn = null;
-      this.attachInput = null;
-      return;
-    }
-    this.attachBtn = makeButton({
-      className: "composer-attach",
-      text: "+",
-      ariaLabel: "Attach files",
-      title: "Attach files",
-    });
-    row.appendChild(this.attachBtn);
-
-    this.attachInput = document.createElement("input");
-    this.attachInput.type = "file";
-    this.attachInput.multiple = true;
-    this.attachInput.style.display = "none";
-    this.attachInput.accept = opts.attachments.accept || ATTACH_DEFAULT_ACCEPT;
-    row.appendChild(this.attachInput);
-  };
-
-  // Live "model · effort" read-out chip — sits between the attach button and
-  // the textarea (matching the mock ``[+] [model · effort] input [↑]``).
-  // DISPLAY ONLY: a plain span the caller repaints via setModel() from the
-  // connected/status SSE events.  A per-session model/effort PICKER (turning
-  // this into an interactive dropdown) is a separate, deferred task; until
-  // then this is intentionally non-interactive.
-  Composer.prototype._buildModelChip = function (row, opts) {
-    if (!opts.modelChip) {
-      this.modelChipEl = null;
-      return;
-    }
-    this.modelChipEl = document.createElement("span");
-    this.modelChipEl.className = "composer-model-chip";
-    this.modelChipEl.setAttribute("aria-label", "Model");
-    this.modelChipEl.textContent = "—";
-    row.appendChild(this.modelChipEl);
-  };
-
-  // Repaint the model chip's read-out (e.g. "gpt-5 · high").  A falsy label
-  // resets it to the em-dash placeholder.  No-op when the chip is disabled.
-  Composer.prototype.setModel = function (label) {
-    if (this.modelChipEl) this.modelChipEl.textContent = label || "—";
-  };
-
-  // Swap the textarea's idle placeholder — e.g. a launcher that reuses one
-  // composer across personas updates the task-prompt hint when the persona
-  // changes.  Leaves a busy-state placeholder swap (setBusy) untouched.
-  Composer.prototype.setPlaceholder = function (text) {
-    this._idlePlaceholder = text == null ? "" : String(text);
-    if (this.inputEl && !this._busy)
-      this.inputEl.placeholder = this._idlePlaceholder;
-  };
-
-  Composer.prototype._buildInput = function (row, opts) {
-    this.inputEl = document.createElement("textarea");
-    this.inputEl.className = "composer-input";
-    this.inputEl.rows = opts.rows && opts.rows > 0 ? opts.rows : 1;
-    var defaultPlaceholder = this._isTouch
-      ? "Type a message\u2026"
-      : "Type a message\u2026 (Shift+Enter for newline)";
-    this._idlePlaceholder =
-      opts.placeholder != null ? opts.placeholder : defaultPlaceholder;
-    this._busyPlaceholder = opts.busyPlaceholder || this._idlePlaceholder;
-    this.inputEl.placeholder = this._idlePlaceholder;
-    this.inputEl.setAttribute("aria-label", opts.ariaLabel || "Message input");
-    row.appendChild(this.inputEl);
-  };
-
-  Composer.prototype._buildSendButton = function (row, opts) {
-    this._sendLabel = opts.sendLabel || "Send";
-    // busyLabel default is context-sensitive: "Queue" only makes sense
-    // when queueWhileBusy=true (the send button stays clickable during
-    // busy to accept queued messages).  Non-queue consumers that omit
-    // busyLabel fall back to sendLabel — no label rotation on busy —
-    // so the disabled button doesn't misleadingly read "Queue" when
-    // queueing isn't actually supported by the caller.
-    this._busyLabel =
-      opts.busyLabel != null
-        ? opts.busyLabel
-        : opts.queueWhileBusy
-          ? "Queue"
-          : this._sendLabel;
-    // Glyph mode (chat composers): show a send GLYPH instead of a word.  The
-    // textual sendLabel stays the aria-label and drives setBusy's a11y
-    // rotation, but the visible glyph is constant (setBusy never overwrites it).
-    this._sendGlyph = opts.sendGlyph || null;
-    this.sendBtn = makeButton({
-      className:
-        "composer-send" + (this._sendGlyph ? " composer-send--glyph" : ""),
-      text: this._sendGlyph || this._sendLabel,
-      ariaLabel: this._sendLabel + " message",
-    });
-    row.appendChild(this.sendBtn);
-  };
-
-  Composer.prototype._buildStopButton = function (row, opts) {
-    if (!opts.stopBtn) {
-      this.stopBtn = null;
-      return;
-    }
-    this._stopLabel = opts.stopLabel || "\u25a0 Stop";
-    this.stopBtn = makeButton({
-      className: "composer-stop",
-      text: this._stopLabel,
-      ariaLabel: "Stop generation",
-    });
-    this.stopBtn.style.display = "none";
-    this.stopBtn.disabled = true;
-    row.appendChild(this.stopBtn);
-  };
-
-  Composer.prototype._buildOptionsToggle = function (row, opts) {
-    if (!opts.options) {
-      this.optionsBtn = null;
-      this.optionsSummaryEl = null;
-      return;
-    }
-    this.optionsBtn = document.createElement("button");
-    this.optionsBtn.type = "button";
-    this.optionsBtn.className = "composer-options-btn";
-    this.optionsBtn.setAttribute("aria-label", "Toggle options");
-    this.optionsBtn.setAttribute("title", "Options");
-    this.optionsBtn.setAttribute("aria-expanded", "false");
-    var labelSpan = document.createElement("span");
-    labelSpan.className = "composer-options-btn-label";
-    labelSpan.textContent = opts.options.toggleLabel || "Options";
-    this.optionsBtn.appendChild(labelSpan);
-    var caret = document.createElement("span");
-    caret.className = "composer-options-caret";
-    caret.setAttribute("aria-hidden", "true");
-    caret.textContent = "\u25be"; // ▾
-    this.optionsBtn.appendChild(caret);
-    row.appendChild(this.optionsBtn);
-
-    this.optionsSummaryEl = document.createElement("span");
-    this.optionsSummaryEl.className = "composer-options-summary";
-    this.optionsSummaryEl.setAttribute("aria-live", "polite");
-    this.optionsSummaryEl.hidden = true;
-    row.appendChild(this.optionsSummaryEl);
-  };
-
-  Composer.prototype._buildOptionsPanel = function (root, opts) {
-    if (!opts.options) {
-      this.optionsPanel = null;
-      this._optionFields = {};
-      return;
-    }
-    this.optionsPanel = document.createElement("div");
-    this.optionsPanel.className = "composer-options-panel";
-    this.optionsPanel.hidden = true;
-    var panelId = "composer-options-" + Math.random().toString(36).slice(2, 10);
-    this.optionsPanel.id = panelId;
-    this.optionsBtn.setAttribute("aria-controls", panelId);
-
-    var fields = (opts.options && opts.options.fields) || [];
-    this._optionFields = {};
-    for (var i = 0; i < fields.length; i++) {
-      this._buildOptionField(fields[i], i, panelId);
-    }
-    root.appendChild(this.optionsPanel);
-  };
-
-  Composer.prototype._buildOptionField = function (field, idx, panelId) {
-    var rowEl = document.createElement("div");
-    rowEl.className = "composer-options-field";
-
-    var lbl = document.createElement("label");
-    lbl.textContent = field.label || field.id || "";
-    var ctrlId =
-      panelId + "-" + (field.id || "f" + idx).replace(/[^a-zA-Z0-9_-]/g, "");
-    lbl.htmlFor = ctrlId;
-    rowEl.appendChild(lbl);
-
-    var ctrl;
-    if (field.type === "select") {
-      ctrl = document.createElement("select");
-      (field.choices || []).forEach(function (c) {
-        var opt = document.createElement("option");
-        opt.value = c.value == null ? "" : String(c.value);
-        opt.textContent = c.text == null ? opt.value : String(c.text);
-        ctrl.appendChild(opt);
-      });
-    } else {
-      ctrl = document.createElement("input");
-      ctrl.type = "text";
-      if (field.placeholder) ctrl.placeholder = field.placeholder;
-      if (field.autocomplete) ctrl.autocomplete = field.autocomplete;
-    }
-    ctrl.id = ctrlId;
-    ctrl.className = "composer-options-control";
-    if (field.initial != null) ctrl.value = String(field.initial);
-    rowEl.appendChild(ctrl);
-
-    this.optionsPanel.appendChild(rowEl);
-    this._optionFields[field.id] = ctrl;
-  };
-
-  Composer.prototype._on = function (el, type, fn) {
-    el.addEventListener(type, fn);
-    this._listeners.push({ el: el, type: type, fn: fn });
-  };
-
-  Composer.prototype._wireEvents = function () {
-    var self = this;
-    var opts = this._opts;
-    var pasteFiles =
-      opts.pasteFiles != null ? opts.pasteFiles : !!opts.attachments;
-    var enterSends = opts.touchEnterSends || !this._isTouch;
-
-    this._on(this.inputEl, "input", function () {
-      if (self._autoResizeEnabled) self.autoResize();
-    });
-
-    this._on(this.inputEl, "keydown", function (e) {
-      // Default: desktop sends on Enter, touch inserts a newline (the
-      // on-screen Return key should behave as the OS expects).
-      // touchEnterSends=true overrides for callers that want Enter to
-      // send on touch too.  isComposing guards against eating Enter
-      // mid-IME (CJK input).  The sendBtn.disabled check mirrors the
-      // click-path semantics: when the send button is disabled (busy
-      // non-queue / subsystem-down), Enter also must not submit, or
-      // a rapid double-press before the first POST resolves would
-      // create duplicate requests.
-      if (
-        e.key === "Enter" &&
-        !e.shiftKey &&
-        !e.isComposing &&
-        enterSends &&
-        !self.sendBtn.disabled
-      ) {
-        e.preventDefault();
-        self._fireSend();
-      }
-    });
-
-    if (pasteFiles && opts.attachments) {
-      this._on(this.inputEl, "paste", function (e) {
-        var items = (e.clipboardData && e.clipboardData.items) || [];
-        var uploaded = 0;
-        for (var i = 0; i < items.length; i++) {
-          var it = items[i];
-          if (it.kind === "file") {
-            var f = it.getAsFile();
-            if (f) {
-              opts.attachments.onAttach(f);
-              uploaded += 1;
-            }
-          }
-        }
-        if (uploaded > 0) e.preventDefault();
-      });
-    }
-
-    if (this.attachBtn) {
-      this._on(this.attachBtn, "click", function () {
-        self.attachInput.click();
-      });
-    }
-    if (this.attachInput) {
-      this._on(this.attachInput, "change", function (e) {
-        var files = Array.from(e.target.files || []);
-        files.forEach(function (f) {
-          opts.attachments.onAttach(f);
-        });
-        // Reset so re-selecting the same file still fires change.
-        self.attachInput.value = "";
-      });
-    }
-
-    this._on(this.sendBtn, "click", function () {
-      self._fireSend();
-    });
-
-    if (this.stopBtn) {
-      this._on(this.stopBtn, "click", function () {
-        if (typeof opts.onStop === "function") opts.onStop();
-      });
-    }
-
-    if (this.optionsBtn) {
-      this._on(this.optionsBtn, "click", function () {
-        self.toggleOptions();
-      });
-      // Hook change events on each field to refresh the summary + fire
-      // caller callback.
-      Object.keys(this._optionFields).forEach(function (id) {
-        var ctrl = self._optionFields[id];
-        self._on(ctrl, "change", function () {
-          self._refreshOptionsSummary();
-          if (typeof opts.options.onChange === "function") {
-            opts.options.onChange(self.getOptionValues());
-          }
-        });
-      });
-      // Restore persisted open/closed state if storageKey is set.
-      this._restoreOptionsState();
-      this._refreshOptionsSummary();
-    }
-
-    if (opts.dragDrop) {
-      var target = opts.dragDrop.targetEl;
-      var dropClass = opts.dragDrop.dropClass;
-      if (!dropClass) {
-        throw new Error("Composer: dragDrop.dropClass is required");
-      }
-      var onAttach = opts.attachments && opts.attachments.onAttach;
-      if (target && typeof onAttach === "function") {
-        this._on(target, "dragover", function (e) {
-          if (
-            e.dataTransfer &&
-            Array.from(e.dataTransfer.types || []).indexOf("Files") !== -1
-          ) {
-            e.preventDefault();
-            target.classList.add(dropClass);
-          }
-        });
-        this._on(target, "dragleave", function (e) {
-          // Clear the hover state only when leaving the target entirely;
-          // dragleave fires for every child the cursor crosses.  Using
-          // relatedTarget lets us check whether the new element is still
-          // inside the drop zone.
-          var related = e.relatedTarget;
-          if (!related || !target.contains(related)) {
-            target.classList.remove(dropClass);
-          }
-        });
-        this._on(target, "dragend", function () {
-          target.classList.remove(dropClass);
-        });
-        this._on(target, "drop", function (e) {
-          target.classList.remove(dropClass);
-          var files = Array.from(
-            (e.dataTransfer && e.dataTransfer.files) || [],
-          );
-          if (files.length > 0) {
-            e.preventDefault();
-            files.forEach(function (f) {
-              onAttach(f);
-            });
-          }
-        });
-      }
-    }
-  };
-
-  Composer.prototype._fireSend = function () {
-    var opts = this._opts;
-    if (typeof opts.onSend === "function") opts.onSend(this.inputEl.value);
-  };
-
-  Composer.prototype.autoResize = function () {
-    if (!this._autoResizeEnabled) return;
-    this.inputEl.style.height = "auto";
-    this.inputEl.style.height =
-      Math.min(this.inputEl.scrollHeight, AUTO_RESIZE_MAX_PX) + "px";
-  };
-
-  Object.defineProperty(Composer.prototype, "value", {
-    get: function () {
-      return this.inputEl.value;
-    },
-    set: function (v) {
-      this.inputEl.value = v == null ? "" : String(v);
-      this.autoResize();
-    },
+  this.attachBtn = makeButton({
+    className: "composer-attach",
+    text: "+",
+    ariaLabel: "Attach files",
+    title: "Attach files",
   });
+  row.appendChild(this.attachBtn);
 
-  Composer.prototype.focus = function () {
-    this.inputEl.focus();
-  };
+  this.attachInput = document.createElement("input");
+  this.attachInput.type = "file";
+  this.attachInput.multiple = true;
+  this.attachInput.style.display = "none";
+  this.attachInput.accept = opts.attachments.accept || ATTACH_DEFAULT_ACCEPT;
+  row.appendChild(this.attachInput);
+};
 
-  Composer.prototype.clear = function () {
-    this.inputEl.value = "";
-    this.autoResize();
-  };
+// Live "model · effort" read-out chip — sits between the attach button and
+// the textarea (matching the mock ``[+] [model · effort] input [↑]``).
+// DISPLAY ONLY: a plain span the caller repaints via setModel() from the
+// connected/status SSE events.  A per-session model/effort PICKER (turning
+// this into an interactive dropdown) is a separate, deferred task; until
+// then this is intentionally non-interactive.
+Composer.prototype._buildModelChip = function (row, opts) {
+  if (!opts.modelChip) {
+    this.modelChipEl = null;
+    return;
+  }
+  this.modelChipEl = document.createElement("span");
+  this.modelChipEl.className = "composer-model-chip";
+  this.modelChipEl.setAttribute("aria-label", "Model");
+  this.modelChipEl.textContent = "—";
+  row.appendChild(this.modelChipEl);
+};
 
-  // setBusy rotates the send button label between sendLabel and
-  // busyLabel, swaps the busy placeholder, and (when stopBtn is
-  // configured) toggles the stop button visibility + resets its label
-  // to the configured stopLabel on every transition so a
-  // cancelGeneration-set "Cancelling…" text doesn't persist into the
-  // next busy cycle.
-  //
-  // The send button's disabled attribute follows this matrix:
-  //   externalDisable=true  → composer never writes sendBtn.disabled
-  //                           (caller manages it via its own reconciler).
-  //   queueWhileBusy=true   → sendBtn.disabled = false (queue stays
-  //                           clickable during busy to accept queued sends).
-  //   otherwise             → sendBtn.disabled = !!b (disable on busy to
-  //                           prevent duplicate-click submits).
-  Composer.prototype.setBusy = function (b) {
-    this._busy = !!b;
-    var opts = this._opts;
+// Repaint the model chip's read-out (e.g. "gpt-5 · high").  A falsy label
+// resets it to the em-dash placeholder.  No-op when the chip is disabled.
+Composer.prototype.setModel = function (label) {
+  if (this.modelChipEl) this.modelChipEl.textContent = label || "—";
+};
 
-    // Label + aria-label rotation — universal so callers can supply a
-    // busyLabel regardless of queueWhileBusy mode.
-    // A glyph send button keeps its constant glyph; only the aria-label
-    // (below) and the queue affordance rotate.  Text buttons rotate the label.
-    if (!this._sendGlyph)
-      this.sendBtn.textContent = b ? this._busyLabel : this._sendLabel;
-    var queueAriaLabel = b
-      ? "Queue message for delivery after current execution"
-      : "Send message";
-    this.sendBtn.setAttribute(
-      "aria-label",
-      opts.queueWhileBusy
-        ? queueAriaLabel
-        : (b ? this._busyLabel : this._sendLabel) + " message",
-    );
+// Swap the textarea's idle placeholder — e.g. a launcher that reuses one
+// composer across personas updates the task-prompt hint when the persona
+// changes.  Leaves a busy-state placeholder swap (setBusy) untouched.
+Composer.prototype.setPlaceholder = function (text) {
+  this._idlePlaceholder = text == null ? "" : String(text);
+  if (this.inputEl && !this._busy)
+    this.inputEl.placeholder = this._idlePlaceholder;
+};
 
-    // --queue class is queue-specific (the colour flip signals "this
-    // button now queues rather than sends").
-    this.sendBtn.classList.toggle(
-      "composer-send--queue",
-      !!(b && opts.queueWhileBusy),
-    );
-    // Placeholder swap applies whenever busy, not only in queue mode —
-    // callers that don't set busyPlaceholder see no visible change
-    // because it defaults to idlePlaceholder.
-    this.inputEl.placeholder = b
-      ? this._busyPlaceholder
-      : this._idlePlaceholder;
+Composer.prototype._buildInput = function (row, opts) {
+  this.inputEl = document.createElement("textarea");
+  this.inputEl.className = "composer-input";
+  this.inputEl.rows = opts.rows && opts.rows > 0 ? opts.rows : 1;
+  var defaultPlaceholder = this._isTouch
+    ? "Type a message\u2026"
+    : "Type a message\u2026 (Shift+Enter for newline)";
+  this._idlePlaceholder =
+    opts.placeholder != null ? opts.placeholder : defaultPlaceholder;
+  this._busyPlaceholder = opts.busyPlaceholder || this._idlePlaceholder;
+  this.inputEl.placeholder = this._idlePlaceholder;
+  this.inputEl.setAttribute("aria-label", opts.ariaLabel || "Message input");
+  row.appendChild(this.inputEl);
+};
 
-    // Disabled state — composer owns it unless caller opted out.
-    if (!opts.externalDisable) {
-      this.sendBtn.disabled = !!b && !opts.queueWhileBusy;
-    }
+Composer.prototype._buildSendButton = function (row, opts) {
+  this._sendLabel = opts.sendLabel || "Send";
+  // busyLabel default is context-sensitive: "Queue" only makes sense
+  // when queueWhileBusy=true (the send button stays clickable during
+  // busy to accept queued messages).  Non-queue consumers that omit
+  // busyLabel fall back to sendLabel — no label rotation on busy —
+  // so the disabled button doesn't misleadingly read "Queue" when
+  // queueing isn't actually supported by the caller.
+  this._busyLabel =
+    opts.busyLabel != null
+      ? opts.busyLabel
+      : opts.queueWhileBusy
+        ? "Queue"
+        : this._sendLabel;
+  // Glyph mode (chat composers): show a send GLYPH instead of a word.  The
+  // textual sendLabel stays the aria-label and drives setBusy's a11y
+  // rotation, but the visible glyph is constant (setBusy never overwrites it).
+  this._sendGlyph = opts.sendGlyph || null;
+  this.sendBtn = makeButton({
+    className:
+      "composer-send" + (this._sendGlyph ? " composer-send--glyph" : ""),
+    text: this._sendGlyph || this._sendLabel,
+    ariaLabel: this._sendLabel + " message",
+  });
+  row.appendChild(this.sendBtn);
+};
 
-    // Paperclip is disabled whenever busy, even in queueWhileBusy mode:
-    // attachments can't ride a queued user turn (would inject a `user`
-    // turn between assistant(tool_calls) and tool — see backend
-    // AttachmentsNotQueueableError).
-    if (this.attachBtn) {
-      this.attachBtn.disabled = !!b;
-      var attachLabel = b
-        ? "Attach files (available once the current turn finishes)"
-        : "Attach files";
-      this.attachBtn.title = attachLabel;
-      this.attachBtn.setAttribute("aria-label", attachLabel);
-    }
+Composer.prototype._buildStopButton = function (row, opts) {
+  if (!opts.stopBtn) {
+    this.stopBtn = null;
+    return;
+  }
+  this._stopLabel = opts.stopLabel || "\u25a0 Stop";
+  this.stopBtn = makeButton({
+    className: "composer-stop",
+    text: this._stopLabel,
+    ariaLabel: "Stop generation",
+  });
+  this.stopBtn.style.display = "none";
+  this.stopBtn.disabled = true;
+  row.appendChild(this.stopBtn);
+};
 
-    // Stop button visibility + label reset — reset every transition so
-    // cancelGeneration's transient "Cancelling…" label doesn't stick.
-    if (this.stopBtn) {
-      this.stopBtn.style.display = b ? "" : "none";
-      this.stopBtn.disabled = !b;
-      this.stopBtn.textContent = this._stopLabel;
-      this.stopBtn.setAttribute("aria-label", "Stop generation");
-      delete this.stopBtn.dataset.forceCancel;
-    }
-  };
+Composer.prototype._buildOptionsToggle = function (row, opts) {
+  if (!opts.options) {
+    this.optionsBtn = null;
+    this.optionsSummaryEl = null;
+    return;
+  }
+  this.optionsBtn = document.createElement("button");
+  this.optionsBtn.type = "button";
+  this.optionsBtn.className = "composer-options-btn";
+  this.optionsBtn.setAttribute("aria-label", "Toggle options");
+  this.optionsBtn.setAttribute("title", "Options");
+  this.optionsBtn.setAttribute("aria-expanded", "false");
+  var labelSpan = document.createElement("span");
+  labelSpan.className = "composer-options-btn-label";
+  labelSpan.textContent = opts.options.toggleLabel || "Options";
+  this.optionsBtn.appendChild(labelSpan);
+  var caret = document.createElement("span");
+  caret.className = "composer-options-caret";
+  caret.setAttribute("aria-hidden", "true");
+  caret.textContent = "\u25be"; // ▾
+  this.optionsBtn.appendChild(caret);
+  row.appendChild(this.optionsBtn);
 
-  // ---------------------------------------------------------------------
-  // Options panel — public API.
-  //
-  // Naming convention: panel-level operations use plural "options"
-  // (toggleOptions, setOptionsOpen, getOptionValues), per-field
-  // operations use singular "option" (setOptionValue, setOptionChoices,
-  // getOptionValue).
-  // ---------------------------------------------------------------------
+  this.optionsSummaryEl = document.createElement("span");
+  this.optionsSummaryEl.className = "composer-options-summary";
+  this.optionsSummaryEl.setAttribute("aria-live", "polite");
+  this.optionsSummaryEl.hidden = true;
+  row.appendChild(this.optionsSummaryEl);
+};
 
-  Composer.prototype.setOptionsOpen = function (open) {
-    if (!this.optionsPanel || !this.optionsBtn) return;
-    this.optionsPanel.hidden = !open;
-    this.optionsBtn.setAttribute("aria-expanded", open ? "true" : "false");
-    var storageKey = this._opts.options && this._opts.options.storageKey;
-    if (storageKey) {
-      try {
-        localStorage.setItem(storageKey, open ? "1" : "0");
-      } catch (_) {
-        /* localStorage unavailable — state persists for this page only. */
-      }
-    }
-  };
+Composer.prototype._buildOptionsPanel = function (root, opts) {
+  if (!opts.options) {
+    this.optionsPanel = null;
+    this._optionFields = {};
+    return;
+  }
+  this.optionsPanel = document.createElement("div");
+  this.optionsPanel.className = "composer-options-panel";
+  this.optionsPanel.hidden = true;
+  var panelId = "composer-options-" + Math.random().toString(36).slice(2, 10);
+  this.optionsPanel.id = panelId;
+  this.optionsBtn.setAttribute("aria-controls", panelId);
 
-  Composer.prototype.toggleOptions = function () {
-    if (!this.optionsPanel) return;
-    this.setOptionsOpen(this.optionsPanel.hidden);
-  };
+  var fields = (opts.options && opts.options.fields) || [];
+  this._optionFields = {};
+  for (var i = 0; i < fields.length; i++) {
+    this._buildOptionField(fields[i], i, panelId);
+  }
+  root.appendChild(this.optionsPanel);
+};
 
-  Composer.prototype._restoreOptionsState = function () {
-    var storageKey = this._opts.options && this._opts.options.storageKey;
-    if (!storageKey) return;
-    var saved = null;
-    try {
-      saved = localStorage.getItem(storageKey);
-    } catch (_) {
-      return;
-    }
-    if (saved === "1") this.setOptionsOpen(true);
-    else if (saved === "0") this.setOptionsOpen(false);
-  };
+Composer.prototype._buildOptionField = function (field, idx, panelId) {
+  var rowEl = document.createElement("div");
+  rowEl.className = "composer-options-field";
 
-  Composer.prototype.getOptionValues = function () {
-    var out = {};
-    if (!this._optionFields) return out;
-    var keys = Object.keys(this._optionFields);
-    for (var i = 0; i < keys.length; i++) {
-      var ctrl = this._optionFields[keys[i]];
-      out[keys[i]] = ctrl ? ctrl.value : "";
-    }
-    return out;
-  };
+  var lbl = document.createElement("label");
+  lbl.textContent = field.label || field.id || "";
+  var ctrlId =
+    panelId + "-" + (field.id || "f" + idx).replace(/[^a-zA-Z0-9_-]/g, "");
+  lbl.htmlFor = ctrlId;
+  rowEl.appendChild(lbl);
 
-  Composer.prototype.getOptionValue = function (id) {
-    var ctrl = this._optionFields && this._optionFields[id];
-    return ctrl ? ctrl.value : "";
-  };
-
-  Composer.prototype.setOptionValue = function (id, value) {
-    var ctrl = this._optionFields && this._optionFields[id];
-    if (!ctrl) return;
-    ctrl.value = value == null ? "" : String(value);
-    this._refreshOptionsSummary();
-  };
-
-  // Replace a select field's <option> list, preserving the first
-  // <option> when one already exists (conventionally the "Default /
-  // Use defaults" placeholder the caller seeded at construction time).
-  // When the field was constructed without any choices, nothing is
-  // preserved — callers get exactly the list they passed in.
-  // Used by callers that populate choices asynchronously — e.g. the
-  // coordinator creation panel fetches /v1/api/skills and feeds the
-  // result here.
-  Composer.prototype.setOptionChoices = function (id, choices) {
-    var ctrl = this._optionFields && this._optionFields[id];
-    if (!ctrl || ctrl.tagName !== "SELECT") return;
-    var keep = ctrl.options.length > 0 ? ctrl.options[0] : null;
-    if (keep) {
-      ctrl.replaceChildren(keep);
-    } else {
-      ctrl.replaceChildren();
-    }
-    (choices || []).forEach(function (c) {
+  var ctrl;
+  if (field.type === "select") {
+    ctrl = document.createElement("select");
+    (field.choices || []).forEach(function (c) {
       var opt = document.createElement("option");
       opt.value = c.value == null ? "" : String(c.value);
       opt.textContent = c.text == null ? opt.value : String(c.text);
       ctrl.appendChild(opt);
     });
+  } else {
+    ctrl = document.createElement("input");
+    ctrl.type = "text";
+    if (field.placeholder) ctrl.placeholder = field.placeholder;
+    if (field.autocomplete) ctrl.autocomplete = field.autocomplete;
+  }
+  ctrl.id = ctrlId;
+  ctrl.className = "composer-options-control";
+  if (field.initial != null) ctrl.value = String(field.initial);
+  rowEl.appendChild(ctrl);
+
+  this.optionsPanel.appendChild(rowEl);
+  this._optionFields[field.id] = ctrl;
+};
+
+Composer.prototype._on = function (el, type, fn) {
+  el.addEventListener(type, fn);
+  this._listeners.push({ el: el, type: type, fn: fn });
+};
+
+Composer.prototype._wireEvents = function () {
+  var self = this;
+  var opts = this._opts;
+  var pasteFiles =
+    opts.pasteFiles != null ? opts.pasteFiles : !!opts.attachments;
+  var enterSends = opts.touchEnterSends || !this._isTouch;
+
+  this._on(this.inputEl, "input", function () {
+    if (self._autoResizeEnabled) self.autoResize();
+  });
+
+  this._on(this.inputEl, "keydown", function (e) {
+    // Default: desktop sends on Enter, touch inserts a newline (the
+    // on-screen Return key should behave as the OS expects).
+    // touchEnterSends=true overrides for callers that want Enter to
+    // send on touch too.  isComposing guards against eating Enter
+    // mid-IME (CJK input).  The sendBtn.disabled check mirrors the
+    // click-path semantics: when the send button is disabled (busy
+    // non-queue / subsystem-down), Enter also must not submit, or
+    // a rapid double-press before the first POST resolves would
+    // create duplicate requests.
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      !e.isComposing &&
+      enterSends &&
+      !self.sendBtn.disabled
+    ) {
+      e.preventDefault();
+      self._fireSend();
+    }
+  });
+
+  if (pasteFiles && opts.attachments) {
+    this._on(this.inputEl, "paste", function (e) {
+      var items = (e.clipboardData && e.clipboardData.items) || [];
+      var uploaded = 0;
+      for (var i = 0; i < items.length; i++) {
+        var it = items[i];
+        if (it.kind === "file") {
+          var f = it.getAsFile();
+          if (f) {
+            opts.attachments.onAttach(f);
+            uploaded += 1;
+          }
+        }
+      }
+      if (uploaded > 0) e.preventDefault();
+    });
+  }
+
+  if (this.attachBtn) {
+    this._on(this.attachBtn, "click", function () {
+      self.attachInput.click();
+    });
+  }
+  if (this.attachInput) {
+    this._on(this.attachInput, "change", function (e) {
+      var files = Array.from(e.target.files || []);
+      files.forEach(function (f) {
+        opts.attachments.onAttach(f);
+      });
+      // Reset so re-selecting the same file still fires change.
+      self.attachInput.value = "";
+    });
+  }
+
+  this._on(this.sendBtn, "click", function () {
+    self._fireSend();
+  });
+
+  if (this.stopBtn) {
+    this._on(this.stopBtn, "click", function () {
+      if (typeof opts.onStop === "function") opts.onStop();
+    });
+  }
+
+  if (this.optionsBtn) {
+    this._on(this.optionsBtn, "click", function () {
+      self.toggleOptions();
+    });
+    // Hook change events on each field to refresh the summary + fire
+    // caller callback.
+    Object.keys(this._optionFields).forEach(function (id) {
+      var ctrl = self._optionFields[id];
+      self._on(ctrl, "change", function () {
+        self._refreshOptionsSummary();
+        if (typeof opts.options.onChange === "function") {
+          opts.options.onChange(self.getOptionValues());
+        }
+      });
+    });
+    // Restore persisted open/closed state if storageKey is set.
+    this._restoreOptionsState();
     this._refreshOptionsSummary();
-  };
+  }
 
-  // Update just the placeholder (first) option's text without disturbing
-  // the rest of the choice list.  Callers that resolve the effective
-  // default asynchronously use this to annotate the empty option with the
-  // concrete alias — e.g. "Default model" → "Default model (gpt-5)".
-  Composer.prototype.setOptionPlaceholder = function (id, text) {
-    var ctrl = this._optionFields && this._optionFields[id];
-    if (!ctrl || ctrl.tagName !== "SELECT") return;
-    if (ctrl.options.length === 0) return;
-    ctrl.options[0].textContent = text == null ? "" : String(text);
-    this._refreshOptionsSummary();
-  };
-
-  // Show/hide a single options field (its label + control row).  Lets a caller
-  // reveal a field conditionally — e.g. the launcher shows the node picker only
-  // for the interactive persona, and the node list only under "Specific node".
-  // Sets inline display because the row is `display: contents` (chat.css:537),
-  // which outweighs the [hidden] attribute's UA `display:none` on specificity —
-  // so toggling [hidden] alone would not actually hide the row.
-  Composer.prototype.setOptionFieldVisible = function (id, visible) {
-    var ctrl = this._optionFields && this._optionFields[id];
-    if (!ctrl) return;
-    var row = ctrl.closest(".composer-options-field");
-    if (row) row.style.display = visible ? "" : "none";
-  };
-
-  Composer.prototype._refreshOptionsSummary = function () {
-    if (!this.optionsSummaryEl) return;
-    var summaryFn = this._opts.options && this._opts.options.summary;
-    if (typeof summaryFn !== "function") {
-      this.optionsSummaryEl.hidden = true;
-      this.optionsSummaryEl.textContent = "";
-      return;
+  if (opts.dragDrop) {
+    var target = opts.dragDrop.targetEl;
+    var dropClass = opts.dragDrop.dropClass;
+    if (!dropClass) {
+      throw new Error("Composer: dragDrop.dropClass is required");
     }
-    var text = summaryFn(this.getOptionValues());
-    if (text) {
-      this.optionsSummaryEl.textContent = text;
-      this.optionsSummaryEl.hidden = false;
-    } else {
-      this.optionsSummaryEl.textContent = "";
-      this.optionsSummaryEl.hidden = true;
+    var onAttach = opts.attachments && opts.attachments.onAttach;
+    if (target && typeof onAttach === "function") {
+      this._on(target, "dragover", function (e) {
+        if (
+          e.dataTransfer &&
+          Array.from(e.dataTransfer.types || []).indexOf("Files") !== -1
+        ) {
+          e.preventDefault();
+          target.classList.add(dropClass);
+        }
+      });
+      this._on(target, "dragleave", function (e) {
+        // Clear the hover state only when leaving the target entirely;
+        // dragleave fires for every child the cursor crosses.  Using
+        // relatedTarget lets us check whether the new element is still
+        // inside the drop zone.
+        var related = e.relatedTarget;
+        if (!related || !target.contains(related)) {
+          target.classList.remove(dropClass);
+        }
+      });
+      this._on(target, "dragend", function () {
+        target.classList.remove(dropClass);
+      });
+      this._on(target, "drop", function (e) {
+        target.classList.remove(dropClass);
+        var files = Array.from(
+          (e.dataTransfer && e.dataTransfer.files) || [],
+        );
+        if (files.length > 0) {
+          e.preventDefault();
+          files.forEach(function (f) {
+            onAttach(f);
+          });
+        }
+      });
     }
-  };
+  }
+};
 
-  Composer.prototype.destroy = function () {
-    if (this._destroyed) return;
-    this._destroyed = true;
-    for (var i = 0; i < this._listeners.length; i++) {
-      var l = this._listeners[i];
-      l.el.removeEventListener(l.type, l.fn);
-    }
-    this._listeners = [];
-    if (this.el && this.el.parentNode) {
-      this.el.parentNode.removeChild(this.el);
-    }
-    // Null out DOM back-references so post-destroy access fails
-    // loudly rather than silently mutating detached nodes.
-    this.inputEl = null;
-    this.sendBtn = null;
-    this.stopBtn = null;
-    this.chipsEl = null;
-    this.attachBtn = null;
-    this.attachInput = null;
-    this.modelChipEl = null;
-    this.optionsBtn = null;
-    this.optionsPanel = null;
-    this.optionsSummaryEl = null;
-    this._optionFields = {};
-    this.el = null;
-  };
+Composer.prototype._fireSend = function () {
+  var opts = this._opts;
+  if (typeof opts.onSend === "function") opts.onSend(this.inputEl.value);
+};
 
-  root.Composer = Composer;
-})(typeof window !== "undefined" ? window : globalThis);
+Composer.prototype.autoResize = function () {
+  if (!this._autoResizeEnabled) return;
+  this.inputEl.style.height = "auto";
+  this.inputEl.style.height =
+    Math.min(this.inputEl.scrollHeight, AUTO_RESIZE_MAX_PX) + "px";
+};
+
+Object.defineProperty(Composer.prototype, "value", {
+  get: function () {
+    return this.inputEl.value;
+  },
+  set: function (v) {
+    this.inputEl.value = v == null ? "" : String(v);
+    this.autoResize();
+  },
+});
+
+Composer.prototype.focus = function () {
+  this.inputEl.focus();
+};
+
+Composer.prototype.clear = function () {
+  this.inputEl.value = "";
+  this.autoResize();
+};
+
+// setBusy rotates the send button label between sendLabel and
+// busyLabel, swaps the busy placeholder, and (when stopBtn is
+// configured) toggles the stop button visibility + resets its label
+// to the configured stopLabel on every transition so a
+// cancelGeneration-set "Cancelling…" text doesn't persist into the
+// next busy cycle.
+//
+// The send button's disabled attribute follows this matrix:
+//   externalDisable=true  → composer never writes sendBtn.disabled
+//                           (caller manages it via its own reconciler).
+//   queueWhileBusy=true   → sendBtn.disabled = false (queue stays
+//                           clickable during busy to accept queued sends).
+//   otherwise             → sendBtn.disabled = !!b (disable on busy to
+//                           prevent duplicate-click submits).
+Composer.prototype.setBusy = function (b) {
+  this._busy = !!b;
+  var opts = this._opts;
+
+  // Label + aria-label rotation — universal so callers can supply a
+  // busyLabel regardless of queueWhileBusy mode.
+  // A glyph send button keeps its constant glyph; only the aria-label
+  // (below) and the queue affordance rotate.  Text buttons rotate the label.
+  if (!this._sendGlyph)
+    this.sendBtn.textContent = b ? this._busyLabel : this._sendLabel;
+  var queueAriaLabel = b
+    ? "Queue message for delivery after current execution"
+    : "Send message";
+  this.sendBtn.setAttribute(
+    "aria-label",
+    opts.queueWhileBusy
+      ? queueAriaLabel
+      : (b ? this._busyLabel : this._sendLabel) + " message",
+  );
+
+  // --queue class is queue-specific (the colour flip signals "this
+  // button now queues rather than sends").
+  this.sendBtn.classList.toggle(
+    "composer-send--queue",
+    !!(b && opts.queueWhileBusy),
+  );
+  // Placeholder swap applies whenever busy, not only in queue mode —
+  // callers that don't set busyPlaceholder see no visible change
+  // because it defaults to idlePlaceholder.
+  this.inputEl.placeholder = b
+    ? this._busyPlaceholder
+    : this._idlePlaceholder;
+
+  // Disabled state — composer owns it unless caller opted out.
+  if (!opts.externalDisable) {
+    this.sendBtn.disabled = !!b && !opts.queueWhileBusy;
+  }
+
+  // Paperclip is disabled whenever busy, even in queueWhileBusy mode:
+  // attachments can't ride a queued user turn (would inject a `user`
+  // turn between assistant(tool_calls) and tool — see backend
+  // AttachmentsNotQueueableError).
+  if (this.attachBtn) {
+    this.attachBtn.disabled = !!b;
+    var attachLabel = b
+      ? "Attach files (available once the current turn finishes)"
+      : "Attach files";
+    this.attachBtn.title = attachLabel;
+    this.attachBtn.setAttribute("aria-label", attachLabel);
+  }
+
+  // Stop button visibility + label reset — reset every transition so
+  // cancelGeneration's transient "Cancelling…" label doesn't stick.
+  if (this.stopBtn) {
+    this.stopBtn.style.display = b ? "" : "none";
+    this.stopBtn.disabled = !b;
+    this.stopBtn.textContent = this._stopLabel;
+    this.stopBtn.setAttribute("aria-label", "Stop generation");
+    delete this.stopBtn.dataset.forceCancel;
+  }
+};
+
+// ---------------------------------------------------------------------
+// Options panel — public API.
+//
+// Naming convention: panel-level operations use plural "options"
+// (toggleOptions, setOptionsOpen, getOptionValues), per-field
+// operations use singular "option" (setOptionValue, setOptionChoices,
+// getOptionValue).
+// ---------------------------------------------------------------------
+
+Composer.prototype.setOptionsOpen = function (open) {
+  if (!this.optionsPanel || !this.optionsBtn) return;
+  this.optionsPanel.hidden = !open;
+  this.optionsBtn.setAttribute("aria-expanded", open ? "true" : "false");
+  var storageKey = this._opts.options && this._opts.options.storageKey;
+  if (storageKey) {
+    try {
+      localStorage.setItem(storageKey, open ? "1" : "0");
+    } catch (_) {
+      /* localStorage unavailable — state persists for this page only. */
+    }
+  }
+};
+
+Composer.prototype.toggleOptions = function () {
+  if (!this.optionsPanel) return;
+  this.setOptionsOpen(this.optionsPanel.hidden);
+};
+
+Composer.prototype._restoreOptionsState = function () {
+  var storageKey = this._opts.options && this._opts.options.storageKey;
+  if (!storageKey) return;
+  var saved = null;
+  try {
+    saved = localStorage.getItem(storageKey);
+  } catch (_) {
+    return;
+  }
+  if (saved === "1") this.setOptionsOpen(true);
+  else if (saved === "0") this.setOptionsOpen(false);
+};
+
+Composer.prototype.getOptionValues = function () {
+  var out = {};
+  if (!this._optionFields) return out;
+  var keys = Object.keys(this._optionFields);
+  for (var i = 0; i < keys.length; i++) {
+    var ctrl = this._optionFields[keys[i]];
+    out[keys[i]] = ctrl ? ctrl.value : "";
+  }
+  return out;
+};
+
+Composer.prototype.getOptionValue = function (id) {
+  var ctrl = this._optionFields && this._optionFields[id];
+  return ctrl ? ctrl.value : "";
+};
+
+Composer.prototype.setOptionValue = function (id, value) {
+  var ctrl = this._optionFields && this._optionFields[id];
+  if (!ctrl) return;
+  ctrl.value = value == null ? "" : String(value);
+  this._refreshOptionsSummary();
+};
+
+// Replace a select field's <option> list, preserving the first
+// <option> when one already exists (conventionally the "Default /
+// Use defaults" placeholder the caller seeded at construction time).
+// When the field was constructed without any choices, nothing is
+// preserved — callers get exactly the list they passed in.
+// Used by callers that populate choices asynchronously — e.g. the
+// coordinator creation panel fetches /v1/api/skills and feeds the
+// result here.
+Composer.prototype.setOptionChoices = function (id, choices) {
+  var ctrl = this._optionFields && this._optionFields[id];
+  if (!ctrl || ctrl.tagName !== "SELECT") return;
+  var keep = ctrl.options.length > 0 ? ctrl.options[0] : null;
+  if (keep) {
+    ctrl.replaceChildren(keep);
+  } else {
+    ctrl.replaceChildren();
+  }
+  (choices || []).forEach(function (c) {
+    var opt = document.createElement("option");
+    opt.value = c.value == null ? "" : String(c.value);
+    opt.textContent = c.text == null ? opt.value : String(c.text);
+    ctrl.appendChild(opt);
+  });
+  this._refreshOptionsSummary();
+};
+
+// Update just the placeholder (first) option's text without disturbing
+// the rest of the choice list.  Callers that resolve the effective
+// default asynchronously use this to annotate the empty option with the
+// concrete alias — e.g. "Default model" → "Default model (gpt-5)".
+Composer.prototype.setOptionPlaceholder = function (id, text) {
+  var ctrl = this._optionFields && this._optionFields[id];
+  if (!ctrl || ctrl.tagName !== "SELECT") return;
+  if (ctrl.options.length === 0) return;
+  ctrl.options[0].textContent = text == null ? "" : String(text);
+  this._refreshOptionsSummary();
+};
+
+// Show/hide a single options field (its label + control row).  Lets a caller
+// reveal a field conditionally — e.g. the launcher shows the node picker only
+// for the interactive persona, and the node list only under "Specific node".
+// Sets inline display because the row is `display: contents` (chat.css:537),
+// which outweighs the [hidden] attribute's UA `display:none` on specificity —
+// so toggling [hidden] alone would not actually hide the row.
+Composer.prototype.setOptionFieldVisible = function (id, visible) {
+  var ctrl = this._optionFields && this._optionFields[id];
+  if (!ctrl) return;
+  var row = ctrl.closest(".composer-options-field");
+  if (row) row.style.display = visible ? "" : "none";
+};
+
+Composer.prototype._refreshOptionsSummary = function () {
+  if (!this.optionsSummaryEl) return;
+  var summaryFn = this._opts.options && this._opts.options.summary;
+  if (typeof summaryFn !== "function") {
+    this.optionsSummaryEl.hidden = true;
+    this.optionsSummaryEl.textContent = "";
+    return;
+  }
+  var text = summaryFn(this.getOptionValues());
+  if (text) {
+    this.optionsSummaryEl.textContent = text;
+    this.optionsSummaryEl.hidden = false;
+  } else {
+    this.optionsSummaryEl.textContent = "";
+    this.optionsSummaryEl.hidden = true;
+  }
+};
+
+Composer.prototype.destroy = function () {
+  if (this._destroyed) return;
+  this._destroyed = true;
+  for (var i = 0; i < this._listeners.length; i++) {
+    var l = this._listeners[i];
+    l.el.removeEventListener(l.type, l.fn);
+  }
+  this._listeners = [];
+  if (this.el && this.el.parentNode) {
+    this.el.parentNode.removeChild(this.el);
+  }
+  // Null out DOM back-references so post-destroy access fails
+  // loudly rather than silently mutating detached nodes.
+  this.inputEl = null;
+  this.sendBtn = null;
+  this.stopBtn = null;
+  this.chipsEl = null;
+  this.attachBtn = null;
+  this.attachInput = null;
+  this.modelChipEl = null;
+  this.optionsBtn = null;
+  this.optionsPanel = null;
+  this.optionsSummaryEl = null;
+  this._optionFields = {};
+  this.el = null;
+};
+
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+window.Composer = Composer;

--- a/turnstone/shared_static/composer_attachments.js
+++ b/turnstone/shared_static/composer_attachments.js
@@ -30,278 +30,278 @@
  *                             surface a toast if any were dropped.
  *   isEmpty()                — true when no chips are pending.
  */
-(function (root) {
-  "use strict";
+function formatSize(n) {
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  return (n / (1024 * 1024)).toFixed(1) + " MB";
+}
 
-  function formatSize(n) {
-    if (n < 1024) return n + " B";
-    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
-    return (n / (1024 * 1024)).toFixed(1) + " MB";
+function _toastError(msg) {
+  if (typeof window.toast !== "undefined" && window.toast.error) {
+    window.toast.error(msg);
+  }
+}
+
+/**
+ * @param {Object} opts
+ *   chipsEl: HTMLElement — chips render target (composer.chipsEl).
+ *   getWsId: () => string — current workstream id (function so the
+ *     interactive pane can swap tabs without re-instantiating).
+ *   authFetch: optional override (default window.authFetch).
+ *   onError: optional (msg, err) => void — replaces the default toast
+ *     for upload failures.
+ */
+export function createAttachmentController(opts) {
+  if (!opts || !opts.chipsEl)
+    throw new Error("createAttachmentController: chipsEl required");
+  if (typeof opts.getWsId !== "function")
+    throw new Error("createAttachmentController: getWsId must be a function");
+  var chipsEl = opts.chipsEl;
+  var getWsId = opts.getWsId;
+  var onError = opts.onError || _toastError;
+  // Lazy authFetch lookup — shared/auth.js is loaded before this
+  // module in production, but being lazy avoids surprising
+  // construction-order failures and keeps the test stub (which
+  // defines window.authFetch later) working.
+  function _authFetch(url, init) {
+    var fn = opts.authFetch || window.authFetch;
+    return fn(url, init);
+  }
+  var pending = new Map();
+
+  function renderChip(info) {
+    var chip = document.createElement("span");
+    chip.className = "composer-chip composer-chip-" + (info.kind || "other");
+    chip.setAttribute("role", "listitem");
+    chip.dataset.attachmentId = info.attachment_id;
+
+    var icon = document.createElement("span");
+    icon.className = "composer-chip-icon";
+    icon.setAttribute("aria-hidden", "true");
+    icon.textContent = info.kind === "image" ? "🖼" : "📄";
+    chip.appendChild(icon);
+
+    var name = document.createElement("span");
+    name.className = "composer-chip-name";
+    name.textContent = info.filename || "(unnamed)";
+    name.title = info.filename || "";
+    chip.appendChild(name);
+
+    var size = document.createElement("span");
+    size.className = "composer-chip-size";
+    size.textContent = formatSize(info.size_bytes || 0);
+    chip.appendChild(size);
+
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "composer-chip-remove";
+    btn.setAttribute(
+      "aria-label",
+      "Remove attachment " + (info.filename || ""),
+    );
+    btn.title = "Remove";
+    btn.textContent = "×";
+    btn.addEventListener("click", function () {
+      remove(info.attachment_id);
+    });
+    chip.appendChild(btn);
+
+    chipsEl.appendChild(chip);
+    return chip;
   }
 
-  function _toastError(msg) {
-    if (typeof root.toast !== "undefined" && root.toast.error) {
-      root.toast.error(msg);
-    }
+  function _findChip(id) {
+    return chipsEl.querySelector('[data-attachment-id="' + id + '"]');
   }
 
-  /**
-   * @param {Object} opts
-   *   chipsEl: HTMLElement — chips render target (composer.chipsEl).
-   *   getWsId: () => string — current workstream id (function so the
-   *     interactive pane can swap tabs without re-instantiating).
-   *   authFetch: optional override (default window.authFetch).
-   *   onError: optional (msg, err) => void — replaces the default toast
-   *     for upload failures.
-   */
-  function createAttachmentController(opts) {
-    if (!opts || !opts.chipsEl)
-      throw new Error("createAttachmentController: chipsEl required");
-    if (typeof opts.getWsId !== "function")
-      throw new Error("createAttachmentController: getWsId must be a function");
-    var chipsEl = opts.chipsEl;
-    var getWsId = opts.getWsId;
-    var onError = opts.onError || _toastError;
-    // Lazy authFetch lookup — shared/auth.js is loaded before this
-    // module in production, but being lazy avoids surprising
-    // construction-order failures and keeps the test stub (which
-    // defines window.authFetch later) working.
-    function _authFetch(url, init) {
-      var fn = opts.authFetch || root.authFetch;
-      return fn(url, init);
-    }
-    var pending = new Map();
+  function _removeChipDom(id) {
+    var chip = _findChip(id);
+    if (chip) chip.remove();
+  }
 
-    function renderChip(info) {
-      var chip = document.createElement("span");
-      chip.className = "composer-chip composer-chip-" + (info.kind || "other");
-      chip.setAttribute("role", "listitem");
+  // Replace one Map key with another in place, preserving insertion
+  // order. JS Map iteration is insertion-ordered, so naïve
+  // `delete + set` would push the entry to the end of the order —
+  // breaking the contract that send() iterates chips in user-
+  // selection order. Localised here so callers (and the swap path
+  // below) don't restate the rationale.
+  function _replaceMapKey(map, oldKey, newKey, newVal) {
+    var rebuilt = new Map();
+    map.forEach(function (val, key) {
+      if (key === oldKey) rebuilt.set(newKey, newVal);
+      else rebuilt.set(key, val);
+    });
+    map.clear();
+    rebuilt.forEach(function (val, key) {
+      map.set(key, val);
+    });
+  }
+
+  function _swapPlaceholder(placeholderId, info) {
+    // If the user removed the placeholder mid-upload (chip + map
+    // entry both gone), drop the response — resurrecting a chip the
+    // user dismissed would attach an untracked element (not in the
+    // map, so coordSend wouldn't include it) and confuse them.
+    if (!pending.has(placeholderId)) return;
+    _replaceMapKey(pending, placeholderId, info.attachment_id, info);
+
+    var chip = _findChip(placeholderId);
+    if (chip) {
       chip.dataset.attachmentId = info.attachment_id;
-
-      var icon = document.createElement("span");
-      icon.className = "composer-chip-icon";
-      icon.setAttribute("aria-hidden", "true");
-      icon.textContent = info.kind === "image" ? "🖼" : "📄";
-      chip.appendChild(icon);
-
-      var name = document.createElement("span");
-      name.className = "composer-chip-name";
-      name.textContent = info.filename || "(unnamed)";
-      name.title = info.filename || "";
-      chip.appendChild(name);
-
-      var size = document.createElement("span");
-      size.className = "composer-chip-size";
-      size.textContent = formatSize(info.size_bytes || 0);
-      chip.appendChild(size);
-
-      var btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "composer-chip-remove";
-      btn.setAttribute(
-        "aria-label",
-        "Remove attachment " + (info.filename || ""),
-      );
-      btn.title = "Remove";
-      btn.textContent = "×";
-      btn.addEventListener("click", function () {
-        remove(info.attachment_id);
-      });
-      chip.appendChild(btn);
-
-      chipsEl.appendChild(chip);
-      return chip;
-    }
-
-    function _findChip(id) {
-      return chipsEl.querySelector('[data-attachment-id="' + id + '"]');
-    }
-
-    function _removeChipDom(id) {
-      var chip = _findChip(id);
-      if (chip) chip.remove();
-    }
-
-    // Replace one Map key with another in place, preserving insertion
-    // order. JS Map iteration is insertion-ordered, so naïve
-    // `delete + set` would push the entry to the end of the order —
-    // breaking the contract that send() iterates chips in user-
-    // selection order. Localised here so callers (and the swap path
-    // below) don't restate the rationale.
-    function _replaceMapKey(map, oldKey, newKey, newVal) {
-      var rebuilt = new Map();
-      map.forEach(function (val, key) {
-        if (key === oldKey) rebuilt.set(newKey, newVal);
-        else rebuilt.set(key, val);
-      });
-      map.clear();
-      rebuilt.forEach(function (val, key) {
-        map.set(key, val);
-      });
-    }
-
-    function _swapPlaceholder(placeholderId, info) {
-      // If the user removed the placeholder mid-upload (chip + map
-      // entry both gone), drop the response — resurrecting a chip the
-      // user dismissed would attach an untracked element (not in the
-      // map, so coordSend wouldn't include it) and confuse them.
-      if (!pending.has(placeholderId)) return;
-      _replaceMapKey(pending, placeholderId, info.attachment_id, info);
-
-      var chip = _findChip(placeholderId);
-      if (chip) {
-        chip.dataset.attachmentId = info.attachment_id;
-        var name = chip.querySelector(".composer-chip-name");
-        if (name) {
-          name.textContent = info.filename || "(unnamed)";
-          name.title = info.filename || "";
-        }
-        var size = chip.querySelector(".composer-chip-size");
-        if (size) size.textContent = formatSize(info.size_bytes || 0);
-      } else {
-        renderChip(info);
+      var name = chip.querySelector(".composer-chip-name");
+      if (name) {
+        name.textContent = info.filename || "(unnamed)";
+        name.title = info.filename || "";
       }
+      var size = chip.querySelector(".composer-chip-size");
+      if (size) size.textContent = formatSize(info.size_bytes || 0);
+    } else {
+      renderChip(info);
     }
+  }
 
-    function upload(file) {
-      var wsId = getWsId();
-      if (!wsId || !file) return;
-      var fd = new FormData();
-      fd.append("file", file, file.name);
+  function upload(file) {
+    var wsId = getWsId();
+    if (!wsId || !file) return;
+    var fd = new FormData();
+    fd.append("file", file, file.name);
 
-      var placeholderId = "__uploading_" + Date.now() + "_" + Math.random();
-      var placeholder = {
-        attachment_id: placeholderId,
-        filename: file.name,
-        size_bytes: file.size,
-        mime_type: file.type || "",
-        kind: (file.type || "").indexOf("image/") === 0 ? "image" : "text",
-        uploading: true,
-      };
-      pending.set(placeholderId, placeholder);
-      renderChip(placeholder);
+    var placeholderId = "__uploading_" + Date.now() + "_" + Math.random();
+    var placeholder = {
+      attachment_id: placeholderId,
+      filename: file.name,
+      size_bytes: file.size,
+      mime_type: file.type || "",
+      kind: (file.type || "").indexOf("image/") === 0 ? "image" : "text",
+      uploading: true,
+    };
+    pending.set(placeholderId, placeholder);
+    renderChip(placeholder);
 
-      _authFetch(
-        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
-        { method: "POST", credentials: "include", body: fd },
-      )
-        .then(function (r) {
-          return r.json().then(function (body) {
-            return { ok: r.ok, status: r.status, body: body };
-          });
-        })
-        .then(function (res) {
-          if (!res.ok) {
-            _removeChipDom(placeholderId);
-            pending.delete(placeholderId);
-            onError((res.body && res.body.error) || "Upload failed");
-            return;
-          }
-          _swapPlaceholder(placeholderId, res.body);
-        })
-        .catch(function (e) {
+    _authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
+      { method: "POST", credentials: "include", body: fd },
+    )
+      .then(function (r) {
+        return r.json().then(function (body) {
+          return { ok: r.ok, status: r.status, body: body };
+        });
+      })
+      .then(function (res) {
+        if (!res.ok) {
           _removeChipDom(placeholderId);
           pending.delete(placeholderId);
-          if (e && e.message !== "auth") onError("Upload failed", e);
-        });
-    }
-
-    function remove(attachmentId) {
-      var info = pending.get(attachmentId);
-      if (!info) return;
-      _removeChipDom(attachmentId);
-      pending.delete(attachmentId);
-      if (info.uploading) return; // no server-side row yet
-      var wsId = getWsId();
-      if (!wsId) return;
-      _authFetch(
-        "/v1/api/workstreams/" +
-          encodeURIComponent(wsId) +
-          "/attachments/" +
-          encodeURIComponent(attachmentId),
-        { method: "DELETE", credentials: "include" },
-      ).catch(function () {
-        // Non-fatal — chip is gone client-side; the row will be
-        // garbage-collected by the attachment GC sweep.
-      });
-    }
-
-    function clearChips() {
-      pending.clear();
-      chipsEl.textContent = "";
-    }
-
-    function rehydrate() {
-      var wsId = getWsId();
-      if (!wsId) return Promise.resolve();
-      return _authFetch(
-        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
-        { method: "GET", credentials: "include" },
-      )
-        .then(function (r) {
-          return r.ok ? r.json() : null;
-        })
-        .then(function (body) {
-          if (!body) return;
-          // Tab swap mid-fetch: a stale response would clobber the new
-          // tab's chips with the old tab's data. Re-check the live
-          // wsId before mutating any DOM.
-          if (getWsId() !== wsId) return;
-          clearChips();
-          (body.attachments || []).forEach(function (a) {
-            pending.set(a.attachment_id, a);
-            renderChip(a);
-          });
-        })
-        .catch(function () {
-          /* non-fatal */
-        });
-    }
-
-    function snapshot() {
-      var attachments = [];
-      var ids = [];
-      pending.forEach(function (info, id) {
-        if (info && !info.uploading) {
-          attachments.push(info);
-          ids.push(id);
+          onError((res.body && res.body.error) || "Upload failed");
+          return;
         }
+        _swapPlaceholder(placeholderId, res.body);
+      })
+      .catch(function (e) {
+        _removeChipDom(placeholderId);
+        pending.delete(placeholderId);
+        if (e && e.message !== "auth") onError("Upload failed", e);
       });
-      return { attachments: attachments, attachment_ids: ids };
-    }
-
-    function consume(attachedIds, droppedIds) {
-      if (Array.isArray(attachedIds)) {
-        attachedIds.forEach(function (id) {
-          _removeChipDom(id);
-          pending.delete(id);
-        });
-        if (Array.isArray(droppedIds) && droppedIds.length) {
-          onError(
-            "Some attachments couldn’t be included (" +
-              droppedIds.length +
-              ") — they’re still in your composer.",
-          );
-        }
-      } else {
-        clearChips();
-      }
-    }
-
-    function isEmpty() {
-      return pending.size === 0;
-    }
-
-    return {
-      upload: upload,
-      remove: remove,
-      clearChips: clearChips,
-      rehydrate: rehydrate,
-      snapshot: snapshot,
-      consume: consume,
-      isEmpty: isEmpty,
-    };
   }
 
-  root.createAttachmentController = createAttachmentController;
-})(typeof window !== "undefined" ? window : globalThis);
+  function remove(attachmentId) {
+    var info = pending.get(attachmentId);
+    if (!info) return;
+    _removeChipDom(attachmentId);
+    pending.delete(attachmentId);
+    if (info.uploading) return; // no server-side row yet
+    var wsId = getWsId();
+    if (!wsId) return;
+    _authFetch(
+      "/v1/api/workstreams/" +
+        encodeURIComponent(wsId) +
+        "/attachments/" +
+        encodeURIComponent(attachmentId),
+      { method: "DELETE", credentials: "include" },
+    ).catch(function () {
+      // Non-fatal — chip is gone client-side; the row will be
+      // garbage-collected by the attachment GC sweep.
+    });
+  }
+
+  function clearChips() {
+    pending.clear();
+    chipsEl.textContent = "";
+  }
+
+  function rehydrate() {
+    var wsId = getWsId();
+    if (!wsId) return Promise.resolve();
+    return _authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
+      { method: "GET", credentials: "include" },
+    )
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
+      .then(function (body) {
+        if (!body) return;
+        // Tab swap mid-fetch: a stale response would clobber the new
+        // tab's chips with the old tab's data. Re-check the live
+        // wsId before mutating any DOM.
+        if (getWsId() !== wsId) return;
+        clearChips();
+        (body.attachments || []).forEach(function (a) {
+          pending.set(a.attachment_id, a);
+          renderChip(a);
+        });
+      })
+      .catch(function () {
+        /* non-fatal */
+      });
+  }
+
+  function snapshot() {
+    var attachments = [];
+    var ids = [];
+    pending.forEach(function (info, id) {
+      if (info && !info.uploading) {
+        attachments.push(info);
+        ids.push(id);
+      }
+    });
+    return { attachments: attachments, attachment_ids: ids };
+  }
+
+  function consume(attachedIds, droppedIds) {
+    if (Array.isArray(attachedIds)) {
+      attachedIds.forEach(function (id) {
+        _removeChipDom(id);
+        pending.delete(id);
+      });
+      if (Array.isArray(droppedIds) && droppedIds.length) {
+        onError(
+          "Some attachments couldn’t be included (" +
+            droppedIds.length +
+            ") — they’re still in your composer.",
+        );
+      }
+    } else {
+      clearChips();
+    }
+  }
+
+  function isEmpty() {
+    return pending.size === 0;
+  }
+
+  return {
+    upload: upload,
+    remove: remove,
+    clearChips: clearChips,
+    rehydrate: rehydrate,
+    snapshot: snapshot,
+    consume: consume,
+    isEmpty: isEmpty,
+  };
+}
+
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+window.createAttachmentController = createAttachmentController;

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -48,182 +48,181 @@
  *       Caller invokes once per busy → idle transition. Strips queued
  *       styling from every bubble and then fires the onIdle hook.
  */
-(function (root) {
-  "use strict";
-
-  function createQueueController(opts) {
-    if (!opts || !opts.messagesEl)
-      throw new Error("createQueueController: messagesEl required");
-    if (typeof opts.getWsId !== "function")
-      throw new Error("createQueueController: getWsId must be a function");
-    var messagesEl = opts.messagesEl;
-    var getWsId = opts.getWsId;
-    var wrapInBody = !!opts.wrapInBody;
-    var onAfterDequeue =
-      typeof opts.onAfterDequeue === "function" ? opts.onAfterDequeue : null;
-    var onIdle = typeof opts.onIdle === "function" ? opts.onIdle : null;
-    // Lazy authFetch lookup — see composer_attachments.js for the
-    // rationale; same load-order robustness applies here.
-    function _authFetch(url, init) {
-      var fn = opts.authFetch || root.authFetch;
-      return fn(url, init);
-    }
-
-    function _scrollIntoView() {
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    }
-
-    function _deleteRequest(msgId) {
-      var wsId = getWsId();
-      if (!wsId || !msgId) return null;
-      return _authFetch(
-        "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
-        {
-          method: "DELETE",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ msg_id: msgId }),
-        },
-      );
-    }
-
-    // Fire-and-forget DELETE — used by bind() on a raced-away bubble
-    // where the caller has no DOM follow-up. Still invokes
-    // onAfterDequeue on success: the server-side reservation release
-    // freed any attachments the queued message held, and the caller
-    // typically rehydrates its chip pile so the user can reuse them.
-    function _sendDelete(msgId) {
-      var p = _deleteRequest(msgId);
-      if (!p) return;
-      p.then(function () {
-        if (onAfterDequeue) onAfterDequeue();
-      }).catch(function () {
-        /* network error — promote loop strips queued styling on idle */
-      });
-    }
-
-    function addQueuedMessage(text, priority) {
-      var el = document.createElement("div");
-      el.className = "msg user msg-queued";
-      el.setAttribute("role", "status");
-      var important = priority === "important";
-      if (important) {
-        el.classList.add("msg-queued-important");
-        el.setAttribute("aria-label", "Important message queued: " + text);
-      } else {
-        el.setAttribute("aria-label", "Message queued: " + text);
-      }
-
-      var badge = document.createElement("span");
-      badge.className = "queued-badge";
-      badge.setAttribute("aria-hidden", "true");
-      badge.textContent = important ? "queued (!!!) " : "queued ";
-
-      var textNode = document.createTextNode(text);
-
-      var dismiss = document.createElement("button");
-      dismiss.type = "button";
-      dismiss.className = "queued-dismiss";
-      dismiss.title = "Remove from queue";
-      dismiss.setAttribute("aria-label", "Remove queued message");
-      dismiss.textContent = "×";
-      dismiss.addEventListener("click", function (e) {
-        e.stopPropagation();
-        dequeue(el);
-      });
-
-      var host;
-      if (wrapInBody) {
-        host = document.createElement("div");
-        host.className = "msg-body";
-        el.appendChild(host);
-      } else {
-        host = el;
-      }
-      host.appendChild(badge);
-      host.appendChild(textNode);
-      host.appendChild(dismiss);
-
-      messagesEl.appendChild(el);
-      _scrollIntoView();
-      return el;
-    }
-
-    // Dismiss flow:
-    // - msg_id known → DELETE /send, optimistically remove on success.
-    // - msg_id not yet bound → mark pendingDismiss; bind() picks it up
-    //   when the send response arrives.
-    function dequeue(el) {
-      var msgId = el.dataset.msgId;
-      if (!msgId) {
-        el.dataset.pendingDismiss = "true";
-        el.remove();
-        return;
-      }
-      var p = _deleteRequest(msgId);
-      if (!p) return;
-      p.then(function (r) {
-        return r.json();
-      })
-        .then(function (data) {
-          if (data && data.status === "removed") el.remove();
-          if (onAfterDequeue) onAfterDequeue();
-        })
-        .catch(function () {
-          /* network error — promote loop strips queued styling on idle */
-        });
-    }
-
-    // Server returned status:queued + msg_id. Stamps msgId onto the
-    // bubble, OR releases the slot server-side when the bubble can no
-    // longer be dequeued from the UI (user dismissed pre-bind, or the
-    // promote sweep raced ahead and stripped .msg-queued / its dismiss
-    // button). Caller need only invoke; the controller handles all
-    // three races without further callbacks.
-    function bind(el, msgId) {
-      if (!el || !msgId) return;
-      var racedAway =
-        el.dataset.pendingDismiss || !el.classList.contains("msg-queued");
-      if (racedAway) {
-        _sendDelete(msgId);
-        return;
-      }
-      el.dataset.msgId = msgId;
-    }
-
-    function remove(el) {
-      if (el && el.parentNode) el.remove();
-    }
-
-    // Caller invokes onIdleEdge() exactly once per busy → idle
-    // transition. The controller strips queued styling from every
-    // bubble (so optimistic queues render as normal user messages
-    // once the worker has drained them) and then fires the optional
-    // onIdle hook so the consumer can run its own edge-only cleanup
-    // (e.g. clearing the cancel/force-stop timers) without each
-    // consumer re-implementing the same edge-detection logic.
-    function onIdleEdge() {
-      var queued = messagesEl.querySelectorAll(".msg-queued");
-      queued.forEach(function (el) {
-        el.classList.remove("msg-queued", "msg-queued-important");
-        delete el.dataset.msgId;
-        el.removeAttribute("role");
-        el.removeAttribute("aria-label");
-        var badge = el.querySelector(".queued-badge");
-        if (badge) badge.remove();
-        var dismiss = el.querySelector(".queued-dismiss");
-        if (dismiss) dismiss.remove();
-      });
-      if (onIdle) onIdle();
-    }
-
-    return {
-      addQueuedMessage: addQueuedMessage,
-      bind: bind,
-      remove: remove,
-      onIdleEdge: onIdleEdge,
-    };
+export function createQueueController(opts) {
+  if (!opts || !opts.messagesEl)
+    throw new Error("createQueueController: messagesEl required");
+  if (typeof opts.getWsId !== "function")
+    throw new Error("createQueueController: getWsId must be a function");
+  var messagesEl = opts.messagesEl;
+  var getWsId = opts.getWsId;
+  var wrapInBody = !!opts.wrapInBody;
+  var onAfterDequeue =
+    typeof opts.onAfterDequeue === "function" ? opts.onAfterDequeue : null;
+  var onIdle = typeof opts.onIdle === "function" ? opts.onIdle : null;
+  // Lazy authFetch lookup — see composer_attachments.js for the
+  // rationale; same load-order robustness applies here.
+  function _authFetch(url, init) {
+    var fn = opts.authFetch || window.authFetch;
+    return fn(url, init);
   }
 
-  root.createQueueController = createQueueController;
-})(typeof window !== "undefined" ? window : globalThis);
+  function _scrollIntoView() {
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function _deleteRequest(msgId) {
+    var wsId = getWsId();
+    if (!wsId || !msgId) return null;
+    return _authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
+      {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ msg_id: msgId }),
+      },
+    );
+  }
+
+  // Fire-and-forget DELETE — used by bind() on a raced-away bubble
+  // where the caller has no DOM follow-up. Still invokes
+  // onAfterDequeue on success: the server-side reservation release
+  // freed any attachments the queued message held, and the caller
+  // typically rehydrates its chip pile so the user can reuse them.
+  function _sendDelete(msgId) {
+    var p = _deleteRequest(msgId);
+    if (!p) return;
+    p.then(function () {
+      if (onAfterDequeue) onAfterDequeue();
+    }).catch(function () {
+      /* network error — promote loop strips queued styling on idle */
+    });
+  }
+
+  function addQueuedMessage(text, priority) {
+    var el = document.createElement("div");
+    el.className = "msg user msg-queued";
+    el.setAttribute("role", "status");
+    var important = priority === "important";
+    if (important) {
+      el.classList.add("msg-queued-important");
+      el.setAttribute("aria-label", "Important message queued: " + text);
+    } else {
+      el.setAttribute("aria-label", "Message queued: " + text);
+    }
+
+    var badge = document.createElement("span");
+    badge.className = "queued-badge";
+    badge.setAttribute("aria-hidden", "true");
+    badge.textContent = important ? "queued (!!!) " : "queued ";
+
+    var textNode = document.createTextNode(text);
+
+    var dismiss = document.createElement("button");
+    dismiss.type = "button";
+    dismiss.className = "queued-dismiss";
+    dismiss.title = "Remove from queue";
+    dismiss.setAttribute("aria-label", "Remove queued message");
+    dismiss.textContent = "×";
+    dismiss.addEventListener("click", function (e) {
+      e.stopPropagation();
+      dequeue(el);
+    });
+
+    var host;
+    if (wrapInBody) {
+      host = document.createElement("div");
+      host.className = "msg-body";
+      el.appendChild(host);
+    } else {
+      host = el;
+    }
+    host.appendChild(badge);
+    host.appendChild(textNode);
+    host.appendChild(dismiss);
+
+    messagesEl.appendChild(el);
+    _scrollIntoView();
+    return el;
+  }
+
+  // Dismiss flow:
+  // - msg_id known → DELETE /send, optimistically remove on success.
+  // - msg_id not yet bound → mark pendingDismiss; bind() picks it up
+  //   when the send response arrives.
+  function dequeue(el) {
+    var msgId = el.dataset.msgId;
+    if (!msgId) {
+      el.dataset.pendingDismiss = "true";
+      el.remove();
+      return;
+    }
+    var p = _deleteRequest(msgId);
+    if (!p) return;
+    p.then(function (r) {
+      return r.json();
+    })
+      .then(function (data) {
+        if (data && data.status === "removed") el.remove();
+        if (onAfterDequeue) onAfterDequeue();
+      })
+      .catch(function () {
+        /* network error — promote loop strips queued styling on idle */
+      });
+  }
+
+  // Server returned status:queued + msg_id. Stamps msgId onto the
+  // bubble, OR releases the slot server-side when the bubble can no
+  // longer be dequeued from the UI (user dismissed pre-bind, or the
+  // promote sweep raced ahead and stripped .msg-queued / its dismiss
+  // button). Caller need only invoke; the controller handles all
+  // three races without further callbacks.
+  function bind(el, msgId) {
+    if (!el || !msgId) return;
+    var racedAway =
+      el.dataset.pendingDismiss || !el.classList.contains("msg-queued");
+    if (racedAway) {
+      _sendDelete(msgId);
+      return;
+    }
+    el.dataset.msgId = msgId;
+  }
+
+  function remove(el) {
+    if (el && el.parentNode) el.remove();
+  }
+
+  // Caller invokes onIdleEdge() exactly once per busy → idle
+  // transition. The controller strips queued styling from every
+  // bubble (so optimistic queues render as normal user messages
+  // once the worker has drained them) and then fires the optional
+  // onIdle hook so the consumer can run its own edge-only cleanup
+  // (e.g. clearing the cancel/force-stop timers) without each
+  // consumer re-implementing the same edge-detection logic.
+  function onIdleEdge() {
+    var queued = messagesEl.querySelectorAll(".msg-queued");
+    queued.forEach(function (el) {
+      el.classList.remove("msg-queued", "msg-queued-important");
+      delete el.dataset.msgId;
+      el.removeAttribute("role");
+      el.removeAttribute("aria-label");
+      var badge = el.querySelector(".queued-badge");
+      if (badge) badge.remove();
+      var dismiss = el.querySelector(".queued-dismiss");
+      if (dismiss) dismiss.remove();
+    });
+    if (onIdle) onIdle();
+  }
+
+  return {
+    addQueuedMessage: addQueuedMessage,
+    bind: bind,
+    remove: remove,
+    onIdleEdge: onIdleEdge,
+  };
+}
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+window.createQueueController = createQueueController;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -130,11 +130,6 @@ function _toolAnnounceText(items) {
 // throws on a shell-only seam.  The standalone shell (app.js) and the console
 // factory (createInteractivePane) each pass a richer host.
 const INTERACTIVE_DEFAULT_HOST = {
-  // Workstream display name — the surrounding shell knows it; a bare pane falls
-  // back to a short id (see updateWsName).
-  getWsName() {
-    return null;
-  },
   // Is THIS pane the user's current focus?  Gates focus-stealing so a caret is
   // never yanked into a backgrounded pane.  A lone pane is always focused.
   isFocused() {
@@ -163,19 +158,17 @@ class Pane {
     this.wsId = wsId || null;
     // Transport + host seam.  ``base`` is the node-proxy URL prefix ("" for a
     // local session, "/node/{id}" when the console proxies a session that lives
-    // on a cluster node — the LOCALITY invariant).  ``embedded`` drops the
-    // standalone split-pane chrome (focus tracking, context menu, split/close
-    // buttons) for the L-shell's tab + slim header.  ``host`` supplies the few
-    // things only the surrounding shell knows (workstream name, which pane is
-    // focused, the stream-error recovery policy, the warning-banner target);
-    // see the standalone adapter in app.js and createInteractivePane below.
+    // on a cluster node — the LOCALITY invariant).  ``host`` supplies the few
+    // things only the surrounding shell knows (which pane is focused, the
+    // stream-error recovery policy, the warning-banner target); see
+    // createInteractivePane below.  Every pane is L-shell-hosted — the
+    // standalone split-pane chrome (focus tracking, context menu, header with
+    // split/close buttons) was retired with the step-6 fork collapse.
     this._base = opts.base || "";
-    this._embedded = !!opts.embedded;
     this._host = opts.host || INTERACTIVE_DEFAULT_HOST;
     this._onClose = typeof opts.onClose === "function" ? opts.onClose : null;
     this.evtSource = null;
     this.el = null;
-    this.headerEl = null;
     this.messagesEl = null;
     this.inputEl = null;
     this.sendBtn = null;
@@ -229,16 +222,6 @@ class Pane {
     this.attachments.clearChips();
     this._stopRecording(true);
     this._stopTTS();
-  }
-
-  updateWsName() {
-    if (!this.headerEl) return; // no header in the embedded L-shell pane
-    const nameEl = this.headerEl.querySelector(".pane-ws-name");
-    if (nameEl) {
-      nameEl.textContent = this.wsId
-        ? this._host.getWsName(this.wsId) || this.wsId.substring(0, 8)
-        : "";
-    }
   }
 
   disconnectSSE() {
@@ -610,8 +593,7 @@ class Pane {
 
   _createDOM() {
     this.el = document.createElement("div");
-    this.el.className = "pane";
-    if (this._embedded) this.el.classList.add("pane--embedded");
+    this.el.className = "pane pane--embedded";
     this.el.dataset.paneId = this.id;
 
     // Approval keyboard shortcuts.  The converged card advertises y/n/a (+Enter/
@@ -648,98 +630,12 @@ class Pane {
       }
     });
 
-    // Standalone split-pane affordances: focus tracking + the right-click
-    // split/close menu.  In the L-shell the tab bar owns focus and the per-tab
-    // action menu, so an embedded pane wires none of it.
-    if (!this._embedded) {
-      // Focus on mousedown (before child clicks)
-      this.el.addEventListener("mousedown", () => {
-        setFocusedPane(this.id);
-      });
-      // Also track keyboard focus moving into this pane (e.g. Tab into textarea)
-      this.el.addEventListener(
-        "focusin",
-        () => {
-          setFocusedPane(this.id);
-        },
-        true,
-      );
-
-      // Right-click context menu for split/close actions — skip interactive
-      // elements (textareas, links, buttons) so native copy/paste works
-      this.el.addEventListener("contextmenu", (e) => {
-        const tag = e.target.tagName;
-        if (
-          tag === "TEXTAREA" ||
-          tag === "INPUT" ||
-          tag === "A" ||
-          tag === "BUTTON" ||
-          e.target.isContentEditable
-        )
-          return;
-        const sel = window.getSelection();
-        if (sel && sel.toString().length > 0) return;
-        e.preventDefault();
-        setFocusedPane(this.id);
-        showPaneContextMenu(e.clientX, e.clientY, this.id);
-      });
-    }
-
-    // No pane header in the L-shell (embedded): the workstream name, persona,
-    // and state are shown by the tab and the rail (Workspaces).  The standalone
-    // split-pane (retired in step 6) still builds a header for its split/close
-    // actions.  The --skip-permissions banner lands in messagesEl now (see the
-    // host warningTarget), not the header.
-    if (!this._embedded) {
-      this.headerEl = document.createElement("div");
-      this.headerEl.className = "pane-header";
-
-      const wsName = document.createElement("span");
-      wsName.className = "pane-ws-name";
-      wsName.textContent = this.wsId
-        ? this._host.getWsName(this.wsId) || this.wsId.substring(0, 8)
-        : "";
-      this.headerEl.appendChild(wsName);
-
-      const actions = document.createElement("div");
-      actions.className = "pane-actions";
-
-      const splitRightBtn = document.createElement("button");
-      splitRightBtn.className = "pane-action-btn";
-      splitRightBtn.title = "Split right";
-      splitRightBtn.setAttribute("aria-label", "Split right");
-      splitRightBtn.textContent = "\u2502";
-      splitRightBtn.onclick = (e) => {
-        e.stopPropagation();
-        splitPane(this.id, "horizontal");
-      };
-      actions.appendChild(splitRightBtn);
-
-      const splitDownBtn = document.createElement("button");
-      splitDownBtn.className = "pane-action-btn";
-      splitDownBtn.title = "Split down";
-      splitDownBtn.setAttribute("aria-label", "Split down");
-      splitDownBtn.textContent = "\u2500";
-      splitDownBtn.onclick = (e) => {
-        e.stopPropagation();
-        splitPane(this.id, "vertical");
-      };
-      actions.appendChild(splitDownBtn);
-
-      const closeBtn = document.createElement("button");
-      closeBtn.className = "pane-action-btn pane-close-btn";
-      closeBtn.title = "Close pane";
-      closeBtn.setAttribute("aria-label", "Close pane");
-      closeBtn.textContent = "\u00d7";
-      closeBtn.onclick = (e) => {
-        e.stopPropagation();
-        if (countLeaves(splitRoot) > 1) closePane(this.id);
-      };
-      actions.appendChild(closeBtn);
-
-      this.headerEl.appendChild(actions);
-      this.el.appendChild(this.headerEl);
-    }
+    // No pane header: the workstream name, persona, and state are shown by the
+    // tab and the rail (Workspaces); the --skip-permissions banner lands in
+    // messagesEl (see the host warningTarget).  The standalone split-pane
+    // chrome that used to live here (focus tracking, right-click context menu,
+    // a header with split/close buttons) was retired with the step-6 fork
+    // collapse.
 
     // Messages area
     this.messagesEl = document.createElement("div");
@@ -3312,24 +3208,6 @@ function createInteractivePane(root, wsId, opts) {
   };
 
   const host = {
-    // Workstream name from the Tier-1 cluster snapshot the shell owns, else the
-    // name the opener passed; Pane falls back to a short id.
-    getWsName(id) {
-      try {
-        const TS = window.TS_APP;
-        const cs = TS && TS.getClusterState && TS.getClusterState();
-        if (cs && cs.nodes) {
-          for (const nid in cs.nodes) {
-            for (const ws of cs.nodes[nid].workstreams || []) {
-              if (ws.id === id) return ws.name || ws.title || null;
-            }
-          }
-        }
-      } catch (e) {
-        /* snapshot not ready yet */
-      }
-      return opts.name || null;
-    },
     // Only the visible tab steals focus — never yank the caret into a
     // backgrounded pane mid background-replay.
     isFocused() {
@@ -3373,7 +3251,6 @@ function createInteractivePane(root, wsId, opts) {
   };
 
   const pane = new Pane(wsId, {
-    embedded: true,
     base,
     host,
     onClose: opts.onClose,

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -11,13 +11,10 @@
 //  session living on a cluster node (the LOCALITY invariant).
 //
 //  ES module — the first legacy pane lifted into a real module (step 5a; the
-//  coordinator pane followed in 5e.0).  The shared substrate it leans on —
-//  composer/renderer/etc. — is still classic, consumed as globals.  The console
-//  shell.js imports the factory directly; the standalone loads it as
-//  `<script type="module">`.  It also publishes `window.InteractivePane` /
-//  `window.createInteractivePane` so the still-classic standalone `app.js`
-//  shell can read the class — safe because app.js builds panes only AFTER the
-//  workstream fetch resolves, well after this deferred module has executed.
+//  coordinator pane followed in 5e.0, and the shared substrate it leans on —
+//  composer/renderer/auth/etc. — became modules too, imported below).  The
+//  console shell.js imports the factory directly; the standalone loads it as
+//  `<script type="module">`.
 //
 //  House style: programmatic DOM, NO innerHTML (the renderer is the sole
 //  sanctioned exception); pane code root-scopes to its own element.
@@ -37,6 +34,14 @@ import {
   batchKicker,
   indexLabel,
 } from "./conversation.js";
+import { authFetch } from "./auth.js";
+import { showToast } from "./toast.js";
+import { Composer } from "./composer.js";
+import { createAttachmentController } from "./composer_attachments.js";
+import { createQueueController } from "./composer_queue.js";
+import { StatusBar } from "./status_bar.js";
+import { streamingRender, streamingRenderFinalize } from "./renderer.js";
+import { setMarkdown, operatorSourceLabel } from "./utils.js";
 
 let _paneCounter = 0;
 

--- a/turnstone/shared_static/kb.js
+++ b/turnstone/shared_static/kb.js
@@ -1,9 +1,12 @@
 /* Shared keyboard shortcuts overlay — turnstone design system
-   Configure: window.TURNSTONE_KB_SHORTCUTS = [{title, keys: [{desc, badge}]}] */
+   Configure: window.TURNSTONE_KB_SHORTCUTS = [{title, keys: [{desc, badge}]}]
+   ES module; the "?" / Escape document listener registers at module eval. */
+
+import { escapeHtml, setSafeHtml } from "./utils.js";
 
 let _kbPreviousFocus = null;
 
-function showKbHelp() {
+export function showKbHelp() {
   _kbPreviousFocus = document.activeElement;
   const existing = document.getElementById("kb-overlay");
   if (existing) existing.remove();
@@ -35,7 +38,7 @@ function showKbHelp() {
   document.getElementById("kb-box").focus();
 }
 
-function hideKbHelp() {
+export function hideKbHelp() {
   const el = document.getElementById("kb-overlay");
   if (el) el.remove();
   if (_kbPreviousFocus && _kbPreviousFocus.focus) {
@@ -62,3 +65,8 @@ document.addEventListener("keydown", function (e) {
     }
   }
 });
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+Object.assign(window, { showKbHelp, hideKbHelp });

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -165,10 +165,16 @@ export function openPopupMenu(anchor, items, opts) {
     ) {
       e.preventDefault();
       if (!btns.length) return;
+      // idx -1 = no item focused (a click on a separator / the menu surface
+      // moves focus off the items without closing).  ArrowDown's modulo
+      // already enters at the top then; ArrowUp must enter at the BOTTOM —
+      // unguarded, (-1 - 1 + n) % n lands on the second-to-last item.
       const idx = btns.indexOf(document.activeElement);
       if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
       else if (e.key === "ArrowUp")
-        btns[(idx - 1 + btns.length) % btns.length].focus();
+        btns[
+          idx < 0 ? btns.length - 1 : (idx - 1 + btns.length) % btns.length
+        ].focus();
       else if (e.key === "Home") btns[0].focus();
       else btns[btns.length - 1].focus();
     }

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -58,6 +58,137 @@ export class ShellPane {
 }
 
 /**
+ * Generic popup menu on the shared `.tab-menu` chrome — items, positioning,
+ * dismissal (Escape/Tab, outside-mousedown), and arrow-key roving in one
+ * place.  Used by the PaneManager's tab-action dropdown and the shell's
+ * footer user menu (one menu vocabulary, one behaviour).
+ *
+ * `items` are `{label, key?, cls?, separator?, action}`.  `opts`:
+ *   - label:         the menu's aria-label.
+ *   - cls:           extra class(es) on the `.tab-menu` element.
+ *   - prefer:        "down" (default) opens under the anchor, flipping up on
+ *                    overflow; "up" the reverse (e.g. a viewport-bottom chip).
+ *   - align:         "end" (default) right-aligns to the anchor; "start" left.
+ *   - expandEl:      element whose aria-expanded mirrors the menu (often the
+ *                    anchor's host button).
+ *   - returnFocusEl: focus target when the menu closes via keyboard.
+ *   - ignoreEl:      outside-mousedown ignore region (defaults to the anchor).
+ *   - onClose:       cleanup notification (fires exactly once).
+ *
+ * Returns `{ menu, close }`; `close()` is idempotent.
+ */
+export function openPopupMenu(anchor, items, opts) {
+  opts = opts || {};
+  const menu = document.createElement("div");
+  menu.className = "tab-menu" + (opts.cls ? " " + opts.cls : "");
+  menu.setAttribute("role", "menu");
+  if (opts.label) menu.setAttribute("aria-label", opts.label);
+
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener("keydown", onKey);
+    document.removeEventListener("mousedown", onDown);
+    if (menu.parentNode) menu.parentNode.removeChild(menu);
+    if (opts.expandEl && opts.expandEl.isConnected)
+      opts.expandEl.setAttribute("aria-expanded", "false");
+    if (opts.onClose) opts.onClose();
+  };
+
+  for (const item of items) {
+    if (item.separator) {
+      const sep = document.createElement("div");
+      sep.className = "tab-menu-sep";
+      sep.setAttribute("role", "separator");
+      menu.append(sep);
+      continue;
+    }
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "tab-menu-item" + (item.cls ? " " + item.cls : "");
+    btn.setAttribute("role", "menuitem");
+    btn.tabIndex = -1;
+    const label = document.createElement("span");
+    label.className = "tab-menu-label";
+    label.textContent = item.label;
+    btn.append(label);
+    if (item.key) {
+      const key = document.createElement("span");
+      key.className = "tab-menu-key";
+      key.setAttribute("aria-hidden", "true"); // a visual hint, not the action
+      key.textContent = item.key;
+      btn.append(key);
+    }
+    btn.addEventListener("click", () => {
+      close();
+      try {
+        item.action();
+      } catch (e) {
+        console.error("popup menu: action failed", item.label, e);
+      }
+    });
+    menu.append(btn);
+  }
+  document.body.append(menu);
+
+  // Position fixed against the anchor; flip on overflow, clamp to viewport.
+  const ar = anchor.getBoundingClientRect();
+  const mr = menu.getBoundingClientRect();
+  let x = opts.align === "start" ? ar.left : ar.right - mr.width;
+  if (x < 4) x = 4;
+  if (x + mr.width > window.innerWidth) x = window.innerWidth - mr.width - 4;
+  let y;
+  if (opts.prefer === "up") {
+    y = ar.top - mr.height - 4;
+    if (y < 4) y = ar.bottom + 4;
+  } else {
+    y = ar.bottom + 2;
+    if (y + mr.height > window.innerHeight) y = ar.top - mr.height - 2;
+    if (y < 4) y = 4; // never strand the menu above the viewport (short window)
+  }
+  menu.style.left = x + "px";
+  menu.style.top = y + "px";
+  if (opts.expandEl) opts.expandEl.setAttribute("aria-expanded", "true");
+
+  const onKey = (e) => {
+    const btns = Array.from(menu.querySelectorAll(".tab-menu-item"));
+    if (e.key === "Escape" || e.key === "Tab") {
+      e.preventDefault();
+      close();
+      if (opts.returnFocusEl) opts.returnFocusEl.focus();
+    } else if (
+      e.key === "ArrowDown" ||
+      e.key === "ArrowUp" ||
+      e.key === "Home" ||
+      e.key === "End"
+    ) {
+      e.preventDefault();
+      if (!btns.length) return;
+      const idx = btns.indexOf(document.activeElement);
+      if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
+      else if (e.key === "ArrowUp")
+        btns[(idx - 1 + btns.length) % btns.length].focus();
+      else if (e.key === "Home") btns[0].focus();
+      else btns[btns.length - 1].focus();
+    }
+  };
+  const ignoreEl = opts.ignoreEl || anchor;
+  const onDown = (e) => {
+    if (!menu.contains(e.target) && !ignoreEl.contains(e.target)) close();
+  };
+  document.addEventListener("keydown", onKey);
+  // Defer the outside-mousedown attach a tick so the opening click that
+  // bubbled to document doesn't immediately re-close the menu.
+  setTimeout(() => {
+    if (!closed) document.addEventListener("mousedown", onDown);
+  }, 0);
+  const first = menu.querySelector(".tab-menu-item");
+  if (first) first.focus();
+  return { menu, close };
+}
+
+/**
  * Owns the tab bar + pane host.  `openPane(type, id?)` is create-or-focus;
  * singletons are keyed by `type`, multi-instance panes by `type:id`.
  */
@@ -436,8 +567,8 @@ export class PaneManager {
 
   /** Open a pane's tab-action dropdown, anchored under its caret.  Generic: the
    *  item set comes from `pane.tabMenu()` (wired per type in the shell); the
-   *  PaneManager owns only the chrome + keyboard + positioning.  Singleton menu —
-   *  opening one closes any other.  Items are
+   *  chrome + keyboard + positioning live in the shared openPopupMenu helper.
+   *  Singleton menu — opening one closes any other.  Items are
    *  `{label, key?, cls?, separator?, action}`. */
   _openTabMenu(tab, pane) {
     this._closeTabMenu();
@@ -449,109 +580,26 @@ export class PaneManager {
       return;
     }
     if (!items.length) return;
-
-    const menu = document.createElement("div");
-    menu.className = "tab-menu";
-    menu.setAttribute("role", "menu");
-    menu.setAttribute("aria-label", (pane.title || "Pane") + " actions");
-    for (const item of items) {
-      if (item.separator) {
-        const sep = document.createElement("div");
-        sep.className = "tab-menu-sep";
-        sep.setAttribute("role", "separator");
-        menu.append(sep);
-        continue;
-      }
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "tab-menu-item" + (item.cls ? " " + item.cls : "");
-      btn.setAttribute("role", "menuitem");
-      btn.tabIndex = -1;
-      const label = document.createElement("span");
-      label.className = "tab-menu-label";
-      label.textContent = item.label;
-      btn.append(label);
-      if (item.key) {
-        const key = document.createElement("span");
-        key.className = "tab-menu-key";
-        key.setAttribute("aria-hidden", "true"); // a visual hint, not the action
-        key.textContent = item.key;
-        btn.append(key);
-      }
-      btn.addEventListener("click", () => {
-        this._closeTabMenu();
-        try {
-          item.action();
-        } catch (e) {
-          console.error("PaneManager: tab action failed", item.label, e);
-        }
-      });
-      menu.append(btn);
-    }
-    document.body.append(menu);
-
-    // Position fixed, right-aligned under the caret; flip up / clamp on overflow.
-    const anchor = tab.querySelector(".tab-caret") || tab;
-    const ar = anchor.getBoundingClientRect();
-    const mr = menu.getBoundingClientRect();
-    let x = ar.right - mr.width;
-    let y = ar.bottom + 2;
-    if (x < 4) x = 4;
-    if (x + mr.width > window.innerWidth) x = window.innerWidth - mr.width - 4;
-    if (y + mr.height > window.innerHeight) y = ar.top - mr.height - 2;
-    if (y < 4) y = 4; // never strand the menu above the viewport (short window)
-    menu.style.left = x + "px";
-    menu.style.top = y + "px";
-    tab.setAttribute("aria-expanded", "true");
-
-    const onKey = (e) => {
-      const btns = Array.from(menu.querySelectorAll(".tab-menu-item"));
-      if (e.key === "Escape" || e.key === "Tab") {
-        e.preventDefault();
-        this._closeTabMenu();
-        tab.focus();
-      } else if (
-        e.key === "ArrowDown" ||
-        e.key === "ArrowUp" ||
-        e.key === "Home" ||
-        e.key === "End"
-      ) {
-        e.preventDefault();
-        if (!btns.length) return;
-        const idx = btns.indexOf(document.activeElement);
-        if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
-        else if (e.key === "ArrowUp")
-          btns[(idx - 1 + btns.length) % btns.length].focus();
-        else if (e.key === "Home") btns[0].focus();
-        else btns[btns.length - 1].focus();
-      }
-    };
-    const onDown = (e) => {
-      if (!menu.contains(e.target) && !tab.contains(e.target))
-        this._closeTabMenu();
-    };
-    this._openMenu = { menu, tab, onKey, onDown };
-    document.addEventListener("keydown", onKey);
-    // Defer the outside-mousedown attach a tick so the opening click that
-    // bubbled to document doesn't immediately re-close the menu.
-    setTimeout(() => {
-      if (this._openMenu && this._openMenu.menu === menu)
-        document.addEventListener("mousedown", onDown);
-    }, 0);
-    const first = menu.querySelector(".tab-menu-item");
-    if (first) first.focus();
+    const handle = openPopupMenu(
+      tab.querySelector(".tab-caret") || tab,
+      items,
+      {
+        label: (pane.title || "Pane") + " actions",
+        expandEl: tab,
+        returnFocusEl: tab,
+        ignoreEl: tab, // a click elsewhere on the tab is menu-adjacent, not "outside"
+        onClose: () => {
+          if (this._openMenu && this._openMenu.handle === handle)
+            this._openMenu = null;
+        },
+      },
+    );
+    this._openMenu = { handle };
   }
 
   /** Tear down the open tab-action dropdown (if any) + its document listeners. */
   _closeTabMenu() {
-    const m = this._openMenu;
-    if (!m) return;
-    this._openMenu = null;
-    document.removeEventListener("keydown", m.onKey);
-    document.removeEventListener("mousedown", m.onDown);
-    if (m.menu.parentNode) m.menu.parentNode.removeChild(m.menu);
-    if (m.tab && m.tab.isConnected)
-      m.tab.setAttribute("aria-expanded", "false");
+    if (this._openMenu) this._openMenu.handle.close(); // onClose clears the ref
   }
 
   _persist() {

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -357,7 +357,12 @@ export class PaneManager {
       tab.append(g);
       pane._glyphEl = g;
     }
-    const titleNode = document.createTextNode(pane.title);
+    // The title is a span (not a bare text node) so CSS can ellipsize it —
+    // tabs cap their width (tighter on mobile) instead of growing unbounded
+    // with a long workstream name.
+    const titleNode = document.createElement("span");
+    titleNode.className = "tab-title";
+    titleNode.textContent = pane.title;
     tab.append(titleNode);
     pane._titleNode = titleNode; // setTabTitle repaints this from Tier-1
     // Tab-action menu (step 7): a pane that exposes `tabMenu()` gets a caret to

--- a/turnstone/shared_static/rail.js
+++ b/turnstone/shared_static/rail.js
@@ -84,10 +84,16 @@ function renderCluster(root, cs, TS) {
     pill.type = "button";
     pill.className = "cpill";
     pill.setAttribute("aria-label", n + " " + STATE_LABEL[st] + ", filter");
+    pill.title = n + " " + STATE_LABEL[st]; // names the glyph+count when the rail is collapsed
     pill.append(glyph(st));
     const b = document.createElement("b");
     b.textContent = String(n);
-    pill.append(b, document.createTextNode(" " + STATE_LABEL[st]));
+    // The label rides in a span so the collapsed rail can hide it and keep the
+    // glyph + count (a bare text node is not CSS-addressable).
+    const lbl = document.createElement("span");
+    lbl.className = "cpill-label";
+    lbl.textContent = " " + STATE_LABEL[st];
+    pill.append(b, lbl);
     pill.addEventListener(
       "click",
       () => TS.drillDownByState && TS.drillDownByState(st),
@@ -148,6 +154,7 @@ function renderCluster(root, cs, TS) {
       item.type = "button";
       item.className = "node-row";
       const st = nodeState(info);
+      item.title = info.node_id; // the .nn label ellipsizes long node ids
       item.setAttribute(
         "aria-label",
         info.node_id + ", " + st + ", " + info.ws_total + " workstreams",
@@ -197,6 +204,9 @@ function sessionRow(ws, childCount, isChild, TS, paneManager, active) {
     "aria-label",
     (ws.name || ws.title || ws.id) + ", " + (ws.state || "idle") + ", " + kind,
   );
+  // Hover name — the expanded row ellipsizes long names; the collapsed rail
+  // shows only the state glyph, so the title is the whole label there.
+  btn.title = ws.name || ws.title || ws.id || "session";
   btn.append(glyph(ws.state || "idle"));
   const nm = document.createElement("span");
   nm.className = "nm";
@@ -244,6 +254,7 @@ function renderWorkspaces(root, cs, TS, paneManager) {
   const dashLi = document.createElement("li");
   const dash = document.createElement("button");
   dash.type = "button";
+  dash.title = "Dashboard"; // the collapsed rail shows only the ◇ glyph
   dash.className =
     "row" + (active && active.type === "dashboard" ? " open" : "");
   const g = document.createElement("span");
@@ -331,6 +342,29 @@ export function mountManage(root, paneManager) {
   const ia = TS.ia || [];
   const allowed = TS.isTabAllowed || (() => true);
   root.replaceChildren();
+
+  // Collapsed-rail representation: the discovery groups need text, so the
+  // collapsed strip shows ONE ⚙ row that opens/focuses the singleton Admin
+  // pane at its current tab (the rail expands back to browse the full map).
+  // Always in the DOM (CSS shows it only while the rail is collapsed), but
+  // permission-gated like the groups: no visible tab, no ⚙ either.
+  if (ia.some((g) => g.tabs.some((t) => allowed(t.tab)))) {
+    const manageGlyph = document.createElement("button");
+    manageGlyph.type = "button";
+    manageGlyph.className = "row manage-glyph";
+    manageGlyph.title = "Manage";
+    manageGlyph.setAttribute("aria-label", "Manage (open admin)");
+    const mg = document.createElement("span");
+    mg.className = "glyph";
+    mg.setAttribute("aria-hidden", "true");
+    mg.textContent = "⚙";
+    manageGlyph.append(mg);
+    manageGlyph.addEventListener(
+      "click",
+      () => paneManager && paneManager.openPane("admin"),
+    );
+    root.append(manageGlyph);
+  }
 
   // If the Admin pane is already open (e.g. restored by PaneManager.rehydrate),
   // seed the rail to its current tab + expand the owning group; otherwise every

--- a/turnstone/shared_static/renderer.js
+++ b/turnstone/shared_static/renderer.js
@@ -1,4 +1,9 @@
 // renderer.js — Markdown + LaTeX rendering (no external deps except KaTeX)
+//
+// ES module (imports utils; vendor hljs/katex/mermaid stay lazy typeof-guarded
+// globals).  Window bridge at the bottom for the still-classic consumers.
+
+import { escapeHtml } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 //  Inline formatting
@@ -8,7 +13,7 @@
 var _SAFE_TAGS =
   /&lt;(\/?(?:br|kbd|mark|sub|sup|ins|wbr|abbr|small|u|s))(?:\s*\/?)&gt;/gi;
 
-function inlineMarkdown(text) {
+export function inlineMarkdown(text) {
   // Escape HTML first so only tags we generate are real
   text = escapeHtml(text);
   // Restore safe HTML tags (attribute-free only — already escaped so no XSS)
@@ -256,7 +261,7 @@ function _langToCssClass(lang) {
 // ---------------------------------------------------------------------------
 //  Main markdown renderer
 // ---------------------------------------------------------------------------
-function renderMarkdown(text) {
+export function renderMarkdown(text) {
   // Scope footnote IDs per top-level render call (prevents collisions across messages)
   if (_fnDepth === 0) _fnScopeId++;
   _fnDepth++;
@@ -808,7 +813,7 @@ function _applyCachedHljs(el, cachedHtml) {
   el.classList.add("hljs");
 }
 
-function postRenderHljs(containerEl) {
+export function postRenderHljs(containerEl) {
   if (typeof hljs === "undefined") return;
   if (!_hljsConfigured) {
     hljs.configure({ ignoreUnescapedHTML: true });
@@ -853,7 +858,7 @@ function postRenderHljs(containerEl) {
   }
 }
 
-function postRenderMarkdown(containerEl) {
+export function postRenderMarkdown(containerEl) {
   postRenderHljs(containerEl);
   // Render mermaid diagrams (lazy-loads mermaid.js on first use)
   postRenderMermaid(containerEl);
@@ -1213,7 +1218,7 @@ function postRenderMermaid(containerEl) {
   });
 }
 
-function reRenderAllMermaid() {
+export function reRenderAllMermaid() {
   if (_mermaidState !== "ready") return;
   _initMermaid();
   var els = document.querySelectorAll(
@@ -1264,7 +1269,7 @@ function _streamingRenderApply(el, buffer) {
   }
 }
 
-function streamingRender(el, buffer) {
+export function streamingRender(el, buffer) {
   if (!el) return;
   // Short-circuit identical-buffer calls (e.g. SSE retry / resume).
   // V8's string === length-compares internally so the explicit check is
@@ -1283,7 +1288,7 @@ function streamingRender(el, buffer) {
   });
 }
 
-function streamingRenderFinalize(el, buffer) {
+export function streamingRenderFinalize(el, buffer) {
   if (!el) return;
   // Flush any pending rAF-scheduled render so the finalize sees the
   // final buffer exactly once, then run the expensive post-render
@@ -1297,3 +1302,16 @@ function streamingRenderFinalize(el, buffer) {
     postRenderMarkdown(el);
   }
 }
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach these as globals at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+Object.assign(window, {
+  renderMarkdown,
+  inlineMarkdown,
+  postRenderHljs,
+  postRenderMarkdown,
+  reRenderAllMermaid,
+  streamingRender,
+  streamingRenderFinalize,
+});

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -474,6 +474,15 @@
   position: relative;
   z-index: 20;
 }
+/* The tabs live in their own strip (the role=tablist element — the burger and
+   the [+] tail sit OUTSIDE it in .tabbar, see shell.js buildShell).  On mobile
+   the strip is the horizontal scroller, so those stay pinned. */
+.tabstrip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
 .tab {
   position: relative;
   flex: none;
@@ -1119,11 +1128,14 @@
   .app.rail-open .rail-scrim {
     display: block;
   }
-  /* tab bar scrolls horizontally; tabs tighten so 2-3 stay legible */
+  /* the tab strip scrolls horizontally (burger + [+] stay pinned); tabs
+     tighten so 2-3 stay legible */
   .tabbar {
+    padding: 8px 8px;
+  }
+  .tabstrip {
     overflow-x: auto;
     scrollbar-width: thin;
-    padding: 8px 8px;
   }
   .tab {
     max-width: 48vw;

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -960,6 +960,10 @@
    stacked cluster glyph+count pills, one ⚙ for Manage.  Hover names come from
    the title attrs rail.js always sets.  Desktop-only: below the drawer
    breakpoint the rail overlays at full width, so the preference lies dormant.
+
+   769 = the drawer's 768 breakpoint + 1 — a matched pair (CSS @media cannot
+   read a shared token).  Change BOTH together or a 1px band gets neither
+   (or both) layouts.
    ========================================================================== */
 @media (min-width: 769px) {
   .app.rail-collapsed {
@@ -1078,6 +1082,9 @@
    ☰ in the tab bar opens it; scrim tap / Escape / opening a pane close it.
    The closed drawer is visibility:hidden so its buttons drop out of the Tab
    order and the a11y tree — not merely translated off-screen.
+
+   768 pairs with the collapse block's min-width: 769px above — change BOTH
+   together (see the note there).
    ========================================================================== */
 @media (max-width: 768px) {
   .app,

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -20,13 +20,13 @@
   height: 100vh;
   overflow: hidden;
 }
-/* Responsive (step 7): DESKTOP-FIRST, by decision — this matches the desktop-only
-   design-system scope (the console's mobile off-canvas drawer was retired in step
-   3b, and the DS itself is desktop-only).  The rail -> off-canvas drawer on mobile
-   is DEFERRED, not dropped: it would slot in here as a `max-width` @media that
-   collapses the 266px rail column into a toggled overlay.  Narrow viewports get a
-   cramped desktop layout (not a broken one) — no silent mobile-support claim.
-   Revisit only if/when the DS takes on a mobile scope. */
+/* Responsive: desktop-first.  Two rail modes beyond the default 266px column,
+   both defined in the "Collapsed rail" / "Mobile drawer" sections at the end of
+   this sheet:
+     - DESKTOP COLLAPSE (user preference, `.app.rail-collapsed`): the rail
+       shrinks to a 52px glyph-only strip — live state glyphs remain the
+       navigation; text labels hide.
+     - The deferred mobile off-canvas drawer (max-width media query). */
 
 /* ===== Rail (the | of the L) ===== */
 .rail {
@@ -80,6 +80,33 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: var(--r-sm);
+}
+/* collapse toggle — far side of the brand row.  Desktop-only: the mobile
+   drawer always presents the full rail, so the button hides there (see the
+   responsive section at the end of this sheet). */
+.rail-collapse {
+  margin-left: auto;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: none;
+  border-radius: var(--r-sm);
+  color: var(--ink-4);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  font-family: var(--font-ui);
+}
+.rail-collapse:hover {
+  background: var(--panel-2);
+  color: var(--ink-2);
+}
+.rail-collapse:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .rail-scroll {
   flex: 1;
@@ -462,6 +489,15 @@
   border: 1px solid transparent;
   background: none;
   font-family: var(--font-ui);
+  /* long workstream names ellipsize (.tab-title) instead of growing the tab */
+  max-width: 240px;
+}
+.tab-title {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 /* Tab glyph spacing — applies to BOTH the static decorative char (Dashboard /
    Admin, via .glyph) and the live state glyph (.ui-glyph-* on conversational
@@ -537,6 +573,39 @@
   align-items: center;
   gap: 8px;
   color: var(--ink-4);
+}
+/* Drawer toggle + backdrop — desktop keeps the rail in the grid, so both are
+   dormant here; the mobile block at the end of this sheet brings them up. */
+.rail-burger {
+  display: none;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-3);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  border: none;
+  background: none;
+  font-family: var(--font-ui);
+  flex: none;
+}
+.rail-burger:hover {
+  background: var(--panel-2);
+  color: var(--ink);
+}
+.rail-burger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.rail-scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 390;
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
 }
 
 /* Tab-action dropdown — promoted to the shared shell sheet so the console and
@@ -809,6 +878,12 @@
 .grp {
   margin-top: 1px;
 }
+/* The Manage section's collapsed-strip stand-in (rail.js mountManage): one ⚙
+   row that opens the Admin pane.  Hidden while the rail is expanded — the
+   collapsed-rail block at the end of this sheet flips it on. */
+.manage-glyph {
+  display: none;
+}
 .grp-head {
   display: flex;
   align-items: center;
@@ -876,4 +951,179 @@
   flex-direction: column;
   /* inset off the tab-bar hairline + rail edge; .admin-content keeps its right pad */
   padding: 16px 0 0 16px;
+}
+
+/* ==========================================================================
+   Collapsed rail (desktop) — `.app.rail-collapsed` shrinks the | of the L to a
+   52px glyph-only strip.  The glyphs ARE the navigation: live session state
+   glyphs (the same Tier-1-fed .ui-glyph-* the expanded rows carry), ◇ home,
+   stacked cluster glyph+count pills, one ⚙ for Manage.  Hover names come from
+   the title attrs rail.js always sets.  Desktop-only: below the drawer
+   breakpoint the rail overlays at full width, so the preference lies dormant.
+   ========================================================================== */
+@media (min-width: 769px) {
+  .app.rail-collapsed {
+    grid-template-columns: 52px 1fr;
+  }
+  /* brand stacks: mark (home) on top, the expand toggle under it */
+  .app.rail-collapsed .rail-brand {
+    flex-direction: column;
+    gap: 10px;
+    padding: 13px 0 11px;
+  }
+  .app.rail-collapsed .brand-name,
+  .app.rail-collapsed .brand-sub {
+    display: none;
+  }
+  .app.rail-collapsed .brand-home {
+    justify-content: center;
+  }
+  .app.rail-collapsed .rail-collapse {
+    margin-left: 0;
+  }
+  .app.rail-collapsed .rail-scroll {
+    padding: 10px 5px 6px;
+    scrollbar-width: thin;
+  }
+  /* section labels become hairline separators (uppercase text won't fit) */
+  .app.rail-collapsed .sec-label {
+    height: 0;
+    padding: 0;
+    margin: 8px 6px;
+    border-top: 1px solid var(--hair);
+    overflow: hidden;
+    font-size: 0;
+  }
+  /* …except the first, which would double the brand row's border-bottom
+     (the conn slot sits between them whether or not #status-bar relocated) */
+  .app.rail-collapsed .rail-conn + .sec-label,
+  .app.rail-collapsed .rail-conn-slot + .sec-label {
+    border-top: 0;
+    margin: 0;
+  }
+  /* connection indicator: glyph-only — the message text collapses away but
+     stays in the DOM for AT; expanding the rail reveals it */
+  .app.rail-collapsed .rail-conn {
+    font-size: 0;
+    padding: 0;
+    text-align: center;
+  }
+  .app.rail-collapsed .rail-conn.disconnected::before {
+    content: "⚠";
+    font-size: 12px;
+    color: var(--warn);
+  }
+  /* cluster card: pills stack as glyph + count; the node list needs text */
+  .app.rail-collapsed .cluster {
+    padding: 7px 4px;
+  }
+  .app.rail-collapsed .cluster-row {
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+  .app.rail-collapsed .cpill-label {
+    display: none;
+  }
+  .app.rail-collapsed .cluster-nodes {
+    display: none;
+  }
+  /* session rows: the live state glyph is the whole row */
+  .app.rail-collapsed .row {
+    justify-content: center;
+    gap: 0;
+    padding: 7px 0;
+  }
+  .app.rail-collapsed .row .nm,
+  .app.rail-collapsed .row .rcount,
+  .app.rail-collapsed .row .tag {
+    display: none;
+  }
+  .app.rail-collapsed .row.open::before {
+    left: 1px;
+  }
+  /* children flatten to peer glyphs — the hierarchy needs text to read, and
+     reachability beats hierarchy in a glyph strip (titles disambiguate) */
+  .app.rail-collapsed .children {
+    margin: 0;
+    padding: 0;
+    border-left: 0;
+  }
+  /* Manage: the ⚙ stand-in replaces the text-only discovery groups */
+  .app.rail-collapsed .grp {
+    display: none;
+  }
+  .app.rail-collapsed .manage-glyph {
+    display: flex;
+  }
+  /* footer stacks: theme toggle above the avatar-only user chip */
+  .app.rail-collapsed .rail-foot {
+    flex-direction: column;
+    gap: 6px;
+    padding: 9px 6px;
+  }
+  .app.rail-collapsed .user-chip {
+    margin: 0;
+    padding: 3px;
+  }
+  .app.rail-collapsed .user-name {
+    display: none;
+  }
+}
+
+/* ==========================================================================
+   Mobile drawer — below the breakpoint the rail leaves the grid and overlays
+   off-canvas at FULL width (the desktop collapse preference lies dormant: a
+   52px strip makes no sense when the rail floats over the content anyway).
+   ☰ in the tab bar opens it; scrim tap / Escape / opening a pane close it.
+   The closed drawer is visibility:hidden so its buttons drop out of the Tab
+   order and the a11y tree — not merely translated off-screen.
+   ========================================================================== */
+@media (max-width: 768px) {
+  .app,
+  .app.rail-collapsed {
+    grid-template-columns: 1fr;
+  }
+  .rail {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(286px, 84vw);
+    z-index: 400;
+    transform: translateX(-100%);
+    visibility: hidden;
+    /* visibility flips AFTER the slide-out finishes (delay = duration) */
+    transition:
+      transform 0.2s ease,
+      visibility 0s linear 0.2s;
+  }
+  .app.rail-open .rail {
+    transform: none;
+    visibility: visible;
+    transition: transform 0.2s ease;
+    box-shadow: 0 0 32px rgba(0, 0, 0, 0.45);
+  }
+  /* the desktop collapse toggle hides — the drawer is always the full rail */
+  .rail-collapse {
+    display: none;
+  }
+  .rail-burger {
+    display: inline-flex;
+  }
+  .app.rail-open .rail-scrim {
+    display: block;
+  }
+  /* tab bar scrolls horizontally; tabs tighten so 2-3 stay legible */
+  .tabbar {
+    overflow-x: auto;
+    scrollbar-width: thin;
+    padding: 8px 8px;
+  }
+  .tab {
+    max-width: 48vw;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .rail {
+    transition: none;
+  }
 }

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -102,8 +102,14 @@ function buildShell(caps) {
   burger.setAttribute("aria-label", "Open navigation");
   burger.setAttribute("aria-controls", "shell-rail");
   burger.setAttribute("aria-expanded", "false");
-  const tail = make("div", "tabbar-right"); // right-floated tab-bar chrome (empty for now)
-  tabbar.append(burger, tail); // managed tabs insert between the two
+  // The tab strip is its OWN element so PaneManager's role="tablist" wraps
+  // ONLY the tabs — the burger and the [+] tail are non-tab focusables and
+  // don't belong inside a tablist's accessibility tree.  It is also the
+  // horizontal scroller on mobile, so burger + [+] stay pinned while tabs
+  // scroll.
+  const tabstrip = make("div", "tabstrip");
+  const tail = make("div", "tabbar-right"); // right-floated tab-bar chrome (the [+])
+  tabbar.append(burger, tabstrip, tail);
   const panes = make("div", "panes");
   content.append(tabbar, panes);
 
@@ -123,6 +129,7 @@ function buildShell(caps) {
     connSlot,
     foot,
     tabbar,
+    tabstrip,
     tail,
     panes,
     clusterSec,
@@ -467,10 +474,12 @@ async function mountShell() {
   };
 
   // ----- PaneManager: one new spine -----
+  // It owns the tabstrip (role=tablist), NOT the whole tab bar: the burger and
+  // the [+] tail live outside the strip so the tablist holds only tabs.  No
+  // tailEl — the strip has no non-tab chrome to anchor before.
   const pm = new PaneManager({
-    tabbarEl: shell.tabbar,
+    tabbarEl: shell.tabstrip,
     panesEl: shell.panes,
-    tailEl: shell.tail,
     caps,
   });
 

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -23,7 +23,7 @@
    (pane code stays root-scoped).
    ========================================================================== */
 
-import { PaneManager, ShellPane } from "./pane.js";
+import { PaneManager, ShellPane, openPopupMenu } from "./pane.js";
 import { mountRail, mountManage, glyph } from "./rail.js";
 import { authFetch } from "./auth.js";
 // The interactive pane is a real ES module beside us in /shared (step 5a) — the
@@ -946,80 +946,41 @@ async function mountShell() {
 }
 
 // --- Footer user menu (Log out lives here) ---------------------------------
-// A small popup anchored to the rail-footer user chip.  Reuses the .tab-menu
-// popup chrome; the one item clicks the hidden #logout-btn so auth.js stays the
-// single owner of logout (incl. its in-flight-refresh race guards).
-let _userMenuCleanup = null;
-
-function closeUserMenu() {
-  if (_userMenuCleanup) _userMenuCleanup();
-}
+// A small popup anchored to the rail-footer user chip, riding the shared
+// openPopupMenu chrome (pane.js — same vocabulary + keyboard behaviour as the
+// tab-action dropdown).  The one item clicks the hidden #logout-btn so auth.js
+// stays the single owner of logout (incl. its in-flight-refresh race guards).
+let _userMenu = null;
 
 function toggleUserMenu(chip) {
-  if (_userMenuCleanup) {
-    closeUserMenu();
+  if (_userMenu) {
+    _userMenu.close();
     return;
   }
-  const menu = document.createElement("div");
-  menu.className = "tab-menu user-menu";
-  menu.setAttribute("role", "menu");
-  menu.setAttribute("aria-label", "Account");
-  const item = document.createElement("button");
-  item.type = "button";
-  item.className = "tab-menu-item destructive";
-  item.setAttribute("role", "menuitem");
-  const label = document.createElement("span");
-  label.className = "tab-menu-label";
-  label.textContent = "Log out";
-  item.append(label);
-  item.addEventListener("click", () => {
-    closeUserMenu();
-    const lb = document.getElementById("logout-btn");
-    if (lb) lb.click();
-  });
-  menu.append(item);
-  document.body.append(menu);
-
-  // Fixed-positioned, popping UP from the chip (the footer sits at the viewport
-  // bottom); flip down only if there is no room above.
-  const ar = chip.getBoundingClientRect();
-  const mr = menu.getBoundingClientRect();
-  let x = ar.left;
-  if (x + mr.width > window.innerWidth) x = window.innerWidth - mr.width - 4;
-  if (x < 4) x = 4;
-  let y = ar.top - mr.height - 4;
-  if (y < 4) y = ar.bottom + 4;
-  menu.style.left = x + "px";
-  menu.style.top = y + "px";
-  chip.setAttribute("aria-expanded", "true");
-
-  const onDown = (e) => {
-    if (!menu.contains(e.target) && !chip.contains(e.target)) closeUserMenu();
-  };
-  const onKey = (e) => {
-    if (e.key === "Escape") {
-      closeUserMenu();
-      chip.focus();
-    }
-  };
-  _userMenuCleanup = () => {
-    document.removeEventListener("mousedown", onDown);
-    document.removeEventListener("keydown", onKey);
-    menu.remove();
-    chip.setAttribute("aria-expanded", "false");
-    _userMenuCleanup = null;
-  };
-  // Defer the listener attach so the click that opened the menu does not
-  // immediately close it.
-  setTimeout(() => {
-    // Bail if the menu was already closed before this deferred attach ran:
-    // closeUserMenu() nulls _userMenuCleanup, so attaching now would leave the
-    // listeners with no cleanup ref to remove them (a permanent leak).
-    if (!_userMenuCleanup) return;
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-  }, 0);
-  item.focus();
+  _userMenu = openPopupMenu(
+    chip,
+    [
+      {
+        label: "Log out",
+        cls: "destructive",
+        action: () => {
+          const lb = document.getElementById("logout-btn");
+          if (lb) lb.click();
+        },
+      },
+    ],
+    {
+      cls: "user-menu",
+      label: "Account",
+      prefer: "up", // the footer chip sits at the viewport bottom
+      align: "start",
+      expandEl: chip,
+      returnFocusEl: chip,
+      onClose: () => {
+        _userMenu = null;
+      },
+    },
+  );
 }
 
 function displayNameFor(caps) {

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -2,12 +2,16 @@
    L-shell bootstrap — builds the unified rail + tab-bar + pane-host frame and
    hands off to the legacy app boot.
 
-   The FIRST ES-module citizen in shared_static (the rest are classic scripts).
-   Being `type="module"` it is deferred, so it runs AFTER every classic script —
-   including app.js, which now defines `window.TS_APP.boot` without auto-running
-   it.  So the order is: classic scripts define globals → this module builds the
-   shell and reparents the existing DOM → it calls `TS_APP.boot()` to start
-   login + the Tier-1 cluster stream under the shell.
+   The shared substrate (utils/toast/auth/composer/renderer/…) is ES modules
+   like this file; only theme.js (FOUC), the vendored libs, and the legacy
+   app/admin/governance bundles remain classic.  Being `type="module"` this
+   file is deferred and last in document order, so it runs AFTER every classic
+   script — including app.js, which defines `window.TS_APP.boot` without
+   auto-running it — and after the substrate modules have installed their
+   transitional window bridges.  So the order is: classic scripts define the
+   legacy globals → substrate modules evaluate → this module builds the shell
+   and reparents the existing DOM → it calls `TS_APP.boot()` to start login +
+   the Tier-1 cluster stream under the shell.
 
    Re-point without rewiring: the cluster stream writes its connection status via
    getElementById("status-bar"); we MOVE that element (id preserved) into the
@@ -21,6 +25,7 @@
 
 import { PaneManager, ShellPane } from "./pane.js";
 import { mountRail, mountManage, glyph } from "./rail.js";
+import { authFetch } from "./auth.js";
 // The interactive pane is a real ES module beside us in /shared (step 5a) — the
 // shell imports it directly, and it exists in every deployment.  The coordinator
 // pane lives at an absolute /static path that only the CONSOLE serves, so it is

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -41,6 +41,7 @@ function buildShell(caps) {
 
   // ----- Rail (the | of the L) -----
   const rail = make("aside", "rail");
+  rail.id = "shell-rail"; // aria-controls target for the collapse toggle
 
   const brand = make("div", "rail-brand");
   // The brand doubles as "go home" — a real <button> so it is keyboard-
@@ -55,6 +56,13 @@ function buildShell(caps) {
     if (typeof window.showHome === "function") window.showHome();
   });
   brand.append(home);
+  // Collapse toggle — shrinks the rail to a glyph-only strip (desktop only; on
+  // mobile the rail is an off-canvas drawer and this button is hidden).  Label,
+  // glyph and aria state are kept in sync by the shell's setRailCollapsed.
+  const collapseBtn = make("button", "rail-collapse");
+  collapseBtn.type = "button";
+  collapseBtn.setAttribute("aria-controls", "shell-rail");
+  brand.append(collapseBtn);
   rail.append(brand);
 
   const scroll = make("div", "rail-scroll");
@@ -81,15 +89,31 @@ function buildShell(caps) {
   // ----- Content (the — of the L): tab bar + pane host -----
   const content = make("main", "content");
   const tabbar = make("div", "tabbar");
+  // Drawer toggle — first tab-bar item, shown only at the mobile breakpoint
+  // (the rail leaves the grid and overlays off-canvas there).  State + focus
+  // hand-off are wired by mountShell's setDrawer.
+  const burger = make("button", "rail-burger", "☰");
+  burger.type = "button";
+  burger.setAttribute("aria-label", "Open navigation");
+  burger.setAttribute("aria-controls", "shell-rail");
+  burger.setAttribute("aria-expanded", "false");
   const tail = make("div", "tabbar-right"); // right-floated tab-bar chrome (empty for now)
-  tabbar.append(tail);
+  tabbar.append(burger, tail); // managed tabs insert between the two
   const panes = make("div", "panes");
   content.append(tabbar, panes);
 
-  app.append(rail, content);
+  // Backdrop scrim for the mobile drawer — fixed overlay between content and
+  // the off-canvas rail; decorative (the burger/Escape carry the semantics).
+  const scrim = make("div", "rail-scrim");
+  scrim.setAttribute("aria-hidden", "true");
+
+  app.append(rail, content, scrim);
   return {
     app,
     rail,
+    collapseBtn,
+    burger,
+    scrim,
     scroll,
     connSlot,
     foot,
@@ -357,6 +381,46 @@ async function mountShell() {
   // (toast, modals, the login overlay appended later by auth.js) stay siblings.
   document.body.insertBefore(shell.app, document.body.firstChild);
 
+  // ----- Rail collapse (desktop) -----
+  // Collapsed = a glyph-only strip: live state glyphs stay (sessions, cluster
+  // counts), text labels hide, Manage becomes a single ⚙ row (rail.js).  A UI
+  // preference, so it persists across sessions in localStorage (same home as
+  // the theme), unlike the per-tab working set in sessionStorage.  CSS scopes
+  // the collapsed layout to desktop; the mobile drawer always shows the full
+  // rail, so the preference simply lies dormant there.
+  const RAIL_COLLAPSE_KEY = "turnstone_interface.rail";
+  const setRailCollapsed = (collapsed, persist) => {
+    shell.app.classList.toggle("rail-collapsed", collapsed);
+    shell.collapseBtn.textContent = collapsed ? "»" : "«"; // » / «
+    const label = collapsed ? "Expand navigation" : "Collapse navigation";
+    shell.collapseBtn.setAttribute("aria-label", label);
+    shell.collapseBtn.title = label;
+    shell.collapseBtn.setAttribute(
+      "aria-expanded",
+      collapsed ? "false" : "true",
+    );
+    if (persist) {
+      try {
+        localStorage.setItem(
+          RAIL_COLLAPSE_KEY,
+          collapsed ? "collapsed" : "expanded",
+        );
+      } catch (e) {
+        /* localStorage unavailable (private mode) — the toggle still works */
+      }
+    }
+  };
+  let railCollapsed = false;
+  try {
+    railCollapsed = localStorage.getItem(RAIL_COLLAPSE_KEY) === "collapsed";
+  } catch (e) {
+    /* unreadable preference — default expanded */
+  }
+  setRailCollapsed(railCollapsed, false);
+  shell.collapseBtn.addEventListener("click", () =>
+    setRailCollapsed(!shell.app.classList.contains("rail-collapsed"), true),
+  );
+
   // Relocate the connection indicator into the rail (id preserved → connectSSE
   // keeps writing to it; just styled as a rail line now).
   if (statusBarEl) {
@@ -404,6 +468,33 @@ async function mountShell() {
     tailEl: shell.tail,
     caps,
   });
+
+  // ----- Mobile drawer (the rail off-canvas below the breakpoint) -----
+  // Open moves focus into the rail (its buttons are unreachable while
+  // off-canvas — the closed drawer is visibility:hidden); close returns it to
+  // the burger only for Escape, the keyboard path.  Any pane activation closes
+  // the drawer: a rail tap that opened/focused a pane has done its job, and
+  // the stale-open drawer would cover the very pane it opened.  Desktop is
+  // untouched — the classes exist but the media query ignores them.
+  const drawerOpen = () => shell.app.classList.contains("rail-open");
+  const setDrawer = (open) => {
+    if (open === drawerOpen()) return;
+    shell.app.classList.toggle("rail-open", open);
+    shell.burger.setAttribute("aria-expanded", open ? "true" : "false");
+    if (open) {
+      const first = shell.rail.querySelector("button");
+      if (first) first.focus();
+    }
+  };
+  shell.burger.addEventListener("click", () => setDrawer(!drawerOpen()));
+  shell.scrim.addEventListener("mousedown", () => setDrawer(false));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && drawerOpen()) {
+      setDrawer(false);
+      shell.burger.focus();
+    }
+  });
+  pm.onActiveChange(() => setDrawer(false));
 
   // [+] new-tab (step 7): a shortcut to the persona launcher.  The Dashboard pane
   // hosts the unified coordinator/interactive launcher (a new session needs a task

--- a/turnstone/shared_static/status_bar.js
+++ b/turnstone/shared_static/status_bar.js
@@ -14,73 +14,76 @@
  * and effort-suffix rules.  Each surface owns its own DOM (different
  * element ids); the formatter takes the three cell spans + the
  * status-bar root + the SSE event.
+ *
+ * ES module; window bridge below for the still-classic consumers.
  */
-(function (root) {
-  "use strict";
+// Context-percent thresholds for the warn / danger paint.  Mirrored
+// by the .ws-sb-warn / .ws-sb-danger CSS toggles in chat.css.
+var CTX_WARN_PCT = 80;
+var CTX_DANGER_PCT = 95;
+var WARN_PREFIX = "▲ "; // ▲
+var DANGER_PREFIX = "⚠ "; // ⚠
+// Effort values that should NOT surface as a suffix on the tokens
+// cell.  "medium" is the implicit default; "" / null means the
+// model doesn't expose a reasoning_effort knob.
+var SILENT_EFFORTS = { medium: 1, "": 1 };
 
-  // Context-percent thresholds for the warn / danger paint.  Mirrored
-  // by the .ws-sb-warn / .ws-sb-danger CSS toggles in chat.css.
-  var CTX_WARN_PCT = 80;
-  var CTX_DANGER_PCT = 95;
-  var WARN_PREFIX = "▲ "; // ▲
-  var DANGER_PREFIX = "⚠ "; // ⚠
-  // Effort values that should NOT surface as a suffix on the tokens
-  // cell.  "medium" is the implicit default; "" / null means the
-  // model doesn't expose a reasoning_effort knob.
-  var SILENT_EFFORTS = { medium: 1, "": 1 };
+/**
+ * Repaint the three-cell status bar from an on_status SSE event.
+ *
+ * @param {Object} els — { rootEl, tokensEl, toolsEl, turnsEl }
+ * @param {Object} evt — on_status payload (total_tokens, context_window,
+ *   pct, effort, tool_calls_this_turn, turn_count).
+ */
+function paintStatusBar(els, evt) {
+  if (!els || !evt) return;
 
-  /**
-   * Repaint the three-cell status bar from an on_status SSE event.
-   *
-   * @param {Object} els — { rootEl, tokensEl, toolsEl, turnsEl }
-   * @param {Object} evt — on_status payload (total_tokens, context_window,
-   *   pct, effort, tool_calls_this_turn, turn_count).
-   */
-  function paintStatusBar(els, evt) {
-    if (!els || !evt) return;
-
-    var totalTokens = evt.total_tokens || 0;
-    var contextWindow = evt.context_window || 0;
-    var pct = evt.pct || 0;
-    var tokenText =
-      totalTokens.toLocaleString() +
-      " / " +
-      (contextWindow ? contextWindow.toLocaleString() : "—") +
-      (contextWindow ? " (" + pct + "%)" : "");
-    var effort = evt.effort || "";
-    if (effort && !(effort in SILENT_EFFORTS)) {
-      tokenText += " · " + effort;
-    }
-    if (pct >= CTX_DANGER_PCT) tokenText = DANGER_PREFIX + tokenText;
-    else if (pct >= CTX_WARN_PCT) tokenText = WARN_PREFIX + tokenText;
-    if (els.tokensEl) els.tokensEl.textContent = tokenText;
-
-    var tc = evt.tool_calls_this_turn || 0;
-    if (els.toolsEl) {
-      els.toolsEl.textContent = tc + " tool" + (tc !== 1 ? "s" : "");
-    }
-    var turns = evt.turn_count || 0;
-    if (els.turnsEl) els.turnsEl.textContent = "turn " + turns;
-
-    if (els.rootEl) {
-      els.rootEl.classList.toggle("ws-sb-warn", pct >= CTX_WARN_PCT);
-      els.rootEl.classList.toggle("ws-sb-danger", pct >= CTX_DANGER_PCT);
-    }
+  var totalTokens = evt.total_tokens || 0;
+  var contextWindow = evt.context_window || 0;
+  var pct = evt.pct || 0;
+  var tokenText =
+    totalTokens.toLocaleString() +
+    " / " +
+    (contextWindow ? contextWindow.toLocaleString() : "—") +
+    (contextWindow ? " (" + pct + "%)" : "");
+  var effort = evt.effort || "";
+  if (effort && !(effort in SILENT_EFFORTS)) {
+    tokenText += " · " + effort;
   }
+  if (pct >= CTX_DANGER_PCT) tokenText = DANGER_PREFIX + tokenText;
+  else if (pct >= CTX_WARN_PCT) tokenText = WARN_PREFIX + tokenText;
+  if (els.tokensEl) els.tokensEl.textContent = tokenText;
 
-  /**
-   * Reset the tokens cell to its placeholder text.  Called by the
-   * coord dashboard on SSE reconnect when no prior status event has
-   * been seen, so the transient "Reconnecting…" copy doesn't stick.
-   */
-  function resetTokensPlaceholder(tokensEl) {
-    if (tokensEl) tokensEl.textContent = "0 / —";
+  var tc = evt.tool_calls_this_turn || 0;
+  if (els.toolsEl) {
+    els.toolsEl.textContent = tc + " tool" + (tc !== 1 ? "s" : "");
   }
+  var turns = evt.turn_count || 0;
+  if (els.turnsEl) els.turnsEl.textContent = "turn " + turns;
 
-  root.StatusBar = {
-    paint: paintStatusBar,
-    resetTokensPlaceholder: resetTokensPlaceholder,
-    CTX_WARN_PCT: CTX_WARN_PCT,
-    CTX_DANGER_PCT: CTX_DANGER_PCT,
-  };
-})(typeof window !== "undefined" ? window : globalThis);
+  if (els.rootEl) {
+    els.rootEl.classList.toggle("ws-sb-warn", pct >= CTX_WARN_PCT);
+    els.rootEl.classList.toggle("ws-sb-danger", pct >= CTX_DANGER_PCT);
+  }
+}
+
+/**
+ * Reset the tokens cell to its placeholder text.  Called by the
+ * coord dashboard on SSE reconnect when no prior status event has
+ * been seen, so the transient "Reconnecting…" copy doesn't stick.
+ */
+function resetTokensPlaceholder(tokensEl) {
+  if (tokensEl) tokensEl.textContent = "0 / —";
+}
+
+export const StatusBar = {
+  paint: paintStatusBar,
+  resetTokensPlaceholder: resetTokensPlaceholder,
+  CTX_WARN_PCT: CTX_WARN_PCT,
+  CTX_DANGER_PCT: CTX_DANGER_PCT,
+};
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+window.StatusBar = StatusBar;

--- a/turnstone/shared_static/toast.js
+++ b/turnstone/shared_static/toast.js
@@ -1,13 +1,14 @@
 /* Shared toast notification — turnstone design system
-   Configure timeout via window.TURNSTONE_TOAST_TIMEOUT (default 3000ms) */
+   Configure timeout via window.TURNSTONE_TOAST_TIMEOUT (default 3000ms).
+   ES module, dependency-free; window bridge below for classic consumers. */
 
-var _toastQueue = [];
-var _toastTimer = null;
-var _toastShowing = false;
-var _TOAST_TIMEOUT = window.TURNSTONE_TOAST_TIMEOUT || 3000;
+const _toastQueue = [];
+let _toastTimer = null;
+let _toastShowing = false;
+const _TOAST_TIMEOUT = window.TURNSTONE_TOAST_TIMEOUT || 3000;
 
-function showToast(message, type) {
-  var el = document.getElementById("toast");
+export function showToast(message, type) {
+  const el = document.getElementById("toast");
   if (!el) return;
   if (_toastShowing) {
     _toastQueue.push({ message: message, type: type });
@@ -29,9 +30,14 @@ function _displayToast(el, message, type) {
     _toastTimer = null;
     if (_toastQueue.length) {
       setTimeout(function () {
-        var item = _toastQueue.shift();
+        const item = _toastQueue.shift();
         _displayToast(el, item.message, item.type);
       }, 300);
     }
   }, _TOAST_TIMEOUT);
 }
+
+// --- Legacy window bridge ---------------------------------------------------
+// Still-classic consumers reach this as a global at event/boot time (after
+// this deferred module evaluated).  New module code imports instead.
+window.showToast = showToast;

--- a/turnstone/shared_static/utils.js
+++ b/turnstone/shared_static/utils.js
@@ -1,18 +1,28 @@
-/* Shared utility functions — turnstone design system */
+/* Shared utility functions — turnstone design system
 
-function escapeHtml(text) {
+   ES module at the BOTTOM of the shared module graph: imports nothing, so
+   renderer.js / auth.js / kb.js / cards.js can import from here without
+   cycles.  The two helpers that call upward (setMarkdown → renderer,
+   exportWorkstreamDownload → toast/auth) late-bind through window at CALL
+   time instead — importing them here would close an import cycle.
+
+   The window bridge at the bottom keeps the still-classic consumers
+   (console app.js / admin.js / governance.js, ui app.js, inline onclick=)
+   working; modules should import instead. */
+
+export function escapeHtml(text) {
   const el = document.createElement("span");
   el.textContent = text;
   return el.innerHTML.replace(/'/g, "&#39;").replace(/"/g, "&quot;");
 }
 
-function formatTokens(n) {
+export function formatTokens(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + "M";
   if (n >= 1000) return (n / 1000).toFixed(1) + "k";
   return String(n || 0);
 }
 
-function ctxClass(ratio) {
+export function ctxClass(ratio) {
   if (ratio <= 0) return "ctx-idle";
   const pct = ratio * 100;
   if (pct < 30) return "ctx-low";
@@ -21,7 +31,7 @@ function ctxClass(ratio) {
   return "ctx-danger";
 }
 
-function formatUptime(seconds) {
+export function formatUptime(seconds) {
   if (!seconds) return "";
   if (seconds < 60) return seconds + "s";
   const min = Math.floor(seconds / 60);
@@ -30,7 +40,7 @@ function formatUptime(seconds) {
   return hr + "h " + (min % 60) + "m";
 }
 
-function formatCount(n) {
+export function formatCount(n) {
   if (n >= 1000) return (n / 1000).toFixed(1) + "k";
   return String(n);
 }
@@ -51,14 +61,14 @@ const OPERATOR_SOURCE_LABELS = {
   tool_error: "tool error",
   skill_hint: "skill hint",
 };
-function operatorSourceLabel(source) {
+export function operatorSourceLabel(source) {
   return OPERATOR_SOURCE_LABELS[source] || source || "operator";
 }
 
 // Naive ISO-8601 → "Nm ago" / "Nh ago" / "Nd ago" / locale date.
 // Tolerates space-as-separator (SQLite default) and missing TZ marker
 // (assumes UTC, matching the storage layer's stamp).
-function formatRelativeTime(iso) {
+export function formatRelativeTime(iso) {
   if (!iso) return "";
   let s = String(iso).replace(" ", "T");
   if (!s.endsWith("Z") && !s.includes("+")) s += "Z";
@@ -83,7 +93,7 @@ function formatRelativeTime(iso) {
 // actually appear in our id formats — hex ws_ids, alphanumeric
 // node_ids — and escapes the characters a CSS attribute selector
 // treats specially.
-function cssEscape(s) {
+export function cssEscape(s) {
   const str = String(s == null ? "" : s);
   if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
     return CSS.escape(str);
@@ -98,7 +108,7 @@ function cssEscape(s) {
 // a DocumentFragment lets callers use either append() or
 // replaceChildren() depending on whether the button is fresh or
 // rebuilt in place.
-function makeKeyLabel(hint, label) {
+export function makeKeyLabel(hint, label) {
   const span = document.createElement("span");
   span.className = "key";
   span.textContent = hint;
@@ -111,7 +121,7 @@ function makeKeyLabel(hint, label) {
 // "Loading…", "Failed to load", and "No active workstreams" states
 // across the dashboard surfaces.  Callers typically pass the result to
 // el.replaceChildren(...) so the empty card replaces existing content.
-function makeEmptyState(text) {
+export function makeEmptyState(text) {
   const div = document.createElement("div");
   div.className = "dashboard-empty";
   div.textContent = text;
@@ -125,7 +135,7 @@ function makeEmptyState(text) {
 // interpolation) — DOMParser will faithfully parse whatever it is
 // given.  The DOMParser path keeps the unsafe sink off the call site
 // without requiring every caller to construct DOM elements by hand.
-function setSafeHtml(el, html) {
+export function setSafeHtml(el, html) {
   const parsed = new DOMParser().parseFromString(html, "text/html");
   el.replaceChildren(...Array.from(parsed.body.childNodes));
 }
@@ -137,9 +147,9 @@ function setSafeHtml(el, html) {
 // as renderer.js is trusted.  postRenderMarkdown finishes the job —
 // hljs highlighting + mermaid SVG rendering for any code blocks the
 // markdown emitted.
-function setMarkdown(el, content) {
-  setSafeHtml(el, renderMarkdown(content));
-  postRenderMarkdown(el);
+export function setMarkdown(el, content) {
+  setSafeHtml(el, window.renderMarkdown(content));
+  window.postRenderMarkdown(el);
 }
 
 // Download a workstream's conversation as OpenAI-shaped JSON.  Hits
@@ -154,9 +164,9 @@ function setMarkdown(el, content) {
 // authFetch already handles the 401 (shows login) and
 // 429 (retry) paths and returns the raw Response, so we read .blob()
 // directly and synthesise an anchor click to trigger the browser save.
-async function exportWorkstreamDownload(wsId, btn, base) {
+export async function exportWorkstreamDownload(wsId, btn, base) {
   if (!wsId) {
-    showToast("No conversation to export", "error");
+    window.showToast("No conversation to export", "error");
     return;
   }
   // Re-entrancy guard: a double-click (or Enter+Enter) must not fire two
@@ -177,14 +187,14 @@ async function exportWorkstreamDownload(wsId, btn, base) {
       "/export";
     let r;
     try {
-      r = await authFetch(url);
+      r = await window.authFetch(url);
     } catch (e) {
       // authFetch throws Error("auth") on 401 after showing the login
       // modal — nothing more to do here.
       return;
     }
     if (!r || !r.ok) {
-      showToast("Export failed", "error");
+      window.showToast("Export failed", "error");
       return;
     }
     let filename = wsId + ".json";
@@ -202,7 +212,7 @@ async function exportWorkstreamDownload(wsId, btn, base) {
     a.click();
     a.remove();
     URL.revokeObjectURL(objUrl);
-    showToast("Exported " + filename);
+    window.showToast("Exported " + filename);
   } finally {
     exportWorkstreamDownload._busy = false;
     if (btn) {
@@ -211,3 +221,24 @@ async function exportWorkstreamDownload(wsId, btn, base) {
     }
   }
 }
+
+// --- Legacy window bridge ---------------------------------------------------
+// Classic consumers (console app.js / admin.js / governance.js, ui app.js,
+// inline onclick=) still reach these as globals; they only do so at event /
+// boot time, well after this deferred module has evaluated.  New module code
+// imports instead.  Drop entries as the classic bundles migrate.
+Object.assign(window, {
+  escapeHtml,
+  formatTokens,
+  ctxClass,
+  formatUptime,
+  formatCount,
+  operatorSourceLabel,
+  formatRelativeTime,
+  cssEscape,
+  makeKeyLabel,
+  makeEmptyState,
+  setSafeHtml,
+  setMarkdown,
+  exportWorkstreamDownload,
+});

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -793,6 +793,12 @@ function updateDashFooter(agg) {
 // the per-app inputs are the column spec, the DOM refs, and the path-keyed
 // delete request.  Coordinators (console/static) use the same helper with a
 // CHILDREN column instead of MSGS.
+let _wsTable = null;
+
+// Built at boot, not parse: the saved-table substrate (/shared/cards.js) is a
+// deferred ES module now, so its bridged globals (SavedColumns,
+// createSavedTable) don't exist yet while this classic file parses.
+function _initSavedWsTable() {
 const WS_COLUMNS = [
   SavedColumns.name(),
   SavedColumns.model(),
@@ -801,7 +807,7 @@ const WS_COLUMNS = [
   SavedColumns.last(),
   SavedColumns.id(),
 ];
-const _wsTable = createSavedTable({
+_wsTable = createSavedTable({
   headerEl: document.getElementById("ws-saved-colheaders"),
   bodyEl: document.getElementById("dashboard-saved-cards"),
   filterEl: document.getElementById("ws-filter"),
@@ -830,6 +836,7 @@ const _wsTable = createSavedTable({
     },
   },
 });
+}
 
 // HTML inline-onclick wrappers — keep the global names the existing markup
 // binds to (`onclick="startWsDeleteMode()"` etc.) and forward to the shared
@@ -2226,6 +2233,7 @@ function initWorkstreams() {
 // roster + stream, the dashboard lists, health polling, and pending MCP
 // consents.  It does NOT auto-run at parse time (the shell sequences it).
 function boot() {
+  _initSavedWsTable(); // substrate modules have evaluated by boot time
   initLogin();
   pollHealth();
   loadInterfaceSettings();

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -478,7 +478,11 @@ function hideNewWsModal() {
     document.removeEventListener("keydown", _newWsTrapHandler);
     _newWsTrapHandler = null;
   }
-  document.getElementById("new-tab-btn").focus();
+  // Hand focus back to the shell's [+] new-session affordance.  The old
+  // #new-tab-btn went with the retired split-pane tab bar — the unguarded
+  // lookup threw on every modal close after that.
+  const back = document.querySelector(".tab-add");
+  if (back) back.focus();
 }
 
 function submitNewWs() {
@@ -1918,28 +1922,9 @@ function closeSettingsPanel() {
 }
 
 // ---------------------------------------------------------------------------
-//  Settings menu (gear icon dropdown — MCP connections + Logout)
+//  MCP connections panel (Manage -> Connections via the rail; the old gear
+//  dropdown that fronted it was retired with the split-pane tab bar)
 // ---------------------------------------------------------------------------
-//
-// Reuses the .ws-tab-dropdown shell for visual + behavioural consistency
-// with the workstream tab dropdown and the console proxy's node-picker.
-// Keyboard handling matches the proxy node-picker (the APG-correct
-// reference): Tab closes the menu WITHOUT preventDefault so focus
-// moves naturally to the next focusable; Escape closes + refocuses
-// the trigger.  showTabDropdown collapses Tab and Escape into a
-// single preventDefault branch — that's a pre-existing divergence,
-// tracked as a follow-up to align showTabDropdown to APG.  ArrowUp
-// uses an `idx <= 0` guard (not modulo) so the no-focus case wraps
-// to the last item rather than the second-to-last — same shape as
-// showTabDropdown and the proxy node-picker.
-
-let _settingsMenu = null;
-let _settingsMenuCloseHandler = null;
-// Cached at open time so closeSettingsMenu can reset ARIA without
-// re-querying by id, and so the menu-item click path can refocus
-// the trigger BEFORE close — that way openSettingsPanel captures
-// the gear (not <body>) as _settingsReturnFocus.
-let _settingsMenuTrigger = null;
 
 function loadMcpConnections() {
   const loadingEl = document.getElementById("settings-mcp-loading");
@@ -2151,14 +2136,6 @@ document.addEventListener("keydown", function (e) {
     const modal = document.getElementById(modalIds[mi]);
     if (modal && modal.style.display !== "none") return;
   }
-  // Settings menu is a transient dropdown, not a modal overlay, but
-  // the global Escape handler must not reach hideDashboard() while
-  // it's open — that would wipe the composer out from under the user
-  // (hideDashboard clears dashboard-input.value and _dashboardStagedFiles).
-  // The menu's own keydown handler (registered async via setTimeout(0)
-  // in openSettingsMenu) handles Escape and Tab.
-  if (_settingsMenu) return;
-
   if (e.key === "Escape" && dashboardVisible) {
     e.preventDefault();
     hideDashboard();

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -559,19 +559,26 @@
         },
       ];
     </script>
-    <script src="/shared/utils.js"></script>
-    <script src="/shared/cards.js"></script>
-    <script src="/shared/toast.js"></script>
-    <script src="/shared/composer.js"></script>
-    <script src="/shared/composer_attachments.js"></script>
-    <script src="/shared/composer_queue.js"></script>
-    <script src="/shared/status_bar.js"></script>
+    <!-- Two script lanes (mirrors console/static/index.html):
+         CLASSIC: theme.js (FOUC — paints the stored theme at parse time),
+         vendored katex/hljs (lazy typeof-guarded by renderer.js), and the
+         legacy app.js bundle.
+         MODULE (deferred): the shared substrate — each exports its API and
+         installs a transitional window bridge for app.js, which only touches
+         the globals at boot/event time (after modules evaluate). -->
     <script src="/shared/theme.js"></script>
-    <script src="/shared/auth.js"></script>
-    <script src="/shared/kb.js"></script>
+    <script type="module" src="/shared/utils.js"></script>
+    <script type="module" src="/shared/cards.js"></script>
+    <script type="module" src="/shared/toast.js"></script>
+    <script type="module" src="/shared/composer.js"></script>
+    <script type="module" src="/shared/composer_attachments.js"></script>
+    <script type="module" src="/shared/composer_queue.js"></script>
+    <script type="module" src="/shared/status_bar.js"></script>
+    <script type="module" src="/shared/auth.js"></script>
+    <script type="module" src="/shared/kb.js"></script>
     <script src="/shared/katex-0.17.0/katex.min.js"></script>
     <script src="/shared/hljs-11.11.1/highlight.min.js"></script>
-    <script src="/shared/renderer.js"></script>
+    <script type="module" src="/shared/renderer.js"></script>
     <!-- The shell module imports the interactive pane (a /shared ES module), so
      it is not <script>-tagged here.  app.js is classic and defines the
      window.TS_APP / TS_ADMIN seams the deferred shell reads after it. -->

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -53,58 +53,8 @@
   font-size: 14px;
   line-height: 1;
 }
-.ws-tab.active {
-  background: var(--bg-highlight);
-  color: var(--fg-bright);
-  border-bottom: 2px solid var(--accent);
-}
-.ws-tab.active .tab-chevron {
-  opacity: 0.7;
-}
-.ws-tab:hover .tab-wsid,
-.ws-tab.active .tab-wsid {
-  opacity: 0.45;
-}
-
 /* .card-wsid moved to /shared/cards.css (with vertical-align added so it
    aligns with .card-meta).  Single source for both surfaces. */
-
-#new-tab-btn {
-  background: none;
-  border: 1px dashed var(--border-strong);
-  color: var(--fg-dim);
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  padding: 6px 10px;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 14px;
-  line-height: 1;
-  flex-shrink: 0;
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-}
-#new-tab-btn:hover {
-  background: var(--bg-highlight);
-  color: var(--accent);
-  border-color: var(--accent);
-}
-#split-btn.hidden {
-  display: none;
-}
-
-/* Tab dropdown menu */
-@keyframes dropdown-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
 /* Edit title & delete modals */
 #edit-title-overlay,
@@ -175,13 +125,10 @@
   color: var(--fg-bright);
   margin: 0 0 16px;
 }
-.split-handle:hover,
-.split-handle:active,
-.split-handle.dragging {
-  background: var(--accent);
-}
-
-/* Pane */
+/* Pane — the interactive pane root (interactive.js).  The split-pane chrome
+   that used to ride it (.split-handle, .pane-header, .pane-action-btn,
+   .focused) was retired with the step-6 fork collapse; the L-shell's tab bar
+   owns those affordances now (shared_static/shell.css). */
 .pane {
   display: flex;
   flex-direction: column;
@@ -190,74 +137,6 @@
   min-height: 150px;
   overflow: hidden;
   position: relative;
-}
-.pane.focused {
-  outline: 1px solid var(--accent-dim);
-  outline-offset: -1px;
-}
-.multi-pane .pane.focused .pane-header {
-  border-bottom-color: var(--accent);
-  background: var(--bg-highlight);
-}
-
-/* Pane header — only visible in multi-pane mode */
-.pane-header {
-  display: none;
-}
-.multi-pane .pane-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 2px 8px;
-  background: var(--bg-surface);
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-  min-height: 24px;
-}
-.pane-ws-name {
-  font-size: 11px;
-  color: var(--fg-dim);
-  font-family: var(--font-mono);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.pane.focused .pane-ws-name {
-  color: var(--accent);
-}
-.pane-actions {
-  display: flex;
-  gap: 2px;
-  flex-shrink: 0;
-}
-.pane-action-btn {
-  background: none;
-  border: none;
-  color: var(--fg-dim);
-  font-size: 12px;
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  line-height: 1;
-  opacity: 0.3;
-  transition:
-    opacity 0.15s,
-    color 0.1s,
-    background 0.1s;
-}
-.pane.focused .pane-action-btn {
-  opacity: 0.5;
-}
-.pane-header:hover .pane-action-btn,
-.pane-action-btn:focus-visible {
-  opacity: 1;
-}
-.pane-action-btn:hover {
-  color: var(--fg-bright);
-  background: var(--bg-highlight);
-}
-.pane-close-btn:hover {
-  color: var(--red);
 }
 
 /* ==========================================================================
@@ -1906,10 +1785,6 @@ audio.media-player {
     animation: none;
     content: "...";
   }
-  .ws-tab,
-  .ws-tab .tab-chevron,
-  #new-tab-btn,
-  #split-btn,
   .ts-approval-btn,
   .ts-approval-feedback,
   .composer button,
@@ -1924,11 +1799,7 @@ audio.media-player {
   #new-ws-cancel,
   #new-ws-submit,
   #new-ws-box input,
-  #new-ws-box select,
-  .split-handle,
-  .pane-action-btn,
-  .pane-ctx-item,
-  .ws-tab-dropdown-item {
+  #new-ws-box select {
     transition: none;
   }
 }


### PR DESCRIPTION
Deferred polish on the L-shell (follow-up to #640/#643): the two deferred responsive modes, the shared_static ESM migration, and a dead-code/dedupe sweep.

## Rail collapse — glyph navigation (desktop)

A persisted preference (`localStorage` `turnstone_interface.rail`, toggle in the brand row) collapses the rail to a 52px glyph-only strip. The glyphs are the navigation: live Tier-1 state glyphs for sessions (same `.ui-glyph-*` vocabulary, same builder as the expanded rows), `◇` home, cluster pills stacked as glyph+count, one `⚙` for Manage (opens the Admin pane), avatar-only footer. Children flatten to peer glyphs — reachability over hierarchy in a strip; `title` attrs (now set unconditionally) carry the names. Shape+colour state survives intact; `aria-expanded`/`aria-controls` on the toggle.

## Mobile off-canvas drawer

Below 768px the rail leaves the grid and overlays at full width behind a scrim: `☰` in the tab bar opens it (focus moves into the rail), Escape (focus returns to the burger), scrim tap, or any pane activation closes it. The closed drawer is `visibility:hidden` so its buttons leave the Tab order — not merely translated off-screen. The collapse preference lies dormant on mobile. Tab titles now ride an ellipsizing `.tab-title` span (240px desktop / 48vw mobile caps) and the tab bar scrolls horizontally on mobile. `prefers-reduced-motion` disables the slide.

## ESM migration — shared_static substrate complete

The 10 remaining classic shared scripts (`utils`, `toast`, `kb`, `cards`, `auth`, `renderer`, `composer`, `composer_attachments`, `composer_queue`, `status_bar`) are real ES modules: explicit exports, real imports for what were implicit script-order dependencies (auth/kb/cards → utils, auth/cards → toast, cards → auth, renderer → utils; utils stays import-free at the bottom of the graph, late-binding its two upward calls), and a transitional `window.*` bridge per module for the still-classic bundles (console app/admin/governance, ui app, inline `onclick=`). `theme.js` deliberately stays classic — deferring it would flash the wrong theme before first paint. Vendored katex/hljs/mermaid stay classic and lazily `typeof`-guarded. `interactive.js` and `shell.js` drop their bare-global reads for imports.

The review pipeline caught a critical here: both classic `app.js` bundles built their saved-list tables at top level (`const _coordTable = createSavedTable(...)`) — a parse-time `ReferenceError` against the not-yet-evaluated module bridges that aborted boot in **both** deployments. Construction now defers into `_initSavedCoordTable()`/`_initSavedWsTable()` called first from each boot path. Verified by new real-page load harnesses (real index.html script chains, only `fetch`/`EventSource` mocked): both deployments boot to a mounted shell with zero uncaught errors.

## Cleanup, dedupe, bugfixes

- `interactive.js` drops the dead `!this._embedded` split-pane branches — they referenced shell globals (`setFocusedPane`, `splitPane`, `splitRoot`, …) deleted with the step-6 fork collapse, so reaching them was a guaranteed `ReferenceError`. The `embedded` opt, `getWsName` host seam, and call-less `updateWsName()` go with them; `pane--embedded` is unconditional.
- `ui/static/style.css` drops the orphaned split-pane/tab-bar vocabulary (`.ws-tab*`, `#new-tab-btn`, `#split-btn`, `.split-handle`, the pane-header/action-button block, the unused `dropdown-in` keyframe, dead reduced-motion entries).
- Real crash fixed: `hideNewWsModal()` focused the removed `#new-tab-btn` unguarded — a `TypeError` on every create/fork modal close. Focus now returns to the shell's `[+]`.
- `pane.js` exports `openPopupMenu` (items, flip+clamp positioning, dismissal, `aria-expanded` mirroring, arrow roving, idempotent close); the tab-action dropdown and the footer user menu both ride it — the user menu picks up Tab-close and arrow roving it previously lacked.

## Tests / verification

- Static suites green (302); full non-live suite green.
- ESM sweep restructured: `test_shell_js.py` parse-guards all 15 shared modules with module semantics (sink scan excludes `renderer.js`, the sanctioned HTML producer; the no-var ratchet covers the var-free subset); `test_app_js.py`'s classic sweep shrinks to the 4 legacy bundles, with the const-reassign guard re-including the converted modules.
- New behavior guards: `test_rail_collapse_glyph_strip`, `test_mobile_drawer_off_canvas`, `test_popup_menu_shared_helper`; `test_interactive_pane_js.py` flips its embedded-gate pins to retired-symbol pins.
- Headless Chrome: 28 behavioral self-tests (collapse persistence + aria, drawer open/close/focus hand-off, popup menus, tab ellipsis) green with zero console errors; screenshots verified expanded/collapsed × dark/light + mobile closed/open.
- Multi-stage review pipeline ran on the branch: security + performance finders clean; all confirmed findings fixed in-session (the parse-time boot break above, plus the test-coverage and breakpoint-coupling notes).
