### PR TITLE
fix(compaction): cooperative + chunked compaction with provider-anchored budget

### DIFF
--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -599,6 +599,28 @@ class TestSummaryInputBudget:
         large_reserve = session._summary_input_budget_chars()
         assert large_reserve < small_reserve  # less room left for input
 
+    def test_budget_never_exceeds_true_input_capacity(self, session):
+        """Review (Copilot): the _MIN_SUMMARY_BUDGET_CHARS floor must not push the
+        budget above what actually fits — output reserve + budgeted input + prompt
+        must stay within context_window, or the summary call overflows on a tiny
+        window instead of bailing.  Without the cap the floor (2000 chars) exceeds
+        capacity here and the call would overflow."""
+        session.context_window = 1200
+        session.compact_max_tokens = 1200
+        session._system_tokens = 0
+        budget_chars = session._summary_input_budget_chars()
+        prompt_tokens = int(
+            (len(session._COMPACTOR_SYSTEM_PROMPT) + len(session._COMPACT_USER_PREFIX))
+            / session._chars_per_token
+        )
+        # The full summary call (output reserve + budgeted input + prompt) fits.
+        total = (
+            session._summary_output_tokens()
+            + budget_chars / session._chars_per_token
+            + prompt_tokens
+        )
+        assert total <= session.context_window
+
 
 class TestChunkedCompaction:
     """The chunked driver: one call when it all fits, recursion when it doesn't,
@@ -714,13 +736,12 @@ class TestChunkedCompaction:
         path) rather than fabricate, and without burning a model call.
 
         Needs a *tiny* window now that Fix 1 keeps the budget healthy on normal
-        windows: at context_window=900 the output reserve (512, the floor) plus
-        the compactor prompt + safety exceed the window, so
-        ``_summary_input_budget_chars`` floors to ``_MIN_SUMMARY_BUDGET_CHARS``
-        (2000).  Each message's content is ~5000 chars, head+tail-capped by
-        ``_format_message_for_summary`` to ~1525 — one block fits the 2000-char
-        budget, but two (1525 + 1525) don't, so ``_pack_blocks`` yields one batch
-        per block: ``len(batches) == len(blocks)`` → irreducible bail at depth 0.
+        windows: at context_window=900 the output reserve + compactor prompt +
+        safety already exceed the window, so the true input capacity is negative
+        and ``_summary_input_budget_chars`` caps the budget to 0.  Each ~5000-char
+        message head+tail-caps to ~1525, far over the 0/1-char budget, so
+        ``_pack_blocks`` truncates each into its own batch:
+        ``len(batches) == len(blocks)`` → irreducible bail at depth 0, no model call.
         """
         session.context_window = 900
         session.compact_max_tokens = 900

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -1,0 +1,457 @@
+"""Tests for provider-anchored context fullness and cooperative compaction.
+
+Covers the pieces that make compaction agree with tool-output truncation about
+how full the context is, and that let the model reach a stopping point before
+the harness collapses the transcript:
+
+- ``_estimated_prompt_tokens`` — the single fullness measure (provider
+  ``prompt_tokens`` + post-calibration delta, with a local fallback).
+- ``_maybe_compact_midturn`` / ``_do_auto_compact`` — the soft-advise /
+  hard-compact escalation and the shared compaction action.
+- the ``_compaction_advised`` latch lifecycle and the ``compaction_pending``
+  advisory plumbing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests._session_helpers import make_session
+from turnstone.core.trajectory import dicts_from_turns, turns_from_dicts
+
+
+@pytest.fixture
+def session(tmp_db, mock_openai_client):
+    """ChatSession with a small window so thresholds are easy to reason about.
+
+    context_window=10_000, auto_compact_pct default 0.8 → soft=8000,
+    hard=min(0.95, 0.9)*10_000=9000.  Built via the shared ``make_session``
+    factory so the session shape stays in lockstep with the sibling
+    truncation/compaction suites that read the same fullness measure.
+    """
+    return make_session(
+        client=mock_openai_client,
+        context_window=10_000,
+        max_tokens=1_000,
+        tool_timeout=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _estimated_prompt_tokens — the shared fullness measure
+# ---------------------------------------------------------------------------
+
+
+class TestEstimatedPromptTokens:
+    def test_falls_back_to_local_without_usage(self, session):
+        """Before the first API call there is no provider anchor."""
+        session._last_usage = None
+        session._system_tokens = 500
+        session._msg_tokens = [100, 200]
+        assert session._estimated_prompt_tokens() == 800
+
+    def test_anchors_to_provider_usage_plus_delta(self, session):
+        """Provider prompt_tokens is ground truth; only post-calibration
+        messages are estimated on top (system + tool-def + cached prefix are
+        all already inside prompt_tokens)."""
+        session._last_usage = {"prompt_tokens": 8000}
+        session._calibrated_msg_count = 2
+        session._msg_tokens = [1, 1, 300, 50]  # delta = msgs after index 2
+        assert session._estimated_prompt_tokens() == 8000 + 350
+
+    def test_clamps_stale_calibrated_count(self, session):
+        """A stale calibration index (post-compaction / mutation) must not
+        over-slice into a negative/garbage delta."""
+        session._last_usage = {"prompt_tokens": 5000}
+        session._calibrated_msg_count = 99  # > len(_msg_tokens)
+        session._msg_tokens = [10, 20]
+        assert session._estimated_prompt_tokens() == 5000
+
+
+# ---------------------------------------------------------------------------
+# _maybe_compact_midturn — soft-advise / hard-compact escalation
+# ---------------------------------------------------------------------------
+
+
+class TestMidturnCompactionPolicy:
+    def test_below_soft_threshold_is_noop(self, session):
+        with (
+            patch.object(session, "_estimated_prompt_tokens", return_value=7_000),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_append_system_turn") as advise,
+        ):
+            session._maybe_compact_midturn()
+        compact.assert_not_called()
+        advise.assert_not_called()
+        assert session._compaction_advised is False
+
+    def test_first_crossing_advises_not_compacts(self, session):
+        """Regression for the dead-zone bug: the provider reported ~85% while
+        the old naive estimate (system + msgs) was far under the 80% soft
+        threshold, so mid-turn compaction never fired and the model flailed on
+        truncated output.  Now the provider-anchored estimate crosses soft and
+        the model is advised to wrap up first."""
+        # Naive estimate is ~10% of the window...
+        session._system_tokens = 1_000
+        session._msg_tokens = [1, 1]
+        session._calibrated_msg_count = 2
+        assert session._system_tokens + sum(session._msg_tokens) < 8_000
+        # ...but the provider counted 8_500 (tool defs + history) = 85%.
+        session._last_usage = {"prompt_tokens": 8_500}
+        session._compaction_advised = False
+
+        with (
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_append_system_turn") as advise,
+        ):
+            session._maybe_compact_midturn()
+
+        compact.assert_not_called()
+        advise.assert_called_once()
+        assert advise.call_args.args[0] == "compaction_pending"
+        assert session._compaction_advised is True
+
+    def test_continue_after_advisory_compacts(self, session):
+        """Already advised + still over soft → the model kept working, compact."""
+        session._compaction_advised = True
+        with (
+            patch.object(session, "_estimated_prompt_tokens", return_value=8_500),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_append_system_turn") as advise,
+        ):
+            session._maybe_compact_midturn()
+        compact.assert_called_once_with("mid-turn")
+        advise.assert_not_called()
+
+    def test_hard_ceiling_compacts_without_advisory(self, session):
+        """Over the hard ceiling → no turn to spare, compact even if never
+        advised."""
+        session._compaction_advised = False
+        with (
+            patch.object(session, "_estimated_prompt_tokens", return_value=9_500),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_append_system_turn") as advise,
+        ):
+            session._maybe_compact_midturn()
+        compact.assert_called_once_with("mid-turn")
+        advise.assert_not_called()
+
+    def test_do_auto_compact_rounds_percentage(self, session):
+        """The notice uses round(), not int() — 0.58 must render '58%', not the
+        float-truncated '57%'."""
+        session.auto_compact_pct = 0.58
+        with (
+            patch.object(session, "_compact_messages") as compact,
+            patch.object(session, "_print_status_line"),
+            patch.object(session.ui, "on_info") as on_info,
+        ):
+            session._do_auto_compact("mid-turn")
+        compact.assert_called_once_with(auto=True, preserve_tail=0)
+        msg = on_info.call_args.args[0]
+        assert "58%" in msg
+        assert "mid-turn" in msg
+
+
+# ---------------------------------------------------------------------------
+# Latch lifecycle + advisory plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionLatch:
+    def test_stale_latch_cleared_on_send(self, session):
+        """A latch left True by a prior abnormal exit (cancel / error /
+        superseded / resume) must not survive into the next send and trigger an
+        advisory-skipping compaction.  send() entry clears it."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
+        session._msg_tokens = [1]
+        session._title_generated = True  # don't spawn the auto-title daemon
+        session._compaction_advised = True  # stale latch from a prior turn
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_compact_messages"),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("hello")
+
+        assert session._compaction_advised is False
+
+    def test_compact_messages_clears_latch_even_when_it_bails(self, session):
+        """_compact_messages must clear the latch on every attempt — including
+        its early-return guards — so a bailed forced compaction falls back to
+        the advisory grace state instead of retry-storming."""
+        session._compaction_advised = True
+        # One message → hits the "Not enough messages to compact" early return.
+        session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
+        session._compact_messages(auto=True)
+        assert session._compaction_advised is False
+
+
+class TestEndOfTurnAutoResume:
+    """End-of-turn: a cooperative stop (model wound down so we could compact)
+    resumes after compaction; a natural finish goes idle."""
+
+    def test_advised_stop_resumes_after_compaction(self, session):
+        """Latch True at the stop → after compaction a user turn re-prompts the
+        model to continue (the loop does not break to idle)."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+
+        # send() entry resets the latch, so simulate the mid-turn advisory
+        # firing *during* the first stream (latch True), then the model stops.
+        calls = {"n": 0}
+
+        def stream(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                session._compaction_advised = True  # advisory fired this turn
+                return {"role": "assistant", "content": "paused; plan recorded"}
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
+            patch.object(session, "_do_auto_compact"),
+            patch.object(session, "_append_user_turn") as resume,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        # send() also appends the user input ("go") via _append_user_turn, so
+        # filter for the resume turn specifically (tagged source=compaction_resume).
+        resume_calls = [
+            c for c in resume.call_args_list if c.kwargs.get("source") == "compaction_resume"
+        ]
+        assert len(resume_calls) == 1
+
+    def test_natural_finish_idles_without_resume(self, session):
+        """Latch False at the stop (task genuinely done) → compact, then idle;
+        no auto-resume."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        session._compaction_advised = False
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(
+                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state") as emit_state,
+            patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_append_user_turn") as resume,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        compact.assert_called_once()
+        # No resume turn (only the user input "go" was appended).
+        assert not [
+            c for c in resume.call_args_list if c.kwargs.get("source") == "compaction_resume"
+        ]
+        emit_state.assert_any_call("idle")
+
+    def test_no_resume_when_compaction_bails(self, session):
+        """q-1 regression: if compaction bails (returns False — summary error /
+        too-large / too-few), the resume must NOT fire — there's no summary to
+        continue from."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        calls = {"n": 0}
+
+        def stream(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                session._compaction_advised = True  # advised stop
+                return {"role": "assistant", "content": "paused"}
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
+            patch.object(session, "_do_auto_compact", return_value=False),  # bailed
+            patch.object(session, "_append_user_turn") as resume,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        assert not [
+            c for c in resume.call_args_list if c.kwargs.get("source") == "compaction_resume"
+        ]
+
+    def test_resume_preserves_alternation(self, session):
+        """The auto-resume must not produce two consecutive user turns — some
+        providers require strict user/assistant alternation.  Compaction leaves
+        a trailing assistant (summary) turn, and the resume user turn follows
+        it.  Drives the real compaction + resume end to end."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do the task"},
+                {"role": "assistant", "content": "on it"},
+            ]
+        )
+        session._msg_tokens = [5, 5]
+        session._title_generated = True
+        session.compact_max_tokens = 100  # positive summary budget at ctx=10k
+        session._system_tokens = 0
+
+        summary = SimpleNamespace(content="## Open tasks\nfinish it", finish_reason="stop")
+        n = {"i": 0}
+
+        def stream(*_a, **_k):
+            n["i"] += 1
+            if n["i"] == 1:
+                session._compaction_advised = True  # advisory fired this turn
+                return {"role": "assistant", "content": "pausing to compact"}
+            return {"role": "assistant", "content": "all done"}
+
+        def est(*_a, **_k):
+            return 9_999 if n["i"] <= 1 else 10  # over threshold only on the stop turn
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_estimated_prompt_tokens", side_effect=est),
+            patch.object(session, "_utility_completion", return_value=summary),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        roles = [m["role"] for m in dicts_from_turns(session.messages)]
+        assert not any(roles[i] == roles[i + 1] == "user" for i in range(len(roles) - 1)), (
+            f"consecutive user turns: {roles}"
+        )
+        # The resume genuinely happened: a user turn sits after the summary.
+        assert "assistant" in roles and roles[-1] != "user"
+
+
+class TestCompactBeforeTruncate:
+    """#2: tail-preserving compaction keeps the in-flight tool-call turn so the
+    fresh tool results aren't orphaned, gated by the shared _compaction_owed."""
+
+    def test_preserve_tail_keeps_in_flight_tool_call(self, session):
+        """compact(preserve_tail=1) summarizes the older history but keeps the
+        last (assistant tool-call) turn verbatim — so a tool result appended
+        after it still has its matching tool_use."""
+        session.compact_max_tokens = 100  # positive summary budget at ctx=10k
+        session._system_tokens = 0
+        tc = {"id": "call_1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do it"},
+                {"role": "assistant", "content": "older reply"},
+                {"role": "user", "content": "more"},
+                {"role": "assistant", "content": "", "tool_calls": [tc]},  # in-flight
+            ]
+        )
+        session._msg_tokens = [5, 5, 5, 5]
+        summary = SimpleNamespace(content="dense summary", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", return_value=summary):
+            session._compact_messages(auto=True, preserve_tail=1)
+
+        wire = dicts_from_turns(session.messages)
+        # [summary_user, summary_asst, preserved assistant-tool-call]
+        assert wire[0]["role"] == "user" and "[Conversation summary]" in wire[0]["content"]
+        assert wire[1]["role"] == "assistant"
+        assert wire[-1]["role"] == "assistant" and wire[-1].get("tool_calls")
+        # The tool_call survived, so a tool result for call_1 won't orphan.
+        ids = [t["id"] for m in wire if m.get("tool_calls") for t in m["tool_calls"]]
+        assert "call_1" in ids
+
+    def test_compaction_owed_predicate(self, session):
+        # over hard ceiling (>9000) → owed regardless of the latch
+        with patch.object(session, "_estimated_prompt_tokens", return_value=9_500):
+            session._compaction_advised = False
+            assert session._compaction_owed() is True
+        # over soft (>8000) → owed only when advised
+        with patch.object(session, "_estimated_prompt_tokens", return_value=8_500):
+            session._compaction_advised = True
+            assert session._compaction_owed() is True
+            session._compaction_advised = False
+            assert session._compaction_owed() is False
+        # under soft → never owed
+        with patch.object(session, "_estimated_prompt_tokens", return_value=7_000):
+            session._compaction_advised = True
+            assert session._compaction_owed() is False
+
+    def test_owed_compaction_runs_before_truncation_in_tool_path(self, session):
+        """Wiring: in the tool path, an owed compaction fires with preserve_tail=1
+        before the truncation budget is sized."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        tc = {"id": "call_1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+        n = {"i": 0}
+
+        def stream(*_a, **_k):
+            n["i"] += 1
+            if n["i"] == 1:
+                return {"role": "assistant", "content": "", "tool_calls": [tc]}
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            # Owed on the tool turn (pre-truncation); _estimated_prompt_tokens stays
+            # small so the end-of-turn path doesn't also compact.
+            patch.object(session, "_compaction_owed", side_effect=lambda: n["i"] == 1),
+            patch.object(session, "_maybe_compact_midturn"),  # isolate the pre-truncation call
+            patch.object(session, "_do_auto_compact") as compact,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        assert any(
+            c.args == ("mid-turn",) and c.kwargs.get("preserve_tail") == 1
+            for c in compact.call_args_list
+        ), compact.call_args_list
+
+
+def test_compaction_advisory_is_registered():
+    """The advisory source and template must be wired across both modules so
+    ``_append_system_turn('compaction_pending', ...)`` cannot raise."""
+    from turnstone.core.metacognition import format_nudge
+    from turnstone.core.tool_advisory import SYSTEM_TURN_SOURCES, make_system_turn
+
+    assert "compaction_pending" in SYSTEM_TURN_SOURCES
+    text = format_nudge("compaction_pending")
+    assert text and "compact" in text.lower()
+    turn = make_system_turn("compaction_pending", text)
+    assert turn["role"] == "system"
+    assert turn["_source"] == "compaction_pending"

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -47,7 +47,13 @@ def session(tmp_db, mock_openai_client):
 
 class TestEstimatedPromptTokens:
     def test_falls_back_to_local_without_usage(self, session):
-        """Before the first API call there is no provider anchor."""
+        """Before the first API call there is no provider anchor.
+
+        Tools cleared so the fallback is the pure system + message sum; the
+        tool-def augmentation of the same fallback is pinned separately by
+        ``TestProactiveToolDefFallback``.
+        """
+        session._tools = []
         session._last_usage = None
         session._system_tokens = 500
         session._msg_tokens = [100, 200]
@@ -441,6 +447,464 @@ class TestCompactBeforeTruncate:
             c.args == ("mid-turn",) and c.kwargs.get("preserve_tail") == 1
             for c in compact.call_args_list
         ), compact.call_args_list
+
+    def test_pre_attempt_suppresses_second_midturn_compaction(self, session):
+        """q-2: when an owed compaction already fired pre-truncation
+        (``pre_attempted_compact=True``), the post-truncation
+        ``_maybe_compact_midturn`` is skipped — re-running would double the
+        summary work (and could retry-storm a failed summary)."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        tc = {"id": "call_1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+        n = {"i": 0}
+
+        def stream(*_a, **_k):
+            n["i"] += 1
+            if n["i"] == 1:
+                return {"role": "assistant", "content": "", "tool_calls": [tc]}
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            # Owed on the tool turn → the pre-truncation compaction fires.
+            # _compaction_owed takes an optional ``used`` arg, so accept *a/**k.
+            patch.object(session, "_compaction_owed", side_effect=lambda *a, **k: n["i"] == 1),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_maybe_compact_midturn") as midturn,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        # The pre-truncation compaction actually fired (preserve_tail=1)...
+        assert any(
+            c.args == ("mid-turn",) and c.kwargs.get("preserve_tail") == 1
+            for c in compact.call_args_list
+        ), compact.call_args_list
+        # ...so the post-truncation mid-turn compaction is suppressed.
+        midturn.assert_not_called()
+
+    def test_no_pre_attempt_runs_midturn_compaction(self, session):
+        """q-2 sibling: with nothing owed pre-truncation
+        (``pre_attempted_compact=False``), the post-truncation
+        ``_maybe_compact_midturn`` runs once for the tool turn."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        tc = {"id": "call_1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+        n = {"i": 0}
+
+        def stream(*_a, **_k):
+            n["i"] += 1
+            if n["i"] == 1:
+                return {"role": "assistant", "content": "", "tool_calls": [tc]}
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
+            patch.object(session, "_stream_response", side_effect=stream),
+            patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            # Never owed → no pre-truncation compaction this iteration.
+            patch.object(session, "_compaction_owed", side_effect=lambda *a, **k: False),
+            patch.object(session, "_do_auto_compact") as compact,
+            patch.object(session, "_maybe_compact_midturn") as midturn,
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        # No pre-truncation (preserve_tail) compaction happened...
+        assert not any(c.kwargs.get("preserve_tail") == 1 for c in compact.call_args_list), (
+            compact.call_args_list
+        )
+        # ...so the post-truncation mid-turn compaction runs once for the tool turn.
+        midturn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Chunked / hierarchical summary compaction
+# ---------------------------------------------------------------------------
+
+
+class TestPackBlocks:
+    """``_pack_blocks`` greedily packs formatted blocks into batches that each
+    fit the budget, in order, with no drops and no reordering."""
+
+    def test_preserves_all_blocks_and_order(self, session):
+        blocks = [f"block-{i}-{'x' * 50}" for i in range(10)]
+        batches = session._pack_blocks(blocks, budget_chars=200)
+        flat = [b for batch in batches for b in batch]
+        assert flat == blocks  # every block present, order preserved
+        assert all(batch for batch in batches)  # never an empty batch
+
+    def test_each_batch_within_budget(self, session):
+        budget = 200
+        blocks = ["a" * 80 for _ in range(12)]
+        batches = session._pack_blocks(blocks, budget_chars=budget)
+        for batch in batches:
+            assert len("\n\n".join(batch)) <= budget
+
+    def test_boundary_block_exactly_at_budget(self, session):
+        budget = 100
+        exact = "y" * budget  # len == budget: fits a batch, not oversized
+        blocks = ["short", exact, "tail"]
+        batches = session._pack_blocks(blocks, budget_chars=budget)
+        flat = [b for batch in batches for b in batch]
+        assert flat == blocks  # order + presence
+        assert exact in flat  # untouched, not truncated
+        for batch in batches:
+            assert len("\n\n".join(batch)) <= budget
+
+    def test_oversized_lone_block_truncated_in_own_batch(self, session):
+        budget = 100
+        huge = "z" * 500  # > budget → its own truncated batch
+        blocks = ["before", huge, "after"]
+        batches = session._pack_blocks(blocks, budget_chars=budget)
+        flat = [b for batch in batches for b in batch]
+        assert flat[0] == "before" and flat[-1] == "after"  # neighbours survive
+        truncated = [b for b in flat if "[truncated]" in b]
+        assert len(truncated) == 1
+        assert len(truncated[0]) <= budget
+        assert truncated[0].startswith("z")  # head preserved
+        for batch in batches:
+            assert len("\n\n".join(batch)) <= budget
+
+
+class TestSummaryInputBudget:
+    """``_summary_input_budget_chars`` derives the per-call input budget from the
+    context window, reserving the output and prompt overhead."""
+
+    def test_scales_with_context_window(self, session):
+        session.compact_max_tokens = 100
+        session.context_window = 20_000
+        smaller = session._summary_input_budget_chars()
+        session.context_window = 40_000
+        larger = session._summary_input_budget_chars()
+        assert larger > smaller
+
+    def test_subtracts_output_reserve(self, session):
+        session.context_window = 50_000
+        session.compact_max_tokens = 100
+        small_reserve = session._summary_input_budget_chars()
+        session.compact_max_tokens = 20_000  # larger output reserve
+        large_reserve = session._summary_input_budget_chars()
+        assert large_reserve < small_reserve  # less room left for input
+
+
+class TestChunkedCompaction:
+    """The chunked driver: one call when it all fits, recursion when it doesn't,
+    and atomicity on a mid-chunk failure."""
+
+    def test_single_batch_is_exactly_one_completion_call(self, session):
+        """When everything fits one batch, compaction is a single model call —
+        preserving today's behavior (and the existing tests that assume it)."""
+        session.compact_max_tokens = 100
+        session._system_tokens = 0
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do the thing"},
+                {"role": "assistant", "content": "did the thing"},
+            ]
+        )
+        session._msg_tokens = [5, 5]
+        summary = SimpleNamespace(content="## Decisions\ndense", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", return_value=summary) as uc:
+            assert session._compact_messages(auto=True) is True
+
+        assert uc.call_count == 1
+        assert len(session.messages) == 2  # summary_user + summary_asst
+
+    def test_multi_batch_recurses_terminates_and_stays_within_budget(self, session):
+        """Core regression: many messages with a tiny per-message token estimate
+        (the OLD prefix budget would pass them all in one shot) but a formatted
+        size that needs several batches.  Every summary call's body must fit
+        ``_summary_input_budget_chars`` — the overflow the chunking fixes — and
+        the recursion must terminate with a real, shrunk summary."""
+        session.context_window = 5_000
+        session.compact_max_tokens = 4_000  # squeezes the input budget to the floor
+        session._system_tokens = 0
+        budget = session._summary_input_budget_chars()
+
+        session.messages = turns_from_dicts(
+            [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"msg-{i:02d} " + "c" * 200,
+                }
+                for i in range(30)
+            ]
+        )
+        session._msg_tokens = [1] * 30  # tiny token estimate; OLD code selects all
+
+        recorded: list[int] = []
+
+        def fake_uc(messages, **_kwargs):
+            body = messages[1]["content"]
+            prefix = session._COMPACT_USER_PREFIX
+            if body.startswith(prefix):
+                body = body[len(prefix) :]
+            recorded.append(len(body))
+            return SimpleNamespace(content="PARTIAL", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", side_effect=fake_uc):
+            result = session._compact_messages(auto=True)
+
+        assert result is True
+        assert len(session.messages) < 30  # genuinely shrank
+        assert len(recorded) > 1  # multi-batch: recursion happened
+        assert all(n <= budget for n in recorded)  # never overflow the summary call
+
+    def test_recursion_depth_ceiling_bails_to_false(self, session):
+        """q-3: the ``depth >= _MAX_SUMMARY_DEPTH`` recursion backstop bails to
+        False (the "too large" path) without fabricating a summary.
+
+        Distinct from ``test_irreducible_input_bails_to_false`` (which bails at
+        depth 0 via the ``len(batches) >= len(blocks)`` arm before any model
+        call): here depth 0 packs into several batches AND reduces, so the level
+        succeeds and recurses; depth 1 still has >1 batch but a strictly smaller
+        count (so the len arm is False), and ``depth >= 1`` fires the bail.  That
+        the depth-0 calls ran first is proven by ``_utility_completion`` being
+        called (≥1) despite the False return.
+        """
+        session.context_window = 5_000
+        session.compact_max_tokens = 4_000  # squeezes the input budget
+        session._system_tokens = 0
+        session._MAX_SUMMARY_DEPTH = 1  # positive, so depth 0 runs before the bail
+        budget = session._summary_input_budget_chars()
+
+        # ~30 messages, each block bigger than 1/6 of the budget → depth 0 packs
+        # into several batches (and len(batches) < len(blocks), so it recurses).
+        session.messages = turns_from_dicts(
+            [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"msg-{i:02d} " + "c" * 900,
+                }
+                for i in range(30)
+            ]
+        )
+        session._msg_tokens = [1] * 30
+        before = list(session.messages)
+
+        # Each depth-0 partial is 0.4*budget chars: two pack per batch but not
+        # three, so depth 1 reduces the batch count without collapsing to one —
+        # the len arm stays False and the depth ceiling is what bails.
+        partial = "P" * ((budget * 2) // 5)
+        summary = SimpleNamespace(content=partial, finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", return_value=summary) as uc:
+            result = session._compact_messages(auto=True)
+
+        assert result is False
+        assert session.messages == before  # untouched on the bail
+        assert uc.call_count >= 1  # depth-0 ran (depth arm), not the len arm
+
+    def test_irreducible_input_bails_to_false(self, session):
+        """A genuinely irreducible case still bails to False (the "too large"
+        path) rather than fabricate, and without burning a model call.
+
+        Needs a *tiny* window now that Fix 1 keeps the budget healthy on normal
+        windows: at context_window=900 the output reserve (512, the floor) plus
+        the compactor prompt + safety exceed the window, so
+        ``_summary_input_budget_chars`` floors to ``_MIN_SUMMARY_BUDGET_CHARS``
+        (2000).  Each message's content is ~5000 chars, head+tail-capped by
+        ``_format_message_for_summary`` to ~1525 — one block fits the 2000-char
+        budget, but two (1525 + 1525) don't, so ``_pack_blocks`` yields one batch
+        per block: ``len(batches) == len(blocks)`` → irreducible bail at depth 0.
+        """
+        session.context_window = 900
+        session.compact_max_tokens = 900
+        session._system_tokens = 0
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "u " + "x" * 5000},
+                {"role": "assistant", "content": "a " + "y" * 5000},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        before = list(session.messages)
+
+        with patch.object(session, "_utility_completion") as uc:
+            result = session._compact_messages(auto=True)
+
+        assert result is False
+        uc.assert_not_called()  # no reduction at depth 0 → bail before any call
+        assert session.messages == before  # untouched
+
+    def test_default_config_summary_call_fits_window(self, session):
+        """Regression for the keystone bug: at the shipped defaults
+        (context_window == compact_max_tokens == 32768, max_output_tokens 64000)
+        the old ``min(compact_max_tokens, max_output_tokens)`` reserve ate the
+        whole window — the input budget floored to 2000 and the summary call
+        requested 32768 output tokens on a 32768 window, overflowing.  Fix 1
+        bounds the reserve to half the window, so compaction actually runs.
+        """
+        session.context_window = 32768
+        session.compact_max_tokens = 32768
+        # Pin the default-collision scenario regardless of how the fixture's
+        # model happens to resolve caps.
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        caps = ModelCapabilities(context_window=32768, max_output_tokens=64000)
+        with patch.object(session, "_get_capabilities", return_value=caps):
+            assert session._get_capabilities().max_output_tokens == 64000
+            # Output reserve never claims more than half the window...
+            assert session._summary_output_tokens() <= session.context_window // 2
+            # ...so the input budget is healthy, not floored to 2000.
+            assert session._summary_input_budget_chars() > 10_000
+
+            session._system_tokens = 0
+            session.messages = turns_from_dicts(
+                [
+                    {
+                        "role": "user" if i % 2 == 0 else "assistant",
+                        "content": f"turn-{i:02d}: " + "word " * 40,
+                    }
+                    for i in range(8)
+                ]
+            )
+            session._msg_tokens = [1] * 8
+
+            recorded: list[int] = []
+
+            def fake_uc(messages, *, max_tokens, **_kwargs):
+                recorded.append(max_tokens)
+                return SimpleNamespace(content="## Decisions\ndense", finish_reason="stop")
+
+            with patch.object(session, "_utility_completion", side_effect=fake_uc):
+                assert session._compact_messages(auto=True) is True
+
+        # The summary call's output reserve stayed within half the window, and a
+        # representative input rides comfortably under the full window alongside it.
+        assert recorded  # at least one summary call happened
+        out_tokens = recorded[0]
+        assert out_tokens <= session.context_window // 2
+        rep_input_tokens = session._summary_input_budget_chars() / session._chars_per_token
+        assert out_tokens + rep_input_tokens < session.context_window
+
+    def test_empty_summary_keeps_history(self, session):
+        """If the summary model returns empty/reasoning-only content, compaction
+        must keep the conversation rather than swap in an empty summary and
+        silently discard everything (returning True)."""
+        session.compact_max_tokens = 100  # positive summary budget at ctx=10k
+        session._system_tokens = 0
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do the thing"},
+                {"role": "assistant", "content": "working on it"},
+                {"role": "user", "content": "and the next thing"},
+            ]
+        )
+        session._msg_tokens = [5, 5, 5]
+        before = list(session.messages)
+        empty = SimpleNamespace(content="", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", return_value=empty):
+            result = session._compact_messages(auto=True)
+
+        assert result is False
+        assert session.messages == before  # no swap, no data loss
+
+    def test_post_compaction_anchor_includes_tool_defs(self, session):
+        """#4/#9: the synthetic ``_last_usage`` written after a successful
+        compaction must fold in tool-def tokens — the same thing the provider
+        counts in ``prompt_tokens`` — so the next ``_remaining_token_budget``
+        doesn't over-state free space by the whole tool-def count."""
+        # A small but non-empty tool set so _tool_def_tokens() > 0 makes the
+        # assertion meaningful.
+        session._tool_search = None
+        session.creative_mode = False
+        session._tools = [
+            {
+                "type": "function",
+                "function": {"name": "noop", "description": "does nothing", "parameters": {}},
+            }
+        ]
+        assert session._tool_def_tokens() > 0  # sanity: tools contribute tokens
+
+        session.compact_max_tokens = 100  # positive summary budget at ctx=10k
+        session._system_tokens = 7
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do the thing"},
+                {"role": "assistant", "content": "did the thing"},
+            ]
+        )
+        session._msg_tokens = [5, 5]
+        session._last_usage = {"prompt_tokens": 9_000, "total_tokens": 9_000}
+        summary = SimpleNamespace(content="## Decisions\ndense", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._compact_messages(auto=True) is True
+
+        expected = session._system_tokens + sum(session._msg_tokens) + session._tool_def_tokens()
+        assert session._last_usage["prompt_tokens"] == expected
+
+    def test_mid_chunk_failure_leaves_messages_untouched(self, session):
+        """Atomicity: batch 1 summarizes, batch 2's call raises non-retryably →
+        no partial swap, returns False, ``self.messages`` / ``_msg_tokens`` intact."""
+        session.context_window = 5_000
+        session.compact_max_tokens = 4_000
+        session._system_tokens = 0
+        session.messages = turns_from_dicts(
+            [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"m{i:02d} " + "c" * 200,
+                }
+                for i in range(30)
+            ]
+        )
+        session._msg_tokens = [1] * 30
+        before = list(session.messages)
+        before_toks = list(session._msg_tokens)
+
+        calls = {"n": 0}
+
+        def fake_uc(_messages, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(content="PARTIAL", finish_reason="stop")
+            raise RuntimeError("summary backend exploded")  # non-retryable
+
+        with patch.object(session, "_utility_completion", side_effect=fake_uc):
+            result = session._compact_messages(auto=True)
+
+        assert result is False
+        assert calls["n"] >= 2  # failed part-way through the batches
+        assert session.messages == before  # no partial swap
+        assert session._msg_tokens == before_toks
+
+
+class TestProactiveToolDefFallback:
+    """The ``_last_usage``-less fallback in ``_estimated_prompt_tokens`` must add a
+    tool-def estimate (tools are resent every request) — otherwise a just-resumed
+    session undercounts and skips proactive compaction."""
+
+    def test_fallback_includes_tool_defs_when_active(self, session):
+        session._last_usage = None
+        session._system_tokens = 100
+        session._msg_tokens = [10, 20]
+        bare = session._system_tokens + sum(session._msg_tokens)
+        assert session._get_active_tools()  # sanity: the default tool set is present
+        assert session._estimated_prompt_tokens() > bare
+
+    def test_fallback_equals_bare_sum_without_tools(self, session):
+        session._tools = []
+        session._last_usage = None
+        session._system_tokens = 100
+        session._msg_tokens = [10, 20]
+        assert session._estimated_prompt_tokens() == 130
 
 
 def test_compaction_advisory_is_registered():

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -88,6 +88,7 @@ class TestTruncateOutput:
 
 class TestRemainingTokenBudget:
     def test_empty_session(self, session):
+        session._tools = []  # isolate the budget formula from the tool-def estimate
         session._system_tokens = 500
         session._msg_tokens = []
         budget = session._remaining_token_budget()
@@ -95,6 +96,7 @@ class TestRemainingTokenBudget:
         assert budget == 8000
 
     def test_partially_full(self, session):
+        session._tools = []  # isolate the budget formula from the tool-def estimate
         session._system_tokens = 500
         session._msg_tokens = [2000, 3000]
         budget = session._remaining_token_budget()
@@ -123,6 +125,7 @@ class TestRemainingTokenBudget:
             context_window=32_768,
             max_tokens=32_768,
         )
+        s._tools = []  # isolate the budget formula from the tool-def estimate
         s._system_tokens = 500
         s._msg_tokens = [1000]
         budget = s._remaining_token_budget()

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -110,6 +110,22 @@ NUDGE_REPEAT = (
     "tool, different arguments, or ask the user for clarification."
 )
 
+NUDGE_COMPACTION = (
+    "The conversation is approaching the context limit and will be compacted "
+    "shortly — older messages will be replaced by a summary. Reach a natural "
+    "stopping point. Before continuing, record in this turn your current goal, "
+    "the tasks that remain, and your intended next steps; anything not written "
+    "down here may be lost when compaction runs. If you can give a final answer "
+    "now, do so — otherwise state clearly where to resume."
+)
+
+NUDGE_COMPACTION_RESUME = (
+    "The conversation was just compacted to free context. If there is remaining "
+    "work, continue from the summary above — pick up the open tasks and next "
+    "steps you recorded and keep going without waiting for further instructions. "
+    "If the task is already complete, give your final answer."
+)
+
 _NUDGE_MAP: dict[str, str] = {
     "correction": NUDGE_CORRECTION,
     "denial": NUDGE_DENIAL,
@@ -118,6 +134,7 @@ _NUDGE_MAP: dict[str, str] = {
     "start": NUDGE_START,
     "tool_error": NUDGE_TOOL_ERROR,
     "repeat": NUDGE_REPEAT,
+    "compaction_pending": NUDGE_COMPACTION,
     # idle_children and watch_triggered carry no static body — the
     # per-fire text comes from a producer (``format_idle_children_nudge``
     # for the former, ``format_watch_message`` + ``sanitize_payload``

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -216,7 +216,9 @@ class _CompactionIrreducibleError(Exception):
     or the depth ceiling is hit.
 
     ``ChatSession._compact_messages`` turns it into the existing ``return False``
-    bail rather than fabricate a summary (chunking only — no honest degradation).
+    bail rather than fabricate a summary.  (Chunked compaction never drops or
+    fabricates whole turns; its one lossy path is ``_truncate_block`` head/tail-
+    truncating a single oversized block as summary *input*.)
     """
 
 
@@ -5800,7 +5802,10 @@ class ChatSession:
         the compactor prompt, and a safety margin; scale the remainder by
         ``_SUMMARY_BUDGET_FRACTION`` to cover the uncalibrated ``_chars_per_token``
         on the reactive path (no ``_last_usage`` yet); convert to chars; floor at
-        ``_MIN_SUMMARY_BUDGET_CHARS`` so a tiny window still makes progress.
+        ``_MIN_SUMMARY_BUDGET_CHARS`` so a usable window still makes progress, but
+        never above the true input capacity — flooring past what actually fits
+        would reintroduce a summary-call overflow on a pathologically small
+        window (the call bails as "irreducible" instead).
         """
         output_reserve = self._summary_output_tokens()
         prompt_chars = len(self._COMPACTOR_SYSTEM_PROMPT) + len(self._COMPACT_USER_PREFIX)
@@ -5808,7 +5813,13 @@ class ChatSession:
         safety = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
         input_tokens = self.context_window - output_reserve - prompt_tokens - safety
         budget_tokens = max(0, int(input_tokens * self._SUMMARY_BUDGET_FRACTION))
-        return max(self._MIN_SUMMARY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token))
+        budget_chars = max(
+            self._MIN_SUMMARY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token)
+        )
+        # Cap the floor at the true input capacity: on a pathologically small
+        # window the floor would otherwise push the summary call (input + output
+        # reserve + prompt) past context_window instead of letting it bail.
+        return min(budget_chars, max(0, int(input_tokens * self._chars_per_token)))
 
     @staticmethod
     def _truncate_block(block: str, budget: int) -> str:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -210,6 +210,16 @@ class AttachmentsNotQueueableError(Exception):
     """
 
 
+class _CompactionIrreducibleError(Exception):
+    """Raised by ``ChatSession._summarize_blocks`` when chunked summarisation
+    cannot shrink the input — a recursion level fails to reduce the block count,
+    or the depth ceiling is hit.
+
+    ``ChatSession._compact_messages`` turns it into the existing ``return False``
+    bail rather than fabricate a summary (chunking only — no honest degradation).
+    """
+
+
 class _CancelRef(list[Any]):
     """List proxy used for ``ChatSession._cancel_ref``.
 
@@ -2452,6 +2462,15 @@ class ChatSession:
         eid = getattr(self.ui, "_event_id", None)
         return eid if isinstance(eid, int) else None
 
+    def _tool_def_chars(self) -> int:
+        """Total serialized char size of the active tool definitions (resent on
+        every request, folded into the provider's ``prompt_tokens``)."""
+        return sum(len(json.dumps(t)) for t in (self._get_active_tools() or []))
+
+    def _tool_def_tokens(self) -> int:
+        """Estimated token cost of the active tool definitions."""
+        return int(self._tool_def_chars() / self._chars_per_token)
+
     def _estimated_prompt_tokens(self) -> int:
         """Best estimate of the current prompt size, in tokens.
 
@@ -2472,7 +2491,13 @@ class ChatSession:
             # over-slice after compaction or message-list mutations.
             start = min(self._calibrated_msg_count, len(self._msg_tokens))
             return self._last_usage["prompt_tokens"] + sum(self._msg_tokens[start:])
-        return self._system_tokens + sum(self._msg_tokens)
+        # No provider anchor yet (e.g. a just-resumed session before its first
+        # API call): add an estimate for the tool definitions, which are resent
+        # on every request and folded into the provider's prompt_tokens above.
+        # Omitting them here made a resumed session undercount and skip proactive
+        # compaction until the first reply re-anchored the estimate.
+        tool_def_tokens = self._tool_def_tokens()
+        return self._system_tokens + sum(self._msg_tokens) + tool_def_tokens
 
     def _remaining_token_budget(self) -> int:
         """Estimate how many tokens are available for new content.
@@ -2510,7 +2535,7 @@ class ChatSession:
         est = self._estimated_prompt_tokens()
         if self._compaction_owed(est):
             self._do_auto_compact("mid-turn")
-        elif est > self.context_window * self.auto_compact_pct:
+        elif self._over_soft(est):
             self._append_system_turn("compaction_pending", format_nudge("compaction_pending"))
             self._compaction_advised = True
 
@@ -2526,9 +2551,17 @@ class ChatSession:
         """
         if used is None:
             used = self._estimated_prompt_tokens()
-        soft = self.context_window * self.auto_compact_pct
         hard = self.context_window * min(0.95, self.auto_compact_pct + 0.10)
-        return used > hard or (used > soft and self._compaction_advised)
+        return used > hard or (self._over_soft(used) and self._compaction_advised)
+
+    def _over_soft(self, used: int) -> bool:
+        """True when ``used`` tokens exceed the soft auto-compaction threshold.
+
+        Single source for the ``context_window * auto_compact_pct`` predicate
+        shared by the mid-turn policy, :meth:`_compaction_owed`, and the
+        end-of-turn check, so they can't drift.
+        """
+        return used > self.context_window * self.auto_compact_pct
 
     def _do_auto_compact(self, where: str = "", preserve_tail: int = 0) -> bool:
         """Emit the auto-compaction notice, compact, and refresh the status
@@ -3801,6 +3834,13 @@ class ChatSession:
     _MAX_RETRIES = 3
     _RETRY_BASE_DELAY = 1.0  # seconds
 
+    # Chunked-compaction tuning (see _summarize_blocks / _summary_input_budget_chars).
+    _SUMMARY_SAFETY_MARGIN = 0.05  # fraction of context_window held back
+    _SUMMARY_BUDGET_FRACTION = 0.75  # derate for the uncalibrated _chars_per_token
+    _MAX_SUMMARY_DEPTH = 5  # recursion ceiling before bailing
+    _MIN_SUMMARY_BUDGET_CHARS = 2000  # floor so a tiny window still makes progress
+    _MIN_SUMMARY_OUTPUT_TOKENS = 512  # floor on summary output even on a tiny window
+
     def _get_health_tracker(self) -> BackendHealthTracker | None:
         """Get the health tracker for this session's current backend.
 
@@ -4517,18 +4557,25 @@ class ChatSession:
                     # done?  Capture before the reset — it gates the auto-resume.
                     stopped_to_compact = self._compaction_advised
                     self._compaction_advised = False
+                    # A concurrent force-cancel may have started a new generation
+                    # while this turn was finishing; don't run end-of-turn
+                    # compaction or persist a resume turn under it (the mid-turn
+                    # and end-of-loop compaction sites guard the same race).
+                    if self._generation != my_generation:
+                        return
                     # Auto-compact when the context exceeds the threshold, so the
                     # next turn starts with headroom.  Bare-soft check (NOT
                     # _compaction_owed()): the turn already ended, so there's no
                     # model cooperation to wait for and the latch was just
                     # consumed above — compact whenever over soft.  None-safe via
                     # _estimated_prompt_tokens(), so no _last_usage guard.
-                    if (
-                        self._estimated_prompt_tokens()
-                        > self.context_window * self.auto_compact_pct
-                    ):
+                    if self._over_soft(self._estimated_prompt_tokens()):
                         compacted = self._do_auto_compact()
-                        if stopped_to_compact and compacted:
+                        # _do_auto_compact's summary call is slow; unlike the
+                        # mid-turn siblings this site also PERSISTS the resume
+                        # turn, so re-check the generation didn't change during
+                        # the call before writing it into history.
+                        if stopped_to_compact and compacted and self._generation == my_generation:
                             # The model paused mid-task to let us compact, not
                             # because it was finished.  Hand the compacted state
                             # back as a user turn so it resumes instead of being
@@ -5528,8 +5575,7 @@ class ChatSession:
         all_msgs = (
             msgs if msgs is not None else self._prepare_wire_messages(self._full_messages())
         )  # system + self.messages (before append)
-        active_tools = self._get_active_tools() or []
-        tool_def_chars = sum(len(json.dumps(t)) for t in active_tools)
+        tool_def_chars = self._tool_def_chars()
         text_chars = 0
         image_count = 0
         for m in all_msgs:
@@ -5582,9 +5628,77 @@ class ChatSession:
 
     # -- Conversation compaction ------------------------------------------------
 
-    def _format_messages_for_summary(self, messages: list[dict[str, Any]]) -> str:
-        """Format messages into a readable string for the summarization prompt."""
-        # Build tool_call_id → tool_name lookup for labeling tool results
+    # Shared "## Output format" section for both compactor prompts — the section
+    # list plus its trailing blank line.  Single-sourced so the two prompts can't
+    # drift (the merge prompt's "explicitly stated" line had already lost "the
+    # user").
+    _COMPACT_OUTPUT_FORMAT = (
+        "1. **Output format** — use these exact sections, omit any that are empty:\n"
+        "   - **## Decisions**: Choices made (architecture, libraries, approaches).\n"
+        "   - **## Files**: Files read, created, or modified, with brief notes.\n"
+        "   - **## Key code**: Exact function names, class names, variable names, "
+        "and short code snippets the assistant will need. "
+        "Preserve identifiers verbatim — do NOT paraphrase.\n"
+        "   - **## Tool results**: Important tool outputs (errors, search matches, "
+        "file contents) that inform ongoing work.\n"
+        "   - **## Open tasks**: What the user asked for that is not yet done, "
+        "with enough context to continue.\n"
+        "   - **## User preferences**: Workflow preferences, constraints, or "
+        "instructions the user stated.\n"
+        "   - **## Memories to save**: Corrections, preferences, or learnings "
+        "the user expressed that should be persisted across sessions. "
+        "Format each as: `name: description — content`. "
+        "Only include items the user explicitly stated, not inferences.\n\n"
+    )
+
+    # System prompt for the depth-0 summary call (the conversation compactor).
+    _COMPACTOR_SYSTEM_PROMPT = (
+        "# Conversation Compactor\n\n"
+        "Your output REPLACES the conversation history — the assistant "
+        "will continue from your summary with no access to the original messages.\n\n"
+        + _COMPACT_OUTPUT_FORMAT
+        + "2. **Density rules:**\n"
+        "   - Every token should carry information.\n"
+        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
+        "   - Omit pleasantries, acknowledgments, and reasoning that led to dead ends.\n"
+        "   - If a tool call's result was an error that was later resolved, "
+        "keep only the resolution.\n\n"
+        "3. **Common mistakes to avoid:**\n"
+        "   - Paraphrasing file paths, function names, or variable names\n"
+        "   - Including dead-end explorations or superseded decisions\n"
+        "   - Omitting the open tasks section when work remains\n"
+        "   - Being verbose — this is a summary, not a transcript"
+    )
+
+    # System prompt for recursion levels (depth > 0): merge partial summaries of
+    # consecutive slices of ONE conversation back into a single summary.
+    _COMPACTOR_MERGE_SYSTEM_PROMPT = (
+        "# Summary Merger\n\n"
+        "You are given several partial summaries of ONE conversation, produced by "
+        "compacting consecutive slices in order. Merge these partial summaries into a "
+        "single summary that REPLACES the conversation history — the assistant will "
+        "continue from your merged summary with no access to the originals.\n\n"
+        + _COMPACT_OUTPUT_FORMAT
+        + "2. **Merge rules:**\n"
+        "   - Preserve every distinct decision, file, identifier, and open task across "
+        "all partials; later partials reflect more recent state, so on conflict prefer "
+        "the later one.\n"
+        "   - Deduplicate: fold repeated items into one, keeping the most specific.\n"
+        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
+        "   - Be dense; this is a summary, not a transcript."
+    )
+
+    # User-message wrapper prepended to every summary-call body (all depths).
+    _COMPACT_USER_PREFIX = "Compact the following conversation:\n\n"
+
+    @staticmethod
+    def _summary_tc_names(messages: list[dict[str, Any]]) -> dict[str, str]:
+        """Build a tool_call_id → tool_name lookup for labeling tool results.
+
+        Built over the full message set (not one batch) so a ``tool_use`` and its
+        later ``tool_result`` keep a consistent name even when chunking packs them
+        into different batches.
+        """
         tc_names: dict[str, str] = {}
         for m in messages:
             for tc in m.get("tool_calls", []):
@@ -5592,48 +5706,242 @@ class ChatSession:
                 tc_name = tc.get("function", {}).get("name", "unknown")
                 if tc_id:
                     tc_names[tc_id] = tc_name
+        return tc_names
 
-        parts = []
-        for m in messages:
-            role = m["role"].upper()
-            content = m.get("content") or ""
+    def _format_message_for_summary(
+        self, m: dict[str, Any], tc_names: dict[str, str]
+    ) -> str | None:
+        """Format one message into a summary line, or ``None`` when it carries no
+        renderable content.
 
-            # Flatten list content (image tool results) to text for summary
-            if isinstance(content, list):
-                text_parts = []
-                for p in content:
-                    if p.get("type") == "text":
-                        text_parts.append(p["text"])
-                    elif p.get("type") in ("image_url", "image"):
-                        # by-reference vision placeholder OR resolved inline image
-                        text_parts.append("[image]")
-                content = " ".join(text_parts)
+        ``tc_names`` (tool_call_id → tool_name, built by the caller over the full
+        selected set) labels tool results.  Long content is capped head+tail so a
+        single message can't dominate the summary input.
+        """
+        role = m["role"].upper()
+        content = m.get("content") or ""
 
-            if m.get("tool_calls"):
-                calls = []
-                for tc in m["tool_calls"]:
-                    name = tc.get("function", {}).get("name", "?")
-                    args = tc.get("function", {}).get("arguments", "")
-                    calls.append(f"{name}({args})")
-                content += "\n[Called: " + ", ".join(calls) + "]"
+        # Flatten list content (image tool results) to text for summary
+        if isinstance(content, list):
+            text_parts = []
+            for p in content:
+                if p.get("type") == "text":
+                    text_parts.append(p["text"])
+                elif p.get("type") in ("image_url", "image"):
+                    # by-reference vision placeholder OR resolved inline image
+                    text_parts.append("[image]")
+            content = " ".join(text_parts)
 
-            # Label tool results with the tool name
-            if role == "TOOL":
-                tc_id = m.get("tool_call_id", "")
-                name = tc_names.get(tc_id, "tool")
-                role = f"TOOL[{name}]"
+        if m.get("tool_calls"):
+            calls = []
+            for tc in m["tool_calls"]:
+                name = tc.get("function", {}).get("name", "?")
+                args = tc.get("function", {}).get("arguments", "")
+                calls.append(f"{name}({args})")
+            content += "\n[Called: " + ", ".join(calls) + "]"
 
-            if content:
-                if len(content) > 2000:
-                    content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
-                parts.append(f"{role}: {content}")
-        return "\n\n".join(parts)
+        # Label tool results with the tool name
+        if role == "TOOL":
+            tc_id = m.get("tool_call_id", "")
+            name = tc_names.get(tc_id, "tool")
+            role = f"TOOL[{name}]"
+
+        if content:
+            if len(content) > 2000:
+                content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
+            return f"{role}: {content}"
+        return None
+
+    def _summary_blocks(self, messages: list[dict[str, Any]]) -> list[str]:
+        """Format messages into summary blocks — one string per renderable
+        message, in order (drops messages with no renderable content)."""
+        tc_names = self._summary_tc_names(messages)
+        return [
+            line
+            for m in messages
+            if (line := self._format_message_for_summary(m, tc_names)) is not None
+        ]
+
+    def _format_messages_for_summary(self, messages: list[dict[str, Any]]) -> str:
+        """Format messages into a readable string for the summarization prompt."""
+        return "\n\n".join(self._summary_blocks(messages))
+
+    def _summary_output_tokens(self) -> int:
+        """Output-token reserve for a summary call, bounded so the input (the
+        history being summarized) always keeps the larger share of the window.
+
+        ``compact_max_tokens`` defaults to the full window (32768); clamped only
+        by ``max_output_tokens`` it would reserve the entire context for output
+        and leave no room to send anything to summarize — flooring the input
+        budget and making the summary call overflow (or bail as "irreducible")
+        on a small/default window.  Cap the reserve at half the window so
+        compaction can actually run; large windows are unaffected because
+        ``compact_max_tokens`` stays the binding limit there.
+        """
+        caps = self._get_capabilities()
+        hard_cap = (
+            min(self.compact_max_tokens, caps.max_output_tokens)
+            if caps.max_output_tokens
+            else self.compact_max_tokens
+        )
+        window_cap = max(self._MIN_SUMMARY_OUTPUT_TOKENS, self.context_window // 2)
+        return min(hard_cap, window_cap)
+
+    def _summary_input_budget_chars(self) -> int:
+        """Per-call input budget for a summary completion, in characters.
+
+        The summary runs on ``self.model`` via :meth:`_utility_completion`, so its
+        input + output must fit ``self.context_window``.  Sizing the *selection* by
+        the per-message token estimate (which disagrees with the head+tail-capped
+        formatted text) is what let a long conversation overflow the summary call
+        itself; this measures the call's real budget instead.
+
+        Reserve the output (the bounded :meth:`_summary_output_tokens` reserve),
+        the compactor prompt, and a safety margin; scale the remainder by
+        ``_SUMMARY_BUDGET_FRACTION`` to cover the uncalibrated ``_chars_per_token``
+        on the reactive path (no ``_last_usage`` yet); convert to chars; floor at
+        ``_MIN_SUMMARY_BUDGET_CHARS`` so a tiny window still makes progress.
+        """
+        output_reserve = self._summary_output_tokens()
+        prompt_chars = len(self._COMPACTOR_SYSTEM_PROMPT) + len(self._COMPACT_USER_PREFIX)
+        prompt_tokens = int(prompt_chars / self._chars_per_token)
+        safety = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
+        input_tokens = self.context_window - output_reserve - prompt_tokens - safety
+        budget_tokens = max(0, int(input_tokens * self._SUMMARY_BUDGET_FRACTION))
+        return max(self._MIN_SUMMARY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token))
+
+    @staticmethod
+    def _truncate_block(block: str, budget: int) -> str:
+        """Hard-truncate a single oversized block to ``budget`` chars, keeping the
+        head and tail around a ``…[truncated]…`` marker.
+
+        Only used for a lone block that can't fit any batch — the one lossy path
+        in chunked compaction.  The result is always ``<= budget``.
+        """
+        marker = "\n…[truncated]…\n"
+        if budget <= len(marker):
+            return block[:budget]
+        keep = budget - len(marker)
+        head = (keep * 2) // 3
+        tail = keep - head
+        return block[:head] + marker + block[-tail:] if tail else block[:head] + marker
+
+    def _pack_blocks(self, blocks: list[str], budget_chars: int) -> list[list[str]]:
+        """Greedily pack formatted blocks into batches that each fit ``budget_chars``.
+
+        In order, no reordering and no drops: blocks accumulate into the current
+        batch until the next one (plus the ``"\\n\\n"`` join) would overflow, then a
+        new batch starts.  A lone block larger than the budget gets its own batch,
+        hard-truncated via :meth:`_truncate_block`.  Never emits an empty batch.
+
+        ``current_len`` tracks ``len("\\n\\n".join(current))`` exactly, so every
+        returned batch's joined length is ``<= budget_chars``.
+        """
+        budget = max(1, budget_chars)
+        sep = len("\n\n")
+        batches: list[list[str]] = []
+        current: list[str] = []
+        current_len = 0
+        for block in blocks:
+            if len(block) > budget:
+                # Oversized lone block: flush the in-progress batch, then emit it
+                # alone, hard-truncated (head + tail preserved).
+                if current:
+                    batches.append(current)
+                    current = []
+                    current_len = 0
+                batches.append([self._truncate_block(block, budget)])
+                continue
+            added = len(block) + (sep if current else 0)
+            if current and current_len + added > budget:
+                batches.append(current)
+                current = [block]
+                current_len = len(block)
+            else:
+                current.append(block)
+                current_len += added
+        if current:
+            batches.append(current)
+        return batches
+
+    def _summarize_once(self, system_prompt: str, body: str) -> str:
+        """Run one summary completion over ``body`` and return the cleaned text.
+
+        Owns the retry loop (transient errors only, exponential backoff) and the
+        reasoning-tag strip.  Raises on a non-retryable error or retry exhaustion
+        so the caller can abort the whole compaction before any message swap.
+        """
+        summary_msgs = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": self._COMPACT_USER_PREFIX + body},
+        ]
+        result: CompletionResult | None = None
+        for attempt in range(self._MAX_RETRIES + 1):
+            try:
+                result = self._utility_completion(
+                    summary_msgs,
+                    max_tokens=self._summary_output_tokens(),
+                )
+                break
+            except Exception as e:
+                ename = type(e).__name__
+                if (
+                    ename not in self._provider.retryable_error_names
+                    or attempt == self._MAX_RETRIES
+                ):
+                    raise
+                delay = self._RETRY_BASE_DELAY * (2**attempt)
+                self.ui.on_info(f"[Compact retrying in {delay:.0f}s: {ename}]")
+                time.sleep(delay)
+        assert result is not None
+        # Strip any <think>/<reasoning> tags the summarizer may emit
+        summary = self._strip_reasoning(result.content or "")
+        if result.finish_reason == "length":
+            self.ui.on_info("[Warning: compaction summary was truncated]")
+        return summary
+
+    def _summarize_blocks(self, blocks: list[str], *, depth: int = 0) -> str:
+        """Summarize ``blocks`` into one dense summary, chunking + recursing so no
+        single model call exceeds :meth:`_summary_input_budget_chars`.
+
+        Base case (everything fits one batch) is a single :meth:`_summarize_once`
+        call — exactly today's behavior, so the common case stays one model call.
+        Otherwise each batch is summarized individually (a partial summary) and the
+        partials are recursively merged one level deeper, until they collapse to a
+        single batch.
+
+        Raises :class:`_CompactionIrreducibleError` when a level fails to reduce the
+        block count (``len(batches) >= len(blocks)``) or recursion would exceed
+        ``_MAX_SUMMARY_DEPTH`` — the caller turns that into a ``return False`` bail
+        rather than fabricate a summary.
+        """
+        batches = self._pack_blocks(blocks, self._summary_input_budget_chars())
+        system_prompt = (
+            self._COMPACTOR_SYSTEM_PROMPT if depth == 0 else self._COMPACTOR_MERGE_SYSTEM_PROMPT
+        )
+        if len(batches) == 1:
+            return self._summarize_once(system_prompt, "\n\n".join(batches[0]))
+
+        # More than one batch: bail rather than loop or over-recurse when this
+        # level can't shrink the count (each block is its own batch) or we've gone
+        # too deep.
+        if len(batches) >= len(blocks) or depth >= self._MAX_SUMMARY_DEPTH:
+            raise _CompactionIrreducibleError
+
+        total = len(batches)
+        summaries: list[str] = []
+        for k, batch in enumerate(batches, start=1):
+            self.ui.on_info(f"[compacting part {k}/{total}…]")
+            summaries.append(self._summarize_once(system_prompt, "\n\n".join(batch)))
+        return self._summarize_blocks(summaries, depth=depth + 1)
 
     def _compact_messages(self, auto: bool = False, preserve_tail: int = 0) -> bool:
         """Compact conversation history by summarizing it into a summary turn.
 
-        Summarizes the conversation via a separate model call, budget-fitted to
-        ``auto_compact_pct`` of the context window.
+        Summarizes the whole selection via :meth:`_summarize_blocks`, which chunks
+        and recursively merges so no single summary call exceeds the model's own
+        window (:meth:`_summary_input_budget_chars`) — the summary call can't
+        overflow, and the most-recent messages are no longer silently dropped.
 
         When auto=True (triggered by context limit), appends a continuation
         hint with the last user message so the model can resume seamlessly.
@@ -5667,105 +5975,34 @@ class ChatSession:
         preserved = self.messages[-preserve_tail:] if preserve_tail > 0 else []
         to_summarize = self.messages[:-preserve_tail] if preserve_tail > 0 else self.messages
 
-        # Budget: fit as many messages as possible into summary request
-        summary_max_tokens = self.compact_max_tokens
-        prompt_budget = (
-            int(self.context_window * self.auto_compact_pct)
-            - summary_max_tokens
-            - self._system_tokens
-        )
-        selected = []
-        running = 0
-        for i, msg in enumerate(to_summarize):
-            msg_tok = (
-                self._msg_tokens[i]
-                if i < len(self._msg_tokens)
-                else max(1, int(self._msg_char_count(msg) / self._chars_per_token))
-            )
-            if running + msg_tok > prompt_budget:
-                break
-            selected.append(msg)
-            running += msg_tok
-
-        if not selected:
-            self.ui.on_info("Messages too large to fit in summary context.")
+        # Build summary blocks from ALL of to_summarize (per-message), then
+        # summarize via chunked/hierarchical compaction.  Sizing by the actual
+        # formatted size (not the per-message token estimate, which disagreed
+        # with the head+tail-capped formatted text) is what bounds the summary
+        # call so it can't overflow self.context_window.  Summarizing the whole
+        # selection — not a fitting prefix — also fixes the latent drop of the
+        # most-recent (unselected) messages.
+        to_summarize_dicts = dicts_from_turns(to_summarize)
+        blocks = self._summary_blocks(to_summarize_dicts)
+        if not blocks:
+            self.ui.on_info("Not enough messages to compact.")
             return False
-
-        # Build summary prompt and call model
-        formatted = self._format_messages_for_summary(dicts_from_turns(selected))
-        summary_msgs = [
-            {
-                "role": "system",
-                "content": (
-                    "# Conversation Compactor\n\n"
-                    "Your output REPLACES the conversation history — the assistant "
-                    "will continue from your summary with no access to the original messages.\n\n"
-                    "1. **Output format** — use these exact sections, omit any that are empty:\n"
-                    "   - **## Decisions**: Choices made (architecture, libraries, approaches).\n"
-                    "   - **## Files**: Files read, created, or modified, with brief notes.\n"
-                    "   - **## Key code**: Exact function names, class names, variable names, "
-                    "and short code snippets the assistant will need. "
-                    "Preserve identifiers verbatim — do NOT paraphrase.\n"
-                    "   - **## Tool results**: Important tool outputs (errors, search matches, "
-                    "file contents) that inform ongoing work.\n"
-                    "   - **## Open tasks**: What the user asked for that is not yet done, "
-                    "with enough context to continue.\n"
-                    "   - **## User preferences**: Workflow preferences, constraints, or "
-                    "instructions the user stated.\n"
-                    "   - **## Memories to save**: Corrections, preferences, or learnings "
-                    "the user expressed that should be persisted across sessions. "
-                    "Format each as: `name: description — content`. "
-                    "Only include items the user explicitly stated, not inferences.\n\n"
-                    "2. **Density rules:**\n"
-                    "   - Every token should carry information.\n"
-                    "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
-                    "   - Omit pleasantries, acknowledgments, and reasoning that led to dead ends.\n"
-                    "   - If a tool call's result was an error that was later resolved, "
-                    "keep only the resolution.\n\n"
-                    "3. **Common mistakes to avoid:**\n"
-                    "   - Paraphrasing file paths, function names, or variable names\n"
-                    "   - Including dead-end explorations or superseded decisions\n"
-                    "   - Omitting the open tasks section when work remains\n"
-                    "   - Being verbose — this is a summary, not a transcript"
-                ),
-            },
-            {
-                "role": "user",
-                "content": ("Compact the following conversation:\n\n" + formatted),
-            },
-        ]
 
         self.ui.on_thinking_start()
         try:
-            result: CompletionResult | None = None
-            for attempt in range(self._MAX_RETRIES + 1):
-                try:
-                    result = self._utility_completion(
-                        summary_msgs,
-                        max_tokens=summary_max_tokens,
-                    )
-                    break
-                except Exception as e:
-                    ename = type(e).__name__
-                    if (
-                        ename not in self._provider.retryable_error_names
-                        or attempt == self._MAX_RETRIES
-                    ):
-                        raise
-                    delay = self._RETRY_BASE_DELAY * (2**attempt)
-                    self.ui.on_info(f"[Compact retrying in {delay:.0f}s: {ename}]")
-                    time.sleep(delay)
-            assert result is not None
-            summary = result.content or ""
-            # Strip any <think>/<reasoning> tags the summarizer may emit
-            summary = self._strip_reasoning(summary)
-            if result.finish_reason == "length":
-                self.ui.on_info("[Warning: compaction summary was truncated]")
+            summary = self._summarize_blocks(blocks)
+        except _CompactionIrreducibleError:
+            self.ui.on_info("Messages too large to fit in summary context.")
+            return False
         except Exception as e:
             self.ui.on_error(f"Compaction failed: {e}")
             return False
         finally:
             self.ui.on_thinking_stop()
+
+        if not summary.strip():
+            self.ui.on_info("Compaction produced an empty summary; keeping history.")
+            return False
 
         # Append continuation hint for auto-compact
         if last_user_content:
@@ -5779,7 +6016,7 @@ class ChatSession:
             )
 
         # Replace messages — summary, then any preserved tail verbatim.
-        before_tokens = self._system_tokens + sum(self._msg_tokens)
+        before_tokens = self._system_tokens + sum(self._msg_tokens) + self._tool_def_tokens()
         summary_user = {"role": "user", "content": "[Conversation summary]"}
         summary_asst = {"role": "assistant", "content": summary}
         self.messages = turns_from_dicts([summary_user, summary_asst]) + list(preserved)
@@ -5795,7 +6032,7 @@ class ChatSession:
         ]
         self._msg_tokens = [su_tok, sa_tok, *tail_toks]
         self._calibrated_msg_count = len(self.messages)  # anchored to compacted state
-        after_tokens = self._system_tokens + sum(self._msg_tokens)
+        after_tokens = self._system_tokens + sum(self._msg_tokens) + self._tool_def_tokens()
 
         # Update usage estimate so the status bar reflects post-compaction state
         if self._last_usage:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -99,6 +99,7 @@ from turnstone.core.memory_relevance import (
     score_memories,
 )
 from turnstone.core.metacognition import (
+    NUDGE_COMPACTION_RESUME,
     RepeatDetector,
     detect_completion,
     detect_correction,
@@ -110,6 +111,7 @@ from turnstone.core.nudge_queue import TOOL_DRAIN, USER_DRAIN, NudgeQueue
 from turnstone.core.providers import create_provider
 from turnstone.core.ratelimit import TokenBucket
 from turnstone.core.safety import is_command_blocked, sanitize_command
+from turnstone.core.settings_registry import DEFAULT_AUTO_COMPACT_PCT
 from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
 from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 from turnstone.core.storage._registry import get_storage
@@ -967,7 +969,7 @@ class ChatSession:
         reasoning_effort: str = "medium",
         context_window: int = 32768,
         compact_max_tokens: int = 32768,
-        auto_compact_pct: float = 0.8,
+        auto_compact_pct: float = DEFAULT_AUTO_COMPACT_PCT,
         agent_max_turns: int = -1,
         tool_truncation: int = 0,
         mcp_client: MCPClientManager | None = None,
@@ -1036,7 +1038,20 @@ class ChatSession:
         self.reasoning_effort = reasoning_effort
         self.context_window = context_window if context_window > 0 else 32768
         self.compact_max_tokens = compact_max_tokens
-        self.auto_compact_pct = auto_compact_pct
+        # auto_compact_pct < 0.1 is invalid: 0 used to mean "disabled" (no
+        # longer supported), and at 0 the "> context_window * pct" checks become
+        # "> 0" (always true → compact every turn). Coerce to the default, not
+        # the 0.1 floor — someone who set 0 wanted *less* compaction, so 0.8 is
+        # closer to intent than near-constant compaction at 10%. Matches the
+        # settings-registry path, which rejects sub-0.1 stored values and
+        # reverts to this same default.
+        self.auto_compact_pct = (
+            auto_compact_pct if auto_compact_pct >= 0.1 else DEFAULT_AUTO_COMPACT_PCT
+        )
+        # Cooperative-compaction latch: set once the model has been advised to
+        # reach a stopping point under context pressure; if it keeps working
+        # past the advisory the send loop forces a compaction.
+        self._compaction_advised = False
         self.agent_max_turns = agent_max_turns
         self._chars_per_token = 4.0  # calibrated from API usage
         # Tool output truncation: 0 means auto (50% of context_window in chars)
@@ -2437,31 +2452,102 @@ class ChatSession:
         eid = getattr(self.ui, "_event_id", None)
         return eid if isinstance(eid, int) else None
 
+    def _estimated_prompt_tokens(self) -> int:
+        """Best estimate of the current prompt size, in tokens.
+
+        Anchors to the provider-reported ``prompt_tokens`` from the last API
+        call — which already includes tool-definition tokens and the cached
+        prefix (providers fold cached + non-cached into one count at the API
+        boundary; see ``_anthropic.py`` ``total_input``) — and adds a local
+        estimate for only the messages appended since calibration.  Falls
+        back to a pure local estimate before the first API call.
+
+        Single source of truth for "how full is the context": tool-output
+        truncation (via :meth:`_remaining_token_budget`) and the
+        auto-compaction triggers all read it, so they cannot disagree about
+        the fullness of the same state.
+        """
+        if self._last_usage:
+            # Clamp the index: a stale _calibrated_msg_count must not
+            # over-slice after compaction or message-list mutations.
+            start = min(self._calibrated_msg_count, len(self._msg_tokens))
+            return self._last_usage["prompt_tokens"] + sum(self._msg_tokens[start:])
+        return self._system_tokens + sum(self._msg_tokens)
+
     def _remaining_token_budget(self) -> int:
         """Estimate how many tokens are available for new content.
 
-        When provider-reported usage is available, uses the last API
-        call's ``prompt_tokens`` as ground truth and only estimates the
-        delta (messages added since that call).  Falls back to pure
-        local estimates otherwise.
-
         Reserves a response budget (capped at 25% of context window, since
-        ``max_tokens`` is an upper bound, not guaranteed consumption) plus
-        a 5% safety margin.  Returns at least 0.
+        ``max_tokens`` is an upper bound, not guaranteed consumption) plus a
+        5% safety margin.  Returns at least 0.  Context fullness comes from
+        :meth:`_estimated_prompt_tokens` (provider-anchored), shared with the
+        auto-compaction triggers so truncation and compaction agree.
         """
-        used = self._system_tokens + sum(self._msg_tokens)
-        if self._last_usage:
-            # Provider-reported tokens from the last API call
-            base = self._last_usage["prompt_tokens"]
-            # Only estimate tokens for messages added AFTER calibration.
-            # Clamp index to prevent stale _calibrated_msg_count from
-            # over-slicing after compaction or message list mutations.
-            start = min(self._calibrated_msg_count, len(self._msg_tokens))
-            new_msg_tokens = sum(self._msg_tokens[start:])
-            used = base + new_msg_tokens
+        used = self._estimated_prompt_tokens()
         response_reserve = min(self.max_tokens, self.context_window // 4)
         safety_margin = int(self.context_window * 0.05)
         return max(0, self.context_window - used - response_reserve - safety_margin)
+
+    def _maybe_compact_midturn(self) -> None:
+        """Cooperative mid-turn compaction policy.
+
+        Reads the provider-anchored fullness estimate (the same measure
+        tool-output truncation uses, so the two cannot disagree about the
+        same state) and escalates:
+
+        - over the **hard** ceiling — no turn to spare, compact now;
+        - over the **soft** threshold and already advised — the model kept
+          working past the wrap-up advisory, compact;
+        - over the **soft** threshold, first crossing — append a
+          ``compaction_pending`` advisory asking the model to reach a stopping
+          point and record its remaining plan, so the summariser preserves it
+          (a register-spill onto the transcript before the tape is collapsed),
+          and latch ``_compaction_advised``.
+
+        No-op below the soft threshold.  The latch is cleared by
+        :meth:`_compact_messages` and at end-of-turn.
+        """
+        est = self._estimated_prompt_tokens()
+        if self._compaction_owed(est):
+            self._do_auto_compact("mid-turn")
+        elif est > self.context_window * self.auto_compact_pct:
+            self._append_system_turn("compaction_pending", format_nudge("compaction_pending"))
+            self._compaction_advised = True
+
+    def _compaction_owed(self, used: int | None = None) -> bool:
+        """True when fullness mandates compaction now: over the hard ceiling, or
+        over the soft threshold after the model worked past a wrap-up advisory.
+
+        Shared by the compact-before-truncate check in the send loop and
+        :meth:`_maybe_compact_midturn`.  Pass a precomputed ``used`` to avoid a
+        redundant :meth:`_estimated_prompt_tokens` sum.  The hard ceiling sits a
+        band above the soft threshold (capped at 95%); if ``auto_compact_pct`` is
+        set above that, the band collapses and any over-soft state is "owed".
+        """
+        if used is None:
+            used = self._estimated_prompt_tokens()
+        soft = self.context_window * self.auto_compact_pct
+        hard = self.context_window * min(0.95, self.auto_compact_pct + 0.10)
+        return used > hard or (used > soft and self._compaction_advised)
+
+    def _do_auto_compact(self, where: str = "", preserve_tail: int = 0) -> bool:
+        """Emit the auto-compaction notice, compact, and refresh the status
+        line.  Shared by the mid-turn policy (:meth:`_maybe_compact_midturn`)
+        and the end-of-turn check so the notice wording, the percentage, and
+        the post-compaction status refresh stay in lockstep.  ``where`` is an
+        optional qualifier for the notice (e.g. ``"mid-turn"``); ``preserve_tail``
+        is forwarded to :meth:`_compact_messages` (e.g. to keep an in-flight
+        tool-call turn during compact-before-truncate).  Returns whether a
+        summary was actually produced (False if compaction bailed) so callers
+        can avoid acting on a compaction that did not happen."""
+        qualifier = f" {where}" if where else ""
+        pct_display = round(self.auto_compact_pct * 100)
+        self.ui.on_info(
+            f"\n[Auto-compacting{qualifier}: prompt exceeds {pct_display}% of context window]"
+        )
+        compacted = self._compact_messages(auto=True, preserve_tail=preserve_tail)
+        self._print_status_line()
+        return compacted
 
     def _truncate_output(self, output: str, remaining_budget_tokens: int | None = None) -> str:
         """Truncate tool output, keeping head + tail.
@@ -3943,6 +4029,7 @@ class ChatSession:
         send_id: str | None = None,
         *,
         from_wake: bool = False,
+        source: str | None = None,
     ) -> int:
         """Append a user turn (plain or multipart) and persist it.
 
@@ -4004,6 +4091,11 @@ class ChatSession:
             # delivered while a wake is in flight, NOT synthetic, so
             # they must not inherit the wake tag.
             user_msg["_source"] = self._wake_source_tag
+        elif source:
+            # Provenance for other self-prompted turns (e.g. the post-compaction
+            # auto-resume): marks the turn for audit / replay / UI so it isn't
+            # mistaken for real user input.  Stripped at the sanitize boundary.
+            user_msg["_source"] = source
         if attachments:
             # Sibling metadata so live history replay has the same shape
             # as reloaded-from-DB (filenames are not recoverable from an
@@ -4240,6 +4332,12 @@ class ChatSession:
             self._budget_exhausted = False
             self._budget_warned = False
         self._notify_count = 0
+        # Per-send cooperative-compaction latch: each send starts a fresh
+        # advise→compact cycle, so reset here.  This single chokepoint covers
+        # the cancel / error / superseded / resume / clear / new exits that
+        # would otherwise leave the latch set on the long-lived session and
+        # trip a premature, advisory-skipping compaction on the next send.
+        self._compaction_advised = False
         self._generation += 1
         my_generation = self._generation
         # Fresh cancel event per generation.  The old event object stays
@@ -4414,19 +4512,36 @@ class ChatSession:
 
                 tool_calls = assistant_msg.get("tool_calls")
                 if not tool_calls:
-                    # Auto-compact when prompt exceeds threshold
+                    # Did the model stop because we asked it to wind down for a
+                    # compaction (cooperative), or because the task is actually
+                    # done?  Capture before the reset — it gates the auto-resume.
+                    stopped_to_compact = self._compaction_advised
+                    self._compaction_advised = False
+                    # Auto-compact when the context exceeds the threshold, so the
+                    # next turn starts with headroom.  Bare-soft check (NOT
+                    # _compaction_owed()): the turn already ended, so there's no
+                    # model cooperation to wait for and the latch was just
+                    # consumed above — compact whenever over soft.  None-safe via
+                    # _estimated_prompt_tokens(), so no _last_usage guard.
                     if (
-                        self._last_usage
-                        and self._last_usage["prompt_tokens"]
+                        self._estimated_prompt_tokens()
                         > self.context_window * self.auto_compact_pct
                     ):
-                        pct_display = int(self.auto_compact_pct * 100)
-                        self.ui.on_info(
-                            f"\n[Auto-compacting: prompt exceeds {pct_display}% of context window]"
-                        )
-                        self._compact_messages(auto=True)
-                        # Update status bar with post-compaction token counts
-                        self._print_status_line()
+                        compacted = self._do_auto_compact()
+                        if stopped_to_compact and compacted:
+                            # The model paused mid-task to let us compact, not
+                            # because it was finished.  Hand the compacted state
+                            # back as a user turn so it resumes instead of being
+                            # stranded at idle — but only when a summary was
+                            # actually produced (else there's nothing to continue
+                            # from).  The prompt lets a genuinely-finished model
+                            # give its final answer and stop.
+                            self._append_user_turn(
+                                NUDGE_COMPACTION_RESUME,
+                                (),
+                                source="compaction_resume",
+                            )
+                            continue
                     # Flush any queued messages that weren't injected
                     # (no tool calls → no advisory seam to inject at).
                     # If anything drained, the model hasn't seen those
@@ -4469,6 +4584,19 @@ class ChatSession:
                 # without per-output bookkeeping, N parallel tool results
                 # could each claim the full remaining budget and collectively
                 # overflow the prompt.
+                # Compact-before-truncate: if a compaction is already owed (over
+                # the hard ceiling, or the model worked past a wrap-up advisory),
+                # do it BEFORE sizing the truncation budget — preserving the
+                # in-flight assistant tool-call turn (preserve_tail=1) so the
+                # results about to be appended aren't orphaned from their
+                # tool_use.  The freed context then lets the fresh results
+                # through (largely) untruncated instead of snipping them only to
+                # summarise them moments later.  Generation-guarded so an
+                # orphaned thread can't replace history under the active one.
+                pre_attempted_compact = False
+                if self._generation == my_generation and self._compaction_owed():
+                    self._do_auto_compact("mid-turn", preserve_tail=1)
+                    pre_attempted_compact = True
                 truncation_budget = self._remaining_token_budget()
                 _truncated: dict[str, str] = {}
                 for tc_id, output in results:
@@ -4654,17 +4782,22 @@ class ChatSession:
                 # joined to queued items by ``\n\n``.
                 self._flush_queued_messages(prefix=user_feedback or "")
 
-                # Mid-turn compaction: prevent context overflow during long
-                # tool chains.  Uses local estimates since _last_usage reflects
-                # the previous API call, not the tool results just appended.
-                estimated_prompt = self._system_tokens + sum(self._msg_tokens)
-                if estimated_prompt > self.context_window * self.auto_compact_pct:
-                    pct_display = int(self.auto_compact_pct * 100)
-                    self.ui.on_info(
-                        f"\n[Auto-compacting mid-turn: estimated prompt "
-                        f"exceeds {pct_display}% of context window]"
-                    )
-                    self._compact_messages(auto=True)
+                # Don't mutate shared history from an orphaned (superseded)
+                # thread: a force-cancel handoff bumps _generation, and
+                # _maybe_compact_midturn can replace self.messages out from
+                # under the active generation.
+                if self._generation != my_generation:
+                    return
+                # Cooperative mid-turn compaction — advise once under context
+                # pressure so the model can reach a stopping point and spill its
+                # plan, then compact if it keeps working (or immediately over
+                # the hard ceiling).  Skip if a compaction was already attempted
+                # pre-truncation this iteration: re-running would double the work
+                # (and retry-storm on a failed summary); truncation already
+                # bounded the batch, and the next iteration / end-of-turn
+                # re-checks.
+                if not pre_attempted_compact:
+                    self._maybe_compact_midturn()
         except GenerationCancelled:
             # If a newer send() has started (force cancel), this thread is
             # orphaned — skip all message mutations and state changes.
@@ -5496,18 +5629,28 @@ class ChatSession:
                 parts.append(f"{role}: {content}")
         return "\n\n".join(parts)
 
-    def _compact_messages(self, auto: bool = False) -> None:
-        """Compact conversation history by summarizing all messages.
+    def _compact_messages(self, auto: bool = False, preserve_tail: int = 0) -> bool:
+        """Compact conversation history by summarizing it into a summary turn.
 
-        Summarizes the entire conversation via a separate model call,
-        budget-fitted to 80% of the context window.
+        Summarizes the conversation via a separate model call, budget-fitted to
+        ``auto_compact_pct`` of the context window.
 
         When auto=True (triggered by context limit), appends a continuation
         hint with the last user message so the model can resume seamlessly.
+
+        ``preserve_tail`` keeps the last N messages verbatim (re-appended after
+        the summary) instead of summarizing them — used to keep an in-flight
+        assistant tool-call turn so the tool results appended after compaction
+        aren't orphaned from their ``tool_use``.
         """
+        # Clear the cooperative latch on every compaction *attempt*, ahead of
+        # the early-return guards below — a bailed compaction (too few/large
+        # messages, summary error) must fall back to the advisory grace state
+        # next cycle rather than retry-storm on the same over-soft estimate.
+        self._compaction_advised = False
         if len(self.messages) < 2:
             self.ui.on_info("Not enough messages to compact.")
-            return
+            return False
 
         # Find the last user message for the continuation hint
         last_user_content = None
@@ -5517,7 +5660,12 @@ class ChatSession:
                     last_user_content = m.text or ""
                     break
 
-        to_summarize = self.messages
+        # Optionally keep the last ``preserve_tail`` messages verbatim — e.g. an
+        # in-flight assistant tool-call whose results are about to be appended —
+        # so compacting them away can't orphan a tool result.  Re-appended after
+        # the summary, below.
+        preserved = self.messages[-preserve_tail:] if preserve_tail > 0 else []
+        to_summarize = self.messages[:-preserve_tail] if preserve_tail > 0 else self.messages
 
         # Budget: fit as many messages as possible into summary request
         summary_max_tokens = self.compact_max_tokens
@@ -5541,7 +5689,7 @@ class ChatSession:
 
         if not selected:
             self.ui.on_info("Messages too large to fit in summary context.")
-            return
+            return False
 
         # Build summary prompt and call model
         formatted = self._format_messages_for_summary(dicts_from_turns(selected))
@@ -5615,7 +5763,7 @@ class ChatSession:
                 self.ui.on_info("[Warning: compaction summary was truncated]")
         except Exception as e:
             self.ui.on_error(f"Compaction failed: {e}")
-            return
+            return False
         finally:
             self.ui.on_thinking_stop()
 
@@ -5630,19 +5778,22 @@ class ChatSession:
                 f"Continue assisting from where we left off."
             )
 
-        # Replace messages
+        # Replace messages — summary, then any preserved tail verbatim.
         before_tokens = self._system_tokens + sum(self._msg_tokens)
         summary_user = {"role": "user", "content": "[Conversation summary]"}
         summary_asst = {"role": "assistant", "content": summary}
-        self.messages = turns_from_dicts([summary_user, summary_asst])
+        self.messages = turns_from_dicts([summary_user, summary_asst]) + list(preserved)
         # File contents are gone after compaction — force re-read before edit_file
         self._read_files.clear()
         self._repeat_detector.clear()
 
-        # Rebuild token table
+        # Rebuild token table — summary turns + preserved-tail estimates.
         su_tok = max(1, int(self._msg_char_count(summary_user) / self._chars_per_token))
         sa_tok = max(1, int(self._msg_char_count(summary_asst) / self._chars_per_token))
-        self._msg_tokens = [su_tok, sa_tok]
+        tail_toks = [
+            max(1, int(self._msg_char_count(m) / self._chars_per_token)) for m in preserved
+        ]
+        self._msg_tokens = [su_tok, sa_tok, *tail_toks]
         self._calibrated_msg_count = len(self.messages)  # anchored to compacted state
         after_tokens = self._system_tokens + sum(self._msg_tokens)
 
@@ -5661,6 +5812,7 @@ class ChatSession:
             lines.append(f"  {line}")
         lines.append(separator)
         self.ui.on_info("\n".join(lines))
+        return True
 
     # -- Intent validation --------------------------------------------------------
 

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -31,6 +31,12 @@ class SettingDef:
     reference_url: str = ""  # link to arXiv, docs, or provider reference
 
 
+# Default auto-compaction trigger as a fraction of the context window.  Shared
+# with the ChatSession constructor (default + sub-0.1 coercion fallback) so the
+# "invalid → default" behavior cannot drift between the registry and the engine.
+DEFAULT_AUTO_COMPACT_PCT = 0.8
+
+
 def _build_registry() -> dict[str, SettingDef]:
     """Build the settings registry from declarative definitions."""
     defs: list[SettingDef] = [
@@ -138,10 +144,10 @@ def _build_registry() -> dict[str, SettingDef]:
         SettingDef(
             "session.auto_compact_pct",
             "float",
-            0.8,
-            "Auto-compact at this fraction of context window (0 = disabled)",
+            DEFAULT_AUTO_COMPACT_PCT,
+            "Auto-compact at this fraction of context window",
             "session",
-            min_value=0.0,
+            min_value=0.1,
             max_value=1.0,
             help="Automatically summarize older messages when the conversation fills this percentage "
             "of the context window. For example, 0.8 means compact when 80% full. This prevents "

--- a/turnstone/core/tool_advisory.py
+++ b/turnstone/core/tool_advisory.py
@@ -122,6 +122,7 @@ SYSTEM_TURN_SOURCES: Final = frozenset(
         "start",
         "tool_error",
         "repeat",
+        "compaction_pending",
         "idle_children",
         "watch_triggered",
     }


### PR DESCRIPTION
## What

Overhauls context compaction so it works reliably against one provider-anchored fullness measure. Two commits:

### `fix(session)`: provider-anchored budget + cooperative compaction
- **One fullness measure** (`_estimated_prompt_tokens`) shared by tool-output truncation and compaction, so they can't disagree — fixes a dead zone (~80–100% full) where the model got honestly-truncated tool output but compaction never fired, so it flailed until going idle.
- **Cooperative pre-advisory:** on first crossing the soft threshold, inject a `compaction_pending` system turn asking the model to reach a stopping point and record its remaining plan (a register-spill before the tape collapses), then compact if it keeps working past the advisory or crosses the hard ceiling.
- **Auto-resume:** after an *advised* end-of-turn compaction, hand the summary back as a user turn so the assistant continues from where it left off instead of stranding at idle.
- **Tail-preserving compact-before-truncate** (`preserve_tail=1`): compact before sizing the truncation budget, keeping the in-flight assistant tool-call turn so the fresh results aren't orphaned from their `tool_use`.
- `auto_compact_pct` floored at 0.1 (the old "0 = disabled" made the threshold always-true → compact every turn).

### `fix(compaction)`: chunk the summary call so it can't overflow
- **Chunked/hierarchical summary** via `_summarize_blocks`: pack the formatted history into batches that each fit the summary call's own input budget, summarize each, recursively merge the partials until one remains. The common case (it all fits) stays a single call; an irreducible input bails rather than fabricate; a mid-chunk failure leaves messages untouched (atomic swap only on success). Fixes the old single call overflowing on a long history, and the prefix-fit silently dropping the most-recent messages.
- **Keystone fix — bound the summary output reserve to half the window** (`_summary_output_tokens`, used by both the budget sizing and the actual call). `compact_max_tokens` defaults to the full window (32768); clamped only by `max_output_tokens` it reserved the entire context for output, flooring the input budget so compaction silently failed (overflow or "irreducible") at exactly the default/small-window config that needs it most. Large windows are unaffected (`compact_max_tokens` stays binding).
- Empty-summary guard (keep history instead of swapping in nothing and reporting success); tool-def tokens folded into the `_last_usage`-less estimate and the post-compaction anchor; generation-guard on the end-of-turn auto-compaction so a force-cancel during the summary call can't compact/persist under a new generation; DRY single-sourcing (`_COMPACT_OUTPUT_FORMAT`, `_over_soft`, `_tool_def_chars`/`_tool_def_tokens`).

## Review

Both commits went through the multi-agent review pipeline. The max-effort pass caught the keystone budget bug — compaction failing at the default config, which the first round of tests had masked by using a small `compact_max_tokens`. The prepush pass caught a missing generation guard on the end-of-turn auto-compaction. All confirmed findings fixed and verified by mutation checks; refuted/false-positive findings dropped.

## Tests

`tests/test_cooperative_compaction.py` (new): the fullness estimate (incl. Anthropic cache-token normalization), the escalation branches including the dead-zone regression, latch lifecycle, auto-resume gating, compact-before-truncate orphan avoidance, chunked packing/recursion/atomicity, the **default-config regression** (the test that would have caught the keystone bug), the empty-summary guard, the `pre_attempted_compact` guard, and the `_MAX_SUMMARY_DEPTH` recursion backstop.

## Gates
- `ruff` + `mypy` clean
- full non-live suite: **7672 passed, 9 skipped**
