### PR TITLE
fix(console): coordinator ws-ref validation, did-you-mean recovery, wait fail-fast

### DIFF
--- a/docs/coordinator-api-tour.md
+++ b/docs/coordinator-api-tour.md
@@ -237,14 +237,21 @@ Key properties:
   tool with a fresh timeout.
 - **Modes** — `mode="any"` returns as soon as one child reaches a
   real terminal state (`idle` / `error` / `closed` / `deleted`);
-  `mode="all"` waits for every polled child.
+  `mode="all"` waits for every polled child to reach a real
+  terminal state.
 - **Progress throttling** — the poll loop runs every 500 ms but the
   SSE emission is diff-on-state-change plus a 5-second heartbeat.  A
   600 s wait generates O(dozens) of progress events, not 1200.
-- **Denied rows** — an id the caller doesn't own (cross-tenant) or a
-  missing row is reported as a `denied` state in the results dict;
-  `mode="any"` won't satisfy on a pure-denied list (the LLM should
-  treat it as a config error, not a completion).
+- **Unresolvable ids** — ws_ids are validated up front (exactly
+  32 hex chars; copy them verbatim): a malformed id fails the call
+  immediately with did-you-mean suggestions and a roster of the
+  coord's children.  An id the caller doesn't own, a missing row, or
+  a child hard-deleted mid-wait is reported as `state="not_found"`
+  and aborts the wait on the tick that observes it (top-level
+  `error` / `not_found` / `children` fields, `complete=false`) — the
+  LLM should fix the id and re-issue, not conclude the child died.
+  Foreign and missing collapse into one shape, so the wait can't be
+  used as an existence oracle.
 
 Prefer `wait_for_workstream` over polling `inspect_workstream` in a
 loop — a wait consumes one assistant turn regardless of how long the

--- a/docs/coordinator-skills.md
+++ b/docs/coordinator-skills.md
@@ -168,19 +168,33 @@ Every ws_id returned by `spawn_workstream` / `spawn_batch` is a
 invent ws_ids — a model that hallucinates `"child-1"` or `"ws-abc"`
 hits the tenant guard in `CoordinatorClient._is_own_subtree`, which
 validates ws_id against `parent_ws_id=coord_ws_id` AND
-`user_id=owner` in storage.  The rejection shape varies by tool:
+`user_id=owner` in storage.  The rejection shape is uniform and
+recovery-oriented:
 
 - **Mutating ops** (`send_to_workstream`, `close_workstream`,
-  `cancel_workstream`, `delete_workstream`) return
-  `{"error": "workstream not in coordinator subtree: <ws_id>", "status": 404}`
-  — the skill should treat this as a tool error, not an empty result.
-- **`inspect_workstream`** returns `{"error": "workstream not found", "ws_id": "<ws_id>"}`
-  (same shape as a genuinely missing row, so the guard can't be
-  used as an existence oracle).
-- **`wait_for_workstream`** reports the offending id with
-  `state="denied"` in its `results` dict; `mode="any"` won't
-  satisfy on a pure-denied list, so a hallucinated id won't trick
-  the wait into reporting "complete".
+  `cancel_workstream`, `delete_workstream`) and
+  **`inspect_workstream`** return
+  `{"error": "no workstream matching '<ref>' among your children; …",
+  "status": 404, "ws_id": "<ref>", "did_you_mean": [...],
+  "children": [...], "children_truncated": bool}` — a did-you-mean
+  (edit distance ≤ 3 against the coord's own children, which catches
+  the garbled-hex incident class: a 32-char id whose `aaa` run
+  collapsed to `a`) plus a roster of the coord's children.  A ref
+  that matches a child's display NAME is called out explicitly with
+  the right id (names are mutable labels, not addresses).  Foreign
+  and nonexistent ids produce the same payload (no existence
+  oracle), every hint references only the coord's own children, and
+  near-miss ids are never auto-resolved — the skill should fix the
+  id and re-issue, not treat the child as dead.
+- **`wait_for_workstream`** validates ids before waiting: a
+  malformed id fails the whole call immediately (`invalid_ws_ids`
+  carries the per-id payloads above, `elapsed=0`); a well-formed id
+  that is foreign, nonexistent, or hard-deleted mid-wait surfaces as
+  `state="not_found"` and aborts the wait on that tick with
+  top-level `error` / `not_found` / `children` fields.
+  `complete=true` therefore means every polled lane really finished
+  — an unobservable id can neither burn the timeout nor ride along
+  to a "complete" result.
 
 Pattern: capture each spawn result in the next tool call's input.
 The JSON tool-result carries `{"child_ws_id": "...", "name": "...",

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -2050,6 +2050,11 @@ def test_wait_for_workstream_not_found_returns_sentinel(hex_storage):
     assert snap["state"] == "not_found"
     assert snap["message"] == "(no workstream with this id among your children)"
     assert snap["truncated"] is False
+    # One key set across real and not_found entries — uniform consumer
+    # access, no per-state conditionals (updated/name empty here).
+    assert set(snap) == {"state", "tokens", "updated", "name", "message", "truncated"}
+    assert snap["updated"] == ""
+    assert snap["name"] == ""
 
 
 def test_wait_for_workstream_running_child_message_is_null(populated_storage):

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -9,6 +9,7 @@ storage-call path.
 from __future__ import annotations
 
 import json
+import threading
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -405,7 +406,10 @@ def test_mutating_ops_reject_foreign_ws_id_without_hitting_proxy():
     ]:
         result = call("ws-foreign", **kwargs)  # type: ignore[arg-type]
         assert result["status"] == 404
-        assert "not in coordinator subtree" in result["error"]
+        assert "no workstream matching" in result["error"]
+        # Recovery payload: a roster of the coord's own children rides
+        # along so a garbled id is fixable in one round-trip.
+        assert {c["ws_id"] for c in result["children"]} == {"ws-x", "ws-y"}
     # No HTTP requests issued — guard rejected before _post.
     assert captured == []
 
@@ -419,6 +423,56 @@ def test_mutating_ops_accept_self_ws_id():
     client.send("coord-1", "hi")
     assert len(captured) == 1
     assert captured[0].url.path == "/v1/api/route/workstreams/coord-1/send"
+
+
+def test_mutating_ops_reject_foreign_hex_id_with_recovery_payload():
+    """A well-formed 32-hex id that isn't ours passes format validation
+    and dies on the ownership guard with the SAME recovery payload as a
+    malformed ref — uniform shape, no existence oracle, no HTTP."""
+    client, captured = _mock_client(_ok_json({"status": 200}))
+    result = client.send("f" * 32, "hi")
+    assert result["status"] == 404
+    assert "no workstream matching" in result["error"]
+    assert {c["ws_id"] for c in result["children"]} == {"ws-x", "ws-y"}
+    assert captured == []
+
+
+def test_mutating_ops_reject_child_name_with_id_pointer(tmp_path):
+    """A model that pastes a child's display NAME instead of its id is
+    pointed straight at the right ws_id — names are mutable, non-unique
+    labels (the title generator can rewrite what the operator sees), so
+    they are deliberately NOT addresses and nothing resolves silently."""
+    st = SQLiteBackend(str(tmp_path / "names.db"))
+    st.register_workstream("coord-1", kind="coordinator", user_id="user-1")
+    real = "7c61eafe470c54caaa89490a4b9c0f7d"
+    st.register_workstream(
+        real,
+        kind="interactive",
+        parent_ws_id="coord-1",
+        state="running",
+        user_id="user-1",
+        name="minisforum-research",
+    )
+    captured: list[httpx.Request] = []
+
+    def _trap(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json={})
+
+    client = CoordinatorClient(
+        console_base_url="http://console",
+        storage=st,
+        token_factory=lambda: "t",
+        coord_ws_id="coord-1",
+        user_id="user-1",
+        http_client=httpx.Client(transport=httpx.MockTransport(_trap)),
+        child_event_bus=ChildEventBus(),
+    )
+    result = client.send("minisforum-research", "status?")
+    assert result["status"] == 404
+    assert "names are display labels" in result["error"]
+    assert result["did_you_mean"][0]["ws_id"] == real
+    assert captured == []
 
 
 # ---------------------------------------------------------------------------
@@ -558,34 +612,42 @@ def test_inspect_missing_ws_returns_error(populated_storage):
     assert "error" in result
 
 
-def test_inspect_not_found_does_not_echo_ws_id_in_error_string(populated_storage):
-    """The error STRING is bare ("workstream not found") — the
-    structured ``ws_id`` field carries the queried id.  Pre-fix the
-    error message echoed the ws_id back at the caller who just sent
-    it, which was redundant and a stylistic departure from the rest
-    of the surface.  Echo-in-string is also one more place a
-    hostile/oversize ws_id could land in operator-facing text."""
+def test_inspect_not_found_references_ref_but_clips_oversize(populated_storage):
+    """The error string names the unresolvable ref — it sits next to
+    the did-you-mean hints now, so it's load-bearing context — but
+    clips it to a bounded length so a hostile / oversize ws_id can't
+    flood operator-facing text (the prior bare-string design's
+    concern).  The structured ``ws_id`` field carries the full
+    value, and the format note reports the true length."""
     client = _make_read_client(populated_storage)
     result = client.inspect("does-not-exist-xyz")
-    assert result["error"] == "workstream not found"
-    # The structured field still carries the ws_id for context.
+    assert "does-not-exist-xyz" in result["error"]
     assert result["ws_id"] == "does-not-exist-xyz"
+    oversize = "z" * 300
+    clipped = client.inspect(oversize)
+    assert oversize not in clipped["error"]
+    assert "(got 300)" in clipped["error"]
+    assert clipped["ws_id"] == oversize
 
 
 def test_inspect_cross_tenant_returns_same_shape_as_missing(populated_storage):
     """The cross-tenant guard MUST return the exact same shape as a
-    genuinely missing ws_id — that's the existence-leak defence the
-    error-string echo was carrying weight for too.  Asserting the
-    shape match here pins the property going forward."""
-    # ``unrelated`` exists in storage but is not a coord-1 child.
+    genuinely missing ws_id — the existence-leak defence.  The error
+    text embeds the (caller-supplied) ref, so compare with the refs
+    factored out; same-length refs make the strings otherwise
+    byte-identical."""
+    # ``unrelated`` exists in storage but is not a coord-1 child;
+    # ``missing-x`` (same length) doesn't exist at all.
     client = _make_read_client(populated_storage)
     cross_tenant = client.inspect("unrelated")
-    missing = client.inspect("does-not-exist-abc")
-    # Same key set, same error string, only the ws_id field differs.
+    missing = client.inspect("missing-x")
     assert cross_tenant.keys() == missing.keys()
-    assert cross_tenant["error"] == missing["error"] == "workstream not found"
+    assert "no workstream matching" in missing["error"]
+    assert cross_tenant["error"].replace("unrelated", "X") == missing["error"].replace(
+        "missing-x", "X"
+    )
     assert cross_tenant["ws_id"] == "unrelated"
-    assert missing["ws_id"] == "does-not-exist-abc"
+    assert missing["ws_id"] == "missing-x"
 
 
 def test_list_children_excludes_closed_by_default(tmp_path):
@@ -1252,76 +1314,266 @@ def test_wait_for_workstream_all_mode_times_out_on_running_child(populated_stora
     assert result["results"]["child-b"]["state"] == "running"
 
 
-def test_wait_for_workstream_denies_foreign_ws_id(populated_storage):
-    """A ws_id outside the coordinator's subtree returns state='denied'.
-    With mode='any' on a pure-denied list there's no real work to wait
-    for, so the wait short-circuits sub-second with complete=False —
-    the model sees the denied state immediately and can correct rather
-    than spinning the timeout."""
+def test_wait_for_workstream_foreign_legacy_ref_fails_validation(populated_storage):
+    """A ref outside the coordinator's subtree that isn't id-shaped
+    ('unrelated') dies at the validation boundary: the call errors
+    immediately with a per-ref recovery payload and performs no
+    waiting at all."""
     client = _make_read_client(populated_storage)
     result = client.wait_for_workstream(["unrelated"], timeout=5, mode="any")
-    assert result["results"]["unrelated"]["state"] == "denied"
     assert result["complete"] is False
-    assert result["elapsed"] < 1.0
+    assert result["elapsed"] == 0.0
+    assert result["results"] == {}
+    assert "no workstream matching" in result["error"]
+    assert result["invalid_ws_ids"][0]["ws_id"] == "unrelated"
+    # Unified channel shape: trimmed per-ref entries, roster once at
+    # top level (same as the in-loop not_found channel).
+    assert "children" not in result["invalid_ws_ids"][0]
+    assert {c["ws_id"] for c in result["children"]} == {"child-a", "child-b", "child-coord"}
 
 
-def test_wait_for_workstream_denies_cross_tenant_child(populated_storage):
+def test_wait_for_workstream_cross_tenant_child_fails_validation(populated_storage):
     """Defense-in-depth (Copilot #506): a row whose ``parent_ws_id``
     matches the coordinator but whose ``user_id`` belongs to a
-    different tenant must collapse to ``denied`` — otherwise a
-    forged / migration-era / pre-tenant-gate row would let a
-    coordinator's LLM observe foreign-tenant state through
+    different tenant must stay unobservable.  The validation roster is
+    tenant-filtered in SQL, so the forged row never resolves and the
+    coordinator's LLM can't observe foreign-tenant state through
     ``wait_for_workstream``.  The ``populated_storage`` fixture's
     ``cross-tenant-child`` row has exactly this shape
-    (parent_ws_id="coord-1", user_id="user-2").
-    """
+    (parent_ws_id="coord-1", user_id="user-2")."""
     client = _make_read_client(populated_storage)
     result = client.wait_for_workstream(["cross-tenant-child"], timeout=5, mode="any")
-    assert result["results"]["cross-tenant-child"]["state"] == "denied"
     assert result["complete"] is False
-    assert result["elapsed"] < 1.0
+    assert result["results"] == {}
+    assert "no workstream matching" in result["error"]
 
 
-def test_wait_for_workstream_missing_ws_id_indistinguishable_from_denied(populated_storage):
-    """A ws_id that doesn't exist collapses into the same 'denied'
-    shape as a foreign ws_id so wait can't be used as an existence
-    oracle (matches the 404-mask contract inspect uses).  Same
-    short-circuit semantics as the pure-foreign case."""
+def test_wait_for_workstream_missing_ref_indistinguishable_from_foreign(populated_storage):
+    """A ref that doesn't exist produces the same payload as a foreign
+    one (same-length refs make the error strings byte-identical once
+    the echoed ref is factored out), so the validation boundary can't
+    be used as an existence oracle."""
     client = _make_read_client(populated_storage)
-    result = client.wait_for_workstream(["does-not-exist"], timeout=5, mode="any")
-    assert result["results"]["does-not-exist"]["state"] == "denied"
+    foreign = client.wait_for_workstream(["unrelated"], timeout=5)
+    missing = client.wait_for_workstream(["missing-x"], timeout=5)
+    f_err, m_err = foreign["invalid_ws_ids"][0], missing["invalid_ws_ids"][0]
+    assert f_err.keys() == m_err.keys()
+    assert f_err["error"].replace("unrelated", "X") == m_err["error"].replace("missing-x", "X")
+
+
+def test_wait_for_workstream_mixed_invalid_ref_errors_whole_call(populated_storage):
+    """Successor to the bug-2 false-positive regression: one valid
+    (running) child plus one unresolvable ref must never produce a
+    'complete' wait.  Under the fail-fast contract the whole call
+    errors immediately — a partial wait over the valid subset would
+    hide exactly the lost-lane failure the validation exists to
+    surface."""
+    client = _make_read_client(populated_storage)
+    result = client.wait_for_workstream(["child-b", "unrelated"], timeout=5, mode="any")
     assert result["complete"] is False
-    assert result["elapsed"] < 1.0
+    assert result["elapsed"] == 0.0
+    assert result["results"] == {}
+    assert result["invalid_ws_ids"][0]["ws_id"] == "unrelated"
+
+    # mode='all' is identical — previously a denied member counted as
+    # 'settled' and the wait completed, silently dropping the lane.
+    result_all = client.wait_for_workstream(["child-a", "unrelated"], timeout=5, mode="all")
+    assert result_all["complete"] is False
+    assert result_all["results"] == {}
 
 
-def test_wait_for_workstream_any_does_not_short_circuit_on_mixed_denied(populated_storage):
-    """Regression for the bug-2 false-positive: mode='any' with one
-    real (running) child and one denied id must NOT return
-    complete=True on the denied id — wait until the real child reaches
-    a real terminal state, or time out."""
-    client = _make_read_client(populated_storage)
-    result = client.wait_for_workstream(["child-b", "unrelated"], timeout=1.0, mode="any")
-    # child-b never reaches terminal in the test fixture; denied alone
-    # must not satisfy the any condition; wait must hit the timeout.
+# ---------------------------------------------------------------------------
+# wait_for_workstream — in-loop not_found fail-fast (32-hex refs)
+# ---------------------------------------------------------------------------
+#
+# Production ws_ids are ``uuid4().hex``.  A well-formed-but-unobservable
+# id passes the validation boundary and must abort the wait on the first
+# tick that sees it — never burn the timeout, never ride along to a
+# "complete" result.  The fixture mirrors the original field incident: a
+# coordinator LLM collapsed the ``aaa`` run in a child's id to a single
+# ``a`` and then read the resulting not-found as a dead child.
+
+REAL_CHILD_HEX = "7c61eafe470c54caaa89490a4b9c0f7d"
+CORRUPTED_CHILD_HEX = "7c61eafe470c54ca89490a4b9c0f7d"  # aaa -> a, 30 chars
+RUNNING_CHILD_HEX = "9cc8205058d528130fb469eaf75650f3"
+FOREIGN_HEX = "f" * 32
+MISSING_HEX = "e" * 32
+FORGED_HEX = "d" * 32  # parent_ws_id forged to coord-1, foreign user_id
+
+
+@pytest.fixture
+def hex_storage(tmp_path):
+    st = SQLiteBackend(str(tmp_path / "coord-hex.db"))
+    st.register_workstream("coord-1", kind="coordinator", user_id="user-1")
+    st.register_workstream(
+        REAL_CHILD_HEX,
+        kind="interactive",
+        parent_ws_id="coord-1",
+        state="idle",
+        user_id="user-1",
+        name="minisforum-research",
+    )
+    st.register_workstream(
+        RUNNING_CHILD_HEX,
+        kind="interactive",
+        parent_ws_id="coord-1",
+        state="running",
+        user_id="user-1",
+        name="beelink-research",
+    )
+    st.register_workstream(FOREIGN_HEX, kind="interactive", user_id="user-2")
+    st.register_workstream(FORGED_HEX, kind="interactive", parent_ws_id="coord-1", user_id="user-2")
+    return st
+
+
+def test_wait_incident_regression_corrupted_id_gets_did_you_mean(hex_storage):
+    """THE incident: a 30-char id (character-run collapse) must fail the
+    call instantly with the real child id as a did-you-mean — pre-fix
+    it burned the full timeout and read as a dead child."""
+    client = _make_read_client(hex_storage)
+    result = client.wait_for_workstream([CORRUPTED_CHILD_HEX], timeout=300, mode="all")
     assert result["complete"] is False
-    assert result["elapsed"] >= 1.0
-    assert result["results"]["unrelated"]["state"] == "denied"
-    assert result["results"]["child-b"]["state"] == "running"
+    assert result["elapsed"] == 0.0
+    assert result["results"] == {}
+    bad = result["invalid_ws_ids"][0]
+    assert bad["ws_id"] == CORRUPTED_CHILD_HEX
+    assert bad["did_you_mean"][0]["ws_id"] == REAL_CHILD_HEX
+    assert bad["did_you_mean"][0]["name"] == "minisforum-research"
+    assert "(got 30)" in bad["error"]
 
 
-def test_wait_for_workstream_all_completes_when_real_terminal_and_denied_mixed(
-    populated_storage,
-):
-    """mode='all' should consider denied ids as 'settled' so a wait on
-    [real-idle, denied] completes after the first tick instead of
-    waiting out the timeout — the model gets the full results dict
-    and can act on the per-id state."""
-    client = _make_read_client(populated_storage)
-    result = client.wait_for_workstream(["child-a", "unrelated"], timeout=5, mode="all")
+def test_wait_foreign_hex_id_aborts_on_first_tick(hex_storage):
+    """A well-formed foreign id passes validation, snapshots as
+    ``not_found``, and aborts the wait immediately — even in mode='any'
+    with a real running child alongside (the old contract silently
+    waited out the timeout here)."""
+    client = _make_read_client(hex_storage)
+    result = client.wait_for_workstream([RUNNING_CHILD_HEX, FOREIGN_HEX], timeout=30, mode="any")
+    assert result["complete"] is False
+    assert result["elapsed"] < 5.0
+    assert result["results"][FOREIGN_HEX]["state"] == "not_found"
+    assert result["results"][FOREIGN_HEX]["message"] == (
+        "(no workstream with this id among your children)"
+    )
+    assert result["results"][RUNNING_CHILD_HEX]["state"] == "running"
+    assert [h["ws_id"] for h in result["not_found"]] == [FOREIGN_HEX]
+    assert "no workstream matching" in result["error"]
+    assert {c["ws_id"] for c in result["children"]} == {REAL_CHILD_HEX, RUNNING_CHILD_HEX}
+
+
+def test_wait_mode_all_never_completes_with_not_found_member(hex_storage):
+    """Successor to the silent-ride-along: mode='all' with [idle,
+    foreign] previously returned complete=True (denied counted as
+    'settled'), reporting success while a lane was missing.  Now the
+    unobservable member aborts the call with complete=False."""
+    client = _make_read_client(hex_storage)
+    result = client.wait_for_workstream([REAL_CHILD_HEX, FOREIGN_HEX], timeout=5, mode="all")
+    assert result["complete"] is False
+    assert result["results"][FOREIGN_HEX]["state"] == "not_found"
+    assert result["results"][REAL_CHILD_HEX]["state"] == "idle"
+
+
+def test_wait_foreign_and_missing_hex_payloads_identical(hex_storage):
+    """Existence-oracle pin for the fail-fast path: an existing
+    foreign-tenant id and a nonexistent id produce identical result
+    entries and identical top-level hints (modulo the echoed ref)."""
+    client = _make_read_client(hex_storage)
+    foreign = client.wait_for_workstream([FOREIGN_HEX], timeout=5)
+    missing = client.wait_for_workstream([MISSING_HEX], timeout=5)
+    assert foreign["results"][FOREIGN_HEX] == missing["results"][MISSING_HEX]
+    f_hint, m_hint = foreign["not_found"][0], missing["not_found"][0]
+    assert f_hint.keys() == m_hint.keys()
+    assert f_hint["error"].replace(FOREIGN_HEX, "ID") == m_hint["error"].replace(MISSING_HEX, "ID")
+
+
+def test_wait_results_carry_child_display_name(hex_storage):
+    """Own-child entries carry the display ``name`` for orientation —
+    a label, not an address."""
+    client = _make_read_client(hex_storage)
+    result = client.wait_for_workstream([REAL_CHILD_HEX], timeout=5, mode="any")
     assert result["complete"] is True
-    assert result["elapsed"] < 1.0
-    assert result["results"]["child-a"]["state"] == "idle"
-    assert result["results"]["unrelated"]["state"] == "denied"
+    assert result["results"][REAL_CHILD_HEX]["name"] == "minisforum-research"
+
+
+def test_wait_mid_wait_hard_delete_aborts(hex_storage, monkeypatch):
+    """A child hard-deleted while a wait is in flight flips to
+    ``not_found`` on the next tick and aborts the wait — the
+    coordinator hears about the vanished lane in seconds, not at
+    timeout."""
+    monkeypatch.setattr(CoordinatorClient, "_WAIT_HEARTBEAT_INTERVAL", 0.05)
+    client = _make_read_client(hex_storage)
+
+    def _delete_soon() -> None:
+        time.sleep(0.3)
+        hex_storage.delete_workstream(RUNNING_CHILD_HEX)
+
+    deleter = threading.Thread(target=_delete_soon)
+    deleter.start()
+    try:
+        result = client.wait_for_workstream([RUNNING_CHILD_HEX], timeout=30, mode="all")
+    finally:
+        deleter.join()
+    assert result["complete"] is False
+    assert result["results"][RUNNING_CHILD_HEX]["state"] == "not_found"
+    assert result["elapsed"] < 10.0
+
+
+def test_inspect_corrupted_id_gets_did_you_mean(hex_storage):
+    """inspect_workstream shares the validation boundary: the incident
+    id gets the did-you-mean pointer, and the real id still inspects."""
+    client = _make_read_client(hex_storage)
+    result = client.inspect(CORRUPTED_CHILD_HEX)
+    assert result["did_you_mean"][0]["ws_id"] == REAL_CHILD_HEX
+    assert "(got 30)" in result["error"]
+    ok = client.inspect(REAL_CHILD_HEX)
+    assert ok["state"] == "idle"
+
+
+def test_inspect_rejects_forged_cross_tenant_hex_row(hex_storage):
+    """Parity with the wait / mutating gates (#506): a row forged with
+    parent_ws_id=coord but a foreign user_id must not be readable
+    through inspect either — same not-found shape, no history leak."""
+    client = _make_read_client(hex_storage)
+    result = client.inspect(FORGED_HEX)
+    assert "no workstream matching" in result["error"]
+    assert "messages" not in result
+
+
+def test_ws_ref_validation_survives_roster_query_failure(hex_storage, monkeypatch):
+    """Storage failure during the roster read degrades hints to empty
+    but validation still errors honestly (never resolves blind)."""
+    client = _make_read_client(hex_storage)
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("storage down")
+
+    monkeypatch.setattr(hex_storage, "list_workstreams", _boom)
+    result = client.send("not-a-real-id", "hi")
+    assert result["status"] == 404
+    assert "no workstream matching" in result["error"]
+    assert result["children"] == []
+
+
+def test_uppercase_full_hex_ref_case_folds(hex_storage):
+    """Models occasionally upcase hex; a full 32-hex ref resolves
+    case-insensitively."""
+    client = _make_read_client(hex_storage)
+    ok = client.inspect(REAL_CHILD_HEX.upper())
+    assert ok.get("error") is None
+    assert ok["state"] == "idle"
+
+
+def test_wait_since_hint_does_not_mask_not_found(hex_storage):
+    """The not_found fail-fast outranks the since-diff early exit — a
+    diffing since hint must not convert an unobservable-id abort into
+    complete=True."""
+    client = _make_read_client(hex_storage)
+    since = {RUNNING_CHILD_HEX: {"state": "idle", "tokens": 0, "updated": ""}}
+    result = client.wait_for_workstream(
+        [RUNNING_CHILD_HEX, FOREIGN_HEX], timeout=5, mode="any", since=since
+    )
+    assert result["complete"] is False
+    assert result["results"][FOREIGN_HEX]["state"] == "not_found"
 
 
 def test_wait_for_workstream_rejects_invalid_mode(populated_storage):
@@ -1788,15 +2040,15 @@ def test_wait_for_workstream_closed_returns_sentinel(populated_storage):
     assert snap["truncated"] is False
 
 
-def test_wait_for_workstream_denied_returns_sentinel(populated_storage):
-    """Cross-tenant / nonexistent ws_ids surface as denied — the
-    sentinel lets the coord LLM recognise the rejection without
-    parsing state strings on its own."""
-    client = _make_read_client(populated_storage)
-    result = client.wait_for_workstream(["unrelated"], timeout=5, mode="any")
-    snap = result["results"]["unrelated"]
-    assert snap["state"] == "denied"
-    assert snap["message"].startswith("(workstream denied")
+def test_wait_for_workstream_not_found_returns_sentinel(hex_storage):
+    """Unobservable ws_ids surface a fixed sentinel message so the
+    coord LLM recognises the rejection without parsing state strings
+    on its own."""
+    client = _make_read_client(hex_storage)
+    result = client.wait_for_workstream([FOREIGN_HEX], timeout=5, mode="any")
+    snap = result["results"][FOREIGN_HEX]
+    assert snap["state"] == "not_found"
+    assert snap["message"] == "(no workstream with this id among your children)"
     assert snap["truncated"] is False
 
 

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -953,9 +953,10 @@ class CoordinatorClient:
         shape.  Foreign and nonexistent ids collapse into one
         indistinguishable payload (no existence oracle); every hint
         references only this coordinator's own children.  Results are
-        keyed by the validated ws_id; own-child entries also carry the
-        display ``name`` for orientation (names are labels, NOT
-        addresses).
+        keyed by the validated ws_id and share one key set —
+        ``not_found`` entries carry empty ``updated`` / ``name`` — with
+        the display ``name`` filled in for own children as orientation
+        (names are labels, NOT addresses).
 
         ``progress_callback`` is invoked once per poll cycle with the
         current snapshot dict + elapsed seconds.  Swallows callback
@@ -1095,7 +1096,14 @@ class CoordinatorClient:
             for wid in cleaned:
                 row = rows.get(wid)
                 if row is None or not self._row_in_own_subtree(wid, row):
-                    snaps[wid] = {"state": "not_found", "tokens": 0}
+                    # Same key set as real entries (updated/name empty)
+                    # so callers consume results[ws_id] uniformly.
+                    snaps[wid] = {
+                        "state": "not_found",
+                        "tokens": 0,
+                        "updated": "",
+                        "name": "",
+                    }
                     continue
                 snaps[wid] = {
                     "state": str(row.get("state") or ""),

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
+import re
 import secrets
 import threading
 import time
@@ -52,16 +53,15 @@ from turnstone.core.workstream import WorkstreamKind
 WAIT_REAL_TERMINAL_STATES: frozenset[str] = frozenset({"idle", "error", "closed", "deleted"})
 
 # Reportable terminal states — superset of the real ones, also includes the
-# ``denied`` short-circuit shape returned for foreign / missing ws_ids.
-# Used inside ``wait_for_workstream`` to decide when ``mode='any'`` on a
-# pure-denied list should short-circuit with ``complete=False`` (no real
-# work to wait for) and when ``mode='all'`` has fully settled.  NOT used
-# for the ``mode='any'`` real-terminal completion condition and NOT used
-# by the resolved-count summary (which counts only real terminals —
-# ``denied`` is a rejection, not a resolution).  A single typo'd /
-# foreign id shouldn't satisfy ``mode="any"`` and let the model declare
-# a wait complete while every real child is still running.
-WAIT_TERMINAL_STATES: frozenset[str] = WAIT_REAL_TERMINAL_STATES | frozenset({"denied"})
+# ``not_found`` shape returned for foreign / missing / mid-wait-deleted
+# ws_ids.  ``not_found`` is NOT a completion state: the wait loop fails
+# fast the moment any polled id reports it (an unobservable member makes
+# the requested wait unsatisfiable — see the fail-fast block in
+# ``wait_for_workstream``), and the resolved-count summary counts only
+# real terminals.  This set's remaining job is the message-sentinel
+# branch in the result enrichment: states whose ``message`` is a fixed
+# sentinel rather than a storage read.
+WAIT_TERMINAL_STATES: frozenset[str] = WAIT_REAL_TERMINAL_STATES | frozenset({"not_found"})
 
 # Hard cap on ws_ids per call.  Polling happens once per ws_id per tick, so a
 # runaway list would amplify storage load without giving the model anything
@@ -121,8 +121,63 @@ _WAIT_MESSAGE_TAIL_LIMIT: int = 20
 # followed by an error) would otherwise produce a sentinel that
 # falsely claims no output exists at all.
 _WAIT_SENTINEL_CLOSED = "(workstream closed)"
-_WAIT_SENTINEL_DENIED = "(workstream denied: not in coordinator subtree or does not exist)"
+_WAIT_SENTINEL_NOT_FOUND = "(no workstream with this id among your children)"
 _WAIT_SENTINEL_NO_RECENT_ASSISTANT = "(no recent assistant output)"
+
+# ---------------------------------------------------------------------------
+# Model-supplied workstream-id validation — the coordinator LLM hand-copies
+# ws_ids between tool results and tool calls, and models garble long hex
+# runs (the canonical incident: a 32-char id whose ``aaa`` run collapsed to
+# a single ``a``, leaving a 30-char id no tool could act on, which then
+# read back to the model as a dead child).  ws_id arguments are therefore
+# validated at the tool boundary:
+#
+# - a full 32-hex id passes straight through (ownership still enforced by
+#   the per-verb guards, at unchanged storage cost);
+# - a direct child's exact id of any other shape still resolves (legacy /
+#   synthetic ids predate the 32-hex convention);
+# - anything else — truncated, garbled, non-hex, or a display name —
+#   fails fast with a did-you-mean + a roster of the coordinator's own
+#   children, so a garbled id is recoverable in one round-trip.
+#
+# Near-miss ids are NEVER auto-resolved — a mutating verb must not guess.
+# Display names are NOT addresses (they're mutable and non-unique); a ref
+# matching a child's name errors with a pointer at the right ws_id.
+# Validation and every hint consult ONLY the coordinator's own direct
+# children, preserving the no-existence-oracle guarantee for foreign ids.
+# ---------------------------------------------------------------------------
+
+# A well-formed ws_id: exactly 32 lowercase hex chars (``uuid4().hex``).
+_WS_REF_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+# Max Levenshtein distance for a did-you-mean candidate.  The incident
+# class (character-run collapse / duplication / single-char typo) sits at
+# distance 1-2; unrelated 32-hex ids sit at ~28+, so 3 is generous
+# headroom with no false-positive risk in practice.
+_WS_REF_SUGGEST_DISTANCE: int = 3
+
+# Children listed inline in an unresolvable-ws_id error.  Enough to
+# re-orient the model without flooding the tool result on wide fan-outs;
+# the error text points at list_workstreams for the rest.
+_WS_REF_ROSTER_CAP: int = 8
+
+# Page size for the validation roster query — far above any practical
+# direct-children count, so the exact-match / did-you-mean scans never
+# judge against a silently truncated page.
+_WS_REF_ROSTER_QUERY_LIMIT: int = 1000
+
+# Did-you-mean candidates surfaced per unresolvable ref.
+_WS_REF_SUGGEST_CAP: int = 2
+
+# Echoed-ref clip applied inside error STRINGS — the structured
+# ``ws_id`` field carries the full value and the format note reports
+# the true length, so the clip only bounds operator-facing text.
+# Covers a full 32-hex id with slack.
+_WS_REF_ECHO_CLIP: int = 48
+
+# Cap on the assembled top-level ``error`` string when several refs
+# fail in one wait call.
+_WS_REF_ERROR_TEXT_CAP: int = 2000
 
 _TASK_STATUSES = frozenset({"pending", "in_progress", "done", "blocked"})
 # Hard cap on tasks per coordinator — the full list is read and re-serialized
@@ -140,6 +195,45 @@ _TASK_TITLE_MAX = 200
 # enough to bound one stall per child per turn regardless of how many
 # inspect calls the model fires.
 _LIVE_CACHE_TTL_SECONDS = 2.0
+
+
+def _levenshtein_capped(a: str, b: str, cap: int) -> int:
+    """Levenshtein distance with an early-exit band.
+
+    Returns ``cap + 1`` as soon as the distance provably exceeds ``cap``,
+    so did-you-mean scans across a coordinator's children stay cheap per
+    candidate instead of O(len^2).  Plain DP otherwise — inputs are short
+    (ws_ids are 32 chars) so nothing cleverer is warranted.
+    """
+    if a == b:
+        return 0
+    la, lb = len(a), len(b)
+    if abs(la - lb) > cap:
+        return cap + 1
+    if la > lb:
+        a, b, la, lb = b, a, lb, la
+    prev = list(range(la + 1))
+    for j in range(1, lb + 1):
+        cur = [j] + [0] * la
+        bj = b[j - 1]
+        row_best = cur[0]
+        for i in range(1, la + 1):
+            cost = 0 if a[i - 1] == bj else 1
+            cur[i] = min(prev[i] + 1, cur[i - 1] + 1, prev[i - 1] + cost)
+            row_best = min(row_best, cur[i])
+        if row_best > cap:
+            return cap + 1
+        prev = cur
+    return prev[la] if prev[la] <= cap else cap + 1
+
+
+def _trim_ws_ref_hint(payload: dict[str, Any]) -> dict[str, Any]:
+    """Per-ref entry for wait's ``invalid_ws_ids`` / ``not_found``
+    channels — one shared shape: ``{ws_id, error, did_you_mean?}``.
+    The children roster is identical across refs in one call, so it
+    rides ONCE at the response top level instead of per entry.
+    """
+    return {key: payload[key] for key in ("ws_id", "error", "did_you_mean") if key in payload}
 
 
 def _utc_now_iso() -> str:
@@ -486,6 +580,177 @@ class CoordinatorClient:
             return False
         return bool(row.get("user_id")) and row.get("user_id") == self._user_id
 
+    # -- model-supplied ws_id validation ------------------------------------
+
+    def _children_roster(self) -> list[dict[str, Any]]:
+        """Direct children of this coordinator (any kind, own tenant only).
+
+        Powers ws_id validation and the did-you-mean / roster blocks in
+        unresolvable-id errors.  Unlike :meth:`list_children` this does
+        NOT filter ``kind`` — a coordinator-kind child passes the
+        per-verb ownership guards (``_is_own_subtree`` checks parent +
+        user only), so validation must see the same set or a legacy
+        exact id could validate for one verb and 404 on another.  One
+        SQL page capped at ``_WS_REF_ROSTER_QUERY_LIMIT``; failures
+        collapse to an empty roster (hints degrade, validation still
+        errors honestly).
+        """
+        try:
+            raw = self._storage.list_workstreams(
+                limit=_WS_REF_ROSTER_QUERY_LIMIT,
+                parent_ws_id=self._coord_ws_id,
+                user_id=self._user_id or None,
+            )
+        except Exception:
+            log.debug("coord_client.ws_ref.roster_failed", exc_info=True)
+            return []
+        roster: list[dict[str, Any]] = []
+        for row in raw:
+            try:
+                m = row._mapping  # SQLAlchemy Row
+            except AttributeError:
+                # Fallback for non-Row tuples (test doubles, etc.) —
+                # column order mirrors list_children's fallback map.
+                m = {"ws_id": row[0], "name": row[2], "state": row[3]}
+            roster.append(
+                {
+                    "ws_id": str(m["ws_id"] or ""),
+                    "name": str(m["name"] or ""),
+                    "state": str(m["state"] or ""),
+                }
+            )
+        return roster
+
+    def _ws_ref_error(
+        self,
+        ref: str,
+        *,
+        roster: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Uniform unresolvable-ws_id error payload.
+
+        One shape for malformed / foreign / nonexistent ids: the message
+        never distinguishes "exists but isn't yours" from "doesn't
+        exist" (no existence oracle), and every hint it carries
+        (did-you-mean, roster) is computed from the coordinator's OWN
+        children only.  Suggestions are advisory text — nothing here
+        auto-resolves, so a near-miss id can never route a mutating verb
+        to a guessed target.
+        """
+        if roster is None:
+            roster = self._children_roster()
+        ref_l = (ref or "").strip().lower()
+        # Clip the echoed ref in the STRING — a hostile / oversize ws_id
+        # must not flood operator-facing text (see _WS_REF_ECHO_CLIP).
+        shown = ref if len(ref) <= _WS_REF_ECHO_CLIP else ref[: _WS_REF_ECHO_CLIP - 3] + "..."
+        parts = [f"no workstream matching {shown!r} among your children"]
+        did: list[dict[str, str]] = []
+        name_hits = [c for c in roster if c["name"] and c["name"].strip().lower() == ref_l]
+        if name_hits:
+            # The model pasted a display NAME.  Point it straight at the
+            # id — names are mutable, non-unique labels, deliberately not
+            # addresses.
+            did = [
+                {"ws_id": c["ws_id"], "name": c["name"]} for c in name_hits[:_WS_REF_SUGGEST_CAP]
+            ]
+            parts.append(
+                "that is a child NAME, not an id — names are display "
+                f"labels; did you mean ws_id {did[0]['ws_id']}?"
+            )
+        else:
+            scored = sorted(
+                (
+                    (_levenshtein_capped(ref_l, c["ws_id"], _WS_REF_SUGGEST_DISTANCE), c)
+                    for c in roster
+                ),
+                key=lambda pair: pair[0],
+            )
+            did = [
+                {"ws_id": c["ws_id"], "name": c["name"]}
+                for dist, c in scored
+                if dist <= _WS_REF_SUGGEST_DISTANCE
+            ][:_WS_REF_SUGGEST_CAP]
+            if did:
+                parts.append(
+                    "did you mean "
+                    + " or ".join(f"{c['ws_id']} ({c['name'] or 'unnamed'})" for c in did)
+                    + "?"
+                )
+        if not _WS_REF_ID_RE.fullmatch(ref_l):
+            parts.append(
+                f"ws ids are exactly 32 lowercase hex chars (got {len(ref_l)}) — "
+                "copy them verbatim from spawn_batch / list_workstreams results"
+            )
+        parts.append("use list_workstreams to re-check ids")
+        payload: dict[str, Any] = {
+            "error": "; ".join(parts),
+            "status": 404,
+            "ws_id": ref,
+        }
+        if did:
+            payload["did_you_mean"] = did
+        payload["children"] = [
+            {"ws_id": c["ws_id"], "name": c["name"], "state": c["state"]}
+            for c in roster[:_WS_REF_ROSTER_CAP]
+        ]
+        payload["children_truncated"] = len(roster) > _WS_REF_ROSTER_CAP
+        return payload
+
+    def _resolve_ws_ref(
+        self,
+        ref: str,
+        *,
+        roster: list[dict[str, Any]] | None = None,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Validate a model-supplied ws_id argument.
+
+        Returns ``(ws_id, None)`` on success, ``("", error_payload)``
+        otherwise.  Accepted shapes, in match order:
+
+        1. the coordinator's own ws_id, verbatim;
+        2. a full 32-lowercase-hex id (case-folded) — passes through
+           WITHOUT a roster read, so the hot path costs exactly what it
+           did before validation existed; ownership stays with the
+           per-verb guards;
+        3. a direct child's EXACT id of any other shape — covers
+           legacy / synthetic ids that predate the 32-hex convention.
+
+        Anything else — truncated, garbled, non-hex, a display name —
+        fails with the did-you-mean payload.  The pasted-a-name case is
+        called out explicitly in the error; near-miss ids are NEVER
+        auto-resolved.
+        """
+        r = (ref or "").strip()
+        if not r:
+            return "", self._ws_ref_error(r, roster=roster)
+        if r == self._coord_ws_id:
+            return r, None
+        rl = r.lower()
+        if _WS_REF_ID_RE.fullmatch(rl):
+            return rl, None
+        if roster is None:
+            roster = self._children_roster()
+        for c in roster:
+            if c["ws_id"] in (r, rl):
+                return c["ws_id"], None
+        return "", self._ws_ref_error(r, roster=roster)
+
+    def _resolve_owned(self, ws_id: str) -> tuple[str, dict[str, Any] | None]:
+        """Resolve + ownership-guard a model-supplied ws_id in one step.
+
+        Shared preamble for the mutating verbs (send / close / cancel /
+        delete): format-resolve via :meth:`_resolve_ws_ref`, then the
+        tenant gate via :meth:`_is_own_subtree`.  Returns
+        ``(ws_id, None)`` or ``("", error_payload)`` — one home so a
+        future guard change (audit hook, logging) lands once.
+        """
+        resolved, ref_err = self._resolve_ws_ref(ws_id)
+        if ref_err is not None:
+            return "", ref_err
+        if not self._is_own_subtree(resolved):
+            return "", self._ws_ref_error(resolved)
+        return resolved, None
+
     # -- model-invoked mutating ops (HTTP) ---------------------------------
 
     def spawn(
@@ -517,9 +782,10 @@ class CoordinatorClient:
         return self._post("spawn", body)
 
     def send(self, ws_id: str, message: str) -> dict[str, Any]:
-        if not self._is_own_subtree(ws_id):
-            return {"error": f"workstream not in coordinator subtree: {ws_id}", "status": 404}
-        return self._post("send", {"message": message}, ws_id=ws_id)
+        resolved, ref_err = self._resolve_owned(ws_id)
+        if ref_err is not None:
+            return ref_err
+        return self._post("send", {"message": message}, ws_id=resolved)
 
     def emit_audit(self, action: str, detail: dict[str, Any]) -> None:
         """Record an audit row attributed to this coordinator session.
@@ -541,12 +807,13 @@ class CoordinatorClient:
         )
 
     def close_workstream(self, ws_id: str, reason: str = "") -> dict[str, Any]:
-        if not self._is_own_subtree(ws_id):
-            return {"error": f"workstream not in coordinator subtree: {ws_id}", "status": 404}
+        resolved, ref_err = self._resolve_owned(ws_id)
+        if ref_err is not None:
+            return ref_err
         body: dict[str, Any] = {}
         if reason:
             body["reason"] = reason
-        return self._post("close", body, ws_id=ws_id)
+        return self._post("close", body, ws_id=resolved)
 
     def close_all_children(self, reason: str = "") -> dict[str, Any]:
         """Soft-close every direct child of this coordinator (console-side fan-out).
@@ -563,9 +830,10 @@ class CoordinatorClient:
         return self._post("close_all_children", body, ws_id=self._coord_ws_id)
 
     def delete(self, ws_id: str) -> dict[str, Any]:
-        if not self._is_own_subtree(ws_id):
-            return {"error": f"workstream not in coordinator subtree: {ws_id}", "status": 404}
-        return self._post("delete", {"ws_id": ws_id})
+        resolved, ref_err = self._resolve_owned(ws_id)
+        if ref_err is not None:
+            return ref_err
+        return self._post("delete", {"ws_id": resolved})
 
     # -- console-endpoint helpers (NOT model-invoked tools) -----------------
 
@@ -587,9 +855,10 @@ class CoordinatorClient:
         return self._post("approve", body, ws_id=ws_id)
 
     def cancel(self, ws_id: str) -> dict[str, Any]:
-        if not self._is_own_subtree(ws_id):
-            return {"error": f"workstream not in coordinator subtree: {ws_id}", "status": 404}
-        return self._post("cancel", {}, ws_id=ws_id)
+        resolved, ref_err = self._resolve_owned(ws_id)
+        if ref_err is not None:
+            return ref_err
+        return self._post("cancel", {}, ws_id=resolved)
 
     def rewind(self, ws_id: str, turns: int) -> dict[str, Any]:
         if not self._is_own_subtree(ws_id):
@@ -630,16 +899,18 @@ class CoordinatorClient:
         because hard-delete cascades the row out of storage, but it
         stays in the set so a legacy / synthetic-test row carrying
         that state still counts).  ``mode='all'`` returns once every
-        ws_id has settled (real terminal OR ``denied``).  Returns
-        ``{"results": {ws_id: {state, tokens, updated, message, truncated}},
-        "elapsed": float, "complete": bool, "mode": mode}``.  ``complete``
-        is True when the wait condition was met before the deadline,
-        False when the timeout fired (results carry whatever last state
-        was observed).
+        ws_id is real-terminal — an id that can't be observed never
+        rides along to a "complete" result (see the not_found fail-fast
+        below).  Returns
+        ``{"results": {ws_id: {state, tokens, updated, name, message,
+        truncated}}, "elapsed": float, "complete": bool, "mode": mode}``.
+        ``complete`` is True when the wait condition was met before the
+        deadline, False when the timeout fired (results carry whatever
+        last state was observed).
 
         ``message`` carries the child's last assistant message text for
         ``idle`` / ``error`` states, or a short status sentinel for
-        ``closed`` / ``denied``.  Non-terminal entries (e.g. ``running``
+        ``closed`` / ``not_found``.  Non-terminal entries (e.g. ``running``
         after a timeout) and ``deleted`` rows carry ``None`` — hard
         deletes cascade rows out of storage so a real ``deleted`` state
         is never observed; the legacy/synthetic-row path falls into the
@@ -665,13 +936,26 @@ class CoordinatorClient:
         dict from silently exiting on tick one (which the naive
         missing-entry-counts-as-changed rule would cause).
 
-        Cross-tenant guard: a ws_id that's neither the coordinator
-        itself nor one of its own children appears with
-        ``state="denied"`` and never blocks the wait — a model that
-        emits a foreign id learns immediately rather than spinning
-        until timeout.  A ws_id that doesn't exist at all collapses
-        into the same ``denied`` shape so wait can't be used as an
-        existence oracle.
+        Unresolvable ids fail fast.  Refs are validated up front — a
+        malformed ws_id (truncated / garbled / non-hex / a display
+        name) errors immediately, before any waiting happens, with
+        top-level ``error`` / ``invalid_ws_ids`` / ``children`` fields.
+        Per-ref entries in ``invalid_ws_ids`` and ``not_found`` share
+        one shape — ``{ws_id, error, did_you_mean}`` — and the children
+        roster rides once at top level on both channels.  A
+        well-formed id that is foreign, nonexistent, or hard-deleted
+        mid-wait surfaces as ``state="not_found"`` and aborts the wait
+        on the tick that observes it: ``complete=False`` plus top-level
+        ``error`` / ``not_found`` / ``children`` fields.  Without this,
+        an unobservable member either burns the whole timeout
+        (``mode='all'`` could never satisfy) or silently rides along to
+        a "complete" result missing a lane — the original incident
+        shape.  Foreign and nonexistent ids collapse into one
+        indistinguishable payload (no existence oracle); every hint
+        references only this coordinator's own children.  Results are
+        keyed by the validated ws_id; own-child entries also carry the
+        display ``name`` for orientation (names are labels, NOT
+        addresses).
 
         ``progress_callback`` is invoked once per poll cycle with the
         current snapshot dict + elapsed seconds.  Swallows callback
@@ -731,6 +1015,45 @@ class CoordinatorClient:
                 "elapsed": 0.0,
                 "mode": mode,
             }
+        # Validate model-supplied refs before anything else touches them.
+        # The roster query is skipped when every ref is already the coord
+        # itself or a full 32-hex id (the overwhelmingly common case), so
+        # validation adds no storage cost to the hot path.
+        needs_roster = any(
+            w != self._coord_ws_id and not _WS_REF_ID_RE.fullmatch(w.lower()) for w in cleaned
+        )
+        roster = self._children_roster() if needs_roster else None
+        resolved_ids: list[str] = []
+        resolved_seen: set[str] = set()
+        invalid: list[dict[str, Any]] = []
+        for ref in cleaned:
+            rid, ref_err = self._resolve_ws_ref(ref, roster=roster)
+            if ref_err is not None:
+                invalid.append(ref_err)
+                continue
+            if rid not in resolved_seen:
+                resolved_seen.add(rid)
+                resolved_ids.append(rid)
+        if invalid:
+            # Tool-boundary fail-fast: error the whole call rather than
+            # waiting on the valid subset — the model asked to observe a
+            # set it can't observe, and a partial wait hides exactly the
+            # lost-lane failure this guards against.  Entries share the
+            # ``not_found`` channel's per-ref shape; the roster rides
+            # once at top level.
+            return {
+                "error": " | ".join(str(e.get("error") or "") for e in invalid)[
+                    :_WS_REF_ERROR_TEXT_CAP
+                ],
+                "invalid_ws_ids": [_trim_ws_ref_hint(e) for e in invalid],
+                "children": invalid[0].get("children", []),
+                "children_truncated": invalid[0].get("children_truncated", False),
+                "results": {},
+                "complete": False,
+                "elapsed": 0.0,
+                "mode": mode,
+            }
+        cleaned = resolved_ids
         try:
             timeout_f = float(timeout)
         except (TypeError, ValueError):
@@ -755,7 +1078,8 @@ class CoordinatorClient:
             aggregate batch) instead of two-per-id, cutting per-tick
             round-trips from O(N) to O(1) at the documented cap.
             Cross-tenant + missing-row cases collapse into a single
-            ``denied`` shape so wait can't be used as an existence oracle.
+            ``not_found`` shape so wait can't be used as an existence
+            oracle.
             """
             try:
                 rows = self._storage.get_workstreams_batch(cleaned)
@@ -771,28 +1095,22 @@ class CoordinatorClient:
             for wid in cleaned:
                 row = rows.get(wid)
                 if row is None or not self._row_in_own_subtree(wid, row):
-                    snaps[wid] = {"state": "denied", "tokens": 0}
+                    snaps[wid] = {"state": "not_found", "tokens": 0}
                     continue
                 snaps[wid] = {
                     "state": str(row.get("state") or ""),
                     "tokens": int(tokens_by_wid.get(wid, 0) or 0),
                     "updated": row.get("updated") or "",
+                    "name": str(row.get("name") or ""),
                 }
             return snaps
 
         def _is_real_terminal(snap: dict[str, Any]) -> bool:
             # Real-terminal — these states drive ``complete=True``.
-            # ``denied`` is intentionally excluded so a single typo'd /
-            # foreign / nonexistent ws_id can't satisfy ``mode="any"``
-            # while every real child is still running.
+            # ``not_found`` is intentionally excluded: an unobservable
+            # member can't satisfy ``mode="any"`` — it aborts the wait
+            # via the fail-fast below instead.
             return snap.get("state", "") in self._WAIT_REAL_TERMINAL_STATES
-
-        def _is_settled(snap: dict[str, Any]) -> bool:
-            # Settled — terminal OR denied.  Used to decide when the
-            # wait should give up because there's nothing left to
-            # observe (no real ws_ids in the polled set, or every real
-            # one has already finished).
-            return snap.get("state", "") in self._WAIT_TERMINAL_STATES
 
         def _diff_since(snap: dict[str, Any], prev: dict[str, Any]) -> bool:
             """True when ``snap`` differs from the ``since`` hint on any
@@ -804,6 +1122,7 @@ class CoordinatorClient:
 
         last_results: dict[str, dict[str, Any]] = {}
         complete = False
+        not_found_ids: list[str] = []
         # Subscribe to in-process state-change events for the watched
         # ws_ids when the bus is wired.  ``register_waiter`` returns a
         # single ``threading.Event`` registered against every id so a
@@ -816,13 +1135,13 @@ class CoordinatorClient:
         # registry on this console process, so a foreign ws_id passed by
         # an untrusted coord LLM (prompt injection) would otherwise leak
         # wake-up timing as a side channel — _snapshot_all returns
-        # ``denied`` for the content, but the *time* at which the wait
+        # ``not_found`` for the content, but the *time* at which the wait
         # un-blocked would correlate with the foreign ws_id's next
         # state-class event.  Filter ``cleaned`` to own-subtree ids
         # before registering; foreign / missing ws_ids stay in the
-        # snapshot list so they still surface as ``denied`` in
-        # ``_snapshot_all`` and exit via the pure-denied short-circuit
-        # below.  Predicate shared with ``_snapshot_all`` via
+        # snapshot list so they still surface as ``not_found`` in
+        # ``_snapshot_all`` and exit via the not_found fail-fast in the
+        # loop.  Predicate shared with ``_snapshot_all`` via
         # :meth:`_row_in_own_subtree`.
         try:
             pre_rows = self._storage.get_workstreams_batch(cleaned)
@@ -849,7 +1168,20 @@ class CoordinatorClient:
                     except Exception:
                         log.debug("coord_client.wait.progress_cb_failed", exc_info=True)
                 real_terminal = [_is_real_terminal(snap) for snap in results.values()]
-                settled = [_is_settled(snap) for snap in results.values()]
+                # Fail fast on unobservable members — foreign, nonexistent,
+                # or hard-deleted mid-wait.  Checked BEFORE the since-diff
+                # and mode conditions: an unobservable member invalidates
+                # the requested wait regardless of what the rest are doing
+                # (``mode='all'`` could never satisfy; ``mode='any'`` /
+                # ``since`` could "succeed" while silently dropping a
+                # lane).  The snapshot already collapsed foreign and
+                # missing into one ``not_found`` shape, so exiting here
+                # leaks nothing a single-tick wait wouldn't.
+                not_found_ids = [
+                    wid for wid, snap in results.items() if snap.get("state") == "not_found"
+                ]
+                if not_found_ids:
+                    break
                 # ``since`` — orthogonal to mode.  If the caller supplied a
                 # prior snapshot, any diff on a ws_id that IS in ``since_map``
                 # exits the wait so a follow-up call doesn't re-count
@@ -869,19 +1201,13 @@ class CoordinatorClient:
                     if any(real_terminal):
                         complete = True
                         break
-                    # Pure-denied list: every snap is settled but none is a
-                    # real terminal — no work to wait for.  Short-circuit so
-                    # the model sees the denied results immediately rather
-                    # than spinning the timeout (``complete=False`` because
-                    # the wait condition never had a real chance to fire).
-                    if all(settled):
-                        break
                 else:  # mode == "all"
-                    if all(settled):
-                        # Every ws_id is settled (real-terminal or denied).
-                        # The wait condition is met — the model gets the
-                        # full results dict and decides what each terminal
-                        # state means.
+                    if all(real_terminal):
+                        # Every ws_id actually finished observable work.
+                        # ``not_found`` members can't ride along to a
+                        # "complete" result — the fail-fast above exits
+                        # first — so ``complete=True`` means every lane
+                        # really resolved.
                         complete = True
                         break
                 remaining = deadline - time.monotonic()
@@ -898,14 +1224,13 @@ class CoordinatorClient:
                     # a deliberate 4x trade vs the pre-bus 0.5 s poll.
                     wake_event.wait(min(remaining, self._WAIT_HEARTBEAT_INTERVAL))
                 else:
-                    # Pure-foreign / pure-denied list: every cleaned
-                    # ws_id was filtered out of ``own_subtree`` so the
-                    # bus has nothing to wake on.  The pure-denied
-                    # short-circuit above exits ``mode='any'`` on the
-                    # first tick; ``mode='all'`` falls through to here
-                    # and must burn the timeout.  Use the heartbeat
-                    # cadence for the deadline carve-up so
-                    # ``progress_callback`` keeps firing.
+                    # No wake source for this wait (no registered own-
+                    # subtree ids — e.g. a bus-less test fixture).  Fall
+                    # back to the heartbeat cadence so
+                    # ``progress_callback`` keeps firing.  Foreign /
+                    # missing ids can't park here past one tick: the
+                    # not_found fail-fast above exits on the tick that
+                    # observes them.
                     time.sleep(min(self._WAIT_HEARTBEAT_INTERVAL, remaining))
         finally:
             # Always unregister so a crash mid-wait can't leak the
@@ -920,7 +1245,7 @@ class CoordinatorClient:
         # Bundle each terminal child's last assistant message inline so the
         # coordinator LLM doesn't have to follow up with one
         # ``inspect_workstream`` per ws.  Only ``idle`` / ``error`` ws_ids
-        # actually hit storage (``closed`` / ``denied`` return a sentinel
+        # actually hit storage (``closed`` / ``not_found`` return a sentinel
         # without I/O), so split them and parallelize the storage-bound
         # subset across a small thread pool — at the WAIT_MAX_WS_IDS=32
         # cap, 8 workers cuts a worst-case all-idle fan-out from 32
@@ -965,12 +1290,30 @@ class CoordinatorClient:
             else:
                 msg, trunc = None, False
             enriched_results[wid] = {**snap, "message": msg, "truncated": trunc}
-        return {
+        response: dict[str, Any] = {
             "results": enriched_results,
             "complete": complete,
             "elapsed": round(time.monotonic() - start, 3),
             "mode": mode,
         }
+        if not_found_ids:
+            # The wait aborted on unobservable members — surface a loud
+            # top-level error with recovery hints (did-you-mean + child
+            # roster) so a garbled id reads as "fix the id and re-issue",
+            # not as a dead child.  Hints reference only this
+            # coordinator's own children; foreign and nonexistent ids
+            # produce identical payloads (no existence oracle).
+            hint_roster = self._children_roster()
+            hints = [self._ws_ref_error(wid, roster=hint_roster) for wid in not_found_ids]
+            response["not_found"] = [_trim_ws_ref_hint(h) for h in hints]
+            response["error"] = " | ".join(str(h.get("error") or "") for h in hints)[
+                :_WS_REF_ERROR_TEXT_CAP
+            ]
+            response["children"] = hints[0].get("children", []) if hints else []
+            response["children_truncated"] = (
+                hints[0].get("children_truncated", False) if hints else False
+            )
+        return response
 
     # -- model-invoked read ops (direct storage) ---------------------------
 
@@ -1495,10 +1838,11 @@ class CoordinatorClient:
 
         Cross-tenant guard: the coordinator's LLM input is untrusted, so
         the inspectable scope is restricted to (a) the coordinator
-        itself or (b) a row whose ``parent_ws_id`` is this coordinator
-        (i.e. one of its own children).  Any other ws_id returns the
-        same not-found shape used for genuine misses, avoiding an
-        existence oracle.
+        itself or (b) one of its own children — ``parent_ws_id`` AND
+        ``user_id`` parity via :meth:`_row_in_own_subtree`, matching
+        the wait / mutating paths.  Any other ws_id returns the same
+        not-found shape used for genuine misses, avoiding an existence
+        oracle.
 
         ``include_provider_content`` defaults to False.  Provider-native
         content blocks (``_provider_content`` / ``provider_blocks``)
@@ -1507,20 +1851,25 @@ class CoordinatorClient:
         them for provider-fidelity replay tooling; regular inspect
         calls get the trimmed shape.
         """
+        resolved, ref_err = self._resolve_ws_ref(ws_id)
+        if ref_err is not None:
+            return ref_err
+        ws_id = resolved
         full = self._storage.get_workstream(ws_id)
-        # Echoing the ws_id back inside the error STRING was a stylistic
-        # carry-over — the structured ``ws_id`` field already carries
-        # the value the caller asked about.  The bare error message
-        # ("workstream not found") is enough; the same shape is used
-        # for cross-tenant rows so the existence-leak guarantee is
-        # preserved either way.
-        miss = {"error": "workstream not found", "ws_id": ws_id}
+        # Misses return the same did-you-mean payload for nonexistent and
+        # cross-tenant rows alike, so the existence-leak guarantee is
+        # preserved while a garbled id stays recoverable in one
+        # round-trip (the structured ``ws_id`` field echoes the value
+        # the caller asked about).
         if full is None:
-            return miss
-        is_self = ws_id == self._coord_ws_id
-        is_own_child = full.get("parent_ws_id") == self._coord_ws_id
-        if not (is_self or is_own_child):
-            return miss
+            return self._ws_ref_error(ws_id)
+        # Ownership parity with every other verb: parent AND user_id
+        # (``_row_in_own_subtree``).  The parent-only check this
+        # replaces let a forged / migration-era row (parent_ws_id=coord,
+        # user_id=other-tenant) be read through inspect while the wait
+        # and mutating paths rejected the same shape (#506).
+        if not self._row_in_own_subtree(ws_id, full):
+            return self._ws_ref_error(ws_id)
         # load_messages returns the full history in chronological order.
         # We slice the tail in Python because the SQL tail-N is
         # approximate across conversation boundaries.  Defensive
@@ -2103,7 +2452,7 @@ def _wait_message_for(
       exhaustion is more actionable than the prior assistant turn,
       and the prior shape's "(no recent assistant output)" sentinel
       hid that signal entirely.
-    - ``closed`` / ``denied`` — short status sentinel.  No
+    - ``closed`` / ``not_found`` — short status sentinel.  No
       message-history read because there's nothing meaningful to
       return — a partial last message could be misleading mid-thought.
     - any other state (e.g. ``running``, or a ``deleted`` synthetic /
@@ -2117,8 +2466,8 @@ def _wait_message_for(
     already completed; the model just gets ``message: null`` for the
     affected ws and can fall back to inspect).
     """
-    if state == "denied":
-        return _WAIT_SENTINEL_DENIED, False
+    if state == "not_found":
+        return _WAIT_SENTINEL_NOT_FOUND, False
     if state == "closed":
         return _WAIT_SENTINEL_CLOSED, False
     if state == "error":

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -10012,7 +10012,17 @@ class ChatSession:
         # Surface client-side validation errors as tool errors rather
         # than rendering them as a "successful" wait result.
         if result.get("error"):
-            msg = f"Error: {result['error']}"
+            if result.get("not_found") or result.get("invalid_ws_ids"):
+                # Unresolvable-id failures carry a structured recovery
+                # payload — per-id ``did_you_mean``, the children
+                # roster, and (on the in-loop abort) live ``results``
+                # for the still-observable lanes.  Serialize the whole
+                # object so the model can fix the id and re-issue; a
+                # bare-string collapse would discard exactly the hints
+                # the client built for it.
+                msg = "Error: " + json.dumps(result, separators=(",", ":"), default=str)
+            else:
+                msg = f"Error: {result['error']}"
             self._report_tool_result(call_id, "wait_for_workstream", msg, is_error=True)
             self._emit_wait_event(
                 "wait_ended",
@@ -10023,7 +10033,7 @@ class ChatSession:
         elapsed = result.get("elapsed", 0.0)
         complete = result.get("complete", False)
         # Count children that genuinely finished work (real terminals
-        # only — ``denied`` is a rejection, not a resolution).  Earlier
+        # only — ``not_found`` is a rejection, not a resolution).  Earlier
         # versions counted any non-empty ``state`` and inverted the
         # truth on timeout (rendered as ``"timeout (N/N resolved)"``).
         # Inline import — ``turnstone.core`` shouldn't import from

--- a/turnstone/tools/cancel_workstream.json
+++ b/turnstone/tools/cancel_workstream.json
@@ -6,7 +6,7 @@
     "properties": {
       "ws_id": {
         "type": "string",
-        "description": "Workstream id to cancel."
+        "description": "Workstream id to cancel — exactly 32 hex chars, copied verbatim. Unknown or malformed ids error with did-you-mean suggestions; nothing is ever guessed."
       }
     },
     "required": ["ws_id"]

--- a/turnstone/tools/close_workstream.json
+++ b/turnstone/tools/close_workstream.json
@@ -6,7 +6,7 @@
     "properties": {
       "ws_id": {
         "type": "string",
-        "description": "Workstream id to soft-close."
+        "description": "Workstream id to soft-close — exactly 32 hex chars, copied verbatim. Unknown or malformed ids error with did-you-mean suggestions; nothing is ever guessed."
       },
       "reason": {
         "type": "string",

--- a/turnstone/tools/delete_workstream.json
+++ b/turnstone/tools/delete_workstream.json
@@ -6,7 +6,7 @@
     "properties": {
       "ws_id": {
         "type": "string",
-        "description": "Workstream id to hard-delete."
+        "description": "Workstream id to hard-delete — exactly 32 hex chars, copied verbatim. Unknown or malformed ids error with did-you-mean suggestions; nothing is ever guessed (this verb is irreversible)."
       }
     },
     "required": ["ws_id"]

--- a/turnstone/tools/inspect_workstream.json
+++ b/turnstone/tools/inspect_workstream.json
@@ -6,7 +6,7 @@
     "properties": {
       "ws_id": {
         "type": "string",
-        "description": "Workstream id to inspect."
+        "description": "Workstream id to inspect — exactly 32 hex chars, copied verbatim from spawn_batch / list_workstreams results. Unknown or malformed ids error with did-you-mean suggestions and a roster of your children; nothing is ever guessed."
       },
       "message_limit": {
         "type": "integer",

--- a/turnstone/tools/send_to_workstream.json
+++ b/turnstone/tools/send_to_workstream.json
@@ -6,7 +6,7 @@
     "properties": {
       "ws_id": {
         "type": "string",
-        "description": "Workstream id that should receive the message."
+        "description": "Workstream id that should receive the message — exactly 32 hex chars, copied verbatim from spawn_batch / list_workstreams results (display names are not addresses)."
       },
       "message": {
         "type": "string",

--- a/turnstone/tools/wait_for_workstream.json
+++ b/turnstone/tools/wait_for_workstream.json
@@ -1,13 +1,13 @@
 {
   "name": "wait_for_workstream",
-  "description": "Block until one or all named child workstreams reach a terminal state. Prefer this over busy-polling inspect_workstream after a fan-out: the tool absorbs the wait, so you get one call + one result regardless of duration. Returns `{results: {ws_id: {state, tokens, updated, message, truncated}}, elapsed, complete, mode}` — `results` is keyed by ws_id (not top-level), `complete` is true when the wait condition fired before the timeout. `message` is the child's last assistant text for `idle`/`error`, a short sentinel for `closed`/`denied`, and `null` for non-terminal rows so a follow-up read knows which children still need work; capped at 10 KiB UTF-8, with `truncated=true` when the cap fires (call inspect_workstream for the rest). Real terminal states: `idle`, `error`, `closed`, `deleted` (the last is unobservable since hard-delete cascades the row out of storage). `mode='any'` returns when the first child hits a real terminal — a `denied` id alone never satisfies the condition, so a typo'd / foreign / nonexistent id can't false-positive a wait. `mode='all'` returns once every id has settled (real terminal OR denied). Cross-tenant guard: only the coordinator's own children (or itself) are visible; everything else is reported `state='denied'`. Capped at 32 ws_ids and 600s; both overflows error rather than silently truncating.",
+  "description": "Block until one or all named child workstreams reach a terminal state. Prefer this over busy-polling inspect_workstream after a fan-out: the tool absorbs the wait, so you get one call + one result regardless of duration. Returns `{results: {ws_id: {state, tokens, updated, name, message, truncated}}, elapsed, complete, mode}` — `results` is keyed by ws_id (not top-level), `complete` is true when the wait condition fired before the timeout. `message` is the child's last assistant text for `idle`/`error`, a short sentinel for `closed`/`not_found`, and `null` for non-terminal rows so a follow-up read knows which children still need work; capped at 10 KiB UTF-8, with `truncated=true` when the cap fires (call inspect_workstream for the rest). Real terminal states: `idle`, `error`, `closed`, `deleted` (the last is unobservable since hard-delete cascades the row out of storage). `mode='any'` returns when the first child hits a real terminal; `mode='all'` returns once every id is real-terminal. Ids are validated up front — ws_ids are exactly 32 hex chars, copy them VERBATIM from spawn_batch/list_workstreams results; a malformed id (truncated/garbled/non-hex) errors immediately with `did_you_mean` suggestions and a roster of your children, and an id that can't be observed (foreign / nonexistent / hard-deleted mid-wait) aborts the wait on the tick that sees it with `state='not_found'` plus top-level `error`/`not_found`/`children` fields. When that happens, fix the id and re-issue — do NOT assume the child is dead; check `did_you_mean` or re-list. Child display names are labels, not addresses; always target ids. Capped at 32 ws_ids and 600s; both overflows error rather than silently truncating.",
   "parameters": {
     "type": "object",
     "properties": {
       "ws_ids": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "Workstream ids to wait on. Accepts 1 or more; capped at 32 per call."
+        "description": "Workstream ids to wait on (each exactly 32 hex chars, copied verbatim from spawn_batch / list_workstreams results). Accepts 1 or more; capped at 32 per call. Unknown or malformed ids fail the call immediately with did-you-mean suggestions — no waiting happens."
       },
       "timeout": {
         "type": "number",
@@ -17,7 +17,7 @@
         "type": "string",
         "enum": ["any", "all"],
         "default": "any",
-        "description": "'any' (default) returns when the first child reaches a real terminal state (idle / error / closed / deleted); 'all' returns once every named child has settled (real terminal OR denied). A pure-denied list with mode='any' short-circuits to complete=false rather than spinning the timeout."
+        "description": "'any' (default) returns when the first child reaches a real terminal state (idle / error / closed / deleted); 'all' returns once every named child is real-terminal. An id that can't be observed (foreign / nonexistent / deleted mid-wait) aborts the wait immediately with state='not_found' and a top-level error, regardless of mode."
       },
       "since": {
         "type": "object",

--- a/turnstone/tools/wait_for_workstream.json
+++ b/turnstone/tools/wait_for_workstream.json
@@ -7,7 +7,7 @@
       "ws_ids": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "Workstream ids to wait on (each exactly 32 hex chars, copied verbatim from spawn_batch / list_workstreams results). Accepts 1 or more; capped at 32 per call. Unknown or malformed ids fail the call immediately with did-you-mean suggestions — no waiting happens."
+        "description": "Workstream ids to wait on (each exactly 32 hex chars, copied verbatim from spawn_batch / list_workstreams results). Accepts 1 or more; capped at 32 per call. Malformed ids fail the call before any waiting; well-formed ids that can't be observed abort it on the first tick — both return did-you-mean suggestions."
       },
       "timeout": {
         "type": "number",


### PR DESCRIPTION
## Summary

Field incident: a coordinator LLM hand-copied a child ws_id and collapsed its `aaa` character run to a single `a`, producing a 30-char id. `inspect_workstream` said "workstream not found", `wait_for_workstream` reported `(workstream denied: not in coordinator subtree or does not exist)`, `mode=all` burned its full timeout (and would have *completed* once the live lanes finished), and the model concluded the child was dead and dropped the lane — silent report degradation while the child kept working the whole time.

This PR makes a garbled id recoverable in one round-trip and makes the wait contract honest about unobservable members.

## Changes

**ws_id validation at the tool boundary** (`send` / `close` / `cancel` / `delete` / `inspect` / `wait`):
- full 32-lowercase-hex ids pass through with zero added storage cost (the dominant path)
- a direct child's exact legacy id still resolves (tenant-filtered roster lookup)
- anything else — truncated / garbled / non-hex / a display name — fails fast with `did_you_mean` (capped Levenshtein ≤ 3 against the coordinator's own children) plus a child roster
- near-misses are **never** auto-resolved; display names are **not** addresses (mutable + non-unique) — a name ref errors with a pointer at the right id

**wait_for_workstream contract** (behavioral):
- per-entry state `denied` → `not_found`; sentinel reworded (`denied` collided with approval semantics and read as a connection/permission failure)
- malformed refs error the whole call before any waiting (`invalid_ws_ids`, `elapsed=0`)
- a well-formed id that is foreign, nonexistent, or hard-deleted mid-wait aborts the wait on the tick that observes it (top-level `error` / `not_found` / `children`); previously `mode=all` either burned the timeout or completed with the lane silently missing
- `mode=all` now completes only when every id is real-terminal
- entries carry the child display `name`; `invalid_ws_ids` and `not_found` share one per-ref shape `{ws_id, error, did_you_mean}` with the roster hoisted top-level

**Security:**
- existence-oracle invariant preserved and now pinned by tests: foreign-existing vs nonexistent ids stay byte-identical, hints reference only the coordinator's own children, echoed refs are length-clipped in error strings
- `inspect` ownership now requires `user_id` parity via `_row_in_own_subtree`, matching the wait/mutating gates — closes the forged-parent cross-tenant read (#506 class)

**Plumbing:**
- session exec serializes the structured recovery payload (results + did_you_mean + children) on unresolvable-id wait errors instead of collapsing to a bare string
- tool JSON descriptions, `docs/coordinator-skills.md`, and `docs/coordinator-api-tour.md` updated to the new contract

## Testing

- ruff + mypy clean
- `tests/test_coordinator_client.py`: 153 pass — incident regression pins the captured `aaa`-collapse ids; oracle-invariance pins for both the validation and fail-fast channels; mid-wait hard-delete; roster-failure degradation; since-vs-not_found precedence; forged-row inspect
- adjacent suites (tools / e2e / adapter / cancel / schema / governance / idle-observer / metacognition): 349 pass