### PR TITLE
chore: revert + re-author --skip-permissions flag for relicense provenance

### DIFF
--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4088,11 +4088,6 @@ def main() -> None:
         default=8080,
         help="Port to listen on (default: 8080)",
     )
-    parser.add_argument(
-        "--skip-permissions",
-        action="store_true",
-        help="Auto-approve all tool calls (no confirmation prompts)",
-    )
     # MCP config path is bootstrap-critical (needed before ConfigStore for tool loading)
     parser.add_argument(
         "--mcp-config",
@@ -4538,7 +4533,7 @@ def main() -> None:
         ws = manager.create(user_id="", name="resumed")
         if not isinstance(ws.ui, WebUI):
             raise TypeError(f"Expected WebUI, got {type(ws.ui).__name__}")
-        if args.skip_permissions or config_store.get("tools.skip_permissions"):
+        if config_store.get("tools.skip_permissions"):
             ws.ui.auto_approve = True
         assert ws.session is not None
         ws.session.set_watch_runner(_watch_runner)
@@ -4574,7 +4569,7 @@ def main() -> None:
         _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.gethostname()
         _advertise_url = f"http://{_advertise_host}:{args.port}"
 
-    _skip_perms = args.skip_permissions or config_store.get("tools.skip_permissions")
+    _skip_perms = config_store.get("tools.skip_permissions")
     app = create_app(
         workstreams=manager,
         global_queue=global_queue,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4088,6 +4088,11 @@ def main() -> None:
         default=8080,
         help="Port to listen on (default: 8080)",
     )
+    parser.add_argument(
+        "--skip-permissions",
+        action="store_true",
+        help="Auto-approve all tool calls without prompting (same as tools.skip_permissions)",
+    )
     # MCP config path is bootstrap-critical (needed before ConfigStore for tool loading)
     parser.add_argument(
         "--mcp-config",
@@ -4533,7 +4538,7 @@ def main() -> None:
         ws = manager.create(user_id="", name="resumed")
         if not isinstance(ws.ui, WebUI):
             raise TypeError(f"Expected WebUI, got {type(ws.ui).__name__}")
-        if config_store.get("tools.skip_permissions"):
+        if args.skip_permissions or config_store.get("tools.skip_permissions"):
             ws.ui.auto_approve = True
         assert ws.session is not None
         ws.session.set_watch_runner(_watch_runner)
@@ -4569,7 +4574,7 @@ def main() -> None:
         _advertise_host = args.host if args.host not in ("0.0.0.0", "::") else socket.gethostname()
         _advertise_url = f"http://{_advertise_host}:{args.port}"
 
-    _skip_perms = config_store.get("tools.skip_permissions")
+    _skip_perms = args.skip_permissions or config_store.get("tools.skip_permissions")
     app = create_app(
         workstreams=manager,
         global_queue=global_queue,


### PR DESCRIPTION
## What

Two commits, intentionally separate:

1. **Revert** of #450 (`2cdf87b1`), the one substantive contribution from a contributor who hasn't responded on #548.
2. **Independent re-implementation** of the same fix, written from the flag's pre-existing spec — the `--help` epilog and `compose.yaml` referenced `--skip-permissions` before #450 existed; the bug was that the argparser never defined it.

Behavior is identical to before: the CLI flag ORs with the `tools.skip_permissions` config-store setting at both consumption sites, so `SKIP_PERMISSIONS=1` containers and the stored setting both keep working.

## Why

Per the relicense process in #548: non-consented logic changes are classified substantive and re-authored rather than relicensed. After this lands, the 1.6.0 tree contains no code requiring consent that wasn't given. The original commit keeps its attribution in history and ships unchanged in all 1.5.x BUSL releases.

The re-implementation is necessarily near-identical to the original — the argparse block follows the file's existing pattern and the OR fallback has one natural form. That's expected; the revert/re-author pair is the provenance record.

## Merge note

**Use rebase-merge, not squash** — squashing would collapse the revert and re-author into a single commit and erase the two-step provenance this PR exists to create.

## Verification

- `ruff check` + `ruff format --check`: clean
- `mypy turnstone/server.py`: clean
- `python -m turnstone.server --help`: flag parses and renders; epilog example intact

Refs #548
