### PR TITLE
feat(cancel): honest cancellation dispositions + coordinator subtree propagation

### DIFF
--- a/docs/bulk-endpoints.md
+++ b/docs/bulk-endpoints.md
@@ -12,7 +12,6 @@ Existing bulk endpoints at time of writing:
 |---------------------------------------------------------|--------------------------|------------------------------------------|
 | `GET  /v1/api/cluster/ws/live?ids=a,b,c`                | bulk read                | `{results, denied, truncated}`           |
 | model tool `spawn_batch`                                 | bulk create (per-item)   | `{results, denied}`                      |
-| `POST /v1/api/workstreams/{ws_id}/stop_cascade`          | cascade mutation         | `{cancelled, failed, skipped}`           |
 | `POST /v1/api/workstreams/{ws_id}/close_all_children`    | cascade mutation         | `{closed, failed, skipped}`              |
 
 ---
@@ -146,7 +145,7 @@ consistently-typed across the read and create cases.
 ```
 
 Where `<bucket>` is the endpoint-specific name for "succeeded" —
-`cancelled` for `stop_cascade`, `closed` for `close_all_children`.
+`closed` for `close_all_children`.
 The three buckets partition the input set exactly once:
 
 | Bucket        | Meaning                                                                       |
@@ -161,20 +160,6 @@ be partial.  `skipped` is pre-resolved — the target is already in
 the terminal state the cascade was aiming at, so it's neither a
 win to report nor a fault to fix.
 
-### Example — `stop_cascade`
-
-```json
-{
-  "status": "ok",
-  "cancelled": ["child-1", "child-3"],
-  "failed":    [],
-  "skipped":   ["child-2"]
-}
-```
-
-A subsequent retry would target only `failed` ids, not `skipped`
-ones — the latter are already done.
-
 ### Example — `close_all_children`
 
 ```json
@@ -186,10 +171,12 @@ ones — the latter are already done.
 }
 ```
 
-Same partition, different success-bucket name.  When `coord_client`
-is unavailable (session loaded but no HTTP client attached — a
-construction bug) every id goes to `failed` so the operator notices
-rather than getting a silent all-skipped response.
+Here the success bucket is `closed`.  A subsequent retry would
+target only `failed` ids, not `skipped` ones — the latter are
+already done.  When `coord_client` is unavailable (session loaded
+but no HTTP client attached — a construction bug) every id goes to
+`failed` so the operator notices rather than getting a silent
+all-skipped response.
 
 ---
 
@@ -232,12 +219,12 @@ rather than getting a silent all-skipped response.
 
 - **Phase 6** shipped `cluster/ws/live` as the first Shape A endpoint
   (`{results, denied, truncated}`).
-- **Phase 7** shipped `stop_cascade` as the first Shape B endpoint
-  (`{cancelled, failed, skipped}`).
+- **Phase 7** introduced the Shape B cascade-mutation envelope
+  (`{<bucket>, failed, skipped}`) for the coordinator's
+  cancel-cascade path.
 - **Phase 8 PR A** shipped `spawn_batch` (Shape A, keyed by idx) and
-  `close_all_children` (Shape B, twin of `stop_cascade`), which
-  crystallised the two-shape-per-semantic-category policy codified
-  here.
+  `close_all_children` (Shape B), which crystallised the
+  two-shape-per-semantic-category policy codified here.
 
 Before adding a third shape, read this doc and argue for why the
 new surface doesn't fit either A or B.  Two idioms in the cluster

--- a/docs/coordinator-api-tour.md
+++ b/docs/coordinator-api-tour.md
@@ -18,7 +18,7 @@ schema changes.
 > auth and the `admin.coordinator` permission.  A session-scoped JWT
 > is minted per login (see [docs/oidc.md](oidc.md) / [docs/security.md](security.md));
 > a service token may call the read paths but destructive governance
-> paths (`/restrict`, `/stop_cascade`, `/close_all_children`) require
+> paths (`/restrict`, `/close_all_children`) require
 > the explicit `admin.coordinator` grant — a service-token owner
 > match isn't enough.
 
@@ -44,7 +44,6 @@ schema changes.
 | 6 | Wait for fan-out             | model-side tool `wait_for_workstream`                       |
 | 7 | Govern                       | `POST /v1/api/workstreams/{ws_id}/trust`                    |
 |   |                              | `POST /v1/api/workstreams/{ws_id}/restrict`                 |
-|   |                              | `POST /v1/api/workstreams/{ws_id}/stop_cascade`             |
 |   |                              | `POST /v1/api/workstreams/{ws_id}/close_all_children`       |
 | 8 | Approve / cancel             | `POST /v1/api/workstreams/{ws_id}/approve`                  |
 |   |                              | `POST /v1/api/workstreams/{ws_id}/cancel`                   |
@@ -53,7 +52,7 @@ schema changes.
 Refer to `/openapi.json` (Swagger UI at `/docs`) on any
 `turnstone-console` process for the authoritative operation ids and
 schemas. Coordinator-only verbs (`/children`, `/trust`, `/restrict`,
-`/stop_cascade`, `/close_all_children`) 404 against `kind=interactive`
+`/close_all_children`) 404 against `kind=interactive`
 rows; the shared verbs (`/send`, `/approve`, `/cancel`, `/events`,
 `/history`, `/open`, `/close`, etc.) work on both kinds.
 
@@ -261,10 +260,10 @@ rounds to a 10× token-efficiency win.
 
 ---
 
-## 7. Governance — trust, restrict, stop_cascade, close_all_children
+## 7. Governance — trust, restrict, close_all_children
 
-These four endpoints let an operator steer a live coordinator session
-mid-flight.  All four emit an audit event tagged
+These three endpoints let an operator steer a live coordinator session
+mid-flight.  All three emit an audit event tagged
 `coordinator.<action>` via the dedicated audit executor so a cascade
 burst can't starve audit writes.
 
@@ -294,28 +293,6 @@ idempotent — calling twice with overlapping lists converges to the
 union.  Revocations don't survive a session close/reopen; operators
 opt in per session.  Cap 256 tool names per request, 128 chars each.
 
-### `POST /stop_cascade` — cancel the subtree
-
-```http
-POST /v1/api/workstreams/{ws_id}/stop_cascade
-{}
-```
-
-Cancels the coordinator's in-flight generation AND dispatches
-`cancel_workstream` through the routing proxy for every direct
-child in the in-memory registry.  Returns:
-
-```json
-{"status": "ok", "cancelled": ["child-1", "child-3"], "failed": [], "skipped": ["child-2"]}
-```
-
-Response uses the [cascade-mutation bulk shape](bulk-endpoints.md):
-`cancelled` = accepted, `failed` = dispatch error worth retrying,
-`skipped` = upstream 404 (already gone — stale registry entry or
-the row was deleted between snapshot and dispatch).  Grandchildren
-aren't touched directly; they sit behind their parent's cancel and
-propagate via the child's SSE stream.
-
 ### `POST /close_all_children` — soft-close the direct fan-out
 
 ```http
@@ -329,16 +306,16 @@ Response:
 {"status": "ok", "closed": ["c-1", "c-2"], "failed": [], "skipped": []}
 ```
 
-Soft-close cascade bounded by the same semaphore as `stop_cascade`.
-The `reason` (up to 512 chars) propagates into each closed child's
-audit + `workstream_config` for postmortem.  Unlike `stop_cascade`
-this does NOT recurse into grandchildren — the model-facing tool
-that pairs with this endpoint asks for a bounded teardown of the
-coordinator's own fan-out.  For a full-subtree teardown, use
-`stop_cascade`.
+Soft-close cascade bounded by a concurrency semaphore.  The `reason`
+(up to 512 chars) propagates into each closed child's audit +
+`workstream_config` for postmortem.  The model-facing tool that
+pairs with this endpoint asks for a bounded teardown of the
+coordinator's own fan-out.  This *soft-closes*; to *cancel* the
+fan-out instead, cancel the coordinator (§8) — a coordinator cancel
+auto-cascades to its direct children.
 
-See [bulk-endpoints.md](bulk-endpoints.md) for why both endpoints
-share the cascade-mutation shape and how it differs from the
+See [bulk-endpoints.md](bulk-endpoints.md) for why `close_all_children`
+uses the cascade-mutation shape and how it differs from the
 `spawn_batch` / `cluster/ws/live` shape.
 
 ---
@@ -356,7 +333,10 @@ POST /v1/api/workstreams/{ws_id}/approve
 {"approved": true, "feedback": null, "always": true}    // always-approve this tool name
 ```
 
-`cancel` drops the in-flight generation but leaves the coordinator
+`cancel` drops the coordinator's in-flight generation and, for a
+coordinator, auto-cascades the cancel to its direct children:
+`cancel_workstream` is dispatched through the routing proxy for
+every direct child in the registry.  The coordinator itself is left
 idle and open for a fresh `send`:
 
 ```http
@@ -373,9 +353,10 @@ POST /v1/api/workstreams/{ws_id}/close
 {}
 ```
 
-Soft-closes the session — state persists, children keep running (use
-`close_all_children` or `stop_cascade` first to wind them down), the
-worker thread exits, SSE streams send a final `stream_end` and
+Soft-closes the session — state persists, children keep running
+(wind them down first with `close_all_children`, or by cancelling
+the coordinator, which cascades the cancel to its direct children),
+the worker thread exits, SSE streams send a final `stream_end` and
 disconnect.  The row is reopenable via
 `POST /v1/api/workstreams/{ws_id}/open` so long as it hasn't been
 deleted.
@@ -390,7 +371,7 @@ deleted.
 - [bulk-endpoints.md](bulk-endpoints.md) — the two bulk-shape
   idioms (`{results, denied, truncated}` vs
   `{<bucket>, failed, skipped}`) used by `cluster/ws/live`,
-  `spawn_batch`, `stop_cascade`, and `close_all_children`.
+  `spawn_batch`, and `close_all_children`.
 - [architecture.md](architecture.md) — cluster-wide architecture
   including how coordinator sessions fit next to node-hosted
   interactive workstreams.

--- a/docs/coordinator-skills.md
+++ b/docs/coordinator-skills.md
@@ -351,7 +351,7 @@ persona drift without a real LLM in the loop.
   `spawn_batch` and `close_all_children` use, so your skill can
   parse results / denied arrays correctly.
 - [governance.md](governance.md) — the broader governance surface
-  (`/trust`, `/restrict`, `/stop_cascade`, role-based permissions)
+  (`/trust`, `/restrict`, role-based permissions)
   that wraps every coord session.
 - [settings.md](settings.md) — `coordinator.model_alias` and
   `coordinator.reasoning_effort` settings that gate which LLM runs

--- a/tests/data/wire_payloads/anthropic_hoist__mid_orphan.json
+++ b/tests/data/wire_payloads/anthropic_hoist__mid_orphan.json
@@ -37,7 +37,7 @@
           "type": "tool_result"
         },
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_2",
           "type": "tool_result"

--- a/tests/data/wire_payloads/anthropic_hoist__native_orphan.json
+++ b/tests/data/wire_payloads/anthropic_hoist__native_orphan.json
@@ -33,7 +33,7 @@
     {
       "content": [
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_1",
           "type": "tool_result"

--- a/tests/data/wire_payloads/anthropic_hoist__trailing_orphan.json
+++ b/tests/data/wire_payloads/anthropic_hoist__trailing_orphan.json
@@ -24,7 +24,7 @@
     {
       "content": [
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_1",
           "type": "tool_result"

--- a/tests/data/wire_payloads/anthropic_native__mid_orphan.json
+++ b/tests/data/wire_payloads/anthropic_native__mid_orphan.json
@@ -37,7 +37,7 @@
           "type": "tool_result"
         },
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_2",
           "type": "tool_result"

--- a/tests/data/wire_payloads/anthropic_native__native_orphan.json
+++ b/tests/data/wire_payloads/anthropic_native__native_orphan.json
@@ -33,7 +33,7 @@
     {
       "content": [
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_1",
           "type": "tool_result"

--- a/tests/data/wire_payloads/anthropic_native__trailing_orphan.json
+++ b/tests/data/wire_payloads/anthropic_native__trailing_orphan.json
@@ -24,7 +24,7 @@
     {
       "content": [
         {
-          "content": "Tool execution was cancelled.",
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
           "is_error": true,
           "tool_use_id": "call_1",
           "type": "tool_result"

--- a/tests/data/wire_payloads/google__mid_orphan.json
+++ b/tests/data/wire_payloads/google__mid_orphan.json
@@ -33,7 +33,7 @@
       "tool_call_id": "call_1"
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_2"
     },

--- a/tests/data/wire_payloads/google__native_orphan.json
+++ b/tests/data/wire_payloads/google__native_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/google__trailing_orphan.json
+++ b/tests/data/wire_payloads/google__trailing_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/openai_chat__mid_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__mid_orphan.json
@@ -33,7 +33,7 @@
       "tool_call_id": "call_1"
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_2"
     },

--- a/tests/data/wire_payloads/openai_chat__native_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__native_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/openai_chat__trailing_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__trailing_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/openai_responses__mid_orphan.json
+++ b/tests/data/wire_payloads/openai_responses__mid_orphan.json
@@ -27,7 +27,7 @@
     },
     {
       "call_id": "call_2",
-      "output": "Tool execution was cancelled.",
+      "output": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "type": "function_call_output"
     },
     {

--- a/tests/data/wire_payloads/openai_responses__native_orphan.json
+++ b/tests/data/wire_payloads/openai_responses__native_orphan.json
@@ -21,7 +21,7 @@
     },
     {
       "call_id": "call_1",
-      "output": "Tool execution was cancelled.",
+      "output": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "type": "function_call_output"
     }
   ],

--- a/tests/data/wire_payloads/openai_responses__trailing_orphan.json
+++ b/tests/data/wire_payloads/openai_responses__trailing_orphan.json
@@ -16,7 +16,7 @@
     },
     {
       "call_id": "call_1",
-      "output": "Tool execution was cancelled.",
+      "output": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "type": "function_call_output"
     }
   ],

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -998,21 +998,55 @@ class TestCancelledAgentDisposition:
         assert "In flight at cancel: web_fetch" in out
         assert "UNKNOWN" in out
 
-    def test_partial_result_boundary_still_unknown(self, tmp_db):
-        # A SIGKILL'd bash appends a partial result before the next
-        # checkpoint raises — it is the boundary and must read UNKNOWN,
-        # not as a clean completion.
+    def test_unanswered_tool_is_in_flight_unknown(self, tmp_db):
+        # An output-flowing bash SIGKILL'd mid-stream raises (no result row) —
+        # it is the in-flight boundary and must read UNKNOWN, never completed.
         session = _make_session()
-        msgs = [self._assistant("t1", "bash"), self._result("t1", "(killed)")]
+        msgs = [self._assistant("t1", "bash")]  # issued, no result
         out = session._cancelled_agent_disposition(msgs, "task")
         assert "In flight at cancel: bash" in out
         assert "UNKNOWN" in out
         assert "Completed before cancel" not in out
 
-    def test_counts_and_not_started(self, tmp_db):
+    def test_all_answered_reports_completed_no_in_flight(self, tmp_db):
+        # Every issued call returned a result — cancel landed between turns,
+        # nothing in flight. Each result carries its own disposition; the
+        # summary just lists what completed, with no UNKNOWN boundary.
         session = _make_session()
-        # Two tool_calls in one turn: t1 ran, t2 cancelled before running,
-        # t3 (a later turn's call) is the in-flight boundary.
+        msgs = [self._assistant("t1", "bash"), self._result("t1", "(killed)")]
+        out = session._cancelled_agent_disposition(msgs, "task")
+        assert "Completed before cancel: bash." in out
+        assert "In flight at cancel" not in out
+
+    def test_boundary_is_first_unanswered_not_last(self, tmp_db):
+        # Regression (bug-1): a turn issues [bash, web_fetch] executed
+        # sequentially; cancel hits during bash (unanswered, side effects
+        # possible) and web_fetch never runs. The in-flight UNKNOWN must be
+        # bash (the FIRST gap), and web_fetch must read "not started" — NOT
+        # the inverse. The old code took the LAST issued call, labelling the
+        # never-run web_fetch UNKNOWN and the actually-in-flight bash "not
+        # started" — inviting a re-run of the destructive bash.
+        session = _make_session()
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "t1", "function": {"name": "bash"}},
+                    {"id": "t2", "function": {"name": "web_fetch"}},
+                ],
+            }
+        ]  # neither answered: bash raised mid-flight, web_fetch never ran
+        out = session._cancelled_agent_disposition(msgs, "task")
+        assert "In flight at cancel: bash" in out
+        assert "In flight at cancel: web_fetch" not in out
+        assert "Not started (cancelled first): web_fetch." in out
+
+    def test_counts_and_not_started(self, tmp_db):
+        # Turn 1 completes [bash, bash, read_file]; turn 2 issues
+        # [web_fetch (in flight), search (never ran)]. Exercises the ×N
+        # count summary, the first-gap boundary, and not-started.
+        session = _make_session()
         msgs = [
             {
                 "role": "assistant",
@@ -1020,14 +1054,25 @@ class TestCancelledAgentDisposition:
                 "tool_calls": [
                     {"id": "t1", "function": {"name": "bash"}},
                     {"id": "t2", "function": {"name": "bash"}},
+                    {"id": "t3", "function": {"name": "read_file"}},
                 ],
             },
             self._result("t1"),
-            self._assistant("t3", "search"),
+            self._result("t2"),
+            self._result("t3"),
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "t4", "function": {"name": "web_fetch"}},
+                    {"id": "t5", "function": {"name": "search"}},
+                ],
+            },
         ]
         out = session._cancelled_agent_disposition(msgs, "task")
-        assert "In flight at cancel: search" in out
-        assert "Not started (cancelled first): bash." in out
+        assert "Completed before cancel: bash×2, read_file." in out
+        assert "In flight at cancel: web_fetch" in out
+        assert "Not started (cancelled first): search." in out
 
     def test_exec_task_routes_cancel_to_disposition(self, tmp_db):
         """_exec_task converts a GenerationCancelled from _run_agent into the

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -888,8 +888,12 @@ class TestSynthesizeCancelledResults:
         # All emitted as errors so the live UI renders them as
         # ``coord-tool-row-result--error``.
         assert all(tr[3] is True for tr in ui.tool_results)
-        # Reason text propagates as the synthetic tool output.
-        assert all(tr[2] == "Cancelled by user." for tr in ui.tool_results)
+        # Reason text propagates as a prefix, now followed by an explicit
+        # UNKNOWN-outcome clause (unknown, never none — see HYPOTHESIS.md):
+        # the call may have begun executing before cancel, so the synthetic
+        # result must not read as "it didn't happen."
+        assert all(tr[2].startswith("Cancelled by user.") for tr in ui.tool_results)
+        assert all("UNKNOWN" in tr[2] for tr in ui.tool_results)
         # And the message list has the synthesized tool entries
         # (preserves the prior contract).
         tool_msgs = [m for m in dicts_from_turns(session.messages) if m.get("role") == "tool"]
@@ -952,3 +956,95 @@ class TestSynthesizeCancelledResults:
 
         tool_msgs = [m for m in dicts_from_turns(session.messages) if m.get("role") == "tool"]
         assert len(tool_msgs) == 1
+
+
+class TestCancelledAgentDisposition:
+    """A cancelled task_agent folds back an honest ledger, not a bare string.
+
+    Regression guard for the HYPOTHESIS.md cancellation appendix: ρ may
+    fabricate the acknowledgment but must not fabricate the outcome —
+    ``unknown``, never ``none``.
+    """
+
+    @staticmethod
+    def _assistant(call_id, name):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": call_id, "function": {"name": name}}],
+        }
+
+    @staticmethod
+    def _result(call_id, text="ok"):
+        return {"role": "tool", "tool_call_id": call_id, "content": text}
+
+    def test_no_actions_reports_no_side_effects(self, tmp_db):
+        session = _make_session()
+        out = session._cancelled_agent_disposition([], "task")
+        assert "no side effects" in out
+        assert "UNKNOWN" not in out
+
+    def test_marks_most_recent_action_unknown(self, tmp_db):
+        session = _make_session()
+        # bash completed; web_fetch was in flight (issued, no result yet).
+        msgs = [
+            self._assistant("t1", "bash"),
+            self._result("t1"),
+            self._assistant("t2", "web_fetch"),
+        ]
+        out = session._cancelled_agent_disposition(msgs, "task")
+        assert out != "(task interrupted by user)"
+        assert "Completed before cancel: bash." in out
+        assert "In flight at cancel: web_fetch" in out
+        assert "UNKNOWN" in out
+
+    def test_partial_result_boundary_still_unknown(self, tmp_db):
+        # A SIGKILL'd bash appends a partial result before the next
+        # checkpoint raises — it is the boundary and must read UNKNOWN,
+        # not as a clean completion.
+        session = _make_session()
+        msgs = [self._assistant("t1", "bash"), self._result("t1", "(killed)")]
+        out = session._cancelled_agent_disposition(msgs, "task")
+        assert "In flight at cancel: bash" in out
+        assert "UNKNOWN" in out
+        assert "Completed before cancel" not in out
+
+    def test_counts_and_not_started(self, tmp_db):
+        session = _make_session()
+        # Two tool_calls in one turn: t1 ran, t2 cancelled before running,
+        # t3 (a later turn's call) is the in-flight boundary.
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "t1", "function": {"name": "bash"}},
+                    {"id": "t2", "function": {"name": "bash"}},
+                ],
+            },
+            self._result("t1"),
+            self._assistant("t3", "search"),
+        ]
+        out = session._cancelled_agent_disposition(msgs, "task")
+        assert "In flight at cancel: search" in out
+        assert "Not started (cancelled first): bash." in out
+
+    def test_exec_task_routes_cancel_to_disposition(self, tmp_db):
+        """_exec_task converts a GenerationCancelled from _run_agent into the
+        honest disposition, reading the in-place-mutated agent_messages."""
+        session = _make_session()
+
+        def fake_run_agent(agent_messages, **kwargs):
+            agent_messages.append(self._assistant("t1", "bash"))
+            agent_messages.append(self._result("t1"))
+            agent_messages.append(self._assistant("t2", "web_fetch"))
+            raise GenerationCancelled()
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            call_id, result = session._exec_task({"call_id": "c1", "prompt": "do x"})
+
+        assert call_id == "c1"
+        assert result != "(task interrupted by user)"
+        assert "UNKNOWN" in result
+        assert "web_fetch" in result  # in-flight boundary
+        assert "bash" in result  # completed

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -984,9 +984,10 @@ class TestCancelledAgentDisposition:
         assert "no side effects" in out
         assert "UNKNOWN" not in out
 
-    def test_marks_most_recent_action_unknown(self, tmp_db):
+    def test_marks_in_flight_action_unknown(self, tmp_db):
         session = _make_session()
-        # bash completed; web_fetch was in flight (issued, no result yet).
+        # bash completed; web_fetch was in flight (issued, no result yet) —
+        # the first unanswered call is the in-flight boundary.
         msgs = [
             self._assistant("t1", "bash"),
             self._result("t1"),

--- a/tests/test_coordinator_close_all_children.py
+++ b/tests/test_coordinator_close_all_children.py
@@ -1,8 +1,7 @@
 """Tests for the coordinator ``close_all_children`` endpoint.
 
-Near-twin of the ``stop_cascade`` tests in
-``test_coordinator_governance.py``.  Keeps the close-cascade surface in
-its own file so PR A's review surface stays tight.
+Keeps the close-cascade surface in its own file so the review surface
+stays tight.
 """
 
 from __future__ import annotations
@@ -219,7 +218,7 @@ def test_close_all_children_404_when_session_not_loaded(storage):
 def test_close_all_children_service_token_cannot_bypass_admin_coordinator(storage):
     """Destructive endpoint — a service token matching the coord owner
     still needs the explicit ``admin.coordinator`` grant.  Mirrors the
-    stop_cascade treatment."""
+    ``restrict`` treatment."""
     mgr = _build_mgr(storage)
     coord = mgr.create(user_id="user-1", name="coord-a")
     coord.session = MagicMock()

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -1692,6 +1692,7 @@ def test_coord_cancel_cascades_to_children(storage):
     down the subtree).  The ``post_cancel`` hook fans ``coord_client.cancel``
     over the direct children after the coordinator's own session is
     cancelled."""
+    import json
     from unittest.mock import MagicMock
 
     from starlette.applications import Starlette
@@ -1720,6 +1721,7 @@ def test_coord_cancel_cascades_to_children(storage):
     handler = make_cancel_handler(cfg, post_cancel=_cascade_cancel_to_children)
     app = Starlette(routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])])
     app.state.coord_adapter = mgr._adapter
+    app.state.auth_storage = storage  # for the cascade audit (sec-2)
     app.add_middleware(_AuthMiddleware)
     client = TestClient(app)
 
@@ -1727,9 +1729,77 @@ def test_coord_cancel_cascades_to_children(storage):
     assert resp.status_code == 200
     # The coordinator's own session was cancelled (owner first)...
     coord.session.cancel.assert_called_once()
-    # ...and every direct child received a cancel (subtree propagation).
+    # ...and every direct child received a cancel (subtree propagation). The
+    # fan-out runs as the response BackgroundTask (perf-1: it does not block
+    # the cancel response); the TestClient drives it before returning.
     cascaded = {c.args[0] for c in coord_client.cancel.call_args_list}
     assert cascaded == {"child-1", "child-2"}
+    # sec-2: the cascade records a forensic audit row with the child lists.
+    events = [
+        e for e in storage.list_audit_events() if e["action"] == "coordinator.cancel_cascaded"
+    ]
+    assert len(events) == 1
+    assert set(json.loads(events[0]["detail"])["cancelled"]) == {"child-1", "child-2"}
+
+
+def test_coord_cancel_cascade_denied_for_service_token_without_grant(storage):
+    """sec-1 regression: the destructive subtree cascade is gated at
+    ``allow_service_bypass=False`` (the bar the removed stop_cascade held).
+    A service-scoped token without ``admin.coordinator`` can still cancel the
+    coordinator's own turn (the cancel route allows the service bypass) but
+    must NOT trigger the child cascade."""
+    from unittest.mock import MagicMock
+
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.console.server import _cascade_cancel_to_children
+    from turnstone.core.auth import AuthResult
+    from turnstone.core.session_routes import SessionEndpointConfig, make_cancel_handler
+
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="svc-user", name="coord-a")
+    _seed_children(mgr._adapter, coord.id, ["child-1", "child-2"])
+    coord_client = MagicMock()
+    coord_client.cancel.return_value = {"status": "ok"}
+    coord.session = MagicMock()
+    coord.session._coord_client = coord_client
+
+    class _ServiceAuth(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            request.state.auth_result = AuthResult(
+                user_id="svc-user",
+                scopes=frozenset({"read", "write", "approve", "service"}),
+                token_source="test",
+                permissions=frozenset(),  # NO admin.coordinator grant
+            )
+            return await call_next(request)
+
+    cfg = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=lambda r: (mgr, None),
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
+    handler = make_cancel_handler(cfg, post_cancel=_cascade_cancel_to_children)
+    app = Starlette(
+        routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])],
+        middleware=[Middleware(_ServiceAuth)],
+    )
+    app.state.coord_adapter = mgr._adapter
+    app.state.auth_storage = storage
+    client = TestClient(app)
+
+    resp = client.post(f"/v1/api/workstreams/{coord.id}/cancel", json={})
+    # Owner's own cancel still succeeds (cancel route allows the service bypass)…
+    assert resp.status_code == 200
+    coord.session.cancel.assert_called_once()
+    # …but the destructive cascade is withheld — no child was cancelled.
+    assert coord_client.cancel.call_count == 0
 
 
 def test_coord_cancel_cascade_failure_does_not_fail_owner_cancel(storage):

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -31,6 +31,7 @@ from tests._coord_test_helpers import (
     _build_mgr_with_factory,
     _fake_registry,
     _FakeConfigStore,
+    _seed_children,
 )
 from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.console.server import (
@@ -1683,6 +1684,89 @@ def test_cancel_idle_workstream_does_not_broadcast_approval_resolved(storage):
     while not listener.empty():
         seen_types.append(listener.get_nowait().get("type"))
     assert "approval_resolved" not in seen_types
+
+
+def test_coord_cancel_cascades_to_children(storage):
+    """Cancelling a coordinator auto-propagates the cancel down its
+    spawned subtree (HYPOTHESIS.md cancellation appendix: cancel flows
+    down the subtree).  The ``post_cancel`` hook fans ``coord_client.cancel``
+    over the direct children after the coordinator's own session is
+    cancelled."""
+    from unittest.mock import MagicMock
+
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.console.server import _cascade_cancel_to_children
+    from turnstone.core.session_routes import SessionEndpointConfig, make_cancel_handler
+
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    _seed_children(mgr._adapter, coord.id, ["child-1", "child-2"])
+
+    coord_client = MagicMock()
+    coord_client.cancel.return_value = {"status": "ok"}
+    coord.session = MagicMock()
+    coord.session._coord_client = coord_client
+
+    cfg = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=lambda r: (mgr, None),
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
+    handler = make_cancel_handler(cfg, post_cancel=_cascade_cancel_to_children)
+    app = Starlette(routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])])
+    app.state.coord_adapter = mgr._adapter
+    app.add_middleware(_AuthMiddleware)
+    client = TestClient(app)
+
+    resp = client.post(f"/v1/api/workstreams/{coord.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    # The coordinator's own session was cancelled (owner first)...
+    coord.session.cancel.assert_called_once()
+    # ...and every direct child received a cancel (subtree propagation).
+    cascaded = {c.args[0] for c in coord_client.cancel.call_args_list}
+    assert cascaded == {"child-1", "child-2"}
+
+
+def test_coord_cancel_cascade_failure_does_not_fail_owner_cancel(storage):
+    """A cascade error must not strand the owner half-cancelled: the
+    ``post_cancel`` exception is swallowed and the owner's cancel still
+    returns 200 (the owner's own session was already cancelled)."""
+    from unittest.mock import MagicMock
+
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from turnstone.core.session_routes import SessionEndpointConfig, make_cancel_handler
+
+    mgr = _build_mgr(storage)
+    coord = mgr.create(user_id="user-1", name="coord-a")
+    coord.session = MagicMock()
+
+    async def _boom(request, ws_id, ws):  # noqa: ARG001
+        raise RuntimeError("cascade blew up")
+
+    cfg = SessionEndpointConfig(
+        permission_gate=_require_admin_coordinator,
+        manager_lookup=lambda r: (mgr, None),
+        tenant_check=None,
+        not_found_label="coordinator not found",
+        audit_action_prefix="coordinator",
+    )
+    handler = make_cancel_handler(cfg, post_cancel=_boom)
+    app = Starlette(routes=[Route("/v1/api/workstreams/{ws_id}/cancel", handler, methods=["POST"])])
+    app.add_middleware(_AuthMiddleware)
+    client = TestClient(app)
+
+    resp = client.post(f"/v1/api/workstreams/{coord.id}/cancel", headers=_COORD_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    coord.session.cancel.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_governance.py
+++ b/tests/test_coordinator_governance.py
@@ -1,10 +1,10 @@
 """Tests for the coordinator governance endpoints and session hooks.
 
-Covers the three console endpoints that let an operator steer a live
-coordinator session mid-flight (``/trust``, ``/restrict``,
-``/stop_cascade``), the two ``ChatSession`` methods the endpoints
-toggle (``set_trust_send`` / ``revoke_tools``), the audit rows the
-handlers emit, and the ``_prepare_tool`` revocation gate.
+Covers the console endpoints that let an operator steer a live
+coordinator session mid-flight (``/trust``, ``/restrict``), the two
+``ChatSession`` methods the endpoints toggle (``set_trust_send`` /
+``revoke_tools``), the audit rows the handlers emit, and the
+``_prepare_tool`` revocation gate.
 """
 
 from __future__ import annotations
@@ -29,7 +29,6 @@ from tests._coord_test_helpers import (
 )
 from turnstone.console.server import (
     coordinator_restrict,
-    coordinator_stop_cascade,
     coordinator_trust,
 )
 from turnstone.core.auth import AuthResult
@@ -42,7 +41,7 @@ def storage(tmp_path):
 
 
 def _make_client(storage, *, coord_mgr, alias="my-model", registry=None) -> TestClient:
-    """Starlette app exposing only the three governance endpoints."""
+    """Starlette app exposing only the governance endpoints."""
     app = Starlette(
         routes=[
             Route(
@@ -53,11 +52,6 @@ def _make_client(storage, *, coord_mgr, alias="my-model", registry=None) -> Test
             Route(
                 "/v1/api/workstreams/{ws_id}/restrict",
                 coordinator_restrict,
-                methods=["POST"],
-            ),
-            Route(
-                "/v1/api/workstreams/{ws_id}/stop_cascade",
-                coordinator_stop_cascade,
                 methods=["POST"],
             ),
         ],
@@ -161,9 +155,9 @@ def _service_token_client(
     """Build a TestClient whose middleware injects a service-scoped token.
 
     Used to verify that the capability-escalating endpoints (``/trust``,
-    ``/restrict``, ``/stop_cascade``) do NOT honor the normal
-    ``require_permission`` service-scope bypass when the caller lacks
-    the specific grant they need.
+    ``/restrict``) do NOT honor the normal ``require_permission``
+    service-scope bypass when the caller lacks the specific grant they
+    need.
     """
     app = Starlette(
         routes=[
@@ -175,11 +169,6 @@ def _service_token_client(
             Route(
                 "/v1/api/workstreams/{ws_id}/restrict",
                 coordinator_restrict,
-                methods=["POST"],
-            ),
-            Route(
-                "/v1/api/workstreams/{ws_id}/stop_cascade",
-                coordinator_stop_cascade,
                 methods=["POST"],
             ),
         ],
@@ -271,25 +260,6 @@ def test_restrict_service_token_cannot_bypass_admin_coordinator(storage):
     resp = client.post(
         f"/v1/api/workstreams/{coord.id}/restrict",
         json={"revoke": ["bash"]},
-    )
-    assert resp.status_code == 403
-
-
-def test_stop_cascade_service_token_cannot_bypass_admin_coordinator(storage):
-    """/stop_cascade mirrors /restrict — same destructive treatment."""
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="svc-user", name="coord-a")
-    coord.session, _ = _make_session_mock()
-
-    client = _service_token_client(
-        storage,
-        mgr,
-        user_id="svc-user",
-        permissions=frozenset(),
-    )
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
     )
     assert resp.status_code == 403
 
@@ -633,137 +603,8 @@ def test_prepare_tool_allows_non_revoked_tool():
 
 
 # ---------------------------------------------------------------------------
-# /stop_cascade endpoint (item 5b)
+# children_snapshot (used by the cancel cascade + close_all_children)
 # ---------------------------------------------------------------------------
-
-
-def test_stop_cascade_cancels_coord_and_each_child(storage):
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="user-1", name="coord-a")
-    _seed_children(mgr._adapter, coord.id, ["child-1", "child-2", "child-3"])
-
-    def _cancel(wid: str) -> dict:
-        if wid == "child-2":
-            return {"error": "gateway_timeout", "status": 502}
-        return {"status": "ok"}
-
-    coord_client = MagicMock()
-    coord_client.cancel.side_effect = _cancel
-    coord.session = MagicMock()
-    coord.session._coord_client = coord_client
-
-    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
-        headers=_COORD_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert set(body["cancelled"] + body["failed"] + body["skipped"]) == {
-        "child-1",
-        "child-2",
-        "child-3",
-    }
-    assert body["failed"] == ["child-2"]
-    assert set(body["cancelled"]) == {"child-1", "child-3"}
-    assert body["skipped"] == []
-    assert coord_client.cancel.call_count == 3
-
-    events = [
-        e for e in storage.list_audit_events() if e["action"] == "coordinator.stopped_cascade"
-    ]
-    assert len(events) == 1
-    detail = json.loads(events[0]["detail"])
-    assert set(detail["cancelled"] + detail["failed"] + detail["skipped"]) == {
-        "child-1",
-        "child-2",
-        "child-3",
-    }
-
-
-def test_stop_cascade_routes_404_to_skipped_bucket(storage):
-    """A stale registry entry (child row already deleted from storage)
-    or an upstream-404 on cancel is semantically 'already gone', not a
-    dispatch failure.  Report it in ``skipped`` so operators can tell
-    them apart."""
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="user-1", name="coord-a")
-    _seed_children(mgr._adapter, coord.id, ["stale-child"])
-
-    coord_client = MagicMock()
-    coord_client.cancel.return_value = {
-        "error": "workstream not in coordinator subtree: stale-child",
-        "status": 404,
-    }
-    coord.session = MagicMock()
-    coord.session._coord_client = coord_client
-
-    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
-        headers=_COORD_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["cancelled"] == []
-    assert body["failed"] == []
-    assert body["skipped"] == ["stale-child"]
-
-
-def test_stop_cascade_empty_children_still_audits(storage):
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="user-1", name="coord-a")
-    coord.session = MagicMock()
-    coord.session._coord_client = MagicMock()
-
-    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
-        headers=_COORD_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body == {"status": "ok", "cancelled": [], "failed": [], "skipped": []}
-    assert [e for e in storage.list_audit_events() if e["action"] == "coordinator.stopped_cascade"]
-
-
-def test_stop_cascade_without_coord_client_marks_all_failed(storage):
-    """If the coord session has no attached coord_client (unexpected
-    state for a loaded session), every child routes to ``failed`` so
-    the operator can investigate."""
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="user-1", name="coord-a")
-    _seed_children(mgr._adapter, coord.id, ["child-a", "child-b"])
-    coord.session = MagicMock()
-    coord.session._coord_client = None
-
-    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
-        headers=_COORD_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["cancelled"] == []
-    assert body["skipped"] == []
-    assert set(body["failed"]) == {"child-a", "child-b"}
-
-
-def test_stop_cascade_404_when_session_not_loaded(storage):
-    mgr = _build_mgr(storage)
-    coord = mgr.create(user_id="user-1", name="coord-a")
-    coord.session = None
-    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
-    resp = client.post(
-        f"/v1/api/workstreams/{coord.id}/stop_cascade",
-        json={},
-        headers=_COORD_HEADERS,
-    )
-    assert resp.status_code == 404
 
 
 def test_children_snapshot_returns_copy_not_live_set(storage):

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -501,6 +501,29 @@ def test_wait_exec_dispatches_raw_args_to_client(coord_session):
     assert parsed["mode"] == "any"
 
 
+def test_wait_exec_progress_callback_observes_cancel(coord_session):
+    """The wait progress heartbeat is the cancel seam.  ``wait_for_workstream``
+    holds no cancel handle, so without this a cancelled coordinator parked in a
+    wait stays pinned for up to WAIT_MAX_TIMEOUT.  A GenerationCancelled raised
+    from the heartbeat callback propagates out of the (otherwise cancel-blind)
+    wait — _exec_wait_for_workstream's ``except Exception`` can't swallow it
+    (GenerationCancelled is a BaseException)."""
+    from turnstone.core.session import GenerationCancelled
+
+    sess, coord, _ui = coord_session
+
+    def _wait(ws_ids, *, timeout, mode, since, progress_callback):
+        # Simulate the wait loop's ~2s heartbeat firing after the owner cancels.
+        sess._cancel_event.set()
+        progress_callback({"a": {"state": "running"}}, 0.1)  # must raise
+        return {"results": {}, "complete": True, "elapsed": 0.1, "mode": mode}
+
+    coord.wait_for_workstream.side_effect = _wait
+    item = sess._prepare_tool(_tc("wait_for_workstream", {"ws_ids": ["a"]}))
+    with pytest.raises(GenerationCancelled):
+        sess._exec_wait_for_workstream(item)
+
+
 def test_wait_exec_default_timeout_when_omitted(coord_session):
     """timeout=None (omitted) becomes 60.0 in exec so the client receives
     a numeric value — explicit ``timeout=0`` is preserved (one-shot
@@ -1383,6 +1406,35 @@ def test_spawn_batch_exec_surfaces_per_item_errors_in_denied(coord_session):
     assert len(body["denied"]) == 1
     assert body["denied"][0]["idx"] == 1
     assert "skill not found" in body["denied"][0]["reason"]
+
+
+def test_spawn_batch_exec_stops_spawning_after_cancel(coord_session):
+    """A cancel mid-batch stops creating the REST of the children.  The
+    already-spawned child stays in ``results`` (it is a live remote
+    workstream); the remainder are marked not-spawned rather than created."""
+    sess, coord, _ui = coord_session
+
+    spawned: list[dict[str, Any]] = []
+
+    def _spawn(**kwargs):
+        n = len(spawned)
+        spawned.append(kwargs)
+        # Owner cancels right after the first child is created.
+        sess._cancel_event.set()
+        return {"ws_id": f"child-{n}", "name": "n", "node_id": "node", "status": 200}
+
+    coord.spawn.side_effect = _spawn
+    item = sess._prepare_tool(_tc("spawn_batch", {"children": _three_children()}))
+    _call_id, output = sess._exec_spawn_batch(item)
+    body = json.loads(output)
+
+    # Only the first child was actually spawned — the cancel halted the rest.
+    assert len(spawned) == 1
+    assert set(body["results"].keys()) == {"0"}
+    assert body["results"]["0"]["child_ws_id"] == "child-0"
+    # The remaining two are reported not-spawned (cancelled), not created.
+    cancelled = [d for d in body["denied"] if "cancelled" in d["reason"].lower()]
+    assert {d["idx"] for d in cancelled} == {1, 2}
 
 
 def test_spawn_batch_exec_continues_past_client_exception(coord_session):

--- a/tests/test_session_routes.py
+++ b/tests/test_session_routes.py
@@ -188,7 +188,6 @@ def test_register_coord_verbs_mounts_seven_paths() -> None:
             metrics=_stub,
             trust=_stub,
             restrict=_stub,
-            stop_cascade=_stub,
             close_all_children=_stub,
         ),
     )
@@ -199,7 +198,6 @@ def test_register_coord_verbs_mounts_seven_paths() -> None:
         ("/api/workstreams/{ws_id}/metrics", frozenset({"GET", "HEAD"})),
         ("/api/workstreams/{ws_id}/trust", frozenset({"POST"})),
         ("/api/workstreams/{ws_id}/restrict", frozenset({"POST"})),
-        ("/api/workstreams/{ws_id}/stop_cascade", frozenset({"POST"})),
         ("/api/workstreams/{ws_id}/close_all_children", frozenset({"POST"})),
     }
 

--- a/tests/test_session_worker.py
+++ b/tests/test_session_worker.py
@@ -189,6 +189,39 @@ def test_worker_finally_clears_flag_when_run_swallows() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_abandoned_worker_does_not_clear_successor_running_flag() -> None:
+    """A force-cancel abandons the worker (``ws.worker_thread`` is cleared /
+    reassigned to a successor).  When the abandoned thread finishes late, its
+    ``finally`` must NOT clear ``_worker_running`` out from under the live
+    successor — otherwise a third send sees ``_worker_running=False`` and
+    spawns a second concurrent worker on the same session."""
+    send_gate = threading.Event()
+    session = _SendSession(send_gate=send_gate)
+    ws = _make_ws(session)
+
+    ok = _send_message(ws, session, "hello")
+    assert ok is True
+    abandoned = ws.worker_thread
+    assert abandoned is not None
+
+    # Simulate force-abandon + a successor send claiming ownership while the
+    # original worker is still pinned inside run().
+    sentinel = threading.Thread(target=lambda: None, name="successor")
+    with ws._lock:
+        ws.worker_thread = sentinel
+        ws._worker_running = True
+
+    # Release the abandoned worker; it runs its finally.
+    send_gate.set()
+    abandoned.join(timeout=3.0)
+    assert not abandoned.is_alive()
+
+    # The successor's ownership is intact — the abandoned worker did not
+    # clobber the flag or the thread handle.
+    assert ws._worker_running is True
+    assert ws.worker_thread is sentinel
+
+
 def test_concurrent_send_produces_exactly_one_worker_thread() -> None:
     """Two simultaneous send() calls must land as exactly one worker
     spawn and one queued message — not two parallel workers on the

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -1349,33 +1349,6 @@ class CoordinatorRestrictResponse(BaseModel):
     revoked_tools: list[str] = Field(description="Full post-revocation set of revoked tool names.")
 
 
-class CoordinatorStopCascadeResponse(BaseModel):
-    """Response body for POST /v1/api/workstreams/{ws_id}/stop_cascade."""
-
-    status: str = Field(default="ok")
-    cancelled: list[str] = Field(
-        default_factory=list,
-        description="Child ws_ids that accepted the cancel dispatch.",
-    )
-    failed: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Child ws_ids whose cancel dispatch returned an error other "
-            "than an already-gone 404 — the cascade continues on per-"
-            "child failure so a single unreachable node doesn't abort "
-            "the whole batch."
-        ),
-    )
-    skipped: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Child ws_ids that returned 404 on cancel (already gone).  "
-            "Reported separately from ``failed`` so operators can "
-            "distinguish already-done from dispatch-broken."
-        ),
-    )
-
-
 class CoordinatorCloseAllChildrenRequest(BaseModel):
     """Body for POST /v1/api/workstreams/{ws_id}/close_all_children."""
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -35,7 +35,6 @@ from turnstone.api.console_schemas import (
     CoordinatorRestrictResponse,
     CoordinatorSendRequest,
     CoordinatorSendResponse,
-    CoordinatorStopCascadeResponse,
     CoordinatorTaskInfo,
     CoordinatorTasksResponse,
     CoordinatorTrustRequest,
@@ -1505,34 +1504,16 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         tags=["Coordinator"],
     ),
     EndpointSpec(
-        "/v1/api/workstreams/{ws_id}/stop_cascade",
-        "POST",
-        "Cancel the coordinator and every direct child",
-        description=(
-            "Cancels the coordinator's in-flight generation AND dispatches "
-            "``cancel_workstream`` through the routing proxy for every "
-            "direct child in the in-memory registry.  Grandchildren are "
-            "not touched directly — they sit behind their parent's cancel, "
-            "which propagates via the child's SSE stream.  Returns the "
-            "per-child disposition (``cancelled`` / ``failed``) so the UI "
-            "can show which children responded.  Writes "
-            "``coordinator.stopped_cascade`` with the two lists."
-        ),
-        response_model=CoordinatorStopCascadeResponse,
-        error_codes=[400, 403, 404, 503],
-        tags=["Coordinator"],
-    ),
-    EndpointSpec(
         "/v1/api/workstreams/{ws_id}/close_all_children",
         "POST",
         "Soft-close every direct child of the coordinator",
         description=(
             "Reads the in-memory child registry and dispatches "
             "``close_workstream`` via the routing proxy for every direct "
-            "child under a bounded (16-concurrency) semaphore.  Unlike "
-            "``stop_cascade`` this does not touch grandchildren — the "
-            "model-facing tool asks for a bounded teardown of its own "
-            "fan-out.  Returns ``{closed, failed, skipped}`` where "
+            "child under a bounded (16-concurrency) semaphore.  Soft-close "
+            "only — it does not touch grandchildren (the model-facing tool "
+            "asks for a bounded teardown of its own direct fan-out).  "
+            "Returns ``{closed, failed, skipped}`` where "
             "``skipped`` distinguishes already-gone (404) from dispatch-"
             "broken (``failed``).  The optional ``reason`` propagates to "
             "every closed child's audit + workstream_config.  Writes "
@@ -1618,7 +1599,6 @@ _ALL_MODELS: list[type[BaseModel]] = [
     CoordinatorRestrictResponse,
     CoordinatorSendRequest,
     CoordinatorSendResponse,
-    CoordinatorStopCascadeResponse,
     CoordinatorTaskInfo,
     CoordinatorTasksResponse,
     CoordinatorTrustRequest,

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -440,9 +440,9 @@ class CoordinatorAdapter:
     def children_snapshot(self, coord_ws_id: str) -> list[str]:
         """Return a snapshot of the coordinator's direct child ws_ids.
 
-        Used by ``stop_cascade`` to iterate children without holding
-        the registry lock during the per-child HTTP dispatch. A
-        mutation racing with the snapshot (child spawned mid-cascade)
+        Used by the cancel cascade and ``close_all_children`` to iterate
+        children without holding the registry lock during the per-child
+        HTTP dispatch. A mutation racing with the snapshot (child spawned mid-cascade)
         either lands before (cancelled) or after (out of scope for
         this batch) — both safe. Returns an empty list for unknown
         coordinators.

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -818,7 +818,7 @@ class CoordinatorClient:
     def close_all_children(self, reason: str = "") -> dict[str, Any]:
         """Soft-close every direct child of this coordinator (console-side fan-out).
 
-        Returns ``{closed, failed, skipped}`` — mirrors ``stop_cascade``.
+        Returns ``{closed, failed, skipped}``.
         The console does the Semaphore-bounded gather so the model-side
         tool call stays a single HTTP round-trip regardless of fan-out
         size.  No tenant guard here: ownership is enforced on the

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from sse_starlette import EventSourceResponse
 from starlette.applications import Starlette
+from starlette.background import BackgroundTask
 from starlette.middleware import Middleware
 from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
@@ -4132,46 +4133,80 @@ async def coordinator_restrict(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok", "revoked_tools": sorted(after)})
 
 
-async def _cascade_cancel_to_children(request: Request, ws_id: str, ws: Any) -> None:
+async def _cascade_cancel_to_children(
+    request: Request, ws_id: str, ws: Any
+) -> BackgroundTask | None:
     """Fan a coordinator's cancel out to its direct children.
 
     Wired into the coordinator cancel handler via ``post_cancel`` so that
     cancelling a coordinator propagates down its spawned subtree — the
     cancellation appendix's "cancel flows down the subtree."  The
     coordinator's own session is already cancelled by ``make_cancel_handler``
-    before this runs; here we only dispatch the per-child cancels via the
-    same ``children_snapshot`` + ``_fanout_on_children`` path the
-    ``close_all_children`` bulk verb uses.
+    before this runs; here we authorize + prepare the per-child fan-out and
+    hand it back as a ``BackgroundTask``.
 
-    Trigger, not drain: each child cancel is itself cooperative and
-    fire-and-forget (it sets the child's cancel flag and returns).  We do
-    not block on the subtree reaching a terminal state — that barrier is
-    deferred.  Children are one level deep today (a coordinator spawns only
-    interactive leaves), so the direct-child fan-out is the whole subtree.
+    Returns a ``BackgroundTask`` (run AFTER the 200 is sent) or ``None``.
+    Returning it rather than awaiting it inline is the "trigger, not drain"
+    contract: the owner's cancel response is never blocked on the child HTTP
+    round-trips (which can each hit a 30s timeout under a 16-wide semaphore).
+    Each child cancel is itself cooperative; we do not wait on the subtree
+    reaching a terminal state.  Children are one level deep today (a
+    coordinator spawns only interactive leaves), so the direct-child fan-out
+    is the whole subtree.
+
+    Authorization: the destructive subtree cancel is gated at
+    ``allow_service_bypass=False`` — matching the bar the removed
+    ``stop_cascade`` held and that ``/restrict`` / ``/close_all_children``
+    still use.  A plain cancel by an under-privileged service token still
+    cancels the coordinator's own turn (the handler already did that) but does
+    NOT cascade.
     """
+    if _require_admin_coordinator(request, allow_service_bypass=False) is not None:
+        log.debug("coordinator.cancel_cascade.skipped_unauthorized ws=%s", ws_id[:8])
+        return None
     coord_adapter = getattr(request.app.state, "coord_adapter", None)
     if coord_adapter is None:
-        return
+        return None
     child_ids = list(coord_adapter.children_snapshot(ws_id))
     if not child_ids:
-        return
+        return None
     session = getattr(ws, "session", None)
     coord_client: Any = getattr(session, "_coord_client", None) if session is not None else None
     if coord_client is None:
-        return
-    ok, failed, skipped = await _fanout_on_children(
-        child_ids,
-        coord_client,
-        lambda cid: coord_client.cancel(cid),
-        log_tag="coordinator_cancel_cascade",
-    )
-    log.info(
-        "coordinator.cancel_cascaded ws=%s cancelled=%d failed=%d skipped=%d",
-        ws_id[:8],
-        len(ok),
-        len(failed),
-        len(skipped),
-    )
+        return None
+    # Capture the audit inputs now, while the request is fresh — the task
+    # below runs after the response is sent.
+    storage, _storage_err = require_storage_or_503(request)
+    user_id = _auth_user_id(request)
+    client_host = request.client.host if request.client else ""
+
+    async def _run_cascade() -> None:
+        ok, failed, skipped = await _fanout_on_children(
+            child_ids,
+            coord_client,
+            lambda cid: coord_client.cancel(cid),
+            log_tag="coordinator_cancel_cascade",
+        )
+        # Restore the per-child forensic record the removed stop_cascade
+        # wrote (the coordinator's own cancel is audited separately).
+        if storage is not None:
+            await _emit_coord_audit(
+                storage,
+                user_id,
+                "coordinator.cancel_cascaded",
+                ws_id,
+                {"src": "coordinator", "cancelled": ok, "failed": failed, "skipped": skipped},
+                client_host,
+            )
+        log.info(
+            "coordinator.cancel_cascaded ws=%s cancelled=%d failed=%d skipped=%d",
+            ws_id[:8],
+            len(ok),
+            len(failed),
+            len(skipped),
+        )
+
+    return BackgroundTask(_run_cascade)
 
 
 _CLOSE_ALL_CHILDREN_MAX_REASON_LEN = 512

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3115,7 +3115,7 @@ def _require_admin_coordinator(
 ) -> JSONResponse | None:
     """Gate a coordinator endpoint on the ``admin.coordinator`` permission.
 
-    Destructive endpoints (/restrict, /stop_cascade) pass
+    Destructive endpoints (/restrict, /close_all_children) pass
     ``allow_service_bypass=False`` so a service-scoped caller whose
     ``user_id`` matches the coord owner still needs an explicit grant.
     """
@@ -3869,8 +3869,8 @@ async def coordinator_metrics(request: Request) -> JSONResponse:
 
 _RESTRICT_MAX_TOOLS = 256
 _RESTRICT_MAX_TOOL_NAME_LEN = 128
-# Bounded concurrency on bulk coordinator fan-out (stop_cascade,
-# close_all_children).  Upstream coord_client calls have a 30s timeout;
+# Bounded concurrency on bulk coordinator fan-out (close_all_children,
+# coordinator-cancel cascade).  Upstream coord_client calls have a 30s timeout;
 # a 100-child cascade at this cap finishes in ~200s worst case,
 # comfortably inside typical 300s proxy limits.
 _COORD_FANOUT_MAX_CONCURRENCY = 16
@@ -3926,8 +3926,8 @@ async def _fanout_on_children(
                 # silently no-op'd on placeholders; this keeps cascade
                 # behaviour parity with the pre-lift outcome.
                 # NOTE: this branch is reachable from the cancel-cascade
-                # caller (``stop_cascade``) but unreachable from the
-                # close-cascade caller (``close_all_children``); the
+                # caller (``_cascade_cancel_to_children``) but unreachable
+                # from the close-cascade caller (``close_all_children``); the
                 # close handler at ``session_routes.py:852-854`` 404s
                 # for both missing and already-closed-evicted rows and
                 # never emits a 400 "No session". Kept as shared code
@@ -4132,51 +4132,45 @@ async def coordinator_restrict(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok", "revoked_tools": sorted(after)})
 
 
-async def coordinator_stop_cascade(request: Request) -> JSONResponse:
-    """POST /v1/api/workstreams/{ws_id}/stop_cascade — cancel the subtree."""
-    resolved = await _resolve_coord_session(request, allow_service_bypass=False)
-    if isinstance(resolved, JSONResponse):
-        return resolved
-    session, storage, user_id, ws_id = resolved
+async def _cascade_cancel_to_children(request: Request, ws_id: str, ws: Any) -> None:
+    """Fan a coordinator's cancel out to its direct children.
 
-    coord_mgr, err503 = _require_coord_mgr(request)
-    if err503 is not None:
-        return err503  # pragma: no cover — _resolve_coord_session already gated this
+    Wired into the coordinator cancel handler via ``post_cancel`` so that
+    cancelling a coordinator propagates down its spawned subtree — the
+    cancellation appendix's "cancel flows down the subtree."  The
+    coordinator's own session is already cancelled by ``make_cancel_handler``
+    before this runs; here we only dispatch the per-child cancels via the
+    same ``children_snapshot`` + ``_fanout_on_children`` path the
+    ``close_all_children`` bulk verb uses.
+
+    Trigger, not drain: each child cancel is itself cooperative and
+    fire-and-forget (it sets the child's cancel flag and returns).  We do
+    not block on the subtree reaching a terminal state — that barrier is
+    deferred.  Children are one level deep today (a coordinator spawns only
+    interactive leaves), so the direct-child fan-out is the whole subtree.
+    """
     coord_adapter = getattr(request.app.state, "coord_adapter", None)
-
-    child_ids = list(coord_adapter.children_snapshot(ws_id)) if coord_adapter is not None else []
-    coord_mgr.cancel(ws_id)
-
-    coord_client: Any = getattr(session, "_coord_client", None)
-    # ``action`` is only called when coord_client is live — the helper
-    # short-circuits on None before invoking it.
-    cancelled, failed, skipped = await _fanout_on_children(
+    if coord_adapter is None:
+        return
+    child_ids = list(coord_adapter.children_snapshot(ws_id))
+    if not child_ids:
+        return
+    session = getattr(ws, "session", None)
+    coord_client: Any = getattr(session, "_coord_client", None) if session is not None else None
+    if coord_client is None:
+        return
+    ok, failed, skipped = await _fanout_on_children(
         child_ids,
         coord_client,
         lambda cid: coord_client.cancel(cid),
-        log_tag="coordinator_stop_cascade",
+        log_tag="coordinator_cancel_cascade",
     )
-
-    await _emit_coord_audit(
-        storage,
-        user_id,
-        "coordinator.stopped_cascade",
-        ws_id,
-        {
-            "src": "coordinator",
-            "cancelled": cancelled,
-            "failed": failed,
-            "skipped": skipped,
-        },
-        request.client.host if request.client else "",
-    )
-    return JSONResponse(
-        {
-            "status": "ok",
-            "cancelled": cancelled,
-            "failed": failed,
-            "skipped": skipped,
-        }
+    log.info(
+        "coordinator.cancel_cascaded ws=%s cancelled=%d failed=%d skipped=%d",
+        ws_id[:8],
+        len(ok),
+        len(failed),
+        len(skipped),
     )
 
 
@@ -4186,12 +4180,10 @@ _CLOSE_ALL_CHILDREN_MAX_REASON_LEN = 512
 async def coordinator_close_all_children(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/{ws_id}/close_all_children — soft-close the direct children.
 
-    Near-twin of ``coordinator_stop_cascade`` — both fan out over
-    ``children_snapshot`` via ``_fanout_on_children``.  Returns
-    ``{closed, failed, skipped}``.  Unlike ``stop_cascade``, this does
-    NOT recurse into grandchildren (the coordinator's model tool asks
-    for a bounded teardown of its own fan-out; operator-level cascade
-    stays behind ``stop_cascade``).
+    Fans out over ``children_snapshot`` via ``_fanout_on_children`` and
+    returns ``{closed, failed, skipped}``.  Soft-close only: this does NOT
+    recurse into grandchildren (the coordinator's model tool asks for a
+    bounded teardown of its own direct fan-out).
     """
     resolved = await _resolve_coord_session(request, allow_service_bypass=False)
     if isinstance(resolved, JSONResponse):
@@ -4953,8 +4945,8 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     app.state.dashboard_cache = _NodeDashboardCache()
     # Dedicated small executor for governance audit writes.  Without
     # this, audit dispatches share the default thread pool with
-    # ``coord_client.cancel`` calls from ``stop_cascade`` and any
-    # other ``asyncio.to_thread`` caller — a burst on one path can
+    # ``coord_client.cancel`` calls from the coordinator-cancel cascade
+    # and any other ``asyncio.to_thread`` caller — a burst on one path can
     # starve the other.  4 workers is ample headroom for
     # admin-driven audit traffic.
     audit_exec = ThreadPoolExecutor(max_workers=4, thread_name_prefix="coord-audit")
@@ -13030,6 +13022,10 @@ def create_app(
             cancel=make_cancel_handler(  # lifted: shared body
                 coord_endpoint_config,
                 audit_emit=_audit_cancel_coordinator,
+                # Auto-propagate: cancelling a coordinator fans the cancel
+                # out to its spawned children (see
+                # ``_cascade_cancel_to_children``).
+                post_cancel=_cascade_cancel_to_children,
             ),
             rewind=make_rewind_handler(  # lifted: shared body (#549)
                 coord_endpoint_config,
@@ -13059,7 +13055,6 @@ def create_app(
             metrics=coordinator_metrics,
             trust=coordinator_trust,
             restrict=coordinator_restrict,
-            stop_cascade=coordinator_stop_cascade,
             close_all_children=coordinator_close_all_children,
         ),
     )

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3928,12 +3928,12 @@ async def _fanout_on_children(
                 # behaviour parity with the pre-lift outcome.
                 # NOTE: this branch is reachable from the cancel-cascade
                 # caller (``_cascade_cancel_to_children``) but unreachable
-                # from the close-cascade caller (``close_all_children``); the
-                # close handler at ``session_routes.py:852-854`` 404s
-                # for both missing and already-closed-evicted rows and
-                # never emits a 400 "No session". Kept as shared code
-                # rather than gated by caller — the branch is cheap and
-                # the symmetry makes future cascade verbs easier to add.
+                # from the close-cascade caller (``close_all_children``):
+                # ``make_close_handler``'s not-found path 404s for both
+                # missing and already-closed-evicted rows and never emits a
+                # 400 "No session". Kept as shared code rather than gated by
+                # caller — the branch is cheap and the symmetry makes future
+                # cascade verbs easier to add.
                 if result.get("status") == 400 and result.get("error") == "No session":
                     return cid, "skipped"
                 return cid, "failed"

--- a/turnstone/core/audit.py
+++ b/turnstone/core/audit.py
@@ -11,8 +11,7 @@ Action-name conventions (non-exhaustive — grep
                         ``.cancel``) plus governance sub-prefixes
                         (``coordinator.trust.toggled``,
                         ``coordinator.send.auto_approved``,
-                        ``coordinator.restricted``,
-                        ``coordinator.stopped_cascade``).
+                        ``coordinator.restricted``).
 
     route.*             multi-node routing proxy hops
                         (``route.workstream.create`` / ``.send`` /

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -50,6 +50,16 @@ from typing import Any
 from turnstone.core import fence
 from turnstone.core.trajectory import Turn, dicts_from_turns
 
+# The "you cannot tell whether it ran" clause, shared by every cancel
+# disposition surface (this wire-repair fallback AND the session-layer
+# synthesis in ChatSession) so they can't drift apart.  Public so session.py
+# can import it rather than re-type the sentence — the new tests assert only
+# the ``UNKNOWN`` token, so silent wording drift would otherwise be invisible.
+UNOBSERVED_OUTCOME_CLAUSE = (
+    "Outcome UNKNOWN — this call may have begun executing before the generation "
+    "was stopped; do not assume it did not run, and reconcile before re-issuing it."
+)
+
 # The synthetic result body for a tool call that never produced output (the
 # last-resort wire-repair for an orphan the session layer didn't synthesize —
 # e.g. a force-abandoned worker).  The neutral turn carries ``is_error=True``;
@@ -57,11 +67,7 @@ from turnstone.core.trajectory import Turn, dicts_from_turns
 # the OpenAI-compatible lanes have no such field and drop it).  The body reads
 # outcome-UNKNOWN, matching the cooperative-cancel disposition: an unobserved
 # call must not read as "did not run" (unknown, never none).
-CANCELLED_TOOL_RESULT = (
-    "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun "
-    "executing before the generation was stopped; do not assume it did not run, "
-    "and reconcile before re-issuing it."
-)
+CANCELLED_TOOL_RESULT = f"Tool execution was cancelled. {UNOBSERVED_OUTCOME_CLAUSE}"
 
 
 def _find_orphaned_tool_calls(

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -50,11 +50,18 @@ from typing import Any
 from turnstone.core import fence
 from turnstone.core.trajectory import Turn, dicts_from_turns
 
-# The synthetic result body for a tool call that never produced output.  The
-# neutral turn carries ``is_error=True``; each translator renders that per its
-# format (Anthropic ``tool_result.is_error``; the OpenAI-compatible lanes have
-# no such field and drop it).
-CANCELLED_TOOL_RESULT = "Tool execution was cancelled."
+# The synthetic result body for a tool call that never produced output (the
+# last-resort wire-repair for an orphan the session layer didn't synthesize —
+# e.g. a force-abandoned worker).  The neutral turn carries ``is_error=True``;
+# each translator renders that per its format (Anthropic ``tool_result.is_error``;
+# the OpenAI-compatible lanes have no such field and drop it).  The body reads
+# outcome-UNKNOWN, matching the cooperative-cancel disposition: an unobserved
+# call must not read as "did not run" (unknown, never none).
+CANCELLED_TOOL_RESULT = (
+    "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun "
+    "executing before the generation was stopped; do not assume it did not run, "
+    "and reconcile before re-issuing it."
+)
 
 
 def _find_orphaned_tool_calls(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -54,6 +54,7 @@ from turnstone.core.history_decoration import (
 )
 from turnstone.core.log import get_logger
 from turnstone.core.lowering import (
+    UNOBSERVED_OUTCOME_CLAUSE,
     drop_empty_user_turns,
     fold_system_turns,
     repair_wire_messages,
@@ -4688,11 +4689,7 @@ class ChatSession:
         # appendix, HYPOTHESIS.md: unknown, never none).  ``is_error`` stays
         # True: it is genuinely not a successful result, and both the SSE
         # batch completion and the existing UI rendering key on it.
-        detail = (
-            f"{reason} Outcome UNKNOWN — this call may have begun executing "
-            "before the generation was stopped; do not assume it did not run, "
-            "and reconcile before re-issuing it."
-        )
+        detail = f"{reason} {UNOBSERVED_OUTCOME_CLAUSE}"
         # Synthesize results for unanswered tool_calls
         for tc in self.messages[assistant_idx].tool_calls:
             tc_id = tc.id
@@ -11912,10 +11909,12 @@ class ChatSession:
         — which causes a double-send as readily as a dropped record causes
         an orphan (cancellation appendix, HYPOTHESIS.md).  Instead we fold
         back the agent's actual ledger: which tool actions completed, which
-        never started, and an explicit ``UNKNOWN`` flag on the single most
-        recent action — the one that was crossing the gate / executing in
-        the tool when cancel landed, whose side effect may or may not have
-        landed and whose result was never observed.
+        never started, and an explicit ``UNKNOWN`` flag on the in-flight
+        action — the FIRST issued call without a result.  ``_run_agent``
+        executes a turn's tool_calls sequentially, so on cancel everything
+        before the first gap completed, the gap itself was executing (its
+        side effect may or may not have landed, its result never observed),
+        and everything after it never ran.
 
         Pure string assembly over the in-memory ``agent_messages`` — no
         model call, because we are on the cancel path and the gate is
@@ -11943,13 +11942,26 @@ class ChatSession:
                 counts[n] = counts.get(n, 0) + 1
             return ", ".join(f"{n}×{c}" if c > 1 else n for n, c in counts.items())
 
-        # The last action issued is the boundary: it was in flight (or about
-        # to run) when cancel was observed, so its outcome is unobserved.
-        # Mark it UNKNOWN rather than implying it did or did not happen.
-        boundary = issued[-1][0]
-        completed = [n for n, ans in issued[:-1] if ans]
-        not_run = [n for n, ans in issued[:-1] if not ans]
+        # The in-flight action is the FIRST issued call without a result.
+        # ``_run_agent`` runs a turn's tool_calls sequentially (cancel raises at
+        # the per-tool checkpoint, or mid-tool for a SIGKILL'd bash), so the
+        # first gap is the call that was executing when cancel landed:
+        # everything before it returned, everything after never started.
+        # (Taking the LAST issued call would invert unknown/none on a
+        # multi-call turn — labelling the never-run tail UNKNOWN and the
+        # actually-in-flight call "not started".)
+        first_gap = next((i for i, (_n, ans) in enumerate(issued) if not ans), None)
         parts = [f"({label} cancelled by user before completion)"]
+        if first_gap is None:
+            # Every issued call returned a result — cancel landed between
+            # turns, nothing in flight.  Each result already carries its own
+            # disposition (a SIGKILL'd tool's row reads UNKNOWN); just
+            # summarise what completed.
+            parts.append("Completed before cancel: " + _summ([n for n, _ in issued]) + ".")
+            return "\n".join(parts)
+        boundary = issued[first_gap][0]
+        completed = [n for n, _ in issued[:first_gap]]
+        not_run = [n for n, _ in issued[first_gap + 1 :]]
         if completed:
             parts.append("Completed before cancel: " + _summ(completed) + ".")
         parts.append(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -8484,6 +8484,19 @@ class ChatSession:
         denied: list[dict[str, Any]] = []
         for spec in children:
             idx = spec["idx"]
+            # A cancel mid-batch stops creating the REST of the children —
+            # don't keep spawning workstreams the owner asked to stop.
+            # Cooperative: observed at this safe point between spawns, never
+            # mid-spawn.  Children already spawned this batch stay in
+            # ``results`` and are reported below (their ws_ids must survive —
+            # they are live remote workstreams, also durably parent-linked in
+            # storage); the rest are marked not-spawned.  Checked with the
+            # raw flag, not ``_check_cancelled``, so we fall through to the
+            # normal report path rather than raising and dropping the
+            # already-spawned ws_ids.
+            if self._cancel_event.is_set():
+                denied.append({"idx": idx, "reason": "not spawned: cancelled"})
+                continue
             # Validation failures from _prepare surface here as denied
             # rows — partial-success: don't abort the rest of the batch.
             if "_error" in spec:
@@ -10434,6 +10447,16 @@ class ChatSession:
         progress_heartbeat_s = 5.0
 
         def _progress(snap: dict[str, Any], elapsed: float) -> None:
+            # Cooperative cancel seam.  ``wait_for_workstream`` holds no
+            # cancel handle and its wait loop blocks on the ChildEventBus
+            # (woken only by *child* state changes), so without this a
+            # cancelled coordinator parked in a wait stays pinned for up to
+            # WAIT_MAX_TIMEOUT (600s).  The loop calls this callback every
+            # ~2s heartbeat and wraps it in ``except Exception`` — but
+            # ``GenerationCancelled`` is a ``BaseException``, so raising
+            # here propagates cleanly out of the wait into the send() cancel
+            # handler.  ~2s abort instead of up to 600s.
+            self._check_cancelled()
             now = time.monotonic()
             changed = snap != progress_state["last_snap"]
             heartbeat_due = (now - progress_state["last_emit_mono"]) >= progress_heartbeat_s
@@ -11157,8 +11180,21 @@ class ChatSession:
             # Distinguish user cancel from unexpected SIGKILL.
             # Popen.returncode is negative of the signal number when killed.
             if cancel.is_set() and proc.returncode == -signal.SIGKILL:
-                msg = "Cancelled by user."
-                self._report_tool_result(call_id, "bash", msg)
+                # SIGKILL'd mid-flight (the command was parked on a silent
+                # read, so the in-loop cooperative check never fired).  Its
+                # side effects are unobserved: record outcome UNKNOWN and
+                # mark it an error, not a clean empty success — a destructive
+                # command killed here must not read as "did not run" on
+                # replay.  Keep whatever partial stdout we captured.
+                partial = "".join(stdout_parts).strip()
+                msg = (
+                    "Cancelled by user. Outcome UNKNOWN — the command was "
+                    "stopped mid-execution; it may have run partially or had "
+                    "side effects. Do not assume it did not run."
+                )
+                if partial:
+                    msg += "\n\nPartial output before cancel:\n" + self._truncate_output(partial)
+                self._report_tool_result(call_id, "bash", msg, is_error=True)
                 return call_id, msg
 
             output = "".join(stdout_parts)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4680,17 +4680,30 @@ class ChatSession:
             if msg.role is Role.TOOL:
                 answered_ids.add(msg.tool_call_id or "")
 
+        # An orphaned tool_call had no result when cancel landed.  We can't
+        # tell here whether it was mid-execution (outcome unobserved) or
+        # never started, so we mark it UNKNOWN rather than let the bare
+        # reason read as "it didn't happen" — which invites a re-send as
+        # readily as a dropped record causes an orphan (cancellation
+        # appendix, HYPOTHESIS.md: unknown, never none).  ``is_error`` stays
+        # True: it is genuinely not a successful result, and both the SSE
+        # batch completion and the existing UI rendering key on it.
+        detail = (
+            f"{reason} Outcome UNKNOWN — this call may have begun executing "
+            "before the generation was stopped; do not assume it did not run, "
+            "and reconcile before re-issuing it."
+        )
         # Synthesize results for unanswered tool_calls
         for tc in self.messages[assistant_idx].tool_calls:
             tc_id = tc.id
             func_name = tc.name
             if tc_id and tc_id not in answered_ids:
-                self.messages.append(Turn.tool(tc_id, reason, is_error=True))
+                self.messages.append(Turn.tool(tc_id, detail, is_error=True))
                 self._msg_tokens.append(1)
                 save_message(
                     self._ws_id,
                     "tool",
-                    reason,
+                    detail,
                     func_name,
                     tool_call_id=tc_id,
                     event_id=self._ui_event_id(),
@@ -4703,7 +4716,7 @@ class ChatSession:
                 # Defensive: we're already on a cancel/error path, so
                 # a UI hook failure must not compound the problem.
                 try:
-                    self.ui.on_tool_result(tc_id, func_name, reason, is_error=True)
+                    self.ui.on_tool_result(tc_id, func_name, detail, is_error=True)
                 except Exception:
                     log.debug(
                         "session.synthesize_cancelled.ui_emit_failed ws=%s",
@@ -11833,11 +11846,85 @@ class ChatSession:
                 auto_tools=TASK_AUTO_TOOLS,
                 agent_alias=item.get("model_override"),
             )
-        except (KeyboardInterrupt, GenerationCancelled):
+        except GenerationCancelled:
+            # Fold back an honest disposition built from the agent's own
+            # ledger.  ``agent_messages`` is mutated in place by
+            # ``_run_agent`` (it appends every assistant turn and tool
+            # result), so at this catch point it holds the full record of
+            # what the sub-agent did before cancel — including a partial
+            # result from a tool that was SIGKILL'd mid-flight.  The old
+            # bare "(task interrupted by user)" string discarded all of
+            # that and fabricated an *outcome*: downstream it read as
+            # "nothing happened" and invited a re-dispatch / double-send.
+            # See the cancellation appendix in HYPOTHESIS.md ("ρ may
+            # fabricate the acknowledgment but must not fabricate the
+            # outcome … unknown, never none").
+            return call_id, self._cancelled_agent_disposition(agent_messages, "task")
+        except KeyboardInterrupt:
+            # CLI Ctrl-C: keep the terse string and let the outer loop own
+            # propagation (unchanged behavior).
             return call_id, "(task interrupted by user)"
         except Exception as e:
             self.ui.on_info(f"[task error] {e}")
             return call_id, f"Task error: {e}"
+
+    def _cancelled_agent_disposition(self, agent_messages: list[dict[str, Any]], label: str) -> str:
+        """Build an honest, deterministic disposition for a cancelled sub-agent.
+
+        A cancelled agent must not report a fabricated *outcome*.  The bare
+        "(interrupted)" string read downstream as *the task did not happen*
+        — which causes a double-send as readily as a dropped record causes
+        an orphan (cancellation appendix, HYPOTHESIS.md).  Instead we fold
+        back the agent's actual ledger: which tool actions completed, which
+        never started, and an explicit ``UNKNOWN`` flag on the single most
+        recent action — the one that was crossing the gate / executing in
+        the tool when cancel landed, whose side effect may or may not have
+        landed and whose result was never observed.
+
+        Pure string assembly over the in-memory ``agent_messages`` — no
+        model call, because we are on the cancel path and the gate is
+        closed.  The owner (parent / coordinator) reads this to decide what,
+        if anything, to compensate.
+        """
+        answered: set[str] = set()
+        for m in agent_messages:
+            if m.get("role") == "tool" and m.get("tool_call_id"):
+                answered.add(str(m["tool_call_id"]))
+        # Ordered (name, was-answered) for every tool_call the agent issued.
+        issued: list[tuple[str, bool]] = []
+        for m in agent_messages:
+            if m.get("role") != "assistant":
+                continue
+            for tc in m.get("tool_calls") or []:
+                name = ((tc.get("function") or {}).get("name") or "tool").strip()
+                issued.append((name, str(tc.get("id") or "") in answered))
+        if not issued:
+            return f"({label} cancelled by user before any action — no side effects)"
+
+        def _summ(names: list[str]) -> str:
+            counts: dict[str, int] = {}
+            for n in names:
+                counts[n] = counts.get(n, 0) + 1
+            return ", ".join(f"{n}×{c}" if c > 1 else n for n, c in counts.items())
+
+        # The last action issued is the boundary: it was in flight (or about
+        # to run) when cancel was observed, so its outcome is unobserved.
+        # Mark it UNKNOWN rather than implying it did or did not happen.
+        boundary = issued[-1][0]
+        completed = [n for n, ans in issued[:-1] if ans]
+        not_run = [n for n, ans in issued[:-1] if not ans]
+        parts = [f"({label} cancelled by user before completion)"]
+        if completed:
+            parts.append("Completed before cancel: " + _summ(completed) + ".")
+        parts.append(
+            f"In flight at cancel: {boundary} — outcome UNKNOWN. It may have "
+            "completed, partially executed, or caused side effects before the "
+            "agent was stopped; its result was never observed. Do not assume "
+            "it did or did not happen — reconcile before re-running."
+        )
+        if not_run:
+            parts.append("Not started (cancelled first): " + _summ(not_run) + ".")
+        return "\n".join(parts)
 
     def _audit_memory_event(
         self,

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -42,6 +42,7 @@ from turnstone.core.log import get_logger
 from turnstone.core.session_ui_base import AutoApproveReason
 
 if TYPE_CHECKING:
+    from starlette.background import BackgroundTask
     from starlette.requests import Request
     from starlette.responses import Response
     from starlette.routing import BaseRoute
@@ -1092,11 +1093,14 @@ CancelAuditEmitter = Callable[
 
 # Optional async step run AFTER the workstream's own cancel sequence
 # (session.cancel + approval resolution + force/SSE + audit), receiving
-# ``(request, ws_id, ws)``.  Coordinator wires this to fan the cancel out
-# to its spawned children (auto-propagation down the subtree); interactive
-# wires ``None`` and the handler is unchanged.  Errors are logged, never
-# surfaced — a cascade failure must not fail the owner's own cancel.
-PostCancelHook = Callable[["Request", str, "Workstream"], Awaitable[None]]
+# ``(request, ws_id, ws)``.  Coordinator wires this to authorize + prepare the
+# cancel fan-out to its spawned children (auto-propagation down the subtree);
+# interactive wires ``None`` and the handler is unchanged.  It RETURNS a
+# ``BackgroundTask`` (or ``None``) which the handler attaches to its response,
+# so the actual per-child fan-out runs AFTER the 200 is sent — the owner's
+# cancel is never blocked on child HTTP.  Errors are logged, never surfaced —
+# a cascade failure must not fail the owner's own cancel.
+PostCancelHook = Callable[["Request", str, "Workstream"], Awaitable["BackgroundTask | None"]]
 
 
 def make_cancel_handler(
@@ -1305,12 +1309,14 @@ def make_cancel_handler(
 
         # Propagate the cancel down the subtree (coordinator only).  Runs
         # after the owner's own cancel is fully recorded so a cascade error
-        # can't strand the owner half-cancelled.  Cooperative/fire-and-forget
-        # per child — we dispatch the cancels, we don't block on the subtree
-        # draining (that barrier is deferred).
+        # can't strand the owner half-cancelled.  ``post_cancel`` authorizes
+        # and prepares the fan-out, returning a BackgroundTask we attach to the
+        # response: the per-child dispatch runs AFTER the 200 is sent, so the
+        # owner's cancel never blocks on child HTTP (and we don't drain).
+        cancel_background: BackgroundTask | None = None
         if post_cancel is not None:
             try:
-                await post_cancel(request, ws_id, ws)
+                cancel_background = await post_cancel(request, ws_id, ws)
             except Exception:
                 log.warning(
                     "ws.cancel.cascade_failed ws=%s",
@@ -1318,7 +1324,7 @@ def make_cancel_handler(
                     exc_info=True,
                 )
 
-        return JSONResponse({"status": "ok", "dropped": dropped})
+        return JSONResponse({"status": "ok", "dropped": dropped}, background=cancel_background)
 
     return cancel
 

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -16,9 +16,9 @@ Three registrar functions:
   All handlers in :class:`SharedSessionVerbHandlers` are optional;
   ``None`` skips the route, so one bundle describes either kind.
 - :func:`register_coord_verbs` — coord-only verbs (``trust``,
-  ``restrict``, ``stop_cascade``, ``close_all_children``,
-  ``children``, ``tasks``, ``metrics``) that read or mutate state
-  that doesn't exist on interactive workstreams.
+  ``restrict``, ``close_all_children``, ``children``, ``tasks``,
+  ``metrics``) that read or mutate state that doesn't exist on
+  interactive workstreams.
 
 Some verbs in :class:`SharedSessionVerbHandlers` ship as factory-
 returned closures (e.g. :func:`make_approve_handler`,
@@ -546,7 +546,6 @@ class CoordOnlyVerbHandlers:
     metrics: Handler  # GET  {prefix}/{ws_id}/metrics
     trust: Handler  # POST {prefix}/{ws_id}/trust
     restrict: Handler  # POST {prefix}/{ws_id}/restrict
-    stop_cascade: Handler  # POST {prefix}/{ws_id}/stop_cascade
     close_all_children: Handler  # POST {prefix}/{ws_id}/close_all_children
 
 
@@ -672,7 +671,6 @@ def register_coord_verbs(
     routes.append(Route(f"{p}/{{ws_id}}/metrics", handlers.metrics, methods=["GET"]))
     routes.append(Route(f"{p}/{{ws_id}}/trust", handlers.trust, methods=["POST"]))
     routes.append(Route(f"{p}/{{ws_id}}/restrict", handlers.restrict, methods=["POST"]))
-    routes.append(Route(f"{p}/{{ws_id}}/stop_cascade", handlers.stop_cascade, methods=["POST"]))
     routes.append(
         Route(
             f"{p}/{{ws_id}}/close_all_children",
@@ -1092,11 +1090,20 @@ CancelAuditEmitter = Callable[
     None,
 ]
 
+# Optional async step run AFTER the workstream's own cancel sequence
+# (session.cancel + approval resolution + force/SSE + audit), receiving
+# ``(request, ws_id, ws)``.  Coordinator wires this to fan the cancel out
+# to its spawned children (auto-propagation down the subtree); interactive
+# wires ``None`` and the handler is unchanged.  Errors are logged, never
+# surfaced — a cascade failure must not fail the owner's own cancel.
+PostCancelHook = Callable[["Request", str, "Workstream"], Awaitable[None]]
+
 
 def make_cancel_handler(
     cfg: SessionEndpointConfig,
     *,
     audit_emit: CancelAuditEmitter | None = None,
+    post_cancel: PostCancelHook | None = None,
 ) -> Handler:
     """Lifted body for ``POST {prefix}/{ws_id}/cancel``.
 
@@ -1292,6 +1299,21 @@ def make_cancel_handler(
                 # shouldn't surface as HTTP 500. Log + continue.
                 log.warning(
                     "ws.cancel.audit_failed ws=%s",
+                    ws_id[:8] if ws_id else "",
+                    exc_info=True,
+                )
+
+        # Propagate the cancel down the subtree (coordinator only).  Runs
+        # after the owner's own cancel is fully recorded so a cascade error
+        # can't strand the owner half-cancelled.  Cooperative/fire-and-forget
+        # per child — we dispatch the cancels, we don't block on the subtree
+        # draining (that barrier is deferred).
+        if post_cancel is not None:
+            try:
+                await post_cancel(request, ws_id, ws)
+            except Exception:
+                log.warning(
+                    "ws.cancel.cascade_failed ws=%s",
                     ws_id[:8] if ws_id else "",
                     exc_info=True,
                 )

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -86,7 +86,16 @@ def send(
             log.exception("session_worker.uncaught ws=%s", ws.id[:8])
         finally:
             with ws._lock:
-                ws._worker_running = False
+                # Only clear the flag if THIS thread is still the current
+                # worker.  A force-cancel abandons the worker
+                # (``ws.worker_thread = None``) and a follow-up send may
+                # already have spawned a successor (``ws.worker_thread`` =
+                # the new thread); an abandoned thread finishing late must
+                # not clear the flag out from under that live successor —
+                # else a third send sees ``_worker_running=False`` and
+                # spawns a second concurrent worker on the same session.
+                if ws.worker_thread is threading.current_thread():
+                    ws._worker_running = False
 
     with ws._lock:
         if ws._worker_running:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2187,7 +2187,14 @@ async def _interactive_create_post_install(
                 except Exception:
                     log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
                 with ws._lock:
-                    ws._worker_running = False
+                    # Only clear the flag if THIS thread is still the current
+                    # worker — a force-cancel abandons this thread and a
+                    # follow-up send may already have spawned a successor; an
+                    # abandoned initial-send worker finishing late must not
+                    # clobber that successor's running flag (mirrors the guard
+                    # in session_worker._runner).
+                    if ws.worker_thread is threading.current_thread():
+                        ws._worker_running = False
 
         # Inlined rather than via ``session_worker.send`` because at
         # workstream creation no live worker can exist by

--- a/turnstone/tools/close_all_children.json
+++ b/turnstone/tools/close_all_children.json
@@ -1,6 +1,6 @@
 {
   "name": "close_all_children",
-  "description": "Soft-close every direct child of this coordinator. Fans out close requests with bounded concurrency. Returns `{status, closed, failed, skipped}`. `skipped` holds 404s — covers both already-hard-deleted children (row purged) AND already-closed children whose in-memory session was evicted (row remains marked `state=closed`); the wire shape doesn't distinguish, so treat `skipped` as \"nothing to close\" rather than \"definitely deleted\". `failed` holds dispatch errors worth retrying. Indirect descendants (children of children) are NOT closed — run `stop_cascade` from the operator UI for a full-subtree teardown. The optional `reason` is propagated to every closed child's audit + workstream_config for postmortem (max 512 chars; over the cap returns a tool error).",
+  "description": "Soft-close every direct child of this coordinator. Fans out close requests with bounded concurrency. Returns `{status, closed, failed, skipped}`. `skipped` holds 404s — covers both already-hard-deleted children (row purged) AND already-closed children whose in-memory session was evicted (row remains marked `state=closed`); the wire shape doesn't distinguish, so treat `skipped` as \"nothing to close\" rather than \"definitely deleted\". `failed` holds dispatch errors worth retrying. The optional `reason` is propagated to every closed child's audit + workstream_config for postmortem (max 512 chars; over the cap returns a tool error).",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## What

Improves cancellation across task agents and coordinator workstreams so a cancelled run reports an **honest disposition** instead of an outcome-fabricating string, and an owner's cancel **propagates down the coordinator subtree**. Implements the discipline in the cancellation appendix of `HYPOTHESIS.md`: cooperative (never preemptive), fold back the real disposition, and *unknown*, never *none*.

## Why

A cancelled `task_agent` previously discarded its ledger and returned `(task interrupted by user)` — which reads downstream as *nothing happened* and invites a double-send as readily as a dropped record causes an orphan. And cancelling a coordinator didn't stop its spawned children at all.

## Changes (3 commits)

**1. Honest dispositions + subtree propagation + `stop_cascade` removal**
- `task_agent` (single + parallel): on cancel, fold back a deterministic ledger built from the agent's own in-memory history — actions completed, the in-flight action flagged outcome-`UNKNOWN`, not-started calls listed separately.
- Cancelling a coordinator auto-propagates the cancel to its direct children via a new `post_cancel` hook on the shared cancel handler.
- Removed the now-redundant `stop_cascade` operator endpoint (handler, route, OpenAPI spec/schema, tests, docs) — a plain coordinator cancel supersedes it.

**2. Self-cancel hardening** (from a completeness review of the workstream's *own* turn)
- `wait_for_workstream`: a cancelled coordinator parked in a wait now aborts in ~2s (was up to `WAIT_MAX_TIMEOUT` = 600s) via a cooperative check on the progress heartbeat.
- `spawn_batch` stops creating children once cancel is observed; already-spawned children stay recorded.
- Worker-identity guard so a force-abandoned worker finishing late can't clobber a live successor's running flag.
- bash silent-SIGKILL and the last-resort wire-repair orphan now read outcome-`UNKNOWN` (not a clean empty success / bland "cancelled").

**3. Code-review fixes** (multi-stage review of the branch)
- **security**: re-gate the destructive cascade at `allow_service_bypass=False` — restores the bar the removed `stop_cascade` held; a service token without `admin.coordinator` cancels its own turn but no longer cascades.
- **correctness**: disposition boundary is the *first unanswered* call (sequential execution), fixing an unknown/none inversion on multi-call turns.
- **performance**: the per-child cancel fan-out is returned as a response `BackgroundTask` so a cancel never blocks on slow/unreachable child HTTP (trigger, not drain).
- restored the per-child cascade audit row (`coordinator.cancel_cascaded`); applied the worker guard to a missed initial-send twin; deduped the shared disposition clause.

## Verification

- ruff + mypy clean across all changed source.
- ~660 tests pass across the affected suites, including new cancellation-disposition, cascade, worker-guard, and security-regression tests (the last replaces the deleted `stop_cascade` service-token guard).

## Deferred / follow-ups (non-blocking)

- MCP / `web_fetch` / `web_search` remain uninterruptible mid-call (bounded by `tool_timeout`, default 120s); only bash is truly preemptible.
- The generated `sdk/typescript/openapi-console.json` still lists `/stop_cascade` — it's frozen at `1.6.0a6` and regenerated out-of-band, so it's left to the normal regen cycle.
- A proposed **cancel / force-cancel collapse** (move the escalation policy server-side, drop the user-facing force flag) — discussed, not yet built.
