### PR TITLE
ui(console): launcher persona toggle wears its kind — amber coord / cyan int

### DIFF
--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -119,21 +119,23 @@
             <button
               type="button"
               id="persona-coordinator"
-              class="persona-btn active"
+              class="persona-btn persona-btn--coord active"
               role="radio"
               aria-checked="true"
               tabindex="0"
             >
+              <span class="persona-led" aria-hidden="true"></span>
               Coordinator
             </button>
             <button
               type="button"
               id="persona-interactive"
-              class="persona-btn"
+              class="persona-btn persona-btn--int"
               role="radio"
               aria-checked="false"
               tabindex="-1"
             >
+              <span class="persona-led" aria-hidden="true"></span>
               Interactive
             </button>
           </div>

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -723,6 +723,10 @@
   .tab-menu {
     animation: none;
   }
+  .persona-btn,
+  .persona-led {
+    transition: none;
+  }
 }
 
 /* pane host — ONE pane visible per tab (no split; the mock's 2-up was a
@@ -829,33 +833,74 @@
 }
 
 /* ===== Dashboard session launcher — persona toggle (coordinator | interactive).
-   A console-dashboard control; lives here because the L-shell loads shell.css. */
+   A console-dashboard control; lives here because the L-shell loads shell.css.
+
+   The active option wears its KIND, not a neutral highlight: amber for
+   coordinator, cyan for interactive — the same vocabulary as the pane-head
+   .ptag chips and the rail's session rows, so "which kind am I starting"
+   reads at a glance.  Tints are 15% (sub-0.10 washes out at chip size) and
+   colour is never alone: the kind LED + label weight carry the state too. */
 .launcher-personas {
   display: inline-flex;
   gap: 2px;
   margin-bottom: 10px;
-  padding: 2px;
-  border: 1px solid var(--hair);
+  padding: 3px;
+  border: 1px solid var(--hair-2);
   border-radius: var(--r-sm);
-  background: var(--panel-2);
+  background: var(--bg); /* recessed track — the .seg precedent */
 }
 .persona-btn {
-  padding: 4px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 14px;
   border: 0;
   background: none;
   color: var(--ink-3);
   font-size: 12px;
+  font-weight: 500;
   font-family: var(--font-ui);
-  border-radius: var(--r-sm);
+  border-radius: 3px;
   cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 .persona-btn:hover {
   color: var(--ink);
 }
+.persona-led {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-4);
+  opacity: 0.35;
+  flex-shrink: 0;
+  transition:
+    background 0.12s,
+    opacity 0.12s,
+    box-shadow 0.12s;
+}
 .persona-btn.active {
-  background: var(--panel);
-  color: var(--ink);
-  box-shadow: inset 0 0 0 1px var(--hair-2);
+  font-weight: 600;
+}
+.persona-btn--coord.active {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+}
+.persona-btn--coord.active .persona-led {
+  background: var(--accent);
+  opacity: 1;
+  box-shadow: 0 0 6px var(--accent-glow-strong);
+}
+.persona-btn--int.active {
+  background: color-mix(in srgb, var(--cyan) 15%, transparent);
+  color: var(--cyan);
+}
+.persona-btn--int.active .persona-led {
+  background: var(--cyan);
+  opacity: 1;
+  box-shadow: 0 0 6px var(--cyan-glow);
 }
 /* persona tag in the saved-sessions table — shares the rail chip base
    (.row .tag above); only no-wrap + the INT colour differ. */

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -860,7 +860,9 @@
   font-size: 12px;
   font-weight: 500;
   font-family: var(--font-ui);
-  border-radius: 3px;
+  /* r-sm, matching the shared :focus-visible rule below — a literal here
+     would make the corner radius pop on keyboard focus */
+  border-radius: var(--r-sm);
   cursor: pointer;
   transition:
     background 0.12s,


### PR DESCRIPTION
The dashboard launcher's Coordinator | Interactive selector styled its active option as a neutral panel highlight — two faint text links that didn't communicate *what kind of workstream* was being chosen.

The active option now speaks the kind vocabulary the shell already uses everywhere else (`.ptag.coord` amber / `.ptag.int` cyan — pane heads, rail rows, saved-sessions table):

- recessed `.seg`-style track (the hatch smart-input precedent)
- active = 15% kind tint + kind-colored bold label (sub-0.10 tints wash out at chip size)
- a kind LED dot per option — lit + glowing in kind color when active, dim when not — so colour is never the only carrier
- reduced-motion: transitions disabled alongside the existing shell rules

No JS changes: `_setLauncherKind` toggles `classList`/`aria-checked`/roving tabindex exactly as before; the new `persona-btn--coord`/`--int` modifiers are static markup.

Verified via headless screenshots of all four states (both kinds × both themes) against the real `base.css` + `shell.css`; markup-pin tests (`test_html`, `test_app_js`, `test_shell_js`: 159) green.