### PR TITLE
feat(deploy): vllm-litellm example — 3-model co-resident shape + HF loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,16 @@ jobs:
             | grep -v '\.py$' | grep -v '\.dist-info' | grep -v '\.pyc' | grep -v '^File$' \
             | sort)
 
-          # Files intentionally excluded from the wheel (one per line)
+          # Files intentionally excluded from the wheel (one per line).
+          # The vllm-litellm/ deploy example ships in the repo, not the wheel
+          # (you clone the repo to run it; the package doesn't reference it).
           ALLOW="
           turnstone/core/storage/migrations/script.py.mako
+          turnstone/deploy/vllm-litellm/.env.example
+          turnstone/deploy/vllm-litellm/README.md
+          turnstone/deploy/vllm-litellm/docker-compose.yml
+          turnstone/deploy/vllm-litellm/gemma.Dockerfile
+          turnstone/deploy/vllm-litellm/litellm-config.yaml
           "
 
           MISSING=$(comm -23 <(echo "$SOURCE") <(echo "$WHEEL") \

--- a/turnstone/deploy/vllm-litellm/.env.example
+++ b/turnstone/deploy/vllm-litellm/.env.example
@@ -1,33 +1,29 @@
-# Copy to .env and edit. Defaults target an NVIDIA DGX Spark (GB10, ~128 GiB).
-# For AMD Strix Halo, see README.md → "Setup — AMD Strix Halo".
+# Copy to .env and edit. Defaults target an NVIDIA DGX Spark (GB10, ~128 GiB)
+# running all three models. For AMD Strix Halo, see README → "Setup — AMD Strix Halo".
 
-# === model weights (mounted read-only at /models) ============================
-# Directory holding the model subdirs, e.g. qwen3.6-27B-FP8/ and gemma-4-12B-it/
-MODELS_DIR=./models
-# HF_TOKEN=hf_...              # only needed for gated weights pulled at runtime
+# === HF model cache ==========================================================
+# Models load by HF id and download into this dir (mounted at /hf) on first
+# `up`; cached on disk after. Expect ~50 GiB across the three models.
+HF_CACHE=./hf-cache
+HF_TOKEN=                     # REQUIRED for gated repos (e.g. google/gemma-4-*)
 
 # === image ===================================================================
-# NVIDIA/CUDA default. AMD: set to a ROCm vLLM build that targets gfx1151.
-VLLM_IMAGE=vllm/vllm-openai:latest
+VLLM_IMAGE=vllm/vllm-openai:latest    # AMD: a ROCm vLLM build that targets gfx1151
 LITELLM_TAG=main-stable
 
-# === models ==================================================================
-# NVIDIA (Blackwell) runs FP8 natively. AMD RDNA3.5 has no FP8 matmul — recent
-# ROCm/vLLM still load FP8 (saves ~half the weight memory) but at bf16 speed and
-# immature; bf16 is the polished path there: QWEN_MODEL=/models/qwen3.6-27B.
-QWEN_MODEL=/models/qwen3.6-27B-FP8
-GEMMA_MODEL=/models/gemma-4-12B-it
-
-# === memory tuning ===========================================================
-# gpu-memory-utilization is a fraction of TOTAL unified memory (NOT free). The
-# two fractions must sum below ~0.9. Qwen gets the larger share; if you run out
-# of memory, shrink GEMMA_UTIL first, then lower QWEN_MAXLEN.
-QWEN_UTIL=0.64
-QWEN_MAXLEN=262144            # full Qwen context; ~2.5x concurrency on a Spark
-GEMMA_UTIL=0.22
-GEMMA_MAXLEN=131072           # full Gemma context; ~1x concurrency
+# === models (HF ids; vLLM streams them from the HF cache) ====================
+# NVIDIA (Blackwell) runs FP8 natively. AMD RDNA3.5 has no FP8 matmul — use the
+# bf16 qwen there (Qwen/Qwen3.6-27B) and expect bf16-speed.
+QWEN_MODEL=Qwen/Qwen3.6-27B-FP8
+GEMMA_MODEL=google/gemma-4-12b-it
+RERANKER_MODEL=Qwen/Qwen3-Reranker-4B
 
 # === published ports =========================================================
-LITELLM_PORT=4000             # Turnstone points here (both API routes)
+LITELLM_PORT=4000             # chat models — point Turnstone here (both routes)
 QWEN_PORT=8000
 GEMMA_PORT=8001
+RERANKER_PORT=8002            # reranker direct: http://HOST:8002/rerank
+
+# Memory tuning (gpu-memory-utilization, contexts) lives in docker-compose.yml
+# as literals — qwen 0.50 / gemma 0.24 / reranker 0.10 (sum ~0.84). Edit there
+# for your card; they're a fraction of TOTAL unified memory and must sum <~0.9.

--- a/turnstone/deploy/vllm-litellm/README.md
+++ b/turnstone/deploy/vllm-litellm/README.md
@@ -97,11 +97,13 @@ Same compose, with these changes:
    [kyuz0/amd-strix-halo-vllm-toolboxes](https://github.com/kyuz0/amd-strix-halo-vllm-toolboxes)
    or the TheRock-ROCm build in [hec-ovi/vllm-qwen](https://github.com/hec-ovi/vllm-qwen)
    — then set `VLLM_IMAGE` to it.
-2. **Qwen weights** — gfx1151 has no FP8 matmul; recent ROCm/vLLM *can* load an FP8
-   checkpoint but compute falls back to BF16 speed and it's rough. Prefer BF16:
-   `QWEN_MODEL=Qwen/Qwen3.6-27B`, and drop `--max-model-len` toward 131072 (bf16
-   27B weights ≈ 54 GiB, leaving less KV room). `runai_streamer` may not help on
-   ROCm — drop it from the qwen command if it errors.
+2. **Qwen weights & loader** — gfx1151 has no FP8 matmul; recent ROCm/vLLM *can*
+   load an FP8 checkpoint but compute falls back to BF16 speed and it's rough.
+   Prefer BF16: set `QWEN_MODEL=Qwen/Qwen3.6-27B` in `.env`. Then, in the
+   `vllm-qwen` command in `docker-compose.yml`, lower `--max-model-len` toward
+   131072 (bf16 27B weights ≈ 54 GiB, less KV room) and remove the
+   `--load-format runai_streamer` line (it may not help on ROCm; drop it if it
+   errors). Those two are compose literals, not `.env` vars.
 3. **GPU access** — ROCm doesn't use the `deploy:` nvidia reservation. In
    `docker-compose.yml`, **delete the `deploy:` block** on *each* vLLM service and
    replace it with:

--- a/turnstone/deploy/vllm-litellm/README.md
+++ b/turnstone/deploy/vllm-litellm/README.md
@@ -1,46 +1,47 @@
 # Turnstone local inference — vLLM + LiteLLM on one unified-memory box
 
-Run Turnstone's reasoning **and** perception models on a single unified-memory
-accelerator — an **NVIDIA DGX Spark (GB10)** or an **AMD Ryzen AI MAX "Strix
-Halo"** — behind one LiteLLM gateway.
+Run Turnstone's **reasoning, perception, and reranking** models — three of them,
+co-resident on a single unified-memory accelerator (an **NVIDIA DGX Spark / GB10**
+or an **AMD Ryzen AI MAX "Strix Halo"**) — behind one LiteLLM gateway.
 
 > Validated on a DGX Spark (GB10, 128 GiB). The AMD Strix Halo path is
 > **guidance, not yet hardware-tested** — the deltas are called out explicitly.
 
 ## What this is
 
-Two vLLM servers co-resident on one GPU, fronted by LiteLLM, which exposes
-**both** an OpenAI route and an Anthropic route on the same port:
+Three vLLM servers on one GPU, with LiteLLM exposing **both** chat API routes on
+one port; the reranker is reached directly (it speaks the `/rerank` wire format):
 
 | Service | Model | Role | Turnstone reaches it via |
 |---|---|---|---|
-| `vllm-qwen` | Qwen 3.6 27B | reasoning + tools | LiteLLM `/v1/messages` (Anthropic) |
+| `vllm-qwen` | Qwen 3.6 27B (FP8) | reasoning + tools | LiteLLM `/v1/messages` (Anthropic) |
 | `vllm-gemma` | Gemma 4 12B | vision + audio (omni) | LiteLLM `/v1/chat/completions` (OpenAI) |
-| `litellm` | — | gateway, both routes | `:4000` |
-
-The **reranker runs on its own host** — it speaks the Cohere/Jina `/rerank` wire
-format, not chat, so Turnstone calls it directly (see *Reranker*, below).
+| `vllm-reranker` | Qwen3-Reranker 4B | retrieval rerank | `:8002/rerank` (direct) |
+| `litellm` | — | gateway (both chat routes) | `:4000` |
 
 ```
-                ┌─ /v1/messages         → vllm-qwen   (reasoning / tools)
+                ┌─ /v1/messages         → vllm-qwen      (reasoning / tools)
 turnstone ─┬─ litellm :4000 ─┤
-           │   └─ /v1/chat/completions  → vllm-gemma  (vision + audio)
-           └──────────────── reranker host :8002/rerank  (direct, separate box)
+           │   └─ /v1/chat/completions  → vllm-gemma     (vision + audio)
+           └──────────────────────────── vllm-reranker :8002/rerank  (direct)
 ```
 
-**Why two routes.** vLLM serves both `/v1/messages` and `/v1/chat/completions`.
+Models **load by HF id into a mounted `HF_HOME` cache** — no hand-staged weight
+dirs; the first `up` downloads them (set `HF_TOKEN` for gated repos), then
+they're cached on disk.
+
+**Why two chat routes.** vLLM serves both `/v1/messages` and `/v1/chat/completions`.
 - Qwen uses the **Anthropic** lane — vLLM's native `/v1/messages` is the stronger
   path for reasoning/tool models.
 - Gemma uses the **OpenAI** lane — perception needs it: audio (`input_audio`) has
   no equivalent in the Anthropic Messages API, so Turnstone gates audio roles to
   OpenAI-SDK providers. Vision works on either lane; audio works only here.
 
-**Two rules for a single unified-memory card** (both enforced/automated below;
-rationale in *Troubleshooting*):
-1. **Drop the page cache before `up`** — vLLM profiles against free memory; a
-   warm cache makes it under-provision KV.
-2. **Sequential startup** — `vllm-gemma` waits for `vllm-qwen` to be healthy
-   (`depends_on`) so Qwen claims its KV against clean memory first.
+**Validated shape (GB10, 128 GiB):** qwen full **256K @ ~1.4×** (MTP spec-decode +
+runai_streamer), gemma full **131072 @ ~2×**, reranker **@ ~1.4×**; ~117/121 GiB
+used. Two hard rules on one unified-memory card (rationale in *Troubleshooting*):
+**drop the page cache before `up`**, and **start sequentially** (enforced via
+`depends_on: service_healthy`) so each model profiles against clean memory.
 
 ## Requirements
 
@@ -48,108 +49,92 @@ rationale in *Troubleshooting*):
   iGPU given most of system RAM via UMA/GTT).
 - Docker + Compose v2, and either the **NVIDIA Container Toolkit** (Spark) or
   **ROCm** with `/dev/kfd` + `/dev/dri` access (Strix Halo).
-- Weights on disk under `$MODELS_DIR`:
-  - `qwen3.6-27B-FP8/` (NVIDIA) or `qwen3.6-27B/` bf16 (AMD)
-  - `gemma-4-12B-it/`
-- `sudo` for `drop_caches`.
-- These examples pass `--trust-remote-code` to vLLM; only use this with trusted model repos (remove the flag if your checkpoint doesn’t require it).
+- An `HF_TOKEN` for gated repos (e.g. `google/gemma-4-*`) and ~50 GiB of disk for
+  the model cache. `sudo` for `drop_caches`.
+- These commands pass `--trust-remote-code`; only use it with model repos you trust.
 
 ## Setup — NVIDIA DGX Spark (GB10)   ✅ validated
 
 ```sh
 cp .env.example .env
-# edit .env: set MODELS_DIR to your weights dir (defaults otherwise suit a Spark)
+# edit .env: set HF_TOKEN (gated gemma); defaults otherwise suit a Spark
 
 # 1. drop the page cache (REQUIRED on unified memory)
 sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
 
-# 2. bring it up — qwen loads first, then gemma, then litellm (auto-sequenced)
+# 2. bring it up — qwen → gemma → reranker → litellm, auto-sequenced.
+#    First run downloads ~50 GiB into ./hf-cache, so the first start is slow.
 docker compose up -d
-
-# 3. watch until both are healthy (qwen ~8 min: FP8 load + graph capture)
 watch -n5 'docker compose ps'
 ```
 
 Verify the KV pools and a round-trip on each route:
 
 ```sh
-# qwen should report "Maximum concurrency for 262144 ...: ~2.5x"
-docker compose logs vllm-qwen | grep "Maximum concurrency"
-docker compose logs vllm-gemma | grep "Maximum concurrency"   # ~1.0x at 131072
+docker compose logs vllm-qwen     | grep "Maximum concurrency"   # ~1.4x @ 262144
+docker compose logs vllm-gemma    | grep "Maximum concurrency"   # ~2x   @ 131072
+docker compose logs vllm-reranker | grep "Maximum concurrency"
 
-# Anthropic route -> qwen
+# qwen — Anthropic route
 curl -s localhost:4000/v1/messages -H 'content-type: application/json' \
   -H 'anthropic-version: 2023-06-01' -H 'x-api-key: dummy' \
   -d '{"model":"qwen3.6-27b","max_tokens":32,"messages":[{"role":"user","content":"hi"}]}'
-
-# OpenAI route -> gemma
+# gemma — OpenAI route
 curl -s localhost:4000/v1/chat/completions -H 'content-type: application/json' \
   -H 'authorization: Bearer dummy' \
   -d '{"model":"gemma-4-12b","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+# reranker — direct
+curl -s localhost:8002/rerank -H 'content-type: application/json' \
+  -d '{"model":"qwen3-reranker-4b","query":"capital of France","documents":["Paris is the capital of France","Berlin is in Germany"]}'
 ```
-
-Reference point (Spark, defaults): Qwen full 256K @ ~2.5× concurrency on default
-KV; Gemma full 131072 @ ~1.0×; ~108/121 GiB used.
 
 ## Setup — AMD Strix Halo (Ryzen AI MAX, ROCm)   ⚠️ guidance, untested here
 
-Same compose, three deltas in `.env` + the GPU device block:
+Same compose, with these changes:
 
 1. **Image** — the stock `vllm/vllm-openai` is CUDA-only; you need a ROCm build for
    `gfx1151`. Easiest is a community Strix Halo setup —
    [kyuz0/amd-strix-halo-vllm-toolboxes](https://github.com/kyuz0/amd-strix-halo-vllm-toolboxes)
    or the TheRock-ROCm build in [hec-ovi/vllm-qwen](https://github.com/hec-ovi/vllm-qwen)
-   — then point `VLLM_IMAGE` at it.
-2. **Weights — BF16 is the polished path.** gfx1151 has no FP8 matmul, so even though
-   recent ROCm/vLLM *can* load an FP8 checkpoint, the compute falls back to BF16 speed —
-   FP8's only win here is ~half the weight memory, and it's still rough (very slow first
-   load). Prefer BF16; qwen3.6-27B BF16 at long context is reported working on Strix Halo
-   (hec-ovi, above). BF16 27B weights ≈ 54 GiB, so leave less KV room:
-   ```sh
-   QWEN_MODEL=/models/qwen3.6-27B   # BF16. The -FP8 dir loads too (memory saving, slow/immature)
-   QWEN_MAXLEN=131072               # start here co-resident; raise toward 262144 and watch the KV log
-   QWEN_UTIL=0.62
-   ```
+   — then set `VLLM_IMAGE` to it.
+2. **Qwen weights** — gfx1151 has no FP8 matmul; recent ROCm/vLLM *can* load an FP8
+   checkpoint but compute falls back to BF16 speed and it's rough. Prefer BF16:
+   `QWEN_MODEL=Qwen/Qwen3.6-27B`, and drop `--max-model-len` toward 131072 (bf16
+   27B weights ≈ 54 GiB, leaving less KV room). `runai_streamer` may not help on
+   ROCm — drop it from the qwen command if it errors.
 3. **GPU access** — ROCm doesn't use the `deploy:` nvidia reservation. In
-   `docker-compose.yml`, **delete the `deploy:` block** on *both* vLLM services
-   and replace it with:
+   `docker-compose.yml`, **delete the `deploy:` block** on *each* vLLM service and
+   replace it with:
    ```yaml
-       devices:
-         - /dev/kfd
-         - /dev/dri
-       group_add:
-         - video
-         - render
+       devices: [/dev/kfd, /dev/dri]
+       group_add: [video, render]
        ipc: host
-       security_opt:
-         - seccomp:unconfined
+       security_opt: [seccomp:unconfined]
    ```
    If the runtime rejects the arch, add `HSA_OVERRIDE_GFX_VERSION=11.5.1` to each
-   service's `environment:` and retry (value depends on your ROCm build).
+   service's `environment:` (value depends on your ROCm build).
 
-Also ensure the iGPU can actually reach ~128 GiB: set the BIOS UMA/"VRAM" split
-high, or rely on Linux GTT (`amdgpu.gttsize=...` kernel param) — otherwise vLLM
-sees only the small carved-out VRAM. Then follow the Spark steps (drop caches →
-`up` → verify).
+Also make sure the iGPU can reach ~128 GiB (BIOS UMA split high, or Linux GTT via
+`amdgpu.gttsize=...`). Then follow the Spark steps (drop caches → `up` → verify).
 
 ## Point Turnstone at it
 
 Run Turnstone separately and add the models (e.g. in
-`~/.config/turnstone/config.toml`). Note the **two different lanes**: Qwen omits
-`/v1` (the SDK appends `/v1/messages`); Gemma includes `/v1`:
+`~/.config/turnstone/config.toml`). Note the **two lanes**: qwen omits `/v1` (the
+SDK appends `/v1/messages`); gemma includes `/v1`; the reranker is direct.
 
 ```toml
 [models.qwen]
 model = "qwen3.6-27b"
 provider = "anthropic-compatible"
-base_url = "http://INFERENCE_HOST:4000"           # /v1/messages (no /v1 suffix)
+base_url = "http://INFERENCE_HOST:4000"            # /v1/messages (no /v1 suffix)
 api_key = "dummy"
 context_window = 262144
 
 [models.gemma]
 model = "gemma-4-12b"
 provider = "openai-compatible"
-base_url = "http://INFERENCE_HOST:4000/v1"         # /v1/chat/completions (perception)
+base_url = "http://INFERENCE_HOST:4000/v1"          # /v1/chat/completions (perception)
 api_key = "dummy"
 context_window = 131072
 [models.gemma.capabilities]
@@ -157,9 +142,9 @@ supports_vision = true
 supports_audio_input = true
 
 [models.reranker]
-model = "qwen3-reranker-8b"
-provider = "openai-compatible"                      # moot — reranker uses the /rerank client
-base_url = "http://RERANKER_HOST:8002/rerank"       # direct, not via LiteLLM
+model = "qwen3-reranker-4b"
+provider = "openai-compatible"                       # moot — reranker uses the /rerank client
+base_url = "http://INFERENCE_HOST:8002/rerank"       # direct, not via LiteLLM
 [models.reranker.capabilities]
 supports_rerank = true
 
@@ -167,65 +152,65 @@ supports_rerank = true
 default = "qwen"
 ```
 
-Set `default = "qwen"` for reasoning; pick Gemma as the workstream model (or the
+`default = "qwen"` for reasoning; pick Gemma as the workstream model (or the
 **STT** role under Models → Roles) for vision/voice; select the reranker under
 **Models → Roles → Reranker**.
 
-## Reranker (separate host)
+## Tuning notes
 
-The reranker is light but doesn't co-reside well with Qwen at full context on one
-128 GiB card, and it speaks a different wire format — so run it on its own box:
-
-```sh
-vllm serve /models/qwen3-reranker-8b \
-  --served-model-name qwen3-reranker-8b --runner pooling \
-  --hf-overrides '{"architectures":["Qwen3ForSequenceClassification"],"classifier_from_token":["no","yes"],"is_original_qwen3_reranker":true}' \
-  --chat-template /models/qwen3-reranker-8b/chat_template.jinja \
-  --gpu-memory-utilization 0.5 --port 8002
-```
-
-Point Turnstone's reranker `base_url` at `http://RERANKER_HOST:8002/rerank`.
+- **`runai_streamer` on qwen only.** It cut qwen's weight load **166 s → ~1 s**
+  (~26×). But its streaming buffers add memory that breaks the *small* models'
+  tight KV budgets ("No available memory for the cache blocks"), so gemma and the
+  reranker use the default loader.
+- **MTP spec-decode on qwen** (`--speculative-config '{"method":"mtp",…}'`): qwen3.6
+  has a built-in MTP head, giving ~1.6× decode (≈8→13 tok/s) at ~84% acceptance,
+  no draft model. Pair with `--max-num-batched-tokens 8192`.
+- **qwen 0.50 default-KV holds full 256K (~1.4×).** `--kv-cache-dtype fp8` is the
+  reserve lever (halves KV) if you need to give the others more room.
+- **Shape:** gemma-4-12B (full-quality perception, `sliding_window` keeps long-ctx
+  KV cheap) + a light **4B** reranker fit alongside qwen; the 8B reranker or
+  gemma-4-E4B are the levers if you need to trade quality for memory.
 
 ## Troubleshooting
 
-**`max seq len (X) larger than available KV cache (Y)` — Qwen won't start.**
-Not enough KV for the context. In order: (1) you forgot to drop the page cache —
-`docker compose down`, drop caches, `up`; (2) raise `QWEN_UTIL`; (3) lower
-`GEMMA_UTIL` to hand memory over; (4) lower `QWEN_MAXLEN`.
+**`No available memory for the cache blocks` (a model won't start).** Its util
+left no room for KV after weights. Raise that model's `--gpu-memory-utilization`,
+or free memory elsewhere (qwen is the big tenant — drop its util or add
+`--kv-cache-dtype fp8`). This is also what `runai_streamer` triggers on small
+models — keep it on qwen only.
 
-**`available KV cache memory (0.45 GiB)` despite plenty of free RAM.** The two
-vLLMs profiled memory *simultaneously* and raced — one grabbed almost everything.
-Keep the `depends_on: vllm-qwen: condition: service_healthy` on gemma (sequential
-startup). Never start them together on one card.
+**`max seq len (X) larger than available KV cache (Y)`.** Same family: not enough
+KV for the context. First check you dropped the page cache before `up`; then raise
+that model's util or lower its `--max-model-len`.
+
+**`available KV cache memory (0.45 GiB)` despite free RAM.** Two models profiled
+memory *simultaneously* and raced. Keep the `depends_on: service_healthy` chain
+(sequential startup); never start them together on one card. Dropping caches
+*between* each model's start helps too.
 
 **`dependency failed to start: container is unhealthy` during `up`.** The cold
-load (weights + graph capture) exceeded the healthcheck `start_period`. We set
-900 s; raise it if your disk is slow. The container keeps loading and recovers
-(`restart: unless-stopped`) — it's slow, not broken.
+load (download + weights + graph capture) exceeded the healthcheck `start_period`
+(we set 1800 s for the first run). It keeps loading and recovers — slow, not broken.
 
-**LiteLLM returns connection-refused right after `up`.** It starts in seconds but
-the vLLMs take minutes; `depends_on` gates it. If you restart *only* LiteLLM,
-give it ~10 s before the first request.
+**LiteLLM connection-refused right after `up`.** It starts in seconds but the
+vLLMs take minutes; `depends_on` gates it. If you restart only LiteLLM, give it ~10 s.
 
-**Gemma audio: "invalid audio file", or audio silently ignored.** Two causes:
-(1) the image lacks `vllm[audio]` — use the bundled `gemma.Dockerfile` (default);
-(2) Gemma is being reached on the Anthropic lane — audio only rides
-`/v1/chat/completions`, so Gemma must be `provider=openai-compatible` in Turnstone
-and `openai/...` in `litellm-config.yaml`.
+**Gemma audio: "invalid audio file" / ignored.** (1) the image lacks `vllm[audio]`
+— use the bundled `gemma.Dockerfile` (default); (2) gemma must be on the **OpenAI**
+lane (`/v1/chat/completions`) — `provider=openai-compatible` in Turnstone — the
+Anthropic Messages API has no audio block.
 
-**Qwen replies are only a `thinking` block, no text.** `preserve_thinking` is on;
-give it a larger `max_tokens`, or render the thinking separately. Not an error.
+**Reranker fails to load the chat template.** Its template ships in the HF repo and
+vLLM usually loads it; if not, add `--chat-template <path-in-cache>` to the
+`vllm-reranker` command.
 
-**Slow generation (single-digit tokens/s).** Expected for a 27B co-resident with
-another model on one Spark/Strix Halo APU — it's memory-bandwidth bound. For more
-speed, drop co-residence or context.
+**Qwen replies are only a `thinking` block.** `preserve_thinking` is on; give it a
+larger `max_tokens`. Not an error.
 
-**Want more headroom / fitting tighter.** `--kv-cache-dtype fp8` (add to the qwen
-command) ~halves KV memory if you're squeezed; default (fp16/bf16) KV is higher
-fidelity and usually fits once the cache is dropped. Gemma over-provisioned (high
-"concurrency" multiple)? Raise `GEMMA_MAXLEN` to spend the headroom on context,
-or lower `GEMMA_UTIL` to free memory.
+**Slow generation (single-digit tok/s).** Expected for a 27B co-resident on one
+Spark/Strix Halo APU — memory-bandwidth bound. MTP helps; otherwise trade
+co-residence or context for speed.
 
-**AMD: `HIP error` / "gfx not supported".** Use a ROCm vLLM build for `gfx1151`,
-set `HSA_OVERRIDE_GFX_VERSION`, confirm `/dev/kfd` + `/dev/dri` are passed and the
-user is in the `video`/`render` groups.
+**AMD `HIP error` / "gfx not supported".** Use a ROCm vLLM build for `gfx1151`, set
+`HSA_OVERRIDE_GFX_VERSION`, confirm `/dev/kfd` + `/dev/dri` are passed and the user
+is in the `video`/`render` groups.

--- a/turnstone/deploy/vllm-litellm/docker-compose.yml
+++ b/turnstone/deploy/vllm-litellm/docker-compose.yml
@@ -1,32 +1,34 @@
-# Turnstone local inference — two models co-resident on ONE unified-memory
+# Turnstone local inference — 3 models co-resident on ONE unified-memory
 # accelerator (NVIDIA DGX Spark / GB10, or AMD Ryzen AI MAX "Strix Halo"),
-# behind a LiteLLM gateway that serves BOTH API routes at once:
+# behind a LiteLLM gateway serving BOTH chat API routes at once:
 #
-#   /v1/messages          (Anthropic)  -> qwen   reasoning + tools
-#   /v1/chat/completions  (OpenAI)     -> gemma  perception (vision + audio)
+#   /v1/messages          (Anthropic)  -> qwen      reasoning + tools
+#   /v1/chat/completions  (OpenAI)     -> gemma     perception (vision + audio)
+#   (direct)              /rerank      -> reranker  retrieval rerank
 #
-# This file targets NVIDIA/CUDA (the default image + GPU reservation). For AMD
-# ROCm, see README.md → "Setup — AMD Strix Halo" (swap VLLM_IMAGE and the GPU
-# device-access block). The reranker runs on its own host (README) — it is not
-# co-resident here.
+# Models load by HF id into a mounted HF_HOME cache (set HF_TOKEN for gated
+# repos; first `up` downloads them, then they're cached on disk under HF_CACHE).
+# This file targets NVIDIA/CUDA; for AMD ROCm see README.md.
 #
-# TWO HARD REQUIREMENTS on a single unified-memory card (see README →
-# Troubleshooting for the why):
-#   1. Drop the page cache before `up`:  sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
-#   2. Sequential startup — enforced below: gemma waits for qwen to be healthy,
-#      so qwen claims its KV against clean memory first (simultaneous starts
-#      race and starve whichever profiles second).
+# Validated on a GB10 Spark (128 GiB): qwen 256K @1.4x, gemma 131072 @2x,
+# reranker @1.4x, ~117/121 GiB used. Two hard rules on one unified-memory card
+# (see README -> Troubleshooting): drop the page cache before `up`, and start
+# sequentially (enforced via depends_on) so each model profiles clean memory.
 #
-# All tuning knobs are in .env.
+# gpu-memory-utilization is a fraction of TOTAL unified memory; the three must
+# sum below ~0.9. Tune for your card.
 name: turnstone-inference
 
 services:
-  # --- reasoning + tools : Qwen 3.6 27B, full context via the Anthropic lane --
+  # --- reasoning + tools : Qwen 3.6 27B (MTP spec-decode, full 256K) ----------
+  # runai_streamer cuts weight load ~26x (166s -> ~1s). Use it ONLY on this big
+  # model: its streaming buffers add memory that breaks the small models' tight
+  # KV budgets. Default KV holds 256K here; add --kv-cache-dtype fp8 if tight.
   vllm-qwen:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
     command:
       - --model
-      - ${QWEN_MODEL:-/models/qwen3.6-27B-FP8}
+      - ${QWEN_MODEL:-Qwen/Qwen3.6-27B-FP8}
       - --served-model-name
       - qwen3.6-27b
       - --host
@@ -34,15 +36,19 @@ services:
       - --port
       - "8000"
       - --trust-remote-code
+      - --load-format
+      - runai_streamer
       - --gpu-memory-utilization
-      - "${QWEN_UTIL:-0.64}"
+      - "0.50"
       - --max-model-len
-      - "${QWEN_MAXLEN:-262144}"
+      - "262144"
       - --max-num-batched-tokens
-      - "4096"
+      - "8192"
       - --max-num-seqs
       - "2"
       - --enable-prefix-caching
+      - --speculative-config
+      - '{"method": "mtp", "num_speculative_tokens": 1}'
       - --reasoning-parser
       - qwen3
       - --enable-auto-tool-choice
@@ -51,38 +57,38 @@ services:
       - --default-chat-template-kwargs
       - '{"preserve_thinking": true}'
     environment:
-      HUGGING_FACE_HUB_TOKEN: ${HF_TOKEN:-}
+      HF_HOME: /hf
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
-      - ${MODELS_DIR:-./models}:/models:ro
+      - ${HF_CACHE:-./hf-cache}:/hf
     ports:
       - "${QWEN_PORT:-8000}:8000"
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 15s
       timeout: 5s
-      retries: 80
-      start_period: 900s          # cold load + graph capture at full ctx is slow
+      retries: 120
+      start_period: 1800s          # first run also downloads the weights
     deploy:
       resources:
         reservations:
           devices:
-            - driver: nvidia       # AMD: delete this `deploy:` block, see README
+            - driver: nvidia        # AMD: delete this deploy: block, see README
               device_ids: ["0"]
               capabilities: [gpu]
     restart: unless-stopped
 
   # --- perception : Gemma 4 12B (vision + audio) via the OpenAI lane ----------
-  # Built from gemma.Dockerfile to add vllm[audio]; audio rides /v1/chat/completions.
   vllm-gemma:
     build:
       context: .
-      dockerfile: gemma.Dockerfile
+      dockerfile: gemma.Dockerfile   # adds vllm[audio] for the audio path
       args:
         VLLM_IMAGE: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
     image: turnstone-inference/vllm-gemma-audio
     command:
       - --model
-      - ${GEMMA_MODEL:-/models/gemma-4-12B-it}
+      - ${GEMMA_MODEL:-google/gemma-4-12b-it}
       - --served-model-name
       - gemma-4-12b
       - --host
@@ -91,9 +97,9 @@ services:
       - "8000"
       - --trust-remote-code
       - --gpu-memory-utilization
-      - "${GEMMA_UTIL:-0.22}"
+      - "0.24"
       - --max-model-len
-      - "${GEMMA_MAXLEN:-131072}"
+      - "131072"
       - --max-num-batched-tokens
       - "4096"
       - --enable-auto-tool-choice
@@ -104,30 +110,77 @@ services:
       - --default-chat-template-kwargs
       - '{"enable_thinking": false}'
     environment:
-      HUGGING_FACE_HUB_TOKEN: ${HF_TOKEN:-}
+      HF_HOME: /hf
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
-      - ${MODELS_DIR:-./models}:/models:ro
+      - ${HF_CACHE:-./hf-cache}:/hf
     ports:
       - "${GEMMA_PORT:-8001}:8000"
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 15s
       timeout: 5s
-      retries: 60
-      start_period: 900s
+      retries: 120
+      start_period: 1800s
     depends_on:
       vllm-qwen:
-        condition: service_healthy   # SEQUENTIAL STARTUP — do not remove
+        condition: service_healthy   # SEQUENTIAL STARTUP — qwen claims KV first
     deploy:
       resources:
         reservations:
           devices:
-            - driver: nvidia          # AMD: delete this `deploy:` block, see README
+            - driver: nvidia          # AMD: delete this deploy: block, see README
               device_ids: ["0"]
               capabilities: [gpu]
     restart: unless-stopped
 
-  # --- gateway : both API routes on :4000 ------------------------------------
+  # --- retrieval : Qwen3-Reranker 4B (Cohere/Jina /rerank, direct) ------------
+  # Light 4B reranker so it co-resides with the full 12B perception model. Its
+  # chat template ships in the repo (vLLM loads it); add --chat-template if your
+  # build needs it explicitly.
+  vllm-reranker:
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
+    command:
+      - --model
+      - ${RERANKER_MODEL:-Qwen/Qwen3-Reranker-4B}
+      - --served-model-name
+      - qwen3-reranker-4b
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "8000"
+      - --runner
+      - pooling
+      - --hf-overrides
+      - '{"architectures":["Qwen3ForSequenceClassification"],"classifier_from_token":["no","yes"],"is_original_qwen3_reranker":true}'
+      - --gpu-memory-utilization
+      - "0.10"
+    environment:
+      HF_HOME: /hf
+      HF_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      - ${HF_CACHE:-./hf-cache}:/hf
+    ports:
+      - "${RERANKER_PORT:-8002}:8000"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 15s
+      timeout: 5s
+      retries: 80
+      start_period: 900s
+    depends_on:
+      vllm-gemma:
+        condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia          # AMD: delete this deploy: block, see README
+              device_ids: ["0"]
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  # --- gateway : both chat API routes on :4000 -------------------------------
   litellm:
     image: ghcr.io/berriai/litellm:${LITELLM_TAG:-main-stable}
     command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]


### PR DESCRIPTION
Updates the `turnstone/deploy/vllm-litellm/` example to the validated **3-model** shape — qwen + gemma + reranker co-resident on one unified-memory accelerator (GB10 Spark / Strix Halo) behind LiteLLM.

## Changes
- **3 models co-resident**: qwen3.6-27B-FP8 (reasoning, Anthropic lane) + gemma-4-12B-it (perception, OpenAI lane) + Qwen3-Reranker-4B (direct `/rerank`).
- **HF-id loader**: models load by HF id into a mounted `HF_HOME` cache (no hand-staged weight dirs).
- **Tuning, validated on a GB10 (128 GiB)**: qwen MTP spec-decode + `runai_streamer` (weight load 166s→~1s) + full **256K @ ~1.4×** at util 0.50; gemma **131072 @ ~2×**; reranker **@ ~1.4×**; ~117/121 GiB used.
- **Learnings baked in**: drop the page cache + sequential startup on unified memory; `runai_streamer` on the big model only (its streaming buffers break the small models' KV budgets); fp8 KV as the reserve lever.
- README covers **DGX Spark** (validated) and **AMD Strix Halo** (ROCm, guidance).

Includes the wheel-check ALLOW entries for the example files, so this **supersedes #687** (close that one).

Verified locally: `docker compose config` + `python -m build --wheel` + the wheel check.