### PR TITLE
fix: intent-verdict lifecycle — replay parity, superseded persistence, bulk-insert race, cancel contract

### DIFF
--- a/docs/judge.md
+++ b/docs/judge.md
@@ -238,7 +238,10 @@ still stream to the UI and persist, stamped with the decision. The daemon is
 aborted only when the next tool batch supersedes it or the session closes —
 then each unfinished item degrades to an `llm_fallback` verdict. With
 `cancel_on_approval = true` the abort additionally fires the moment the gate
-resolves, trading verdict completeness for inference savings.
+resolves, trading verdict completeness for inference savings — recommended
+when the judge shares a single local inference backend with the session model,
+where a large batch's remaining judge calls would otherwise compete with the
+next turn's completion.
 
 Verdicts that arrive after a *newer batch* has replaced the judge generation
 are withheld from the live surfaces (a reused call_id must never ride a stale

--- a/docs/judge.md
+++ b/docs/judge.md
@@ -231,6 +231,20 @@ calls for approval, it calls `_evaluate_intent()` which:
 4. Attaches each heuristic verdict to its item as `_heuristic_verdict`
 5. The daemon thread runs the LLM judge and delivers results via `ui.on_intent_verdict()`
 
+The daemon evaluates items sequentially, so a large parallel batch can outlive
+its approval gate. With `cancel_on_approval = false` (the default) the daemon
+runs every item to completion: verdicts that land after the operator decided
+still stream to the UI and persist, stamped with the decision. The daemon is
+aborted only when the next tool batch supersedes it or the session closes —
+then each unfinished item degrades to an `llm_fallback` verdict. With
+`cancel_on_approval = true` the abort additionally fires the moment the gate
+resolves, trading verdict completeness for inference savings.
+
+Verdicts that arrive after a *newer batch* has replaced the judge generation
+are withheld from the live surfaces (a reused call_id must never ride a stale
+`approve` into Smart Approvals) but still persist with
+`user_decision = "superseded"` so the audit trail records the judge's answer.
+
 Sub-agents (plan agent, task agent) are exempt from intent validation -- they
 always get full tool visibility without judge evaluation.
 
@@ -242,7 +256,13 @@ All verdicts are persisted to the `intent_verdicts` table (migration 012):
 
 - Heuristic verdicts are stored when the `approve_request` event is emitted
 - LLM verdicts are stored when the `intent_verdict` event is delivered
-- The `user_decision` column is updated when the user approves or denies
+- The `user_decision` column is updated when the user approves or denies;
+  auto-approved rows carry the bypass reason (`policy`, `blanket`,
+  `auto_approve_tools`, `smart_approval`), and rows whose verdict landed only
+  after a newer batch replaced the judge generation carry `superseded`
+- Every stored verdict — including the benign `risk_level = "none"` majority —
+  is re-attached to its tool call on history replay, so a reloaded workstream
+  shows the same verdict badges the live stream did
 
 The console admin panel exposes verdict history via:
 

--- a/tests/test_history_decoration.py
+++ b/tests/test_history_decoration.py
@@ -24,12 +24,16 @@ class TestBuildVerdictPayload:
     """The wire-shape projection that's the single source of truth for
     what intent_verdict fields ship to the client."""
 
-    def test_skips_unflagged_baseline(self) -> None:
-        """``risk_level`` "none" is the unflagged-tool baseline; the
-        client filters those anyway, so projecting None at the wire
-        layer keeps the payload tight on long workstreams."""
-        row = {"risk_level": "none", "recommendation": "approve", "tier": "heuristic"}
-        assert build_verdict_payload(row) is None
+    def test_ships_unflagged_baseline(self) -> None:
+        """``risk_level`` "none" rows ship like any other — the live
+        path paints a badge for every delivered verdict (the client
+        has no risk filter), so replay must carry the same set or
+        benign verdicts vanish on rehydrate (live/replay parity)."""
+        row = {"risk_level": "none", "recommendation": "approve", "tier": "llm"}
+        out = build_verdict_payload(row)
+        assert out["risk_level"] == "none"
+        assert out["recommendation"] == "approve"
+        assert out["tier"] == "llm"
 
     def test_drops_call_id_and_func_name(self) -> None:
         """The client already has these on ``tc.id`` / ``tc.name``;
@@ -243,13 +247,14 @@ class TestDecorateToolCall:
         decorate_tool_call(tc, verdicts, {})
         assert "verdict" not in tc
 
-    def test_skips_unflagged_verdict(self) -> None:
-        """``build_verdict_payload`` returns None for unflagged rows;
-        decorate_tool_call must not stamp ``verdict`` in that case."""
+    def test_stamps_unflagged_verdict(self) -> None:
+        """A ``risk_level="none"`` row still stamps ``verdict`` — the
+        operator saw the badge live, so it must survive rehydrate."""
         tc: dict[str, object] = {"id": "call_1", "name": "bash"}
-        verdicts = {"call_1": {"risk_level": "none", "tier": "heuristic"}}
+        verdicts = {"call_1": {"risk_level": "none", "tier": "llm"}}
         decorate_tool_call(tc, verdicts, {})
-        assert "verdict" not in tc
+        assert "verdict" in tc
+        assert tc["verdict"]["risk_level"] == "none"  # type: ignore[index]
 
     def test_handles_empty_id(self) -> None:
         """A tool_call with no id can't be paired against the lookup
@@ -310,6 +315,38 @@ class TestDecorateHistoryMessages:
         assert "advisories" not in messages[2]
         assert messages[3]["content"] == "short"
         assert "advisories" not in messages[3]
+
+    def test_parallel_batch_keeps_every_judged_verdict(self) -> None:
+        """Regression: a parallel batch where the judge cleared most
+        calls (``risk_level="none"``) must rehydrate with a verdict on
+        EVERY judged call, not just the flagged minority.  The old
+        wire-layer ``none`` filter made benign verdicts vanish after a
+        restart while the live stream had shown all of them."""
+        calls = [f"call_{i}" for i in range(8)]
+        verdicts = {
+            cid: {
+                "risk_level": "low" if i < 2 else "none",
+                "recommendation": "approve",
+                "confidence": 0.9,
+                "intent_summary": f"benign op {i}",
+                "tier": "llm",
+            }
+            for i, cid in enumerate(calls)
+        }
+        messages: list[dict[str, object]] = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": cid, "function": {"name": "read_file", "arguments": "{}"}}
+                    for cid in calls
+                ],
+            },
+        ]
+        decorate_history_messages(messages, verdicts, {})
+        tool_calls = messages[0]["tool_calls"]  # type: ignore[index]
+        decorated = [tc["verdict"]["risk_level"] for tc in tool_calls]
+        assert decorated == ["low", "low"] + ["none"] * 6
 
     def test_no_op_on_empty_indexes(self) -> None:
         """When neither table has rows for the workstream, the wire

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -312,7 +312,7 @@ def _wait_for(results: list[IntentVerdict], count: int, timeout: float = 5.0) ->
 class TestCancelEventSemantics:
     """The cancel event is an unconditional abort signal at the judge
     layer: once it fires, no further inference is spent and every undone
-    item degrades to a heuristic fallback verdict.  WHO fires it is
+    item degrades to an ``llm_fallback`` verdict (heuristic-derived).  WHO fires it is
     ChatSession policy (always on generation supersede / close; on
     approval resolution only when ``cancel_on_approval`` is enabled) —
     this loop must not second-guess the signal against its own config,

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -295,6 +296,75 @@ class TestErrorHandling:
         assert result is None
         # Should have been called exactly once — no retries
         assert provider.create_completion.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cancel-event semantics
+# ---------------------------------------------------------------------------
+
+
+def _wait_for(results: list[IntentVerdict], count: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while len(results) < count and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+
+class TestCancelEventSemantics:
+    """The cancel event is an unconditional abort signal at the judge
+    layer: once it fires, no further inference is spent and every undone
+    item degrades to a heuristic fallback verdict.  WHO fires it is
+    ChatSession policy (always on generation supersede / close; on
+    approval resolution only when ``cancel_on_approval`` is enabled) —
+    this loop must not second-guess the signal against its own config,
+    which is what previously broke the run-to-completion contract."""
+
+    def test_fired_event_aborts_with_default_config(self):
+        provider = _make_mock_provider(_good_verdict_json())
+        judge = _make_judge(provider)
+        assert judge._config.cancel_on_approval is False  # pin the default
+        cancel = threading.Event()
+        cancel.set()  # supersede/close happened before the daemon started
+
+        results: list[IntentVerdict] = []
+        items = [_make_item(call_id=f"tc_{i}") for i in range(3)]
+        judge.evaluate(
+            items,
+            [{"role": "user", "content": "test"}],
+            results.append,
+            cancel_event=cancel,
+        )
+        _wait_for(results, 3)
+
+        # Every item still gets exactly one verdict (Smart Approvals and
+        # the advisory UI wait on the full set) — all fallbacks...
+        assert [v.call_id for v in results] == ["tc_0", "tc_1", "tc_2"]
+        assert all(v.tier == "llm_fallback" for v in results)
+        assert all("cancelled" in v.reasoning for v in results)
+        # ...and no inference was spent after the abort signal.
+        assert provider.create_completion.call_count == 0
+
+    def test_unfired_event_runs_every_item_with_default_config(self):
+        """The run-to-completion contract: with cancel_on_approval=False
+        and no abort signal, all items get REAL LLM verdicts — resolving
+        the gate must not have fired the event (that's pinned on the
+        session side), and this loop must keep evaluating."""
+        provider = _make_mock_provider(_good_verdict_json())
+        judge = _make_judge(provider)
+        cancel = threading.Event()  # never fired
+
+        results: list[IntentVerdict] = []
+        items = [_make_item(call_id=f"tc_{i}") for i in range(3)]
+        judge.evaluate(
+            items,
+            [{"role": "user", "content": "test"}],
+            results.append,
+            cancel_event=cancel,
+        )
+        _wait_for(results, 3)
+
+        assert [v.call_id for v in results] == ["tc_0", "tc_1", "tc_2"]
+        assert all(v.tier == "llm" for v in results)
+        assert provider.create_completion.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_judge_storage.py
+++ b/tests/test_judge_storage.py
@@ -287,6 +287,40 @@ class TestIntentVerdictBulkInsert:
         assert v1["risk_level"] == "low" and v1["tier"] == "heuristic"
         assert v2["risk_level"] == "high" and v2["tier"] == "llm"
 
+    def test_bulk_insert_pk_collision_skips_only_colliding_row(self, db):
+        """Regression: the async judge daemon can UPSERT a fallback row —
+        reusing a heuristic verdict_id from the incoming batch — BEFORE
+        ``approve_tools`` runs the bulk write.  The bulk insert must skip
+        just that row (keeping the daemon's tier upgrade) instead of
+        aborting the whole statement and silently losing every sibling
+        row in the batch."""
+        # Daemon won the race: fallback row already sits on b2's PK.
+        db.upsert_intent_verdict(
+            **_make_verdict_kwargs(
+                verdict_id="b2",
+                call_id="c2",
+                tier="llm_fallback",
+                judge_model="judge-model",
+            )
+        )
+        db.create_intent_verdicts_bulk(
+            [
+                _make_verdict_kwargs(verdict_id="b1", call_id="c1"),
+                _make_verdict_kwargs(verdict_id="b2", call_id="c2"),  # collides
+                _make_verdict_kwargs(verdict_id="b3", call_id="c3"),
+            ]
+        )
+        # Siblings landed despite the mid-batch collision.
+        for vid in ("b1", "b3"):
+            v = db.get_intent_verdict(vid)
+            assert v is not None, f"sibling row {vid} lost to the collision"
+            assert v["tier"] == "heuristic"
+        # The colliding row kept the daemon's upgrade, not the bulk stamp.
+        v2 = db.get_intent_verdict("b2")
+        assert v2 is not None
+        assert v2["tier"] == "llm_fallback"
+        assert v2["judge_model"] == "judge-model"
+
 
 # ---------------------------------------------------------------------------
 # List queries

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -561,7 +561,7 @@ class TestTaskExec:
         item to completion so each call lands a real LLM verdict, exactly
         what the setting's help text promises.  An unconditional set in the
         gate's ``finally`` used to degrade every still-queued item to a
-        heuristic fallback row the instant the operator approved."""
+        llm_fallback row the instant the operator approved."""
         session = _make_session()
         event = self._drive_gate(session, monkeypatch, cancel_on_approval=False)
         assert event is not None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 import subprocess
 import time
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -456,12 +457,15 @@ class TestTaskExec:
 
     def test_evaluate_intent_drops_superseded_generation_verdict(self, tmp_db, monkeypatch) -> None:
         """A prior turn's judge daemon (still running because
-        cancel_on_approval defaults False) must NOT deliver verdicts once a
-        newer turn has superseded it — otherwise a model that reuses a
-        call_id across turns could ride a stale ``approve`` into a wrongful
-        Smart Approval of a different call."""
+        cancel_on_approval defaults False) must NOT deliver verdicts to the
+        live surfaces once a newer turn has superseded it — otherwise a model
+        that reuses a call_id across turns could ride a stale ``approve``
+        into a wrongful Smart Approval of a different call.  The superseded
+        verdict is NOT lost, though: it routes to the persist-only audit
+        hook so ``intent_verdicts`` still records the judge's ruling."""
         session = _make_session()
         session.ui.on_intent_verdict = MagicMock()
+        session.ui.on_superseded_intent_verdict = MagicMock()
         fake_verdict = MagicMock()
         fake_verdict.to_dict.return_value = {"verdict_id": "v0", "call_id": "c1", "tier": "llm"}
         captured: list[Any] = []
@@ -476,13 +480,38 @@ class TestTaskExec:
         session._evaluate_intent([dict(item)])  # generation B supersedes A
         callback_a, callback_b = captured[0], captured[1]
 
-        # A's late verdict (the superseded daemon) is dropped.
+        # A's late verdict: withheld from the live surfaces, persisted for audit.
         callback_a(fake_verdict)
         session.ui.on_intent_verdict.assert_not_called()
+        session.ui.on_superseded_intent_verdict.assert_called_once_with(
+            {"verdict_id": "v0", "call_id": "c1", "tier": "llm"}
+        )
 
         # B's verdict (the current generation) is delivered normally.
         callback_b(fake_verdict)
         session.ui.on_intent_verdict.assert_called_once()
+        session.ui.on_superseded_intent_verdict.assert_called_once()  # unchanged
+
+    def test_superseded_verdict_skips_persist_on_display_only_ui(self, tmp_db, monkeypatch) -> None:
+        """Display-only UIs (CLI / eval) don't define the persist-only hook;
+        the superseded path must degrade to a plain drop, not raise."""
+        session = _make_session()
+        session.ui = SimpleNamespace(on_intent_verdict=MagicMock())  # no superseded hook
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "call_id": "c1", "tier": "llm"}
+        captured: list[Any] = []
+        fake_judge = MagicMock()
+        fake_judge.evaluate.side_effect = lambda items, *_a, **kw: (
+            captured.append(kw.get("callback")) or [fake_verdict] * len(items)
+        )
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        item = {"call_id": "c1", "func_name": "bash", "needs_approval": True, "command": "ls"}
+        session._evaluate_intent([dict(item)])  # generation A
+        session._evaluate_intent([dict(item)])  # generation B supersedes A
+
+        captured[0](fake_verdict)  # must not raise
+        session.ui.on_intent_verdict.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -513,6 +513,75 @@ class TestTaskExec:
         captured[0](fake_verdict)  # must not raise
         session.ui.on_intent_verdict.assert_not_called()
 
+    def _drive_gate(self, session, monkeypatch, *, cancel_on_approval: bool):
+        """Run one needs_approval bash item through ``_execute_tools`` with a
+        stubbed judge + approval gate; return the cancel event the judge
+        daemon would be watching."""
+        from unittest.mock import PropertyMock
+
+        from turnstone.core.judge import JudgeConfig
+
+        captured: dict[str, Any] = {}
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {
+            "verdict_id": "v0",
+            "call_id": "c1",
+            "tier": "heuristic",
+        }
+        fake_judge = MagicMock()
+
+        def _eval(items, *_a, **kw):
+            captured["event"] = kw.get("cancel_event")
+            return [fake_verdict] * len(items)
+
+        fake_judge.evaluate.side_effect = _eval
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        cfg = JudgeConfig(enabled=True, cancel_on_approval=cancel_on_approval)
+        item = {
+            "call_id": "c1",
+            "func_name": "bash",
+            "needs_approval": True,
+            "command": "ls",
+            "execute": lambda _it: "ok",
+        }
+        with (
+            patch.object(type(session), "_judge_cfg", new_callable=PropertyMock, return_value=cfg),
+            patch.object(session, "_safe_prepare_tool", return_value=item),
+            patch.object(session.ui, "approve_tools", return_value=(True, None)),
+        ):
+            session._execute_tools(
+                [{"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}]
+            )
+        return captured["event"]
+
+    def test_gate_resolution_keeps_judge_running_by_default(self, tmp_db, monkeypatch) -> None:
+        """cancel_on_approval=False (the default): resolving the approval
+        gate must NOT fire the judge's abort signal — the daemon runs every
+        item to completion so each call lands a real LLM verdict, exactly
+        what the setting's help text promises.  An unconditional set in the
+        gate's ``finally`` used to degrade every still-queued item to a
+        heuristic fallback row the instant the operator approved."""
+        session = _make_session()
+        event = self._drive_gate(session, monkeypatch, cancel_on_approval=False)
+        assert event is not None
+        assert not event.is_set()
+
+        # The supersede path still aborts unconditionally: the next batch
+        # fires the previous generation's event before spawning its own.
+        session._judge_cancel_event = event
+        self._drive_gate(session, monkeypatch, cancel_on_approval=False)
+        assert event.is_set()
+
+    def test_gate_resolution_cancels_judge_when_opted_in(self, tmp_db, monkeypatch) -> None:
+        """cancel_on_approval=True: the gate's ``finally`` fires the abort
+        signal as soon as the approval resolves, trading verdict
+        completeness for inference savings."""
+        session = _make_session()
+        event = self._drive_gate(session, monkeypatch, cancel_on_approval=True)
+        assert event is not None
+        assert event.is_set()
+
 
 # ---------------------------------------------------------------------------
 # Per-call model override on task_agent

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -173,6 +173,35 @@ def test_on_intent_verdict_stamps_immediately_when_decision_already_set() -> Non
     storage.update_intent_verdict.assert_called_once_with("v-late", user_decision="approved")
 
 
+def test_on_superseded_intent_verdict_persists_without_live_surfaces() -> None:
+    """The persist-only audit hook for verdicts that landed after a newer
+    turn replaced their judge generation: the row reaches storage with
+    user_decision="superseded", but NONE of the live surfaces move — no
+    SSE event, no ``_llm_verdicts`` cache entry (Smart Approvals must
+    never see a stale call_id), no ``_pending_verdicts`` park (the next
+    ``resolve_approval`` must not stamp it with the wrong decision)."""
+    storage = MagicMock()
+    ui = _make_ui()
+    lq = ui._register_listener()
+    verdict = {
+        "verdict_id": "v-late",
+        "call_id": "c-late",
+        "func_name": "bash",
+        "risk_level": "low",
+        "tier": "llm",
+    }
+    with _patch_get_storage(storage):
+        ui.on_superseded_intent_verdict(verdict)
+    storage.upsert_intent_verdict.assert_called_once()
+    kwargs = storage.upsert_intent_verdict.call_args.kwargs
+    assert kwargs["verdict_id"] == "v-late"
+    assert kwargs["user_decision"] == "superseded"
+    assert lq.empty()  # no SSE delivery
+    assert "c-late" not in ui._llm_verdicts  # no replay-cache write
+    assert ui._pending_verdicts == []  # no decision-stamp park
+    assert "user_decision" not in verdict  # caller's dict not mutated
+
+
 def test_llm_verdict_cache_evicts_oldest_at_cap() -> None:
     """FIFO eviction at ``_LLM_VERDICT_CACHE_MAX`` prevents unbounded
     growth on a long-running session."""

--- a/turnstone/core/history_decoration.py
+++ b/turnstone/core/history_decoration.py
@@ -98,13 +98,17 @@ def load_verdict_indexes(
     return verdicts_by_call_id, assessments_by_call_id
 
 
-def build_verdict_payload(vrow: dict[str, Any]) -> dict[str, Any] | None:
+def build_verdict_payload(vrow: dict[str, Any]) -> dict[str, Any]:
     """Project a stored ``intent_verdicts`` row into the wire shape.
 
-    Returns ``None`` when the verdict is the unflagged baseline
-    (``risk_level == "none"``) — the client's ``renderVerdictBadge``
-    helper would suppress those anyway, so skipping at the wire layer
-    keeps the payload tight on long workstreams.
+    Ships every row, including the unflagged baseline (``risk_level ==
+    "none"``) — the live path renders a badge for every verdict the
+    judge delivers (``buildConvVerdict`` has no risk filter), so the
+    replay payload must carry the same set or rehydration silently
+    "loses" verdicts the operator watched land live.  An earlier
+    revision suppressed ``none`` rows here on the assumption the
+    client filtered them anyway; it never did, and the asymmetry
+    surfaced as benign verdicts vanishing after a restart.
 
     Drops ``call_id`` and ``func_name`` from the wire payload — they're
     already carried on the parent ``tc.id`` / ``tc.name`` fields.
@@ -115,10 +119,8 @@ def build_verdict_payload(vrow: dict[str, Any]) -> dict[str, Any] | None:
     badge can render ``⚖ llm:claude-haiku-4`` on history-only batches
     rather than the bare ``⚖ llm`` label.
     """
-    if (vrow.get("risk_level") or "none") == "none":
-        return None
     payload: dict[str, Any] = {
-        "risk_level": vrow.get("risk_level", "medium"),
+        "risk_level": vrow.get("risk_level") or "none",
         "recommendation": vrow.get("recommendation", "review"),
         "confidence": vrow.get("confidence", 0.0),
         "intent_summary": vrow.get("intent_summary", ""),
@@ -190,17 +192,15 @@ def decorate_tool_call(
     either the OpenAI-nested ``{id, function: {name, arguments}}`` shape —
     what ``decorate_history_messages`` passes from the REST ``/history``
     pipeline — or a flattened ``{id, name, arguments}`` shape.  No-ops
-    cleanly when the call_id has no matching row (unflagged tools stay
-    clean).
+    cleanly when the call_id has no matching row (tools the judge never
+    evaluated stay clean).
     """
     call_id = tc.get("id", "") or ""
     if not call_id:
         return
     vrow = verdicts_by_call_id.get(call_id)
     if vrow is not None:
-        verdict = build_verdict_payload(vrow)
-        if verdict is not None:
-            tc["verdict"] = verdict
+        tc["verdict"] = build_verdict_payload(vrow)
     slot = assessments_by_call_id.get(call_id)
     if slot is not None:
         assessment = build_merged_output_assessment_payload(slot)

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -95,7 +95,8 @@ class JudgeConfig:
     output_guard_llm_timeout: float = 30.0  # wall-clock budget for the LLM stage
     redact_secrets: bool = True
     # True = the approval gate's resolution aborts remaining evaluations
-    # (saves inference; undone items degrade to heuristic fallbacks).
+    # (saves inference; undone items degrade to ``llm_fallback`` verdicts
+    # carrying the heuristic content).
     # False (default) = the daemon runs every item to completion; only a
     # generation supersede (next batch) or session close aborts it.
     cancel_on_approval: bool = False
@@ -989,8 +990,9 @@ class IntentJudge:
             messages: Conversation history (OpenAI message format).
             callback: Called with each LLM verdict (or timeout/error fallback).
             cancel_event: Unconditional abort signal — when set, the
-                daemon abandons remaining work and delivers heuristic
-                fallback verdicts for every undone item.  The caller
+                daemon abandons remaining work and delivers
+                ``llm_fallback`` verdicts (heuristic-derived) for every
+                undone item.  The caller
                 owns the firing policy: ChatSession fires it when a
                 newer batch supersedes this generation, on session
                 close, and — only when ``cancel_on_approval`` is
@@ -1039,8 +1041,9 @@ class IntentJudge:
         """Daemon thread: run LLM judge for each item and invoke callback.
 
         ``cancel_event`` is an unconditional abort signal: once it fires,
-        in-flight work stops and every remaining item is delivered as a
-        heuristic fallback verdict (each call still gets exactly one
+        in-flight work stops and every remaining item is delivered as an
+        ``llm_fallback`` verdict — the heuristic verdict's content,
+        relabeled (each call still gets exactly one
         verdict — Smart Approvals and the advisory UI both rely on the
         full set arriving).  Which actor fires the event is the CALLER's
         policy, not this loop's: ChatSession fires it at approval
@@ -1145,7 +1148,7 @@ class IntentJudge:
         callback: Callable[[IntentVerdict], None],
         reason: str,
     ) -> None:
-        """Deliver heuristic fallback verdicts for items the judge didn't complete."""
+        """Deliver ``llm_fallback`` verdicts (heuristic content) for items the judge didn't complete."""
         for _item, h_verdict in zip(remaining_items, remaining_verdicts, strict=True):
             fallback = IntentVerdict(
                 verdict_id=h_verdict.verdict_id,

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -94,7 +94,11 @@ class JudgeConfig:
     output_guard_model: str = ""  # alias for the LLM stage; empty = inherit session model
     output_guard_llm_timeout: float = 30.0  # wall-clock budget for the LLM stage
     redact_secrets: bool = True
-    cancel_on_approval: bool = False  # True = abort remaining items on user approval
+    # True = the approval gate's resolution aborts remaining evaluations
+    # (saves inference; undone items degrade to heuristic fallbacks).
+    # False (default) = the daemon runs every item to completion; only a
+    # generation supersede (next batch) or session close aborts it.
+    cancel_on_approval: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -984,10 +988,13 @@ class IntentJudge:
                 ``func_args``, ``approval_label``, ``call_id``).
             messages: Conversation history (OpenAI message format).
             callback: Called with each LLM verdict (or timeout/error fallback).
-            cancel_event: When set, the daemon judge thread abandons
-                remaining work.  Callers should set this after the user
-                has already made an approval decision so the judge does
-                not keep consuming inference resources.
+            cancel_event: Unconditional abort signal — when set, the
+                daemon abandons remaining work and delivers heuristic
+                fallback verdicts for every undone item.  The caller
+                owns the firing policy: ChatSession fires it when a
+                newer batch supersedes this generation, on session
+                close, and — only when ``cancel_on_approval`` is
+                enabled — as soon as the approval gate resolves.
 
         Returns:
             List of heuristic verdicts (one per item), available immediately.
@@ -1031,21 +1038,29 @@ class IntentJudge:
     ) -> None:
         """Daemon thread: run LLM judge for each item and invoke callback.
 
-        When ``cancel_on_approval`` is True, remaining evaluations are
-        aborted as soon as the user approves/denies.  When False (default),
-        every evaluation runs to completion so all verdicts are delivered.
+        ``cancel_event`` is an unconditional abort signal: once it fires,
+        in-flight work stops and every remaining item is delivered as a
+        heuristic fallback verdict (each call still gets exactly one
+        verdict — Smart Approvals and the advisory UI both rely on the
+        full set arriving).  Which actor fires the event is the CALLER's
+        policy, not this loop's: ChatSession fires it at approval
+        resolution only when ``cancel_on_approval`` is enabled, and
+        always when the next batch supersedes this generation or the
+        session closes.  With ``cancel_on_approval=False`` (default) and
+        no supersede, every evaluation runs to completion so all
+        verdicts are delivered.
         """
         client = self._create_client()
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="judge-api")
         try:
             for idx, (item, h_verdict) in enumerate(zip(items, heuristic_verdicts, strict=True)):
-                if cancel_event and cancel_event.is_set() and self._config.cancel_on_approval:
+                if cancel_event and cancel_event.is_set():
                     log.info("judge.cancelled", remaining=len(items) - idx)
                     self._deliver_fallbacks(
                         items[idx:],
                         heuristic_verdicts[idx:],
                         callback,
-                        "judge cancelled by user approval",
+                        "judge cancelled before evaluating this call",
                     )
                     return
                 try:
@@ -1087,15 +1102,15 @@ class IntentJudge:
                             call_id=fallback.call_id,
                         )
                         callback(fallback)
-                    # After delivering this item's verdict, check if we should
-                    # abort remaining items due to user approval.
-                    if cancel_event and cancel_event.is_set() and self._config.cancel_on_approval:
+                    # After delivering this item's verdict, check whether the
+                    # abort signal fired while we were evaluating it.
+                    if cancel_event and cancel_event.is_set():
                         log.info("judge.cancelled.after_eval", call_id=item.get("call_id", ""))
                         self._deliver_fallbacks(
                             items[idx + 1 :],
                             heuristic_verdicts[idx + 1 :],
                             callback,
-                            "judge cancelled by user approval",
+                            "judge cancelled before evaluating this call",
                         )
                         return
                 except _ExecutorPoisonedError:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5433,18 +5433,32 @@ class ChatSession:
         def _on_verdict(verdict: object) -> None:
             """Callback from the daemon judge thread.
 
-            Drop the verdict when a newer turn has replaced this judge
-            generation.  With ``cancel_on_approval=False`` (the default) the
-            prior turn's daemon runs to completion and would otherwise write a
-            stale verdict — keyed only by ``call_id`` — into the freshly-reset
-            ``_llm_verdicts`` cache; a model that reuses a ``call_id`` across
-            turns could then ride that stale ``approve`` to a wrongful Smart
-            Approval of a *different* call.  Identity-comparing the live
-            generation closes that without affecting same-turn late delivery
-            (``cancel_on_approval=False`` still streams this turn's verdicts,
-            since the session event still points at this ``cancel_event``).
+            Withhold the verdict from the live surfaces when a newer turn has
+            replaced this judge generation.  With ``cancel_on_approval=False``
+            (the default) the prior turn's daemon runs to completion and would
+            otherwise write a stale verdict — keyed only by ``call_id`` — into
+            the freshly-reset ``_llm_verdicts`` cache; a model that reuses a
+            ``call_id`` across turns could then ride that stale ``approve`` to
+            a wrongful Smart Approval of a *different* call.  Identity-
+            comparing the live generation closes that without affecting
+            same-turn late delivery (``cancel_on_approval=False`` still
+            streams this turn's verdicts, since the session event still
+            points at this ``cancel_event``).
+
+            Superseded verdicts still reach the audit table via the UI's
+            ``on_superseded_intent_verdict`` (persist-only, duck-typed —
+            display-only UIs like the CLI don't define it and skip straight
+            to the drop).  Without that, every judge ruling that landed after
+            the next turn began left ``intent_verdicts`` claiming the judge
+            never answered.
             """
             if self._judge_cancel_event is not cancel_event:
+                persist_only = getattr(self.ui, "on_superseded_intent_verdict", None)
+                if persist_only is not None:
+                    try:
+                        persist_only(verdict.to_dict())  # type: ignore[attr-defined]
+                    except Exception:
+                        log.debug("judge.superseded_verdict_persist_failed", exc_info=True)
                 return
             try:
                 self.ui.on_intent_verdict(verdict.to_dict())  # type: ignore[attr-defined]

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5277,7 +5277,8 @@ class ChatSession:
 
         Returns a cancel event that, when set, tells the daemon judge
         thread to abandon remaining work (each undone item degrades to
-        a heuristic fallback verdict).  ``_execute_tools`` fires it
+        an ``llm_fallback`` verdict carrying the heuristic content).
+        ``_execute_tools`` fires it
         unconditionally when the next batch supersedes this generation,
         ``close()`` fires it on session teardown, and the approval
         gate's ``finally`` fires it on decision only when
@@ -6096,7 +6097,8 @@ class ChatSession:
             # Gate resolution fires the judge's abort signal only when the
             # operator opted in: with ``judge.cancel_on_approval`` the daemon
             # stops spending inference the moment a decision lands (remaining
-            # items degrade to heuristic fallback verdicts).  With the
+            # items degrade to ``llm_fallback`` verdicts, heuristic
+            # content relabeled).  With the
             # default False the daemon runs every item to completion — the
             # contract the setting's help text promises — and late verdicts
             # stream + persist through ``_on_verdict``.  An unconditional

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5276,8 +5276,14 @@ class ChatSession:
         async LLM judge that delivers final verdicts via UI callback.
 
         Returns a cancel event that, when set, tells the daemon judge
-        thread to abandon remaining work.  Callers should set this
-        after the user has made an approval decision.
+        thread to abandon remaining work (each undone item degrades to
+        a heuristic fallback verdict).  ``_execute_tools`` fires it
+        unconditionally when the next batch supersedes this generation,
+        ``close()`` fires it on session teardown, and the approval
+        gate's ``finally`` fires it on decision only when
+        ``judge.cancel_on_approval`` is enabled — the default leaves
+        the daemon running to completion so every call gets a real
+        LLM verdict for the audit trail.
         """
         judge = self._ensure_judge()
         if not judge:
@@ -6087,8 +6093,22 @@ class ChatSession:
         try:
             approved, user_feedback = self.ui.approve_tools(items)
         finally:
-            if judge_cancel:
-                judge_cancel.set()  # user decided (or disconnected) — stop judge
+            # Gate resolution fires the judge's abort signal only when the
+            # operator opted in: with ``judge.cancel_on_approval`` the daemon
+            # stops spending inference the moment a decision lands (remaining
+            # items degrade to heuristic fallback verdicts).  With the
+            # default False the daemon runs every item to completion — the
+            # contract the setting's help text promises — and late verdicts
+            # stream + persist through ``_on_verdict``.  An unconditional
+            # set here used to defeat that: ``_evaluate_single`` polls the
+            # event regardless of config, so every undone item silently
+            # became a fallback row the instant the gate resolved.  A stale
+            # daemon is still bounded to one batch of real work by the
+            # unconditional supersede-set at the top of the next batch and
+            # by ``close()``.
+            jc_live = self._judge_cfg
+            if judge_cancel and jc_live and jc_live.cancel_on_approval:
+                judge_cancel.set()
         self._emit_state("running")
         if not approved:
             # Mark all pending items as denied

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1387,6 +1387,34 @@ class SessionUIBase:
         if decision:
             self._persist_verdict_decisions([verdict], decision)
 
+    def on_superseded_intent_verdict(self, verdict: dict[str, Any]) -> None:
+        """Persist (audit-only) a verdict whose judge generation was superseded.
+
+        ``ChatSession._on_verdict`` routes here instead of
+        :meth:`on_intent_verdict` when a newer turn has replaced the
+        daemon's generation.  The live surfaces deliberately stay
+        untouched — no ``_llm_verdicts`` cache write, no SSE enqueue,
+        no ``_verdict_cond`` notify, no ``_pending_verdicts`` park —
+        because the verdict's call_id belongs to an already-resolved
+        batch, and a model that reuses call_ids across turns could
+        ride a stale cached ``approve`` into a wrongful Smart Approval
+        of a *different* call.  Dropping the verdict entirely (the
+        previous behavior) kept that safety property but left a
+        permanent hole in ``intent_verdicts``: the audit table said
+        "the judge never answered" for calls it actually ruled on.
+
+        ``user_decision`` is stamped ``"superseded"`` — no decision was
+        ever taken on THIS verdict; its call's gate resolved before the
+        judge finished.  The stamp only lands on fresh ``tier="llm"``
+        rows: a superseded *fallback* reuses its heuristic row's
+        verdict_id, and ``upsert_intent_verdict`` excludes
+        ``user_decision`` from the on-conflict SET, so the decision
+        already recorded on that row survives the tier upgrade.
+        """
+        row = dict(verdict)
+        row.setdefault("user_decision", "superseded")
+        self._persist_intent_verdict(row)
+
     def _record_judge_metric(self, verdict: dict[str, Any]) -> None:
         """Extension point for transport-specific Prometheus metrics.
 

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1480,25 +1480,22 @@ class SessionUIBase:
                 }
                 for v in verdicts
             ]
-            # Plain INSERT (not UPSERT) at the bulk site.  The race
-            # where a daemon-judge verdict lands BEFORE this bulk
-            # write IS reachable today: ``_evaluate_intent``
-            # (session.py) spawns the daemon thread before
-            # ``approve_tools`` is called, and the daemon's first
-            # emission (heuristic-only short batch, fast LLM response,
-            # or cancel-event ``_deliver_fallbacks`` from judge.py)
-            # can fire ``_persist_intent_verdict`` before this bulk
-            # INSERT runs.  Outcome of that race is unchanged by the
-            # per-row UPSERT switch: the bulk INSERT statement aborts
-            # on PK collision regardless of whether the colliding row
-            # was planted by INSERT or UPSERT, and the wrapping
-            # ``try/except`` swallows it.  Race A (daemon fires AFTER
-            # bulk) IS improved by the fix: heuristic→llm_fallback
-            # upgrade-in-place now lands.  Future bulk-side hardening
-            # (``ON CONFLICT DO NOTHING``) would preserve the OTHER
-            # rows in the batch when one collides, but would keep the
-            # daemon's ``tier`` ("llm"/"llm_fallback") for the
-            # colliding row instead of the bulk's heuristic stamp.
+            # The daemon-judge race where a verdict lands BEFORE this
+            # bulk write IS reachable: ``_evaluate_intent`` (session.py)
+            # spawns the daemon thread before ``approve_tools`` is
+            # called, and the daemon's first emission (heuristic-only
+            # short batch, fast LLM response, or cancel-event
+            # ``_deliver_fallbacks`` from judge.py) can fire
+            # ``_persist_intent_verdict`` first — a fallback UPSERT
+            # plants the very ``verdict_id`` this batch is about to
+            # INSERT.  The bulk site inserts ``ON CONFLICT DO NOTHING``
+            # so that one collision skips only its own row: the rest of
+            # the batch still lands, and the colliding row keeps the
+            # daemon's ``llm_fallback`` tier upgrade instead of being
+            # regressed to the heuristic stamp.  (Plain INSERT here used
+            # to abort the entire statement — and the ``try/except``
+            # below swallowed it — discarding the whole batch's
+            # heuristic rows.)
             storage.create_intent_verdicts_bulk(rows)
         except Exception:
             log.debug("Failed to bulk-persist intent verdicts", exc_info=True)

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -3642,14 +3642,8 @@ class PostgreSQLBackend:
             conn.commit()
 
     def create_intent_verdicts_bulk(self, verdicts: list[dict[str, Any]]) -> None:
-        # ON CONFLICT DO NOTHING per row: the async judge daemon can land
-        # an UPSERT (which INSERTs the heuristic verdict_id it reuses)
-        # before this bulk write runs.  A plain INSERT would abort the
-        # whole statement on that one collision — silently discarding
-        # every OTHER row in the batch (the caller swallows storage
-        # errors).  Skipping just the colliding row also keeps the
-        # daemon's tier upgrade ("llm_fallback") instead of regressing
-        # it to the bulk's heuristic stamp.
+        # ON CONFLICT DO NOTHING — see the protocol docstring for the
+        # daemon-races-the-bulk-write rationale.
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
         if not verdicts:

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -3642,6 +3642,16 @@ class PostgreSQLBackend:
             conn.commit()
 
     def create_intent_verdicts_bulk(self, verdicts: list[dict[str, Any]]) -> None:
+        # ON CONFLICT DO NOTHING per row: the async judge daemon can land
+        # an UPSERT (which INSERTs the heuristic verdict_id it reuses)
+        # before this bulk write runs.  A plain INSERT would abort the
+        # whole statement on that one collision — silently discarding
+        # every OTHER row in the batch (the caller swallows storage
+        # errors).  Skipping just the colliding row also keeps the
+        # daemon's tier upgrade ("llm_fallback") instead of regressing
+        # it to the bulk's heuristic stamp.
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
         if not verdicts:
             return
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
@@ -3667,7 +3677,10 @@ class PostgreSQLBackend:
             for v in verdicts
         ]
         with self._conn() as conn:
-            conn.execute(sa.insert(intent_verdicts), rows)
+            conn.execute(
+                pg_insert(intent_verdicts).on_conflict_do_nothing(index_elements=["verdict_id"]),
+                rows,
+            )
             conn.commit()
 
     def get_intent_verdict(self, verdict_id: str) -> dict[str, Any] | None:

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1676,6 +1676,11 @@ class StorageBackend(Protocol):
         ``"approved"`` / ``"denied"`` / ``"timeout"`` (user-driven) or
         ``"policy"`` / ``"blanket"`` / ``"auto_approve_tools"``
         (auto-approve reason, mirroring :class:`AutoApproveReason`).
+        Rows whose verdict landed only after a newer turn replaced the
+        judge generation are written directly with ``"superseded"`` —
+        no decision was ever taken on that verdict (its call's gate
+        resolved before the judge finished); see
+        ``SessionUIBase.on_superseded_intent_verdict``.
         """
         ...
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1736,8 +1736,10 @@ class StorageBackend(Protocol):
 
         Used by :meth:`SessionUIBase._persist_intent_verdict` for every
         async LLM-tier delivery; the synchronous heuristic-bulk path
-        (:meth:`create_intent_verdicts_bulk`) stays as plain INSERT
-        since each heuristic UUID is freshly generated per turn.
+        (:meth:`create_intent_verdicts_bulk`) inserts with per-row
+        ``ON CONFLICT DO NOTHING`` instead — its UUIDs are freshly
+        generated per turn, but the daemon can race a fallback UPSERT
+        of one of those same IDs in ahead of the bulk write.
         """
         ...
 
@@ -1754,6 +1756,15 @@ class StorageBackend(Protocol):
         vocabulary. Used by the synchronous heuristic-verdict
         persistence loop in ``approve_tools`` so a tool-heavy turn
         doesn't pay N×commit latency before the approval prompt renders.
+
+        Inserts ``ON CONFLICT (verdict_id) DO NOTHING``: the async judge
+        daemon's first delivery can UPSERT a fallback row — which reuses
+        a heuristic ``verdict_id`` from this very batch — before the
+        bulk write runs.  Aborting the whole statement on that collision
+        (plain-INSERT behavior) silently discarded every other row in
+        the batch; skipping just the colliding row keeps the rest AND
+        preserves the daemon's ``llm_fallback`` tier upgrade rather
+        than regressing it to the heuristic stamp.
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -3815,14 +3815,8 @@ class SQLiteBackend:
             conn.commit()
 
     def create_intent_verdicts_bulk(self, verdicts: list[dict[str, Any]]) -> None:
-        # ON CONFLICT DO NOTHING per row: the async judge daemon can land
-        # an UPSERT (which INSERTs the heuristic verdict_id it reuses)
-        # before this bulk write runs.  A plain INSERT would abort the
-        # whole statement on that one collision — silently discarding
-        # every OTHER row in the batch (the caller swallows storage
-        # errors).  Skipping just the colliding row also keeps the
-        # daemon's tier upgrade ("llm_fallback") instead of regressing
-        # it to the bulk's heuristic stamp.
+        # ON CONFLICT DO NOTHING — see the protocol docstring for the
+        # daemon-races-the-bulk-write rationale.
         from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
         if not verdicts:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -3815,6 +3815,16 @@ class SQLiteBackend:
             conn.commit()
 
     def create_intent_verdicts_bulk(self, verdicts: list[dict[str, Any]]) -> None:
+        # ON CONFLICT DO NOTHING per row: the async judge daemon can land
+        # an UPSERT (which INSERTs the heuristic verdict_id it reuses)
+        # before this bulk write runs.  A plain INSERT would abort the
+        # whole statement on that one collision — silently discarding
+        # every OTHER row in the batch (the caller swallows storage
+        # errors).  Skipping just the colliding row also keeps the
+        # daemon's tier upgrade ("llm_fallback") instead of regressing
+        # it to the bulk's heuristic stamp.
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
         if not verdicts:
             return
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
@@ -3840,7 +3850,12 @@ class SQLiteBackend:
             for v in verdicts
         ]
         with self._conn() as conn:
-            conn.execute(sa.insert(intent_verdicts), rows)
+            conn.execute(
+                sqlite_insert(intent_verdicts).on_conflict_do_nothing(
+                    index_elements=["verdict_id"]
+                ),
+                rows,
+            )
             conn.commit()
 
     def get_intent_verdict(self, verdict_id: str) -> dict[str, Any] | None:


### PR DESCRIPTION
## Incident

A 22-call parallel tool batch showed LLM intent-validation verdicts for every call while streaming live, but after restarting turnstone and rehydrating the workstream only 3 of the 22 still showed a verdict. Root-causing that surfaced four distinct defects in the verdict lifecycle, one per commit.

## Fixes

**1. Replay parity (`history_decoration.py`)** — the /history decoration layer suppressed verdict rows with `risk_level="none"` from the wire payload, assuming the client filtered them anyway. It never did: `buildConvVerdict` renders every verdict it receives, so live painted all badges while rehydrate dropped the benign majority — exactly the 3-of-22 symptom (the 3 survivors were the flagged calls). Every stored row now ships on replay. The output-guard chip pair, which suppresses consistently on both sides, is unchanged.

**2. Superseded-verdict audit gap (`session.py`, `session_ui_base.py`)** — `_on_verdict` drops verdicts arriving after a newer turn replaces the judge generation, protecting Smart Approvals from stale call_id reuse — but it dropped them *before persistence*, leaving `intent_verdicts` claiming the judge never answered. Superseded verdicts now route to a persist-only hook (`on_superseded_intent_verdict`) landing with `user_decision="superseded"` while every live surface stays untouched. `upsert_intent_verdict` already excludes `user_decision` from its on-conflict SET, so a superseded fallback can't clobber a recorded decision.

**3. Bulk-insert wholesale abort (`_sqlite.py`, `_postgresql.py`)** — the judge daemon can UPSERT a fallback row (reusing a heuristic verdict_id) before `approve_tools` bulk-inserts the batch's heuristic rows; the resulting PK collision aborted the entire INSERT and the best-effort wrapper swallowed it, silently discarding every heuristic row in the batch. Now inserts `ON CONFLICT (verdict_id) DO NOTHING`: siblings survive, and the colliding row keeps the daemon's tier upgrade.

**4. `cancel_on_approval=False` contract (`session.py`, `judge.py`)** — the setting's default promises the judge evaluates every call to completion, but the approval gate's `finally` fired the cancel event unconditionally and `_evaluate_single` honors that event regardless of config — so on a 22-call batch, approving after the third verdict silently degraded the other 19 to heuristic `llm_fallback` rows. The event is now a pure abort signal whose firing policy lives with the caller: the gate fires it only when `cancel_on_approval=true`; generation supersede and `close()` keep firing unconditionally, bounding a stale daemon to one batch. The judge loop drops its own config second-guessing.

## Testing

- Full suite: 7315 passed, 8 skipped (sqlite backend); PostgreSQL lane relies on CI (`--storage-backend postgresql`)
- New regression tests: replay keeps every judged verdict on a parallel batch; superseded persist-only semantics (no SSE/cache/park, decision not clobbered); bulk-insert mid-batch collision keeps siblings + tier upgrade; gate resolution leaves the event unfired by default / fires it when opted in; judge loop aborts-with-fallbacks vs runs-to-completion under each event state
- `docs/judge.md` gains the verdict lifecycle section (run-to-completion default, superseded rows, replay parity, local-inference guidance)