### PR TITLE
fix(audio): make omni STT work (transcode + thinking-off) + streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN rm -f /etc/dpkg/dpkg.cfg.d/docker
 # ripgrep is the preferred backend for the search tool — natively bounds
 # per-line, per-file, and per-filesize so pathological inputs (minified
 # bundles, training-data JSONL with multi-MB single records) can't OOM us.
+# ffmpeg transcodes omni STT uploads (browser webm/opus) to the 16 kHz mono
+# WAV the omni chat-audio lane decodes.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    libpq5 git curl jq man-db manpages procps file ripgrep \
+    libpq5 git curl jq man-db manpages procps file ripgrep ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js LTS (for npx-based MCP servers like @modelcontextprotocol/server-github)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -7,6 +7,7 @@ helper code runs end-to-end without a network call.
 
 from __future__ import annotations
 
+import shutil
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,11 +19,16 @@ class _Cfg:
     """Stand-in for ModelConfig — only the fields audio.py reads."""
 
     def __init__(
-        self, model: str, capabilities: dict | None = None, provider: str = "openai"
+        self,
+        model: str,
+        capabilities: dict | None = None,
+        provider: str = "openai",
+        server_compat: dict | None = None,
     ) -> None:
         self.model = model
         self.capabilities = capabilities or {}
         self.provider = provider
+        self.server_compat = server_compat or {}
 
 
 class _FakeConfigStore:
@@ -191,7 +197,8 @@ class TestTranscribe:
         with pytest.raises(audio.AudioBackendError):
             audio.transcribe(registry=reg, alias="voice", data=b"x", filename="a.wav")
 
-    def test_omni_model_transcribes_via_chat(self):
+    def test_omni_model_transcribes_via_chat(self, monkeypatch):
+        monkeypatch.setattr(audio, "_to_wav_16k_mono", lambda data: data)
         client = MagicMock()
         msg = MagicMock(content="  the transcript  ")
         client.chat.completions.create.return_value = MagicMock(choices=[MagicMock(message=msg)])
@@ -202,15 +209,18 @@ class TestTranscribe:
         assert res.transcript == "the transcript"
         # The dedicated transcription endpoint is NOT used for an omni model.
         client.audio.transcriptions.create.assert_not_called()
-        # Audio rides as an input_audio chat part; format comes from the filename.
         parts = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+        # Prompt precedes the audio part — the order Gemma documents for transcription.
+        assert [p["type"] for p in parts] == ["text", "input_audio"]
+        # The clip is transcoded to wav regardless of the upload container.
         audio_part = next(p for p in parts if p["type"] == "input_audio")
-        assert audio_part["input_audio"]["format"] == "webm"
+        assert audio_part["input_audio"]["format"] == "wav"
         # A blank prompt falls back to the omni STT default instruction.
         text_part = next(p for p in parts if p["type"] == "text")
         assert "Only output the transcription" in text_part["text"]
 
-    def test_omni_prompt_override_used(self):
+    def test_omni_prompt_override_used(self, monkeypatch):
+        monkeypatch.setattr(audio, "_to_wav_16k_mono", lambda data: data)
         client = MagicMock()
         client.chat.completions.create.return_value = MagicMock(
             choices=[MagicMock(message=MagicMock(content="x"))]
@@ -338,3 +348,190 @@ class TestTranscribeCached:
         assert audio.transcribe_cached(**kw) == ""
         audio.transcribe_cached(**kw)
         assert len(calls) == 2  # failure not cached -> retried
+
+
+# ---------------------------------------------------------------------------
+# Omni chat request shaping — transcode + thinking-off + token cap
+# ---------------------------------------------------------------------------
+
+
+class TestOmniChatExtraBody:
+    """``_omni_chat_extra_body`` re-applies what the raw-client STT path skips."""
+
+    _THINKING = {"thinking_mode": "manual", "thinking_param": "enable_thinking"}
+
+    def test_disables_thinking_via_model_param(self):
+        cfg = _Cfg("gemma", dict(self._THINKING))
+        assert audio._omni_chat_extra_body(cfg) == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+
+    def test_thinking_off_wins_over_operator_flag(self):
+        cfg = _Cfg(
+            "gemma",
+            dict(self._THINKING),
+            server_compat={"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}},
+        )
+        # STT never wants reasoning, even if an operator stored thinking on.
+        assert audio._omni_chat_extra_body(cfg)["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_forwards_operator_server_compat_extra_body(self):
+        cfg = _Cfg(
+            "model",
+            dict(self._THINKING),
+            server_compat={"extra_body": {"reasoning_format": "auto"}},
+        )
+        extra = audio._omni_chat_extra_body(cfg)
+        assert extra["reasoning_format"] == "auto"
+        assert extra["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_empty_for_non_thinking_model(self):
+        cfg = _Cfg("omni", {"supports_audio_input": True})
+        assert audio._omni_chat_extra_body(cfg) == {}
+
+
+class TestOmniChatCall:
+    """The omni chat call carries the thinking-off extra_body and a token cap."""
+
+    def test_sends_thinking_off_and_token_cap(self, monkeypatch):
+        monkeypatch.setattr(audio, "_to_wav_16k_mono", lambda data: data)
+        client = MagicMock()
+        client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="hi"))]
+        )
+        cfg = _Cfg(
+            "gemma-omni",
+            {
+                "supports_audio_input": True,
+                "thinking_mode": "manual",
+                "thinking_param": "enable_thinking",
+            },
+        )
+        audio.transcribe(
+            registry=_FakeRegistry("omni", cfg, client),
+            alias="omni",
+            data=b"webmbytes",
+            filename="speech.webm",
+        )
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+        assert kwargs["max_tokens"] == audio._OMNI_STT_MAX_TOKENS
+
+
+class TestTranscode:
+    """``_to_wav_16k_mono`` normalizes any container to 16 kHz mono WAV via ffmpeg."""
+
+    def _stereo_wav_44k(self) -> bytes:
+        import io
+        import wave
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as w:
+            w.setnchannels(2)
+            w.setsampwidth(2)
+            w.setframerate(44100)
+            w.writeframes(b"\x00\x01\x00\x01" * 4410)  # 0.1 s of stereo
+        return buf.getvalue()
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+    def test_transcodes_to_16k_mono(self):
+        import io
+        import wave
+
+        out = audio._to_wav_16k_mono(self._stereo_wav_44k())
+        with wave.open(io.BytesIO(out), "rb") as w:
+            assert w.getnchannels() == 1
+            assert w.getframerate() == 16000
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+    def test_undecodable_bytes_raise_backend_error(self):
+        with pytest.raises(audio.AudioBackendError):
+            audio._to_wav_16k_mono(b"this is not audio at all")
+
+    def test_missing_ffmpeg_raises_backend_error(self, monkeypatch):
+        def _no_ffmpeg(*a, **k):
+            raise FileNotFoundError("ffmpeg")
+
+        monkeypatch.setattr(audio.subprocess, "run", _no_ffmpeg)
+        with pytest.raises(audio.AudioBackendError, match="ffmpeg is not installed"):
+            audio._to_wav_16k_mono(b"x")
+
+    def test_invokes_ffmpeg_with_hardened_argv(self, monkeypatch):
+        # Covers the argv shaping even on a CI image without ffmpeg installed.
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["input"] = kwargs.get("input")
+            return MagicMock(returncode=0, stdout=b"RIFF....WAVE", stderr=b"")
+
+        monkeypatch.setattr(audio.subprocess, "run", _fake_run)
+        assert audio._to_wav_16k_mono(b"rawclip") == b"RIFF....WAVE"
+        cmd = captured["cmd"]
+        assert cmd[0] == "ffmpeg"
+        assert captured["input"] == b"rawclip"
+        # SSRF/decompression-bomb hardening + the 16 kHz mono normalization.
+        assert cmd[cmd.index("-protocol_whitelist") + 1] == "pipe"
+        assert "-vn" in cmd
+        assert cmd[cmd.index("-ac") + 1] == "1"
+        assert cmd[cmd.index("-ar") + 1] == "16000"
+        assert cmd[cmd.index("-f") + 1] == "wav"
+
+    def test_nonzero_returncode_raises_backend_error(self, monkeypatch):
+        monkeypatch.setattr(
+            audio.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(returncode=1, stdout=b"", stderr=b"boom"),
+        )
+        with pytest.raises(audio.AudioBackendError, match="Audio transcode failed"):
+            audio._to_wav_16k_mono(b"x")
+
+
+def _stream_chunk(content):
+    return MagicMock(choices=[MagicMock(delta=MagicMock(content=content))])
+
+
+class TestTranscribeStream:
+    """``transcribe_stream`` yields content deltas; resolve/transcode are eager."""
+
+    def test_streams_chat_deltas_with_thinking_off(self, monkeypatch):
+        monkeypatch.setattr(audio, "_to_wav_16k_mono", lambda data: data)
+        client = MagicMock()
+        client.chat.completions.create.return_value = iter(
+            [_stream_chunk("and so"), _stream_chunk(None), _stream_chunk(" my fellow americans")]
+        )
+        cfg = _Cfg(
+            "gemma-omni",
+            {
+                "supports_audio_input": True,
+                "thinking_mode": "manual",
+                "thinking_param": "enable_thinking",
+            },
+        )
+        gen = audio.transcribe_stream(
+            registry=_FakeRegistry("omni", cfg, client), alias="omni", data=b"webmbytes"
+        )
+        # Empty/None deltas are skipped; the rest stream through in order.
+        assert list(gen) == ["and so", " my fellow americans"]
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_non_audio_provider_raises_before_streaming(self):
+        client = MagicMock()
+        cfg = _Cfg("gemma", {"supports_audio_input": True}, provider="anthropic-compatible")
+        with pytest.raises(audio.AudioUnavailableError, match="OpenAI-compatible provider"):
+            audio.transcribe_stream(
+                registry=_FakeRegistry("omni", cfg, client), alias="omni", data=b"x"
+            )
+        client.chat.completions.create.assert_not_called()
+
+    def test_whisper_alias_emits_single_chunk(self):
+        client = MagicMock()
+        client.audio.transcriptions.create.return_value = MagicMock(text="  full transcript  ")
+        cfg = _Cfg("whisper-1")  # name inference -> dedicated endpoint, no chat stream
+        gen = audio.transcribe_stream(
+            registry=_FakeRegistry("w", cfg, client), alias="w", data=b"x"
+        )
+        assert list(gen) == ["full transcript"]
+        client.chat.completions.create.assert_not_called()

--- a/tests/test_server_compat.py
+++ b/tests/test_server_compat.py
@@ -19,7 +19,8 @@ class TestSuggestProfile:
         p = suggest_profile("vllm", "google/gemma-4-31B-it")
         assert p["capabilities"]["thinking_mode"] == "manual"
         assert p["capabilities"]["thinking_param"] == "enable_thinking"
-        assert p["server_compat"]["extra_body"]["skip_special_tokens"] is False
+        # No bug-workaround extra_body — gemma-4 needs only the thinking param.
+        assert "extra_body" not in p["server_compat"]
 
     def test_vllm_gemma3(self) -> None:
         p = suggest_profile("vllm", "google/gemma-3-27b-it")
@@ -147,14 +148,14 @@ class TestMergeServerCompat:
         result = merge_server_compat(None, {"extra_body": {"skip_special_tokens": False}})
         assert result == {"skip_special_tokens": False}
 
-    def test_full_vllm_gemma_compat_no_base(self) -> None:
-        """vLLM workaround forwards on its own."""
+    def test_full_server_compat_extra_body_no_base(self) -> None:
+        """A server workaround (e.g. llama.cpp reasoning_format) forwards on its own."""
         compat = {
-            "server_type": "vllm",
-            "extra_body": {"skip_special_tokens": False},
+            "server_type": "llama.cpp",
+            "extra_body": {"reasoning_format": "auto"},
         }
         result = merge_server_compat(None, compat)
-        assert result == {"skip_special_tokens": False}
+        assert result == {"reasoning_format": "auto"}
 
     def test_operator_chat_template_kwargs_only(self) -> None:
         """Operator can set chat_template_kwargs explicitly without seeding the base."""
@@ -210,21 +211,27 @@ class TestEndToEndRequestShaping:
     """Compose both layers — session builds extra_params, provider applies thinking."""
 
     def test_vllm_gemma_full_flow(self) -> None:
-        """Session forwards server workarounds, provider adds thinking param."""
+        """Gemma now needs only the thinking param — no server workaround."""
         caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
-        server_compat = {
-            "server_type": "vllm",
-            "extra_body": {"skip_special_tokens": False},
-        }
+        server_compat = {"server_type": "vllm"}
         # Step 1: session forwards (no auto-injection of reasoning_effort).
         extra_params = merge_server_compat(None, server_compat)
         # Step 2: provider injects thinking param into chat_template_kwargs.
         extra_body = dict(extra_params)
         OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
 
+        assert extra_body == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_server_workaround_composes_with_thinking(self) -> None:
+        """A top-level server workaround forwards alongside the injected thinking param."""
+        caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
+        compat = {"server_type": "llama.cpp", "extra_body": {"reasoning_format": "auto"}}
+        extra_body = dict(merge_server_compat(None, compat))
+        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+
         assert extra_body == {
             "chat_template_kwargs": {"enable_thinking": True},
-            "skip_special_tokens": False,
+            "reasoning_format": "auto",
         }
 
     def test_granite_thinking_key(self) -> None:
@@ -292,7 +299,7 @@ class TestProbeIntegration:
         assert result["server_type"] == "vllm"
         assert result["suggested_capabilities"]["thinking_mode"] == "manual"
         assert result["suggested_capabilities"]["thinking_param"] == "enable_thinking"
-        assert result["suggested_server_compat"]["extra_body"]["skip_special_tokens"] is False
+        assert "extra_body" not in result["suggested_server_compat"]
 
     def test_detect_non_thinking_no_suggested_capabilities(self) -> None:
         """Non-thinking vLLM model gets server_compat but no capabilities suggestion."""

--- a/turnstone/core/audio.py
+++ b/turnstone/core/audio.py
@@ -15,11 +15,16 @@ backend is surfaced as a typed error the endpoint maps to 503 / 502.
 
 from __future__ import annotations
 
+import subprocess
 import threading
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from turnstone.core.log import get_logger
+from turnstone.core.server_compat import merge_server_compat
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 log = get_logger(__name__)
 
@@ -82,6 +87,22 @@ _OMNI_STT_PROMPT = (
     "* When transcribing numbers, write the digits, i.e. write 1.7 and not one point "
     "seven, and write 3 instead of three"
 )
+
+# Bound the omni STT decode.  Gemma caps audio at 30 s and a 30 s transcript is
+# well under this, so the cap only catches a pathological runaway — it never
+# truncates a real transcript.
+_OMNI_STT_MAX_TOKENS = 1024
+
+# Hard limit on the ffmpeg transcode subprocess (seconds).
+_FFMPEG_TIMEOUT_S = 30
+
+# Cap the decoded audio duration so a crafted clip can't expand into an
+# unbounded decode (the upload itself is already size-capped at the endpoint).
+_MAX_AUDIO_SECONDS = 300
+
+# Per-request timeout for the streaming STT chat call — bounds a hung backend
+# (the whole transcription is ~1 s; this only catches a stalled stream).
+_OMNI_STT_TIMEOUT_S = 60
 
 
 @dataclass(frozen=True)
@@ -185,30 +206,115 @@ def _serves_transcription_endpoint(cfg: Any, model: str) -> bool:
     return _infer_audio_capability(model, "stt")
 
 
-def _transcribe_via_chat(client: Any, model: str, data: bytes, filename: str, prompt: str) -> str:
+def _to_wav_16k_mono(data: bytes) -> bytes:
+    """Decode any ffmpeg-readable audio container to 16 kHz mono PCM WAV.
+
+    Browsers record webm/opus (or ogg/mp4); the omni chat lane — vLLM in
+    particular — only decodes wav/mp3 and sniffs the bytes, so the raw upload is
+    rejected as an "Invalid or unsupported audio file".  ffmpeg reads the
+    container from the byte stream (no reliance on the filename) and resamples to
+    the 16 kHz mono PCM the model documents.  Raises :class:`AudioBackendError`
+    (the endpoint maps it to 502) if ffmpeg is missing or the bytes don't decode.
+    """
+    # ffmpeg reads only the piped bytes (-protocol_whitelist pipe) so a crafted
+    # container can't open file:/http: references (SSRF / local file read); -vn
+    # drops video streams and -t bounds the decode against a decompression bomb.
+    try:
+        proc = subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-protocol_whitelist",
+                "pipe",
+                "-i",
+                "pipe:0",
+                "-vn",
+                "-t",
+                str(_MAX_AUDIO_SECONDS),
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                "-f",
+                "wav",
+                "pipe:1",
+            ],
+            input=data,
+            capture_output=True,
+            timeout=_FFMPEG_TIMEOUT_S,
+        )
+    except FileNotFoundError as exc:
+        raise AudioBackendError("ffmpeg is not installed; cannot transcode audio") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise AudioBackendError("Audio transcode timed out") from exc
+    if proc.returncode != 0 or not proc.stdout:
+        detail = proc.stderr.decode("utf-8", "replace").strip()
+        raise AudioBackendError(f"Audio transcode failed: {detail[-200:] or 'no output'}")
+    return proc.stdout
+
+
+def _omni_chat_extra_body(cfg: Any) -> dict[str, Any]:
+    """Build the chat ``extra_body`` for an omni STT call.
+
+    The STT path calls the raw client, so it bypasses the provider's request
+    shaping.  Reuse ``merge_server_compat`` to forward any operator-stored
+    ``server_compat["extra_body"]``, then force **thinking OFF** via the model's
+    own ``thinking_param``: transcription needs no reasoning, and leaving it on
+    multiplies latency ~10x and (on some chat templates) empties the content.
+    The override is applied last so it wins over any operator thinking flag.
+    """
+    server_compat = getattr(cfg, "server_compat", None)
+    extra = merge_server_compat(None, server_compat) if isinstance(server_compat, dict) else {}
+    caps = getattr(cfg, "capabilities", None) or {}
+    thinking_param = caps.get("thinking_param")
+    if thinking_param and caps.get("thinking_mode") in ("manual", "adaptive"):
+        extra.setdefault("chat_template_kwargs", {})[thinking_param] = False
+    return extra
+
+
+def _omni_chat_messages(prompt: str, audio_b64: str) -> list[dict[str, Any]]:
+    """The single user turn for an omni STT chat call: the prompt precedes the
+    audio part — the order Gemma documents for transcription."""
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "input_audio", "input_audio": {"data": audio_b64, "format": "wav"}},
+            ],
+        }
+    ]
+
+
+def _transcribe_via_chat(
+    client: Any,
+    model: str,
+    data: bytes,
+    prompt: str,
+    *,
+    extra_body: dict[str, Any] | None = None,
+    max_tokens: int = _OMNI_STT_MAX_TOKENS,
+) -> str:
     """Transcribe by handing the clip to an omni *chat* model as ``input_audio``.
 
     For models that accept audio in chat (``supports_audio_input``) but don't
-    serve ``/audio/transcriptions``.  The instruction ``prompt`` steers the model
-    to emit only the transcript.  The audio format is taken from the upload's
-    filename extension (the same shape the attachment wire path uses).
+    serve ``/audio/transcriptions``.  The clip is transcoded to 16 kHz mono WAV
+    first (browsers record webm/opus, which the chat lane can't decode).  The
+    instruction ``prompt`` precedes the audio part — the order Gemma documents
+    for transcription — and ``extra_body`` carries the thinking-off / server
+    compat params the raw-client path would otherwise skip.
     """
     import base64
 
-    name = filename or "speech.webm"
-    fmt = name.rsplit(".", 1)[-1].lower() if "." in name else "wav"
-    audio_b64 = base64.b64encode(data).decode("ascii")
+    wav = _to_wav_16k_mono(data)
+    audio_b64 = base64.b64encode(wav).decode("ascii")
     resp = client.chat.completions.create(
         model=model,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prompt},
-                    {"type": "input_audio", "input_audio": {"data": audio_b64, "format": fmt}},
-                ],
-            }
-        ],
+        messages=_omni_chat_messages(prompt, audio_b64),
+        max_tokens=max_tokens,
+        extra_body=extra_body or None,
     )
     choices = getattr(resp, "choices", None) or []
     if not choices:
@@ -261,11 +367,84 @@ def transcribe(
             transcript = (getattr(resp, "text", "") or "").strip()
         else:
             transcript = _transcribe_via_chat(
-                client, model, data, filename, prompt or _OMNI_STT_PROMPT
+                client,
+                model,
+                data,
+                prompt or _OMNI_STT_PROMPT,
+                extra_body=_omni_chat_extra_body(cfg),
             )
+    except AudioBackendError:
+        # Transcode errors already carry an actionable message — keep it.
+        raise
     except Exception as exc:
         raise AudioBackendError(f"Transcription backend failed: {exc}") from exc
     return TranscriptionResult(transcript=transcript, model_alias=alias, model=model)
+
+
+def _iter_stream_deltas(stream: Any) -> Iterator[str]:
+    """Yield non-empty content deltas from an OpenAI streaming chat response.
+
+    Owns the stream's lifecycle: exhausting or closing this generator releases
+    the underlying HTTP connection, so an abandoned stream can't leak it.
+    """
+    try:
+        for chunk in stream:
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            delta = getattr(choices[0].delta, "content", None)
+            if delta:
+                yield delta
+    finally:
+        close = getattr(stream, "close", None)
+        if callable(close):
+            close()
+
+
+def transcribe_stream(*, registry: Any, alias: str, data: bytes, prompt: str = "") -> Iterator[str]:
+    """Stream transcript content deltas for the STT role alias.
+
+    Resolve, transcode, and opening the streaming-chat request all run eagerly
+    (before the returned generator yields its first delta) so the caller can
+    surface a clean 503 / 502; only the token iteration is deferred.  A
+    whisper-style endpoint alias has no chat stream, so it emits the whole
+    transcript as a single chunk.
+    """
+    try:
+        client, model, cfg = registry.resolve(alias)
+    except Exception as exc:  # unknown/removed alias
+        raise AudioUnavailableError(f"STT model alias {alias!r} is not available") from exc
+    if not _provider_carries_audio(cfg):
+        raise AudioUnavailableError(
+            f"STT model alias {alias!r} (provider {getattr(cfg, 'provider', 'unknown')!r}) "
+            "can't transcribe audio — audio roles require an OpenAI-compatible provider."
+        )
+    if _serves_transcription_endpoint(cfg, model):
+        # Whisper-style endpoint: no chat stream — emit the whole transcript once.
+        text = transcribe(
+            registry=registry, alias=alias, data=data, filename="speech.webm", prompt=prompt
+        ).transcript
+        return iter([text] if text else [])
+    caps = getattr(cfg, "capabilities", None) or {}
+    if not caps.get("supports_audio_input"):
+        raise AudioUnavailableError(f"STT model alias {alias!r} cannot transcribe audio")
+
+    import base64
+
+    wav = _to_wav_16k_mono(data)
+    audio_b64 = base64.b64encode(wav).decode("ascii")
+    try:
+        stream = client.chat.completions.create(
+            model=model,
+            messages=_omni_chat_messages(prompt or _OMNI_STT_PROMPT, audio_b64),
+            max_tokens=_OMNI_STT_MAX_TOKENS,
+            extra_body=_omni_chat_extra_body(cfg) or None,
+            stream=True,
+            timeout=_OMNI_STT_TIMEOUT_S,
+        )
+    except Exception as exc:
+        raise AudioBackendError(f"Transcription backend failed: {exc}") from exc
+    return _iter_stream_deltas(stream)
 
 
 # -- transcript memoization (no-native-audio wire fallback) -------------------

--- a/turnstone/core/server_compat.py
+++ b/turnstone/core/server_compat.py
@@ -14,10 +14,12 @@ request shaping.  This module separates three concerns:
    Stored under ``server_compat`` because it's an endpoint property,
    not a model property.
 
-3. **Server workarounds** — ``extra_body`` overrides like
-   ``skip_special_tokens=false`` are properties of the *server* (vLLM
-   bug workaround).  These stay in ``server_compat`` and get merged
-   into the request's ``extra_body`` at call time.
+3. **Server workarounds** — ``extra_body`` overrides like llama.cpp's
+   ``reasoning_format`` are properties of the *server*, not the model.
+   These stay in ``server_compat`` and get merged into the request's
+   ``extra_body`` at call time.  Reserve these for stable server config:
+   bug-workaround flags for fast-moving open models go stale the moment
+   the upstream bug is fixed, so we don't carry them speculatively.
 
 Profiles are *suggestions* only.  The admin UI auto-fills them on
 Detect; the operator has final say, and the stored DB config is what
@@ -45,11 +47,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         },
         "server_compat": {
             "server_type": "vllm",
-            # Workaround: vLLM strips special tokens before the Gemma4
-            # reasoning parser sees them.  skip_special_tokens=false
-            # preserves <|channel> / <channel|> markers so reasoning
-            # content is extracted correctly.
-            "extra_body": {"skip_special_tokens": False},
         },
     },
     "vllm-qwen-thinking": {

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -39,7 +39,7 @@ from sse_starlette import EventSourceResponse
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -1288,6 +1288,100 @@ async def speech_to_text(request: Request) -> JSONResponse:
             "model_alias": result.model_alias,
         }
     )
+
+
+async def speech_to_text_stream(request: Request) -> Response:
+    """POST /v1/api/workstreams/{ws_id}/speech-to-text/stream — stream the
+    transcript as plain-text deltas for lower perceived latency than the JSON
+    ``speech-to-text`` endpoint.  Resolve/transcode failures surface as
+    503 / 502 before any bytes are sent; once streaming begins the body is
+    best-effort (a mid-stream backend error just ends the partial stream)."""
+    from turnstone.core.audio import (
+        AudioBackendError,
+        AudioUnavailableError,
+        resolve_role_alias,
+        transcribe_stream,
+    )
+    from turnstone.core.web_helpers import read_multipart_file_or_400
+
+    ws_id = request.path_params.get("ws_id", "")
+    if not ws_id:
+        return JSONResponse({"error": "ws_id is required"}, status_code=400)
+    _user_id, err = _require_ws_access(request, ws_id)
+    if err:
+        return err
+
+    registry = getattr(request.app.state, "registry", None)
+    config_store = getattr(request.app.state, "config_store", None)
+    alias = resolve_role_alias(config_store=config_store, registry=registry, role="stt")
+    if not alias:
+        return JSONResponse(
+            {
+                "error": (
+                    "Speech-to-text is not configured. Assign an STT model role in Models → Roles."
+                )
+            },
+            status_code=503,
+        )
+
+    got = await read_multipart_file_or_400(request, field="audio", max_bytes=_STT_UPLOAD_CAP)
+    if isinstance(got, JSONResponse):
+        return got
+    _filename, _claimed_mime, data = got
+    if not data:
+        return JSONResponse({"error": "Empty audio upload"}, status_code=400)
+
+    stt_prompt = ""
+    if config_store is not None:
+        stt_prompt = (config_store.get("audio.stt_prompt") or "").strip()
+
+    # Resolve + transcode + open the stream eagerly (off the event loop) so the
+    # common failures map to a clean status before any bytes are sent.
+    try:
+        deltas = await asyncio.to_thread(
+            transcribe_stream, registry=registry, alias=alias, data=data, prompt=stt_prompt
+        )
+    except AudioUnavailableError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=503)
+    except AudioBackendError:
+        log.warning("speech_to_text_stream.backend_failed", exc_info=True)
+        return JSONResponse({"error": "Speech transcription backend failed"}, status_code=502)
+
+    # Drive the blocking stream from one worker thread that owns (and closes)
+    # the upstream connection, handing deltas to the loop via a queue.  A client
+    # disconnect sets ``stop`` so the thread releases the connection promptly
+    # instead of being pinned mid-``next()`` (which can't be cancelled).
+    async def _body() -> AsyncGenerator[bytes, None]:
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        stop = threading.Event()
+
+        def _pump() -> None:
+            try:
+                for delta in deltas:
+                    if stop.is_set():
+                        break
+                    loop.call_soon_threadsafe(queue.put_nowait, delta.encode("utf-8"))
+            except Exception:
+                # Mid-stream backend failure: end the partial stream (logged).
+                log.warning("speech_to_text_stream.mid_stream_failed", exc_info=True)
+            finally:
+                close = getattr(deltas, "close", None)
+                if callable(close):
+                    close()
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        loop.run_in_executor(None, _pump)
+        try:
+            while True:
+                chunk = await queue.get()
+                if chunk is None:
+                    break
+                yield chunk
+        finally:
+            stop.set()
+
+    return StreamingResponse(_body(), media_type="text/plain; charset=utf-8")
 
 
 async def text_to_speech(request: Request) -> Response:
@@ -3898,6 +3992,13 @@ def create_app(
         Route(
             "/api/workstreams/{ws_id}/speech-to-text",
             speech_to_text,
+            methods=["POST"],
+        )
+    )
+    v1_routes.append(
+        Route(
+            "/api/workstreams/{ws_id}/speech-to-text/stream",
+            speech_to_text_stream,
             methods=["POST"],
         )
     )

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -1580,32 +1580,62 @@ class Pane {
       this._micBtn.classList.add("is-busy");
     }
     voiceAnnounce("Transcribing…");
+    const resetMic = () => {
+      if (this._micBtn && !this._micDenied) {
+        this._micBtn.disabled = !!this.busy;
+        this._micBtn.classList.remove("is-busy");
+      }
+    };
     authFetch(
       this._base +
         "/v1/api/workstreams/" +
         encodeURIComponent(this.wsId) +
-        "/speech-to-text",
+        "/speech-to-text/stream",
       { method: "POST", body: fd },
     )
-      .then((r) => r.json().then((body) => ({ ok: r.ok, body })))
-      .then((res) => {
-        if (!res.ok) {
-          showToast(
-            (res.body && res.body.error) || "Transcription failed",
-            "error",
-          );
+      .then(async (r) => {
+        if (!r.ok) {
+          let msg = "Transcription failed";
+          try {
+            const body = await r.json();
+            if (body && body.error) msg = body.error;
+          } catch (_e) {
+            /* non-JSON error body */
+          }
+          showToast(msg, "error");
           return;
         }
-        const text = (res.body && res.body.transcript) || "";
-        if (text && this.inputEl) {
-          const cur = this.inputEl.value || "";
-          this.inputEl.value = cur
-            ? cur.replace(/\s*$/, "") + " " + text
-            : text;
+        // Stream transcript deltas into the composer as they arrive (first word
+        // in ~0.3s) instead of waiting for the whole transcript.
+        const reader = r.body.getReader();
+        const decoder = new TextDecoder();
+        let started = false;
+        let got = false;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value, { stream: true });
+          if (!chunk || !this.inputEl) continue;
+          got = true;
+          if (!started) {
+            // Read the composer's value now (not before the await) so text the
+            // user typed while transcribing isn't clobbered.
+            const cur = this.inputEl.value || "";
+            this.inputEl.value = cur
+              ? cur.replace(/\s*$/, "") + " " + chunk
+              : chunk;
+            started = true;
+          } else {
+            this.inputEl.value += chunk;
+          }
           // Drive the composer's auto-resize + send-enable listeners.
           this.inputEl.dispatchEvent(new Event("input", { bubbles: true }));
-          this.inputEl.focus();
+        }
+        if (got) {
+          if (this.inputEl) this.inputEl.focus();
           voiceAnnounce("Transcript added to message.");
+        } else {
+          showToast("No speech detected", "error");
         }
       })
       .catch((err) => {
@@ -1614,12 +1644,7 @@ class Pane {
           "error",
         );
       })
-      .finally(() => {
-        if (this._micBtn && !this._micDenied) {
-          this._micBtn.disabled = !!this.busy;
-          this._micBtn.classList.remove("is-busy");
-        }
-      });
+      .finally(resetMic);
   }
 
   _addTtsAction(el) {


### PR DESCRIPTION
## What

Omni speech-to-text (mic → composer, against a Gemma-4-class omni model on vLLM) was broken and, once unblocked, slow. This repairs it and adds a streaming path.

### Core fix (`audio.py`, `Dockerfile`)
- **Transcode** the browser clip (webm/opus/ogg/mp4) → 16 kHz mono WAV via ffmpeg before the chat call — the omni lane only decodes wav/mp3 and *sniffs the bytes*, so raw webm was rejected with `400 "Invalid or unsupported audio file"`. ffmpeg runs with `-protocol_whitelist pipe -vn -t <cap>` to bound the SSRF / decompression-bomb surface of the untrusted upload.
- **Disable thinking** for the STT call (`enable_thinking=false` via the model's `thinking_param`). The chat STT path uses the raw client, so it bypassed the provider's request shaping; leaving reasoning on cost ~11× latency (12.6s → 1.15s on an 11 s clip) and returned empty content on some clips.
- Prompt precedes the audio part (the order Google documents for Gemma transcription); `max_tokens` is capped as a runaway guard.

### Streaming (`server.py`, `interactive.js`)
- New `POST /v1/api/workstreams/{ws_id}/speech-to-text/stream` returns the transcript as plain-text deltas; the composer fills them live (~0.3 s to first word). Driven from a single worker thread that owns and closes the upstream stream so a client disconnect can't leak the connection.

### Cleanup
- Removed the `vllm-gemma-thinking` `skip_special_tokens` workaround — the vLLM bug it patched is fixed upstream, and a stale shim can corrupt output.

## Verification
- ruff + mypy clean; 669 tests pass (new coverage: transcode, thinking-off, token cap, ffmpeg argv, streaming deltas).
- Request shapes verified against the live vLLM box: pipe-WAV accepted (HTTP 200), thinking-off transcript correct, streamed deltas clean (no channel markers).

## To run live
The node image now installs **ffmpeg** — rebuild and recreate the nodes (`docker compose build && docker compose up -d`), then click the mic and speak.
