### PR TITLE
fix(console): manage-pane scroll regressions — interior scroller, hatch-host clip, hidden-input anchors

### DIFF
--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -26,11 +26,17 @@ UI harness (?open=): new-ws · new-ws-fork · edit-title · delete-ws ·
 Console harness (?open=): schedule-create · schedule-edit · model-create ·
   model-edit · model-save (drives a Save click; document.title becomes
   PUT-OK-<n> on success) · policy · confirm · token
-  Plus &tall=1 (90-row users panel — the .admin-content scroll state; add
-  &scrolled=1 to land mid-list, combinable with ?open= to pin a shelf over
-  scrolled content).  The console page wraps the fragment in the REAL
-  L-shell chain — pane-pinned height, interior scroller — so scroll/dock
-  geometry matches production; keep it that way.
+  Plus &tall=1 (90-row users panel — the .admin-content scroll state; the
+  synthetic rows wrap to two lines, so judge overflow geometry, not row
+  cadence) · &scrolled=1 lands mid-list, &scrolled=bottom shows the 24px
+  scroll tail · &focuslast=1 focuses the last shelf-body control (the
+  displaced-dock regression probe: only .sh-body may scroll; head/foot stay
+  pinned).  All combinable with ?open=.  The console page wraps the fragment
+  in the REAL L-shell chain — pane-pinned height, interior scroller — so
+  scroll/dock geometry matches production; keep it that way.  Body-level
+  dialogs (confirm/install/coord-delete) are injected as riders; a driven
+  ?open= that ends with no open dialog stamps OPEN-FAILED-<state> into the
+  title instead of passing silently.
   Governance surfaces (roles/HR/OGP/memory/skill) need fixtures that are not
   canned yet — add a fixture + driver branch below when you need one.
 
@@ -217,8 +223,9 @@ UI_TEMPLATE = """<!doctype html>
 """
 
 # --------------------------------------------------------------------------
-# Console harness — the admin pane fragment hosts the shelves; body-level
-# hatch dialogs (confirm/token/install/batch) ride along inside it.
+# Console harness — the admin pane fragment hosts the shelves (token-created
+# included); dialog-tier markup outside the fragment (confirm/install/
+# coord-delete) is injected via the RIDERS marker in build().
 # model-save click-drives the submit: document.title flips to PUT-OK-<n>.
 # --------------------------------------------------------------------------
 CONSOLE_TEMPLATE = """<!doctype html>
@@ -266,6 +273,12 @@ CONSOLE_TEMPLATE = """<!doctype html>
         </div>
       </main>
     </div>
+    <!-- Body-level dialog tier (confirm / install / coord-delete): their
+         markup sits OUTSIDE #admin-layout in index.html, so the fragment
+         extraction misses them — build() injects every hatch dialog the
+         fragment does not already contain. -->
+    <!-- RIDERS:BEGIN -->
+    <!-- RIDERS:END -->
     <div id="toast" role="status" aria-live="polite"></div>
     <script>
       (function () {
@@ -383,7 +396,10 @@ CONSOLE_TEMPLATE = """<!doctype html>
           }
           var content = document.getElementById("admin-content");
           if (content && q.get("scrolled"))
-            content.scrollTop = content.scrollHeight / 2; // land mid-list
+            content.scrollTop =
+              q.get("scrolled") === "bottom"
+                ? content.scrollHeight // the 24px scroll-tail state
+                : content.scrollHeight / 2; // land mid-list
         }
         setTimeout(function () {
           if (open === "schedule-create") showCreateScheduleModal();
@@ -415,6 +431,22 @@ CONSOLE_TEMPLATE = """<!doctype html>
               var d = document.querySelector("dialog[open]");
               if (d) window.TurnstoneHatch.setBusy(d, true);
             }, 400);
+          // A driven state that ends with nothing open must fail LOUDLY in
+          // the screenshot pipeline, not render a quietly dialog-less page.
+          setTimeout(function () {
+            var top = document.querySelector("dialog[open]");
+            if (open && !top) document.title = "OPEN-FAILED-" + open;
+            // &focuslast=1 — the displaced-dock regression probe: focus the
+            // last form control in the shelf BODY (the visually-hidden
+            // toggle/radio inputs live there).  Only .sh-body may scroll;
+            // the head/foot strips must stay pinned in the screenshot.
+            if (top && q.get("focuslast")) {
+              var els = top.querySelectorAll(
+                ".sh-body input, .sh-body select, .sh-body textarea",
+              );
+              if (els.length) els[els.length - 1].focus();
+            }
+          }, 600);
         }, 150);
       });
     </script>
@@ -441,11 +473,15 @@ def build(out: Path) -> None:
 
     symlink(con / "shared", ROOT / "turnstone/shared_static")
     symlink(con / "console-static", ROOT / "turnstone/console/static")
-    (con / "livepass.html").write_text(
-        inject(CONSOLE_TEMPLATE, "FRAGMENT", extract_admin_fragment()),
-        encoding="utf-8",
-    )
-    print(f"{con}/livepass.html — admin fragment embedded")
+    frag = extract_admin_fragment()
+    # Dialog-tier markup living OUTSIDE #admin-layout (confirm, install,
+    # coord-delete) would otherwise be silently absent — and ?open=confirm
+    # would screenshot a dialog-less page while the gate stayed green.
+    riders = [b for b in extract_dialogs(CONSOLE_INDEX) if b not in frag]
+    page = inject(CONSOLE_TEMPLATE, "FRAGMENT", frag)
+    page = inject(page, "RIDERS", "\n".join(riders))
+    (con / "livepass.html").write_text(page, encoding="utf-8")
+    print(f"{con}/livepass.html — admin fragment + {len(riders)} rider dialogs")
 
 
 def main() -> None:

--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -26,6 +26,11 @@ UI harness (?open=): new-ws · new-ws-fork · edit-title · delete-ws ·
 Console harness (?open=): schedule-create · schedule-edit · model-create ·
   model-edit · model-save (drives a Save click; document.title becomes
   PUT-OK-<n> on success) · policy · confirm · token
+  Plus &tall=1 (90-row users panel — the .admin-content scroll state; add
+  &scrolled=1 to land mid-list, combinable with ?open= to pin a shelf over
+  scrolled content).  The console page wraps the fragment in the REAL
+  L-shell chain — pane-pinned height, interior scroller — so scroll/dock
+  geometry matches production; keep it that way.
   Governance surfaces (roles/HR/OGP/memory/skill) need fixtures that are not
   canned yet — add a fixture + driver branch below when you need one.
 
@@ -222,18 +227,44 @@ CONSOLE_TEMPLATE = """<!doctype html>
     <meta charset="utf-8" />
     <title>console livepass</title>
     <link rel="stylesheet" href="shared/base.css" />
+    <link rel="stylesheet" href="shared/ui-base.css" />
     <link rel="stylesheet" href="console-static/style.css" />
+    <link rel="stylesheet" href="shared/shell.css" />
     <link rel="stylesheet" href="shared/hatch.css" />
-    <style>
-      body { padding: 0; }
-      #view-admin { padding: 20px; height: 100vh; box-sizing: border-box; }
-      #admin-layout { height: 100%; }
-    </style>
   </head>
   <body>
-    <div id="view-admin">
-      <!-- FRAGMENT:BEGIN -->
-      <!-- FRAGMENT:END -->
+    <!-- The REAL L-shell chain (shell.js buildShell + pane.js DOM, verbatim
+         class names) so the harness inherits production scroll geometry:
+         .pane-body > #view-admin > .admin-layout height-pin the hatch-host
+         and .admin-content is the pane's interior scroller.  Never replace
+         this with bespoke height overrides — the clipped-pane / displaced-
+         shelf regressions were invisible to the harness precisely because
+         it used to pin #admin-layout with its own CSS. -->
+    <div class="app">
+      <aside class="rail" id="shell-rail">
+        <div class="rail-brand">
+          <button class="brand-home" type="button">
+            <div class="brand-mark"></div>
+            <span class="brand-name">turnstone</span>
+            <span class="brand-sub">console</span>
+          </button>
+        </div>
+      </aside>
+      <main class="content">
+        <div class="tabbar"></div>
+        <div class="panes">
+          <section class="pane">
+            <!-- no .pane-head: PaneManager._mount builds section.pane >
+                 div.pane-body only -->
+            <div class="pane-body">
+              <div id="view-admin">
+                <!-- FRAGMENT:BEGIN -->
+                <!-- FRAGMENT:END -->
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
     </div>
     <div id="toast" role="status" aria-live="polite"></div>
     <script>
@@ -331,6 +362,29 @@ CONSOLE_TEMPLATE = """<!doctype html>
         if (q.get("theme") === "light")
           document.documentElement.dataset.theme = "light";
         var open = q.get("open") || "";
+        // ?tall=1 — the scroll state: one panel visible with enough rows to
+        // overflow the pane, so a screenshot shows .admin-content scrolling
+        // (and a shelf staying docked above it).  Mirrors switchAdminTab's
+        // one-panel-visible invariant without booting the tab loaders.
+        if (q.get("tall")) {
+          var panels = document.querySelectorAll(".admin-panel");
+          for (var i = 0; i < panels.length; i++)
+            panels[i].style.display =
+              panels[i].id === "admin-users" ? "" : "none";
+          // No fallback: a fragment rename must fail loudly, not misplace rows.
+          var rowHost = document.querySelector("#admin-users [role=list]");
+          rowHost.textContent = ""; // drop the static "Loading users…" stub
+          for (var r = 0; r < 90; r++) {
+            var row = document.createElement("div");
+            row.className = "admin-row"; // real row chrome — geometry tracks production
+            row.textContent =
+              "user-" + String(r).padStart(3, "0") + " \\u00b7 synthetic row";
+            rowHost.appendChild(row);
+          }
+          var content = document.getElementById("admin-content");
+          if (content && q.get("scrolled"))
+            content.scrollTop = content.scrollHeight / 2; // land mid-list
+        }
         setTimeout(function () {
           if (open === "schedule-create") showCreateScheduleModal();
           else if (open === "schedule-edit") showEditScheduleModal("t1");

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -178,6 +178,7 @@ function showAdmin(tab) {
 }
 
 function switchAdminTab(tab) {
+  const tabChanged = tab !== _adminTab;
   _adminTab = tab;
   // Hide no-permissions empty state if it was showing
   const noPerms = document.getElementById("admin-no-permissions");
@@ -205,6 +206,15 @@ function switchAdminTab(tab) {
   for (let p = 0; p < panels.length; p++) {
     const el = document.getElementById("admin-" + panels[p]);
     if (el) el.style.display = panels[p] === tab ? "" : "none";
+  }
+
+  // One #admin-content scroller serves every panel — a leftover offset from
+  // a tall tab must not carry into the next (the app.js #main reset is the
+  // precedent for pane-local navigation).  Same-tab re-entry (showAdmin on
+  // pane focus) keeps the user's place.
+  if (tabChanged) {
+    const contentEl = document.getElementById("admin-content");
+    if (contentEl) contentEl.scrollTop = 0;
   }
 
   if (tab === "users") loadAdminUsers();

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -411,11 +411,20 @@
   flex: 1;
 }
 
-/* Content area */
+/* Content area — the manage pane's interior scroller.  The chain above it
+   (#view-admin → .admin-layout) is height-pinned by the L-shell pane and the
+   .hatch-host clips, so this is the last box that can own tab overflow.  It
+   scrolls so the docked shelf — positioned against .admin-layout, OUTSIDE
+   this scroller — stays put while tab content moves beneath it; the same
+   division of labor as #main inside the dashboard pane. */
 .admin-content {
   flex: 1;
   min-width: 0;
+  overflow-y: auto;
   padding-right: 20px;
+  /* scroll tail — the last row must not hug the pane edge (#main keeps 60px;
+     the admin tables are denser, so less) */
+  padding-bottom: 24px;
 }
 
 .admin-toolbar {
@@ -746,9 +755,10 @@
    text-overflow "…".  The actions cell inherits `.admin-col`'s
    `overflow: hidden`, which would re-clip a dropdown, so we override it
    to `visible` and anchor an absolutely-positioned menu to the kebab
-   container.  `.admin-content` does not scroll (the document does), so
-   the menu — glued to its cell — overlays the page without being
-   clipped by any ancestor. */
+   container.  The menu lives inside the `.admin-content` scroller and
+   rides with its row; the viewport-aware flip-up in _initKebabMenus
+   keeps bottom rows' menus inside the visible box, and scrolling
+   dismisses an open menu before the scroller's edge could clip it. */
 .admin-col-actions,
 .admin-col-mactions {
   overflow: visible;
@@ -951,6 +961,11 @@
  * a hatch body, hatch.css restates this layout at higher specificity —
  * the .sh-body label.toggle-switch exception.) */
 label.toggle-switch {
+  /* The containing block for the visually-hidden abspos input below: without
+     it the input sits at its static position outside whatever scroller the
+     toggle lives in (.sh-body, .admin-content) and focus-scrolls the wrong
+     ancestor — inside a shelf that shoved the whole hatch off its dock. */
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -1090,6 +1105,11 @@ label.toggle-switch.toggle--flush {
    first letters and unselected rows lose their dot entirely). */
 .sh-body label.segmented-option,
 .segmented-option {
+  /* The containing block for the visually-hidden abspos radio below — same
+     anchor label.toggle-switch and .sh-body label.cap carry: an unanchored
+     input sits at its static position outside the .sh-body scroller and
+     focus-scrolls the wrong ancestor when the radiogroup is below the fold. */
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/turnstone/shared_static/hatch.css
+++ b/turnstone/shared_static/hatch.css
@@ -35,10 +35,18 @@
    narrow-pane sheet breakpoint (a SPLIT pane is narrow even on a desktop
    viewport, so the breakpoint is a container query, not a media query).
    contain:layout (implied by container-type) also makes this the containing
-   block for the absolutely-positioned shelf. */
+   block for the absolutely-positioned shelf.
+
+   overflow must be `clip`, never `hidden`: hidden makes the host a
+   PROGRAMMATIC scroll container — focus-into-view (tabbing to a control,
+   clicking a visually-hidden toggle input) silently scrolls it, dragging
+   the docked shelf and the pane content out of alignment with no scrollbar
+   to recover by.  clip only clips paint; the host can never scroll, so
+   scrolling stays where it belongs — the pane's interior scroller and the
+   shelf's .sh-body. */
 .hatch-host {
   position: relative;
-  overflow: hidden;
+  overflow: clip;
   container-type: inline-size;
   container-name: pane;
 }
@@ -862,6 +870,10 @@
   margin-top: 8px;
 }
 .sh-body label.cap {
+  /* The containing block for the visually-hidden abspos input below: without
+     it the input sits at its static position OUTSIDE the .sh-body scroller,
+     overhangs the shelf, and focus-scrolls the wrong ancestor. */
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Problem

Two symptoms, one mechanism, from the L-shell + hatch renovations stacking:

- **Manage tabs taller than the pane were hard-clipped.** The L-shell height-pins the admin chain (`.pane-body → #view-admin → #admin-layout`) and `.hatch-host{overflow:hidden}` severed the last overflow path to the pane scroller. Measured: 5225px of users-tab content clipped dead in a 716px box, no scrollbar anywhere.
- **Docked shelves could be shoved off their dock.** `overflow:hidden` makes the host a *programmatic* scroll container. The visually-hidden abspos checkbox/radio inputs (toggle switches, capability chips, segmented radios) escape the `.sh-body` scroller — their labels were unpositioned, so their containing block is the shelf — overhang the host, and a Tab keypress focus-scrolled it: shelf head/foot cut off, with no scrollbar to recover by. Reproduced: one focus call → host `scrollTop=136`, header gone.

## Fix

- `.admin-content` becomes the manage pane's interior scroller (the `#main` precedent), with a 24px scroll tail; `switchAdminTab` resets it on real tab changes only
- `.hatch-host`: `overflow: hidden → clip` — paint clipping that can never scroll, so focus cannot displace the dock
- `position: relative` anchors on the three hidden-input labels (`label.toggle-switch`, `.sh-body label.cap`, `.segmented-option`); `.settings-toggle` already carried one

## Harness

The livepass console page used to pin `#admin-layout` with bespoke CSS — exactly why this bug class was invisible to the screenshot gates. It now wraps the real fragment in the real L-shell chain (`buildShell`/`pane.js` DOM, verbatim class names), plus:

- `?tall=1` with `&scrolled=1|bottom` — the scroll states
- `&focuslast=1` — the displaced-dock regression probe (only `.sh-body` may scroll; head/foot strips stay pinned)
- body-level dialog-tier riders: confirm/install/coord-delete markup sits outside `#admin-layout`, so `?open=confirm` had been a silently-green no-op gate; driven states that end dialog-less now stamp `OPEN-FAILED-<state>` into the title

## Verification

- Headless before/after geometry probes (per-element scrollability matrix; focus-displacement now 0; shelf overhang gone)
- Screenshot matrix: tall tab top/mid/bottom, shelf docked over scrolled content, 640px bottom sheet, dialog tier — both themes
- 7-angle review round, then dual designer review (primed + neutral): product CSS passed both; the harness dialog-tier gap was the one should-fix and is fixed here. Convergent polish items (sticky column headers, app-wide Firefox scrollbar treatment) filed to the design-doc backlog.
- Full non-live suite: 7335 passed, 8 skipped