### PR TITLE
test(console): make dedupe-pin slice bounds reformat-tolerant

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -293,8 +293,13 @@ def test_system_turn_dedups_against_history_by_event_id() -> None:
     # End at the NEXT switch case, not the first ``break;`` — the dedup-skip
     # path breaks before the ``.add(``, so a ``break;``-bounded slice would
     # drop the record half and false-fail the ``.add(`` assertion below.
-    live_end = body.index('\n      case "', live_start + 1)
-    live_block = body[live_start:live_end]
+    # Whitespace-tolerant so a reformat can't silently break the bound.
+    next_case = re.search(r'\n\s*case "', body[live_start + 1 :])
+    assert next_case, (
+        "no switch case found after system_turn to bound the pin slice — if "
+        "system_turn became the last case, re-anchor this pin's end marker."
+    )
+    live_block = body[live_start : live_start + 1 + next_case.start()]
     assert re.search(r"_renderedSystemEventIds[\s\S]*?\.\s*has\(", live_block), (
         "the live system_turn handler must CONSULT the dedup set (skip an id "
         "already painted from /history), not merely reference the Set elsewhere."

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -8,6 +8,8 @@ visitor lands on the page but all API calls fail).
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
@@ -412,8 +414,13 @@ def test_coord_dedups_system_turn_against_history_by_event_id():
     # End at the NEXT switch case, not the first ``break;`` — the dedup-skip
     # ``...has(sysEid)) break;`` is itself a break that precedes the ``.add(``,
     # so a ``break;``-bounded slice would drop the record half.
-    sys_case_end = body.index('\n      case "', sys_case + 1)
-    live_block = body[sys_case:sys_case_end]
+    # Whitespace-tolerant so a reformat can't silently break the bound.
+    next_case = re.search(r'\n\s*case "', body[sys_case + 1 :])
+    assert next_case, (
+        "no switch case found after system_turn to bound the pin slice — if "
+        "system_turn became the last case, re-anchor this pin's end marker."
+    )
+    live_block = body[sys_case : sys_case + 1 + next_case.start()]
     assert "renderedSystemEventIds.has(" in live_block, (
         "the live system_turn handler must CONSULT the dedup set (skip an id "
         "already painted from /history) — not just reference the Set elsewhere."
@@ -424,10 +431,16 @@ def test_coord_dedups_system_turn_against_history_by_event_id():
     )
 
     # The history render path must seed the set from each replayed system row's
-    # event_id, so a subsequent live replay of the same id is skipped.
+    # event_id, so a subsequent live replay of the same id is skipped.  Bound
+    # the slice structurally — from the system-role branch to the next role
+    # branch in the same chain (falling back to a generous window when it's
+    # the last branch) — so adding comments/fields inside the branch can't
+    # false-fail a pin that only cares about the wiring.
     assert 'role === "system"' in body
     sys_replay = body.index('role === "system"', body.index("refetchHistory"))
-    replay_window = body[sys_replay : sys_replay + 600]
+    next_role = re.search(r"role\s*===", body[sys_replay + 1 :])
+    replay_end = sys_replay + 1 + next_role.start() if next_role else sys_replay + 1500
+    replay_window = body[sys_replay:replay_end]
     assert "renderedSystemEventIds.add(" in replay_window, (
         "the history render's system-role branch must record each replayed "
         "turn's event_id so the live system_turn handler can dedup against it."


### PR DESCRIPTION
Follow-up to #655, which merged while its Copilot review feedback was being addressed — this carries the review commit on a fresh branch off main (the original push landed on the auto-deleted branch after the merge).

The three findings, all applied:
- The next-case slice bounds in both pin tests were exact-indentation string finds that raised a bare ValueError when unmatched. Now whitespace-tolerant regexes with actionable assertion messages covering the system_turn-becomes-last-case scenario.
- The coordinator history-replay window was a fixed 600 chars; now bounded structurally at the next role branch in the chain (generous fallback when system is the last branch), so comments/fields added inside the branch can't false-fail a pin that only cares about wiring.

77 tests green against current main; ruff clean.