### PR TITLE
fix(compaction): persist checkpoint markers to bound resume rehydration

### DIFF
--- a/tests/test_compaction_checkpoint.py
+++ b/tests/test_compaction_checkpoint.py
@@ -58,6 +58,19 @@ class TestWatermark:
         # Keep the newest 2 verbatim → boundary is the 3rd-newest id.
         assert st.get_compaction_watermark(ws, 2) == ids[-3]
 
+    def test_preserve_tail_ignores_existing_markers(self, storage_backend):
+        # A compaction marker is saved as a NEW row but is not part of the
+        # preserved in-memory tail, so it must not shift the (preserve_tail+1)
+        # boundary — without the exclusion, this returns ids[-1] (the marker
+        # consumes an offset slot) and resume would drop a real tail row.
+        st = storage_backend
+        ws = _register(st)
+        ids = [st.save_message(ws, "user", f"m{i}") for i in range(5)]
+        st.save_message(ws, "assistant", "SUM", source="compaction", meta=_marker_meta(max(ids)))
+        st.save_message(ws, "user", "m5")
+        # Real rows newest-first: m5, m4, m3, ... → 3rd-newest real row is m3.
+        assert st.get_compaction_watermark(ws, 2) == ids[-2]
+
     def test_empty_workstream_is_none(self, storage_backend):
         st = storage_backend
         ws = _register(st)

--- a/tests/test_compaction_checkpoint.py
+++ b/tests/test_compaction_checkpoint.py
@@ -1,0 +1,436 @@
+"""Tests for persisted compaction checkpoints (rehydration-deadlock fix).
+
+Compaction swaps a session's in-memory history for a summary but leaves the full
+transcript in storage.  Without a durable marker, ``resume()`` reloaded the full
+pre-compaction history, which on a long session — or one switched to a smaller-
+context model — exceeds the window and deadlocks the first send.
+
+The fix persists one ``_source="compaction"`` marker (summary + watermark) so
+resume rehydrates ``[summary] + [rows after the watermark]`` while the full
+history stays in storage for ``/history``/export.  Covered here:
+
+- ``get_compaction_watermark`` — the boundary id (max-summarized), with and
+  without a preserved tail, and on an empty workstream.
+- ``load_message_turns`` (resume) — checkpoint-aware slice, latest-marker-wins,
+  preserved-tail handling, and the full-history fallbacks (no marker, malformed
+  marker) that keep every pre-checkpoint session loading exactly as before.
+- ``load_messages`` (display) — markers stay invisible to ``/history``.
+- End-to-end: ``_compact_messages`` writes the marker and a fresh ``resume()``
+  rehydrates the bounded view, not the full transcript.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._session_helpers import make_session
+from turnstone.core.trajectory import turns_from_dicts
+
+
+def _marker_meta(watermark: int | None) -> str | None:
+    """The marker's stored ``meta`` JSON (``None`` simulates a legacy/malformed marker)."""
+    return json.dumps({"watermark": watermark}) if watermark is not None else None
+
+
+def _register(st, ws: str = "ws1") -> str:
+    st.register_workstream(ws, user_id="u1", title="t", kind="interactive")
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# get_compaction_watermark
+# ---------------------------------------------------------------------------
+
+
+class TestWatermark:
+    def test_preserve_tail_zero_is_max_id(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        ids = [st.save_message(ws, "user", f"m{i}") for i in range(5)]
+        assert st.get_compaction_watermark(ws, 0) == max(ids)
+
+    def test_preserve_tail_n_is_nth_newest(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        ids = sorted(st.save_message(ws, "user", f"m{i}") for i in range(5))
+        # Keep the newest 2 verbatim → boundary is the 3rd-newest id.
+        assert st.get_compaction_watermark(ws, 2) == ids[-3]
+
+    def test_empty_workstream_is_none(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        assert st.get_compaction_watermark(ws, 0) is None
+
+    def test_preserve_tail_exceeding_row_count_is_none(self, storage_backend):
+        # Fewer rows than the preserved tail → no boundary, so compaction skips
+        # the marker rather than writing a watermark that points past the history.
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "only")
+        assert st.get_compaction_watermark(ws, 5) is None
+
+
+# ---------------------------------------------------------------------------
+# load_message_turns — checkpoint-aware resume
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointResume:
+    def test_loads_summary_plus_tail_not_full_history(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        for i in range(5):
+            st.save_message(ws, "user" if i % 2 == 0 else "assistant", f"old{i}")
+        watermark = st.get_compaction_watermark(ws, 0)
+        st.save_message(
+            ws, "assistant", "THE SUMMARY", source="compaction", meta=_marker_meta(watermark)
+        )
+        st.save_message(ws, "user", "new question")
+        st.save_message(ws, "assistant", "new answer")
+
+        texts = [t.text for t in st.load_message_turns(ws)]
+        assert texts == ["[Conversation summary]", "THE SUMMARY", "new question", "new answer"]
+        assert not any("old" in x for x in texts)  # summarized prefix is gone
+
+    def test_preserved_tail_kept_after_summary(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        ids = sorted(st.save_message(ws, "user", f"m{i}") for i in range(4))
+        # Mid-turn compaction keeps the newest row (m3) verbatim.
+        watermark = st.get_compaction_watermark(ws, 1)
+        assert watermark == ids[-2]
+        st.save_message(ws, "assistant", "SUM", source="compaction", meta=_marker_meta(watermark))
+
+        texts = [t.text for t in st.load_message_turns(ws)]
+        assert texts == ["[Conversation summary]", "SUM", "m3"]
+
+    def test_latest_marker_wins(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "old")
+        st.save_message(
+            ws,
+            "assistant",
+            "SUMMARY 1",
+            source="compaction",
+            meta=_marker_meta(st.get_compaction_watermark(ws, 0)),
+        )
+        st.save_message(ws, "user", "mid")
+        st.save_message(
+            ws,
+            "assistant",
+            "SUMMARY 2",
+            source="compaction",
+            meta=_marker_meta(st.get_compaction_watermark(ws, 0)),
+        )
+        st.save_message(ws, "user", "after")
+
+        texts = [t.text for t in st.load_message_turns(ws)]
+        assert texts == ["[Conversation summary]", "SUMMARY 2", "after"]
+        assert "SUMMARY 1" not in texts and "old" not in texts and "mid" not in texts
+
+    def test_no_marker_loads_full_history(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        for i in range(3):
+            st.save_message(ws, "user", f"m{i}")
+        assert [t.text for t in st.load_message_turns(ws)] == ["m0", "m1", "m2"]
+
+    def test_malformed_marker_falls_back_to_full_history(self, storage_backend):
+        # A marker with no watermark (legacy/corrupt) must NOT slice — losing
+        # real messages is worse than reloading more than necessary.
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "a")
+        st.save_message(ws, "assistant", "SUMMARY", source="compaction", meta=None)
+        st.save_message(ws, "user", "b")
+        texts = [t.text for t in st.load_message_turns(ws)]
+        assert "a" in texts and "b" in texts  # no real message dropped
+
+
+# ---------------------------------------------------------------------------
+# load_messages — display path keeps markers invisible
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayPath:
+    def test_history_excludes_marker(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "q")
+        st.save_message(ws, "assistant", "a")
+        st.save_message(
+            ws,
+            "assistant",
+            "SUMMARY",
+            source="compaction",
+            meta=_marker_meta(st.get_compaction_watermark(ws, 0)),
+        )
+
+        contents = [m.get("content") for m in st.load_messages(ws)]
+        assert "SUMMARY" not in contents
+        assert contents == ["q", "a"]  # true transcript, no injected summary
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compaction writes the marker, resume is bounded
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_persists_checkpoint_and_resume_is_bounded(tmp_db, mock_openai_client):
+    """The deadlock-fix proof: a session compacts, a fresh session reopens it,
+    and resume rehydrates [summary]+[tail] — never the full pre-compaction
+    transcript that would overflow the window on reopen."""
+    from unittest.mock import patch
+
+    from turnstone.core.memory import register_workstream, save_message
+
+    ws = "wsE2E"
+    register_workstream(ws, user_id="u1", name="t")
+    history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"} for i in range(6)
+    ]
+    for h in history:
+        save_message(ws, h["role"], h["content"])
+
+    sess = make_session(client=mock_openai_client, context_window=10_000, max_tokens=1_000)
+    sess._ws_id = ws
+    sess.messages = turns_from_dicts(history)
+    sess._msg_tokens = [1] * len(history)
+    with patch.object(sess, "_summarize_blocks", return_value="DENSE SUMMARY"):
+        assert sess._compact_messages(auto=False) is True
+
+    # Conversation continues after the compaction.
+    save_message(ws, "user", "after compaction")
+
+    # A fresh session reopens the workstream.
+    sess2 = make_session(client=mock_openai_client, context_window=10_000, max_tokens=1_000)
+    assert sess2.resume(ws) is True
+    texts = [t.text for t in sess2.messages]
+
+    assert texts[:2] == ["[Conversation summary]", "DENSE SUMMARY"]
+    assert "after compaction" in texts
+    assert not any(t.startswith("turn ") for t in texts)  # full history NOT reloaded
+
+
+# ---------------------------------------------------------------------------
+# Malformed / edge-case markers — the watermark guards and the empty tail
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerEdges:
+    @pytest.mark.parametrize(
+        "meta",
+        [
+            json.dumps({"watermark": "5"}),  # non-int (string)
+            json.dumps({"watermark": True}),  # bool — True is an int subclass
+            json.dumps({}),  # key absent
+            json.dumps({"watermark": None}),  # null
+        ],
+    )
+    def test_non_int_watermark_falls_back_to_full_history(self, storage_backend, meta):
+        # A watermark that isn't a real int must NOT slice (a True watermark
+        # would otherwise cut at id 1 and drop real history).
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "a")
+        st.save_message(ws, "assistant", "b")
+        st.save_message(ws, "assistant", "SUMMARY", source="compaction", meta=meta)
+        st.save_message(ws, "user", "c")
+        texts = [t.text for t in st.load_message_turns(ws)]
+        assert "a" in texts and "b" in texts and "c" in texts  # nothing sliced away
+        # ...and the malformed marker is DROPPED, not leaked as a stray summary turn.
+        assert "SUMMARY" not in texts
+
+    def test_marker_as_final_row_yields_empty_tail(self, storage_backend):
+        # watermark == max id, marker is the last row → resume is just the summary.
+        st = storage_backend
+        ws = _register(st)
+        for i in range(3):
+            st.save_message(ws, "user", f"old{i}")
+        wm = st.get_compaction_watermark(ws, 0)
+        st.save_message(ws, "assistant", "SUMMARY", source="compaction", meta=_marker_meta(wm))
+        assert [t.text for t in st.load_message_turns(ws)] == ["[Conversation summary]", "SUMMARY"]
+
+
+# ---------------------------------------------------------------------------
+# checkpointed=False — export/audit gets the FULL transcript (markers dropped)
+# ---------------------------------------------------------------------------
+
+
+class TestFullHistoryLoad:
+    def test_checkpointed_false_returns_full_history_without_marker(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        for i in range(4):
+            st.save_message(ws, "user" if i % 2 == 0 else "assistant", f"old{i}")
+        wm = st.get_compaction_watermark(ws, 0)
+        st.save_message(ws, "assistant", "SUMMARY", source="compaction", meta=_marker_meta(wm))
+        st.save_message(ws, "user", "after")
+
+        # Resume (default) is bounded; export (checkpointed=False) is full + marker-free.
+        assert [t.text for t in st.load_message_turns(ws)] == [
+            "[Conversation summary]",
+            "SUMMARY",
+            "after",
+        ]
+        full = [t.text for t in st.load_message_turns(ws, checkpointed=False)]
+        assert full == ["old0", "old1", "old2", "old3", "after"]
+        assert "SUMMARY" not in full and "[Conversation summary]" not in full
+
+
+# ---------------------------------------------------------------------------
+# search — compaction markers stay out of search results
+# ---------------------------------------------------------------------------
+
+
+class TestSearchExclusion:
+    def test_search_history_excludes_markers(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "findme apple")
+        st.save_message(
+            ws,
+            "assistant",
+            "findme SUMMARY banana",
+            source="compaction",
+            meta=_marker_meta(st.get_compaction_watermark(ws, 0)),
+        )
+        contents = [r[3] for r in st.search_history("findme")]
+        assert any("apple" in (c or "") for c in contents)  # real row matched
+        assert not any("SUMMARY" in (c or "") for c in contents)  # marker excluded
+        # ...and normal rows (whose _source is NULL) are NOT dropped by the filter.
+        assert contents
+
+    def test_search_history_recent_excludes_markers(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "real")
+        st.save_message(
+            ws,
+            "assistant",
+            "SUMMARY",
+            source="compaction",
+            meta=_marker_meta(st.get_compaction_watermark(ws, 0)),
+        )
+        recent = [r[3] for r in st.search_history_recent(10)]
+        assert "real" in recent and "SUMMARY" not in recent
+
+
+# ---------------------------------------------------------------------------
+# rewind / retry — compaction-safe truncation (never delete the summary backing)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionFloor:
+    def test_floor_and_count(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        for i in range(3):
+            st.save_message(ws, "user", f"old{i}")  # summarized prefix
+        wm = st.get_compaction_watermark(ws, 0)
+        st.save_message(ws, "assistant", "SUMMARY", source="compaction", meta=_marker_meta(wm))
+        st.save_message(ws, "user", "tail1")
+        st.save_message(ws, "assistant", "tail2")
+        assert st.get_compaction_floor(ws) == 4  # 3 prefix + 1 marker
+        assert st.count_messages(ws) == 6
+
+    def test_floor_zero_without_marker(self, storage_backend):
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "x")
+        assert st.get_compaction_floor(ws) == 0
+
+
+def test_rewind_after_compaction_never_deletes_summary_backing(tmp_db, mock_openai_client):
+    """The review's major rewind finding: after a compaction, a tail-trim must
+    delete from the storage TAIL and floor at the marker, not keep the oldest
+    summarized rows and drop the marker."""
+    from turnstone.core.memory import get_storage, register_workstream, save_message
+
+    ws = "wsRW"
+    register_workstream(ws, user_id="u1", name="t")
+    for i in range(3):
+        save_message(ws, "user", f"old{i}")  # prefix
+    st = get_storage()
+    wm = st.get_compaction_watermark(ws, 0)
+    save_message(
+        ws, "assistant", "SUMMARY", source="compaction", meta=json.dumps({"watermark": wm})
+    )
+    save_message(ws, "user", "q1")  # tail
+    save_message(ws, "assistant", "a1")  # tail
+    assert st.get_compaction_floor(ws) == 4 and st.count_messages(ws) == 6
+
+    sess = make_session(client=mock_openai_client, context_window=10_000, max_tokens=1_000)
+    sess._ws_id = ws
+
+    # Trim one tail turn → keep = max(floor 4, total 6 - 1) = 5 → deletes only "a1".
+    sess._persist_truncation(1)
+    assert st.count_messages(ws) == 5
+    survived = [t.text for t in st.load_message_turns(ws)]
+    assert survived[:2] == ["[Conversation summary]", "SUMMARY"]  # marker + prefix intact
+    assert "q1" in survived
+
+    # Over-deep trim → clamps at the floor; the marker + prefix still survive.
+    sess._persist_truncation(100)
+    assert st.count_messages(ws) == 4  # floored at prefix + marker
+    after = [t.text for t in st.load_message_turns(ws)]
+    assert after == ["[Conversation summary]", "SUMMARY"]  # summary backing never deleted
+
+
+def test_persist_truncation_uncompacted_matches_plain_tail_delete(tmp_db, mock_openai_client):
+    """With no compaction (floor 0), the new path is identical to the old
+    keep=len(self.messages) tail delete."""
+    from turnstone.core.memory import get_storage, register_workstream, save_message
+
+    ws = "wsPlain"
+    register_workstream(ws, user_id="u1", name="t")
+    for i in range(5):
+        save_message(ws, "user", f"m{i}")
+    st = get_storage()
+    assert st.get_compaction_floor(ws) == 0
+
+    sess = make_session(client=mock_openai_client, context_window=10_000, max_tokens=1_000)
+    sess._ws_id = ws
+    sess._persist_truncation(2)  # remove the last 2
+    assert st.count_messages(ws) == 3
+
+
+def test_persist_truncation_skips_delete_when_count_unavailable(tmp_db, mock_openai_client):
+    """count_messages==0 (the storage-error sentinel) must NOT delete — a wrong
+    truncation would lose user history."""
+    from unittest.mock import patch
+
+    from turnstone.core.memory import get_storage, register_workstream, save_message
+
+    ws = "wsCnt"
+    register_workstream(ws, user_id="u1", name="t")
+    for i in range(4):
+        save_message(ws, "user", f"m{i}")
+    st = get_storage()
+    sess = make_session(client=mock_openai_client)
+    sess._ws_id = ws
+    with patch("turnstone.core.session.count_messages", return_value=0):
+        sess._persist_truncation(2)
+    assert st.count_messages(ws) == 4  # nothing deleted
+
+
+def test_persist_truncation_skips_delete_when_floor_unavailable(tmp_db, mock_openai_client):
+    """get_compaction_floor==-1 (the storage-error sentinel) must NOT delete — a 0
+    floor on a compacted ws could otherwise drop the marker on an over-deep trim."""
+    from unittest.mock import patch
+
+    from turnstone.core.memory import get_storage, register_workstream, save_message
+
+    ws = "wsFloor"
+    register_workstream(ws, user_id="u1", name="t")
+    for i in range(4):
+        save_message(ws, "user", f"m{i}")
+    st = get_storage()
+    sess = make_session(client=mock_openai_client)
+    sess._ws_id = ws
+    with patch("turnstone.core.session.get_compaction_floor", return_value=-1):
+        sess._persist_truncation(2)
+    assert st.count_messages(ws) == 4  # nothing deleted

--- a/turnstone/core/export.py
+++ b/turnstone/core/export.py
@@ -99,7 +99,12 @@ def _build_openai_json(storage: StorageBackend, ws_id: str) -> bytes:
             if (part := attachment_to_content_part(att)) is not None
         }
 
-    repaired = repair_wire_messages(dicts_from_turns(storage.load_message_turns(ws_id)))
+    # Export the FULL transcript, not the resume-only checkpoint view: a compacted
+    # workstream must export its complete pre-compaction history (markers dropped),
+    # never the bounded [summary]+[tail] slice load_message_turns returns by default.
+    repaired = repair_wire_messages(
+        dicts_from_turns(storage.load_message_turns(ws_id, checkpointed=False))
+    )
     dicts = materialize_attachments(repaired, _resolve)
     messages = sanitize_messages(_attach_reasoning_content(dicts))
     return json.dumps({"messages": messages}, ensure_ascii=False, indent=2).encode("utf-8")

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -107,17 +107,33 @@ def load_messages(ws_id: str, *, repair: bool = True) -> list[dict[str, Any]]:
         return []
 
 
-def load_message_turns(ws_id: str) -> list[Turn]:
+def load_message_turns(ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
     """Load a workstream's history as canonical ``Turn``s (by-reference content).
 
     The resume path — see :meth:`StorageBackend.load_message_turns`.  Returns an
     empty list on any storage error (a failed resume must not crash the session).
+
+    ``checkpointed=True`` (resume default) returns the bounded ``[summary]+[tail]``
+    view when a compaction marker exists; ``checkpointed=False`` returns the full
+    transcript (markers dropped) for export/audit.
     """
     try:
-        return get_storage().load_message_turns(ws_id)
+        return get_storage().load_message_turns(ws_id, checkpointed=checkpointed)
     except Exception:
         log.warning("Failed to load message turns for ws=%s", ws_id, exc_info=True)
         return []
+
+
+def get_compaction_watermark(ws_id: str, preserve_tail: int = 0) -> int | None:
+    """Boundary id for a compaction checkpoint marker — see
+    :meth:`StorageBackend.get_compaction_watermark`.  Returns ``None`` on any
+    storage error (a failed watermark just skips the checkpoint write — the next
+    reopen reloads more history, the pre-checkpoint behavior, rather than crash)."""
+    try:
+        return get_storage().get_compaction_watermark(ws_id, preserve_tail)
+    except Exception:
+        log.warning("Failed to get compaction watermark for ws=%s", ws_id, exc_info=True)
+        return None
 
 
 # -- Workstream attachments ---------------------------------------------------
@@ -194,6 +210,34 @@ def attachment_referenced_in_ws(attachment_id: str, ws_id: str) -> bool:
     except Exception:
         log.warning("Failed to check attachment reference id=%s", attachment_id, exc_info=True)
         return False
+
+
+def count_messages(ws_id: str) -> int:
+    """Total conversation rows for ``ws_id`` (markers included).
+
+    Returns ``0`` on error — callers that truncate on this count (rewind/retry)
+    must treat ``0`` as "unknown, do not delete" rather than "empty", so a
+    transient count failure never turns into a wrong deletion.
+    """
+    try:
+        return get_storage().count_messages(ws_id)
+    except Exception:
+        log.warning("Failed to count messages for ws=%s", ws_id, exc_info=True)
+        return 0
+
+
+def get_compaction_floor(ws_id: str) -> int:
+    """Rows backing the latest compaction summary that rewind/retry must keep —
+    see :meth:`StorageBackend.get_compaction_floor`.  Returns ``-1`` on error: a
+    sentinel distinct from a legitimate ``0`` (never compacted), because a ``0``
+    floor on a *compacted* ws would let an over-deep trim delete the summary's
+    backing.  Callers that floor a deletion on this (rewind/retry) MUST skip the
+    delete when it is negative."""
+    try:
+        return get_storage().get_compaction_floor(ws_id)
+    except Exception:
+        log.warning("Failed to get compaction floor for ws=%s", ws_id, exc_info=True)
+        return -1
 
 
 def delete_messages_after(ws_id: str, keep_count: int) -> int:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -61,11 +61,14 @@ from turnstone.core.lowering import (
     repair_wire_messages,
 )
 from turnstone.core.memory import (
+    count_messages,
     count_structured_memories,
     delete_messages_after,
     delete_structured_memory_by_id,
     delete_workstream,
     get_attachments,
+    get_compaction_floor,
+    get_compaction_watermark,
     get_skill_by_name,
     get_structured_memory_by_name,
     get_workstream_display_name,
@@ -116,6 +119,8 @@ from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
 from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 from turnstone.core.storage._registry import get_storage
 from turnstone.core.storage._utils import (
+    COMPACTION_SOURCE,
+    COMPACTION_SUMMARY_LABEL,
     attachment_to_content_part,
     normalize_search_terms,
     strip_orphan_client_tool_blocks,
@@ -5011,6 +5016,40 @@ class ChatSession:
         """Return indices of user messages in self.messages (turn start positions)."""
         return [i for i, m in enumerate(self.messages) if m.role is Role.USER]
 
+    def _persist_truncation(self, removed_count: int) -> None:
+        """Mirror a rewind/retry tail-trim into storage, compaction-safe.
+
+        rewind/retry remove turns from the in-memory TAIL, which map 1:1 to the
+        most recent storage rows.  Deleting by *removed-row count* from the
+        storage end — rather than keeping the first ``len(self.messages)`` rows —
+        stays correct after a compaction, where ``self.messages`` holds synthetic
+        summary turns with no 1:1 storage rows while storage still holds the full
+        pre-compaction transcript plus the checkpoint marker.  The keep-count is
+        floored at the compaction boundary (:func:`get_compaction_floor`) so the
+        summary's backing rows and the marker are never deleted.  Identical to the
+        old ``keep = len(self.messages)`` when the ws never compacted (floor 0,
+        total == in-memory length).
+
+        Residual: an over-deep rewind that would cross the summary boundary clamps
+        at the floor in storage, so the in-memory trim can drop more than storage
+        does; a later resume rehydrates ``[summary] + [surviving tail]`` and the
+        two reconcile.
+        """
+        if removed_count <= 0:
+            return
+        total = count_messages(self._ws_id)
+        if total <= 0:
+            # Count unavailable (storage error) — skip the delete rather than risk
+            # a wrong truncation; the in-memory trim holds and resume reconciles.
+            return
+        floor = get_compaction_floor(self._ws_id)
+        if floor < 0:
+            # Floor unavailable (storage error). A 0 here is indistinguishable from
+            # "never compacted", so an over-deep trim could delete the marker and
+            # summarized prefix — skip rather than risk it; resume reconciles.
+            return
+        delete_messages_after(self._ws_id, max(floor, total - removed_count))
+
     def rewind(self, n: int) -> int:
         """Drop the last *n* complete turns from the conversation.
 
@@ -5028,7 +5067,7 @@ class ChatSession:
         removed_count = len(self.messages) - cut_index
         del self.messages[cut_index:]
         del self._msg_tokens[cut_index:]
-        delete_messages_after(self._ws_id, len(self.messages))
+        self._persist_truncation(removed_count)
         return removed_count
 
     def retry(self) -> str | None:
@@ -5048,9 +5087,10 @@ class ChatSession:
             return None
         # Drop everything from (and including) the user message onward;
         # send() will re-append the user message.
+        removed_count = len(self.messages) - last_user_idx
         del self.messages[last_user_idx:]
         del self._msg_tokens[last_user_idx:]
-        delete_messages_after(self._ws_id, len(self.messages))
+        self._persist_truncation(removed_count)
         return content
 
     @staticmethod
@@ -6028,7 +6068,7 @@ class ChatSession:
 
         # Replace messages — summary, then any preserved tail verbatim.
         before_tokens = self._system_tokens + sum(self._msg_tokens) + self._tool_def_tokens()
-        summary_user = {"role": "user", "content": "[Conversation summary]"}
+        summary_user = {"role": "user", "content": COMPACTION_SUMMARY_LABEL}
         summary_asst = {"role": "assistant", "content": summary}
         self.messages = turns_from_dicts([summary_user, summary_asst]) + list(preserved)
         # File contents are gone after compaction — force re-read before edit_file
@@ -6060,6 +6100,28 @@ class ChatSession:
             lines.append(f"  {line}")
         lines.append(separator)
         self.ui.on_info("\n".join(lines))
+
+        # Persist a compaction checkpoint so a reopen rehydrates [summary]+[tail]
+        # instead of the full transcript — which, on a long session or one switched
+        # to a smaller-context model, can exceed the window and deadlock the first
+        # send. Storage keeps the full history for /history/export/audit; this
+        # marker only governs the resume slice (load_message_turns). The watermark
+        # is read BEFORE the marker row is written, so it bounds the summarized
+        # rows and the marker takes the next (higher) id. Best-effort: both calls
+        # swallow storage errors, so a failed marker just means the next reopen
+        # reloads more history (today's behavior) rather than crashing compaction.
+        if self._ws_id:
+            watermark = get_compaction_watermark(self._ws_id, preserve_tail)
+            if watermark is not None:
+                save_message(
+                    self._ws_id,
+                    "assistant",
+                    summary,
+                    source=COMPACTION_SOURCE,
+                    meta=json.dumps({"watermark": watermark}),
+                    event_id=self._ui_event_id(),
+                    producer=self._provider.provider_name if self._provider else None,
+                )
         return True
 
     # -- Intent validation --------------------------------------------------------

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -486,13 +486,23 @@ class PostgreSQLBackend:
         """Boundary id for a compaction checkpoint: the max conversation ``id``
         among the rows a compaction would summarize (see the sqlite twin).
 
-        ``preserve_tail=0`` → ``max(id)``; ``preserve_tail=N`` → the ``(N+1)``-th
-        newest id (the newest ``N`` rows are kept verbatim).  ``None`` when empty.
+        The ``(N+1)``-th newest id counting REAL rows; compaction markers are
+        excluded (summary artifacts, never part of the preserved tail — counting
+        them would skew the boundary and drop real tail rows on resume).  ``None``
+        when empty.
         """
         with self._conn() as conn:
             row = conn.execute(
                 sa.select(conversations.c.id)
-                .where(conversations.c.ws_id == ws_id)
+                .where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        sa.or_(
+                            conversations.c._source.is_(None),
+                            conversations.c._source != _COMPACTION_SOURCE,
+                        ),
+                    )
+                )
                 .order_by(conversations.c.id.desc())
                 .limit(1)
                 .offset(max(0, preserve_tail))
@@ -1209,12 +1219,17 @@ class PostgreSQLBackend:
                             # Exclude compaction-checkpoint markers (resume-only
                             # summary artifacts); IS DISTINCT FROM is NULL-safe so
                             # normal rows (_source NULL) are not dropped.
-                            "AND c._source IS DISTINCT FROM 'compaction' "
+                            "AND c._source IS DISTINCT FROM :compaction_source "
                             "ORDER BY ts_rank(to_tsvector('english', COALESCE(c.content, '')), "
                             "   plainto_tsquery('english', :query)) DESC "
                             "LIMIT :limit OFFSET :offset"
                         ),
-                        {"query": query, "limit": capped, "offset": capped_offset},
+                        {
+                            "query": query,
+                            "compaction_source": _COMPACTION_SOURCE,
+                            "limit": capped,
+                            "offset": capped_offset,
+                        },
                     ).fetchall()
                 )
             except Exception:
@@ -1224,10 +1239,15 @@ class PostgreSQLBackend:
                         sa.text(
                             "SELECT timestamp, ws_id, role, content, tool_name "
                             "FROM conversations WHERE content ILIKE :pattern "
-                            "AND _source IS DISTINCT FROM 'compaction' "
+                            "AND _source IS DISTINCT FROM :compaction_source "
                             "ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"
                         ),
-                        {"pattern": f"%{query}%", "limit": capped, "offset": capped_offset},
+                        {
+                            "pattern": f"%{query}%",
+                            "compaction_source": _COMPACTION_SOURCE,
+                            "limit": capped,
+                            "offset": capped_offset,
+                        },
                     ).fetchall()
                 )
 
@@ -1239,10 +1259,10 @@ class PostgreSQLBackend:
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
                         "FROM conversations "
-                        "WHERE _source IS DISTINCT FROM 'compaction' "
+                        "WHERE _source IS DISTINCT FROM :compaction_source "
                         "ORDER BY timestamp DESC LIMIT :limit"
                     ),
-                    {"limit": capped},
+                    {"limit": capped, "compaction_source": _COMPACTION_SOURCE},
                 ).fetchall()
             )
 

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -75,6 +75,9 @@ from turnstone.core.storage._schema import (
     prompt_policies as prompt_policies_t,
 )
 from turnstone.core.storage._utils import (
+    COMPACTION_SOURCE as _COMPACTION_SOURCE,
+)
+from turnstone.core.storage._utils import (
     HEURISTIC_RULE_MUTABLE as _HEURISTIC_RULE_MUTABLE,
 )
 from turnstone.core.storage._utils import (
@@ -136,7 +139,7 @@ from turnstone.core.storage._utils import (
     reconstruct_messages as _reconstruct_messages,
 )
 from turnstone.core.storage._utils import (
-    reconstruct_turns as _reconstruct_turns,
+    reconstruct_turns_checkpointed as _reconstruct_turns_checkpointed,
 )
 from turnstone.core.storage._utils import (
     recover_trajectory as _recover_trajectory,
@@ -435,11 +438,19 @@ class PostgreSQLBackend:
         msg_rows, attachments = self._conversation_rows(ws_id, limit)
         return _reconstruct_messages(msg_rows, ws_id, attachments, repair=repair)
 
-    def load_message_turns(self, ws_id: str) -> list[Turn]:
+    def load_message_turns(self, ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
         """Load the conversation as canonical ``Turn``s (unresolved AttachmentRef)
-        for resume; bytes materialize at each output, never here."""
+        for resume; bytes materialize at each output, never here.
+
+        Checkpoint-aware (``checkpointed=True``, resume default): a persisted
+        compaction marker rehydrates only ``[summary] + [rows after its
+        watermark]`` instead of the full pre-compaction transcript (which can
+        overflow the window on reopen).  ``checkpointed=False`` returns the full
+        transcript (markers dropped) for export/audit consumers."""
         msg_rows, attachments = self._conversation_rows(ws_id, None)
-        return _recover_trajectory(_reconstruct_turns(msg_rows, ws_id, attachments))
+        return _recover_trajectory(
+            _reconstruct_turns_checkpointed(msg_rows, ws_id, attachments, checkpoint=checkpointed)
+        )
 
     def _resolve_row_attachments(self, rows: Sequence[Any]) -> dict[int, list[dict[str, Any]]]:
         """Build the ``reconstruct_messages`` attachment map from row ref-lists.
@@ -470,6 +481,61 @@ class PostgreSQLBackend:
                 )
             ).fetchone()
         return int(row[0]) if row is not None and row[0] is not None else None
+
+    def get_compaction_watermark(self, ws_id: str, preserve_tail: int = 0) -> int | None:
+        """Boundary id for a compaction checkpoint: the max conversation ``id``
+        among the rows a compaction would summarize (see the sqlite twin).
+
+        ``preserve_tail=0`` → ``max(id)``; ``preserve_tail=N`` → the ``(N+1)``-th
+        newest id (the newest ``N`` rows are kept verbatim).  ``None`` when empty.
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(conversations.c.id)
+                .where(conversations.c.ws_id == ws_id)
+                .order_by(conversations.c.id.desc())
+                .limit(1)
+                .offset(max(0, preserve_tail))
+            ).fetchone()
+        return int(row[0]) if row is not None else None
+
+    def count_messages(self, ws_id: str) -> int:
+        """Total conversation rows for ``ws_id`` (compaction markers included)."""
+        with self._conn() as conn:
+            n = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(conversations)
+                .where(conversations.c.ws_id == ws_id)
+            ).scalar()
+        return int(n or 0)
+
+    def get_compaction_floor(self, ws_id: str) -> int:
+        """Rows backing the latest compaction summary that must survive rewind/
+        retry: every row with ``id <= the latest marker's id`` (see the sqlite
+        twin).  ``0`` when the ws never compacted.
+        """
+        with self._conn() as conn:
+            marker_id = conn.execute(
+                sa.select(sa.func.max(conversations.c.id)).where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        conversations.c._source == _COMPACTION_SOURCE,
+                    )
+                )
+            ).scalar()
+            if marker_id is None:
+                return 0
+            n = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(conversations)
+                .where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        conversations.c.id <= marker_id,
+                    )
+                )
+            ).scalar()
+        return int(n or 0)
 
     def delete_messages_after(self, ws_id: str, keep_count: int) -> int:
         with self._conn() as conn:
@@ -1140,6 +1206,10 @@ class PostgreSQLBackend:
                             "FROM conversations c "
                             "WHERE to_tsvector('english', COALESCE(c.content, '')) "
                             "   @@ plainto_tsquery('english', :query) "
+                            # Exclude compaction-checkpoint markers (resume-only
+                            # summary artifacts); IS DISTINCT FROM is NULL-safe so
+                            # normal rows (_source NULL) are not dropped.
+                            "AND c._source IS DISTINCT FROM 'compaction' "
                             "ORDER BY ts_rank(to_tsvector('english', COALESCE(c.content, '')), "
                             "   plainto_tsquery('english', :query)) DESC "
                             "LIMIT :limit OFFSET :offset"
@@ -1154,6 +1224,7 @@ class PostgreSQLBackend:
                         sa.text(
                             "SELECT timestamp, ws_id, role, content, tool_name "
                             "FROM conversations WHERE content ILIKE :pattern "
+                            "AND _source IS DISTINCT FROM 'compaction' "
                             "ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"
                         ),
                         {"pattern": f"%{query}%", "limit": capped, "offset": capped_offset},
@@ -1167,7 +1238,9 @@ class PostgreSQLBackend:
                 conn.execute(
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
-                        "FROM conversations ORDER BY timestamp DESC LIMIT :limit"
+                        "FROM conversations "
+                        "WHERE _source IS DISTINCT FROM 'compaction' "
+                        "ORDER BY timestamp DESC LIMIT :limit"
                     ),
                     {"limit": capped},
                 ).fetchall()

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -225,14 +225,19 @@ class StorageBackend(Protocol):
         """
         ...
 
-    def load_message_turns(self, ws_id: str) -> list[Turn]:
-        """Load a workstream's full history as canonical ``Turn``s for resume.
+    def load_message_turns(self, ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
+        """Load a workstream's history as canonical ``Turn``s for resume.
 
         Unlike :meth:`load_messages` this keeps attachments *by reference*
         (:class:`AttachmentRef`) — ``session.messages`` is the canonical Turn
         trajectory and materializes bytes only at each output (wire / display).
         The trailing-incomplete-tool-call strip (``recover_trajectory``) is
         applied; mid-conversation orphans are left for the send-time repair.
+
+        ``checkpointed=True`` (resume default) honors a persisted compaction
+        marker and returns the bounded ``[summary] + [tail]`` view;
+        ``checkpointed=False`` returns the full transcript (markers dropped) for
+        export/audit consumers that must not lose pre-compaction history.
         """
         ...
 
@@ -246,6 +251,30 @@ class StorageBackend(Protocol):
         the per-ws event-id space stays monotonic across process
         restarts / rehydrates (it resets to 0 otherwise, which would
         re-issue ids the ring buffer already handed out).
+        """
+        ...
+
+    def get_compaction_watermark(self, ws_id: str, preserve_tail: int = 0) -> int | None:
+        """Boundary id for a compaction checkpoint marker.
+
+        The max conversation ``id`` among the rows a compaction would
+        summarize: ``max(id)`` when ``preserve_tail=0`` (the auto/overflow
+        path), or the ``(N+1)``-th newest id when ``preserve_tail=N`` keeps
+        the newest ``N`` rows verbatim.  Persisted in the marker's ``meta`` so
+        resume can rehydrate ``[summary] + [rows after the watermark]``.
+        ``None`` when the workstream has no rows.
+        """
+        ...
+
+    def count_messages(self, ws_id: str) -> int:
+        """Total conversation rows for ``ws_id`` (compaction markers included)."""
+        ...
+
+    def get_compaction_floor(self, ws_id: str) -> int:
+        """Rows backing the latest compaction summary that rewind/retry must not
+        delete: every row with ``id <= the latest marker's id`` (summarized
+        prefix + marker).  ``0`` when the workstream never compacted.  Used to
+        floor the rewind/retry truncation so the summary's backing survives.
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -75,6 +75,9 @@ from turnstone.core.storage._schema import (
     prompt_policies as prompt_policies_t,
 )
 from turnstone.core.storage._utils import (
+    COMPACTION_SOURCE as _COMPACTION_SOURCE,
+)
+from turnstone.core.storage._utils import (
     HEURISTIC_RULE_MUTABLE as _HEURISTIC_RULE_MUTABLE,
 )
 from turnstone.core.storage._utils import (
@@ -136,7 +139,7 @@ from turnstone.core.storage._utils import (
     reconstruct_messages as _reconstruct_messages,
 )
 from turnstone.core.storage._utils import (
-    reconstruct_turns as _reconstruct_turns,
+    reconstruct_turns_checkpointed as _reconstruct_turns_checkpointed,
 )
 from turnstone.core.storage._utils import (
     recover_trajectory as _recover_trajectory,
@@ -500,14 +503,24 @@ class SQLiteBackend:
         msg_rows, attachments = self._conversation_rows(ws_id, limit)
         return _reconstruct_messages(msg_rows, ws_id, attachments, repair=repair)
 
-    def load_message_turns(self, ws_id: str) -> list[Turn]:
+    def load_message_turns(self, ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
         """Load the conversation as canonical ``Turn``s (unresolved AttachmentRef).
 
         The resume path: ``session.messages`` holds the by-reference content;
         bytes are materialized at each output (wire / display), never here.
+
+        Checkpoint-aware (``checkpointed=True``, the resume default): if the
+        conversation carries a persisted compaction marker, only ``[summary] +
+        [rows after its watermark]`` rehydrate (the bounded view the live session
+        held when it compacted) — not the full pre-compaction transcript, which
+        can overflow the model window on reopen.  ``checkpointed=False`` returns
+        the full transcript (markers dropped) for export/audit consumers that
+        must not lose pre-compaction history.
         """
         msg_rows, attachments = self._conversation_rows(ws_id, None)
-        return _recover_trajectory(_reconstruct_turns(msg_rows, ws_id, attachments))
+        return _recover_trajectory(
+            _reconstruct_turns_checkpointed(msg_rows, ws_id, attachments, checkpoint=checkpointed)
+        )
 
     def _resolve_row_attachments(self, rows: Sequence[Any]) -> dict[int, list[dict[str, Any]]]:
         """Build the ``reconstruct_messages`` attachment map from row ref-lists.
@@ -538,6 +551,71 @@ class SQLiteBackend:
                 )
             ).fetchone()
         return int(row[0]) if row is not None and row[0] is not None else None
+
+    def get_compaction_watermark(self, ws_id: str, preserve_tail: int = 0) -> int | None:
+        """Boundary id for a compaction checkpoint: the max conversation ``id``
+        among the rows a compaction would summarize.
+
+        With ``preserve_tail=0`` (the auto/overflow path) every current row is
+        summarized, so this is ``max(id)``.  With ``preserve_tail=N`` the newest
+        ``N`` rows are kept verbatim, so the boundary is the ``(N+1)``-th newest
+        id — counting storage rows from the newest, which the preserved in-memory
+        tail maps onto even after prior compactions (the synthetic summary turns
+        sit at the front, never in the tail).  ``None`` when there are no rows.
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(conversations.c.id)
+                .where(conversations.c.ws_id == ws_id)
+                .order_by(conversations.c.id.desc())
+                .limit(1)
+                .offset(max(0, preserve_tail))
+            ).fetchone()
+        return int(row[0]) if row is not None else None
+
+    def count_messages(self, ws_id: str) -> int:
+        """Total conversation rows for ``ws_id`` (compaction markers included)."""
+        with self._conn() as conn:
+            n = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(conversations)
+                .where(conversations.c.ws_id == ws_id)
+            ).scalar()
+        return int(n or 0)
+
+    def get_compaction_floor(self, ws_id: str) -> int:
+        """Rows that back the latest compaction summary and must survive a
+        rewind/retry: every row with ``id <= the latest marker's id`` (the
+        summarized prefix plus the marker).  ``0`` when the ws never compacted.
+
+        rewind/retry trim the conversation TAIL, but after a compaction the
+        in-memory summary turns no longer map 1:1 to storage rows, so a delete
+        keyed on ``len(self.messages)`` would keep the oldest summarized rows and
+        drop the marker.  Flooring the delete at this count keeps the summary's
+        backing intact.
+        """
+        with self._conn() as conn:
+            marker_id = conn.execute(
+                sa.select(sa.func.max(conversations.c.id)).where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        conversations.c._source == _COMPACTION_SOURCE,
+                    )
+                )
+            ).scalar()
+            if marker_id is None:
+                return 0
+            n = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(conversations)
+                .where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        conversations.c.id <= marker_id,
+                    )
+                )
+            ).scalar()
+        return int(n or 0)
 
     def delete_messages_after(self, ws_id: str, keep_count: int) -> int:
         with self._conn() as conn:
@@ -1303,6 +1381,10 @@ class SQLiteBackend:
                             "FROM conversations_fts f "
                             "JOIN conversations c ON c.id = f.rowid "
                             "WHERE conversations_fts MATCH :query "
+                            # Exclude compaction-checkpoint markers (resume-only
+                            # summary artifacts); normal rows store _source NULL,
+                            # so the filter must be NULL-safe or it drops everything.
+                            "AND (c._source IS NULL OR c._source <> 'compaction') "
                             "ORDER BY f.rank ASC LIMIT :limit OFFSET :offset"
                         ),
                         {"query": _fts5_query(query), "limit": capped, "offset": capped_offset},
@@ -1313,6 +1395,7 @@ class SQLiteBackend:
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
                         "FROM conversations WHERE content LIKE :pattern ESCAPE '\\' "
+                        "AND (_source IS NULL OR _source <> 'compaction') "
                         "ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"
                     ),
                     {
@@ -1330,7 +1413,9 @@ class SQLiteBackend:
                 conn.execute(
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
-                        "FROM conversations ORDER BY timestamp DESC LIMIT :limit"
+                        "FROM conversations "
+                        "WHERE (_source IS NULL OR _source <> 'compaction') "
+                        "ORDER BY timestamp DESC LIMIT :limit"
                     ),
                     {"limit": capped},
                 ).fetchall()

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -557,16 +557,25 @@ class SQLiteBackend:
         among the rows a compaction would summarize.
 
         With ``preserve_tail=0`` (the auto/overflow path) every current row is
-        summarized, so this is ``max(id)``.  With ``preserve_tail=N`` the newest
-        ``N`` rows are kept verbatim, so the boundary is the ``(N+1)``-th newest
-        id — counting storage rows from the newest, which the preserved in-memory
-        tail maps onto even after prior compactions (the synthetic summary turns
-        sit at the front, never in the tail).  ``None`` when there are no rows.
+        summarized, so this is the newest real id.  With ``preserve_tail=N`` the
+        newest ``N`` rows are kept verbatim, so the boundary is the ``(N+1)``-th
+        newest id — counting REAL rows from the newest.  Compaction markers are
+        excluded: they are summary artifacts written as new rows but never part
+        of the preserved in-memory tail, so counting them would skew the boundary
+        and drop real tail rows on resume.  ``None`` when there are no rows.
         """
         with self._conn() as conn:
             row = conn.execute(
                 sa.select(conversations.c.id)
-                .where(conversations.c.ws_id == ws_id)
+                .where(
+                    sa.and_(
+                        conversations.c.ws_id == ws_id,
+                        sa.or_(
+                            conversations.c._source.is_(None),
+                            conversations.c._source != _COMPACTION_SOURCE,
+                        ),
+                    )
+                )
                 .order_by(conversations.c.id.desc())
                 .limit(1)
                 .offset(max(0, preserve_tail))
@@ -1384,10 +1393,15 @@ class SQLiteBackend:
                             # Exclude compaction-checkpoint markers (resume-only
                             # summary artifacts); normal rows store _source NULL,
                             # so the filter must be NULL-safe or it drops everything.
-                            "AND (c._source IS NULL OR c._source <> 'compaction') "
+                            "AND (c._source IS NULL OR c._source <> :compaction_source) "
                             "ORDER BY f.rank ASC LIMIT :limit OFFSET :offset"
                         ),
-                        {"query": _fts5_query(query), "limit": capped, "offset": capped_offset},
+                        {
+                            "query": _fts5_query(query),
+                            "compaction_source": _COMPACTION_SOURCE,
+                            "limit": capped,
+                            "offset": capped_offset,
+                        },
                     ).fetchall()
                 )
             return list(
@@ -1395,11 +1409,12 @@ class SQLiteBackend:
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
                         "FROM conversations WHERE content LIKE :pattern ESCAPE '\\' "
-                        "AND (_source IS NULL OR _source <> 'compaction') "
+                        "AND (_source IS NULL OR _source <> :compaction_source) "
                         "ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"
                     ),
                     {
                         "pattern": f"%{_escape_like(query)}%",
+                        "compaction_source": _COMPACTION_SOURCE,
                         "limit": capped,
                         "offset": capped_offset,
                     },
@@ -1414,10 +1429,10 @@ class SQLiteBackend:
                     sa.text(
                         "SELECT timestamp, ws_id, role, content, tool_name "
                         "FROM conversations "
-                        "WHERE (_source IS NULL OR _source <> 'compaction') "
+                        "WHERE (_source IS NULL OR _source <> :compaction_source) "
                         "ORDER BY timestamp DESC LIMIT :limit"
                     ),
-                    {"limit": capped},
+                    {"limit": capped, "compaction_source": _COMPACTION_SOURCE},
                 ).fetchall()
             )
 

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -766,6 +766,12 @@ def reconstruct_messages(
     the user sees the actual partial state — refreshing during tool execution
     otherwise silently drops the trailing turn from the UI.
     """
+    # Drop compaction checkpoint markers: they are resume-only artifacts (the
+    # persisted summary that lets a reopened session rehydrate a bounded context,
+    # see reconstruct_turns_checkpointed), not real conversation turns, so
+    # /history, export, and search show the true transcript without an injected
+    # summary.
+    rows = [r for r in rows if not _is_compaction_marker(r)]
     turns = reconstruct_turns(rows, ws_id, attachments_by_msg)
     if repair:
         turns = recover_trajectory(turns)
@@ -981,3 +987,92 @@ def recover_trajectory(turns: list[Turn]) -> list[Turn]:
             break
         del turns[asst_idx:]
     return turns
+
+
+# -- Compaction checkpoints ---------------------------------------------------
+#
+# When a live session compacts, it swaps its in-memory history for a summary but
+# leaves the full transcript in storage. A persisted *checkpoint marker* lets a
+# reopened session rehydrate that same bounded view instead of the full history
+# (which can exceed the model window — e.g. a long session, or one switched to a
+# smaller-context model — and deadlock the first send). The marker is one
+# ``assistant`` row tagged ``_source="compaction"`` whose content is the summary
+# and whose ``meta`` carries ``{"watermark": <id>}``: every conversation row with
+# id <= the watermark was folded into the summary; rows after it are still live.
+
+COMPACTION_SOURCE = "compaction"
+COMPACTION_SUMMARY_LABEL = "[Conversation summary]"
+
+
+def _is_compaction_marker(row: Any) -> bool:
+    """True when a stored row is a compaction checkpoint marker (``_source`` = row index 7)."""
+    return len(row) > 7 and row[7] == COMPACTION_SOURCE
+
+
+def _compaction_watermark(row: Any) -> int | None:
+    """Read a marker row's checkpoint watermark from its ``meta`` column (row index 10).
+
+    Returns the boundary conversation id, or ``None`` for a marker that predates
+    the watermark field or whose meta is malformed (caller falls back to the full
+    transcript — never load *less* than is safe)."""
+    meta = _source_meta_from_json(row[10] if len(row) > 10 else None)
+    wm = meta.get("watermark") if meta else None
+    return wm if isinstance(wm, int) and not isinstance(wm, bool) else None
+
+
+def reconstruct_turns_checkpointed(
+    rows: list[Any],
+    ws_id: str,
+    attachments_by_msg: dict[int, list[dict[str, Any]]] | None = None,
+    *,
+    checkpoint: bool = True,
+) -> list[Turn]:
+    """Resume-path reconstruction that honors a persisted compaction checkpoint.
+
+    The full-history twin :func:`reconstruct_turns` rehydrates every row — correct
+    for a session that never compacted, but on a compacted one it reloads the
+    whole pre-compaction transcript the live session had already summarized away,
+    which can overflow the context window on reopen and deadlock the first send.
+
+    If a compaction marker is present, load only ``[summary] + [rows after its
+    watermark]`` — the in-memory view the session held when it compacted. The
+    summarized prefix and any older markers (id <= watermark) are dropped; the
+    full history stays in storage for ``/history``/export/audit. The marker
+    reconstructs as a plain ``assistant`` turn (``reconstruct_turns`` drops
+    ``_source`` for assistant rows), and a synthetic ``[Conversation summary]``
+    user label is prepended to match what ``session._compact_messages`` builds
+    in memory (and to satisfy the leading-user-turn wire contract).
+
+    Falls back to the full reconstruction when there is no marker or its watermark
+    is absent/corrupt, so every pre-checkpoint session loads exactly as before.
+
+    ``checkpoint=False`` (export/audit): return the FULL transcript as Turns —
+    every real row, no watermark slice — but still drop marker rows, since
+    :func:`reconstruct_turns` does not filter them and a leaked marker would land
+    as a stray ``assistant`` summary turn mid-history. This is the Turn-path twin
+    of the marker filter :func:`reconstruct_messages` already applies on the dict
+    (display) path; resume passes the default ``True``.
+    """
+    marker = max((r for r in rows if _is_compaction_marker(r)), key=lambda r: r[0], default=None)
+    watermark = _compaction_watermark(marker) if marker is not None else None
+    if not checkpoint or marker is None or watermark is None:
+        # Full transcript, marker rows dropped — three cases collapse here:
+        # ``checkpoint=False`` (export/audit), no marker, and a malformed/legacy
+        # watermark.  ``reconstruct_turns`` does not filter markers, so a corrupt
+        # marker would otherwise leak its summary as a stray ``assistant`` turn
+        # mid-history (and a malformed marker must NOT slice — losing real
+        # messages is worse than reloading the whole transcript).
+        return reconstruct_turns(
+            [r for r in rows if not _is_compaction_marker(r)], ws_id, attachments_by_msg
+        )
+    # Keep the marker (the summary) plus every non-marker row written after the
+    # watermark — the preserved tail and everything since. Reconstruct the two
+    # slices separately so the summary leads regardless of row-id ordering (a
+    # preserved tail kept verbatim sits at a *lower* id than the marker).
+    tail = [r for r in rows if r[0] > watermark and not _is_compaction_marker(r)]
+    label = Turn(Role.USER, _content_blocks(COMPACTION_SUMMARY_LABEL, []))
+    return [
+        label,
+        *reconstruct_turns([marker], ws_id, attachments_by_msg),
+        *reconstruct_turns(tail, ws_id, attachments_by_msg),
+    ]


### PR DESCRIPTION
## Problem

Compaction swaps a session's in-memory history for a summary but leaves the full transcript in storage, so `resume()` reloaded **all** of it. On a long session — or one switched to a smaller-context model — the rehydrated context exceeds the model window and the first post-resume send is rejected (the compact-and-retry path also bails), deadlocking the workstream.

## Fix

On successful compaction, persist one `_source="compaction"` marker row (the summary, with `meta={"watermark": <id>}`). On resume, `load_message_turns` rehydrates `[summary] + [rows after the watermark]` — the bounded view the live session held when it compacted — instead of the full transcript.

The full history stays in storage for `/history`, export, and audit. Markers are filtered from the display path, search (both backends), and export (`load_message_turns(..., checkpointed=False)`). `rewind`/`retry` truncation is floored at the compaction boundary (`get_compaction_floor`) so the summary's backing rows and the marker are never deleted.

**No migration** — reuses the existing `_source` and `meta` columns.

## How the watermark works

`W = max conversation id among the summarized rows` (`preserve_tail=0` → `max(id)`; `preserve_tail=N` → the `(N+1)`-th newest id). The marker is written after `W` is read, so `marker.id > W`. Resume drops every row with `id <= W` plus older markers, keeps the marker as the summary and `[non-marker rows id > W]` as the tail, and prepends a synthesized `[Conversation summary]` label. Latest-marker-wins handles repeated compactions.

## Tests

`tests/test_compaction_checkpoint.py` (~33 tests, cross-backend via the `storage_backend` fixture): watermark math, checkpoint-aware resume, latest-marker-wins, preserved-tail, the no-marker / malformed / empty-tail fallbacks, display/search/export exclusion, the rewind-doesn't-corrupt-the-summary scenario, and the `count`/`floor` storage-error skip guards. `ruff` + `mypy` clean.

## Deferred follow-ups

- Proactive pre-send compaction for a switch-to-smaller-model session with **no** prior compaction (the marker only helps a session that already compacted).
- SSE / frontend "context compacted here" divider (the marker row makes this trivial).
- Two infrequent-path perf optimizations: a bounded DB read on resume (still fetches all rows, slices in Python), and a `_source` partial index for the `get_compaction_floor` lookup.
- rewind residual: an over-deep rewind clamps at the floor in storage; the in-memory trim and storage reconcile on the next resume.
