### PR TITLE
fix(attachments): interactive-session attachments, EXIF orientation, omni STT

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -650,6 +650,22 @@ def test_perception_role_surfaced_in_admin_and_filtered_from_settings() -> None:
     assert "roleKeys[MODEL_ROLES[ri].aliasKey] = 1" in admin
 
 
+def test_audio_roles_gated_to_openai_sdk_providers() -> None:
+    """Voice roles (stt/tts) ride the OpenAI-SDK audio surface — an Anthropic
+    (-compatible) model has no audio content block, so admin must exclude it
+    from those role dropdowns (mirrors ``_provider_carries_audio`` in
+    core/audio.py).  Reranker is a ``/rerank`` endpoint, not audio, so it must
+    NOT be provider-gated."""
+    admin = _CONSOLE_ADMIN_JS.read_text(encoding="utf-8")
+    assert "function _providerCarriesAudio(" in admin, "the provider-audio gate helper must exist"
+    body = admin[admin.index("function _audioModelEligible(") :]
+    body = body[: body.index("\nfunction ")]
+    assert '(mediaRole === "stt" || mediaRole === "tts")' in body, (
+        "only the voice roles are provider-gated (reranker is not an audio role)"
+    )
+    assert "_providerCarriesAudio(md && md.provider)" in body
+
+
 def test_shared_utils_defines_set_markdown_helper() -> None:
     """The ``setMarkdown`` helper in ``shared/utils.js`` is the single
     audited entry point for rendering markdown content into a DOM

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -631,6 +631,25 @@ def test_no_unsafe_code_sinks_in_static_assets(label: str, path: Path) -> None:
     )
 
 
+def test_perception_role_surfaced_in_admin_and_filtered_from_settings() -> None:
+    """The perception fallback (``perception.model_alias``) landed backend-only —
+    its admin UI was missing.  It must (1) appear as a Models → Roles row so an
+    operator can point it at a vision / omni model, and (2) be filtered OUT of the
+    raw Settings tab.  The Settings filter derives its skip-set from MODEL_ROLES,
+    so no role can quietly drift back into the Settings list again (the original
+    miss — stt/tts/reranker had leaked the same way)."""
+    admin = _CONSOLE_ADMIN_JS.read_text(encoding="utf-8")
+    # (1) Roles sub-tab row.
+    assert 'label: "Perception"' in admin, "the perception role must carry a UX label"
+    assert '"perception.model_alias"' in admin, "perception must have a MODEL_ROLES entry"
+    # (2) Settings filter derives the skip-set from MODEL_ROLES — drift-proof, so
+    # perception (and every other role alias) is excluded, not hand-listed.
+    assert "for (let ri = 0; ri < MODEL_ROLES.length; ri++)" in admin, (
+        "the Settings role-key filter must derive from MODEL_ROLES"
+    )
+    assert "roleKeys[MODEL_ROLES[ri].aliasKey] = 1" in admin
+
+
 def test_shared_utils_defines_set_markdown_helper() -> None:
     """The ``setMarkdown`` helper in ``shared/utils.js`` is the single
     audited entry point for rendering markdown content into a DOM

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -663,7 +663,9 @@ def test_audio_roles_gated_to_openai_sdk_providers() -> None:
     assert '(mediaRole === "stt" || mediaRole === "tts")' in body, (
         "only the voice roles are provider-gated (reranker is not an audio role)"
     )
-    assert "_providerCarriesAudio(md && md.provider)" in body
+    # A blank/unset provider must default to "openai" (matches the backend's
+    # _provider_carries_audio), else a provider-less model is wrongly excluded.
+    assert '_providerCarriesAudio((md && md.provider) || "openai")' in body
 
 
 def test_shared_utils_defines_set_markdown_helper() -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -17,9 +17,12 @@ from turnstone.core import audio
 class _Cfg:
     """Stand-in for ModelConfig — only the fields audio.py reads."""
 
-    def __init__(self, model: str, capabilities: dict | None = None) -> None:
+    def __init__(
+        self, model: str, capabilities: dict | None = None, provider: str = "openai"
+    ) -> None:
         self.model = model
         self.capabilities = capabilities or {}
+        self.provider = provider
 
 
 class _FakeConfigStore:
@@ -78,6 +81,20 @@ class TestModelSupportsRole:
         # Audio *input* alone does not make it a TTS (speech-synthesis) model.
         assert not audio.model_supports_role(
             _Cfg("gemma-omni", {"supports_audio_input": True}), "tts"
+        )
+
+    def test_anthropic_provider_excluded_from_audio_roles(self):
+        # Anthropic(-compatible) has no audio content block, so it can't serve
+        # any audio role — even with a capability flag or a whisper-style name.
+        assert not audio.model_supports_role(
+            _Cfg("gemma-omni", {"supports_audio_input": True}, provider="anthropic-compatible"),
+            "stt",
+        )
+        assert not audio.model_supports_role(
+            _Cfg("whisper-1", provider="anthropic-compatible"), "stt"
+        )
+        assert not audio.model_supports_role(
+            _Cfg("voice", {"supports_speech_synthesis": True}, provider="anthropic"), "tts"
         )
 
     def test_chat_model_not_eligible(self):
@@ -205,6 +222,20 @@ class TestTranscribe:
         parts = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
         text_part = next(p for p in parts if p["type"] == "text")
         assert text_part["text"] == "custom instruction"
+
+    def test_non_audio_provider_raises_clear_error(self):
+        # A stale config could still point STT at an anthropic-compatible model
+        # (no audio surface): fail with an actionable message, not an opaque
+        # ``'Anthropic' object has no attribute 'chat'``.
+        client = MagicMock()
+        reg = _FakeRegistry(
+            "omni",
+            _Cfg("gemma", {"supports_audio_input": True}, provider="anthropic-compatible"),
+            client,
+        )
+        with pytest.raises(audio.AudioUnavailableError, match="OpenAI-compatible provider"):
+            audio.transcribe(registry=reg, alias="omni", data=b"x", filename="a.webm")
+        client.chat.completions.create.assert_not_called()
 
 
 class TestSynthesize:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -71,6 +71,15 @@ class TestModelSupportsRole:
         assert audio.model_supports_role(_Cfg("gpt-4o-mini-tts"), "tts")
         assert audio.model_supports_role(_Cfg("tts-1"), "tts")
 
+    def test_omni_audio_input_eligible_for_stt(self):
+        # An omni model (chat audio input) qualifies for STT via the chat path,
+        # even with no transcription endpoint and a non-whisper name.
+        assert audio.model_supports_role(_Cfg("gemma-omni", {"supports_audio_input": True}), "stt")
+        # Audio *input* alone does not make it a TTS (speech-synthesis) model.
+        assert not audio.model_supports_role(
+            _Cfg("gemma-omni", {"supports_audio_input": True}), "tts"
+        )
+
     def test_chat_model_not_eligible(self):
         assert not audio.model_supports_role(_Cfg("gpt-5"), "stt")
         # Anthropic has no audio API — gated out of every audio role.
@@ -164,6 +173,38 @@ class TestTranscribe:
         reg = _FakeRegistry("voice", _Cfg("whisper-1"), client)
         with pytest.raises(audio.AudioBackendError):
             audio.transcribe(registry=reg, alias="voice", data=b"x", filename="a.wav")
+
+    def test_omni_model_transcribes_via_chat(self):
+        client = MagicMock()
+        msg = MagicMock(content="  the transcript  ")
+        client.chat.completions.create.return_value = MagicMock(choices=[MagicMock(message=msg)])
+        reg = _FakeRegistry("omni", _Cfg("gemma-omni", {"supports_audio_input": True}), client)
+        res = audio.transcribe(
+            registry=reg, alias="omni", data=b"webmbytes", filename="speech.webm"
+        )
+        assert res.transcript == "the transcript"
+        # The dedicated transcription endpoint is NOT used for an omni model.
+        client.audio.transcriptions.create.assert_not_called()
+        # Audio rides as an input_audio chat part; format comes from the filename.
+        parts = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+        audio_part = next(p for p in parts if p["type"] == "input_audio")
+        assert audio_part["input_audio"]["format"] == "webm"
+        # A blank prompt falls back to the omni STT default instruction.
+        text_part = next(p for p in parts if p["type"] == "text")
+        assert "Only output the transcription" in text_part["text"]
+
+    def test_omni_prompt_override_used(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="x"))]
+        )
+        reg = _FakeRegistry("omni", _Cfg("gemma-omni", {"supports_audio_input": True}), client)
+        audio.transcribe(
+            registry=reg, alias="omni", data=b"x", filename="a.wav", prompt="custom instruction"
+        )
+        parts = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+        text_part = next(p for p in parts if p["type"] == "text")
+        assert text_part["text"] == "custom instruction"
 
 
 class TestSynthesize:

--- a/tests/test_console_routing_proxy.py
+++ b/tests/test_console_routing_proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -283,6 +284,67 @@ class TestRouteCreate503Retry:
         assert data["ws_id"] == "retry_ws"
         assert data["node_id"] == "node-b"
         assert post_count == 2
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests — cluster create (capacity-routed proxy)
+# ---------------------------------------------------------------------------
+
+
+class TestClusterCreate:
+    """POST /v1/api/cluster/workstreams/new — the launcher's create proxy.
+
+    Create-with-attachments rides multipart (a ``meta`` JSON field + ``file``
+    parts) and must forward to the node AS multipart — not collapse to JSON,
+    which would silently drop the files (the pre-fix behaviour, gated in the UI
+    as "Attachments aren't supported for interactive sessions yet")."""
+
+    def _app_with_node(self, mock_post: MagicMock) -> Any:
+        collector = _make_mock_collector()
+        collector.get_node_detail.return_value = {"server_url": "http://a:8080"}
+        app = _make_app(collector=collector)
+        _wire_proxy(app, mock_post)
+        return app
+
+    def test_cluster_create_json_forwards_json(self):
+        mock_post = _make_proxy_post(json_data={"ws_id": "abc123"})
+        client = TestClient(self._app_with_node(mock_post), raise_server_exceptions=False)
+        resp = client.post(
+            "/v1/api/cluster/workstreams/new",
+            json={"node_id": "node-a", "name": "j", "initial_message": "hi"},
+            headers=_TEST_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["correlation_id"] == "abc123"
+        kwargs = mock_post.call_args.kwargs
+        assert "json" in kwargs and "files" not in kwargs, "no-file create must stay JSON"
+        assert kwargs["json"]["initial_message"] == "hi"
+        client.close()
+
+    def test_cluster_create_multipart_forwards_files(self):
+        mock_post = _make_proxy_post(json_data={"ws_id": "withfile"})
+        client = TestClient(self._app_with_node(mock_post), raise_server_exceptions=False)
+        meta = {"node_id": "node-a", "name": "i", "initial_message": "describe"}
+        resp = client.post(
+            "/v1/api/cluster/workstreams/new",
+            data={"meta": json.dumps(meta)},
+            files={"file": ("a.txt", b"hello world", "text/plain")},
+            headers=_TEST_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["correlation_id"] == "withfile"
+        kwargs = mock_post.call_args.kwargs
+        # Forwarded as multipart: a `meta` JSON field + `file` parts, never json=.
+        assert "json" not in kwargs, "a multipart create must not collapse to JSON"
+        assert kwargs.get("files"), "the blob must be forwarded to the node"
+        forwarded_meta = json.loads(kwargs["data"]["meta"])
+        assert forwarded_meta["initial_message"] == "describe"
+        assert "user_id" in forwarded_meta, "the proxy must inject the owner uid"
+        # The file part carries our blob unchanged: ("file", (name, bytes, ctype)).
+        name, payload = kwargs["files"][0]
+        assert name == "file"
+        assert payload[0] == "a.txt" and payload[1] == b"hello world"
         client.close()
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,49 @@
+"""Tests for EXIF-orientation normalisation (turnstone.core.images)."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+
+from turnstone.core.images import normalize_image_orientation
+
+Image = pytest.importorskip("PIL.Image")
+
+_ORIENTATION_TAG = 0x0112  # EXIF orientation (standard tag id)
+
+
+def _oriented_jpeg(orientation: int, size: tuple[int, int] = (4, 2)) -> bytes:
+    img = Image.new("RGB", size, "red")
+    exif = img.getexif()
+    exif[_ORIENTATION_TAG] = orientation
+    buf = BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+    return buf.getvalue()
+
+
+def test_applies_rotation_and_strips_tag() -> None:
+    # Orientation 6 = "rotate 90° for display": a 4×2 landscape becomes 2×4.
+    data = _oriented_jpeg(6, size=(4, 2))
+    out = normalize_image_orientation(data)
+    assert out != data, "a rotated image must be re-encoded upright"
+    img = Image.open(BytesIO(out))
+    assert img.size == (2, 4), "the 90° rotation must be baked into the pixels"
+    assert img.getexif().get(_ORIENTATION_TAG) in (None, 1), "the orientation tag must be cleared"
+
+
+def test_passthrough_when_upright() -> None:
+    data = _oriented_jpeg(1, size=(4, 2))
+    assert normalize_image_orientation(data) == data, "identity orientation must not re-encode"
+
+
+def test_passthrough_when_no_exif() -> None:
+    buf = BytesIO()
+    Image.new("RGB", (3, 3), "blue").save(buf, format="PNG")
+    data = buf.getvalue()
+    assert normalize_image_orientation(data) == data, "a tag-less image must pass through verbatim"
+
+
+def test_never_raises_on_garbage() -> None:
+    assert normalize_image_orientation(b"not an image") == b"not an image"
+    assert normalize_image_orientation(b"") == b""

--- a/tests/test_server_attachments_on_create.py
+++ b/tests/test_server_attachments_on_create.py
@@ -407,6 +407,33 @@ class TestCreateMultipart:
         # Drained from the buffer post-commit.
         assert get_attachment_buffer().get(aid, ws_id=ws_id, user_id="userA") is None
 
+    def test_create_drains_staged_synchronously(self, app_client, monkeypatch):
+        """A create-time attachment dispatched on the first turn must be drained
+        by the create handler itself, not only by the async dispatch worker —
+        else the freshly-opened pane's rehydrate races the worker's write-time
+        drain and paints the image as a still-pending composer chip.
+
+        Neuter the worker's drain (stub ``send``) so only the synchronous
+        post-install drain can clear the buffer, then assert it's empty right
+        after the response with NO polling."""
+        from turnstone.core.attachment_buffer import get_attachment_buffer
+
+        client, _sessions, _gq = app_client
+        monkeypatch.setattr(_FakeSession, "send", lambda self, *a, **k: None)
+        meta = {"name": "demo", "initial_message": "describe this image"}
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            data={"meta": json.dumps(meta)},
+            files=[("file", ("tiny.png", PNG_1x1, "image/png"))],
+            headers=_auth("userA"),
+        )
+        assert resp.status_code == 200, resp.text
+        ws_id = resp.json()["ws_id"]
+        aid = resp.json()["attachment_ids"][0]
+        # No poll: the create handler drained it before returning, so the new
+        # pane's rehydrate can't observe it as still-staged.
+        assert get_attachment_buffer().get(aid, ws_id=ws_id, user_id="userA") is None
+
     def test_create_with_attachments_no_initial_message_keeps_staged(self, app_client):
         import hashlib
 

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -291,6 +291,27 @@ def test_console_launcher_node_strategy() -> None:
     )
 
 
+def test_console_launcher_interactive_create_carries_attachments() -> None:
+    """Create-time attachments for interactive sessions: the launcher gate is gone
+    and ``_createInteractive`` frames a multipart body (``meta`` JSON + ``file``
+    parts) when files are staged, so the cluster proxy can forward the blobs to
+    the node — mirroring ``_createCoordinator``.  Was previously blocked with
+    "Attachments aren't supported for interactive sessions yet"."""
+    app = _CONSOLE_APP.read_text(encoding="utf-8")
+    assert "Attachments aren't supported for interactive sessions yet." not in app, (
+        "the create-time interactive attachment gate must be removed"
+    )
+    # Scope the multipart-framing assertions to _createInteractive's own body so
+    # they can't be satisfied by _createCoordinator alone.
+    rest = app[app.index("function _createInteractive(") + 1 :]
+    cut = rest.find("\nfunction ")
+    body = rest if cut == -1 else rest[:cut]
+    assert "new FormData()" in body, "_createInteractive must build a multipart body"
+    assert 'form.append("meta"' in body and 'form.append("file"' in body, (
+        "_createInteractive must send meta JSON + file parts"
+    )
+
+
 def test_pane_persists_meta_for_rehydrate() -> None:
     """Workstream-lifecycle bugfix: PaneManager persists a pane's serializable
     open-time meta (the interactive pane's resolved nodeId) and hands it back as

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -642,6 +642,35 @@ def test_tab_menu_dead_controller_prefers_live_node() -> None:
     )
 
 
+def test_attachment_lane_is_base_aware() -> None:
+    """Console regression: an interactive pane is node-proxied, so its attachment
+    upload / list / delete / preview requests must ride the pane's transport base
+    ("/node/{id}").  Without it they hit the console's OWN coord route and 404 as
+    "coordinator not found" (the standalone server, base="", was unaffected —
+    which masked the bug).  Mirrors the base-aware verb lane: the controller
+    resolves a base from ``opts.getBase`` and prefixes every attachment URL;
+    ``buildAttachmentPreview`` takes the base for its thumbnail / content src; the
+    interactive pane wires both."""
+    attach = (_SHARED / "composer_attachments.js").read_text(encoding="utf-8")
+    assert "function _attachUrl(base, wsId, id, suffix)" in attach, (
+        "the per-attachment URL builder must be base-first"
+    )
+    assert "function _base()" in attach and "opts.getBase" in attach, (
+        "the controller must resolve a node base from opts.getBase"
+    )
+    assert "base: _base()" in attach, "committed-chip previews must carry the base"
+    assert "base = opts.base" in attach, "buildAttachmentPreview must consume opts.base"
+    # upload + remove + rehydrate must each base-prefix their collection/row URL.
+    assert attach.count("_base() +") >= 3, (
+        "upload, remove, and rehydrate must each base-prefix their URL"
+    )
+    pane = (_SHARED / "interactive.js").read_text(encoding="utf-8")
+    assert "getBase: () =>" in pane, (
+        "the interactive pane must pass its node base into the attachment controller"
+    )
+    assert "base: attachBase" in pane, "history-pill previews must ride the pane's base too"
+
+
 def test_step7_tab_menu_css_promoted_shared() -> None:
     """Step 7: the dropdown chrome is promoted to the SHARED shell sheet (so both
     deployments render it), recovered from the retired .ws-tab-dropdown design but

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -294,21 +294,27 @@ def test_console_launcher_node_strategy() -> None:
 def test_console_launcher_interactive_create_carries_attachments() -> None:
     """Create-time attachments for interactive sessions: the launcher gate is gone
     and ``_createInteractive`` frames a multipart body (``meta`` JSON + ``file``
-    parts) when files are staged, so the cluster proxy can forward the blobs to
-    the node — mirroring ``_createCoordinator``.  Was previously blocked with
-    "Attachments aren't supported for interactive sessions yet"."""
+    parts, via the shared ``_createWorkstreamFetchOpts`` helper) when files are
+    staged, so the cluster proxy can forward the blobs to the node.  Was
+    previously blocked with "Attachments aren't supported for interactive
+    sessions yet"."""
     app = _CONSOLE_APP.read_text(encoding="utf-8")
     assert "Attachments aren't supported for interactive sessions yet." not in app, (
         "the create-time interactive attachment gate must be removed"
     )
-    # Scope the multipart-framing assertions to _createInteractive's own body so
-    # they can't be satisfied by _createCoordinator alone.
+    # The shared create-fetch helper frames multipart (meta JSON + file parts).
+    helper = app[app.index("function _createWorkstreamFetchOpts(") :]
+    helper = helper[: helper.index("\nfunction ")]
+    assert "new FormData()" in helper
+    assert 'form.append("meta"' in helper and 'form.append("file"' in helper, (
+        "the create-fetch helper must send meta JSON + file parts"
+    )
+    # _createInteractive routes through that helper, so staged files are sent.
     rest = app[app.index("function _createInteractive(") + 1 :]
     cut = rest.find("\nfunction ")
-    body = rest if cut == -1 else rest[:cut]
-    assert "new FormData()" in body, "_createInteractive must build a multipart body"
-    assert 'form.append("meta"' in body and 'form.append("file"' in body, (
-        "_createInteractive must send meta JSON + file parts"
+    interactive = rest if cut == -1 else rest[:cut]
+    assert "_createWorkstreamFetchOpts(body, files)" in interactive, (
+        "_createInteractive must build its create body via the shared helper"
     )
 
 

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+
 import pytest
 
 from turnstone.core.thumbnails import make_thumbnail
@@ -41,6 +43,18 @@ class TestMakeThumbnail:
     def test_image_thumbnail_is_png(self) -> None:
         out = make_thumbnail(PNG_1x1, "image")
         assert out is not None and out[:8] == _PNG_MAGIC
+
+    def test_image_thumbnail_honours_exif_orientation(self) -> None:
+        pil = pytest.importorskip("PIL.Image")
+        src = pil.new("RGB", (40, 20), "red")  # landscape source
+        exif = src.getexif()
+        exif[0x0112] = 6  # "rotate 90° for display" → the thumbnail should be portrait
+        buf = BytesIO()
+        src.save(buf, format="JPEG", exif=exif)
+        out = make_thumbnail(buf.getvalue(), "image")
+        assert out is not None
+        thumb = pil.open(BytesIO(out))
+        assert thumb.height > thumb.width, "thumbnail must reflect the applied EXIF rotation"
 
     def test_pdf_thumbnail_is_png(self) -> None:
         out = make_thumbnail(_minimal_pdf(), "pdf")

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1224,7 +1224,7 @@ class CoordinatorSendResponse(BaseModel):
     attached_ids: list[str] = Field(
         default_factory=list,
         description=(
-            "Attachment ids actually reserved onto this turn. Subset of "
+            "Attachment ids actually attached to this turn. Subset of "
             "the request's `attachment_ids` (or the auto-consumed pending "
             "set). Empty when the send carries no attachments."
         ),

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1261,10 +1261,10 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "Queue a user message onto the coordinator session",
         description=(
             "Worker thread picks up the message via the session's queue. "
-            "Optional ``attachment_ids`` reserve attachments under the "
-            "message's send_id token (parity with the interactive surface). "
+            "Optional ``attachment_ids`` select staged uploads to attach to "
+            "the message (parity with the interactive surface). "
             "Response carries ``attached_ids`` / ``dropped_attachment_ids`` "
-            "so callers can detect partial reservations and ``priority`` / "
+            "so callers can detect partial attaches and ``priority`` / "
             "``msg_id`` on the queued path. "
             "``status: queue_full`` when the worker queue is full — caller "
             "should back off."
@@ -1284,7 +1284,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
             "the interactive surface: magic-byte image sniff, UTF-8 text "
             "decode, per-kind size cap, per-(ws,user) pending cap. "
             "Attachments stay pending until a subsequent ``/send`` "
-            "reserves them under its ``send_id`` token."
+            "attaches them to a message."
         ),
         response_model=UploadAttachmentResponse,
         error_codes=[400, 403, 404, 409, 413, 503],

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -45,7 +45,7 @@ class SendResponse(BaseModel):
     attached_ids: list[str] = Field(
         default_factory=list,
         description=(
-            "Attachment ids actually reserved onto this turn. Subset of "
+            "Attachment ids actually attached to this turn. Subset of "
             "the request's `attachment_ids` (or the auto-consumed pending "
             "set). Empty when the send carries no attachments."
         ),
@@ -159,7 +159,7 @@ class CreateWorkstreamRequest(BaseModel):
         description=(
             "Optional first user message dispatched as a background turn after "
             "the workstream is created. When attachments are also provided "
-            "(via the multipart variant), they are reserved onto this turn."
+            "(via the multipart variant), they are attached to this turn."
         ),
     )
     ws_id: str = Field(
@@ -201,7 +201,7 @@ class CreateWorkstreamResponse(BaseModel):
         default_factory=list,
         description=(
             "Ids of attachments saved by this request (multipart variant only). "
-            "Already reserved onto the initial_message turn when one was provided; "
+            "Already attached to the initial_message turn when one was provided; "
             "otherwise left pending for a follow-up POST "
             "/v1/api/workstreams/{ws_id}/send."
         ),

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -75,7 +75,7 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
             "with one `meta` field (JSON-encoded `CreateWorkstreamRequest` shape) "
             "plus zero-or-more `file` parts saves each file as an attachment "
             "under the new workstream. When `initial_message` is also set, "
-            "attachments are reserved onto that turn before the worker thread "
+            "attachments are resolved onto that turn before the worker thread "
             "dispatches; otherwise they remain pending for a follow-up "
             "`POST /v1/api/workstreams/{ws_id}/send`."
         ),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3408,8 +3408,8 @@ async def _coord_create_post_install(
     Wired onto :attr:`SessionEndpointConfig.create_post_install`. When
     an ``initial_message`` is provided, dispatches via
     :meth:`CoordinatorAdapter.send`; any uploaded ``attachment_ids``
-    are reserved onto the same ``send_id`` token so the worker's
-    first turn picks them up exactly the way interactive's
+    are resolved from the buffer onto the first turn (and drained) so
+    the worker picks them up exactly the way interactive's
     ``post_install`` worker thread does.
 
     Returns ``{}`` — coord's response carries only the always-include

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3434,6 +3434,16 @@ async def _coord_create_post_install(
     resolved_atts: list[Any] = []
     if attachment_ids:
         resolved_atts, _ord, _drop = resolve_staged_attachments(attachment_ids, ws.id, uid)
+        # Drain the staged uploads now: the create-time dispatch is their only
+        # consumer, so leaving them staged would let the new coord pane's
+        # rehydrate race the worker's write-time drain and show them as still-
+        # pending composer chips (the committing send's discard then no-ops).
+        if _ord:
+            from turnstone.core.attachment_buffer import get_attachment_buffer
+
+            _buf = get_attachment_buffer()
+            for _aid in _ord:
+                _buf.discard(_aid, ws_id=ws.id, user_id=uid)
     coord_adapter.send(
         ws.id,
         initial_message,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1766,8 +1766,9 @@ async def create_workstream(request: Request) -> JSONResponse:
     - ``node_id`` omitted or ``"auto"`` → console picks the node with most headroom
     - ``node_id`` set to ``"pool"`` → console picks any available node
     """
+    from turnstone.core.attachments import IMAGE_SIZE_CAP
     from turnstone.core.auth import require_any_permission
-    from turnstone.core.web_helpers import read_json_or_400
+    from turnstone.core.web_helpers import read_json_or_400, read_multipart_create_or_400
 
     # Gate on workstreams.create OR admin.coordinator before proxying —
     # keeps the 403 attributed at the console (audit clarity) and avoids
@@ -1779,9 +1780,30 @@ async def create_workstream(request: Request) -> JSONResponse:
     if err is not None:
         return err
 
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
+    # Create-with-attachments: the launcher sends multipart (a ``meta`` JSON
+    # field + ``file`` parts) instead of JSON.  The node create endpoint already
+    # accepts that shape (create_supports_attachments on interactive_endpoint_config
+    # in turnstone/server.py); the proxy just picks the node as usual and forwards
+    # the files instead of re-serialising JSON.  Caps mirror the node-side parse so
+    # an oversized upload is rejected here, before the cluster hop.
+    content_type = (request.headers.get("content-type") or "").lower()
+    uploaded_files: list[tuple[str, str, bytes]] = []
+    body: dict[str, Any]
+    if content_type.startswith("multipart/form-data"):
+        parsed = await read_multipart_create_or_400(
+            request,
+            max_files=10,
+            max_per_file_bytes=IMAGE_SIZE_CAP,
+            max_total_bytes=10 * IMAGE_SIZE_CAP,
+        )
+        if isinstance(parsed, JSONResponse):
+            return parsed
+        body, uploaded_files = parsed
+    else:
+        json_body = await read_json_or_400(request)
+        if isinstance(json_body, JSONResponse):
+            return json_body
+        body = json_body
 
     collector: ClusterCollector = request.app.state.collector
 
@@ -1865,12 +1887,22 @@ async def create_workstream(request: Request) -> JSONResponse:
 
     client: httpx.AsyncClient = request.app.state.proxy_client
     headers = _proxy_auth_headers(request)
+    node_url = f"{server_url.rstrip('/')}/v1/api/workstreams/new"
     try:
-        resp = await client.post(
-            f"{server_url.rstrip('/')}/v1/api/workstreams/new",
-            json=ws_body,
-            headers=headers,
-        )
+        if uploaded_files:
+            # Re-frame for the node: create metadata rides one ``meta`` JSON
+            # field, each blob a ``file`` part — the shape the node's
+            # read_multipart_create_or_400 expects.  ``user_id`` in the meta is
+            # honoured because the proxy auth header marks a ``console`` source.
+            files_payload = [("file", (fn, data, ctype)) for (fn, ctype, data) in uploaded_files]
+            resp = await client.post(
+                node_url,
+                data={"meta": json.dumps(ws_body)},
+                files=files_payload,
+                headers=headers,
+            )
+        else:
+            resp = await client.post(node_url, json=ws_body, headers=headers)
         resp.raise_for_status()
     except httpx.HTTPError as exc:
         log.warning("Workstream dispatch to %s failed: %s", node_id, exc)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1892,8 +1892,9 @@ async def create_workstream(request: Request) -> JSONResponse:
         if uploaded_files:
             # Re-frame for the node: create metadata rides one ``meta`` JSON
             # field, each blob a ``file`` part — the shape the node's
-            # read_multipart_create_or_400 expects.  ``user_id`` in the meta is
-            # honoured because the proxy auth header marks a ``console`` source.
+            # read_multipart_create_or_400 expects.  ``ws_body`` already carries
+            # the authenticated user's uid (set above, as on the JSON path); the
+            # caller-supplied meta never overrides the owner.
             files_payload = [("file", (fn, data, ctype)) for (fn, ctype, data) in uploaded_files]
             resp = await client.post(
                 node_url,

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5196,7 +5196,7 @@ const MODEL_ROLES = [
   {
     label: "Speech-to-text",
     description:
-      "Transcribes microphone audio in the workstream composer (voice input), and is the preferred transcript for audio attachments. Empty disables the mic affordance; audio attachments then fall back to the Perception model if one is configured.",
+      "Transcribes microphone audio in the workstream composer (voice input), and is the preferred transcript for audio attachments. Point at a transcription model (Whisper-style) or an audio-capable omni model — the omni path transcribes via chat. Empty disables the mic affordance; audio attachments then fall back to the Perception model if one is configured.",
     aliasKey: "audio.stt_model_alias",
     fallbackKind: "disabled",
     mediaCapability: "supports_transcription",
@@ -5254,6 +5254,9 @@ function _audioModelEligible(md, capFlag, mediaRole) {
     }
   }
   if (!caps || typeof caps !== "object") caps = {};
+  // An omni model (chat audio input) can serve STT via the chat transcription
+  // path — mirror model_supports_role in turnstone/core/audio.py.
+  if (mediaRole === "stt" && caps.supports_audio_input) return true;
   if (Object.prototype.hasOwnProperty.call(caps, capFlag))
     return !!caps[capFlag];
   const name = ((md && md.model) || "").toLowerCase();

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5244,6 +5244,19 @@ const AUDIO_MODEL_HINTS = {
   tts: ["tts-", "-tts"],
 };
 
+// Providers whose client speaks the OpenAI-SDK audio surface. Mirror
+// _AUDIO_SDK_PROVIDERS / _provider_carries_audio in turnstone/core/audio.py:
+// anthropic(-compatible) has no audio content block, so it can't serve the
+// voice roles regardless of capability flags.
+function _providerCarriesAudio(provider) {
+  return (
+    provider === "openai" ||
+    provider === "openai-compatible" ||
+    provider === "google" ||
+    provider === "xai"
+  );
+}
+
 function _audioModelEligible(md, capFlag, mediaRole) {
   let caps = md && md.capabilities;
   if (typeof caps === "string") {
@@ -5254,6 +5267,16 @@ function _audioModelEligible(md, capFlag, mediaRole) {
     }
   }
   if (!caps || typeof caps !== "object") caps = {};
+  // Voice roles (stt/tts) ride the OpenAI-SDK audio surface; an Anthropic
+  // (-compatible) provider can't serve them even with a capability flag set.
+  // Reranker is NOT an audio role (it hits a /rerank endpoint), so it is not
+  // provider-gated here.
+  if (
+    (mediaRole === "stt" || mediaRole === "tts") &&
+    !_providerCarriesAudio(md && md.provider)
+  ) {
+    return false;
+  }
   // An omni model (chat audio input) can serve STT via the chat transcription
   // path — mirror model_supports_role in turnstone/core/audio.py.
   if (mediaRole === "stt" && caps.supports_audio_input) return true;

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2889,17 +2889,19 @@ function loadSettings() {
         schemaMap[schemaArr[i].key] = schemaArr[i];
       }
 
-      // Merge values + schema.  Skip role-assignment settings owned by
-      // the Models → Roles sub-tab (judge.* settings still live on the
-      // Judge tab; the model-tab roles render only there).
+      // Merge values + schema.  Skip role-assignment settings owned by the
+      // Models → Roles sub-tab.  Derive the skip-set straight from MODEL_ROLES
+      // (alias + optional effort key) so a newly-added role can't drift back
+      // into this list — perception was exactly that miss, and stt/tts/reranker
+      // had quietly leaked the same way.  judge.* keeps its own prefix skip
+      // below: it covers more than the two judge role aliases (the output-guard
+      // toggle, thresholds, ...), all of which live on the Judge tab.
       const merged = {};
-      const roleKeys = {
-        "coordinator.model_alias": 1,
-        "coordinator.reasoning_effort": 1,
-        "model.task_alias": 1,
-        "model.task_effort": 1,
-        "channels.default_model_alias": 1,
-      };
+      const roleKeys = {};
+      for (let ri = 0; ri < MODEL_ROLES.length; ri++) {
+        roleKeys[MODEL_ROLES[ri].aliasKey] = 1;
+        if (MODEL_ROLES[ri].effortKey) roleKeys[MODEL_ROLES[ri].effortKey] = 1;
+      }
       for (let j = 0; j < valuesArr.length; j++) {
         const v = valuesArr[j];
         if (v.key.startsWith("judge.")) continue;
@@ -5194,7 +5196,7 @@ const MODEL_ROLES = [
   {
     label: "Speech-to-text",
     description:
-      "Transcribes microphone audio in the workstream composer (voice input). Empty disables the mic affordance — there is no audio-capable session fallback.",
+      "Transcribes microphone audio in the workstream composer (voice input), and is the preferred transcript for audio attachments. Empty disables the mic affordance; audio attachments then fall back to the Perception model if one is configured.",
     aliasKey: "audio.stt_model_alias",
     fallbackKind: "disabled",
     mediaCapability: "supports_transcription",
@@ -5210,11 +5212,20 @@ const MODEL_ROLES = [
     mediaRole: "tts",
   },
   {
+    label: "Perception",
+    description:
+      "Bottom-tier fallback for attachments the primary model can't ingest natively (image / PDF / audio): the perception model perceives the attachment and its description is passed to the primary as text. Point at a vision-capable or omni model and enable the matching capabilities on it — supports_vision for image/PDF, supports_audio_input for audio. Empty disables the fallback; native handling and the speech-to-text role still take precedence.",
+    aliasKey: "perception.model_alias",
+    fallbackKind: "disabled",
+    disabledLabel: "(disabled — no fallback)",
+  },
+  {
     label: "Reranker",
     description:
       "Reranks web_search results. Point at a model whose base_url is a Cohere/Jina-compatible /rerank endpoint and whose capabilities include supports_rerank. Empty disables reranking. Enabling a reranker sends web_search results AND BM25 retrieval candidates (tool/skill descriptions and memory content) to this endpoint; self-hosted endpoints keep it on your infrastructure.",
     aliasKey: "tools.reranker_alias",
     fallbackKind: "disabled",
+    disabledLabel: "(disabled — reranking off)",
     mediaCapability: "supports_rerank",
     mediaRole: "rerank",
   },
@@ -5446,7 +5457,7 @@ function _renderModelRoles(container, values, schema) {
     const blank = document.createElement("option");
     blank.value = "";
     if (role.fallbackKind === "disabled") {
-      blank.textContent = "(disabled — voice off)";
+      blank.textContent = role.disabledLabel || "(disabled — voice off)";
     } else if (role.fallbackKind === "inherit") {
       blank.textContent = "(inherit)";
     } else {

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5269,11 +5269,13 @@ function _audioModelEligible(md, capFlag, mediaRole) {
   if (!caps || typeof caps !== "object") caps = {};
   // Voice roles (stt/tts) ride the OpenAI-SDK audio surface; an Anthropic
   // (-compatible) provider can't serve them even with a capability flag set.
-  // Reranker is NOT an audio role (it hits a /rerank endpoint), so it is not
-  // provider-gated here.
+  // A blank/unset provider defaults to "openai" — matching the backend's
+  // _provider_carries_audio (ModelConfig.provider defaults to "openai") so a
+  // provider-less model isn't wrongly excluded. Reranker is NOT an audio role
+  // (it hits a /rerank endpoint), so it is not provider-gated here.
   if (
     (mediaRole === "stt" || mediaRole === "tts") &&
-    !_providerCarriesAudio(md && md.provider)
+    !_providerCarriesAudio((md && md.provider) || "openai")
   ) {
     return false;
   }

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -943,6 +943,27 @@ function _hasCoordPermission() {
 // loading-state UX (button label swap, composer disabled flag, etc.).
 // On success redirects to /coordinator/{ws_id}; on failure surfaces
 // the server's error text inline through errEl.
+// Build the fetch options for a workstream-create POST: multipart (a `meta`
+// JSON field + one `file` part per staged attachment) when files are present,
+// else plain JSON.  Shared by the coordinator and interactive launchers so the
+// create wire shape lives in one place.
+function _createWorkstreamFetchOpts(body, files) {
+  if (files.length > 0) {
+    const form = new FormData();
+    form.append("meta", JSON.stringify(body));
+    for (let i = 0; i < files.length; i++) {
+      form.append("file", files[i], files[i].name);
+    }
+    // Don't set Content-Type — the browser adds the correct multipart boundary.
+    return { method: "POST", body: form };
+  }
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
 function _createCoordinator(opts) {
   const name = (opts.name || "").trim();
   const skill = opts.skill || "";
@@ -967,28 +988,11 @@ function _createCoordinator(opts) {
   if (judgeModel) body.judge_model = judgeModel;
   if (task) body.initial_message = task;
 
-  // Multipart when files are staged — the coord create endpoint
-  // accepts a `meta` JSON field plus zero-or-more `file` parts and
-  // reserves attachments for the very first turn (same flow the
-  // interactive UI's new-ws modal uses against the server).  Plain
-  // JSON stays the default when no files are attached.
+  // Multipart when files are staged (meta JSON + file parts); the coord create
+  // endpoint reserves the attachments for the very first turn.  Plain JSON
+  // otherwise.
   const files = Array.isArray(opts.files) ? opts.files : [];
-  let fetchOpts;
-  if (files.length > 0) {
-    const form = new FormData();
-    form.append("meta", JSON.stringify(body));
-    for (let i = 0; i < files.length; i++) {
-      form.append("file", files[i], files[i].name);
-    }
-    // Don't set Content-Type — the browser adds the correct boundary.
-    fetchOpts = { method: "POST", body: form };
-  } else {
-    fetchOpts = {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    };
-  }
+  const fetchOpts = _createWorkstreamFetchOpts(body, files);
 
   authFetch("/v1/api/workstreams/new", fetchOpts)
     .then(function (r) {
@@ -1173,26 +1177,11 @@ function _createInteractive(opts) {
   if (judgeModel) body.judge_model = judgeModel;
   if (task) body.initial_message = task;
 
-  // Multipart when files are staged — `meta` JSON + zero-or-more `file`
-  // parts.  The cluster proxy picks the node (node_id in meta) and forwards
-  // the files to its create endpoint; plain JSON stays the default otherwise.
+  // Multipart when files are staged (meta JSON + file parts); the cluster proxy
+  // picks the node (node_id in meta) and forwards the files to its create
+  // endpoint.  Plain JSON otherwise.
   const files = Array.isArray(opts.files) ? opts.files : [];
-  let fetchOpts;
-  if (files.length > 0) {
-    const form = new FormData();
-    form.append("meta", JSON.stringify(body));
-    for (let i = 0; i < files.length; i++) {
-      form.append("file", files[i], files[i].name);
-    }
-    // Don't set Content-Type — the browser adds the correct boundary.
-    fetchOpts = { method: "POST", body: form };
-  } else {
-    fetchOpts = {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    };
-  }
+  const fetchOpts = _createWorkstreamFetchOpts(body, files);
 
   authFetch("/v1/api/cluster/workstreams/new", fetchOpts)
     .then(function (r) {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1173,11 +1173,28 @@ function _createInteractive(opts) {
   if (judgeModel) body.judge_model = judgeModel;
   if (task) body.initial_message = task;
 
-  authFetch("/v1/api/cluster/workstreams/new", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
+  // Multipart when files are staged — `meta` JSON + zero-or-more `file`
+  // parts.  The cluster proxy picks the node (node_id in meta) and forwards
+  // the files to its create endpoint; plain JSON stays the default otherwise.
+  const files = Array.isArray(opts.files) ? opts.files : [];
+  let fetchOpts;
+  if (files.length > 0) {
+    const form = new FormData();
+    form.append("meta", JSON.stringify(body));
+    for (let i = 0; i < files.length; i++) {
+      form.append("file", files[i], files[i].name);
+    }
+    // Don't set Content-Type — the browser adds the correct boundary.
+    fetchOpts = { method: "POST", body: form };
+  } else {
+    fetchOpts = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    };
+  }
+
+  authFetch("/v1/api/cluster/workstreams/new", fetchOpts)
     .then(function (r) {
       return r.json().then(function (data) {
         return { ok: r.ok, status: r.status, data: data };
@@ -1666,13 +1683,10 @@ function submitHomeCoord(textFromComposer) {
     },
   };
   if (kind === "interactive") {
-    // The cluster create proxy is JSON-only; attachments stay coordinator-only.
-    if (files.length > 0) {
-      _homeShowError(
-        "Attachments aren't supported for interactive sessions yet.",
-      );
-      return;
-    }
+    // Create-with-attachments rides multipart through the cluster proxy to the
+    // node (see _createInteractive); the files-need-a-task guard above already
+    // ensures an initial turn to dispatch them on.
+    shared.files = files;
     // Node placement from the launcher's node-strategy picker (interactive-only).
     shared.node_strategy = opts.node_strategy || "auto";
     shared.node_id = (opts.node_id || "").trim();

--- a/turnstone/core/audio.py
+++ b/turnstone/core/audio.py
@@ -34,6 +34,15 @@ _ROLE_CAPABILITY: dict[str, str] = {
     "tts": "supports_speech_synthesis",
 }
 
+# Providers whose client speaks the OpenAI-SDK surface audio.py relies on
+# (``client.audio.*`` for the transcription/speech endpoints, ``client.chat.
+# completions.*`` with ``input_audio`` for the omni chat path).  Anthropic and
+# anthropic-compatible (e.g. a vLLM Messages-API endpoint) use a different SDK
+# whose protocol has NO audio content block, so they can't serve audio in ANY
+# role — gated out here.  Mirrors the OpenAI-lane split in
+# turnstone.core.providers and the JS ``_providerCarriesAudio`` in admin.js.
+_AUDIO_SDK_PROVIDERS: frozenset[str] = frozenset({"openai", "openai-compatible", "google", "xai"})
+
 # Known-model-name hints for capability inference. The explicit
 # ``capabilities`` flag is ALWAYS canonical (see ``model_supports_role``); these
 # only fill the gap so a stock OpenAI audio model alias works without an
@@ -113,14 +122,24 @@ def _infer_audio_capability(model: str, role: str) -> bool:
     return any(hint in name for hint in _AUDIO_MODEL_HINTS.get(role, ()))
 
 
+def _provider_carries_audio(cfg: Any) -> bool:
+    """Whether the alias's provider can carry audio over the OpenAI-SDK surface."""
+    return getattr(cfg, "provider", "openai") in _AUDIO_SDK_PROVIDERS
+
+
 def model_supports_role(cfg: Any, role: str) -> bool:
     """Whether the alias's model is eligible for a media *role*.
 
     Explicit ``capabilities[<flag>]`` wins; otherwise fall back to a
-    known-model-name inference for OpenAI audio models.
+    known-model-name inference for OpenAI audio models.  Either way the
+    provider must speak the OpenAI-SDK audio surface (see
+    :data:`_AUDIO_SDK_PROVIDERS`) — an Anthropic(-compatible) model can't carry
+    audio in any role even if a capability flag is ticked.
     """
     flag = _ROLE_CAPABILITY.get(role)
     if not flag:
+        return False
+    if not _provider_carries_audio(cfg):
         return False
     caps = getattr(cfg, "capabilities", None) or {}
     # An omni model (accepts audio in chat) can serve STT via the chat
@@ -215,6 +234,16 @@ def transcribe(
         client, model, cfg = registry.resolve(alias)
     except Exception as exc:  # unknown/removed alias
         raise AudioUnavailableError(f"STT model alias {alias!r} is not available") from exc
+    # Defence in depth: resolve_role_alias already gates this, but a stale
+    # config or a direct caller could still point STT at a non-OpenAI-SDK
+    # provider (Anthropic has no audio surface).  Fail with an actionable
+    # message instead of an opaque ``'Anthropic' object has no attribute 'chat'``.
+    if not _provider_carries_audio(cfg):
+        raise AudioUnavailableError(
+            f"STT model alias {alias!r} (provider "
+            f"{getattr(cfg, 'provider', 'unknown')!r}) can't transcribe audio — "
+            "audio roles require an OpenAI-compatible provider."
+        )
     caps = getattr(cfg, "capabilities", None) or {}
     endpoint = _serves_transcription_endpoint(cfg, model)
     if not endpoint and not caps.get("supports_audio_input"):

--- a/turnstone/core/audio.py
+++ b/turnstone/core/audio.py
@@ -62,6 +62,18 @@ _MEDIA_TYPES: dict[str, str] = {
 
 _DEFAULT_VOICE = "alloy"
 
+# Default instruction for transcribing via an omni *chat* model (one that accepts
+# audio in chat but doesn't serve the dedicated /audio/transcriptions endpoint).
+# Steers the model to emit only the transcript; an operator can override it
+# per-deployment with the ``audio.stt_prompt`` setting.
+_OMNI_STT_PROMPT = (
+    "Transcribe the following speech segment in its original language. Follow these "
+    "specific instructions for formatting the answer:\n"
+    "* Only output the transcription, with no newlines.\n"
+    "* When transcribing numbers, write the digits, i.e. write 1.7 and not one point "
+    "seven, and write 3 instead of three"
+)
+
 
 @dataclass(frozen=True)
 class TranscriptionResult:
@@ -111,6 +123,11 @@ def model_supports_role(cfg: Any, role: str) -> bool:
     if not flag:
         return False
     caps = getattr(cfg, "capabilities", None) or {}
+    # An omni model (accepts audio in chat) can serve STT via the chat
+    # transcription path even without the dedicated /audio/transcriptions
+    # endpoint — see :func:`transcribe`.  Mirrored in admin.js _audioModelEligible.
+    if role == "stt" and caps.get("supports_audio_input"):
+        return True
     if flag in caps:
         return bool(caps.get(flag))
     return _infer_audio_capability(getattr(cfg, "model", ""), role)
@@ -137,29 +154,86 @@ def resolve_role_alias(*, config_store: Any | None, registry: Any | None, role: 
     return alias
 
 
+def _serves_transcription_endpoint(cfg: Any, model: str) -> bool:
+    """Whether the alias serves the dedicated ``/audio/transcriptions`` endpoint
+    (whisper-style), as opposed to an omni chat model that ingests audio inline.
+
+    Explicit ``supports_transcription`` wins; otherwise infer from the model name.
+    """
+    caps = getattr(cfg, "capabilities", None) or {}
+    if "supports_transcription" in caps:
+        return bool(caps["supports_transcription"])
+    return _infer_audio_capability(model, "stt")
+
+
+def _transcribe_via_chat(client: Any, model: str, data: bytes, filename: str, prompt: str) -> str:
+    """Transcribe by handing the clip to an omni *chat* model as ``input_audio``.
+
+    For models that accept audio in chat (``supports_audio_input``) but don't
+    serve ``/audio/transcriptions``.  The instruction ``prompt`` steers the model
+    to emit only the transcript.  The audio format is taken from the upload's
+    filename extension (the same shape the attachment wire path uses).
+    """
+    import base64
+
+    name = filename or "speech.webm"
+    fmt = name.rsplit(".", 1)[-1].lower() if "." in name else "wav"
+    audio_b64 = base64.b64encode(data).decode("ascii")
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "input_audio", "input_audio": {"data": audio_b64, "format": fmt}},
+                ],
+            }
+        ],
+    )
+    choices = getattr(resp, "choices", None) or []
+    if not choices:
+        return ""
+    return (getattr(choices[0].message, "content", "") or "").strip()
+
+
 def transcribe(
     *, registry: Any, alias: str, data: bytes, filename: str, prompt: str = ""
 ) -> TranscriptionResult:
     """Transcribe ``data`` using the STT role alias's audio backend.
 
-    ``prompt`` (when non-empty) is forwarded as the transcription ``prompt``
-    parameter to bias the model toward domain vocabulary / instructions; it is
-    omitted entirely when blank so backends that don't accept it aren't sent it.
+    A whisper-style alias (``supports_transcription`` / a transcription model
+    name) goes through ``/audio/transcriptions``; an omni alias
+    (``supports_audio_input``) transcribes via chat ``input_audio`` instead.
+
+    ``prompt`` (when non-empty) is forwarded as the transcription ``prompt`` on
+    the endpoint path (vocabulary bias) and as the instruction on the chat path;
+    the chat path falls back to :data:`_OMNI_STT_PROMPT` so a bare omni call still
+    emits a clean transcript rather than a conversational reply.
     """
     try:
-        client, model, _cfg = registry.resolve(alias)
+        client, model, cfg = registry.resolve(alias)
     except Exception as exc:  # unknown/removed alias
         raise AudioUnavailableError(f"STT model alias {alias!r} is not available") from exc
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "file": (filename or "speech.webm", data),
-        "response_format": "json",
-    }
-    if prompt:
-        kwargs["prompt"] = prompt
+    caps = getattr(cfg, "capabilities", None) or {}
+    endpoint = _serves_transcription_endpoint(cfg, model)
+    if not endpoint and not caps.get("supports_audio_input"):
+        raise AudioUnavailableError(f"STT model alias {alias!r} cannot transcribe audio")
     try:
-        resp = client.audio.transcriptions.create(**kwargs)
-        transcript = (getattr(resp, "text", "") or "").strip()
+        if endpoint:
+            kwargs: dict[str, Any] = {
+                "model": model,
+                "file": (filename or "speech.webm", data),
+                "response_format": "json",
+            }
+            if prompt:
+                kwargs["prompt"] = prompt
+            resp = client.audio.transcriptions.create(**kwargs)
+            transcript = (getattr(resp, "text", "") or "").strip()
+        else:
+            transcript = _transcribe_via_chat(
+                client, model, data, filename, prompt or _OMNI_STT_PROMPT
+            )
     except Exception as exc:
         raise AudioBackendError(f"Transcription backend failed: {exc}") from exc
     return TranscriptionResult(transcript=transcript, model_alias=alias, model=model)

--- a/turnstone/core/images.py
+++ b/turnstone/core/images.py
@@ -1,0 +1,63 @@
+"""Image-pixel utilities shared across the thumbnail, wire, and perception paths.
+
+Currently: EXIF-orientation normalisation.  Kept separate from
+:mod:`turnstone.core.thumbnails` (which downscales for the UI) — this operates on
+full-resolution bytes at the read/wire boundary so every consumer of an
+attachment sees the same upright pixels.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from turnstone.core.log import get_logger
+
+log = get_logger(__name__)
+
+# EXIF tag 0x0112 (274) — image orientation (1 = upright; 2-8 = flips/rotations).
+_EXIF_ORIENTATION_TAG = 0x0112
+
+# Mirror turnstone.core.thumbnails: bound decoded pixels so a small compressed
+# file that expands to an enormous bitmap can't OOM the node during re-encode.
+_MAX_IMAGE_PIXELS = 40_000_000
+
+
+def normalize_image_orientation(data: bytes) -> bytes:
+    """Bake an image's EXIF orientation into its pixels; return re-encoded bytes.
+
+    Images with no orientation tag (or an identity orientation) are returned
+    UNCHANGED — no decode/re-encode, so the pristine original is preserved and
+    there is no per-send cost in the common case.  Never raises: any failure
+    (Pillow missing, decode error, oversized) returns the original bytes.
+
+    Why this exists: a phone photo stores landscape pixels plus an orientation
+    tag.  Browsers honour the tag for ``<img>``, but Pillow (our thumbnails) and
+    many vision-model image decoders do NOT — so the model literally perceives
+    the photo rotated.  Normalising at the read/wire boundary makes every
+    consumer (browser, thumbnail, model) see the same upright image.
+    """
+    try:
+        from PIL import Image, ImageOps
+    except ImportError:  # pragma: no cover - declared dependency; defensive
+        return data
+    try:
+        img = Image.open(BytesIO(data))
+        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
+        if not orientation or orientation == 1:
+            return data  # upright already — keep the original bytes verbatim
+        if img.size[0] * img.size[1] > _MAX_IMAGE_PIXELS:
+            log.warning("orientation normalize skipped: image exceeds pixel cap")
+            return data
+        fmt = img.format or "PNG"
+        upright = ImageOps.exif_transpose(img)  # applies the rotation + drops the tag
+        if upright is None:  # pragma: no cover - in_place=False never returns None
+            return data
+        buf = BytesIO()
+        save_kwargs: dict[str, object] = {}
+        if fmt in ("JPEG", "WEBP"):
+            save_kwargs["quality"] = 90
+        upright.save(buf, format=fmt, **save_kwargs)
+        return buf.getvalue()
+    except Exception as exc:
+        log.warning("orientation normalize failed: %s", exc)
+        return data

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6166,7 +6166,7 @@ class ChatSession:
         the current turn to finish before allowing an attached send.
 
         ``queue_msg_id`` lets the caller supply the id (so it matches the
-        attachment-reservation token already taken server-side) — when
+        ``send_id`` tracking token threaded through the send) — when
         omitted, an id is generated.
         """
         from turnstone.core.tool_advisory import parse_priority
@@ -6181,10 +6181,9 @@ class ChatSession:
         # Cap individual message length to prevent context bloat
         if len(cleaned) > 2000:
             cleaned = cleaned[:2000] + "..."
-        # Full UUID hex (128 bits) rather than a truncated prefix — this
-        # id doubles as a cross-table reservation token on
-        # workstream_attachments, and a 48-bit truncation narrows the
-        # birthday bound unnecessarily.
+        # Full UUID hex (128 bits) rather than a truncated prefix — this id is
+        # the ``send_id`` tracking token threaded through the turn, so the wide
+        # space keeps the birthday bound comfortable.
         msg_id = queue_msg_id or uuid.uuid4().hex
         with self._queued_lock:
             if len(self._queued_messages) >= self._QUEUE_MAX:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -327,7 +327,7 @@ class SessionEndpointConfig:
     Capability flags (added with the P1.5 ``send`` body lift):
 
     - ``supports_attachments``: when ``True``, the lifted ``send``
-      handler resolves attachment_ids, reserves under a send_id token,
+      handler resolves attachment_ids from the per-node upload buffer
       and threads them through ``ChatSession.send`` /
       ``ChatSession.queue_message``. Both kinds wire ``True`` post-P1.5
       (the storage layer was always kind-agnostic; the gate stays
@@ -2065,8 +2065,8 @@ def make_create_handler(
       the lifted body parses multipart bodies on coord and saves
       attachments through the kind-agnostic storage layer (§ Post-P3
       reckoning item #1). When the same request supplies an
-      ``initial_message``, the uploads are reserved onto the
-      dispatched first turn via ``CoordinatorAdapter.send`` (which
+      ``initial_message``, the uploads are resolved from the buffer onto
+      the dispatched first turn via ``CoordinatorAdapter.send`` (which
       gained ``attachments`` + ``send_id`` kwargs in the same
       release).
     - **No phantom create→close pair on coord rollback.** The lifted
@@ -3416,9 +3416,9 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     Capability flags on ``cfg`` toggle the kind-specific behaviour:
 
     - ``supports_attachments``: when ``False``, the entire
-      attachment-resolution block (reservation, fetch, scope-check)
+      attachment-resolution block (buffer peek + scope-check)
       short-circuits and any ``attachment_ids`` in the body are
-      silently ignored — no reservation, no error. Both kinds wire
+      silently ignored — no resolution, no error. Both kinds wire
       ``True`` post-P1.5; the flag exists so a kind that hasn't
       lit up its UI surface yet can defer.
     - ``spawn_metrics``: when set, fires once on the spawn path with
@@ -3490,8 +3490,8 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         # ----- Attachment resolution (from the per-node upload buffer) -----
         send_id = ""
         requested_ids: list[str] = []
-        ordered_reserved: list[str] = []
-        reserved_set: set[str] = set()
+        ordered_taken: list[str] = []
+        taken_set: set[str] = set()
         resolved_atts: list[Any] = []
         attach_user_id = ""
 
@@ -3524,18 +3524,10 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             # turn the queue rejects can still be retried; the committing
             # ``send`` drains them at write time.  ``resolved`` carries the
             # bytes the session persists content-addressed.
-            resolved_atts, ordered_reserved, _dropped_resolve = resolve_staged_attachments(
+            resolved_atts, ordered_taken, _dropped_resolve = resolve_staged_attachments(
                 requested_ids, ws_id, attach_user_id
             )
-            reserved_set = set(ordered_reserved)
-
-        def _release_reservation_on_fail() -> None:
-            """No-op: the upload buffer is a peek, not a lock.
-
-            Retained as the worker-failure hook so the call sites below read
-            the same as the pre-cutover reservation flow; there is nothing to
-            release — undrained staged bytes simply expire on the buffer TTL.
-            """
+            taken_set = set(ordered_taken)
 
         # If a cancel was just issued, briefly poll for the worker to
         # exit before dispatching — avoids spawning into a stale
@@ -3548,7 +3540,6 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 if not ws._worker_running:
                     break
         if ws.session is None:
-            _release_reservation_on_fail()
             return JSONResponse({"error": "No session"}, status_code=500)
 
         session = ws.session
@@ -3560,7 +3551,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             try:
                 cleaned, priority, msg_id = session.queue_message(
                     message,
-                    attachment_ids=list(ordered_reserved),
+                    attachment_ids=list(ordered_taken),
                     queue_msg_id=send_id or None,
                 )
             except AttachmentsNotQueueableError:
@@ -3606,16 +3597,13 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 # Safety net — send() normally handles this internally.
                 # If this thread was force-abandoned, ws.worker_thread
                 # was set to None — don't emit spurious events.
-                _release_reservation_on_fail()
                 if ws.worker_thread is me:
                     _emit_ui("on_stream_end")
                     _emit_ui("on_state_change", "idle")
             except Exception:
-                # Release the reservation so attachments don't stay
-                # soft-locked forever on a worker crash before the
-                # consume step. Idempotent: once consume cleared the
-                # token, a follow-up unreserve is a no-op.
-                _release_reservation_on_fail()
+                # Undrained staged uploads aren't locked (the buffer is a peek,
+                # not a reservation) — they expire on the buffer TTL — so the
+                # only cleanup owed here is the UI streaming hook.
                 if ws.worker_thread is me:
                     # ``session.send()`` already fired ``on_error``
                     # (with sanitized text), persisted ``last_error``,
@@ -3634,12 +3622,10 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         )
         if not ok:
             # queue.Full or session-disappeared race — surface as
-            # queue_full so clients retry rather than 500. Reservations
-            # released above; ``attached_ids`` is always empty on this
-            # path (the dispatch never took ownership). The empty
-            # arrays preserve the response-shape guarantee so SDK
-            # consumers don't branch on status.
-            _release_reservation_on_fail()
+            # queue_full so clients retry rather than 500. ``attached_ids``
+            # is always empty on this path (the dispatch never took
+            # ownership); the empty arrays preserve the response-shape
+            # guarantee so SDK consumers don't branch on status.
             return JSONResponse(
                 {
                     "status": "queue_full",
@@ -3651,9 +3637,8 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         if queue_outcome.get("rejected") == "attachments_busy":
             # Attachments can't ride a queued user turn (see
             # AttachmentsNotQueueableError for the role-ordering reason).
-            # Release reservations and surface to the caller so the
+            # The staged uploads stay in the buffer (peek, not drain) so the
             # client can hold the file and retry once the worker idles.
-            _release_reservation_on_fail()
             return JSONResponse(
                 {
                     "status": "attachments_busy",
@@ -3662,7 +3647,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 }
             )
 
-        dropped = [aid for aid in requested_ids if aid not in reserved_set]
+        dropped = [aid for aid in requested_ids if aid not in taken_set]
         if queue_outcome:
             # Reused a live worker; ``queue_message`` succeeded.
             if cfg.emit_message_queued and hasattr(ui, "_enqueue"):
@@ -3679,7 +3664,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     "status": "queued",
                     "priority": queue_outcome["priority"],
                     "msg_id": queue_outcome["msg_id"],
-                    "attached_ids": list(ordered_reserved),
+                    "attached_ids": list(ordered_taken),
                     "dropped_attachment_ids": dropped,
                 }
             )
@@ -3697,7 +3682,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         return JSONResponse(
             {
                 "status": "ok",
-                "attached_ids": list(ordered_reserved),
+                "attached_ids": list(ordered_taken),
                 "dropped_attachment_ids": dropped,
             }
         )

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -20,7 +20,7 @@ fix.
 
 This module owns ONLY the dispatch decision and the
 ``_worker_running`` lifecycle. Per-kind concerns — session resolution,
-attachments reservation, error surfacing, UI callbacks,
+attachment resolution, error surfacing, UI callbacks,
 ``GenerationCancelled`` handling — live in the caller's
 ``enqueue`` / ``run`` no-arg closures.
 """

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -302,7 +302,12 @@ def attachment_to_content_part(att: dict[str, Any]) -> dict[str, Any] | None:
     raw = att.get("content")
     mime = att.get("mime_type") or "application/octet-stream"
     if kind == "image" and isinstance(raw, bytes):
-        b64 = base64.b64encode(raw).decode("ascii")
+        from turnstone.core.images import normalize_image_orientation
+
+        # Bake EXIF orientation into the pixels — the model's image decoder, like
+        # Pillow, ignores the orientation tag, so a phone photo would otherwise be
+        # perceived sideways.  Unrotated images pass through untouched.
+        b64 = base64.b64encode(normalize_image_orientation(raw)).decode("ascii")
         return {
             "type": "image_url",
             "image_url": {"url": f"data:{mime};base64,{b64}"},

--- a/turnstone/core/thumbnails.py
+++ b/turnstone/core/thumbnails.py
@@ -24,7 +24,7 @@ _MAX_IMAGE_PIXELS = 40_000_000
 def make_thumbnail(data: bytes, kind: str, *, max_px: int = _THUMB_MAX_PX) -> bytes | None:
     """Return a small PNG thumbnail for an ``image``/``pdf`` blob, else ``None``."""
     try:
-        from PIL import Image
+        from PIL import Image, ImageOps
     except ImportError:  # pragma: no cover - declared dependency; defensive
         log.warning("Pillow not installed; thumbnails unavailable")
         return None
@@ -44,11 +44,11 @@ def make_thumbnail(data: bytes, kind: str, *, max_px: int = _THUMB_MAX_PX) -> by
             img = Image.open(BytesIO(data))
         else:
             return None
-        # Reject oversized images explicitly before decoding.  Pillow's
+        # Reject oversized images explicitly before any decode.  Pillow's
         # MAX_IMAGE_PIXELS only *raises* above 2x the cap; between the cap and 2x
         # it merely warns and decodes fully (a 40-80M px image → ~480MB RGB),
         # defeating the bound.  The header-declared size is known after open(),
-        # so gate on it before convert() — nothing past the cap is ever decoded.
+        # so gate on it before exif_transpose / convert (both decode the pixels).
         # (Explicit check, not a warnings filter: make_thumbnail runs in a thread
         # and the global warnings state is not thread-safe.)
         px = img.size[0] * img.size[1]
@@ -61,7 +61,11 @@ def make_thumbnail(data: bytes, kind: str, *, max_px: int = _THUMB_MAX_PX) -> by
                 _MAX_IMAGE_PIXELS,
             )
             return None
-        rgb = img.convert("RGB")
+        # Honour EXIF orientation so a phone photo's thumbnail isn't rotated:
+        # Pillow doesn't auto-apply the tag and PNG can't carry it.  No-op for
+        # the rasterized-PDF branch (its pages carry no EXIF).
+        oriented = ImageOps.exif_transpose(img) or img
+        rgb = oriented.convert("RGB")
         rgb.thumbnail((max_px, max_px))
         buf = BytesIO()
         rgb.save(buf, format="PNG")

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -346,9 +346,9 @@ class AsyncTurnstoneConsole(_BaseClient):
     ) -> dict[str, Any]:
         """Send a message to a coordinator workstream.
 
-        ``attachment_ids`` reserves attachments under the message's
-        ``send_id`` token; pass ``None`` to auto-consume the caller's
-        pending attachments, or ``[]`` to disable auto-consume.
+        ``attachment_ids`` selects which staged uploads to attach to the
+        message; pass ``None`` to auto-consume the caller's pending
+        attachments, or ``[]`` to disable auto-consume.
         """
         body: dict[str, Any] = {"message": message}
         if attachment_ids is not None:

--- a/turnstone/sdk/server.py
+++ b/turnstone/sdk/server.py
@@ -120,7 +120,7 @@ class AsyncTurnstoneServer(_BaseClient):
         field and one ``file`` part per attachment.  A ws_id is
         auto-generated client-side when not supplied so cluster-routed
         callers can bind the body to the owning node up front.  When
-        *initial_message* is also set, the server reserves the
+        *initial_message* is also set, the server resolves the staged
         attachments onto that turn before its background worker
         dispatches.
         """

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1917,8 +1917,9 @@ async def _interactive_create_post_install(
     8. Pin the workstream's routing to this node when no caller-
        supplied ``ws_id`` was provided (direct creates).
     9. Spawn the initial-message worker thread when ``initial_message``
-       is set, reserving any uploaded attachments for that first
-       turn.
+       is set, resolving any staged uploads from the buffer onto that
+       first turn (then draining them so a freshly-opened pane's
+       rehydrate can't observe them as still-pending).
 
     Returns ``{resumed, message_count}`` for the response. On the
     no-resume path both default to ``False`` / ``0``.

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2058,9 +2058,19 @@ async def _interactive_create_post_install(
         send_id = uuid.uuid4().hex
         resolved_atts: list[Any] = []
         if attachment_ids:
-            # Resolve (peek) the staged uploads; the committing send drains
-            # them from the buffer.  No reservation to release on failure.
+            # Resolve (peek) the staged uploads, then drain them from the buffer
+            # now.  The inlined first turn is their only consumer and it always
+            # commits at create (no queue rejection by construction), so leaving
+            # them staged would let the freshly-opened pane's rehydrate race the
+            # worker's write-time drain and paint them as still-pending composer
+            # chips.  ``_append_user_turn``'s own per-id discard then no-ops.
             resolved_atts, _ord, _drop = _resolve_staged(attachment_ids, ws.id, uid)
+            if _ord:
+                from turnstone.core.attachment_buffer import get_attachment_buffer
+
+                _buf = get_attachment_buffer()
+                for _aid in _ord:
+                    _buf.discard(_aid, ws_id=ws.id, user_id=uid)
 
         def _run_initial() -> None:
             try:

--- a/turnstone/shared_static/composer_attachments.js
+++ b/turnstone/shared_static/composer_attachments.js
@@ -1,7 +1,8 @@
 /* composer_attachments.js — shared paperclip / chip / upload pipeline.
  *
  * Used by both:
- *   - turnstone/ui/static/app.js (interactive Pane)
+ *   - turnstone/shared_static/interactive.js (interactive Pane — standalone
+ *     server at the origin, console node-proxied via opts.getBase)
  *   - turnstone/console/static/coordinator/coordinator.js (coord IIFE)
  *
  * Owns: the in-flight `pendingAttachments` Map (insertion-ordered, so
@@ -47,8 +48,14 @@ function _inferKind(file) {
   return "text";
 }
 
-function _attachUrl(wsId, id, suffix) {
+// ``base`` is the node-proxy prefix ("/node/{id}") for a console-hosted
+// interactive pane, or "" for the standalone server / console-local coordinator
+// panes where the attachment routes are mounted at the origin.  Without it a
+// console interactive pane's request lands on the console's own coord route and
+// 404s as "coordinator not found".
+function _attachUrl(base, wsId, id, suffix) {
   return (
+    base +
     "/v1/api/workstreams/" +
     encodeURIComponent(wsId) +
     "/attachments/" +
@@ -70,10 +77,12 @@ export function kindIcon(kind) {
 // Build an inline preview node for a committed attachment (real id), or null.
 // image/pdf → server-rendered thumbnail; audio → <audio> player; text → a lazy
 // snippet.  Auth is cookie-based, so a plain media `src` works same-origin.
+// ``opts.base`` is the node-proxy prefix (see _attachUrl) — "" by default.
 export function buildAttachmentPreview(opts) {
   var kind = opts.kind,
     wsId = opts.wsId,
-    id = opts.attachmentId;
+    id = opts.attachmentId,
+    base = opts.base || "";
   if (!wsId || !id) return null;
   if (kind === "image" || kind === "pdf") {
     var img = document.createElement("img");
@@ -81,7 +90,7 @@ export function buildAttachmentPreview(opts) {
     img.loading = "lazy";
     img.decoding = "async";
     img.alt = "";
-    img.src = _attachUrl(wsId, id, "/thumbnail");
+    img.src = _attachUrl(base, wsId, id, "/thumbnail");
     // If the thumbnail can't render, swap in the kind glyph rather than removing
     // the node: the caller has already replaced the original icon span with this
     // img, so a bare remove() would leave a blank gap (no icon at all).
@@ -99,7 +108,7 @@ export function buildAttachmentPreview(opts) {
     audio.className = "attach-preview attach-preview-audio";
     audio.controls = true;
     audio.preload = "none";
-    audio.src = _attachUrl(wsId, id, "/content");
+    audio.src = _attachUrl(base, wsId, id, "/content");
     // Native control is keyboard-focusable; name it so it isn't announced as a
     // bare "audio" with no indication of which attachment it plays.
     audio.setAttribute(
@@ -119,7 +128,7 @@ export function buildAttachmentPreview(opts) {
       (opts && opts.authFetch) ||
       (typeof window !== "undefined" ? window.authFetch : null);
     if (typeof fetchFn !== "function") return null;
-    fetchFn(_attachUrl(wsId, id, "/content"), {
+    fetchFn(_attachUrl(base, wsId, id, "/content"), {
       method: "GET",
       credentials: "include",
     })
@@ -180,6 +189,11 @@ function _toastError(msg) {
  *   chipsEl: HTMLElement — chips render target (composer.chipsEl).
  *   getWsId: () => string — current workstream id (function so the
  *     interactive pane can swap tabs without re-instantiating).
+ *   getBase: optional () => string — node-proxy prefix ("/node/{id}")
+ *     for a console-hosted interactive pane; "" (default) for the
+ *     standalone server and console-local coordinator panes.  A
+ *     function, like getWsId, so a tab swap to a session on another
+ *     node retargets without re-instantiating the controller.
  *   authFetch: optional override (default window.authFetch).
  *   onError: optional (msg, err) => void — replaces the default toast
  *     for upload failures.
@@ -199,6 +213,11 @@ export function createAttachmentController(opts) {
   function _authFetch(url, init) {
     var fn = opts.authFetch || window.authFetch;
     return fn(url, init);
+  }
+  // Node-proxy prefix for the active tab (see opts.getBase).  Resolved per call
+  // so a tab swap onto a different node retargets every subsequent request.
+  function _base() {
+    return (typeof opts.getBase === "function" && opts.getBase()) || "";
   }
   var pending = new Map();
 
@@ -256,6 +275,7 @@ export function createAttachmentController(opts) {
     var prev = buildAttachmentPreview({
       kind: info.kind,
       wsId: getWsId(),
+      base: _base(),
       attachmentId: info.attachment_id,
       filename: info.filename,
       authFetch: _authFetch,
@@ -348,7 +368,10 @@ export function createAttachmentController(opts) {
     renderChip(placeholder);
 
     _authFetch(
-      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
+      _base() +
+        "/v1/api/workstreams/" +
+        encodeURIComponent(wsId) +
+        "/attachments",
       { method: "POST", credentials: "include", body: fd },
     )
       .then(function (r) {
@@ -381,7 +404,8 @@ export function createAttachmentController(opts) {
     var wsId = getWsId();
     if (!wsId) return;
     _authFetch(
-      "/v1/api/workstreams/" +
+      _base() +
+        "/v1/api/workstreams/" +
         encodeURIComponent(wsId) +
         "/attachments/" +
         encodeURIComponent(attachmentId),
@@ -401,7 +425,10 @@ export function createAttachmentController(opts) {
     var wsId = getWsId();
     if (!wsId) return Promise.resolve();
     return _authFetch(
-      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/attachments",
+      _base() +
+        "/v1/api/workstreams/" +
+        encodeURIComponent(wsId) +
+        "/attachments",
       { method: "GET", credentials: "include" },
     )
       .then(function (r) {

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -370,6 +370,7 @@ class Pane {
       const pills = document.createElement("div");
       pills.className = "msg-user-attach";
       const attachWsId = this.wsId;
+      const attachBase = this._base;
       attachments.forEach(function (a) {
         const pill = document.createElement("span");
         pill.className = "msg-user-attach-pill";
@@ -393,6 +394,7 @@ class Pane {
             ? window.buildAttachmentPreview({
                 kind: a.kind,
                 wsId: attachWsId,
+                base: attachBase,
                 attachmentId: a.attachment_id,
                 filename: a.filename,
               })
@@ -750,6 +752,9 @@ class Pane {
       chipsEl: this.composer.chipsEl,
       getWsId: () => {
         return this.wsId;
+      },
+      getBase: () => {
+        return this._base;
       },
       onError: (msg) => {
         showToast(msg);


### PR DESCRIPTION
## Summary

Five changes, all stemming from broken or half-wired attachment handling on the **console** (the standalone single-node server was largely unaffected, which masked most of these):

### Bugfixes
- **A — in-session attachments (console interactive panes).** The attachment controller built bare `/v1/api/workstreams/...` URLs with no node-proxy prefix, so every upload / list / delete / preview from a console interactive pane hit the console's *own* coord route → `coordinator not found`. Thread the pane's transport `base` (`/node/{id}`) through the controller and previews. Standalone (`base=""`) and console-local coordinator panes are unaffected.
- **C — create-time attachments (console launcher).** Creating an interactive session with a staged file was gated ("Attachments aren't supported for interactive sessions yet") because the cluster create proxy was JSON-only. Teach `create_workstream` to accept `multipart/form-data` (`meta` JSON + `file` parts) and forward it to the node — which already supports the shape — preserving auto / pool / pinned node selection. Launcher drops the gate.
- **B — perception role admin UI.** The `perception.model_alias` fallback shipped backend-only, so it had no admin surface. Add its Models → Roles row, and derive the Settings skip-set from `MODEL_ROLES` so it (and the previously-leaking `stt`/`tts`/`reranker` keys) stay out of the raw Settings tab — drift-proof against future roles.
- **D — EXIF orientation.** Phone photos rendered rotated in thumbnails *and* were perceived sideways by vision models (noticed earlier as model "hallucinations"). Normalize orientation on read (`core/images.normalize_image_orientation`) at the thumbnail and wire-content surfaces; unrotated images pass through untouched (pristine, no re-encode). Because it's on read, it fixes already-stored uploads too.

### Feature
- **E — omni models as speech-to-text.** Let an omni chat model (`supports_audio_input`, e.g. Gemma) back the STT role: `transcribe()` branches to a chat `input_audio` path with an instruction prompt when the model has no `/audio/transcriptions` endpoint. The mic affordance then draws for omni setups, and audio attachments transcribe the same way.

## Review
Self-reviewed with four parallel dimension-finders (correctness / security / performance / quality) over the branch diff — clean on correctness, security, and performance. One quality finding (duplicated multipart create-body framing) fixed via a shared `_createWorkstreamFetchOpts` helper; one inaccurate proxy comment corrected.

## Test plan
- `ruff` + `mypy` clean on all touched modules.
- New / extended tests: node-base wiring (`test_shell_js`), multipart create-proxy forwarding (`test_console_routing_proxy`), perception role surfacing + settings filter (`test_app_js`), EXIF normalize + thumbnail orientation (`test_images`, `test_thumbnails`), omni-STT chat path (`test_audio`).
- Full non-live suite: **7510 passed, 8 skipped**.

## Notes for the reviewer
- Create-time attachments are capped at 4 MB/file (the node's pre-existing multipart-create limit, faithfully mirrored by the proxy — not a regression). Larger PDFs / audio go through in-session upload (fixed by **A**) at their full 32 / 25 MB caps.
- Omni-STT sends the recorded clip's container format (e.g. `webm`) to the model; the deployment's omni server must decode it (vLLM needs `vllm[audio]` / ffmpeg).
