### PR TITLE
docs: drop Ollama from local-model lists (README + bootstrap wizard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [docs/releasing.md](docs/releasing.md) for the full release process.
 
 Turnstone gives LLMs tools — shell, files, search, web, planning — and orchestrates multi-turn conversations where the model investigates, acts, and reports.
 
-- **Local-first & private** — runs entirely on hardware you control, with no telemetry and no phone-home. Point it at local models (vLLM, llama.cpp, Ollama) or commercial APIs you hold the keys to — your prompts and data never transit a third party you didn't choose.
+- **Local-first & private** — runs entirely on hardware you control, with no telemetry and no phone-home. Point it at local models (vLLM, llama.cpp) or commercial APIs you hold the keys to — your prompts and data never transit a third party you didn't choose.
 - **Bring your own models** — OpenAI-compatible APIs (vLLM, llama.cpp, NIM), the Anthropic Messages API, and Google Gemini, mixed freely per role
 - **Interactive sessions** — terminal CLI or browser UI with parallel workstreams
 - **Cluster dashboard** — real-time view of every node and workstream, with a rendezvous routing proxy

--- a/turnstone/bootstrap.py
+++ b/turnstone/bootstrap.py
@@ -72,7 +72,7 @@ The compose.yaml reads these from a `.env` file:
 
 ### LLM Provider (required)
 - `LLM_BASE_URL` — OpenAI-compatible API endpoint (default: http://host.docker.internal:8000/v1). \
-For local models (vLLM, llama.cpp, Ollama), this points to the local server. \
+For local models (vLLM, llama.cpp), this points to the local server. \
 From inside Docker, use `http://host.docker.internal:<port>/v1` to reach the host machine.
 - `OPENAI_API_KEY` — API key for the LLM provider. For local models that don't require \
 authentication, set this to `dummy` (the compose.yaml defaults to `dummy` if unset). \
@@ -202,7 +202,7 @@ ghcr.io images — no local Docker build is needed.
 - If an existing .env is detected, summarize what's configured and ask what to change.
 - The `TURNSTONE_DB_URL` for docker compose internal networking uses the hostname `postgres` \
 (e.g., `postgresql+psycopg://turnstone:<password>@postgres:5432/turnstone`).
-- For local LLM backends (vLLM, llama.cpp, Ollama, etc.), set `OPENAI_API_KEY=dummy` in the \
+- For local LLM backends (vLLM, llama.cpp, etc.), set `OPENAI_API_KEY=dummy` in the \
 .env file — local servers typically don't require authentication. The `LLM_BASE_URL` should \
 use `host.docker.internal` to reach the host machine from inside Docker \
 (e.g., `http://host.docker.internal:8000/v1`).


### PR DESCRIPTION
Removes Ollama from the user-facing "local models" lists in the README and the bootstrap setup-wizard prompt.

**Why:** Turnstone has no dedicated Ollama provider — local servers are driven through the single `openai-compatible` handler — and Ollama support isn't currently at a level worth advertising. The pre-agentic models people typically reach for under Ollama (deepseek-coder-v2, Mixtral 8x7B, CodeLlama) lack reliable tool-calling and are a poor fit for an agent framework, which generated repeated setup confusion.

vLLM and llama.cpp stay listed — those are the local backends actually exercised via the OpenAI-compatible lane.

Context: #708, #709, #710 (triaged and closed separately).
