### PR TITLE
feat(coordinator): port Regenerate/Edit title to coordinators

### DIFF
--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -65,8 +65,10 @@ from turnstone.core.session_routes import (
     make_history_handler,
     make_list_handler,
     make_open_handler,
+    make_refresh_title_handler,
     make_saved_handler,
     make_send_handler,
+    make_set_title_handler,
 )
 from turnstone.core.workstream import WorkstreamKind
 
@@ -202,6 +204,16 @@ def _make_client(
                     audit_emit=_audit_close_coordinator,
                     supports_close_reason=False,
                 ),
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/refresh-title",
+                make_refresh_title_handler(_coord_endpoint_config),
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/workstreams/{ws_id}/title",
+                make_set_title_handler(_coord_endpoint_config),
                 methods=["POST"],
             ),
             Route(
@@ -368,6 +380,114 @@ def test_unresolvable_alias_returns_503(storage):
 
 
 _COORD_HEADERS = {"X-Test-User": "user-1", "X-Test-Perms": "admin.coordinator"}
+
+
+# ---------------------------------------------------------------------------
+# Title verbs — refresh-title (LLM regenerate) + set title (manual alias),
+# ported to coordinators via the lifted make_refresh_title_handler /
+# make_set_title_handler factories so both kinds share one body.
+# ---------------------------------------------------------------------------
+
+
+def test_coord_refresh_title_triggers_regeneration(storage):
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1", name="c1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/refresh-title", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    # The lifted handler resolves the current display name and asks the
+    # live session to regenerate a (different) title in the background.
+    ws.session.request_title_refresh.assert_called_once_with("c1")
+
+
+def test_coord_refresh_title_requires_operator_permission(storage):
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1", name="c1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/refresh-title",
+        headers={"X-Test-User": "user-1", "X-Test-Perms": "read"},
+    )
+    assert resp.status_code == 403
+    ws.session.request_title_refresh.assert_not_called()
+
+
+def test_coord_refresh_title_unknown_ws_404(storage):
+    mgr = _build_mgr(storage)
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        "/v1/api/workstreams/" + ("0" * 32) + "/refresh-title", headers=_COORD_HEADERS
+    )
+    assert resp.status_code == 404
+
+
+def test_coord_set_title_stores_alias_and_broadcasts(storage):
+    from turnstone.core.memory import get_workstream_display_name
+
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1", name="c1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/title",
+        json={"title": "Nightly migration sweep"},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Nightly migration sweep"
+    # Stored as the alias (outranks the auto-title) ...
+    assert get_workstream_display_name(ws.id) == "Nightly migration sweep"
+    # ... and broadcast live to the dashboard via the session UI.
+    ws.session.ui.on_rename.assert_called_once_with("Nightly migration sweep")
+
+
+def test_coord_set_title_empty_400(storage):
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1", name="c1")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/title", json={"title": "   "}, headers=_COORD_HEADERS
+    )
+    assert resp.status_code == 400
+
+
+def test_coord_set_title_alias_conflict_409(storage):
+    mgr = _build_mgr(storage)
+    first = mgr.create(user_id="user-1", name="c1")
+    second = mgr.create(user_id="user-1", name="c2")
+    storage.set_workstream_alias(first.id, "taken")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{second.id}/title", json={"title": "taken"}, headers=_COORD_HEADERS
+    )
+    assert resp.status_code == 409
+
+
+def test_coord_set_title_rejects_unowned_ws_404(storage):
+    """An admin.coordinator operator can't rename a workstream the coord
+    manager doesn't own (here a cross-kind interactive row) via the coord
+    /title route: set_workstream_alias is a global kind-unscoped UPDATE, so
+    the handler 404s on the in-memory coord lookup BEFORE writing — no
+    silent 200, no cross-kind alias write."""
+    from turnstone.core.memory import get_workstream_display_name
+
+    mgr = _build_mgr(storage)
+    # An interactive-kind row in storage, NOT held by coord_mgr.
+    storage.register_workstream(
+        "i" * 32,
+        node_id="node-1",
+        user_id="user-1",
+        name="interactive-ws",
+        kind=WorkstreamKind.INTERACTIVE,
+    )
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{'i' * 32}/title",
+        json={"title": "hijacked"},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 404
+    # The interactive ws's display name is untouched — the alias write never fired.
+    assert get_workstream_display_name("i" * 32) == "interactive-ws"
 
 
 def test_active_list_row_shape_includes_unified_fields(storage):

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -602,6 +602,27 @@ def test_step7_tab_menu_wired_per_persona() -> None:
     )
 
 
+def test_coordinator_tab_menu_enables_title_verbs() -> None:
+    """Coordinators carry LLM/auto titles like interactive workstreams, so
+    their tab dropdown must surface Refresh/Edit title — convTabMenu's
+    ``titleVerbs`` block, POSTed to the console-origin coord
+    ``refresh-title`` / ``title`` routes via the base-aware lane (default
+    base ""). Scoped to the coordinator registerType block so it can't
+    pass on the interactive pane's long-standing ``titleVerbs``."""
+    shell = _SHELL_JS.read_text(encoding="utf-8")
+    start = shell.index('registerType("coordinator"')
+    tail = shell[start:]
+    nxt = tail.find("registerType(", 1)  # bound at the next pane registration
+    coord_block = tail[:nxt] if nxt != -1 else tail
+    assert "pane._ctl.closeSession()" in coord_block, (
+        "sanity: the extracted block is the coordinator pane"
+    )
+    assert "convTabMenu(" in coord_block, "the coordinator pane must wire a tab menu"
+    assert "titleVerbs: true" in coord_block, (
+        "the coordinator tab menu must enable titleVerbs (Refresh/Edit title)"
+    )
+
+
 def test_tab_menu_base_aware_verb_lane() -> None:
     """Lifecycle round 2: a proxied interactive pane's tab menu must act on the
     pane's OWN transport base, not the console origin — the globals lane only

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -31,16 +31,17 @@ from turnstone.core.session_routes import (
     make_export_handler,
     make_history_handler,
     make_open_handler,
+    make_refresh_title_handler,
     make_retry_handler,
     make_rewind_handler,
+    make_set_title_handler,
 )
 from turnstone.core.storage._sqlite import SQLiteBackend
 from turnstone.core.workstream import WorkstreamKind
 from turnstone.server import (
+    _interactive_tenant_check,
     delete_workstream_endpoint,
     list_interface_settings,
-    refresh_workstream_title,
-    set_workstream_title,
     update_interface_setting,
 )
 
@@ -113,6 +114,18 @@ def delete_client(_inject_storage):
 
 @pytest.fixture
 def title_client(_inject_storage):
+    # Build the lifted refresh/set-title handlers the same way server.py
+    # wires the interactive bundle — same SessionEndpointConfig
+    # (manager_lookup + _interactive_tenant_check) so the tests exercise
+    # the production resolution path (mgr fast-path → storage ownership).
+    mock_mgr = MagicMock()
+    cfg = SessionEndpointConfig(
+        permission_gate=None,
+        manager_lookup=lambda _r: (mock_mgr, None),
+        tenant_check=_interactive_tenant_check,
+        not_found_label="Workstream not found",
+        audit_action_prefix="workstream",
+    )
     app = Starlette(
         routes=[
             Mount(
@@ -120,12 +133,12 @@ def title_client(_inject_storage):
                 routes=[
                     Route(
                         "/api/workstreams/{ws_id}/title",
-                        set_workstream_title,
+                        make_set_title_handler(cfg),
                         methods=["POST"],
                     ),
                     Route(
                         "/api/workstreams/{ws_id}/refresh-title",
-                        refresh_workstream_title,
+                        make_refresh_title_handler(cfg),
                         methods=["POST"],
                     ),
                 ],
@@ -133,7 +146,6 @@ def title_client(_inject_storage):
         ],
         middleware=[Middleware(_InjectAuthMiddleware)],
     )
-    mock_mgr = MagicMock()
     app.state.workstreams = mock_mgr
     return TestClient(app), mock_mgr
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -75,9 +75,11 @@ from turnstone.core.session_routes import (
     make_history_handler,
     make_list_handler,
     make_open_handler,
+    make_refresh_title_handler,
     make_retry_handler,
     make_rewind_handler,
     make_send_handler,
+    make_set_title_handler,
     make_unified_saved_handler,
     register_coord_verbs,
     register_session_routes,
@@ -12979,6 +12981,8 @@ def create_app(
                 audit_emit=_audit_close_coordinator,
                 supports_close_reason=False,
             ),
+            refresh_title=make_refresh_title_handler(coord_endpoint_config),  # lifted: shared body
+            set_title=make_set_title_handler(coord_endpoint_config),  # lifted: shared body
             send=make_send_handler(coord_endpoint_config),  # lifted: shared body (P1.5)
             dequeue=make_dequeue_handler(coord_endpoint_config),  # lifted: shared body
             approve=make_approve_handler(coord_endpoint_config),  # lifted: shared body

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -493,9 +493,8 @@ class SharedSessionVerbHandlers:
     """Bundle of HTTP handler callables for verbs both kinds expose.
 
     All handlers are optional; ``None`` skips that route. One bundle
-    describes either kind — coord omits ``delete`` / ``refresh_title``
-    / ``set_title`` / attachments; interactive populates every
-    interaction verb post-Stage-2.
+    describes either kind — coord omits ``delete``; interactive
+    populates every interaction verb post-Stage-2.
     """
 
     # Listing
@@ -970,6 +969,122 @@ def make_close_handler(
         return JSONResponse({"status": "ok"})
 
     return close
+
+
+def make_refresh_title_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/refresh-title``.
+
+    Regenerates the workstream title via a background LLM call
+    (:meth:`ChatSession.request_title_refresh`). Both kinds share the
+    auth → mgr → ws-lookup → request sequence; the session must be live
+    in memory (``mgr.get``, not ``open``) since the refresh runs on the
+    loaded :class:`ChatSession`. The current display name is passed so
+    the generator is steered toward a *different* title on a manual
+    refresh.
+    """
+
+    async def refresh_title(request: Request) -> Response:
+        import asyncio
+
+        from turnstone.core.memory import get_workstream_display_name
+
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        # See ``make_approve_handler`` for the cast rationale.
+        mgr = cast("SessionManager", mgr_opt)
+        ws_id = request.path_params.get("ws_id", "")
+
+        if cfg.tenant_check is not None:
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        ws = mgr.get(ws_id)
+        if ws is None or ws.session is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        current_title = await asyncio.to_thread(get_workstream_display_name, ws_id) or ""
+        ws.session.request_title_refresh(current_title)
+        return JSONResponse({"status": "ok"})
+
+    return refresh_title
+
+
+def make_set_title_handler(cfg: SessionEndpointConfig) -> Handler:
+    """Lifted body for ``POST {prefix}/{ws_id}/title``.
+
+    Sets a user-chosen title manually. Stored as the workstream *alias*
+    so it outranks the LLM auto-title in the display fallback chain
+    (``alias > title > name``). Both kinds share the auth → validate →
+    ``set_workstream_alias`` → ``on_rename`` sequence. Returns 409 when
+    the name collides with another workstream's alias.
+
+    Behavior matches the pre-lift interactive handler: the alias is set
+    against storage regardless of whether the session is loaded (so a
+    saved/closed workstream can still be renamed), and the live
+    ``on_rename`` broadcast fires only when the session is in memory.
+    """
+
+    async def set_title(request: Request) -> Response:
+        import asyncio
+
+        from turnstone.core.memory import set_workstream_alias
+        from turnstone.core.web_helpers import read_json_or_400
+
+        if cfg.permission_gate is not None:
+            err = cfg.permission_gate(request)
+            if err is not None:
+                return err
+        mgr_opt, err503 = cfg.manager_lookup(request)
+        if err503 is not None:
+            return err503
+        mgr = cast("SessionManager", mgr_opt)
+        ws_id = request.path_params.get("ws_id", "")
+        if not ws_id:
+            return JSONResponse({"error": "ws_id is required"}, status_code=400)
+
+        if cfg.tenant_check is not None:
+            err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
+            if err_tenant is not None:
+                return err_tenant
+
+        # Resolve the workstream BEFORE writing the alias. ``set_workstream_alias``
+        # is a global, kind-unscoped UPDATE keyed on ``ws_id`` alone (it returns
+        # True even on a 0-row match), so a kind that has no ``tenant_check``
+        # storage gate (coord — the in-memory manager is its existence + kind
+        # authority) must 404 here, or an operator could rename a workstream this
+        # manager doesn't own (e.g. an interactive ws via the coord route) and a
+        # bogus id would silently 200. Interactive keeps ``tenant_check`` as its
+        # existence gate, so this stays skipped there and a non-loaded
+        # saved/closed ws still renames.
+        ws = mgr.get(ws_id)
+        if cfg.tenant_check is None and ws is None:
+            return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+
+        body = await read_json_or_400(request)
+        if isinstance(body, JSONResponse):
+            return body
+        title = str(body.get("title", "")).strip()
+        if not title:
+            return JSONResponse({"error": "title is required"}, status_code=400)
+        title = title[:80]
+
+        if not await asyncio.to_thread(set_workstream_alias, ws_id, title):
+            return JSONResponse(
+                {"error": "That name is already used by another workstream"},
+                status_code=409,
+            )
+
+        if ws is not None and ws.session is not None and ws.session.ui is not None:
+            ws.session.ui.on_rename(title)
+        return JSONResponse({"status": "ok", "title": title})
+
+    return set_title
 
 
 CancelAuditEmitter = Callable[

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -77,10 +77,12 @@ from turnstone.core.session_routes import (
     make_history_handler,
     make_list_handler,
     make_open_handler,
+    make_refresh_title_handler,
     make_retry_handler,
     make_rewind_handler,
     make_saved_handler,
     make_send_handler,
+    make_set_title_handler,
     register_session_routes,
 )
 from turnstone.core.session_ui_base import (
@@ -2309,74 +2311,6 @@ async def delete_workstream_endpoint(request: Request) -> JSONResponse:
         return JSONResponse({"error": "Delete failed"}, status_code=500)
 
 
-async def refresh_workstream_title(request: Request, ws_id: str = "") -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/refresh-title — regenerate workstream title via LLM."""
-    from turnstone.core.log import get_logger
-    from turnstone.core.memory import get_workstream_display_name
-
-    log = get_logger(__name__)
-    ws_id = request.path_params.get("ws_id", "")
-    log.info("ws.title.refresh_requested", ws_id=ws_id[:8] if ws_id else "empty")
-    mgr = request.app.state.workstreams
-    _owner, err = _require_ws_access(request, ws_id, mgr=mgr)
-    if err:
-        return err
-    ws = mgr.get(ws_id)
-    if not ws or not ws.session:
-        log.warning(
-            "ws.title.refresh_failed",
-            ws_id=ws_id[:8] if ws_id else "empty",
-            reason="workstream_not_found",
-        )
-        return JSONResponse({"error": "Workstream not found or not active"}, status_code=404)
-    # Fetch current title so the LLM can generate something different
-    current_title = get_workstream_display_name(ws_id) or ""
-    log.info("ws.title.refresh_triggered", ws_id=ws_id[:8], current_title=current_title[:50])
-    ws.session.request_title_refresh(current_title)
-    return JSONResponse({"status": "ok"})
-
-
-async def set_workstream_title(request: Request, ws_id: str = "") -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/title — set workstream title manually.
-
-    Stores the user-chosen title as the workstream *alias* so it takes
-    priority over the LLM auto-generated title in the display name
-    fallback chain (alias -> title -> name).
-    """
-    from turnstone.core.log import get_logger
-    from turnstone.core.memory import set_workstream_alias
-    from turnstone.core.web_helpers import read_json_or_400
-
-    log = get_logger(__name__)
-    ws_id = request.path_params.get("ws_id", "")
-    log.info("ws.title.set_requested", ws_id=ws_id[:8] if ws_id else "empty")
-    if not ws_id:
-        return JSONResponse({"error": "ws_id is required"}, status_code=400)
-    mgr = request.app.state.workstreams
-    _owner, err = _require_ws_access(request, ws_id, mgr=mgr)
-    if err:
-        return err
-    body = await read_json_or_400(request)
-    if isinstance(body, JSONResponse):
-        return body
-    title = str(body.get("title", "")).strip()
-    if not title:
-        return JSONResponse({"error": "title is required"}, status_code=400)
-    title = title[:80]
-    if not set_workstream_alias(ws_id, title):
-        log.warning("ws.title.set_alias_conflict", ws_id=ws_id[:8], title=title[:50])
-        return JSONResponse(
-            {"error": "That name is already used by another workstream"},
-            status_code=409,
-        )
-    log.info("ws.title.set_alias_updated", ws_id=ws_id[:8])
-    ws = mgr.get(ws_id)
-    if ws and ws.session and ws.session.ui:
-        ws.session.ui.on_rename(title)
-    log.info("ws.title.set_success", ws_id=ws_id[:8], title=title)
-    return JSONResponse({"status": "ok", "title": title})
-
-
 def _auth_user_id(request: Request) -> str:
     """Return the authenticated user's id (empty string when absent).
 
@@ -3959,6 +3893,8 @@ def create_app(
     history_handler = make_history_handler(interactive_endpoint_config)
     export_handler = make_export_handler(interactive_endpoint_config)
     detail_handler = make_detail_handler(interactive_endpoint_config)
+    refresh_title_handler = make_refresh_title_handler(interactive_endpoint_config)
+    set_title_handler = make_set_title_handler(interactive_endpoint_config)
     v1_routes: list[Any] = [
         Route("/api/events/global", global_events_sse),
     ]
@@ -3973,8 +3909,8 @@ def create_app(
             detail=detail_handler,  # lifted: shared body (interactive feature gain)
             open=open_handler,  # lifted: shared body
             close=close_handler,  # lifted: shared body
-            refresh_title=refresh_workstream_title,
-            set_title=set_workstream_title,
+            refresh_title=refresh_title_handler,  # lifted: shared body
+            set_title=set_title_handler,  # lifted: shared body
             send=send_handler,  # lifted: shared body (P1.5)
             dequeue=dequeue_handler,  # lifted (P1.5) — DELETE /send
             approve=approve_handler,  # lifted: shared body

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -837,6 +837,11 @@ async function mountShell() {
         });
         pane.tabMenu = () =>
           convTabMenu(pane, pm, id, {
+            // Coordinators carry titles like interactive workstreams now:
+            // surface Refresh/Edit title. The default base ("") targets the
+            // console origin, where the coord refresh-title / title routes
+            // are mounted (same base coordinator.js posts every verb to).
+            titleVerbs: true,
             closeSession: () => {
               if (pane._ctl && pane._ctl.closeSession) pane._ctl.closeSession();
             },


### PR DESCRIPTION
## What

Coordinators carry LLM/auto titles like interactive workstreams (see the title-persistence/timing fix in #676), but the dashboard gave no way to **regenerate** or **rename** them. This ports the interactive "Refresh title" (LLM regenerate) + "Edit title" (manual alias) tab-dropdown actions to coordinators.

## How

The frontend `convTabMenu` and the workstream route table were already kind-agnostic — coordinators simply didn't opt in, and the title handlers were the **only shared verbs not yet lifted**. So this completes the lift:

- **`session_routes.py`** — add `make_refresh_title_handler` / `make_set_title_handler` factories (the `SessionEndpointConfig` cfg pattern, mirroring `make_close_handler`).
- **`server.py`** — re-point the interactive bundle to the lifted handlers; delete the standalone `refresh_workstream_title` / `set_workstream_title`.
- **`console/server.py`** — wire `refresh_title` / `set_title` into the coord bundle (gated by the existing `admin.coordinator` operator check).
- **`shell.js`** — enable `titleVerbs` on the coordinator pane's tab menu. The base-aware lane (default base `""`) posts to the console-origin coord routes, exactly where coordinator.js posts every other verb.

## Security note (caught in review)

`set_workstream_alias` is a **global, kind-unscoped** `UPDATE`. The lifted `set_title` therefore resolves the workstream and **404s before the write** when the kind has no `tenant_check` storage gate (coord — the in-memory manager is its existence/kind authority). Without this, an `admin.coordinator` operator could rename a workstream the coord manager doesn't own (e.g. an interactive ws via the coord `/title` route), and a bogus id would silently `200`. Interactive is unaffected: its `tenant_check` (`_require_ws_access`) stays the existence gate, so renaming a non-loaded saved/closed workstream still works.

## Testing
- `ruff` + `mypy turnstone/` clean.
- New coord tests: refresh triggers regeneration, operator-permission gate (403), 404 unknown, set stores alias + live broadcast, empty (400), conflict (409), **cross-kind reject (404, no alias write)**.
- Interactive title tests re-pointed to the lifted handlers (lift-parity, incl. the non-loaded rename path).
- `test_shell_js.py` coord-menu assertion (scoped to the coordinator `registerType` block).
- ~800 tests pass across the affected coordinator / session / workstream / authz suites.

## Follow-up
Independent of #676; cherry-pick to `stable/1.6` after merge.