### PR TITLE
test: eliminate leaked-thread test pollution + guard against it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,10 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-markers = ["live: requires a running LLM backend"]
+markers = [
+    "live: requires a running LLM backend",
+    "allow_thread_leak: test intentionally leaves a background thread running (opts out of the leaked-thread guard)",
+]
 filterwarnings = [
     # mcp v1 deprecates streamablehttp_client for an entry point whose call
     # shape only settles in v2 — adoption rides the deliberate v2 migration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,10 @@ def _no_leaked_threads(request: pytest.FixtureRequest) -> Iterator[None]:
     if request.node.get_closest_marker("allow_thread_leak"):
         yield
         return
-    before = {t.ident for t in threading.enumerate()}
+    # Snapshot the Thread OBJECTS, not their idents: Thread.ident is recycled
+    # after a thread exits, so an ident-based snapshot could mistake a new
+    # leaked thread (reusing an exited thread's ident) for a pre-existing one.
+    before = set(threading.enumerate())
     yield
     main = threading.main_thread()
     current = threading.current_thread()
@@ -97,7 +100,7 @@ def _no_leaked_threads(request: pytest.FixtureRequest) -> Iterator[None]:
     deadline = time.monotonic() + _THREAD_LEAK_GRACE
     leaked = []
     for t in threading.enumerate():
-        if t.ident in before or t is main or t is current or not t.is_alive():
+        if t in before or t is main or t is current or not t.is_alive():
             continue
         t.join(timeout=max(0.0, deadline - time.monotonic()))
         if t.is_alive():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,113 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import logging
 import os
+import threading
+import time
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
 
+
+def stop_loop_thread(loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+    """Fully tear down a ``loop.run_forever``-in-a-thread test loop.
+
+    Shuts the loop's default executor down ON the loop (joining its worker
+    threads — the ``asyncio_N`` threads that otherwise leak past the test),
+    then stops the loop, joins the thread, and closes the loop. Use in the
+    ``finally`` of a background-loop fixture so nothing outlives the test.
+    """
+    with contextlib.suppress(Exception):
+        asyncio.run_coroutine_threadsafe(loop.shutdown_default_executor(), loop).result(timeout=5)
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    with contextlib.suppress(Exception):
+        loop.close()
+
+
+def serve_until_exit(server: Any) -> None:
+    """Run a uvicorn ``Server`` on a fresh event loop until it exits.
+
+    The thread target for an in-thread test upstream: when ``server.serve()``
+    returns (the fixture set ``server.should_exit`` / ``force_exit``), the loop
+    is closed so it doesn't leak past the fixture.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(server.serve())
+    finally:
+        # Cancel + drain anything the app left pending (e.g. sse_starlette's
+        # shutdown watcher) so loop.close() doesn't warn "Task was destroyed
+        # but it is pending".
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            with contextlib.suppress(Exception):
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+
+
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from turnstone.core.mcp_client import MCPClientManager, StaticServerState
     from turnstone.core.mcp_crypto import MCPTokenCipher
     from turnstone.core.oidc import OIDCConfig
+
+
+# A background daemon (e.g. title generation) can log into pytest's per-test
+# capture as it is torn down — a benign "I/O operation on closed file" handler
+# error. Don't let the logging module turn that race into noisy stderr
+# tracebacks. (Process-global, test-only — product runtime keeps the default.)
+logging.raiseExceptions = False
+
+
+# Threads a test leaves running after teardown bleed into LATER tests' captured
+# output (the "I/O operation on closed file" heisenbug) and, worse, can wedge
+# the whole run (a leaked event loop / server that never stops). This grace
+# lets a legitimately-finishing quick daemon settle before we judge a leak.
+_THREAD_LEAK_GRACE = 5.0
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_threads(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Fail a test that leaves a background thread running past teardown.
+
+    Snapshots the live threads at setup; at teardown, gives any NEW thread a
+    short grace to finish, then fails listing those still alive — so a leak is
+    caught here instead of as a heisenbug days later. Opt out with
+    ``@pytest.mark.allow_thread_leak`` (e.g. module-scoped servers in the live
+    suite).
+    """
+    if request.node.get_closest_marker("allow_thread_leak"):
+        yield
+        return
+    before = {t.ident for t in threading.enumerate()}
+    yield
+    main = threading.main_thread()
+    current = threading.current_thread()
+    # One deadline shared across all joined threads — a deliberate TOTAL
+    # teardown budget (not per-thread), so a pathological test can't stall
+    # teardown by N×grace. A genuine never-stopping leak exhausts it and fails.
+    deadline = time.monotonic() + _THREAD_LEAK_GRACE
+    leaked = []
+    for t in threading.enumerate():
+        if t.ident in before or t is main or t is current or not t.is_alive():
+            continue
+        t.join(timeout=max(0.0, deadline - time.monotonic()))
+        if t.is_alive():
+            leaked.append(t.name)
+    if leaked:
+        pytest.fail(
+            f"test left background threads running after teardown: {leaked}. "
+            "Stop them in teardown (shut down servers / close event loops / join "
+            "threads), or mark @pytest.mark.allow_thread_leak if intentional."
+        )
 
 
 def make_mcp_token_cipher() -> MCPTokenCipher:

--- a/tests/test_docker_healthcheck.py
+++ b/tests/test_docker_healthcheck.py
@@ -54,7 +54,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
 
 @pytest.fixture
 def serve():
-    """Factory that starts an HTTP(S) server on an ephemeral port and returns it.
+    """Factory that starts an HTTP(S) server on an ephemeral port and returns
+    that port.
 
     Every server it starts is shut down + its serve_forever thread joined at
     teardown, so the thread never outlives the test (which would otherwise bleed

--- a/tests/test_docker_healthcheck.py
+++ b/tests/test_docker_healthcheck.py
@@ -52,13 +52,31 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def _serve(handler_cls, ssl_context: ssl.SSLContext | None = None) -> int:
-    """Start a daemon-thread HTTP(S) server on an ephemeral port."""
-    httpd = http.server.HTTPServer(("127.0.0.1", 0), handler_cls)
-    if ssl_context is not None:
-        httpd.socket = ssl_context.wrap_socket(httpd.socket, server_side=True)
-    threading.Thread(target=httpd.serve_forever, daemon=True).start()
-    return httpd.server_address[1]
+@pytest.fixture
+def serve():
+    """Factory that starts an HTTP(S) server on an ephemeral port and returns it.
+
+    Every server it starts is shut down + its serve_forever thread joined at
+    teardown, so the thread never outlives the test (which would otherwise bleed
+    into a later test's captured output / leak the listener).
+    """
+    started: list[tuple[http.server.HTTPServer, threading.Thread]] = []
+
+    def _factory(handler_cls, ssl_context: ssl.SSLContext | None = None) -> int:
+        httpd = http.server.HTTPServer(("127.0.0.1", 0), handler_cls)
+        if ssl_context is not None:
+            httpd.socket = ssl_context.wrap_socket(httpd.socket, server_side=True)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        started.append((httpd, thread))
+        return httpd.server_address[1]
+
+    yield _factory
+
+    for httpd, thread in started:
+        httpd.shutdown()  # break the serve_forever loop
+        httpd.server_close()  # release the listening socket
+        thread.join(timeout=5)
 
 
 @pytest.fixture
@@ -90,29 +108,29 @@ def mtls_setup(tmp_path):
 # ── Plain HTTP (mTLS disabled — the default deployment) ─────────────────────
 
 
-def test_plain_http_ok():
+def test_plain_http_ok(serve):
     """Default path: plain probe succeeds, PEM dir never consulted."""
-    port = _serve(_Handler)
+    port = serve(_Handler)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health")
     assert result.returncode == 0, result.stderr
 
 
-def test_plain_http_degraded_is_healthy():
+def test_plain_http_degraded_is_healthy(serve):
     """'degraded' (backend down, server up) still counts as container-healthy."""
 
     class Degraded(_Handler):
         payload = {"status": "degraded"}
 
-    port = _serve(Degraded)
+    port = serve(Degraded)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health")
     assert result.returncode == 0, result.stderr
 
 
-def test_plain_http_bad_status_fails():
+def test_plain_http_bad_status_fails(serve):
     class Bad(_Handler):
         payload = {"status": "error"}
 
-    port = _serve(Bad)
+    port = serve(Bad)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health")
     assert result.returncode == 1
     assert "unhealthy payload" in result.stderr
@@ -128,40 +146,40 @@ def test_server_down_fails():
 # ── mTLS (tls.enabled) ───────────────────────────────────────────────────────
 
 
-def test_mtls_probe_with_pem_dir(mtls_setup):
+def test_mtls_probe_with_pem_dir(mtls_setup, serve):
     """The regression case: mTLS node + plain-HTTP probe URL.
 
     The plain attempt is rejected at the socket; the script must fall back
     to HTTPS with the node cert as client cert and report healthy."""
     pem_root, server_ctx = mtls_setup
-    port = _serve(_Handler, ssl_context=server_ctx)
+    port = serve(_Handler, ssl_context=server_ctx)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health", pem_root=pem_root)
     assert result.returncode == 0, result.stderr
 
 
-def test_mtls_probe_without_pems_fails(mtls_setup):
+def test_mtls_probe_without_pems_fails(mtls_setup, serve):
     """mTLS node but no PEM material on disk: the probe must fail."""
     _, server_ctx = mtls_setup
-    port = _serve(_Handler, ssl_context=server_ctx)
+    port = serve(_Handler, ssl_context=server_ctx)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health", pem_root=None)
     assert result.returncode == 1
     assert "Health check failed" in result.stderr
 
 
-def test_mtls_unhealthy_payload_fails(mtls_setup):
+def test_mtls_unhealthy_payload_fails(mtls_setup, serve):
     """A reachable mTLS server with a bad payload is still unhealthy."""
     pem_root, server_ctx = mtls_setup
 
     class Bad(_Handler):
         payload = {"status": "error"}
 
-    port = _serve(Bad, ssl_context=server_ctx)
+    port = serve(Bad, ssl_context=server_ctx)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health", pem_root=pem_root)
     assert result.returncode == 1
     assert "unhealthy payload" in result.stderr
 
 
-def test_mtls_incomplete_pem_dir_fails(mtls_setup, tmp_path):
+def test_mtls_incomplete_pem_dir_fails(mtls_setup, tmp_path, serve):
     """A PEM dir missing the key is skipped, not half-used."""
     _, server_ctx = mtls_setup
     incomplete = tmp_path / "incomplete-root"
@@ -170,7 +188,7 @@ def test_mtls_incomplete_pem_dir_fails(mtls_setup, tmp_path):
     (d / "fullchain.pem").write_text("not a cert")
     (d / "ca.pem").write_text("not a cert")
 
-    port = _serve(_Handler, ssl_context=server_ctx)
+    port = serve(_Handler, ssl_context=server_ctx)
     result = run_healthcheck(f"http://127.0.0.1:{port}/health", pem_root=incomplete)
     assert result.returncode == 1
 

--- a/tests/test_mcp_pool_auth_integration.py
+++ b/tests/test_mcp_pool_auth_integration.py
@@ -38,7 +38,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import make_mcp_token_cipher, serve_until_exit, stop_loop_thread
 from turnstone.core.mcp_client import MCPClientManager
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.mcp_oauth import TokenLookupResult
@@ -187,7 +187,14 @@ def _build_server(port: int, behaviour: dict[str, Any]) -> uvicorn.Server:
 
     app = mcp.streamable_http_app()
     app.add_middleware(BehaviorMiddleware, behaviour=behaviour)
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", access_log=False)
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        timeout_graceful_shutdown=0,  # don't block teardown on a held-open stream
+    )
     return uvicorn.Server(config)
 
 
@@ -215,9 +222,7 @@ def upstream():
     server = _build_server(port, behaviour)
 
     def _run() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(server.serve())
+        serve_until_exit(server)
 
     t = threading.Thread(target=_run, daemon=True, name="phase6-upstream")
     t.start()
@@ -225,7 +230,11 @@ def upstream():
         _wait_ready(port)
         yield f"http://127.0.0.1:{port}/mcp", behaviour
     finally:
+        # should_exit alone triggers a GRACEFUL shutdown that can wait forever
+        # on a held-open streamable-http stream; force_exit skips that wait so
+        # serve() returns and the upstream thread doesn't leak past the test.
         server.should_exit = True
+        server.force_exit = True
         t.join(timeout=5)
 
 
@@ -311,8 +320,7 @@ def running_loop_mgr():
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
+        stop_loop_thread(loop, thread)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -34,7 +34,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import make_mcp_token_cipher, stop_loop_thread
 from turnstone.core.mcp_client import (
     MCPClientManager,
     _AuthCapture,
@@ -131,8 +131,7 @@ def running_loop_mgr():
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
+        stop_loop_thread(loop, thread)
 
 
 def _run_on_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:

--- a/tests/test_mcp_pool_auth_prompt_integration.py
+++ b/tests/test_mcp_pool_auth_prompt_integration.py
@@ -26,7 +26,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import make_mcp_token_cipher, serve_until_exit, stop_loop_thread
 from turnstone.core.mcp_client import MCPClientManager
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.mcp_oauth import TokenLookupResult
@@ -130,7 +130,14 @@ def _build_server(port: int, behaviour: dict[str, Any]) -> uvicorn.Server:
 
     app = mcp.streamable_http_app()
     app.add_middleware(BehaviorMiddleware, behaviour=behaviour)
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", access_log=False)
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        timeout_graceful_shutdown=0,  # don't block teardown on a held-open stream
+    )
     return uvicorn.Server(config)
 
 
@@ -152,9 +159,7 @@ def upstream():
     server = _build_server(port, behaviour)
 
     def _run() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(server.serve())
+        serve_until_exit(server)
 
     t = threading.Thread(target=_run, daemon=True, name="phase7b-prompt-upstream")
     t.start()
@@ -162,7 +167,11 @@ def upstream():
         _wait_ready(port)
         yield f"http://127.0.0.1:{port}/mcp", behaviour
     finally:
+        # should_exit alone triggers a GRACEFUL shutdown that can wait forever
+        # on a held-open streamable-http stream; force_exit skips that wait so
+        # serve() returns and the upstream thread doesn't leak past the test.
         server.should_exit = True
+        server.force_exit = True
         t.join(timeout=5)
 
 
@@ -248,8 +257,7 @@ def running_loop_mgr():
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
+        stop_loop_thread(loop, thread)
 
 
 def _seed_pool_prompt_map(

--- a/tests/test_mcp_pool_auth_resource_integration.py
+++ b/tests/test_mcp_pool_auth_resource_integration.py
@@ -26,7 +26,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import make_mcp_token_cipher, serve_until_exit, stop_loop_thread
 from turnstone.core.mcp_client import MCPClientManager
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.mcp_oauth import TokenLookupResult
@@ -139,7 +139,14 @@ def _build_server(port: int, behaviour: dict[str, Any]) -> uvicorn.Server:
 
     app = mcp.streamable_http_app()
     app.add_middleware(BehaviorMiddleware, behaviour=behaviour)
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", access_log=False)
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        timeout_graceful_shutdown=0,  # don't block teardown on a held-open stream
+    )
     return uvicorn.Server(config)
 
 
@@ -161,9 +168,7 @@ def upstream():
     server = _build_server(port, behaviour)
 
     def _run() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(server.serve())
+        serve_until_exit(server)
 
     t = threading.Thread(target=_run, daemon=True, name="phase7b-resource-upstream")
     t.start()
@@ -171,7 +176,11 @@ def upstream():
         _wait_ready(port)
         yield f"http://127.0.0.1:{port}/mcp", behaviour
     finally:
+        # should_exit alone triggers a GRACEFUL shutdown that can wait forever
+        # on a held-open streamable-http stream; force_exit skips that wait so
+        # serve() returns and the upstream thread doesn't leak past the test.
         server.should_exit = True
+        server.force_exit = True
         t.join(timeout=5)
 
 
@@ -257,8 +266,7 @@ def running_loop_mgr():
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
+        stop_loop_thread(loop, thread)
 
 
 def _seed_pool_resource_map(

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import make_mcp_token_cipher, stop_loop_thread
 from turnstone.core.mcp_client import MCPClientManager, PoolEntryState
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.storage._sqlite import SQLiteBackend
@@ -123,8 +123,7 @@ def running_loop_mgr():
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
+        stop_loop_thread(loop, thread)
 
 
 def _run_on_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -94,6 +94,11 @@ class ClusterCollector:
         self._nodes: dict[str, NodeSnapshot] = {}
         self._running = False
         self._threads: list[threading.Thread] = []
+        # Wakes the discovery loop out of its inter-scan sleep so ``stop()``
+        # can join it promptly instead of blocking up to ``discovery_interval``
+        # (a long interval would otherwise leave the thread sleeping past
+        # join's timeout — a leaked background thread).
+        self._discovery_wake = threading.Event()
 
         # SSE fan-out to browser clients
         self._listeners: list[queue.Queue[dict[str, Any]]] = []
@@ -135,6 +140,9 @@ class ClusterCollector:
     def start(self) -> None:
         """Start background threads."""
         self._running = True
+        # Clear the shutdown wake so a restarted collector (stop() set it) sleeps
+        # the full interval again instead of busy-spinning the discovery loop.
+        self._discovery_wake.clear()
         # Subscribe to the ``services`` channel for reactive node discovery.
         # NOTIFY-driven wake-ups bring new-node visibility from up-to-60 s
         # (next discovery tick) down to ~500 ms on Postgres; the 60 s
@@ -161,6 +169,7 @@ class ClusterCollector:
         its ``finally`` cleanup (cancel tasks, close AsyncClient).
         """
         self._running = False
+        self._discovery_wake.set()  # wake the discovery loop out of its sleep
         if self._notify_unsubscribe is not None:
             with contextlib.suppress(Exception):
                 self._notify_unsubscribe()
@@ -417,7 +426,9 @@ class ClusterCollector:
                 pass  # already logged by storage layer
             except Exception:
                 log.exception("Node discovery error")
-            time.sleep(self._discovery_interval)
+            # Interruptible inter-scan sleep — ``stop()`` sets the event to
+            # wake us immediately instead of blocking out the full interval.
+            self._discovery_wake.wait(self._discovery_interval)
 
     def _discover_nodes(self) -> None:
         """Query the service registry and update the node map."""


### PR DESCRIPTION
## Problem

Background daemons, event loops, and test servers that outlived their test bled into *later* tests' captured output — surfacing as intermittent `ValueError: I/O operation on closed file` (a daemon logging into pytest's already-closed capture). It's a heisenbug (only reproduces across the full suite, never a single module) and the same class of pollution behind a past multi-day CI-hang investigation.

A diagnostic pass found the real leakers: the collector's `console-discovery` thread, docker_healthcheck's HTTP test servers, and the MCP pool-auth tests' background event loops (`asyncio_N`) + FastMCP uvicorn upstreams.

## What this does

**Guard (so the next one is caught in minutes, not days)**
- `tests/conftest.py`: `_no_leaked_threads` — an autouse fail-on-leak guard that snapshots live threads at setup and **fails any test that leaves a thread running past teardown** (5s shared grace-join), with an `@pytest.mark.allow_thread_leak` opt-out.
- `logging.raiseExceptions = False` — mutes the benign logging-handler-vs-capture-teardown race (a pytest artifact; production stderr isn't closed mid-run).
- Shared teardown helpers `stop_loop_thread` / `serve_until_exit`.

**Product fix**
- `turnstone/console/collector.py`: the node-discovery loop slept uninterruptibly (`time.sleep(discovery_interval)`), so `ClusterCollector.stop()` couldn't join the `console-discovery` thread until the full interval elapsed — **a real shutdown hang in production** (up to `discovery_interval`, default 60s). It now sleeps on an interruptible `Event` that `stop()` sets and `start()` clears.

**Test-fixture teardown fixes**
- docker_healthcheck: `_serve` → a `serve` fixture-factory that shuts down its HTTP servers + joins their threads.
- MCP pool-auth (5 files): `running_loop_mgr` loops close cleanly (`shutdown_default_executor` + `close`); FastMCP uvicorn upstreams stop via `timeout_graceful_shutdown=0` + `force_exit` (graceful shutdown was hanging on a held-open streamable-http stream).

## Testing
- `ruff` + `mypy` clean; reviewed via `/review` (1 minor + nits, all applied; the minor was the collector `start()` wake-clear).
- **Full non-live suite: 7456 passed, 0 "I/O operation on closed file", 0 leaked-thread failures** — and ~1.5 min faster (2:53 vs 4:41), since the leaked servers/loops were dragging it.

## Follow-up (separate)
Production uvicorn (server.py / console/server.py) doesn't bound `timeout_graceful_shutdown`. It likely shuts down fine (sse_starlette closes SSE streams on the exit signal, unlike FastMCP's transport here), but bounding it would be cheap defensive hardening against a SIGTERM-hang edge case — out of scope for this branch.