### PR TITLE
feat(effect-status): type tool dispositions, not just prose

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,6 +1,7 @@
 """Tests for generation cancellation (cooperative cancel via threading.Event)."""
 
 import contextlib
+import json
 import threading
 import time
 from dataclasses import dataclass, field
@@ -8,8 +9,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from turnstone.core.session import ChatSession, GenerationCancelled, _CancelRef
-from turnstone.core.trajectory import dicts_from_turns, turn_from_dict
+from turnstone.core.session import (
+    ChatSession,
+    GenerationCancelled,
+    _CancelRef,
+    _effect_status_meta,
+)
+from turnstone.core.trajectory import EffectStatus, Role, dicts_from_turns, turn_from_dict
 
 
 class NullUI:
@@ -898,6 +904,9 @@ class TestSynthesizeCancelledResults:
         # (preserves the prior contract).
         tool_msgs = [m for m in dicts_from_turns(session.messages) if m.get("role") == "tool"]
         assert len(tool_msgs) == 2
+        # Typed twin of the prose (Thread A): each synthesized turn is UNKNOWN.
+        tool_turns = [m for m in session.messages if m.role is Role.TOOL]
+        assert tool_turns and all(t.effect_status is EffectStatus.UNKNOWN for t in tool_turns)
 
     def test_skips_calls_already_answered(self, tmp_db):
         ui = self._ui_with_tool_result_tracking()
@@ -976,6 +985,8 @@ class TestTimeoutDisposition:
         assert call_id == "c1"
         assert "timed out" in result.lower()
         assert "UNKNOWN" in result
+        # Typed twin of the prose (Thread A): the producer records UNKNOWN.
+        assert session._tool_status.get("c1") is EffectStatus.UNKNOWN
 
     def test_mcp_tool_timeout_reads_unknown(self):
         """An MCP tool is an opaque action — the server may have run it to
@@ -989,10 +1000,12 @@ class TestTimeoutDisposition:
         assert call_id == "c1"
         assert "timed out" in result.lower()
         assert "UNKNOWN" in result
+        assert session._tool_status.get("c1") is EffectStatus.UNKNOWN
 
     def test_mcp_resource_read_timeout_stays_plain(self):
         """A resource read is an idempotent read with nothing to reconcile, so
-        its timeout stays a plain failure — no UNKNOWN/reconcile advice."""
+        its timeout stays a plain failure — no UNKNOWN/reconcile advice and no
+        typed status."""
         session = _make_session()
         session._mcp_client = MagicMock()
         session._mcp_client.read_resource_sync.side_effect = TimeoutError()
@@ -1002,6 +1015,7 @@ class TestTimeoutDisposition:
         assert call_id == "c1"
         assert "timed out" in result.lower()
         assert "UNKNOWN" not in result
+        assert session._tool_status.get("c1") is None
 
 
 class TestCancelledAgentDisposition:
@@ -1023,6 +1037,24 @@ class TestCancelledAgentDisposition:
     @staticmethod
     def _result(call_id, text="ok"):
         return {"role": "tool", "tool_call_id": call_id, "content": text}
+
+    def test_status_none_when_no_actions(self):
+        """Typed twin of the disposition: a task cancelled before any action is
+        NONE, not UNKNOWN — the complement of the in-flight case."""
+        session = _make_session()
+        assert session._cancelled_agent_status([]) is EffectStatus.NONE
+
+    def test_status_unknown_when_in_flight(self):
+        session = _make_session()
+        msgs = [self._assistant("t1", "bash")]  # issued, no result → in flight
+        assert session._cancelled_agent_status(msgs) is EffectStatus.UNKNOWN
+
+    def test_status_partial_when_all_answered(self):
+        """Every issued call returned but the agent was stopped before finishing
+        — effects are known (not UNKNOWN) yet the task is incomplete: PARTIAL."""
+        session = _make_session()
+        msgs = [self._assistant("t1", "bash"), self._result("t1")]
+        assert session._cancelled_agent_status(msgs) is EffectStatus.PARTIAL
 
     def test_no_actions_reports_no_side_effects(self, tmp_db):
         session = _make_session()
@@ -1140,3 +1172,58 @@ class TestCancelledAgentDisposition:
         assert "UNKNOWN" in result
         assert "web_fetch" in result  # in-flight boundary
         assert "bash" in result  # completed
+        # Thread A: the task call's typed status is UNKNOWN (web_fetch in flight).
+        assert session._tool_status.get("c1") is EffectStatus.UNKNOWN
+
+
+class TestEffectStatusPersistence:
+    """Typed effect status rides the role-exclusive ``meta`` column and
+    round-trips through ``reconstruct_turns`` without disturbing the SYSTEM
+    ``source_meta`` that shares the column (no migration; HYPOTHESIS.md
+    effect-record appendix — the ledger persists for audit)."""
+
+    def test_effect_status_meta_envelope(self):
+        assert _effect_status_meta(None) is None
+        assert json.loads(_effect_status_meta(EffectStatus.UNKNOWN)) == {"effect_status": "unknown"}
+
+    def test_reconstruct_routes_tool_effect_status(self):
+        from turnstone.core.storage._utils import reconstruct_turns
+
+        # row: (id, role, content, tool_name, tc_id, provider_data,
+        #       tool_calls, source, event_id, is_error, meta)
+        tool_row = (
+            1,
+            "tool",
+            "timed out. Outcome UNKNOWN ...",
+            None,
+            "call_a",
+            None,
+            None,
+            None,
+            None,
+            True,
+            json.dumps({"effect_status": "unknown"}),
+        )
+        turns = reconstruct_turns([tool_row], "ws1")
+        assert turns[0].effect_status is EffectStatus.UNKNOWN
+        assert turns[0].is_error is True
+
+    def test_reconstruct_leaves_system_source_meta_untouched(self):
+        from turnstone.core.storage._utils import reconstruct_turns
+
+        sys_row = (
+            2,
+            "system",
+            "watch fired",
+            None,
+            None,
+            None,
+            None,
+            "watch_triggered",
+            None,
+            False,
+            json.dumps({"watch_name": "x"}),
+        )
+        turns = reconstruct_turns([sys_row], "ws1")
+        assert turns[0].meta.extra.get("source_meta") == {"watch_name": "x"}
+        assert turns[0].effect_status is None

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -126,6 +126,9 @@ def test_repair_synthesizes_trailing_orphan() -> None:
         "tool_call_id": "c1",
         "content": CANCELLED_TOOL_RESULT,
         "is_error": True,
+        # The unobserved synth carries the typed disposition (wire-invisible
+        # side channel, stripped by the translator before the provider wire).
+        "_effect_status": "unknown",
     }
 
 

--- a/tests/test_session_mcp_dispatch_error.py
+++ b/tests/test_session_mcp_dispatch_error.py
@@ -105,7 +105,11 @@ def _record_outputs(session) -> list[tuple[str, str, str, bool]]:
     """Patch ``_report_tool_result`` to capture (call_id, name, output, is_error)."""
     captures: list[tuple[str, str, str, bool]] = []
 
-    def _capture(call_id: str, name: str, output: str, *, is_error: bool = False) -> None:
+    def _capture(
+        call_id: str, name: str, output: str, *, is_error: bool = False, **_: object
+    ) -> None:
+        # ``**_`` swallows the typed ``status`` kwarg (and any future ones) so
+        # the stub stays signature-compatible with ``_report_tool_result``.
         captures.append((call_id, name, output, is_error))
 
     session._report_tool_result = _capture  # type: ignore[method-assign]

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 from typing import Any
 
 from turnstone.core import fence
-from turnstone.core.trajectory import Turn, dicts_from_turns
+from turnstone.core.trajectory import EffectStatus, Turn, dicts_from_turns
 
 # The "you cannot tell whether it ran" clause, shared by every cancel
 # disposition surface (this wire-repair fallback AND the session-layer
@@ -147,7 +147,12 @@ def repair_wire_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
     # highest down so each splice can't shift an as-yet-unused lower position.
     for insert_at, ids in sorted(orphans, key=lambda pair: pair[0], reverse=True):
         synthetic = dicts_from_turns(
-            [Turn.tool(uid, CANCELLED_TOOL_RESULT, is_error=True) for uid in ids]
+            [
+                Turn.tool(
+                    uid, CANCELLED_TOOL_RESULT, is_error=True, effect_status=EffectStatus.UNKNOWN
+                )
+                for uid in ids
+            ]
         )
         out[insert_at:insert_at] = synthetic
     return out

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -134,6 +134,7 @@ from turnstone.core.tools import (
     merge_mcp_tools,
 )
 from turnstone.core.trajectory import (
+    EffectStatus,
     Role,
     Turn,
     dicts_from_turns,
@@ -910,6 +911,14 @@ def _notify_auth_headers() -> dict[str, str]:
     return header
 
 
+def _effect_status_meta(status: EffectStatus | None) -> str | None:
+    """Serialize a tool effect status to the ``conversations.meta`` JSON
+    envelope. Role-exclusive with ``source_meta`` (which rides SYSTEM turns),
+    so a tool row's meta column holds only ``{"effect_status": ...}``; the
+    decode + role routing lives in ``reconstruct_turns``. ``None`` → no meta."""
+    return json.dumps({"effect_status": status.value}) if status is not None else None
+
+
 # ---------------------------------------------------------------------------
 # ChatSession — the core engine
 # ---------------------------------------------------------------------------
@@ -1138,6 +1147,10 @@ class ChatSession:
         self._repeat_detector = RepeatDetector()
         # Tool error tracking: call_id → is_error for message persistence
         self._tool_error_flags: dict[str, bool] = {}
+        # Typed effect disposition: call_id → EffectStatus, set by the producer
+        # (only for non-ordinary outcomes — e.g. UNKNOWN on a timeout/cancel)
+        # and popped at the fold; same lifecycle as ``_tool_error_flags``.
+        self._tool_status: dict[str, EffectStatus] = {}
         # Cooperative cancellation: set from outside to stop generation
         self._cancel_event = threading.Event()
         self._cancel_ref: _CancelRef = _CancelRef(self)  # provider appends SDK stream here
@@ -2345,10 +2358,18 @@ class ChatSession:
         output: str,
         *,
         is_error: bool = False,
+        status: EffectStatus | None = None,
     ) -> None:
-        """Notify the UI and record error flag for message persistence."""
+        """Notify the UI and record error flag for message persistence.
+
+        ``status`` is the typed effect disposition (HYPOTHESIS.md effect-record
+        appendix), set only for non-ordinary outcomes — UNKNOWN on a timeout or
+        mid-flight cancel — and folded onto the persisted tool turn. ``None``
+        leaves the turn unclassified (the ordinary case)."""
         if is_error:
             self._tool_error_flags[call_id] = True
+        if status is not None:
+            self._tool_status[call_id] = status
         self.ui.on_tool_result(call_id, name, output, is_error=is_error)
 
     def _ui_event_id(self) -> int | None:
@@ -4484,6 +4505,9 @@ class ChatSession:
                     tool_is_error = self._tool_error_flags.pop(tc_id, False)
                     if tool_is_error:
                         tool_msg["is_error"] = True
+                    tool_status = self._tool_status.pop(tc_id, None)
+                    if tool_status is not None:
+                        tool_msg["_effect_status"] = tool_status.value
                     self.messages.append(turn_from_dict(tool_msg))
 
                     # Token estimation — image content uses a fixed heuristic
@@ -4525,6 +4549,7 @@ class ChatSession:
                         tool_call_id=tc_id,
                         event_id=self._ui_event_id(),
                         is_error=tool_is_error,
+                        meta=_effect_status_meta(tool_status),
                     )
                     if tool_image_atts and tool_message_id:
                         self._persist_attachment_refs(
@@ -4696,7 +4721,9 @@ class ChatSession:
             tc_id = tc.id
             func_name = tc.name
             if tc_id and tc_id not in answered_ids:
-                self.messages.append(Turn.tool(tc_id, detail, is_error=True))
+                self.messages.append(
+                    Turn.tool(tc_id, detail, is_error=True, effect_status=EffectStatus.UNKNOWN)
+                )
                 self._msg_tokens.append(1)
                 save_message(
                     self._ws_id,
@@ -4706,6 +4733,7 @@ class ChatSession:
                     tool_call_id=tc_id,
                     event_id=self._ui_event_id(),
                     is_error=True,
+                    meta=_effect_status_meta(EffectStatus.UNKNOWN),
                 )
                 # Emit synthetic tool_result so live SSE listeners can
                 # complete the in-DOM tool batch — without this the
@@ -10876,6 +10904,7 @@ class ChatSession:
 
         assert self._mcp_client is not None
         mcp_error = False
+        mcp_status: EffectStatus | None = None
         try:
             output = self._mcp_client.call_tool_sync(
                 func_name,
@@ -10892,6 +10921,7 @@ class ChatSession:
             # with nothing to reconcile.
             output = f"MCP tool timed out after {self.tool_timeout}s. {TIMEOUT_OUTCOME_CLAUSE}"
             mcp_error = True
+            mcp_status = EffectStatus.UNKNOWN
             self.ui.on_error(output)
         except Exception as e:
             output = _format_mcp_dispatch_error("MCP tool error", e)
@@ -10899,7 +10929,7 @@ class ChatSession:
             self.ui.on_error(output)
 
         output = self._truncate_output(output)
-        self._report_tool_result(call_id, func_name, output, is_error=mcp_error)
+        self._report_tool_result(call_id, func_name, output, is_error=mcp_error, status=mcp_status)
         return call_id, output
 
     @staticmethod
@@ -11197,7 +11227,9 @@ class ChatSession:
                 )
                 if partial:
                     msg += "\n\nPartial output before cancel:\n" + self._truncate_output(partial)
-                self._report_tool_result(call_id, "bash", msg, is_error=True)
+                self._report_tool_result(
+                    call_id, "bash", msg, is_error=True, status=EffectStatus.UNKNOWN
+                )
                 return call_id, msg
 
             output = "".join(stdout_parts)
@@ -11232,7 +11264,9 @@ class ChatSession:
             partial = "".join(stdout_parts).strip()
             if partial:
                 msg += "\n\nPartial output before timeout:\n" + self._truncate_output(partial)
-            self._report_tool_result(call_id, "bash", msg, is_error=True)
+            self._report_tool_result(
+                call_id, "bash", msg, is_error=True, status=EffectStatus.UNKNOWN
+            )
             return call_id, msg
         except Exception as e:
             msg = f"Error executing command: {e}"
@@ -11907,6 +11941,7 @@ class ChatSession:
             # See the cancellation appendix in HYPOTHESIS.md ("ρ may
             # fabricate the acknowledgment but must not fabricate the
             # outcome … unknown, never none").
+            self._tool_status[call_id] = self._cancelled_agent_status(agent_messages)
             return call_id, self._cancelled_agent_disposition(agent_messages, "task")
         except KeyboardInterrupt:
             # CLI Ctrl-C: keep the terse string and let the outer loop own
@@ -11915,6 +11950,48 @@ class ChatSession:
         except Exception as e:
             self.ui.on_info(f"[task error] {e}")
             return call_id, f"Task error: {e}"
+
+    @staticmethod
+    def _cancel_ledger(
+        agent_messages: list[dict[str, Any]],
+    ) -> tuple[list[tuple[str, bool]], int | None]:
+        """Read a cancelled sub-agent's ledger: every issued tool call as
+        ``(name, was_answered)`` in order, plus the index of the first in-flight
+        gap (the first issued call with no result), or ``None`` if every call
+        returned.
+
+        ``_run_agent`` runs a turn's tool_calls sequentially (cancel raises at
+        the per-tool checkpoint, or mid-tool for a SIGKILL'd bash), so the first
+        gap is the call that was executing when cancel landed: everything before
+        it returned, everything after never started. (The LAST gap would invert
+        unknown/none on a multi-call turn.) Shared by the disposition string and
+        its typed status so the two can't disagree.
+        """
+        answered: set[str] = set()
+        for m in agent_messages:
+            if m.get("role") == "tool" and m.get("tool_call_id"):
+                answered.add(str(m["tool_call_id"]))
+        issued: list[tuple[str, bool]] = []
+        for m in agent_messages:
+            if m.get("role") != "assistant":
+                continue
+            for tc in m.get("tool_calls") or []:
+                name = ((tc.get("function") or {}).get("name") or "tool").strip()
+                issued.append((name, str(tc.get("id") or "") in answered))
+        first_gap = next((i for i, (_n, ans) in enumerate(issued) if not ans), None)
+        return issued, first_gap
+
+    def _cancelled_agent_status(self, agent_messages: list[dict[str, Any]]) -> EffectStatus:
+        """Typed twin of :meth:`_cancelled_agent_disposition`: ``none`` if the
+        agent never acted, ``unknown`` if a tool was in flight when cancel
+        landed (its effect unobserved), else ``partial`` — every issued call
+        returned, but the agent was stopped before finishing."""
+        issued, first_gap = self._cancel_ledger(agent_messages)
+        if not issued:
+            return EffectStatus.NONE
+        if first_gap is not None:
+            return EffectStatus.UNKNOWN
+        return EffectStatus.PARTIAL
 
     def _cancelled_agent_disposition(self, agent_messages: list[dict[str, Any]], label: str) -> str:
         """Build an honest, deterministic disposition for a cancelled sub-agent.
@@ -11936,18 +12013,7 @@ class ChatSession:
         closed.  The owner (parent / coordinator) reads this to decide what,
         if anything, to compensate.
         """
-        answered: set[str] = set()
-        for m in agent_messages:
-            if m.get("role") == "tool" and m.get("tool_call_id"):
-                answered.add(str(m["tool_call_id"]))
-        # Ordered (name, was-answered) for every tool_call the agent issued.
-        issued: list[tuple[str, bool]] = []
-        for m in agent_messages:
-            if m.get("role") != "assistant":
-                continue
-            for tc in m.get("tool_calls") or []:
-                name = ((tc.get("function") or {}).get("name") or "tool").strip()
-                issued.append((name, str(tc.get("id") or "") in answered))
+        issued, first_gap = self._cancel_ledger(agent_messages)
         if not issued:
             return f"({label} cancelled by user before any action — no side effects)"
 
@@ -11957,15 +12023,6 @@ class ChatSession:
                 counts[n] = counts.get(n, 0) + 1
             return ", ".join(f"{n}×{c}" if c > 1 else n for n, c in counts.items())
 
-        # The in-flight action is the FIRST issued call without a result.
-        # ``_run_agent`` runs a turn's tool_calls sequentially (cancel raises at
-        # the per-tool checkpoint, or mid-tool for a SIGKILL'd bash), so the
-        # first gap is the call that was executing when cancel landed:
-        # everything before it returned, everything after never started.
-        # (Taking the LAST issued call would invert unknown/none on a
-        # multi-call turn — labelling the never-run tail UNKNOWN and the
-        # actually-in-flight call "not started".)
-        first_gap = next((i for i, (_n, ans) in enumerate(issued) if not ans), None)
         parts = [f"({label} cancelled by user before completion)"]
         if first_gap is None:
             # Every issued call returned a result — cancel landed between

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -903,9 +903,17 @@ def reconstruct_turns(
         event_id = int(row[8]) if len(row) > 8 and row[8] is not None else None
         is_error = bool(row[9]) if len(row) > 9 else False
         meta = TurnMeta(event_id=event_id)
-        source_meta = _source_meta_from_json(row[10]) if len(row) > 10 else None
-        if source_meta is not None:
-            meta.extra["source_meta"] = source_meta
+        raw_meta = _source_meta_from_json(row[10]) if len(row) > 10 else None
+        if raw_meta is not None:
+            # The ``meta`` column is role-exclusive: a TOOL row carries the
+            # typed ``{"effect_status": ...}`` envelope; a SYSTEM row carries
+            # operator-context ``source_meta``. Route so a tool's disposition
+            # doesn't land under source_meta (and vice versa). Legacy SYSTEM
+            # rows (bare source_meta dict, no effect_status key) fall through.
+            if role == "tool" and "effect_status" in raw_meta:
+                meta.extra["effect_status"] = raw_meta["effect_status"]
+            else:
+                meta.extra["source_meta"] = raw_meta
         src = str(source) if source else None
 
         if role == "user":

--- a/turnstone/core/trajectory.py
+++ b/turnstone/core/trajectory.py
@@ -37,6 +37,26 @@ class Role(StrEnum):
     SYSTEM = "system"
 
 
+class EffectStatus(StrEnum):
+    """The typed disposition of a tool call's *effect* — the machine-readable
+    twin of the prose the result body already carries.
+
+    Rides ``TurnMeta.extra["effect_status"]`` (wire-invisible, like the other
+    side-channel meta): the *model* reads the body, while *deterministic*
+    consumers — a re-issue guard, owner-side compensation — read this. The
+    ``unknown`` vs ``none`` split is the load-bearing one (HYPOTHESIS.md
+    effect-record appendix: *unknown, never none*): an unobserved outcome must
+    not read as "did not happen." ``None`` (the field unset) means an ordinary
+    result that no producer classified — not a fourth status.
+    """
+
+    COMMITTED = "committed"  # ran to completion; effects, if any, landed
+    NONE = "none"  # definitively did nothing (denied / never started)
+    UNKNOWN = "unknown"  # stopped mid-flight; may or may not have acted
+    PARTIAL = "partial"  # ran part-way
+    ROLLED_BACK = "rolled_back"  # ran, then reverted
+
+
 @dataclass(slots=True)
 class TextBlock:
     """Portable text content."""
@@ -130,6 +150,20 @@ class Turn:
         contribute nothing (you cannot full-text-search an image)."""
         return "".join(b.text for b in self.content if isinstance(b, TextBlock))
 
+    @property
+    def effect_status(self) -> EffectStatus | None:
+        """The typed effect disposition recorded on a TOOL turn, or ``None`` if
+        unset (an ordinary, unclassified result). Read by deterministic
+        consumers; never sent to the model. Lenient on a corrupt stored value
+        (returns ``None`` rather than raising), mirroring the meta decoders."""
+        raw = self.meta.extra.get("effect_status")
+        if not raw:
+            return None
+        try:
+            return EffectStatus(raw)
+        except ValueError:
+            return None
+
     # -- construction helpers (blunt the wrapping cost of uniform block content) --
     @classmethod
     def user(cls, text: str) -> Turn:
@@ -151,12 +185,23 @@ class Turn:
         )
 
     @classmethod
-    def tool(cls, tool_call_id: str, text: str, *, is_error: bool = False) -> Turn:
+    def tool(
+        cls,
+        tool_call_id: str,
+        text: str,
+        *,
+        is_error: bool = False,
+        effect_status: EffectStatus | None = None,
+    ) -> Turn:
+        meta = TurnMeta()
+        if effect_status is not None:
+            meta.extra["effect_status"] = effect_status.value
         return cls(
             Role.TOOL,
             (TextBlock(text),) if text else (),
             tool_call_id=tool_call_id,
             is_error=is_error,
+            meta=meta,
         )
 
     @classmethod
@@ -253,6 +298,10 @@ def turn_from_dict(msg: dict[str, Any]) -> Turn:
     sm = msg.get("_source_meta")
     if sm:
         meta.extra["source_meta"] = sm
+    # Typed tool-effect disposition (wire-invisible side channel, like the above).
+    es = msg.get("_effect_status")
+    if es:
+        meta.extra["effect_status"] = es
 
     return Turn(
         role=role,
@@ -296,6 +345,9 @@ def turn_to_dict(turn: Turn) -> dict[str, Any]:
     sm = turn.meta.extra.get("source_meta")
     if sm:
         msg["_source_meta"] = sm
+    es = turn.meta.extra.get("effect_status")
+    if es:
+        msg["_effect_status"] = es
     return msg
 
 

--- a/turnstone/core/trajectory.py
+++ b/turnstone/core/trajectory.py
@@ -161,7 +161,10 @@ class Turn:
             return None
         try:
             return EffectStatus(raw)
-        except ValueError:
+        except (ValueError, TypeError):
+            # ValueError: not a known status string. TypeError: a corrupt
+            # non-string value (e.g. a dict survived into the meta). Mirror the
+            # meta decoders and degrade to None rather than crash a consumer.
             return None
 
     # -- construction helpers (blunt the wrapping cost of uniform block content) --


### PR DESCRIPTION
## Problem

The `unknown` / `none` / `committed` distinction the cancel and timeout paths carry lived **only in the result's free text**. The typed shape was just `is_error: bool`, so `{unknown, none, committed-failure}` all collapsed to `is_error=True`. A deterministic reader — a re-issue guard, owner-side compensation — couldn't recover the distinction without parsing prose, which is exactly what the typed ledger is meant to avoid (`HYPOTHESIS.md` effect-record appendix: *unknown, never none*).

## Change

Promote the disposition to a typed `EffectStatus` on the canonical `Turn`.

- **`EffectStatus`** (`committed` / `none` / `unknown` / `partial` / `rolled_back`) rides `TurnMeta.extra["effect_status"]` — **wire-invisible**, like the other meta side channels. The model still reads the body; deterministic code reads the type.
- **Persisted** in the role-exclusive `conversations.meta` column — `source_meta` rides SYSTEM turns, `effect_status` rides TOOL turns, so they share the column and `reconstruct_turns` routes by role. **No migration**; survives reload for the audit trail.
- **Producer seam**: `_report_tool_result(status=)` + a `_tool_status` dict popped at the fold, mirroring `_tool_error_flags`.
- **Populated where the disposition is already determined**: `UNKNOWN` at the six unobserved sites (bash / MCP-tool timeout, bash SIGKILL-cancel, cancel synthesis, wire-repair) and a precise `none` / `partial` / `unknown` on a cancelled task agent via a shared `_cancel_ledger` (so the typed status and the prose disposition can't disagree). Ordinary results stay unset (= "ordinary completion", not a fourth status).

## Scope

Only the `unknown` / `none` split is load-bearing and gets populated; the full per-effect `effects[(resource, op, reversible)]` list stays deferred (the "open interface"). This is the first of two PRs for the effect-record work — a follow-up adds the per-tool Smart-Approval floor and surfaces a reversibility mark at the gate.

## Tests

- New: `TestEffectStatusPersistence` (meta envelope + role-routed reconstruct), typed-status assertions across the timeout / synth / disposition / `_exec_task` paths, and `_cancelled_agent_status` none/partial/unknown.
- 502 existing tests green across cancel / trajectory / reconstruct / storage / sessions / session; ruff + mypy clean.
