### PR TITLE
fix(tools): timed-out side-effecting tools read UNKNOWN, not a flat failure

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -958,6 +958,52 @@ class TestSynthesizeCancelledResults:
         assert len(tool_msgs) == 1
 
 
+class TestTimeoutDisposition:
+    """A tool stopped at its deadline has unobserved side effects, so its
+    result must read UNKNOWN — the same ``unknown, never none`` discipline as
+    cancellation (HYPOTHESIS.md effect-record appendix), applied to timeouts.
+    Read-only timeouts stay a plain failure: an idempotent read has nothing to
+    reconcile, and "reconcile before re-issuing" would be misleading there.
+    """
+
+    def test_bash_timeout_reads_unknown(self):
+        """A bash command is SIGKILL'd at its deadline — the same mid-flight
+        kill as cancel — so it may have run partially or had side effects and
+        must read UNKNOWN, not a flat 'timed out' that invites a blind re-run."""
+        session = _make_session(tool_timeout=1)
+        # Sleeps silently past the 1s deadline → watchdog SIGKILL → TimeoutExpired.
+        call_id, result = session._exec_bash({"call_id": "c1", "command": "sleep 30"})
+        assert call_id == "c1"
+        assert "timed out" in result.lower()
+        assert "UNKNOWN" in result
+
+    def test_mcp_tool_timeout_reads_unknown(self):
+        """An MCP tool is an opaque action — the server may have run it to
+        completion before we stopped waiting, so the outcome reads UNKNOWN."""
+        session = _make_session()
+        session._mcp_client = MagicMock()
+        session._mcp_client.call_tool_sync.side_effect = TimeoutError()
+        call_id, result = session._exec_mcp_tool(
+            {"call_id": "c1", "mcp_func_name": "send_email", "mcp_args": {}}
+        )
+        assert call_id == "c1"
+        assert "timed out" in result.lower()
+        assert "UNKNOWN" in result
+
+    def test_mcp_resource_read_timeout_stays_plain(self):
+        """A resource read is an idempotent read with nothing to reconcile, so
+        its timeout stays a plain failure — no UNKNOWN/reconcile advice."""
+        session = _make_session()
+        session._mcp_client = MagicMock()
+        session._mcp_client.read_resource_sync.side_effect = TimeoutError()
+        call_id, result = session._exec_read_resource(
+            {"call_id": "c1", "resource_uri": "file:///doc"}
+        )
+        assert call_id == "c1"
+        assert "timed out" in result.lower()
+        assert "UNKNOWN" not in result
+
+
 class TestCancelledAgentDisposition:
     """A cancelled task_agent folds back an honest ledger, not a bare string.
 

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -60,6 +60,20 @@ UNOBSERVED_OUTCOME_CLAUSE = (
     "was stopped; do not assume it did not run, and reconcile before re-issuing it."
 )
 
+# The timeout twin of UNOBSERVED_OUTCOME_CLAUSE.  A tool stopped at its deadline
+# was killed (bash is SIGKILL'd) or abandoned (an MCP action the server may still
+# be running) mid-flight, so its side effects are as unobserved as a cancelled
+# call's — the same "unknown, never none" discipline, a different cause.  Only
+# side-effecting tools use it: read-only timeouts (search, MCP resource/prompt
+# reads) stay a plain "timed out", because an idempotent read has nothing to
+# reconcile and "reconcile before re-issuing" would be misleading there.  Shared
+# (so bash and MCP can't drift) and asserted by the UNKNOWN token in tests.
+TIMEOUT_OUTCOME_CLAUSE = (
+    "Outcome UNKNOWN — the call was stopped at its deadline; it may have run "
+    "partially or had side effects, so do not assume it did not run, and "
+    "reconcile before re-issuing it."
+)
+
 # The synthetic result body for a tool call that never produced output (the
 # last-resort wire-repair for an orphan the session layer didn't synthesize —
 # e.g. a force-abandoned worker).  The neutral turn carries ``is_error=True``;

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -54,6 +54,7 @@ from turnstone.core.history_decoration import (
 )
 from turnstone.core.log import get_logger
 from turnstone.core.lowering import (
+    TIMEOUT_OUTCOME_CLAUSE,
     UNOBSERVED_OUTCOME_CLAUSE,
     drop_empty_user_turns,
     fold_system_turns,
@@ -10884,7 +10885,12 @@ class ChatSession:
                 is_interactive_for_consent=self._is_interactive_for_consent,
             )
         except TimeoutError:
-            output = f"MCP tool timed out after {self.tool_timeout}s"
+            # An MCP tool is an opaque action — the server may have run it to
+            # completion before we stopped waiting, so the outcome is unobserved.
+            # Read UNKNOWN, never none (HYPOTHESIS.md effect-record appendix).
+            # Resource/prompt reads below stay plain: they are idempotent reads
+            # with nothing to reconcile.
+            output = f"MCP tool timed out after {self.tool_timeout}s. {TIMEOUT_OUTCOME_CLAUSE}"
             mcp_error = True
             self.ui.on_error(output)
         except Exception as e:
@@ -11216,7 +11222,16 @@ class ChatSession:
             return call_id, output if output else "(no output)"
 
         except subprocess.TimeoutExpired:
-            msg = f"Command timed out after {timeout}s"
+            # The watchdog SIGKILL'd the command at its deadline — the same
+            # mid-flight kill as the cooperative-cancel branch above, so its
+            # side effects are equally unobserved.  Read UNKNOWN, never a flat
+            # failure that invites a blind re-run (HYPOTHESIS.md effect-record
+            # appendix: unknown, never none).  Keep any partial stdout captured
+            # before the kill, exactly as the cancel path does.
+            msg = f"Command timed out after {timeout}s. {TIMEOUT_OUTCOME_CLAUSE}"
+            partial = "".join(stdout_parts).strip()
+            if partial:
+                msg += "\n\nPartial output before timeout:\n" + self._truncate_output(partial)
             self._report_tool_result(call_id, "bash", msg, is_error=True)
             return call_id, msg
         except Exception as e:


### PR DESCRIPTION
## Problem

A timed-out **bash** command is SIGKILL'd at its deadline (`_exec_bash`), and a timed-out **MCP tool** call is abandoned while the server may still be acting (`_exec_mcp_tool`). Both leave side effects exactly as unobserved as a cancelled call — yet both read as a definitive `"timed out after Ns"`.

That is the conflation the effect-record appendix of `HYPOTHESIS.md` warns about: an unobserved outcome that reads as a definite one invites a blind re-run (a double-send) just as readily as a dropped record invites an orphan. Same bug, opposite sign. The cancel path already gets this right (`Outcome UNKNOWN …`); the timeout path did not.

## Fix

- **`TIMEOUT_OUTCOME_CLAUSE`** (new, in `lowering.py`) — the timeout twin of `UNOBSERVED_OUTCOME_CLAUSE`, shared so bash and MCP can't drift and asserted by the `UNKNOWN` token in tests.
- **bash + MCP-tool timeouts** now read `Outcome UNKNOWN … do not assume it did not run, and reconcile before re-issuing it`. bash also keeps any partial stdout captured before the kill, mirroring the cancel path.

## Deliberate scope: side effects, not observation

The five `"timed out"` sites split by whether the call can have a side effect to reconcile:

| Tool | Timeout reads | Why |
|---|---|---|
| bash | **UNKNOWN** | SIGKILL'd mid-flight; may have run partially / had effects |
| MCP tool call | **UNKNOWN** | opaque action; server may have completed it |
| search | plain | local read; nothing to reconcile |
| MCP resource read | plain | idempotent read |
| MCP prompt fetch | plain | idempotent read |

A timed-out idempotent read has nothing to reconcile, so `reconcile before re-issuing` would be misleading advice there. The `test_mcp_resource_read_timeout_stays_plain` test locks in that asymmetry.

## Tests

New `TestTimeoutDisposition` in `tests/test_cancel.py`: bash-timeout → UNKNOWN, MCP-tool-timeout → UNKNOWN, MCP-resource-read-timeout → stays plain.

- ruff + mypy clean (strict)
- `test_cancel` (44, 3 new), `test_mcp_pool_auth_introspection` (46), and the bash/timeout/search subset of `test_session` (31) all pass.

## Context

This is the timeout sibling of the cooperative-cancellation honest-disposition work, and the same `unknown, never none` discipline from the `HYPOTHESIS.md` effect-record appendix. A follow-on (Tier 2) would promote that distinction out of the result's free text into a typed `status` discriminator on the effect record, plus a reversibility mark the gate can read — left out of scope here.
