### PR TITLE
feat(deploy): add vLLM + LiteLLM unified-memory inference example

### DIFF
--- a/turnstone/deploy/vllm-litellm/.env.example
+++ b/turnstone/deploy/vllm-litellm/.env.example
@@ -1,0 +1,33 @@
+# Copy to .env and edit. Defaults target an NVIDIA DGX Spark (GB10, ~128 GiB).
+# For AMD Strix Halo, see README.md → "Setup — AMD Strix Halo".
+
+# === model weights (mounted read-only at /models) ============================
+# Directory holding the model subdirs, e.g. qwen3.6-27B-FP8/ and gemma-4-12B-it/
+MODELS_DIR=./models
+# HF_TOKEN=hf_...              # only needed for gated weights pulled at runtime
+
+# === image ===================================================================
+# NVIDIA/CUDA default. AMD: set to a ROCm vLLM build that targets gfx1151.
+VLLM_IMAGE=vllm/vllm-openai:latest
+LITELLM_TAG=main-stable
+
+# === models ==================================================================
+# NVIDIA (Blackwell) runs FP8 natively. AMD RDNA3.5 has no FP8 matmul — recent
+# ROCm/vLLM still load FP8 (saves ~half the weight memory) but at bf16 speed and
+# immature; bf16 is the polished path there: QWEN_MODEL=/models/qwen3.6-27B.
+QWEN_MODEL=/models/qwen3.6-27B-FP8
+GEMMA_MODEL=/models/gemma-4-12B-it
+
+# === memory tuning ===========================================================
+# gpu-memory-utilization is a fraction of TOTAL unified memory (NOT free). The
+# two fractions must sum below ~0.9. Qwen gets the larger share; if you run out
+# of memory, shrink GEMMA_UTIL first, then lower QWEN_MAXLEN.
+QWEN_UTIL=0.64
+QWEN_MAXLEN=262144            # full Qwen context; ~2.5x concurrency on a Spark
+GEMMA_UTIL=0.22
+GEMMA_MAXLEN=131072           # full Gemma context; ~1x concurrency
+
+# === published ports =========================================================
+LITELLM_PORT=4000             # Turnstone points here (both API routes)
+QWEN_PORT=8000
+GEMMA_PORT=8001

--- a/turnstone/deploy/vllm-litellm/README.md
+++ b/turnstone/deploy/vllm-litellm/README.md
@@ -52,6 +52,7 @@ rationale in *Troubleshooting*):
   - `qwen3.6-27B-FP8/` (NVIDIA) or `qwen3.6-27B/` bf16 (AMD)
   - `gemma-4-12B-it/`
 - `sudo` for `drop_caches`.
+- These examples pass `--trust-remote-code` to vLLM; only use this with trusted model repos (remove the flag if your checkpoint doesn’t require it).
 
 ## Setup — NVIDIA DGX Spark (GB10)   ✅ validated
 

--- a/turnstone/deploy/vllm-litellm/README.md
+++ b/turnstone/deploy/vllm-litellm/README.md
@@ -1,0 +1,230 @@
+# Turnstone local inference — vLLM + LiteLLM on one unified-memory box
+
+Run Turnstone's reasoning **and** perception models on a single unified-memory
+accelerator — an **NVIDIA DGX Spark (GB10)** or an **AMD Ryzen AI MAX "Strix
+Halo"** — behind one LiteLLM gateway.
+
+> Validated on a DGX Spark (GB10, 128 GiB). The AMD Strix Halo path is
+> **guidance, not yet hardware-tested** — the deltas are called out explicitly.
+
+## What this is
+
+Two vLLM servers co-resident on one GPU, fronted by LiteLLM, which exposes
+**both** an OpenAI route and an Anthropic route on the same port:
+
+| Service | Model | Role | Turnstone reaches it via |
+|---|---|---|---|
+| `vllm-qwen` | Qwen 3.6 27B | reasoning + tools | LiteLLM `/v1/messages` (Anthropic) |
+| `vllm-gemma` | Gemma 4 12B | vision + audio (omni) | LiteLLM `/v1/chat/completions` (OpenAI) |
+| `litellm` | — | gateway, both routes | `:4000` |
+
+The **reranker runs on its own host** — it speaks the Cohere/Jina `/rerank` wire
+format, not chat, so Turnstone calls it directly (see *Reranker*, below).
+
+```
+                ┌─ /v1/messages         → vllm-qwen   (reasoning / tools)
+turnstone ─┬─ litellm :4000 ─┤
+           │   └─ /v1/chat/completions  → vllm-gemma  (vision + audio)
+           └──────────────── reranker host :8002/rerank  (direct, separate box)
+```
+
+**Why two routes.** vLLM serves both `/v1/messages` and `/v1/chat/completions`.
+- Qwen uses the **Anthropic** lane — vLLM's native `/v1/messages` is the stronger
+  path for reasoning/tool models.
+- Gemma uses the **OpenAI** lane — perception needs it: audio (`input_audio`) has
+  no equivalent in the Anthropic Messages API, so Turnstone gates audio roles to
+  OpenAI-SDK providers. Vision works on either lane; audio works only here.
+
+**Two rules for a single unified-memory card** (both enforced/automated below;
+rationale in *Troubleshooting*):
+1. **Drop the page cache before `up`** — vLLM profiles against free memory; a
+   warm cache makes it under-provision KV.
+2. **Sequential startup** — `vllm-gemma` waits for `vllm-qwen` to be healthy
+   (`depends_on`) so Qwen claims its KV against clean memory first.
+
+## Requirements
+
+- One unified-memory accelerator, ≈128 GiB (Spark GB10, or Strix Halo with the
+  iGPU given most of system RAM via UMA/GTT).
+- Docker + Compose v2, and either the **NVIDIA Container Toolkit** (Spark) or
+  **ROCm** with `/dev/kfd` + `/dev/dri` access (Strix Halo).
+- Weights on disk under `$MODELS_DIR`:
+  - `qwen3.6-27B-FP8/` (NVIDIA) or `qwen3.6-27B/` bf16 (AMD)
+  - `gemma-4-12B-it/`
+- `sudo` for `drop_caches`.
+
+## Setup — NVIDIA DGX Spark (GB10)   ✅ validated
+
+```sh
+cp .env.example .env
+# edit .env: set MODELS_DIR to your weights dir (defaults otherwise suit a Spark)
+
+# 1. drop the page cache (REQUIRED on unified memory)
+sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
+
+# 2. bring it up — qwen loads first, then gemma, then litellm (auto-sequenced)
+docker compose up -d
+
+# 3. watch until both are healthy (qwen ~8 min: FP8 load + graph capture)
+watch -n5 'docker compose ps'
+```
+
+Verify the KV pools and a round-trip on each route:
+
+```sh
+# qwen should report "Maximum concurrency for 262144 ...: ~2.5x"
+docker compose logs vllm-qwen | grep "Maximum concurrency"
+docker compose logs vllm-gemma | grep "Maximum concurrency"   # ~1.0x at 131072
+
+# Anthropic route -> qwen
+curl -s localhost:4000/v1/messages -H 'content-type: application/json' \
+  -H 'anthropic-version: 2023-06-01' -H 'x-api-key: dummy' \
+  -d '{"model":"qwen3.6-27b","max_tokens":32,"messages":[{"role":"user","content":"hi"}]}'
+
+# OpenAI route -> gemma
+curl -s localhost:4000/v1/chat/completions -H 'content-type: application/json' \
+  -H 'authorization: Bearer dummy' \
+  -d '{"model":"gemma-4-12b","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+Reference point (Spark, defaults): Qwen full 256K @ ~2.5× concurrency on default
+KV; Gemma full 131072 @ ~1.0×; ~108/121 GiB used.
+
+## Setup — AMD Strix Halo (Ryzen AI MAX, ROCm)   ⚠️ guidance, untested here
+
+Same compose, three deltas in `.env` + the GPU device block:
+
+1. **Image** — the stock `vllm/vllm-openai` is CUDA-only; you need a ROCm build for
+   `gfx1151`. Easiest is a community Strix Halo setup —
+   [kyuz0/amd-strix-halo-vllm-toolboxes](https://github.com/kyuz0/amd-strix-halo-vllm-toolboxes)
+   or the TheRock-ROCm build in [hec-ovi/vllm-qwen](https://github.com/hec-ovi/vllm-qwen)
+   — then point `VLLM_IMAGE` at it.
+2. **Weights — BF16 is the polished path.** gfx1151 has no FP8 matmul, so even though
+   recent ROCm/vLLM *can* load an FP8 checkpoint, the compute falls back to BF16 speed —
+   FP8's only win here is ~half the weight memory, and it's still rough (very slow first
+   load). Prefer BF16; qwen3.6-27B BF16 at long context is reported working on Strix Halo
+   (hec-ovi, above). BF16 27B weights ≈ 54 GiB, so leave less KV room:
+   ```sh
+   QWEN_MODEL=/models/qwen3.6-27B   # BF16. The -FP8 dir loads too (memory saving, slow/immature)
+   QWEN_MAXLEN=131072               # start here co-resident; raise toward 262144 and watch the KV log
+   QWEN_UTIL=0.62
+   ```
+3. **GPU access** — ROCm doesn't use the `deploy:` nvidia reservation. In
+   `docker-compose.yml`, **delete the `deploy:` block** on *both* vLLM services
+   and replace it with:
+   ```yaml
+       devices:
+         - /dev/kfd
+         - /dev/dri
+       group_add:
+         - video
+         - render
+       ipc: host
+       security_opt:
+         - seccomp:unconfined
+   ```
+   If the runtime rejects the arch, add `HSA_OVERRIDE_GFX_VERSION=11.5.1` to each
+   service's `environment:` and retry (value depends on your ROCm build).
+
+Also ensure the iGPU can actually reach ~128 GiB: set the BIOS UMA/"VRAM" split
+high, or rely on Linux GTT (`amdgpu.gttsize=...` kernel param) — otherwise vLLM
+sees only the small carved-out VRAM. Then follow the Spark steps (drop caches →
+`up` → verify).
+
+## Point Turnstone at it
+
+Run Turnstone separately and add the models (e.g. in
+`~/.config/turnstone/config.toml`). Note the **two different lanes**: Qwen omits
+`/v1` (the SDK appends `/v1/messages`); Gemma includes `/v1`:
+
+```toml
+[models.qwen]
+model = "qwen3.6-27b"
+provider = "anthropic-compatible"
+base_url = "http://INFERENCE_HOST:4000"           # /v1/messages (no /v1 suffix)
+api_key = "dummy"
+context_window = 262144
+
+[models.gemma]
+model = "gemma-4-12b"
+provider = "openai-compatible"
+base_url = "http://INFERENCE_HOST:4000/v1"         # /v1/chat/completions (perception)
+api_key = "dummy"
+context_window = 131072
+[models.gemma.capabilities]
+supports_vision = true
+supports_audio_input = true
+
+[models.reranker]
+model = "qwen3-reranker-8b"
+provider = "openai-compatible"                      # moot — reranker uses the /rerank client
+base_url = "http://RERANKER_HOST:8002/rerank"       # direct, not via LiteLLM
+[models.reranker.capabilities]
+supports_rerank = true
+
+[model]
+default = "qwen"
+```
+
+Set `default = "qwen"` for reasoning; pick Gemma as the workstream model (or the
+**STT** role under Models → Roles) for vision/voice; select the reranker under
+**Models → Roles → Reranker**.
+
+## Reranker (separate host)
+
+The reranker is light but doesn't co-reside well with Qwen at full context on one
+128 GiB card, and it speaks a different wire format — so run it on its own box:
+
+```sh
+vllm serve /models/qwen3-reranker-8b \
+  --served-model-name qwen3-reranker-8b --runner pooling \
+  --hf-overrides '{"architectures":["Qwen3ForSequenceClassification"],"classifier_from_token":["no","yes"],"is_original_qwen3_reranker":true}' \
+  --chat-template /models/qwen3-reranker-8b/chat_template.jinja \
+  --gpu-memory-utilization 0.5 --port 8002
+```
+
+Point Turnstone's reranker `base_url` at `http://RERANKER_HOST:8002/rerank`.
+
+## Troubleshooting
+
+**`max seq len (X) larger than available KV cache (Y)` — Qwen won't start.**
+Not enough KV for the context. In order: (1) you forgot to drop the page cache —
+`docker compose down`, drop caches, `up`; (2) raise `QWEN_UTIL`; (3) lower
+`GEMMA_UTIL` to hand memory over; (4) lower `QWEN_MAXLEN`.
+
+**`available KV cache memory (0.45 GiB)` despite plenty of free RAM.** The two
+vLLMs profiled memory *simultaneously* and raced — one grabbed almost everything.
+Keep the `depends_on: vllm-qwen: condition: service_healthy` on gemma (sequential
+startup). Never start them together on one card.
+
+**`dependency failed to start: container is unhealthy` during `up`.** The cold
+load (weights + graph capture) exceeded the healthcheck `start_period`. We set
+900 s; raise it if your disk is slow. The container keeps loading and recovers
+(`restart: unless-stopped`) — it's slow, not broken.
+
+**LiteLLM returns connection-refused right after `up`.** It starts in seconds but
+the vLLMs take minutes; `depends_on` gates it. If you restart *only* LiteLLM,
+give it ~10 s before the first request.
+
+**Gemma audio: "invalid audio file", or audio silently ignored.** Two causes:
+(1) the image lacks `vllm[audio]` — use the bundled `gemma.Dockerfile` (default);
+(2) Gemma is being reached on the Anthropic lane — audio only rides
+`/v1/chat/completions`, so Gemma must be `provider=openai-compatible` in Turnstone
+and `openai/...` in `litellm-config.yaml`.
+
+**Qwen replies are only a `thinking` block, no text.** `preserve_thinking` is on;
+give it a larger `max_tokens`, or render the thinking separately. Not an error.
+
+**Slow generation (single-digit tokens/s).** Expected for a 27B co-resident with
+another model on one Spark/Strix Halo APU — it's memory-bandwidth bound. For more
+speed, drop co-residence or context.
+
+**Want more headroom / fitting tighter.** `--kv-cache-dtype fp8` (add to the qwen
+command) ~halves KV memory if you're squeezed; default (fp16/bf16) KV is higher
+fidelity and usually fits once the cache is dropped. Gemma over-provisioned (high
+"concurrency" multiple)? Raise `GEMMA_MAXLEN` to spend the headroom on context,
+or lower `GEMMA_UTIL` to free memory.
+
+**AMD: `HIP error` / "gfx not supported".** Use a ROCm vLLM build for `gfx1151`,
+set `HSA_OVERRIDE_GFX_VERSION`, confirm `/dev/kfd` + `/dev/dri` are passed and the
+user is in the `video`/`render` groups.

--- a/turnstone/deploy/vllm-litellm/docker-compose.yml
+++ b/turnstone/deploy/vllm-litellm/docker-compose.yml
@@ -1,0 +1,143 @@
+# Turnstone local inference — two models co-resident on ONE unified-memory
+# accelerator (NVIDIA DGX Spark / GB10, or AMD Ryzen AI MAX "Strix Halo"),
+# behind a LiteLLM gateway that serves BOTH API routes at once:
+#
+#   /v1/messages          (Anthropic)  -> qwen   reasoning + tools
+#   /v1/chat/completions  (OpenAI)     -> gemma  perception (vision + audio)
+#
+# This file targets NVIDIA/CUDA (the default image + GPU reservation). For AMD
+# ROCm, see README.md → "Setup — AMD Strix Halo" (swap VLLM_IMAGE and the GPU
+# device-access block). The reranker runs on its own host (README) — it is not
+# co-resident here.
+#
+# TWO HARD REQUIREMENTS on a single unified-memory card (see README →
+# Troubleshooting for the why):
+#   1. Drop the page cache before `up`:  sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
+#   2. Sequential startup — enforced below: gemma waits for qwen to be healthy,
+#      so qwen claims its KV against clean memory first (simultaneous starts
+#      race and starve whichever profiles second).
+#
+# All tuning knobs are in .env.
+name: turnstone-inference
+
+services:
+  # --- reasoning + tools : Qwen 3.6 27B, full context via the Anthropic lane --
+  vllm-qwen:
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
+    command:
+      - --model
+      - ${QWEN_MODEL:-/models/qwen3.6-27B-FP8}
+      - --served-model-name
+      - qwen3.6-27b
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "8000"
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "${QWEN_UTIL:-0.64}"
+      - --max-model-len
+      - "${QWEN_MAXLEN:-262144}"
+      - --max-num-batched-tokens
+      - "4096"
+      - --max-num-seqs
+      - "2"
+      - --enable-prefix-caching
+      - --reasoning-parser
+      - qwen3
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --default-chat-template-kwargs
+      - '{"preserve_thinking": true}'
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      - ${MODELS_DIR:-./models}:/models:ro
+    ports:
+      - "${QWEN_PORT:-8000}:8000"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 15s
+      timeout: 5s
+      retries: 80
+      start_period: 900s          # cold load + graph capture at full ctx is slow
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia       # AMD: delete this `deploy:` block, see README
+              device_ids: ["0"]
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  # --- perception : Gemma 4 12B (vision + audio) via the OpenAI lane ----------
+  # Built from gemma.Dockerfile to add vllm[audio]; audio rides /v1/chat/completions.
+  vllm-gemma:
+    build:
+      context: .
+      dockerfile: gemma.Dockerfile
+      args:
+        VLLM_IMAGE: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
+    image: turnstone-inference/vllm-gemma-audio
+    command:
+      - --model
+      - ${GEMMA_MODEL:-/models/gemma-4-12B-it}
+      - --served-model-name
+      - gemma-4-12b
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "8000"
+      - --trust-remote-code
+      - --gpu-memory-utilization
+      - "${GEMMA_UTIL:-0.22}"
+      - --max-model-len
+      - "${GEMMA_MAXLEN:-131072}"
+      - --max-num-batched-tokens
+      - "4096"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - gemma4
+      - --tool-call-parser
+      - gemma4
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      - ${MODELS_DIR:-./models}:/models:ro
+    ports:
+      - "${GEMMA_PORT:-8001}:8000"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 15s
+      timeout: 5s
+      retries: 60
+      start_period: 900s
+    depends_on:
+      vllm-qwen:
+        condition: service_healthy   # SEQUENTIAL STARTUP — do not remove
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia          # AMD: delete this `deploy:` block, see README
+              device_ids: ["0"]
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  # --- gateway : both API routes on :4000 ------------------------------------
+  litellm:
+    image: ghcr.io/berriai/litellm:${LITELLM_TAG:-main-stable}
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    volumes:
+      - ./litellm-config.yaml:/etc/litellm/config.yaml:ro
+    ports:
+      - "${LITELLM_PORT:-4000}:4000"
+    depends_on:
+      vllm-qwen:
+        condition: service_healthy
+      vllm-gemma:
+        condition: service_healthy
+    restart: unless-stopped

--- a/turnstone/deploy/vllm-litellm/gemma.Dockerfile
+++ b/turnstone/deploy/vllm-litellm/gemma.Dockerfile
@@ -1,0 +1,10 @@
+# Gemma 4 is an omni model (vision + audio). The stock vLLM image ships without
+# the audio extra, so audio uploads fail with a misleading "invalid audio file".
+# This layer adds vllm[audio]. Builds on top of whatever VLLM_IMAGE you use, so
+# it works for both the NVIDIA and ROCm base images.
+#
+# Vision works WITHOUT this — if you only need vision, point vllm-gemma at
+# ${VLLM_IMAGE} directly in docker-compose.yml and drop the build: block.
+ARG VLLM_IMAGE=vllm/vllm-openai:latest
+FROM ${VLLM_IMAGE}
+RUN python3 -m pip install --no-cache-dir "vllm[audio]"

--- a/turnstone/deploy/vllm-litellm/litellm-config.yaml
+++ b/turnstone/deploy/vllm-litellm/litellm-config.yaml
@@ -1,0 +1,27 @@
+# LiteLLM gateway config — serves BOTH API routes on :4000 at once, each model
+# on the backend protocol its role needs:
+#
+#   /v1/messages          (Anthropic)  -> qwen   (reasoning; vLLM's native
+#                                          /v1/messages beats its OpenAI lane)
+#   /v1/chat/completions  (OpenAI)     -> gemma  (perception: vision + audio;
+#                                          audio `input_audio` has no Anthropic
+#                                          Messages equivalent, so it MUST use
+#                                          the OpenAI chat lane)
+#
+# Turnstone reaches qwen as provider=anthropic-compatible (base_url :4000, no /v1)
+# and gemma as provider=openai-compatible (base_url :4000/v1). The reranker is
+# NOT here — Cohere/Jina /rerank wire format; Turnstone calls it directly.
+model_list:
+  - model_name: qwen3.6-27b
+    litellm_params:
+      model: anthropic/qwen3.6-27b
+      api_base: http://vllm-qwen:8000
+      api_key: dummy
+  - model_name: gemma-4-12b
+    litellm_params:
+      model: openai/gemma-4-12b
+      api_base: http://vllm-gemma:8000/v1
+      api_key: dummy
+
+litellm_settings:
+  drop_params: true        # tolerate params a backend doesn't accept


### PR DESCRIPTION
A docker-compose example for running Turnstone's reasoning and perception models on a single unified-memory accelerator (NVIDIA DGX Spark / AMD Strix Halo) behind one LiteLLM gateway.

## What it does
- **Qwen 3.6 27B** on the Anthropic `/v1/messages` lane (vLLM's native Messages API — the stronger path for reasoning/tools), full 256K context.
- **Gemma 4 12B** on the OpenAI `/v1/chat/completions` lane — required for perception: audio (`input_audio`) has no Anthropic Messages equivalent, so it must use the OpenAI lane.
- **LiteLLM** fronts both routes on one port; each backend uses the protocol its role needs.
- Sequential startup (`depends_on: service_healthy`) + a page-cache drop, which are the two things that make KV provisioning reliable when two models co-reside on one unified-memory card.

## Docs
`README.md` covers setup for **DGX Spark** (validated on a GB10) and **AMD Strix Halo** (ROCm — guidance, not yet hardware-tested), plus a troubleshooting section drawn from real bring-up. The reranker is documented as a separate-host service.

Config + docs only — no code changes.