### PR TITLE
fix(composer): node-proxy-correct, reliable queued-message dismiss

### DIFF
--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -259,10 +259,12 @@ function createCoordinatorPane(root, wsId, opts) {
     // Coord chat bubbles wrap content in a .msg-body div (appendMsg
     // below); the queue bubble matches so its border + padding align.
     wrapInBody: true,
-    // Re-fetch attachments after a dequeue so the user can see (and
-    // reuse) any reservations the server-side dequeue released. Trades
-    // a small in-flight-placeholder clobbering window for the strictly
-    // worse alternative of attachments lingering invisibly until the
+    // Re-sync the staged-attachment chips after a confirmed dequeue so the
+    // composer view matches server truth. Queued messages are text-only, so
+    // this isn't reclaiming a reservation (there is none) — it's a cheap
+    // correctness refresh, fired by the controller only on the `removed`
+    // verdict. Trades a small in-flight-placeholder clobbering window for the
+    // strictly worse alternative of attachments lingering invisibly until the
     // next page load.
     onAfterDequeue: function () {
       attachments.rehydrate();
@@ -1886,8 +1888,21 @@ function createCoordinatorPane(root, wsId, opts) {
         // this guard it falls through to the "unknown status" branch and gets
         // promote()'d — a server-refused message shown as delivered (with a
         // false "already sent" notice if it was dismissed). Route it to the
-        // .catch (removes the bubble + shows the error) instead.
-        if (!r.ok) throw new Error("send_http_" + r.status);
+        // .catch (removes the bubble + shows the error) instead, surfacing the
+        // server's {error} text ("No session", a rate-limit reason, etc.)
+        // rather than a bare status code. A wedged proxy can answer non-JSON
+        // (502/504 HTML); the parse-failure arm falls back to the status code
+        // so that can't surface as an "Unexpected token <" error.
+        if (!r.ok) {
+          return r.json().then(
+            (b) => {
+              throw new Error((b && b.error) || "send_http_" + r.status);
+            },
+            () => {
+              throw new Error("send_http_" + r.status);
+            },
+          );
+        }
         return r.json();
       })
       .then((data) => {

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -267,6 +267,12 @@ function createCoordinatorPane(root, wsId, opts) {
     onAfterDequeue: function () {
       attachments.rehydrate();
     },
+    // Surface dequeue feedback in the chat log (coord has no toast): the
+    // "already sent" / "couldn't remove" / "no longer available" notices the
+    // controller raises. Reuses the transient "info" row (cf. force-stop).
+    onNotice: function (msg) {
+      appendText("info", msg, { label: "info" });
+    },
     // Idle-edge cleanup of the cancel/force-stop timers — without
     // this they fire on the *next* busy turn, relabel Stop to "Force
     // Stop", and surface a misleading "Cancel didn't complete in
@@ -1849,7 +1855,13 @@ function createCoordinatorPane(root, wsId, opts) {
     }
     composer.clear();
 
-    authFetch("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send", {
+    // Bound the send POST with an AbortController + ~15s timeout (mirrors
+    // composer_queue.js _deleteRequest) so a wedged proxied node can't leave a
+    // pre-bind-dismissed card frozen forever — bind/promote/remove only run
+    // off this response, so the .catch must always eventually fire.
+    const sendCtrl =
+      typeof AbortController === "function" ? new AbortController() : null;
+    const sendInit = {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
@@ -1857,8 +1869,27 @@ function createCoordinatorPane(root, wsId, opts) {
         message: trimmed,
         attachment_ids: snap.attachment_ids,
       }),
-    })
-      .then((r) => r.json())
+    };
+    let sendTimer = null;
+    if (sendCtrl) {
+      sendInit.signal = sendCtrl.signal;
+      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
+    }
+    let sendReq = authFetch(
+      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
+      sendInit,
+    );
+    if (sendTimer) sendReq = sendReq.finally(() => clearTimeout(sendTimer));
+    sendReq
+      .then((r) => {
+        // A rejected send (4xx/5xx) carries {error}, not {status}; without
+        // this guard it falls through to the "unknown status" branch and gets
+        // promote()'d — a server-refused message shown as delivered (with a
+        // false "already sent" notice if it was dismissed). Route it to the
+        // .catch (removes the bubble + shows the error) instead.
+        if (!r.ok) throw new Error("send_http_" + r.status);
+        return r.json();
+      })
       .then((data) => {
         if (data && data.status === "queued" && data.msg_id) {
           // Race: server returned queued but the client thought it was
@@ -1895,6 +1926,9 @@ function createCoordinatorPane(root, wsId, opts) {
             { label: "error" },
           );
         } else {
+          // Unknown / "ok" status (stale-busy race): settle the optimistic
+          // bubble so a pre-bind × can't strand it in the dismissing state.
+          if (queuedEl) queue.promote(queuedEl);
           attachments.consume(
             data && data.attached_ids,
             data && data.dropped_attachment_ids,

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -431,6 +431,17 @@
 .queued-dismiss:hover {
   color: var(--red, var(--err));
 }
+.queued-dismiss[aria-disabled="true"] {
+  cursor: default;
+  color: var(--fg-dim, var(--ink-3));
+  opacity: 0.5;
+}
+/* In-flight dequeue (× clicked, awaiting the server's confirm): dim the
+   card so the "dismissing" state is visible to sighted users, not just
+   exposed via aria-busy to assistive tech. */
+.msg-queued[aria-busy="true"] {
+  opacity: 0.4;
+}
 
 /* ============================================================
    Stacked layout — textarea above, actions row below.

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -39,9 +39,13 @@
  *               .msg element. Default false to match the historical
  *               interactive shape.
  *   authFetch:  optional override (default window.authFetch).
- *   onAfterDequeue: optional () => void — interactive hooks attachment
- *               re-fetch here. Fires only on a confirmed `removed` (the
- *               only case that released a server-side reservation). Coord omits.
+ *   onAfterDequeue: optional () => void — re-sync the composer's staged
+ *               attachment chips (interactive and coord both wire it to
+ *               attachments.rehydrate). Fires only on a confirmed `removed`
+ *               — the one verdict that mutated server-side queue state;
+ *               `not_found`/error change nothing, so re-fetching would be
+ *               wasted. Queued messages are text-only, so this isn't undoing
+ *               an attachment reservation — there is none.
  *   onNotice:   optional (msg) => void — surfaces a user-facing notice
  *               (e.g. a toast): "already sent" when a dismiss lost the race
  *               to delivery, or "couldn't remove" when the DELETE failed.
@@ -257,7 +261,8 @@ export function createQueueController(opts) {
         var status = data && data.status;
         if (status === "removed") {
           el.remove();
-          // Only a real removal released a server-side reservation.
+          // `removed` is the only verdict that mutated server-side queue
+          // state, so it's the only one worth re-syncing composer state for.
           if (onAfterDequeue) onAfterDequeue();
         } else if (status === "not_found") {
           // Already drained — present it as the sent message it now is;

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -13,14 +13,26 @@
  * What this does NOT own:
  *   - Sending. Caller renders the bubble before the POST, then later
  *     calls bind(el, msgId) when the server's response carries the id,
- *     or remove(el) on a queue_full / busy reject path.
- *   - Busy state. The shape is "addQueuedMessage on send, promote on
- *     idle"; caller orchestrates both around its own busy flag.
+ *     promote(el) when the response settled the message another way
+ *     (e.g. an "ok"/unknown status), or remove(el) on a reject path.
+ *   - Busy state. The shape is "addQueuedMessage on send, settle on
+ *     response / promote on idle"; caller orchestrates around its busy flag.
+ *
+ * Dismiss contract: a queued card is NEVER removed before the server
+ * confirms the cancel. Clicking × marks the card "dismissing" (aria-disabled
+ * × + aria-busy); the bubble only leaves the DOM on a confirmed `removed`.
+ * On `not_found` (already drained) it is promoted to a normal sent bubble
+ * with an "already sent" notice; on any error/timeout the × is re-enabled
+ * so the user can retry. This avoids the trust-eroding divergence of a
+ * card that shows "cancelled" while the message is still delivered.
  *
  * Caller options:
  *   messagesEl: HTMLElement — chat log container.
  *   getWsId:    () => string — current ws id (function so the
  *               interactive pane can swap tabs without re-instantiating).
+ *   getBase:    optional () => string — node-proxy URL prefix ("" local,
+ *               "/node/{id}" proxied). Applied to the dequeue DELETE so it
+ *               reaches the node that owns the session. Default "".
  *   wrapInBody: bool — when true (coord), wrap the queued content in a
  *               .msg-body div to match the surrounding .msg shape; when
  *               false (interactive), append children directly to the
@@ -28,7 +40,11 @@
  *               interactive shape.
  *   authFetch:  optional override (default window.authFetch).
  *   onAfterDequeue: optional () => void — interactive hooks attachment
- *               re-fetch here. Coord deliberately omits.
+ *               re-fetch here. Fires only on a confirmed `removed` (the
+ *               only case that released a server-side reservation). Coord omits.
+ *   onNotice:   optional (msg) => void — surfaces a user-facing notice
+ *               (e.g. a toast): "already sent" when a dismiss lost the race
+ *               to delivery, or "couldn't remove" when the DELETE failed.
  *   onIdle:     optional () => void — fires inside onIdleEdge() after
  *               the bubble sweep, so the consumer can run its own
  *               edge-only cleanup (e.g. clearing cancel/force-stop
@@ -38,15 +54,19 @@
  *   addQueuedMessage(text, priority) -> el
  *       priority: "important" | anything-else (treated as "notice")
  *   bind(el, msgId)
- *       Server returned a queued msg_id. Stamps msgId onto the bubble,
- *       or releases the slot server-side when the bubble can no longer
- *       be dequeued (user dismissed pre-bind, or the promote sweep
- *       raced ahead). Caller need only invoke.
+ *       Server returned status:queued + msg_id. Stamps msgId so the × can
+ *       dequeue; if the user already clicked × (pre-bind) runs the
+ *       confirming delete now; if the idle sweep already promoted the
+ *       bubble (already delivered), leaves it untouched.
+ *   promote(el)
+ *       Settle an optimistic bubble as a normal sent message — used by the
+ *       consumer when the send response wasn't "queued" (e.g. an "ok"
+ *       stale-busy race) so a pre-bind × can't strand the card.
  *   remove(el)
  *       Drop the bubble (busy / queue_full / connection-error path).
  *   onIdleEdge()
- *       Caller invokes once per busy → idle transition. Strips queued
- *       styling from every bubble and then fires the onIdle hook.
+ *       Caller invokes once per busy → idle transition. Promotes every
+ *       not-in-flight queued bubble and then fires the onIdle hook.
  */
 export function createQueueController(opts) {
   if (!opts || !opts.messagesEl)
@@ -56,9 +76,24 @@ export function createQueueController(opts) {
   var messagesEl = opts.messagesEl;
   var getWsId = opts.getWsId;
   var wrapInBody = !!opts.wrapInBody;
+  // Node-proxy URL prefix for the active tab ("" local, "/node/{id}"
+  // proxied). Mirrors composer_attachments's getBase so the dequeue
+  // DELETE lands on the node that owns the ChatSession, not the console
+  // root — without it, x-delete on a proxied interactive workstream
+  // 404s and the queued message is never removed (it gets delivered).
+  var getBase =
+    typeof opts.getBase === "function"
+      ? opts.getBase
+      : function () {
+          return "";
+        };
   var onAfterDequeue =
     typeof opts.onAfterDequeue === "function" ? opts.onAfterDequeue : null;
   var onIdle = typeof opts.onIdle === "function" ? opts.onIdle : null;
+  var onNotice = typeof opts.onNotice === "function" ? opts.onNotice : null;
+  // Upper bound on the dequeue DELETE so a wedged proxied node (the exact
+  // case this flow targets) can't leave a card stuck "dismissing" forever.
+  var DELETE_TIMEOUT_MS = 15000;
   // Lazy authFetch lookup — see composer_attachments.js for the
   // rationale; same load-order robustness applies here.
   function _authFetch(url, init) {
@@ -73,29 +108,47 @@ export function createQueueController(opts) {
   function _deleteRequest(msgId) {
     var wsId = getWsId();
     if (!wsId || !msgId) return null;
-    return _authFetch(
-      "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
-      {
-        method: "DELETE",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ msg_id: msgId }),
-      },
+    var base = getBase() || "";
+    var init = {
+      method: "DELETE",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ msg_id: msgId }),
+    };
+    // Abort on timeout so the promise always settles — without this a hung
+    // request leaves the × disabled + aria-busy with no recovery path.
+    var ctrl =
+      typeof AbortController === "function" ? new AbortController() : null;
+    var timer = null;
+    if (ctrl) {
+      init.signal = ctrl.signal;
+      timer = setTimeout(function () {
+        ctrl.abort();
+      }, DELETE_TIMEOUT_MS);
+    }
+    var p = _authFetch(
+      base + "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
+      init,
     );
-  }
-
-  // Fire-and-forget DELETE — used by bind() on a raced-away bubble
-  // where the caller has no DOM follow-up. Still invokes
-  // onAfterDequeue on success: the server-side reservation release
-  // freed any attachments the queued message held, and the caller
-  // typically rehydrates its chip pile so the user can reuse them.
-  function _sendDelete(msgId) {
-    var p = _deleteRequest(msgId);
-    if (!p) return;
-    p.then(function () {
-      if (onAfterDequeue) onAfterDequeue();
-    }).catch(function () {
-      /* network error — promote loop strips queued styling on idle */
+    if (timer) {
+      return p.finally(function () {
+        clearTimeout(timer);
+      });
+    }
+    // No AbortController (old runtime): can't cancel the fetch, but still
+    // bound the promise — race a rejecting timeout so a hung request settles
+    // into _confirmDequeue's catch (re-enable + notice). The fetch keeps
+    // running; its result is then ignored.
+    var fbTimer = null;
+    return Promise.race([
+      p,
+      new Promise(function (_resolve, reject) {
+        fbTimer = setTimeout(function () {
+          reject(new Error("dequeue_timeout"));
+        }, DELETE_TIMEOUT_MS);
+      }),
+    ]).finally(function () {
+      clearTimeout(fbTimer);
     });
   }
 
@@ -146,77 +199,162 @@ export function createQueueController(opts) {
     return el;
   }
 
-  // Dismiss flow:
-  // - msg_id known → DELETE /send, optimistically remove on success.
-  // - msg_id not yet bound → mark pendingDismiss; bind() picks it up
-  //   when the send response arrives.
-  function dequeue(el) {
-    var msgId = el.dataset.msgId;
-    if (!msgId) {
-      el.dataset.pendingDismiss = "true";
-      el.remove();
+  // Toggle a queued bubble's in-flight "dismissing" state: mark the row
+  // aria-busy and the × aria-disabled so a click gives immediate feedback
+  // without removing the card before the server confirms. We use
+  // aria-disabled rather than the real `disabled` attribute so disabling the
+  // focused × doesn't drop keyboard/AT focus to <body> (WCAG 2.4.3); the
+  // dequeue() guard makes the in-flight × inert. Reversible — a failed or
+  // declined delete clears it (and the dismiss flag) so the user can retry.
+  function _setDismissing(el, on) {
+    var dismiss = el.querySelector(".queued-dismiss");
+    if (on) {
+      el.setAttribute("aria-busy", "true");
+      if (dismiss) dismiss.setAttribute("aria-disabled", "true");
+    } else {
+      el.removeAttribute("aria-busy");
+      if (dismiss) dismiss.removeAttribute("aria-disabled");
+      // Clear the dismiss-intent flag on the re-enable off-ramp so a later
+      // idle-sweep _promote can't fire a contradictory "already sent" after
+      // we've told the user the removal didn't take.
+      delete el.dataset.dismissAttempted;
+    }
+  }
+
+  // Issue the DELETE and reconcile the card with the server's verdict:
+  //   removed   → drop the card (the message never reached the assistant)
+  //   not_found → already drained; _promote() to a sent bubble (+ notice)
+  //   404 gone  → workstream reaped/closed; drop the card with a terminal
+  //               "no longer available" notice (a retry would just 404 again)
+  //   else / non-2xx / transport / timeout → keep the card, re-enable the
+  //     × and tell the user it didn't take so they can retry.
+  function _confirmDequeue(el, msgId) {
+    var p = _deleteRequest(msgId);
+    if (!p) {
+      _setDismissing(el, false);
       return;
     }
-    var p = _deleteRequest(msgId);
-    if (!p) return;
     p.then(function (r) {
+      // 404 = reaped/closed workstream (distinct from a 200 not_found): the
+      // message is gone and a retry would just 404 again. Terminal — drop the
+      // card rather than stranding it un-dismissable in the retry loop.
+      if (r.status === 404) {
+        el.remove();
+        if (onNotice)
+          onNotice(
+            "This conversation is no longer available — the message wasn't delivered.",
+          );
+        return null;
+      }
+      // Other non-2xx (400 "No session" / 5xx) carry no {status}; route them
+      // through the catch so the user is told, not a silent re-enable that
+      // reads as "delete is broken".
+      if (!r.ok) throw new Error("dequeue_http_" + r.status);
       return r.json();
     })
       .then(function (data) {
-        if (data && data.status === "removed") el.remove();
-        if (onAfterDequeue) onAfterDequeue();
+        if (data === null) return; // 404 handled above
+        var status = data && data.status;
+        if (status === "removed") {
+          el.remove();
+          // Only a real removal released a server-side reservation.
+          if (onAfterDequeue) onAfterDequeue();
+        } else if (status === "not_found") {
+          // Already drained — present it as the sent message it now is;
+          // _promote fires the "already sent" notice (dismissAttempted).
+          _promote(el);
+        } else {
+          // Unexpected 2xx shape — keep the card cancellable.
+          _setDismissing(el, false);
+        }
       })
       .catch(function () {
-        /* network error — promote loop strips queued styling on idle */
+        _setDismissing(el, false);
+        if (onNotice)
+          onNotice("Couldn't remove the message — please try again.");
       });
   }
 
-  // Server returned status:queued + msg_id. Stamps msgId onto the
-  // bubble, OR releases the slot server-side when the bubble can no
-  // longer be dequeued from the UI (user dismissed pre-bind, or the
-  // promote sweep raced ahead and stripped .msg-queued / its dismiss
-  // button). Caller need only invoke; the controller handles all
-  // three races without further callbacks.
-  function bind(el, msgId) {
-    if (!el || !msgId) return;
-    var racedAway =
-      el.dataset.pendingDismiss || !el.classList.contains("msg-queued");
-    if (racedAway) {
-      _sendDelete(msgId);
+  // × handler. Marks the card dismissing and either confirms now (msg_id
+  // known) or defers to bind() (pre-bind). We never remove optimistically:
+  // if the deferred delete failed, the message would still be delivered
+  // while the card showed "cancelled". dismissAttempted lets _promote fire
+  // the "already sent" notice if the message turns out to have been
+  // delivered before we could cancel it, and signals bind() to confirm.
+  function dequeue(el) {
+    // Ignore re-clicks while a dismiss is in flight — the × stays
+    // aria-disabled (not real `disabled`, so focus isn't lost), which means
+    // the click still fires; this guard is what makes the in-flight × inert.
+    if (el.getAttribute("aria-busy") === "true") return;
+    el.dataset.dismissAttempted = "1";
+    _setDismissing(el, true);
+    var msgId = el.dataset.msgId;
+    if (!msgId) {
+      // Pre-bind: bind() confirms once the server returns the msg_id (it
+      // reads dismissAttempted).
       return;
     }
+    _confirmDequeue(el, msgId);
+  }
+
+  // Server returned status:queued + msg_id.
+  function bind(el, msgId) {
+    if (!el || !msgId) return;
+    // Idle sweep already promoted the bubble (worker drained mid-POST): the
+    // message is on its way, so leave it as a sent bubble. We deliberately do
+    // NOT delete here — idle can be emitted before the worker actually drains,
+    // so a delete could cancel a still-queued message; and a dismissed card
+    // never reaches this branch (onIdleEdge skips aria-busy cards), so doing
+    // nothing is the safe action.
+    if (!el.classList.contains("msg-queued")) return;
     el.dataset.msgId = msgId;
+    // User clicked × before the id arrived → confirm the delete now
+    // (removes only on a confirmed `removed`; promotes on not_found).
+    if (el.dataset.dismissAttempted) _confirmDequeue(el, msgId);
   }
 
   function remove(el) {
     if (el && el.parentNode) el.remove();
   }
 
-  // Caller invokes onIdleEdge() exactly once per busy → idle
-  // transition. The controller strips queued styling from every
-  // bubble (so optimistic queues render as normal user messages
-  // once the worker has drained them) and then fires the optional
-  // onIdle hook so the consumer can run its own edge-only cleanup
-  // (e.g. clearing the cancel/force-stop timers) without each
-  // consumer re-implementing the same edge-detection logic.
+  // Strip the queued affordances so a bubble renders as a normal
+  // (delivered) user message. Shared by the idle sweep, the not_found
+  // dequeue path, and the consumer's "ok"/unknown send-response path: a
+  // message the worker already drained is on its way and can't be
+  // cancelled, so present it as sent. If the user had clicked × first
+  // (dismissAttempted), tell them it was too late.
+  function _promote(el) {
+    var attempted = el.dataset.dismissAttempted;
+    el.classList.remove("msg-queued", "msg-queued-important");
+    delete el.dataset.msgId;
+    delete el.dataset.dismissAttempted;
+    el.removeAttribute("role");
+    el.removeAttribute("aria-label");
+    el.removeAttribute("aria-busy");
+    var badge = el.querySelector(".queued-badge");
+    if (badge) badge.remove();
+    var dismiss = el.querySelector(".queued-dismiss");
+    if (dismiss) dismiss.remove();
+    if (attempted && onNotice)
+      onNotice("Already sent — too late to remove from the queue.");
+  }
+
+  // Caller invokes onIdleEdge() exactly once per busy → idle transition.
+  // Promotes every queued bubble that isn't mid-dequeue (a [aria-busy] card
+  // has a DELETE in flight — let _confirmDequeue settle it so the sweep
+  // can't promote a card the delete is about to remove) and then fires the
+  // onIdle hook so the consumer can run edge-only cleanup (e.g. clearing
+  // cancel/force-stop timers).
   function onIdleEdge() {
-    var queued = messagesEl.querySelectorAll(".msg-queued");
-    queued.forEach(function (el) {
-      el.classList.remove("msg-queued", "msg-queued-important");
-      delete el.dataset.msgId;
-      el.removeAttribute("role");
-      el.removeAttribute("aria-label");
-      var badge = el.querySelector(".queued-badge");
-      if (badge) badge.remove();
-      var dismiss = el.querySelector(".queued-dismiss");
-      if (dismiss) dismiss.remove();
-    });
+    var queued = messagesEl.querySelectorAll(".msg-queued:not([aria-busy])");
+    queued.forEach(_promote);
     if (onIdle) onIdle();
   }
 
   return {
     addQueuedMessage: addQueuedMessage,
     bind: bind,
+    promote: _promote,
     remove: remove,
     onIdleEdge: onIdleEdge,
   };

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -2666,8 +2666,21 @@ class Pane {
         // this guard it falls through to the "unknown status" branch and gets
         // promote()'d — a server-refused message shown as delivered (with a
         // false "already sent" toast if it was dismissed). Route it to the
-        // .catch (removes the bubble + shows the error) instead.
-        if (!r.ok) throw new Error("send_http_" + r.status);
+        // .catch (removes the bubble + shows the error) instead, surfacing the
+        // server's {error} text ("No session", a rate-limit reason, etc.)
+        // rather than a bare status code. A wedged proxy can answer non-JSON
+        // (502/504 HTML); the parse-failure arm falls back to the status code
+        // so that can't surface as an "Unexpected token <" error.
+        if (!r.ok) {
+          return r.json().then(
+            (b) => {
+              throw new Error((b && b.error) || "send_http_" + r.status);
+            },
+            () => {
+              throw new Error("send_http_" + r.status);
+            },
+          );
+        }
         return r.json();
       })
       .then((data) => {

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -774,8 +774,18 @@ class Pane {
       getWsId: () => {
         return this.wsId;
       },
+      // Node-proxy prefix — same seam the attachment controller uses, so
+      // the dequeue DELETE reaches the node owning the session (a proxied
+      // remote-node workstream has base "/node/{id}"; without this the
+      // x-delete hit the console root and silently failed).
+      getBase: () => {
+        return this._base;
+      },
       onAfterDequeue: () => {
         this.attachments.rehydrate();
+      },
+      onNotice: (msg) => {
+        showToast(msg);
       },
       // Idle-edge cleanup of the cancel/force-stop timers — without
       // this they fire on the *next* busy turn, relabel Stop to "Force
@@ -2623,21 +2633,41 @@ class Pane {
     }
     this.composer.clear();
 
-    authFetch(
+    // Bound the send POST with an AbortController + ~15s timeout (mirrors
+    // composer_queue.js _deleteRequest) so a wedged proxied node can't leave a
+    // pre-bind-dismissed card frozen forever — bind/promote/remove only run
+    // off this response, so the .catch must always eventually fire.
+    const sendCtrl =
+      typeof AbortController === "function" ? new AbortController() : null;
+    const sendInit = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: text,
+        attachment_ids: snap.attachment_ids,
+      }),
+    };
+    let sendTimer = null;
+    if (sendCtrl) {
+      sendInit.signal = sendCtrl.signal;
+      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
+    }
+    let sendReq = authFetch(
       this._base +
         "/v1/api/workstreams/" +
         encodeURIComponent(this.wsId) +
         "/send",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message: text,
-          attachment_ids: snap.attachment_ids,
-        }),
-      },
-    )
+      sendInit,
+    );
+    if (sendTimer) sendReq = sendReq.finally(() => clearTimeout(sendTimer));
+    sendReq
       .then((r) => {
+        // A rejected send (4xx/5xx) carries {error}, not {status}; without
+        // this guard it falls through to the "unknown status" branch and gets
+        // promote()'d — a server-refused message shown as delivered (with a
+        // false "already sent" toast if it was dismissed). Route it to the
+        // .catch (removes the bubble + shows the error) instead.
+        if (!r.ok) throw new Error("send_http_" + r.status);
         return r.json();
       })
       .then((data) => {
@@ -2674,6 +2704,12 @@ class Pane {
               "Send a text-only message now, or wait and resend with attachments.",
           );
         } else {
+          // Unknown / "ok" status (e.g. the stale-busy race: the client
+          // optimistically queued but the server ran the send on a fresh
+          // worker). Settle the optimistic bubble as a normal sent message
+          // so a pre-bind × can't strand it in the dismissing state;
+          // promote() notifies "already sent" if it was dismissed.
+          if (queuedEl) this.queue.promote(queuedEl);
           this.attachments.consume(
             data.attached_ids,
             data.dropped_attachment_ids,


### PR DESCRIPTION
## What

The queued-message dismiss (the × on a queued message) silently failed to cancel the message on proxied (remote-node) interactive workstreams — and the message got delivered anyway.

## Root cause

`composer_queue.js`'s dequeue `DELETE` hardcoded `/v1/api/workstreams/{ws}/send` with **no node-proxy base prefix**. `_base` is `""` for a local workstream but `/node/{id}` when the console proxies to a remote node. Interactive prepends `_base` on every other request and passes `getBase` to the attachment controller — but not the queue controller. So a remote-node dismiss hit the console root, 404'd, and the queued message was never removed → it got delivered. Local-node and the coordinator (both base `""`) didn't repro — hence "interactive only".

## Fix

**The bug:** `composer_queue` gains a `getBase` option, prefixed onto the dequeue `DELETE`; interactive passes `getBase: () => this._base` (mirrors its attachment controller). Coordinator stays at base `""`.

**Reliability hardening of the dismiss flow** (the card no longer diverges from server state):
- Never remove the card before the server confirms: `removed` → drop; `not_found` (already drained) → promote to a normal sent bubble + "already sent" notice; `404` (reaped session) → terminal drop; error/timeout → re-enable + "couldn't remove" notice.
- Bound the dequeue `DELETE` **and** the send `POST` (both consumers) with a 15s `AbortController` so a wedged node can't freeze the card.
- `r.ok` guard on the send response so a rejected send (4xx/5xx) surfaces as an error instead of being rendered as "delivered".
- a11y: `aria-disabled` (not the real `disabled` attribute) keeps keyboard/AT focus on the dismiss control (WCAG 2.4.3); in-flight state shown via `aria-busy` + CSS.
- Coordinator wires `onNotice` → `appendText`.

## Testing

Verified manually in a clustered repro (remote-node workstream): dismiss now removes the card and the message is not delivered. `node --check` passes on the three JS files; byte-clean. No automated coverage yet — a JS test harness pinning the dequeue/bind/idle-sweep races is the immediate follow-up.

## Scope

Frontend only (`composer_queue.js`, `interactive.js`, `coordinator.js`, `chat.css`). Separate from the idle-seam wake work.
