### PR TITLE
chore(ui): refresh favicon to chevron mark across web entry points

### DIFF
--- a/turnstone/console/static/coordinator/index.html
+++ b/turnstone/console/static/coordinator/index.html
@@ -6,7 +6,7 @@
     <title>coordinator · turnstone</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%2315211f'/%3E%3Cpath%20d='M9%2020%2016%2012%2023%2020'%20fill='none'%20stroke='%236bb7a8'%20stroke-width='2.4'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3Ccircle%20cx='16'%20cy='23.5'%20r='2.1'%20fill='%23e5a042'/%3E%3C/svg%3E"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -6,7 +6,7 @@
     <title>turnstone console</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%2315211f'/%3E%3Cpath%20d='M9%2020%2016%2012%2023%2020'%20fill='none'%20stroke='%236bb7a8'%20stroke-width='2.4'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3Ccircle%20cx='16'%20cy='23.5'%20r='2.1'%20fill='%23e5a042'/%3E%3C/svg%3E"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -6,7 +6,7 @@
     <title>turnstone</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230e1013'/%3E%3Cpath%20d='M8%2022a8%208%200%201%201%2016%200'%20fill='none'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3Cpath%20d='M16%2021%20L21%2014'%20stroke='%23e5a042'%20stroke-width='3'%20stroke-linecap='round'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%2315211f'/%3E%3Cpath%20d='M9%2020%2016%2012%2023%2020'%20fill='none'%20stroke='%236bb7a8'%20stroke-width='2.4'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3Ccircle%20cx='16'%20cy='23.5'%20r='2.1'%20fill='%23e5a042'/%3E%3C/svg%3E"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## What

Refreshes the browser favicon across all three web entry points — console (`turnstone/console/static/index.html`), coordinator (`turnstone/console/static/coordinator/index.html`), and the standalone UI (`turnstone/ui/static/index.html`).

The old amber gauge/needle mark on a near-black field is replaced with a teal up-chevron and amber dot on a dark-teal field:

| | Mark | Background |
|---|---|---|
| before | amber gauge + needle (`#e5a042`) | `#0e1013` |
| after | teal chevron (`#6bb7a8`) + amber dot (`#e5a042`) | `#15211f` |

## Notes

- The inline SVG data URI is **byte-identical** across all three files.
- Self-contained data URI — no network/asset dependency.
- Verified well-formed and legible when rasterized at both 32px (actual favicon size) and zoomed.
- No `theme-color`/manifest/`apple-touch-icon`/`og:image` metadata exists to keep in sync, and no committed file still references the old mark.