### PR TITLE
fix(ci): exclude vllm-litellm deploy example from wheel-completeness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,16 @@ jobs:
             | grep -v '\.py$' | grep -v '\.dist-info' | grep -v '\.pyc' | grep -v '^File$' \
             | sort)
 
-          # Files intentionally excluded from the wheel (one per line)
+          # Files intentionally excluded from the wheel (one per line).
+          # The vllm-litellm/ deploy example ships in the repo, not the wheel
+          # (you clone the repo to run it; the package doesn't reference it).
           ALLOW="
           turnstone/core/storage/migrations/script.py.mako
+          turnstone/deploy/vllm-litellm/.env.example
+          turnstone/deploy/vllm-litellm/README.md
+          turnstone/deploy/vllm-litellm/docker-compose.yml
+          turnstone/deploy/vllm-litellm/gemma.Dockerfile
+          turnstone/deploy/vllm-litellm/litellm-config.yaml
           "
 
           MISSING=$(comm -23 <(echo "$SOURCE") <(echo "$WHEEL") \


### PR DESCRIPTION
#686 added `turnstone/deploy/vllm-litellm/` under the package dir, which trips the "all data files in wheel" CI check (those files aren't in the wheel) and is currently failing `main`.

They're a deploy **example** (compose + README + .env.example + Dockerfile): you clone the repo to run it; the package never references them. So they belong in the repo, not the wheel — added to the check's intentional-exclusion ALLOW list rather than shipping example docs in the wheel.

Verified locally: `python -m build --wheel` + the exact CI check → no missing files.