### PR TITLE
feat(task-agent): modernize backend + web UI (Turn-IR sub-harness, nested card, recall)

### DIFF
--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -69,7 +69,13 @@ Task-agent harness (/taskagent/livepass.html): the task_agent card — a task
   2-tool batch, for the rail-bleed rules); &recall=1 (the RECALL path —
   replayHistory rebuilding the card from a /history `agent_steps` overlay, i.e.
   a reload while the ws is in memory); &expand=1 (open every card so a shot
-  shows the nested steps).  document.title stamps TASKAGENT-READY-<steps> on
+  shows the nested steps); &race=1 (child steps emitted BEFORE the task_agent
+  row paints — the parallel-pool ordering window; the orphan buffer must nest
+  them rather than let them escape to top-level); &orphan=1 (child steps whose
+  task_agent row NEVER paints — the safety valve must escape them to visible
+  top-level rows after the grace window, stamping TASKAGENT-ORPHANS-ESCAPED-<n>,
+  not leave them buffered/invisible).  document.title stamps
+  TASKAGENT-READY-<steps> on
   success, TASKAGENT-FAILED-... / TASKAGENT-ERROR when routing breaks, so a
   broken card can't screenshot green.
 
@@ -870,6 +876,50 @@ TASKAGENT_TEMPLATE = """<!doctype html>
             }] },
             { role: "tool", tool_call_id: "task1", content: "resolve_alias has 4 call sites (registry.py:120, session.py:12200, model_registry.py:88, eval.py:54); all pass a validated alias before use." },
           ]);
+        } else if (q.get("race") === "1") {
+          // ?race=1: reproduce the parallel-pool ordering window — each
+          // sub-tool's tool_pending is emitted exactly once (as in production)
+          // but AHEAD of the task_agent row paint, as happens when a pooled
+          // sub-agent's SSE event is handled before its parent row commits.
+          // The orphan buffer must hold them and nest them when the parent row
+          // lands; pre-fix they escaped to top-level rows and the card came up
+          // short (steps < 4 -> TASKAGENT-FAILED), so this can't screenshot
+          // green without the fix.
+          const raceTask = {
+            call_id: "task1", func_name: "task_agent",
+            header: 'task_agent: "Find all call sites of resolve_alias and summarize them"',
+            needs_approval: false,
+          };
+          const childPending = (cid, fn, header) =>
+            ev({ type: "tool_pending", items: [{ call_id: cid, parent_call_id: "task1", func_name: fn, header: header, needs_approval: false }] });
+          // a) Orphan child pendings arrive first — no parent row yet.
+          childPending("task1::c1", "search", 'search: "resolve_alias"');
+          childPending("task1::c2", "read_file", "read_file: core/registry.py");
+          childPending("task1::c3", "bash", "pytest -k registry");
+          childPending("task1::c4", "notify", "notify: post summary to #eng");
+          // b) Parent task_agent row paints (pending -> resolved): must flush the
+          //    buffered orphans into the card AND survive the upgrade rebuild.
+          ev({ type: "tool_pending", items: [raceTask] });
+          ev({ type: "tool_info", items: [Object.assign({ auto_approved: false }, raceTask)] });
+          // c) Results + a streamed chunk follow, nesting into the flushed rows.
+          ev({ type: "tool_result", call_id: "task1::c1", parent_call_id: "task1", name: "search", output: "12 matches across 4 files" });
+          ev({ type: "tool_result", call_id: "task1::c2", parent_call_id: "task1", name: "read_file", output: "4.1 KB read" });
+          ev({ type: "tool_output_chunk", call_id: "task1::c3", parent_call_id: "task1", chunk: "collected 12 items ... " });
+          ev({ type: "tool_result", call_id: "task1::c3", parent_call_id: "task1", name: "bash", output: "12 passed in 1.2s" });
+          ev({ type: "tool_result", call_id: "task1::c4", parent_call_id: "task1", name: "notify", output: "posted to #eng" });
+          ev({ type: "tool_result", call_id: "task1", name: "task_agent", output: "resolve_alias has 4 call sites (registry.py:120, session.py:12200, model_registry.py:88, eval.py:54); all pass a validated alias before use." });
+        } else if (q.get("orphan") === "1") {
+          // ?orphan=1: the SAFETY VALVE — child steps whose task_agent row
+          // NEVER paints (an id-correlation mismatch, or an agent aborted
+          // before its row painted).  They must not vanish: after the grace
+          // window the buffer escapes them to visible top-level rows (the
+          // pre-buffer behaviour) rather than holding them forever.  The parent
+          // task_agent row is deliberately never emitted here.
+          const orphanPending = (cid, fn, header) =>
+            ev({ type: "tool_pending", items: [{ call_id: cid, parent_call_id: "task1", func_name: fn, header: header, needs_approval: false }] });
+          orphanPending("task1::c1", "search", 'search: "resolve_alias"');
+          orphanPending("task1::c2", "read_file", "read_file: core/registry.py");
+          orphanPending("task1::c3", "bash", "pytest -k registry");
         } else {
 
         // 1. Parent paints the task_agent call (a top-level tool row).
@@ -925,7 +975,18 @@ TASKAGENT_TEMPLATE = """<!doctype html>
         }
 
         // Loud failure — broken routing must not screenshot green.
+        const orphanMode = q.get("orphan") === "1";
         setTimeout(function () {
+          if (orphanMode) {
+            // The parent never painted; after the grace window the buffered
+            // steps must have ESCAPED to visible top-level rows, not vanished.
+            const escaped = document.querySelectorAll('.conv-batch .conv-row[data-call-id^="task1::"]').length;
+            const leaked = document.querySelector('.conv-row[data-call-id="task1"] .conv-agent');
+            document.title = escaped >= 3 && !leaked
+              ? "TASKAGENT-ORPHANS-ESCAPED-" + escaped
+              : "TASKAGENT-FAILED-escaped" + escaped + "-card" + (leaked ? 1 : 0);
+            return;
+          }
           const row = document.querySelector('.conv-row[data-call-id="task1"]');
           const card = row && row.querySelector(".conv-agent");
           const steps = card ? card.querySelectorAll(".conv-agent-body .conv-row").length : 0;
@@ -933,7 +994,7 @@ TASKAGENT_TEMPLATE = """<!doctype html>
           document.title = card && steps >= 4 && hasResult
             ? "TASKAGENT-READY-" + steps
             : "TASKAGENT-FAILED-card" + (card ? 1 : 0) + "-steps" + steps + "-result" + (hasResult ? 1 : 0);
-        }, 300);
+        }, orphanMode ? 900 : 300);
       } catch (e) {
         messages.textContent = "HARNESS ERROR: " + e.message + "\\n" + (e.stack || "");
         document.title = "TASKAGENT-ERROR";

--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -58,6 +58,15 @@ Attachments harness (/attachments/livepass.html): the composer attachment
   thumbnail crop/size, the native audio-control fit at the constrained
   height, the snippet contrast, and how a long filename behaves at the
   340px chip cap.
+Task-agent harness (/taskagent/livepass.html): the task_agent card — a task
+  agent's sub-tool steps nested under its conversation row, driven through the
+  REAL InteractivePane.handleEvent (parent tool_pending/tool_info -> child
+  tool_pending/tool_result/tool_output_chunk/approve_request -> task_agent
+  tool_result) so the SSE->card routing (_routeAgentItems / _ensureAgentCard,
+  and appendToolOutput finding the nested row by call_id) is exercised, not
+  just the leaf builders.  + &theme=light, &collapsed=1.  document.title stamps
+  TASKAGENT-READY-<steps> on success, TASKAGENT-FAILED-... / TASKAGENT-ERROR
+  when routing breaks, so a broken card can't screenshot green.
 
 Rebuild after ANY markup change: the dialog blocks are embedded at build
 time. Assets are symlinked, so CSS/JS edits are live on refresh.
@@ -767,6 +776,137 @@ ATTACH_TEMPLATE = """<!doctype html>
 """
 
 
+# --------------------------------------------------------------------------
+# Task-agent harness — the task_agent card: a task agent's sub-tool steps
+# nested under its conversation row.  Driven through the REAL
+# InteractivePane.handleEvent so the SSE->card ROUTING (_routeAgentItems /
+# _ensureAgentCard, plus appendToolOutput finding the nested row by call_id)
+# is exercised, not just the leaf builders.  The page frame is harness-only
+# chrome; the .conv-batch / task_agent card is what's under review.
+# --------------------------------------------------------------------------
+TASKAGENT_TEMPLATE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>task_agent livepass</title>
+    <link rel="stylesheet" href="shared/base.css" />
+    <link rel="stylesheet" href="shared/ui-base.css" />
+    <link rel="stylesheet" href="shared/chat.css" />
+    <link rel="stylesheet" href="shared/conversation.css" />
+    <link rel="stylesheet" href="shared/cards.css" />
+    <link rel="stylesheet" href="shared/interactive.css" />
+    <style>
+      /* Harness-only framing (NOT under review) — a plausible pane context. */
+      body {
+        padding: 24px; margin: 0; background: var(--bg); color: var(--ink);
+        font-family: var(--font-sans, system-ui, sans-serif);
+      }
+      .demo-frame { max-width: 720px; margin: 0 auto; }
+      .demo-label {
+        font: 11px var(--font-mono, monospace); color: var(--ink-3);
+        text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-frame">
+      <div class="demo-label">conversation — task_agent card (real InteractivePane.handleEvent)</div>
+      <div class="messages" id="messages"></div>
+    </div>
+    <script>
+      // interactive.js reads window.toast / window.authFetch; the static render
+      // never POSTs, so no-op stubs are enough.
+      window.toast = { error: function (m) { console.log("toast:", m); } };
+      window.authFetch = function () {
+        return Promise.resolve({
+          ok: true,
+          json: function () { return Promise.resolve({}); },
+          text: function () { return Promise.resolve(""); },
+        });
+      };
+    </script>
+    <script type="module">
+      import { InteractivePane } from "./shared/interactive.js";
+      const q = new URLSearchParams(location.search);
+      if (q.get("theme") === "light")
+        document.documentElement.dataset.theme = "light";
+
+      const messages = document.getElementById("messages");
+      try {
+        // Drive the REAL pane; stub only the host seams a mounted pane provides.
+        const pane = new InteractivePane("demo-ws");
+        pane.messagesEl = messages;
+        pane.inputEl = document.createElement("textarea");
+        pane.sendBtn = document.createElement("button");
+        pane.isNearBottom = () => false;
+        pane.scrollToBottom = () => {};
+        pane.removeEmptyState = () => {};
+        pane.removeThinkingIndicator = () => {};
+        pane.setBusy = () => {};
+        const ev = (e) => pane.handleEvent(e);
+
+        // 1. Parent paints the task_agent call (a top-level tool row).
+        const taskItem = {
+          call_id: "task1", func_name: "task_agent",
+          header: 'task_agent: "Find all call sites of resolve_alias and summarize them"',
+          needs_approval: false,
+        };
+        // ?parallel=1 puts the task_agent in a 2-tool parallel batch so the
+        // nested-step rail-bleed fix can be verified against the rail rules.
+        const parentItems = q.get("parallel") === "1"
+          ? [taskItem, { call_id: "sib1", func_name: "bash", header: "git status", needs_approval: false }]
+          : [taskItem];
+        ev({ type: "tool_pending", items: parentItems });
+        ev({ type: "tool_info", items: parentItems.map((it) => Object.assign({ auto_approved: false }, it)) });
+        if (parentItems.length > 1)
+          ev({ type: "tool_result", call_id: "sib1", name: "bash", output: "clean" });
+
+        // 2. Sub-agent steps tagged parent_call_id="task1" — exercises routing.
+        function stepRow(cid, fn, header, result) {
+          ev({ type: "tool_pending", items: [{ call_id: cid, parent_call_id: "task1", func_name: fn, header: header, needs_approval: false }] });
+          if (result != null)
+            ev({ type: "tool_result", call_id: cid, parent_call_id: "task1", name: fn, output: result });
+        }
+        stepRow("task1::c1", "search", 'search: "resolve_alias"', "12 matches across 4 files");
+        stepRow("task1::c2", "read_file", "read_file: core/registry.py", "4.1 KB read");
+        ev({ type: "tool_pending", items: [{ call_id: "task1::c3", parent_call_id: "task1", func_name: "bash", header: "pytest -k registry", needs_approval: false }] });
+        ev({ type: "tool_output_chunk", call_id: "task1::c3", parent_call_id: "task1", chunk: "collected 12 items ... " });
+        ev({ type: "tool_result", call_id: "task1::c3", parent_call_id: "task1", name: "bash", output: "12 passed in 1.2s" });
+        // 4th step.  Default: a nested sub-tool approval (notify is not
+        // auto-approved) — the pane must auto-expand the collapse-by-default
+        // card so the blocking prompt is visible.  ?collapsed=1: a plain
+        // completed step instead, so nothing forces the card open and the
+        // screenshot shows the natural collapsed state (the common case).
+        if (q.get("collapsed") === "1") {
+          stepRow("task1::c4", "notify", "notify: post summary to #eng", "posted to #eng");
+        } else {
+          ev({ type: "approve_request", judge_pending: false, items: [{ call_id: "task1::c4", parent_call_id: "task1", func_name: "notify", header: "notify: post summary to #eng", needs_approval: true }] });
+        }
+
+        // 3. The task agent's own synthesis, rendered below the card.
+        ev({ type: "tool_result", call_id: "task1", name: "task_agent", output: "resolve_alias has 4 call sites (registry.py:120, session.py:12200, model_registry.py:88, eval.py:54); all pass a validated alias before use." });
+
+        // Loud failure — broken routing must not screenshot green.
+        setTimeout(function () {
+          const row = document.querySelector('.conv-row[data-call-id="task1"]');
+          const card = row && row.querySelector(".conv-agent");
+          const steps = card ? card.querySelectorAll(".conv-agent-body .conv-row").length : 0;
+          const hasResult = !!(row && /call sites/.test(row.textContent || ""));
+          document.title = card && steps >= 4 && hasResult
+            ? "TASKAGENT-READY-" + steps
+            : "TASKAGENT-FAILED-card" + (card ? 1 : 0) + "-steps" + steps + "-result" + (hasResult ? 1 : 0);
+        }, 300);
+      } catch (e) {
+        messages.textContent = "HARNESS ERROR: " + e.message + "\\n" + (e.stack || "");
+        document.title = "TASKAGENT-ERROR";
+      }
+    </script>
+  </body>
+</html>
+"""
+
+
 # Fixture media for the attachments harness.  image/pdf thumbnails and the
 # audio clip load via element .src (NOT authFetch), so the --serve dev server
 # answers those paths directly with representative bytes: a photo-like image,
@@ -882,6 +1022,12 @@ def build(out: Path) -> None:
     symlink(att / "shared", ROOT / "turnstone/shared_static")
     (att / "livepass.html").write_text(ATTACH_TEMPLATE, encoding="utf-8")
     print(f"{att}/livepass.html — composer chips + message attachment pills")
+
+    ta = out / "taskagent"
+    ta.mkdir(parents=True, exist_ok=True)
+    symlink(ta / "shared", ROOT / "turnstone/shared_static")
+    (ta / "livepass.html").write_text(TASKAGENT_TEMPLATE, encoding="utf-8")
+    print(f"{ta}/livepass.html — task_agent card (real Pane.handleEvent routing)")
 
 
 def main() -> None:

--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -64,9 +64,14 @@ Task-agent harness (/taskagent/livepass.html): the task_agent card — a task
   tool_pending/tool_result/tool_output_chunk/approve_request -> task_agent
   tool_result) so the SSE->card routing (_routeAgentItems / _ensureAgentCard,
   and appendToolOutput finding the nested row by call_id) is exercised, not
-  just the leaf builders.  + &theme=light, &collapsed=1.  document.title stamps
-  TASKAGENT-READY-<steps> on success, TASKAGENT-FAILED-... / TASKAGENT-ERROR
-  when routing breaks, so a broken card can't screenshot green.
+  just the leaf builders.  Query flags: &theme=light; &collapsed=1 (all-auto,
+  no approval -> the natural collapse-by-default state); &parallel=1 (card in a
+  2-tool batch, for the rail-bleed rules); &recall=1 (the RECALL path —
+  replayHistory rebuilding the card from a /history `agent_steps` overlay, i.e.
+  a reload while the ws is in memory); &expand=1 (open every card so a shot
+  shows the nested steps).  document.title stamps TASKAGENT-READY-<steps> on
+  success, TASKAGENT-FAILED-... / TASKAGENT-ERROR when routing breaks, so a
+  broken card can't screenshot green.
 
 Rebuild after ANY markup change: the dialog blocks are embedded at build
 time. Assets are symlinked, so CSS/JS edits are live on refresh.
@@ -846,6 +851,27 @@ TASKAGENT_TEMPLATE = """<!doctype html>
         pane.setBusy = () => {};
         const ev = (e) => pane.handleEvent(e);
 
+        // ?recall=1: exercise the RECALL path — replayHistory rebuilding the
+        // card from the /history `agent_steps` overlay (a reload / reopen while
+        // the ws is still in memory), as opposed to the live SSE path below.
+        const recall = q.get("recall") === "1";
+        if (recall) {
+          pane.replayHistory([
+            { role: "user", content: "Find all call sites of resolve_alias and summarize them" },
+            { role: "assistant", tool_calls: [{
+              name: "task_agent", id: "task1",
+              arguments: JSON.stringify({ prompt: "Find call sites of resolve_alias" }),
+              agent_steps: [
+                { id: "task1::c1", name: "search", arguments: JSON.stringify({ query: "resolve_alias" }), output: "12 matches across 4 files", is_error: false },
+                { id: "task1::c2", name: "read_file", arguments: JSON.stringify({ path: "core/registry.py" }), output: "4.1 KB read", is_error: false },
+                { id: "task1::c3", name: "bash", arguments: JSON.stringify({ command: "pytest -k registry" }), output: "12 passed in 1.2s", is_error: false },
+                { id: "task1::c4", name: "notify", arguments: JSON.stringify({ channel: "#eng", message: "post summary" }), output: "posted to #eng", is_error: false },
+              ],
+            }] },
+            { role: "tool", tool_call_id: "task1", content: "resolve_alias has 4 call sites (registry.py:120, session.py:12200, model_registry.py:88, eval.py:54); all pass a validated alias before use." },
+          ]);
+        } else {
+
         // 1. Parent paints the task_agent call (a top-level tool row).
         const taskItem = {
           call_id: "task1", func_name: "task_agent",
@@ -886,6 +912,17 @@ TASKAGENT_TEMPLATE = """<!doctype html>
 
         // 3. The task agent's own synthesis, rendered below the card.
         ev({ type: "tool_result", call_id: "task1", name: "task_agent", output: "resolve_alias has 4 call sites (registry.py:120, session.py:12200, model_registry.py:88, eval.py:54); all pass a validated alias before use." });
+        }
+
+        // ?expand=1: open every card so a screenshot shows the nested steps
+        // (cards collapse by default; recall has no approval to auto-expand).
+        if (q.get("expand") === "1") {
+          document.querySelectorAll(".conv-agent").forEach(function (c) {
+            c.dataset.collapsed = "false";
+            const t = c.querySelector(".conv-agent-toggle");
+            if (t) t.setAttribute("aria-expanded", "true");
+          });
+        }
 
         // Loud failure — broken routing must not screenshot green.
         setTimeout(function () {

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1589,6 +1589,89 @@ def test_early_paint_tool_pending_wiring() -> None:
     assert "if (!announced) this.messagesEl.appendChild(block);" in body
 
 
+def test_task_agent_steps_never_escape_their_card() -> None:
+    """A task agent's sub-tool steps (``parent_call_id`` stamped) must nest in
+    the task card, never render as top-level rows that look like the main
+    harness issued them.  Two seams keep that true; this guards both against a
+    rename/deletion:
+
+    1. ``tool_info`` routes through ``_routeAgentItems`` first — a sub-tool
+       auto-resolved by policy / "Always" arrives as a ``tool_info`` and must
+       nest, not paint a duplicate top-level block (Copilot review on #732).
+    2. A child step whose ``task_agent`` row hasn't painted yet (the 4-wide
+       tool pool's ordering window) is BUFFERED and flushed when the row lands,
+       instead of escaping to top-level; the card also survives the parent
+       row's pending->resolved rebuild.
+    3. SAFETY VALVE: a buffered step whose parent row NEVER paints (an id-
+       correlation mismatch / aborted agent) is escaped to a top-level row after
+       a grace window, so it stays VISIBLE rather than buffered forever.
+    """
+    body = _INTERACTIVE_JS.read_text(encoding="utf-8")
+    # 1. tool_info nests via the same router as tool_pending / approve_request.
+    info = body[body.index('case "tool_info":') : body.index('case "approve_request":')]
+    assert 'this._routeAgentItems(evt.items, "info")' in info, (
+        "tool_info must route a parent-tagged sub-tool into the task card "
+        "before any top-level showInlineToolBlock fallback."
+    )
+    # 2. _routeAgentItems buffers an orphan child (instead of returning false,
+    #    which escapes it to top-level) when the parent card isn't painted yet.
+    route = body[
+        _pane_method_offset(body, "_routeAgentItems") : _pane_method_offset(
+            body, "_ensureAgentCard"
+        )
+    ]
+    assert "_bufferAgentOrphan(parentId, items, mode)" in route, (
+        "a parent-tagged child with no card yet must buffer, not fall through to a top-level paint."
+    )
+    # The buffer / flush / escape / relink helpers exist.
+    assert "_bufferAgentOrphan(parentId, items, mode) {" in body
+    assert "_flushAgentOrphans(parentIds) {" in body
+    assert "_escapeAgentOrphans(parentId) {" in body
+    assert "_relinkAgentCards(items) {" in body
+    assert body.count("this._relinkAgentCards(") >= 2, (
+        "both announceToolBlock and showInlineToolBlock must relink + flush so "
+        "a buffered step nests as soon as a tool row appears."
+    )
+    # 3. Safety valve: _bufferAgentOrphan arms a grace timer to _escapeAgentOrphans
+    #    so a never-painting parent's steps can't vanish (or leak) — they escape
+    #    back to a visible top-level paint.
+    buf = body[
+        _pane_method_offset(body, "_bufferAgentOrphan") : _pane_method_offset(
+            body, "_flushAgentOrphans"
+        )
+    ]
+    assert "setTimeout(" in buf and "_escapeAgentOrphans(parentId)" in buf, (
+        "a buffered orphan must arm a grace-window escape so it never stays "
+        "buffered (invisible) forever."
+    )
+    escape = body[
+        _pane_method_offset(body, "_escapeAgentOrphans") : _pane_method_offset(
+            body, "_relinkAgentCards"
+        )
+    ]
+    assert "announceToolBlock(" in escape, (
+        "the escape valve must render the steps top-level (visible), the "
+        "pre-buffer behaviour, rather than dropping them."
+    )
+    # Flush is targeted to the just-painted parents, not the whole map.
+    flush = body[
+        _pane_method_offset(body, "_flushAgentOrphans") : _pane_method_offset(
+            body, "_escapeAgentOrphans"
+        )
+    ]
+    assert "parentIds.forEach" in flush
+    # _ensureAgentCard re-attaches a DETACHED card across a parent-row rebuild,
+    # but builds fresh on a still-attached (cross-turn reused) call_id rather
+    # than stealing the prior agent's steps.
+    ensure = body[
+        _pane_method_offset(body, "_ensureAgentCard") : _pane_method_offset(
+            body, "_bufferAgentOrphan"
+        )
+    ]
+    assert "!card.wrap.isConnected" in ensure
+    assert "parentRow.appendChild(card.wrap);" in ensure
+
+
 def test_risk_level_normalized_before_dom_interpolation() -> None:
     """Server-supplied ``risk_level`` lands in className / data-risk strings the
     verdict + warning CSS depend on, so every interpolation must funnel through

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -530,15 +530,17 @@ def test_phase8_appendtooloutput_dispatches_mcp_error_before_renderer() -> None:
     end = _pane_method_offset(body, "sendMessage")
     fn = body[start:end]
     parse_idx = fn.find("tryParseMcpError(")
-    render_idx = fn.find("renderToolOutput(")
+    # The plain-output render is the shared renderCollapsibleOutput helper; the
+    # ordering invariant is unchanged — MCP dispatch must precede it.
+    render_idx = fn.find("renderCollapsibleOutput(")
     assert parse_idx >= 0, (
         "appendToolOutput must call tryParseMcpError on the error path "
-        "before renderToolOutput, otherwise the consent card never "
+        "before the plain renderer, otherwise the consent card never "
         "replaces the plain JSON output."
     )
-    assert render_idx >= 0, "renderToolOutput call must remain present"
+    assert render_idx >= 0, "renderCollapsibleOutput call must remain present"
     assert parse_idx < render_idx, (
-        "tryParseMcpError must run BEFORE renderToolOutput so the "
+        "tryParseMcpError must run BEFORE the plain renderer so the "
         "interactive card path takes precedence over plain rendering."
     )
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -15,7 +15,14 @@ from turnstone.core.session import (
     _CancelRef,
     _effect_status_meta,
 )
-from turnstone.core.trajectory import EffectStatus, Role, dicts_from_turns, turn_from_dict
+from turnstone.core.trajectory import (
+    EffectStatus,
+    Role,
+    ToolCall,
+    Turn,
+    dicts_from_turns,
+    turn_from_dict,
+)
 
 
 class NullUI:
@@ -1028,15 +1035,11 @@ class TestCancelledAgentDisposition:
 
     @staticmethod
     def _assistant(call_id, name):
-        return {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [{"id": call_id, "function": {"name": name}}],
-        }
+        return Turn.assistant("", tool_calls=(ToolCall(id=call_id, name=name, arguments=""),))
 
     @staticmethod
     def _result(call_id, text="ok"):
-        return {"role": "tool", "tool_call_id": call_id, "content": text}
+        return Turn.tool(call_id, text)
 
     def test_status_none_when_no_actions(self):
         """Typed twin of the disposition: a task cancelled before any action is
@@ -1107,14 +1110,13 @@ class TestCancelledAgentDisposition:
         # started" — inviting a re-run of the destructive bash.
         session = _make_session()
         msgs = [
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "t1", "function": {"name": "bash"}},
-                    {"id": "t2", "function": {"name": "web_fetch"}},
-                ],
-            }
+            Turn.assistant(
+                "",
+                tool_calls=(
+                    ToolCall(id="t1", name="bash", arguments=""),
+                    ToolCall(id="t2", name="web_fetch", arguments=""),
+                ),
+            )
         ]  # neither answered: bash raised mid-flight, web_fetch never ran
         out = session._cancelled_agent_disposition(msgs, "task")
         assert "In flight at cancel: bash" in out
@@ -1127,26 +1129,24 @@ class TestCancelledAgentDisposition:
         # count summary, the first-gap boundary, and not-started.
         session = _make_session()
         msgs = [
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "t1", "function": {"name": "bash"}},
-                    {"id": "t2", "function": {"name": "bash"}},
-                    {"id": "t3", "function": {"name": "read_file"}},
-                ],
-            },
+            Turn.assistant(
+                "",
+                tool_calls=(
+                    ToolCall(id="t1", name="bash", arguments=""),
+                    ToolCall(id="t2", name="bash", arguments=""),
+                    ToolCall(id="t3", name="read_file", arguments=""),
+                ),
+            ),
             self._result("t1"),
             self._result("t2"),
             self._result("t3"),
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "t4", "function": {"name": "web_fetch"}},
-                    {"id": "t5", "function": {"name": "search"}},
-                ],
-            },
+            Turn.assistant(
+                "",
+                tool_calls=(
+                    ToolCall(id="t4", name="web_fetch", arguments=""),
+                    ToolCall(id="t5", name="search", arguments=""),
+                ),
+            ),
         ]
         out = session._cancelled_agent_disposition(msgs, "task")
         assert "Completed before cancel: bash×2, read_file." in out
@@ -1155,13 +1155,13 @@ class TestCancelledAgentDisposition:
 
     def test_exec_task_routes_cancel_to_disposition(self, tmp_db):
         """_exec_task converts a GenerationCancelled from _run_agent into the
-        honest disposition, reading the in-place-mutated agent_messages."""
+        honest disposition, reading the in-place-mutated agent_turns."""
         session = _make_session()
 
-        def fake_run_agent(agent_messages, **kwargs):
-            agent_messages.append(self._assistant("t1", "bash"))
-            agent_messages.append(self._result("t1"))
-            agent_messages.append(self._assistant("t2", "web_fetch"))
+        def fake_run_agent(agent_turns, **kwargs):
+            agent_turns.append(self._assistant("t1", "bash"))
+            agent_turns.append(self._result("t1"))
+            agent_turns.append(self._assistant("t2", "web_fetch"))
             raise GenerationCancelled()
 
         with patch.object(session, "_run_agent", side_effect=fake_run_agent):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -15,6 +15,7 @@ from turnstone.core.model_registry import (
     detect_model,
     load_model_registry,
 )
+from turnstone.core.trajectory import Turn
 
 # ---------------------------------------------------------------------------
 # ModelConfig
@@ -1244,8 +1245,8 @@ class TestSessionAgentModel:
         agent_client.chat.completions.create = fake_create
 
         agent_msgs = [
-            {"role": "developer", "content": "You are an agent."},
-            {"role": "user", "content": "Do something."},
+            Turn.system("You are an agent."),
+            Turn.user("Do something."),
         ]
         session._run_agent(agent_msgs)
         assert captured_model == "agent-model"
@@ -1335,14 +1336,14 @@ class TestSessionAgentModel:
         reg = self._three_model_registry(agent_model="smart", task_model="fast")
         session = _make_session(registry=reg, model_alias="main")
         captured = self._capture(reg, "fast")
-        session._run_agent([{"role": "user", "content": "x"}], label="task")
+        session._run_agent([Turn.user("x")], label="task")
         assert captured["model"] == "fast-model"
 
     def test_plan_falls_back_to_agent_model(self) -> None:
         reg = self._three_model_registry(agent_model="fast")
         session = _make_session(registry=reg, model_alias="main")
         captured = self._capture(reg, "fast")
-        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        session._run_agent([Turn.user("x")], label="plan")
         assert captured["model"] == "fast-model"
 
     def test_plan_uses_session_model_when_no_overrides(self) -> None:
@@ -1351,7 +1352,7 @@ class TestSessionAgentModel:
         reg = self._three_model_registry()
         session = _make_session(registry=reg, model_alias="main")
         captured = self._capture_on(session.client)
-        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        session._run_agent([Turn.user("x")], label="plan")
         assert captured["model"] == "test-model"
 
     def test_task_effort_inherits_session_when_unset(self) -> None:
@@ -1362,7 +1363,7 @@ class TestSessionAgentModel:
         reg = self._three_model_registry()
         session = _make_session(registry=reg, model_alias="main", reasoning_effort="low")
         captured = self._capture_on(session.client)
-        session._run_agent([{"role": "user", "content": "x"}], label="task")
+        session._run_agent([Turn.user("x")], label="task")
         assert self._captured_effort(captured) == "low"
 
     def test_agent_model_routes_both_plan_and_task(self) -> None:
@@ -1372,20 +1373,18 @@ class TestSessionAgentModel:
         session = _make_session(registry=reg, model_alias="main")
 
         plan_captured = self._capture(reg, "fast")
-        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        session._run_agent([Turn.user("x")], label="plan")
         assert plan_captured["model"] == "fast-model"
 
         task_captured = self._capture(reg, "fast")
-        session._run_agent([{"role": "user", "content": "y"}], label="task")
+        session._run_agent([Turn.user("y")], label="task")
         assert task_captured["model"] == "fast-model"
 
     def test_explicit_effort_wins_over_registry(self) -> None:
         reg = self._three_model_registry(task_effort="low")
         session = _make_session(registry=reg, model_alias="main")
         captured = self._capture_on(session.client)
-        session._run_agent(
-            [{"role": "user", "content": "x"}], label="task", reasoning_effort="minimal"
-        )
+        session._run_agent([Turn.user("x")], label="task", reasoning_effort="minimal")
         assert self._captured_effort(captured) == "minimal"
 
     # -- per-call agent_alias override (LLM passes model="<alias>") ----------
@@ -1395,7 +1394,7 @@ class TestSessionAgentModel:
         reg = self._three_model_registry()
         session = _make_session(registry=reg, model_alias="main")
         captured = self._capture(reg, "fast")
-        session._run_agent([{"role": "user", "content": "x"}], label="task", agent_alias="fast")
+        session._run_agent([Turn.user("x")], label="task", agent_alias="fast")
         assert captured["model"] == "fast-model"
 
     def test_session_fallback_inherits_primary_alias_for_caps(self) -> None:
@@ -1426,7 +1425,7 @@ class TestSessionAgentModel:
         session._resolve_capabilities = spy_resolve  # type: ignore[method-assign]
 
         self._capture_on(session.client)  # patch client.chat.completions.create
-        session._run_agent([{"role": "user", "content": "x"}], label="plan")
+        session._run_agent([Turn.user("x")], label="plan")
 
         assert captured_extra_alias and captured_extra_alias[-1] == "main", (
             f"agent fallback path did not inherit primary alias for extra_params: "
@@ -1443,9 +1442,7 @@ class TestSessionAgentModel:
         reg = self._three_model_registry()
         session = _make_session(registry=reg, model_alias="main")
         with pytest.raises(ValueError, match="Unknown agent_alias"):
-            session._run_agent(
-                [{"role": "user", "content": "x"}], label="plan", agent_alias="bogus"
-            )
+            session._run_agent([Turn.user("x")], label="plan", agent_alias="bogus")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1658,6 +1658,110 @@ class TestAgentChildRegistration:
         session.ui.note_agent_child.assert_called_once_with("task-1::call_1", "task-1")
 
 
+class TestRunAgentDenialMessage:
+    """A denied sub-tool must surface the SPECIFIC denial reason that
+    ``approve_tools`` already stamped (operator feedback / matched policy),
+    not a flat "Denied by user" — so the sub-agent can adapt.  The pre-fix
+    code clobbered ``denial_msg`` unconditionally and dropped the feedback
+    returned as ``approve_tools``'s second value."""
+
+    def _run_with_denial(self, approve_side_effect):
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.trajectory import Turn
+
+        session = _make_session()
+        session._provider = OpenAIChatCompletionsProvider()
+
+        call_count = [0]
+
+        def fake_create(**_kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            choice = MagicMock()
+            if call_count[0] == 1:
+                choice.finish_reason = "tool_calls"
+                tc = MagicMock()
+                tc.id = "call_1"
+                tc.function.name = "notify"
+                tc.function.arguments = '{"message": "hi"}'
+                choice.message.tool_calls = [tc]
+                choice.message.content = None
+            else:
+                choice.finish_reason = "stop"
+                choice.message.tool_calls = None
+                choice.message.content = "done"
+            resp.choices = [choice]
+            resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+            return resp
+
+        session.client.chat.completions.create = fake_create
+        # approve_tools is the real two-phase gate: on denial it stamps a
+        # specific denial_msg on the item AND returns the reason as its 2nd
+        # value.  The sub-agent must honour both, not overwrite them.
+        session.ui.approve_tools = MagicMock(side_effect=approve_side_effect)
+
+        def fake_prepare(tc_dict, **_kwargs):
+            return {
+                "call_id": tc_dict["id"],
+                "func_name": "notify",
+                "needs_approval": True,
+                # Must NOT run — a denied tool never executes.
+                "execute": lambda p: (p["call_id"], "EXECUTED — should not happen"),
+            }
+
+        agent_turns: list[Turn] = [Turn.user("x")]
+        with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
+            session._run_agent(
+                agent_turns,
+                tools=[{"type": "function", "function": {"name": "notify"}}],
+                auto_tools=set(),  # nothing auto -> notify routes through approval
+                label="task",
+                parent_call_id="task-1",
+            )
+        tool_turns = [t for t in agent_turns if t.role.value == "tool"]
+        assert tool_turns, "expected a tool turn for the denied sub-tool"
+        return tool_turns[-1].text
+
+    def test_human_feedback_preserved(self):
+        def approve(items):
+            items[0]["denied"] = True
+            items[0]["denial_msg"] = "Denied by user: use /tmp instead"
+            return False, "use /tmp instead"
+
+        text = self._run_with_denial(approve)
+        assert text == "Denied by user: use /tmp instead"
+
+    def test_policy_reason_preserved(self):
+        def approve(items):
+            items[0]["denied"] = True
+            items[0]["denial_msg"] = "Blocked by tool policy (pattern match for 'notify')"
+            return False, "Blocked by tool policy"
+
+        text = self._run_with_denial(approve)
+        assert text == "Blocked by tool policy (pattern match for 'notify')"
+
+    def test_default_when_gate_sets_nothing(self):
+        # Defensive: a not-approved result that left no denial_msg still yields
+        # a sensible default rather than executing the tool.
+        def approve(items):
+            return False, None
+
+        text = self._run_with_denial(approve)
+        assert text == "Denied by user"
+
+    def test_cli_policy_block_error_field_preserved(self):
+        # The CLI gate records a policy block in ``error`` (not ``denial_msg``)
+        # and returns approved=True; the specific reason must still reach the
+        # sub-agent rather than collapsing to a flat "Denied by user".
+        def approve(items):
+            items[0]["denied"] = True
+            items[0]["error"] = "Blocked by tool policy ('notify')"
+            return True, None
+
+        text = self._run_with_denial(approve)
+        assert text == "Blocked by tool policy ('notify')"
+
+
 class TestProjectAgentSteps:
     """``_project_agent_steps`` projects a finished sub-agent's trajectory into
     recall step items for the task card — one per tool call, matched to its

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -13,6 +13,7 @@ import pytest
 
 from turnstone.core.session import _IMAGE_EXTENSIONS, _IMAGE_SIZE_CAP, ChatSession
 from turnstone.core.trajectory import (
+    Turn,
     dicts_from_turns,
     turn_from_dict,
     turn_to_dict,
@@ -291,7 +292,7 @@ class TestTaskExec:
 
         with patch.object(session, "_run_agent", side_effect=fake_run_agent):
             session._exec_task(item)
-        return captured["messages"][0]["content"]
+        return captured["messages"][0].text
 
     def test_known_skill_renders_into_system_message(self, tmp_db) -> None:
         """Validated skill content (with template vars resolved) replaces
@@ -1346,7 +1347,7 @@ class TestAgentOutputGuard:
 
             with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
                 session._run_agent(
-                    [{"role": "user", "content": "test"}],
+                    [Turn.user("test")],
                     tools=[{"type": "function", "function": {"name": "read_file"}}],
                     label="test",
                 )
@@ -1409,7 +1410,7 @@ class TestAgentOutputGuard:
 
             with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
                 session._run_agent(
-                    [{"role": "user", "content": "test"}],
+                    [Turn.user("test")],
                     tools=[{"type": "function", "function": {"name": "read_file"}}],
                     label="test",
                 )
@@ -1449,7 +1450,7 @@ class TestAgentOutputGuard:
             session.client.chat.completions.create = fake_create
 
             result = session._run_agent(
-                [{"role": "user", "content": "test"}],
+                [Turn.user("test")],
                 tools=[{"type": "function", "function": {"name": "read_file"}}],
                 label="plan",
             )
@@ -1487,7 +1488,7 @@ class TestAgentOutputGuard:
 
             session.client.chat.completions.create = fake_create
             result = session._run_agent(
-                [{"role": "user", "content": "test"}],
+                [Turn.user("test")],
                 tools=[{"type": "function", "function": {"name": "read_file"}}],
                 label="task",
             )
@@ -1522,8 +1523,8 @@ class TestAgentOutputGuard:
             session.client.chat.completions.create = fake_create
             result = session._run_agent(
                 [
-                    {"role": "user", "content": "test"},
-                    {"role": "assistant", "content": prior},
+                    Turn.user("test"),
+                    Turn.assistant(prior),
                 ],
                 tools=[{"type": "function", "function": {"name": "read_file"}}],
                 label="plan",
@@ -1587,7 +1588,7 @@ class TestAgentOutputGuard:
 
             with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
                 result = session._run_agent(
-                    [{"role": "user", "content": "test"}],
+                    [Turn.user("test")],
                     tools=[{"type": "function", "function": {"name": "read_file"}}],
                     label="task",
                 )
@@ -1599,6 +1600,60 @@ class TestAgentOutputGuard:
             assert synth_args[0].startswith("agent_synth_task_")
             assert synth_args[1] == forced
             assert synth_args[2] == "task_agent_synthesis"
+
+
+class TestAgentChildRegistration:
+    """_run_agent registers each sub-tool under the task's parent_call_id so the
+    UI can nest the step (the producer side of the SessionUIBase tagging)."""
+
+    def test_sub_tool_registered_under_parent(self):
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        session = _make_session()
+        session._provider = OpenAIChatCompletionsProvider()
+        session.ui.note_agent_child = MagicMock()
+
+        call_count = [0]
+
+        def fake_create(**_kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            choice = MagicMock()
+            if call_count[0] == 1:
+                choice.finish_reason = "tool_calls"
+                tc = MagicMock()
+                tc.id = "call_1"
+                tc.function.name = "read_file"
+                tc.function.arguments = '{"path": "/tmp/x"}'
+                choice.message.tool_calls = [tc]
+                choice.message.content = None
+            else:
+                choice.finish_reason = "stop"
+                choice.message.tool_calls = None
+                choice.message.content = "done"
+            resp.choices = [choice]
+            resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+            return resp
+
+        session.client.chat.completions.create = fake_create
+
+        def fake_prepare(tc_dict, **_kwargs):
+            return {
+                "call_id": tc_dict["id"],
+                "func_name": "read_file",
+                "needs_approval": False,
+                "execute": lambda p: ("call_1", "contents"),
+            }
+
+        with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
+            session._run_agent(
+                [Turn.user("x")],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+                label="task",
+                parent_call_id="task-1",
+            )
+
+        session.ui.note_agent_child.assert_called_once_with("call_1", "task-1")
 
 
 class TestEvaluateOutputLLMStage:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1653,7 +1653,9 @@ class TestAgentChildRegistration:
                 parent_call_id="task-1",
             )
 
-        session.ui.note_agent_child.assert_called_once_with("call_1", "task-1")
+        # Sub-agent tool ids are namespaced by the parent so the UI registry
+        # can't collide across concurrent task agents (local sequential ids).
+        session.ui.note_agent_child.assert_called_once_with("task-1::call_1", "task-1")
 
 
 class TestEvaluateOutputLLMStage:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1658,6 +1658,310 @@ class TestAgentChildRegistration:
         session.ui.note_agent_child.assert_called_once_with("task-1::call_1", "task-1")
 
 
+class TestProjectAgentSteps:
+    """``_project_agent_steps`` projects a finished sub-agent's trajectory into
+    recall step items for the task card — one per tool call, matched to its
+    result by call_id, landmine-safe on a multimodal result."""
+
+    def test_calls_matched_to_results_in_order(self):
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = [
+            Turn.system("sys"),
+            Turn.user("go"),
+            Turn.assistant(
+                tool_calls=(ToolCall(id="c1", name="search", arguments='{"query":"x"}'),)
+            ),
+            Turn.tool("c1", "12 matches"),
+            Turn.assistant(
+                tool_calls=(ToolCall(id="c2", name="bash", arguments='{"command":"ls"}'),)
+            ),
+            Turn.tool("c2", "boom", is_error=True),
+        ]
+        steps = ChatSession._project_agent_steps(turns)
+        assert [s["id"] for s in steps] == ["c1", "c2"]
+        assert steps[0] == {
+            "id": "c1",
+            "name": "search",
+            "arguments": '{"query":"x"}',
+            "output": "12 matches",
+            "is_error": False,
+        }
+        assert steps[1]["is_error"] is True
+        assert steps[1]["output"] == "boom"
+
+    def test_multimodal_result_placeholdered_not_crashed(self):
+        # A vision tool result is a list[dict] mis-stored as TextBlock.text; the
+        # projection must NOT call Turn.text (would TypeError) — it reads the
+        # payload directly and placeholders a non-str so /history stays text-only.
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = [
+            Turn.assistant(
+                tool_calls=(ToolCall(id="c1", name="read_file", arguments='{"path":"a.png"}'),)
+            ),
+            Turn.tool("c1", [{"type": "image_url"}]),
+        ]
+        steps = ChatSession._project_agent_steps(turns)
+        assert steps[0]["output"] == "[non-text result]"
+
+    def test_output_capped(self):
+        from turnstone.core.session import _AGENT_STEP_OUTPUT_CAP
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        big = "a" * (_AGENT_STEP_OUTPUT_CAP + 500)
+        turns = [
+            Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),)),
+            Turn.tool("c1", big),
+        ]
+        steps = ChatSession._project_agent_steps(turns)
+        assert len(steps[0]["output"]) < len(big)
+        assert "truncated from 2500 chars" in steps[0]["output"]
+
+    def test_unanswered_call_has_empty_output(self):
+        # A tool call with no matching result (cancelled mid-flight) recalls
+        # honestly as empty, not dropped.
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = [Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),))]
+        steps = ChatSession._project_agent_steps(turns)
+        assert steps == [
+            {"id": "c1", "name": "bash", "arguments": "{}", "output": "", "is_error": False}
+        ]
+
+    def test_colliding_ids_paired_fifo_not_last_wins(self):
+        # A local provider reuses id "call_0" across turns; FIFO pairing gives
+        # each call its OWN result, not last-wins (which would show out-B twice).
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = [
+            Turn.assistant(
+                tool_calls=(ToolCall(id="call_0", name="bash", arguments='{"command":"a"}'),)
+            ),
+            Turn.tool("call_0", "out-A"),
+            Turn.assistant(
+                tool_calls=(ToolCall(id="call_0", name="bash", arguments='{"command":"b"}'),)
+            ),
+            Turn.tool("call_0", "out-B"),
+        ]
+        steps = ChatSession._project_agent_steps(turns)
+        assert [s["output"] for s in steps] == ["out-A", "out-B"]
+
+    def test_step_count_capped_with_honest_marker(self):
+        from turnstone.core.session import _AGENT_STEP_COUNT_CAP
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = []
+        for i in range(_AGENT_STEP_COUNT_CAP + 5):
+            turns.append(
+                Turn.assistant(tool_calls=(ToolCall(id=f"c{i}", name="bash", arguments="{}"),))
+            )
+            turns.append(Turn.tool(f"c{i}", f"out{i}"))
+        steps = ChatSession._project_agent_steps(turns)
+        # Capped + one honest LEADING marker, keeping the most RECENT steps (the
+        # tail) — not the earliest — and naming how many earlier ones fell out.
+        assert len(steps) == _AGENT_STEP_COUNT_CAP + 1
+        assert steps[0]["name"] == "…"
+        assert "5 earlier steps not retained" in steps[0]["output"]
+        # c0..c4 dropped; c5 is the first retained, the newest call is last.
+        assert steps[1]["id"] == "c5"
+        assert steps[-1]["id"] == f"c{_AGENT_STEP_COUNT_CAP + 4}"
+
+
+class TestAgentTrajectoryStashWiring:
+    """``_stash_agent_trajectory`` projects + forwards to the UI, getattr-guarded."""
+
+    def test_projects_and_forwards(self):
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        session = _make_session()
+        session.ui = MagicMock()
+        turns = [
+            Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),)),
+            Turn.tool("c1", "ok"),
+        ]
+        session._stash_agent_trajectory("task1", turns)
+        session.ui.stash_agent_trajectory.assert_called_once()
+        cid, steps = session.ui.stash_agent_trajectory.call_args[0]
+        assert cid == "task1"
+        assert steps == [
+            {"id": "c1", "name": "bash", "arguments": "{}", "output": "ok", "is_error": False}
+        ]
+
+    def test_noop_without_call_id(self):
+        session = _make_session()
+        session.ui = MagicMock()
+        session._stash_agent_trajectory(None, [])
+        session.ui.stash_agent_trajectory.assert_not_called()
+
+    def test_noop_on_ui_without_support(self):
+        # NullUI has no stash_agent_trajectory → getattr None → no-op, no raise.
+        _make_session()._stash_agent_trajectory("task1", [])
+
+
+class TestReadFilesIsolation:
+    """A task agent's file-read tracking is isolated from the main session and
+    its pool siblings via ``_active_read_files`` so the blind-overwrite guard
+    can't be cross-contaminated (a sibling's read suppressing another's guard)."""
+
+    def test_defaults_to_main_set(self):
+        session = _make_session()
+        assert session._current_read_files is session._read_files
+
+    def test_active_contextvar_overrides_then_restores(self):
+        from turnstone.core.session import _active_read_files
+
+        session = _make_session()
+        sub: set[str] = set()
+        token = _active_read_files.set(sub)
+        try:
+            assert session._current_read_files is sub
+        finally:
+            _active_read_files.reset(token)
+        assert session._current_read_files is session._read_files
+
+    def test_empty_active_set_is_used_not_main(self):
+        # The resolver guards on `is not None`, not truthiness — an EMPTY
+        # per-agent set must be used, NOT fall through to the main set, or a
+        # fresh agent would inherit the main session's reads and mis-suppress
+        # its own blind-overwrite guard.
+        from turnstone.core.session import _active_read_files
+
+        session = _make_session()
+        session._read_files.add("/main/file")
+        token = _active_read_files.set(set())
+        try:
+            assert session._current_read_files == set()
+        finally:
+            _active_read_files.reset(token)
+
+    def test_exec_task_copies_parent_reads_and_merges_back(self):
+        # Drive the REAL _exec_task wiring (not a hand-rolled contextvar dance):
+        # it copies the parent's reads into an INDEPENDENT per-agent set (so the
+        # agent can edit a file the parent read for it, without leaking mid-run
+        # to a sibling) and merges the agent's own reads back on completion.
+        session = _make_session()
+        session._agent_system_messages = []
+        session._task_tools = []
+        session._read_files.add("/parent/read")
+        seen = {}
+
+        def fake_run_agent(agent_turns, **_kwargs):
+            seen["sees_parent"] = "/parent/read" in session._current_read_files
+            session._current_read_files.add("/child/read")
+            seen["child_isolated"] = "/child/read" not in session._read_files
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            cid, out = session._exec_task({"call_id": "t1", "prompt": "go"})
+
+        assert (cid, out) == ("t1", "done")
+        assert seen["sees_parent"] is True  # copy-on-spawn: inherits parent's reads
+        assert seen["child_isolated"] is True  # independent set mid-run (no leak)
+        assert "/child/read" in session._read_files  # merged back on completion
+        assert session._current_read_files is session._read_files  # contextvar reset
+
+
+class TestSubAgentErrorRecall:
+    """_run_agent stamps is_error on a sub-tool's Turn from the authoritative
+    _tool_error_flags, so a failed sub-tool recalls styled as an error rather
+    than a green 'done' step (the most serious review finding)."""
+
+    def test_errored_sub_tool_turn_marked_is_error(self):
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.trajectory import Role
+
+        session = _make_session()
+        session._provider = OpenAIChatCompletionsProvider()
+        calls = [0]
+
+        def fake_create(**_kwargs):
+            calls[0] += 1
+            resp = MagicMock()
+            choice = MagicMock()
+            if calls[0] == 1:
+                choice.finish_reason = "tool_calls"
+                tc = MagicMock()
+                tc.id = "call_1"
+                tc.function.name = "bash"
+                tc.function.arguments = '{"command":"false"}'
+                choice.message.tool_calls = [tc]
+                choice.message.content = None
+            else:
+                choice.finish_reason = "stop"
+                choice.message.tool_calls = None
+                choice.message.content = "done"
+            resp.choices = [choice]
+            resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+            return resp
+
+        session.client.chat.completions.create = fake_create
+
+        def fake_prepare(tc_dict, **_kwargs):
+            cid = tc_dict["id"]
+
+            def _exec(p):
+                # Simulate an errored tool: the real exec records is_error via
+                # _report_tool_result, which sets _tool_error_flags.
+                session._tool_error_flags[p["call_id"]] = True
+                return cid, "boom"
+
+            return {
+                "call_id": cid,
+                "func_name": "bash",
+                "needs_approval": False,
+                "execute": _exec,
+            }
+
+        turns = [Turn.user("run it")]
+        with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
+            session._run_agent(
+                turns,
+                tools=[{"type": "function", "function": {"name": "bash"}}],
+                label="task",
+                auto_tools={"bash"},
+                parent_call_id="t1",
+            )
+
+        tool_turns = [t for t in turns if t.role is Role.TOOL]
+        assert tool_turns, "expected a tool result turn"
+        assert tool_turns[-1].is_error is True
+        # And it carries through the projection to the recalled step.
+        assert ChatSession._project_agent_steps(turns)[-1]["is_error"] is True
+
+
+class TestExecTaskReporting:
+    """_exec_task self-reports the task_agent's OWN result — the live card's
+    only completion signal (the parent loop reports error/denied results
+    centrally but relies on each tool self-reporting its success result)."""
+
+    def _bare_session(self):
+        session = _make_session()
+        session._agent_system_messages = []
+        session._task_tools = []
+        return session
+
+    def test_success_reports_result(self):
+        session = self._bare_session()
+        with (
+            patch.object(session, "_run_agent", return_value="the synthesis"),
+            patch.object(session, "_report_tool_result") as rpt,
+        ):
+            cid, out = session._exec_task({"call_id": "t1", "prompt": "go"})
+        assert (cid, out) == ("t1", "the synthesis")
+        rpt.assert_called_once_with("t1", "task_agent", "the synthesis")
+
+    def test_error_reports_is_error(self):
+        session = self._bare_session()
+        with (
+            patch.object(session, "_run_agent", side_effect=RuntimeError("boom")),
+            patch.object(session, "_report_tool_result") as rpt,
+        ):
+            cid, out = session._exec_task({"call_id": "t1", "prompt": "go"})
+        assert out == "Task error: boom"
+        rpt.assert_called_once_with("t1", "task_agent", "Task error: boom", is_error=True)
+
+
 class TestEvaluateOutputLLMStage:
     """End-to-end coverage of _evaluate_output with the LLM judge stage."""
 

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -2089,3 +2089,74 @@ def test_tool_pending_precedes_smart_approval_gate() -> None:
 
     assert approved is True
     assert captured and captured[0] == "tool_pending", captured
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent step tagging (task_agent child events nest under the parent card)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentChildTagging:
+    """``note_agent_child`` makes ``_enqueue`` stamp ``parent_call_id`` on a
+    sub-tool's events so the UI can nest a task agent's steps under its card.
+    Keyed on the immutable child call_id (correct under the parent's parallel
+    tool pool); cleared when the task agent finishes."""
+
+    def test_registered_child_event_is_stamped(self) -> None:
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.note_agent_child("child-1", "task-A")
+        ui._enqueue({"type": "tool_result", "call_id": "child-1", "name": "bash", "output": "ok"})
+        assert lq.get_nowait()["parent_call_id"] == "task-A"
+
+    def test_unregistered_call_id_is_not_stamped(self) -> None:
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.note_agent_child("child-1", "task-A")
+        ui._enqueue({"type": "tool_result", "call_id": "other", "name": "x", "output": "y"})
+        assert "parent_call_id" not in lq.get_nowait()
+
+    def test_no_registry_no_stamp(self) -> None:
+        """Empty registry short-circuits — events pass through untouched."""
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui._enqueue({"type": "tool_result", "call_id": "child-1", "name": "x", "output": "y"})
+        assert "parent_call_id" not in lq.get_nowait()
+
+    def test_items_payload_is_stamped_per_entry(self) -> None:
+        """approve_request / tool_pending carry an ``items`` list; each child
+        entry is tagged independently, leaving non-child entries alone."""
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.note_agent_child("child-1", "task-A")
+        ui._enqueue(
+            {
+                "type": "tool_pending",
+                "items": [
+                    {"call_id": "child-1", "func_name": "bash"},
+                    {"call_id": "top-level", "func_name": "search"},
+                ],
+            }
+        )
+        items = lq.get_nowait()["items"]
+        assert items[0]["parent_call_id"] == "task-A"
+        assert "parent_call_id" not in items[1]
+
+    def test_clear_agent_children_stops_stamping(self) -> None:
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.note_agent_child("child-1", "task-A")
+        ui.clear_agent_children("task-A")
+        ui._enqueue({"type": "tool_result", "call_id": "child-1", "name": "x", "output": "y"})
+        assert "parent_call_id" not in lq.get_nowait()
+
+    def test_clear_is_scoped_to_one_parent(self) -> None:
+        """Two task agents in flight: clearing one leaves the other's children
+        tagged — the parallel-pool invariant."""
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.note_agent_child("child-A", "task-A")
+        ui.note_agent_child("child-B", "task-B")
+        ui.clear_agent_children("task-A")
+        ui._enqueue({"type": "tool_result", "call_id": "child-B", "name": "x", "output": "y"})
+        assert lq.get_nowait()["parent_call_id"] == "task-B"

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -2160,3 +2160,54 @@ class TestAgentChildTagging:
         ui.clear_agent_children("task-A")
         ui._enqueue({"type": "tool_result", "call_id": "child-B", "name": "x", "output": "y"})
         assert lq.get_nowait()["parent_call_id"] == "task-B"
+
+
+class TestAgentScopeInfoSuppression:
+    """While a task agent runs, its ``on_info`` progress chatter ("[task done] N
+    chars", a tool's "fetched N chars") carries no call_id, so it can't nest
+    under the task card.  The web pane drops it for the duration rather than let
+    it escape to the top level; the depth counter keeps it correct under the
+    parent's parallel task pool."""
+
+    def test_on_info_suppressed_within_scope(self) -> None:
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.begin_agent_scope()
+        ui.on_info("fetched 5663 chars, extracting...")
+        ui.end_agent_scope()
+        assert lq.empty()
+
+    def test_on_info_passes_through_outside_scope(self) -> None:
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.on_info("top-level status")
+        assert lq.get_nowait() == {
+            "type": "info",
+            "message": "top-level status",
+            "ws_id": "ws-1",
+            "_event_id": 1,
+        }
+
+    def test_nested_scopes_need_matching_exits(self) -> None:
+        """Parallel task agents: info stays suppressed until the LAST one
+        leaves (the depth returns to zero)."""
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.begin_agent_scope()
+        ui.begin_agent_scope()
+        ui.end_agent_scope()
+        ui.on_info("still inside a sibling task agent")
+        assert lq.empty()
+        ui.end_agent_scope()
+        ui.on_info("now top-level again")
+        assert lq.get_nowait()["message"] == "now top-level again"
+
+    def test_end_scope_floored_at_zero(self) -> None:
+        """An unmatched ``end_agent_scope`` can't drive the depth negative and
+        wedge suppression off."""
+        ui = _make_ui()
+        lq = ui._register_listener()
+        ui.end_agent_scope()
+        ui.begin_agent_scope()
+        ui.on_info("suppressed")
+        assert lq.empty()

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -18,6 +18,8 @@ import threading
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from turnstone.core.session_ui_base import SessionUIBase
 
 
@@ -2166,8 +2168,19 @@ class TestAgentScopeInfoSuppression:
     """While a task agent runs, its ``on_info`` progress chatter ("[task done] N
     chars", a tool's "fetched N chars") carries no call_id, so it can't nest
     under the task card.  The web pane drops it for the duration rather than let
-    it escape to the top level; the depth counter keeps it correct under the
-    parent's parallel task pool."""
+    it escape to the top level; the per-thread contextvar keeps it correct under
+    the parent's parallel task pool (siblings in other threads aren't suppressed)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_scope(self):
+        # The scope depth is a module-level contextvar that persists across tests
+        # in the same thread; reset it around each so an unbalanced test (or a
+        # leak from elsewhere) can't bleed suppression into another test.
+        from turnstone.core.session_ui_base import _agent_scope_var
+
+        token = _agent_scope_var.set(0)
+        yield
+        _agent_scope_var.reset(token)
 
     def test_on_info_suppressed_within_scope(self) -> None:
         ui = _make_ui()
@@ -2211,3 +2224,42 @@ class TestAgentScopeInfoSuppression:
         ui.begin_agent_scope()
         ui.on_info("suppressed")
         assert lq.empty()
+
+
+class TestAgentTrajectoryStash:
+    """The recall store retains a finished task agent's projected sub-trajectory
+    keyed by call_id, LRU-bounded.  A miss is the honest "not retained" signal —
+    /history then renders the flat parent record, never a fabricated 0-step card."""
+
+    def test_stash_and_get_roundtrip(self) -> None:
+        ui = _make_ui()
+        steps = [
+            {"id": "t1::c1", "name": "search", "arguments": "{}", "output": "ok", "is_error": False}
+        ]
+        ui.stash_agent_trajectory("t1", steps)
+        assert ui.get_agent_trajectory("t1") == steps
+
+    def test_missing_returns_none(self) -> None:
+        assert _make_ui().get_agent_trajectory("nope") is None
+
+    def test_empty_call_id_ignored(self) -> None:
+        ui = _make_ui()
+        ui.stash_agent_trajectory("", [{"id": "x"}])
+        assert ui.get_agent_trajectory("") is None
+
+    def test_restash_updates_value(self) -> None:
+        ui = _make_ui()
+        ui.stash_agent_trajectory("k", [{"id": "v1"}])
+        ui.stash_agent_trajectory("k", [{"id": "v2"}])
+        assert ui.get_agent_trajectory("k") == [{"id": "v2"}]
+
+    def test_lru_evicts_oldest(self) -> None:
+        from turnstone.core.session_ui_base import _AGENT_TRAJECTORY_CAP
+
+        ui = _make_ui()
+        for i in range(_AGENT_TRAJECTORY_CAP + 3):
+            ui.stash_agent_trajectory(f"t{i}", [{"id": f"t{i}"}])
+        # The three oldest fell out → honest None; the newest is retained.
+        assert ui.get_agent_trajectory("t0") is None
+        assert ui.get_agent_trajectory("t2") is None
+        assert ui.get_agent_trajectory(f"t{_AGENT_TRAJECTORY_CAP + 2}") is not None

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1117,6 +1117,77 @@ class TestExportInteractive:
         assert "should not leak" not in r.text
 
 
+class TestHistoryAgentStepsOverlay:
+    """The history handler attaches a live task agent's stashed sub-trajectory to
+    its ``task_agent`` tool_call (``agent_steps``) so the client rebuilds the
+    card.  A cold ws / evicted entry has none → no overlay (honest flat row)."""
+
+    def _save_task_agent_turn(self, storage, ws_id):
+        storage.register_workstream(ws_id, kind="interactive", user_id="test-user")
+        storage.save_message(ws_id, "user", "kick off")
+        tc_json = json.dumps(
+            [
+                {
+                    "id": "task1",
+                    "type": "function",
+                    "function": {
+                        "name": "task_agent",
+                        "arguments": '{"prompt":"find call sites"}',
+                    },
+                }
+            ]
+        )
+        storage.save_message(ws_id, "assistant", "Working", tool_calls=tc_json)
+        storage.save_message(ws_id, "tool", "4 call sites found", tool_call_id="task1")
+
+    def test_attaches_agent_steps_from_live_stash(self, _inject_storage):
+        ws_id = "ws-recall-warm"
+        self._save_task_agent_turn(_inject_storage, ws_id)
+        steps = [
+            {
+                "id": "task1::c1",
+                "name": "search",
+                "arguments": "{}",
+                "output": "12 matches",
+                "is_error": False,
+            }
+        ]
+        mock_ws = MagicMock()
+        mock_ws.id = ws_id
+        mock_ws.ui._pending_approval = None
+        mock_ws.ui.get_agent_trajectory = lambda cid: steps if cid == "task1" else None
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = mock_ws
+
+        r = _build_history_app(mock_mgr, _inject_storage).get(
+            f"/v1/api/workstreams/{ws_id}/history"
+        )
+        assert r.status_code == 200
+        assistant = next(m for m in r.json()["messages"] if m.get("role") == "assistant")
+        tc = assistant["tool_calls"][0]
+        assert tc["id"] == "task1"
+        assert tc["agent_steps"] == steps
+
+    def test_no_overlay_when_not_retained(self, _inject_storage):
+        # Cold / evicted: get_agent_trajectory returns None → no agent_steps key,
+        # so the client renders the flat parent record (never a 0-step card).
+        ws_id = "ws-recall-cold"
+        self._save_task_agent_turn(_inject_storage, ws_id)
+        mock_ws = MagicMock()
+        mock_ws.id = ws_id
+        mock_ws.ui._pending_approval = None
+        mock_ws.ui.get_agent_trajectory = lambda cid: None
+        mock_mgr = MagicMock()
+        mock_mgr.get.return_value = mock_ws
+
+        r = _build_history_app(mock_mgr, _inject_storage).get(
+            f"/v1/api/workstreams/{ws_id}/history"
+        )
+        assert r.status_code == 200
+        assistant = next(m for m in r.json()["messages"] if m.get("role") == "assistant")
+        assert "agent_steps" not in assistant["tool_calls"][0]
+
+
 class TestHistoryInteractive:
     """Interactive parity for the lifted ``GET /v1/api/workstreams/{ws_id}/history``."""
 

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -285,6 +285,12 @@ class TerminalUI(SessionUI):
     def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
         pass  # Terminal shows spinner during tool execution
 
+    def on_agent_step(self, parent_call_id: str, item: dict[str, Any]) -> None:
+        # CLI keeps an inline "leg" per sub-agent step — the structured nesting
+        # card is web-only.
+        hdr = item.get("header") or item.get("func_name") or "tool"
+        print(f"{DIM}  - {hdr}{RESET}")
+
     def on_status(self, usage: dict[str, Any], context_window: int, effort: str) -> None:
         total_tok = usage["prompt_tokens"] + usage["completion_tokens"]
         pct = total_tok / context_window * 100 if context_window > 0 else 0

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7021,9 +7021,17 @@ class ChatSession:
             for item in items:
                 if item.get("needs_approval") and not item.get("error"):
                     item["denied"] = True
-                    item["denial_msg"] = (
-                        f"Denied by user: {user_feedback}" if user_feedback else "Denied by user"
-                    )
+                    if not item.get("denial_msg"):
+                        # approve_tools already stamps the specific reason (the
+                        # matched policy pattern, or the operator's feedback) on
+                        # a denied item; only fill the flat default when it left
+                        # denial_msg unset — never clobber the specific reason
+                        # (mirrors the sub-agent loop's guard).
+                        item["denial_msg"] = (
+                            f"Denied by user: {user_feedback}"
+                            if user_feedback
+                            else "Denied by user"
+                        )
             user_feedback = None  # feedback is in the denial_msg
             if self._mem_cfg.nudges and should_nudge(
                 "denial",
@@ -12572,14 +12580,35 @@ class ChatSession:
                         is_tool_error = self._tool_error_flags.pop(tc_dict["id"], False)
                     # Tools not in auto_tools require user approval.
                     elif "execute" in prepared:
-                        approved, _ = self.ui.approve_tools([prepared])
-                        if not approved:
+                        approved, denial_feedback = self.ui.approve_tools([prepared])
+                        if not approved and not prepared.get("denied"):
+                            # ``approve_tools`` already stamps a SPECIFIC
+                            # denial_msg on a denied item (the matched policy
+                            # pattern, or the operator's feedback) and returns
+                            # the reason as its second value.  Only fill a
+                            # default when some other not-approved path left it
+                            # unset — never clobber the specific reason with a
+                            # flat "Denied by user", and fold the returned
+                            # feedback in so the sub-agent can adapt (mirrors the
+                            # main tool loop's denial handling).
                             prepared["denied"] = True
-                            prepared["denial_msg"] = "Denied by user"
+                            prepared["denial_msg"] = (
+                                f"Denied by user: {denial_feedback}"
+                                if denial_feedback
+                                else "Denied by user"
+                            )
                         if prepared.get("denied"):
                             # A denial is not an execution error — keep is_error
                             # False so recall shows the denial text, not red.
-                            output = prepared.get("denial_msg", "Denied by user")
+                            # The web gate records the reason in ``denial_msg``;
+                            # the CLI gate records a policy block in ``error``
+                            # (and returns approved=True) — honour whichever the
+                            # gate set before the flat default.
+                            output = (
+                                prepared.get("denial_msg")
+                                or prepared.get("error")
+                                or "Denied by user"
+                            )
                         else:
                             _, output = prepared["execute"](prepared)
                             is_tool_error = self._tool_error_flags.pop(tc_dict["id"], False)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -12,6 +12,7 @@ import base64
 import collections
 import concurrent.futures
 import contextlib
+import contextvars
 import copy
 import dataclasses
 import difflib
@@ -138,6 +139,7 @@ from turnstone.core.tools import (
 from turnstone.core.trajectory import (
     EffectStatus,
     Role,
+    TextBlock,
     ToolCall,
     Turn,
     dicts_from_turns,
@@ -271,6 +273,34 @@ def _encode_image_data_uri(raw: bytes, mime: str) -> str:
 
 # Upper bound on total skill content injected into system messages
 _MAX_SKILL_CONTENT: int = 32768
+
+# Cap on a sub-agent tool's RAW output before it enters the trajectory (the
+# in-loop truncation in _run_agent) — bounds what the sub-agent's own model sees
+# on its next turn.  Distinct from (and larger than) the recall per-step cap.
+_AGENT_TOOL_OUTPUT_CAP: int = 16000
+
+# Per-step output/arguments cap for a recalled task-agent sub-trajectory (the
+# projected step items /history attaches for the card rebuild).  Keeps the
+# recall payload small — the card shows a summary, not the full tool output.
+_AGENT_STEP_OUTPUT_CAP: int = 2000
+
+# Cap on the NUMBER of recalled steps per task agent.  With the per-step output
+# cap above, this bounds each stash entry's size (the LRU caps the agent count,
+# not per-entry bytes), so a 100+-tool agent can't blow the memory budget; the
+# overflow is replaced by one honest "(+N not retained)" marker step.
+_AGENT_STEP_COUNT_CAP: int = 100
+
+# Per-task-agent file-read tracking.  ``_read_files`` (the blind-overwrite guard's
+# memory of "files this agent has read") is a single set on the session, but the
+# parent runs task agents in a 4-wide pool — sharing it lets a sibling's read
+# suppress another agent's overwrite guard (a real blind-overwrite hazard).
+# ``_exec_task`` installs a fresh per-run set in this ContextVar for the sub-
+# agent's duration; ``_current_read_files`` reads it.  ``None`` outside a sub-
+# agent → the main session's set.  A ContextVar (not threading.local) so the
+# set/reset is balanced per ``_exec_task`` call and survives pool-thread reuse.
+_active_read_files: contextvars.ContextVar[set[str] | None] = contextvars.ContextVar(
+    "turnstone_active_read_files", default=None
+)
 
 # Cap on the *content portion* (text after ``path:lineno:``) of an
 # emitted search result line. Defends the context budget against
@@ -7404,6 +7434,15 @@ class ChatSession:
             "stop_on_error": args.get("stop_on_error") is True,
         }
 
+    @property
+    def _current_read_files(self) -> set[str]:
+        """The read-tracking set for the current execution context: a task
+        agent's own per-run set while one is active (so the 4-wide pool can't
+        cross-contaminate the blind-overwrite guard), else the main session's
+        ``_read_files``.  See :data:`_active_read_files`."""
+        active = _active_read_files.get()
+        return active if active is not None else self._read_files
+
     def _prepare_read_file(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         path = args.get("path", "")
         if not path:
@@ -7457,7 +7496,7 @@ class ChatSession:
                 "error": f"Error: limit must be >= 1 (got {limit})",
             }
         # Register early so a same-batch edit_file can pass the read guard.
-        self._read_files.add(resolved)
+        self._current_read_files.add(resolved)
         # Build header showing range if specified
         header = f"\u2699 read_file: {path}"
         if offset is not None or limit is not None:
@@ -7579,7 +7618,7 @@ class ChatSession:
         if mode not in ("overwrite", "append"):
             mode = "overwrite"
         is_append = mode == "append"
-        is_overwrite = exists and resolved not in self._read_files and not is_append
+        is_overwrite = exists and resolved not in self._current_read_files and not is_append
 
         # Build preview
         preview_parts = []
@@ -7729,7 +7768,7 @@ class ChatSession:
         resolved = os.path.realpath(path)
         is_symlink = os.path.abspath(path) != resolved
 
-        if resolved not in self._read_files:
+        if resolved not in self._current_read_files:
             return {
                 "call_id": call_id,
                 "func_name": "edit_file",
@@ -11858,11 +11897,11 @@ class ChatSession:
 
         all_lines, _, err = self._read_text_lines(path)
         if err:
-            self._read_files.discard(resolved)
+            self._current_read_files.discard(resolved)
             self._report_tool_result(call_id, "read_file", err, is_error=True)
             return call_id, err
 
-        self._read_files.add(resolved)
+        self._current_read_files.add(resolved)
         total_lines = len(all_lines)
 
         # Slice if offset/limit specified
@@ -11895,11 +11934,11 @@ class ChatSession:
             try:
                 size = os.path.getsize(resolved)
             except OSError as e:
-                self._read_files.discard(resolved)
+                self._current_read_files.discard(resolved)
                 msg = f"Error: {path}: {e}"
                 self._report_tool_result(call_id, "read_file", msg, is_error=True)
                 return call_id, msg
-            self._read_files.add(resolved)
+            self._current_read_files.add(resolved)
             desc = f"image (no vision, {size:,} bytes)"
             self._report_tool_result(call_id, "read_file", desc)
             return call_id, (
@@ -11911,18 +11950,18 @@ class ChatSession:
             with open(resolved, "rb") as f:
                 raw = f.read()
         except FileNotFoundError:
-            self._read_files.discard(resolved)
+            self._current_read_files.discard(resolved)
             msg = f"Error: {path} not found"
             self._report_tool_result(call_id, "read_file", msg, is_error=True)
             return call_id, msg
         except Exception as e:
-            self._read_files.discard(resolved)
+            self._current_read_files.discard(resolved)
             msg = f"Error reading {path}: {e}"
             self._report_tool_result(call_id, "read_file", msg, is_error=True)
             return call_id, msg
 
         if len(raw) > _IMAGE_SIZE_CAP:
-            self._read_files.discard(resolved)
+            self._current_read_files.discard(resolved)
             size_mb = len(raw) / (1024 * 1024)
             cap_mb = _IMAGE_SIZE_CAP / (1024 * 1024)
             msg = (
@@ -11932,7 +11971,7 @@ class ChatSession:
             self._report_tool_result(call_id, "read_file", msg, is_error=True)
             return call_id, msg
 
-        self._read_files.add(resolved)
+        self._current_read_files.add(resolved)
         mime, _ = mimetypes.guess_type(path)
         if not mime:
             mime = "image/png"
@@ -12121,7 +12160,7 @@ class ChatSession:
         if err:
             self._report_tool_result(call_id, "diff_file", err, is_error=True)
             return call_id, err
-        self._read_files.add(resolved_a)
+        self._current_read_files.add(resolved_a)
 
         if path_b:
             label_b = path_b
@@ -12129,7 +12168,7 @@ class ChatSession:
             if err:
                 self._report_tool_result(call_id, "diff_file", err, is_error=True)
                 return call_id, err
-            self._read_files.add(resolved_b)
+            self._current_read_files.add(resolved_b)
         else:
             label_b = "(provided content)"
             lines_b = (content_b or "").splitlines(keepends=True)
@@ -12201,6 +12240,105 @@ class ChatSession:
         fn = getattr(self.ui, "end_agent_scope", None)
         if fn is not None:
             fn()
+
+    @staticmethod
+    def _clip_with_count(text: str, cap: int) -> str:
+        """Head-clip ``text`` to ``cap`` chars with a uniform truncation marker.
+        The one format for sub-agent output clips — the in-loop 16k clip and the
+        recall per-step cap — distinct from the token-budget-aware
+        :meth:`_truncate_output`."""
+        if len(text) <= cap:
+            return text
+        return text[:cap] + f"\n\n... (truncated from {len(text)} chars)"
+
+    @staticmethod
+    def _iter_agent_tool_results(
+        agent_turns: list[Turn],
+    ) -> Iterator[tuple[ToolCall, Turn | None]]:
+        """Yield ``(tool_call, result_turn_or_None)`` for every sub-tool the
+        sub-agent issued, in order, pairing each call to its result FIFO per
+        call_id — a queue per id consumed once, NOT a last-wins dict, so a local
+        provider that reuses ids across turns (``call_0`` …) can't collapse
+        distinct calls onto one result.  Shared by :meth:`_project_agent_steps`
+        (recall) and :meth:`_cancel_ledger` (cancel disposition)."""
+        pending: dict[str, collections.deque[Turn]] = {}
+        for t in agent_turns:
+            if t.role is Role.TOOL and t.tool_call_id:
+                pending.setdefault(t.tool_call_id, collections.deque()).append(t)
+        for t in agent_turns:
+            if t.role is not Role.ASSISTANT:
+                continue
+            for tc in t.tool_calls:
+                q = pending.get(tc.id)
+                yield tc, (q.popleft() if q else None)
+
+    @staticmethod
+    def _project_agent_steps(agent_turns: list[Turn]) -> list[dict[str, Any]]:
+        """Project a finished sub-agent's trajectory into recall step items for
+        the task card — one per sub-tool call, matched to its result (FIFO per
+        call_id via :meth:`_iter_agent_tool_results`).
+
+        Reads the tool turn's payload directly rather than via ``Turn.text``,
+        which raises on a multimodal ``list[dict]`` result (the deferred-finding
+        landmine); a non-``str`` payload becomes a light placeholder so the
+        recall stays text-only and ``/history`` doesn't carry image bytes.  Each
+        step's output AND arguments are capped (:data:`_AGENT_STEP_OUTPUT_CAP`)
+        and the step COUNT (:data:`_AGENT_STEP_COUNT_CAP`); on overflow the most
+        RECENT steps are kept (a sub-agent's latest edits/writes matter more on
+        recall than its opening searches) behind an honest leading marker — so
+        the stash stays memory-bounded even for a 100+-tool agent and never
+        silently under-reports its step count."""
+        pairs = list(ChatSession._iter_agent_tool_results(agent_turns))
+        dropped = max(0, len(pairs) - _AGENT_STEP_COUNT_CAP)
+        # Build dicts only for the retained tail, not the dropped head.
+        tail = pairs[-_AGENT_STEP_COUNT_CAP:] if dropped else pairs
+        steps: list[dict[str, Any]] = []
+        if dropped:
+            # Leading marker naming how many earlier steps fell out — honest, and
+            # correct now that the RETAINED steps are the recent ones.
+            steps.append(
+                {
+                    "id": "",
+                    "name": "…",
+                    "arguments": "{}",
+                    "output": f"(+{dropped} earlier steps not retained)",
+                    "is_error": False,
+                }
+            )
+        for tc, res in tail:
+            output, is_error = "", False
+            if res is not None:
+                is_error = res.is_error
+                raw = (
+                    res.content[0].text
+                    if res.content and isinstance(res.content[0], TextBlock)
+                    else ""
+                )
+                output = raw if isinstance(raw, str) else "[non-text result]"
+            steps.append(
+                {
+                    "id": tc.id,
+                    "name": tc.name,
+                    # Clip arguments too: a write_file/edit_file call carries full
+                    # file content here, which the per-step output cap alone would
+                    # leave unbounded in the in-memory stash.
+                    "arguments": ChatSession._clip_with_count(tc.arguments, _AGENT_STEP_OUTPUT_CAP),
+                    "output": ChatSession._clip_with_count(output, _AGENT_STEP_OUTPUT_CAP),
+                    "is_error": is_error,
+                }
+            )
+        return steps
+
+    def _stash_agent_trajectory(self, call_id: str | None, agent_turns: list[Turn]) -> None:
+        """Retain a finished task agent's projected sub-trajectory for ``/history``
+        card recall (getattr-guarded → no-op on CLI / eval / fixtures).  Called
+        from ``_exec_task``'s ``finally`` so it captures the full record on
+        success and the partial one on cancel/error — both honest."""
+        if not call_id:
+            return
+        fn = getattr(self.ui, "stash_agent_trajectory", None)
+        if fn is not None:
+            fn(call_id, self._project_agent_steps(agent_turns))
 
     def _run_agent(
         self,
@@ -12399,9 +12537,16 @@ class ChatSession:
                 # output_warning still nests under the task card.
                 self._note_agent_child(tc_dict["id"], parent_call_id)
 
+                # is_error for the recalled step: the guard / prepare / unknown
+                # branches produce explicit error text; the execute paths record
+                # the authoritative flag via ``_report_tool_result`` (consumed
+                # below).  Without this every recalled sub-step reads as success
+                # and a failed sub-tool recalls as a green "done" card.
+                is_tool_error = False
                 # Guard 1: block recursive agent calls.
                 if tool_name == "task_agent":
                     output = "Error: agents cannot spawn further agents"
+                    is_tool_error = True
                 # Guard 2: tool not in this agent's API tool list.
                 elif tool_name not in tool_names:
                     output = (
@@ -12409,11 +12554,13 @@ class ChatSession:
                         f"agent mode. "
                         f"Available: {', '.join(sorted(tool_names))}"
                     )
+                    is_tool_error = True
                 else:
                     prepared = self._prepare_tool(tc_dict)
 
                     if prepared.get("error"):
                         output = prepared["error"]
+                        is_tool_error = True
                     # Auto-execute tools in the auto_tools set.
                     elif tool_name in auto_tools:
                         # Paint the step pending under the task card before it
@@ -12422,6 +12569,7 @@ class ChatSession:
                         # paint via approve_tools instead.
                         self._paint_agent_step(parent_call_id, prepared)
                         _, output = prepared["execute"](prepared)
+                        is_tool_error = self._tool_error_flags.pop(tc_dict["id"], False)
                     # Tools not in auto_tools require user approval.
                     elif "execute" in prepared:
                         approved, _ = self.ui.approve_tools([prepared])
@@ -12429,11 +12577,15 @@ class ChatSession:
                             prepared["denied"] = True
                             prepared["denial_msg"] = "Denied by user"
                         if prepared.get("denied"):
+                            # A denial is not an execution error — keep is_error
+                            # False so recall shows the denial text, not red.
                             output = prepared.get("denial_msg", "Denied by user")
                         else:
                             _, output = prepared["execute"](prepared)
+                            is_tool_error = self._tool_error_flags.pop(tc_dict["id"], False)
                     else:
                         output = f"Unknown tool: {tool_name}"
+                        is_tool_error = True
 
                 # Output guard: evaluate before truncation so the guard
                 # sees full output (credentials split by truncation would
@@ -12449,8 +12601,8 @@ class ChatSession:
                 # Truncate large tool outputs to avoid blowing context limits.
                 # Agents operate autonomously; they can refine their queries
                 # if truncation loses important detail.
-                if isinstance(output, str) and len(output) > 16000:
-                    output = output[:16000] + f"\n\n... (truncated from {len(output)} chars)"
+                if isinstance(output, str) and len(output) > _AGENT_TOOL_OUTPUT_CAP:
+                    output = self._clip_with_count(output, _AGENT_TOOL_OUTPUT_CAP)
 
                 # NOTE: for a vision tool result ``output`` is a list[dict] of
                 # inline content parts (read_file on an image).  It lowers back
@@ -12462,7 +12614,7 @@ class ChatSession:
                 # ``create_completion`` (it currently isn't) plus content-
                 # addressed byte storage — deferred to the recall/persist work
                 # where that attachment path is already in scope.
-                agent_turns.append(Turn.tool(tc_dict["id"], output))
+                agent_turns.append(Turn.tool(tc_dict["id"], output, is_error=is_tool_error))
             turn += 1
 
         # Exhausted tool turns — force a final synthesis response.
@@ -12544,8 +12696,14 @@ class ChatSession:
             Turn.user(prompt),
         ]
         self._begin_agent_scope()
+        # Per-sub-agent file-read tracking.  COPY the parent's current set in (so
+        # the agent can edit a file the parent already read for it — no spurious
+        # "must read before editing"), but as an INDEPENDENT set, so a pool
+        # sibling's reads can't suppress THIS agent's blind-overwrite guard.  The
+        # agent's own reads merge back to the parent in ``finally``.
+        read_token = _active_read_files.set(set(self._current_read_files))
         try:
-            return call_id, self._run_agent(
+            result = self._run_agent(
                 agent_turns,
                 label="task",
                 tools=self._task_tools,
@@ -12553,6 +12711,14 @@ class ChatSession:
                 agent_alias=item.get("model_override"),
                 parent_call_id=call_id,
             )
+            # Self-report the task_agent's OWN result.  The parent run-loop only
+            # reports error/denied/exception results centrally; success results
+            # rely on each tool self-reporting (bash, search, … all do), and the
+            # task_agent never did — so without this the live card has no
+            # completion signal (it stays "running" and the synthesis never
+            # renders live, only on reload).
+            self._report_tool_result(call_id, "task_agent", result)
+            return call_id, result
         except GenerationCancelled:
             # Fold back an honest disposition built from the agent's own
             # ledger.  ``agent_turns`` is mutated in place by
@@ -12567,17 +12733,35 @@ class ChatSession:
             # fabricate the acknowledgment but must not fabricate the
             # outcome … unknown, never none").
             self._tool_status[call_id] = self._cancelled_agent_status(agent_turns)
-            return call_id, self._cancelled_agent_disposition(agent_turns, "task")
+            disposition = self._cancelled_agent_disposition(agent_turns, "task")
+            self._report_tool_result(call_id, "task_agent", disposition)
+            return call_id, disposition
         except KeyboardInterrupt:
             # CLI Ctrl-C: keep the terse string and let the outer loop own
             # propagation (unchanged behavior).
             return call_id, "(task interrupted by user)"
         except Exception as e:
-            self.ui.on_info(f"[task error] {e}")
-            return call_id, f"Task error: {e}"
+            # Report as the task_agent's errored result so the card flips to
+            # "failed" and the message renders (replaces the old on_info, which
+            # was suppressed during the agent scope anyway).
+            msg = f"Task error: {e}"
+            self._report_tool_result(call_id, "task_agent", msg, is_error=True)
+            return call_id, msg
         finally:
+            # Teardown first (cheap + critical): merge the agent's reads back to
+            # the parent, restore the contextvar, drop the scope + child tags —
+            # all BEFORE the best-effort stash, so a stash raise can't leak the
+            # scope depth (phantom card nesting) or the child registry.
+            sub_reads = _active_read_files.get()
+            _active_read_files.reset(read_token)
+            if sub_reads:
+                self._current_read_files.update(sub_reads)
             self._end_agent_scope()
             self._clear_agent_children(call_id)
+            try:
+                self._stash_agent_trajectory(call_id, agent_turns)
+            except Exception:
+                log.debug("task_agent.stash_failed call_id=%s", call_id, exc_info=True)
 
     @staticmethod
     def _cancel_ledger(
@@ -12594,18 +12778,15 @@ class ChatSession:
         it returned, everything after never started. (The LAST gap would invert
         unknown/none on a multi-call turn.) Shared by the disposition string and
         its typed status so the two can't disagree.
+
+        Pairs via :meth:`_iter_agent_tool_results` (FIFO per call_id), so on a
+        provider that reuses ids a half-answered colliding pair is correctly read
+        as one answered + one in-flight gap, not (set-membership) both answered.
         """
-        answered: set[str] = set()
-        for t in agent_turns:
-            if t.role is Role.TOOL and t.tool_call_id:
-                answered.add(t.tool_call_id)
-        issued: list[tuple[str, bool]] = []
-        for t in agent_turns:
-            if t.role is not Role.ASSISTANT:
-                continue
-            for tc in t.tool_calls:
-                name = (tc.name or "tool").strip()
-                issued.append((name, tc.id in answered))
+        issued = [
+            ((tc.name or "tool").strip(), res is not None)
+            for tc, res in ChatSession._iter_agent_tool_results(agent_turns)
+        ]
         first_gap = next((i for i, (_n, ans) in enumerate(issued) if not ans), None)
         return issued, first_gap
 
@@ -13410,7 +13591,7 @@ class ChatSession:
             os.makedirs(os.path.dirname(resolved) or ".", exist_ok=True)
             with open(resolved, "a" if is_append else "w") as f:
                 f.write(content)
-            self._read_files.add(resolved)
+            self._current_read_files.add(resolved)
             verb = "Appended" if is_append else "Wrote"
             msg = f"{verb} {len(content)} chars to {path}"
             self._report_tool_result(call_id, "write_file", msg)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -12176,6 +12176,32 @@ class ChatSession:
         if fn is not None:
             fn(parent_call_id)
 
+    def _paint_agent_step(self, parent_call_id: str | None, item: dict[str, Any]) -> None:
+        """Paint a sub-agent's auto-tool step (web pending row / CLI leg) — the
+        typed successor to the old per-turn ``on_info`` leg.  No-op without a
+        parent or on a UI that doesn't render agent steps (eval / fixtures)."""
+        if not parent_call_id:
+            return
+        fn = getattr(self.ui, "on_agent_step", None)
+        if fn is not None:
+            fn(parent_call_id, item)
+
+    def _begin_agent_scope(self) -> None:
+        """Mark a task agent as in flight so the web pane drops its ``on_info``
+        progress chatter (it can't nest under the card — no call_id).  Bracketed
+        with :meth:`_end_agent_scope`; getattr-guarded → no-op on the CLI (keeps
+        its info lines) and on eval / fixtures."""
+        fn = getattr(self.ui, "begin_agent_scope", None)
+        if fn is not None:
+            fn()
+
+    def _end_agent_scope(self) -> None:
+        """Leave a task agent's scope — getattr-guarded twin of
+        :meth:`_begin_agent_scope`."""
+        fn = getattr(self.ui, "end_agent_scope", None)
+        if fn is not None:
+            fn()
+
     def _run_agent(
         self,
         agent_turns: list[Turn],
@@ -12336,6 +12362,17 @@ class ChatSession:
             agent_tool_calls: tuple[ToolCall, ...] = ()
             if result.tool_calls:
                 self._ensure_tool_call_ids(result.tool_calls)
+                # Namespace sub-agent tool ids by the parent task_agent so the
+                # UI nesting registry can't collide across concurrent task
+                # agents whose (local) provider reuses sequential ids ("call_0").
+                # Tool-call ids are opaque correlation tokens — a provider
+                # validates only intra-request assistant/tool consistency on
+                # replay, never against its own prior generation — so rewriting
+                # them in this ephemeral sub-conversation is wire-safe.  Skipped
+                # for a top-level run (no parent → no nesting).
+                if parent_call_id:
+                    for tc in result.tool_calls:
+                        tc["id"] = f"{parent_call_id}::{tc['id']}"
                 agent_tool_calls = tuple(
                     ToolCall(
                         id=tc["id"],
@@ -12375,13 +12412,15 @@ class ChatSession:
                 else:
                     prepared = self._prepare_tool(tc_dict)
 
-                    lbl = prepared.get("header", tool_name)
-                    self.ui.on_info(f"[{label} turn {turn + 1}] {lbl}")
-
                     if prepared.get("error"):
                         output = prepared["error"]
                     # Auto-execute tools in the auto_tools set.
                     elif tool_name in auto_tools:
+                        # Paint the step pending under the task card before it
+                        # runs (web) / print the leg (CLI) — the typed successor
+                        # to the old on_info turn-leg.  Approval-gated tools
+                        # paint via approve_tools instead.
+                        self._paint_agent_step(parent_call_id, prepared)
                         _, output = prepared["execute"](prepared)
                     # Tools not in auto_tools require user approval.
                     elif "execute" in prepared:
@@ -12504,6 +12543,7 @@ class ChatSession:
             Turn.system(base + "\n\n" + identity),
             Turn.user(prompt),
         ]
+        self._begin_agent_scope()
         try:
             return call_id, self._run_agent(
                 agent_turns,
@@ -12536,6 +12576,7 @@ class ChatSession:
             self.ui.on_info(f"[task error] {e}")
             return call_id, f"Task error: {e}"
         finally:
+            self._end_agent_scope()
             self._clear_agent_children(call_id)
 
     @staticmethod

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -138,6 +138,7 @@ from turnstone.core.tools import (
 from turnstone.core.trajectory import (
     EffectStatus,
     Role,
+    ToolCall,
     Turn,
     dicts_from_turns,
     turn_from_dict,
@@ -12155,19 +12156,43 @@ class ChatSession:
         self._report_tool_result(call_id, "diff_file", desc)
         return call_id, output
 
+    def _note_agent_child(self, child_call_id: str, parent_call_id: str | None) -> None:
+        """Register a sub-agent tool call under its parent task_agent call so the
+        UI can nest the step (see ``SessionUIBase.note_agent_child``).  No-op when
+        there's no parent (a top-level ``_run_agent``) or the UI doesn't support
+        it (CLI / eval / fixtures)."""
+        if not parent_call_id:
+            return
+        fn = getattr(self.ui, "note_agent_child", None)
+        if fn is not None:
+            fn(child_call_id, parent_call_id)
+
+    def _clear_agent_children(self, parent_call_id: str | None) -> None:
+        """Drop a finished task agent's child registrations — getattr-guarded
+        twin of :meth:`_note_agent_child`."""
+        if not parent_call_id:
+            return
+        fn = getattr(self.ui, "clear_agent_children", None)
+        if fn is not None:
+            fn(parent_call_id)
+
     def _run_agent(
         self,
-        agent_messages: list[dict[str, Any]],
+        agent_turns: list[Turn],
         label: str = "agent",
         tools: list[dict[str, Any]] | None = None,
         auto_tools: set[str] | None = None,
         reasoning_effort: str | None = None,
         agent_alias: str | None = None,
+        parent_call_id: str | None = None,
     ) -> str:
         """Run an autonomous agent loop.
 
         Args:
-            agent_messages: Pre-built message list (system + developer + user).
+            agent_turns: Pre-built sub-harness trajectory (system + user) as
+                neutral ``Turn`` objects, lowered to wire dicts at the API
+                boundary.  Mutated in place — every assistant turn and tool
+                result is appended as the loop runs.
             label: Display prefix for progress lines (e.g. "task").
             tools: Tool definitions to send to the API. Defaults to the
                 session's task tool set.
@@ -12179,6 +12204,9 @@ class ChatSession:
                 the registry's per-kind resolution when set.  Caller is
                 expected to have validated the alias against the registry;
                 an unknown alias here raises ``ValueError``.
+            parent_call_id: The task_agent call_id this sub-agent runs under,
+                threaded so each sub-tool's events get tagged for UI nesting.
+                ``None`` for a top-level run (no nesting).
 
         Returns:
             Final content string from the agent.
@@ -12228,7 +12256,7 @@ class ChatSession:
         )
 
         def _api_call(
-            messages: list[dict[str, Any]],
+            turns: list[Turn],
             _tools: list[dict[str, Any]] | None = tools,
         ) -> CompletionResult:
             # NOTE: Phase 5 vLLM ``reasoning`` field replay is intentionally
@@ -12238,13 +12266,17 @@ class ChatSession:
             # every turn anyway.  Task agents are excluded from the
             # persistence/replay contract — their conversation history
             # is in-memory and rebuilt per ``_run_agent`` invocation.
+            # Lower the trajectory once, not once per retry attempt — ``turns``
+            # is invariant across attempts (the retry path only sleeps and
+            # re-sends the same messages).
+            wire = dicts_from_turns(turns)
             last_err: Exception | None = None
             for attempt in range(self._MAX_RETRIES + 1):
                 try:
                     agent_result = agent_provider.create_completion(
                         client=agent_client,
                         model=agent_model,
-                        messages=messages,
+                        messages=wire,
                         tools=_tools,
                         max_tokens=self.max_tokens,
                         temperature=self.temperature,
@@ -12278,7 +12310,7 @@ class ChatSession:
         while max_tool_turns < 0 or turn < max_tool_turns:
             self._check_cancelled()
             try:
-                result = _api_call(agent_messages)
+                result = _api_call(agent_turns)
             except Exception as e:
                 # Context-exceeded or other non-retryable API error.
                 # Return what we have so far rather than crashing.
@@ -12286,9 +12318,9 @@ class ChatSession:
                 if "context" in err_str or "token" in err_str:
                     self.ui.on_info(f"[{label}] context limit reached, stopping early")
                     # Find the last assistant content we have
-                    for msg in reversed(agent_messages):
-                        if msg.get("role") == "assistant" and msg.get("content"):
-                            return self._guard_subagent_synthesis(str(msg["content"]), label)
+                    for t in reversed(agent_turns):
+                        if t.role is Role.ASSISTANT and t.text:
+                            return self._guard_subagent_synthesis(t.text, label)
                     return f"({label} stopped: context limit exceeded)"
                 raise
 
@@ -12300,15 +12332,19 @@ class ChatSession:
                 self.ui.on_info(f"[{label}] blocked by content filter")
                 return "(content filter)"
 
-            # Build message dict for agent history
-            msg_dict: dict[str, Any] = {
-                "role": "assistant",
-                "content": result.content or "",
-            }
+            # Append the assistant turn to the sub-harness trajectory.
+            agent_tool_calls: tuple[ToolCall, ...] = ()
             if result.tool_calls:
                 self._ensure_tool_call_ids(result.tool_calls)
-                msg_dict["tool_calls"] = result.tool_calls
-            agent_messages.append(msg_dict)
+                agent_tool_calls = tuple(
+                    ToolCall(
+                        id=tc["id"],
+                        name=tc.get("function", {}).get("name", ""),
+                        arguments=tc.get("function", {}).get("arguments", ""),
+                    )
+                    for tc in result.tool_calls
+                )
+            agent_turns.append(Turn.assistant(result.content or "", tool_calls=agent_tool_calls))
 
             if not result.tool_calls:
                 content = result.content or "(no output)"
@@ -12321,6 +12357,10 @@ class ChatSession:
             for tc_dict in result.tool_calls:
                 self._check_cancelled()
                 tool_name = tc_dict["function"]["name"].strip()
+                # Register every issued sub-tool under its parent task_agent —
+                # not only the execute path — so a guard-branch error's
+                # output_warning still nests under the task card.
+                self._note_agent_child(tc_dict["id"], parent_call_id)
 
                 # Guard 1: block recursive agent calls.
                 if tool_name == "task_agent":
@@ -12373,28 +12413,29 @@ class ChatSession:
                 if isinstance(output, str) and len(output) > 16000:
                     output = output[:16000] + f"\n\n... (truncated from {len(output)} chars)"
 
-                agent_messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc_dict["id"],
-                        "content": output,
-                    }
-                )
+                # NOTE: for a vision tool result ``output`` is a list[dict] of
+                # inline content parts (read_file on an image).  It lowers back
+                # to the same inline list on the wire (behaviour preserved), but
+                # it is NOT a valid ``TextBlock`` — ``Turn.text`` would raise on
+                # it.  No consumer evaluates ``.text`` on a sub-agent tool turn
+                # today.  The proper by-reference representation needs the
+                # attachment resolver wired into this sub-agent's
+                # ``create_completion`` (it currently isn't) plus content-
+                # addressed byte storage — deferred to the recall/persist work
+                # where that attachment path is already in scope.
+                agent_turns.append(Turn.tool(tc_dict["id"], output))
             turn += 1
 
         # Exhausted tool turns — force a final synthesis response.
         self.ui.on_info(f"[{label}] turn limit reached, requesting synthesis...")
-        agent_messages.append(
-            {
-                "role": "user",
-                "content": (
-                    "You have reached the tool call limit. "
-                    "Provide your complete response now using "
-                    "the information you have gathered so far."
-                ),
-            }
+        agent_turns.append(
+            Turn.user(
+                "You have reached the tool call limit. "
+                "Provide your complete response now using "
+                "the information you have gathered so far."
+            )
         )
-        result = _api_call(agent_messages, _tools=[])
+        result = _api_call(agent_turns, _tools=[])
         content = result.content or "(no output)"
         self.ui.on_info(f"[{label} done] {len(content)} chars")
         return self._guard_subagent_synthesis(content, label)
@@ -12459,21 +12500,22 @@ class ChatSession:
         # history — it's an autonomous sub-agent. Merged to avoid
         # multi-system-message errors on models like Qwen.
         base = self._agent_system_messages[0]["content"] if self._agent_system_messages else ""
-        agent_messages = [
-            {"role": "system", "content": base + "\n\n" + identity},
-            {"role": "user", "content": prompt},
+        agent_turns: list[Turn] = [
+            Turn.system(base + "\n\n" + identity),
+            Turn.user(prompt),
         ]
         try:
             return call_id, self._run_agent(
-                agent_messages,
+                agent_turns,
                 label="task",
                 tools=self._task_tools,
                 auto_tools=TASK_AUTO_TOOLS,
                 agent_alias=item.get("model_override"),
+                parent_call_id=call_id,
             )
         except GenerationCancelled:
             # Fold back an honest disposition built from the agent's own
-            # ledger.  ``agent_messages`` is mutated in place by
+            # ledger.  ``agent_turns`` is mutated in place by
             # ``_run_agent`` (it appends every assistant turn and tool
             # result), so at this catch point it holds the full record of
             # what the sub-agent did before cancel — including a partial
@@ -12484,8 +12526,8 @@ class ChatSession:
             # See the cancellation appendix in HYPOTHESIS.md ("ρ may
             # fabricate the acknowledgment but must not fabricate the
             # outcome … unknown, never none").
-            self._tool_status[call_id] = self._cancelled_agent_status(agent_messages)
-            return call_id, self._cancelled_agent_disposition(agent_messages, "task")
+            self._tool_status[call_id] = self._cancelled_agent_status(agent_turns)
+            return call_id, self._cancelled_agent_disposition(agent_turns, "task")
         except KeyboardInterrupt:
             # CLI Ctrl-C: keep the terse string and let the outer loop own
             # propagation (unchanged behavior).
@@ -12493,10 +12535,12 @@ class ChatSession:
         except Exception as e:
             self.ui.on_info(f"[task error] {e}")
             return call_id, f"Task error: {e}"
+        finally:
+            self._clear_agent_children(call_id)
 
     @staticmethod
     def _cancel_ledger(
-        agent_messages: list[dict[str, Any]],
+        agent_turns: list[Turn],
     ) -> tuple[list[tuple[str, bool]], int | None]:
         """Read a cancelled sub-agent's ledger: every issued tool call as
         ``(name, was_answered)`` in order, plus the index of the first in-flight
@@ -12511,32 +12555,32 @@ class ChatSession:
         its typed status so the two can't disagree.
         """
         answered: set[str] = set()
-        for m in agent_messages:
-            if m.get("role") == "tool" and m.get("tool_call_id"):
-                answered.add(str(m["tool_call_id"]))
+        for t in agent_turns:
+            if t.role is Role.TOOL and t.tool_call_id:
+                answered.add(t.tool_call_id)
         issued: list[tuple[str, bool]] = []
-        for m in agent_messages:
-            if m.get("role") != "assistant":
+        for t in agent_turns:
+            if t.role is not Role.ASSISTANT:
                 continue
-            for tc in m.get("tool_calls") or []:
-                name = ((tc.get("function") or {}).get("name") or "tool").strip()
-                issued.append((name, str(tc.get("id") or "") in answered))
+            for tc in t.tool_calls:
+                name = (tc.name or "tool").strip()
+                issued.append((name, tc.id in answered))
         first_gap = next((i for i, (_n, ans) in enumerate(issued) if not ans), None)
         return issued, first_gap
 
-    def _cancelled_agent_status(self, agent_messages: list[dict[str, Any]]) -> EffectStatus:
+    def _cancelled_agent_status(self, agent_turns: list[Turn]) -> EffectStatus:
         """Typed twin of :meth:`_cancelled_agent_disposition`: ``none`` if the
         agent never acted, ``unknown`` if a tool was in flight when cancel
         landed (its effect unobserved), else ``partial`` — every issued call
         returned, but the agent was stopped before finishing."""
-        issued, first_gap = self._cancel_ledger(agent_messages)
+        issued, first_gap = self._cancel_ledger(agent_turns)
         if not issued:
             return EffectStatus.NONE
         if first_gap is not None:
             return EffectStatus.UNKNOWN
         return EffectStatus.PARTIAL
 
-    def _cancelled_agent_disposition(self, agent_messages: list[dict[str, Any]], label: str) -> str:
+    def _cancelled_agent_disposition(self, agent_turns: list[Turn], label: str) -> str:
         """Build an honest, deterministic disposition for a cancelled sub-agent.
 
         A cancelled agent must not report a fabricated *outcome*.  The bare
@@ -12551,12 +12595,12 @@ class ChatSession:
         side effect may or may not have landed, its result never observed),
         and everything after it never ran.
 
-        Pure string assembly over the in-memory ``agent_messages`` — no
+        Pure string assembly over the in-memory ``agent_turns`` — no
         model call, because we are on the cancel path and the gate is
         closed.  The owner (parent / coordinator) reads this to decide what,
         if anything, to compensate.
         """
-        issued, first_gap = self._cancel_ledger(agent_messages)
+        issued, first_gap = self._cancel_ledger(agent_turns)
         if not issued:
             return f"({label} cancelled by user before any action — no side effects)"
 

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3240,6 +3240,29 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
                 messages = await asyncio.to_thread(
                     project_history_messages, to_project, awaiting_approval
                 )
+                # Task-agent recall: attach each task_agent tool_call's stashed
+                # sub-trajectory (projected step items) so the client's
+                # ``replayHistory`` can rebuild the collapsible card.  Live
+                # in-memory session only — a cold/closed ws, or an entry evicted
+                # past the LRU cap, has none, so the card renders the flat parent
+                # record ("not retained"), never a fabricated 0-step card.
+                # [[HYPOTHESIS]] an unobserved sub-trajectory is unknown, not none.
+                get_traj = getattr(getattr(live_session, "ui", None), "get_agent_trajectory", None)
+                if get_traj is not None:
+                    for msg in messages:
+                        for tc in msg.get("tool_calls") or ():
+                            # Only task_agent calls ever stash — skip the rest so
+                            # we don't take the agent-state lock once per tool_call
+                            # on a long history for ids that can never match.
+                            if tc.get("name") != "task_agent":
+                                continue
+                            steps = get_traj(tc.get("id") or "")
+                            # Attach only a well-formed, non-empty list — the
+                            # ``get_agent_trajectory`` contract is ``list | None``,
+                            # and the guard keeps a malformed result out of the
+                            # JSON payload (a non-list can't be serialized).
+                            if isinstance(steps, list) and steps:
+                                tc["agent_steps"] = steps
             except Exception:
                 # Operationally interesting: a persistent decoration
                 # failure (missing migration, driver mismatch, schema

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -251,6 +251,17 @@ class SessionUIBase:
         # in :meth:`_enqueue`); the snapshot helper for the in-progress
         # replay path captures it under ``_listeners_lock`` too.
         self._event_id: int = 0
+        # Sub-agent step tagging: child tool call_id -> parent task_agent
+        # call_id.  ``_enqueue`` reads it to stamp ``parent_call_id`` on every
+        # child event (tool_pending / approve_request / tool_result /
+        # tool_output_chunk / output_warning) so the UI can nest a task agent's
+        # steps under its card.  Written by ``note_agent_child`` /
+        # ``clear_agent_children`` (the session brackets each ``_run_agent``);
+        # keyed on the immutable call_id so it stays correct under the parent's
+        # 4-wide parallel tool pool (several task agents in flight at once).  Its
+        # own lock so the hot fan-out path never serializes on ``_listeners_lock``.
+        self._agent_children: dict[str, str] = {}
+        self._agent_children_lock = threading.Lock()
         # Approval blocking — the worker thread calls approve_tools
         # which waits on _approval_event; the /approve endpoint sets
         # it via resolve_approval.
@@ -445,6 +456,11 @@ class SessionUIBase:
         """
         if "ws_id" not in data:
             data = {**data, "ws_id": self.ws_id}
+        # Only events that can carry a child step — a top-level ``call_id`` or an
+        # ``items`` list — need the parent-tag lookup; skip the lock+scan for the
+        # high-frequency rest (content / reasoning / status / info / …).
+        if self._agent_children and ("call_id" in data or "items" in data):
+            data = self._stamp_agent_parent(data)
         with self._listeners_lock:
             self._event_id += 1
             event_id = self._event_id
@@ -461,6 +477,65 @@ class SessionUIBase:
             with contextlib.suppress(queue.Full):
                 lq.put_nowait(data)
         return event_id
+
+    def _stamp_agent_parent(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Stamp ``parent_call_id`` on a sub-agent's child event.
+
+        A task agent's sub-tool events flow through the same emit path as
+        top-level tool events; the only thing marking them as a *child* is the
+        ``call_id`` registered in ``_agent_children`` by the session running
+        ``_run_agent``.  Stamping at this one fan-out choke point (rather than at
+        each call site) also catches events emitted from a tool's own background
+        thread — a streaming bash's ``tool_output_chunk`` — which an ambient
+        context var set on the worker thread would miss.  Returns a shallow copy
+        when it stamps; the input dict is never mutated."""
+        with self._agent_children_lock:
+            if not self._agent_children:
+                return data
+            cid = data.get("call_id")
+            if isinstance(cid, str) and cid in self._agent_children:
+                data = {**data, "parent_call_id": self._agent_children[cid]}
+            items = data.get("items")
+            if isinstance(items, list) and any(
+                isinstance(it, dict) and it.get("call_id") in self._agent_children for it in items
+            ):
+                data = {
+                    **data,
+                    "items": [
+                        {**it, "parent_call_id": self._agent_children[it["call_id"]]}
+                        if isinstance(it, dict) and it.get("call_id") in self._agent_children
+                        else it
+                        for it in items
+                    ],
+                }
+        return data
+
+    def note_agent_child(self, child_call_id: str, parent_call_id: str) -> None:
+        """Register a sub-agent's child tool call so ``_enqueue`` tags its events
+        with ``parent_call_id``.  Called by the session for each sub-tool a
+        ``_run_agent`` issues, before the tool emits anything.
+
+        KNOWN LIMITATION (to be closed with the chunk-3 nesting consumer): the
+        registry keys on ``child_call_id`` alone — unique for commercial
+        providers (``call_<hash>`` / ``toolu_…``) but NOT for local servers that
+        assign per-response sequential ids (``call_0``).  Two task agents in the
+        parent's 4-wide pool can then collide and mis-nest steps.  The fix
+        (namespacing child ids by parent, verified against each provider's
+        id-replay rules) lands with the frontend consumer that renders the
+        nesting — until then the tag is wire-invisible and unconsumed."""
+        if not child_call_id or not parent_call_id:
+            return
+        with self._agent_children_lock:
+            self._agent_children[child_call_id] = parent_call_id
+
+    def clear_agent_children(self, parent_call_id: str) -> None:
+        """Drop every child registered under ``parent_call_id`` (the task agent
+        finished).  Bounds the registry to in-flight task agents.  Deletes in
+        place rather than reallocating the whole dict, so one agent completing
+        doesn't churn other in-flight agents' entries."""
+        with self._agent_children_lock:
+            for c in [c for c, p in self._agent_children.items() if p == parent_call_id]:
+                del self._agent_children[c]
 
     def _register_listener(
         self, maxsize: int = _DEFAULT_LISTENER_QUEUE_MAX

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -262,6 +262,16 @@ class SessionUIBase:
         # own lock so the hot fan-out path never serializes on ``_listeners_lock``.
         self._agent_children: dict[str, str] = {}
         self._agent_children_lock = threading.Lock()
+        # Sub-agent scope depth.  A task agent's progress chatter reaches the UI
+        # as ``on_info`` lines ("[task done] N chars", a tool's "fetched N
+        # chars, extracting...") that carry no call_id — so they can't nest under
+        # the task card and would escape to the top level.  While any ``_run_agent``
+        # is in flight this is > 0 and the web pane drops those info lines (the
+        # card already shows the steps + result).  A depth, not a flag, so the
+        # parent's 4-wide parallel task pool nests correctly; guarded by
+        # ``_agent_children_lock``.  The CLI overrides ``on_info`` and is
+        # unaffected (it has no card, so the lines are its only signal).
+        self._agent_scope_depth = 0
         # Approval blocking — the worker thread calls approve_tools
         # which waits on _approval_event; the /approve endpoint sets
         # it via resolve_approval.
@@ -515,14 +525,11 @@ class SessionUIBase:
         with ``parent_call_id``.  Called by the session for each sub-tool a
         ``_run_agent`` issues, before the tool emits anything.
 
-        KNOWN LIMITATION (to be closed with the chunk-3 nesting consumer): the
-        registry keys on ``child_call_id`` alone — unique for commercial
-        providers (``call_<hash>`` / ``toolu_…``) but NOT for local servers that
-        assign per-response sequential ids (``call_0``).  Two task agents in the
-        parent's 4-wide pool can then collide and mis-nest steps.  The fix
-        (namespacing child ids by parent, verified against each provider's
-        id-replay rules) lands with the frontend consumer that renders the
-        nesting — until then the tag is wire-invisible and unconsumed."""
+        The session namespaces each sub-agent's child ids by parent
+        (``f"{parent_call_id}::{tc_id}"``) before registering them here, so the
+        key is unique even for local servers that assign per-response sequential
+        ids (``call_0``) — two task agents in the parent's 4-wide pool can't
+        collide and mis-nest steps."""
         if not child_call_id or not parent_call_id:
             return
         with self._agent_children_lock:
@@ -536,6 +543,28 @@ class SessionUIBase:
         with self._agent_children_lock:
             for c in [c for c, p in self._agent_children.items() if p == parent_call_id]:
                 del self._agent_children[c]
+
+    def on_agent_step(self, parent_call_id: str, item: dict[str, Any]) -> None:
+        """Paint a sub-agent's auto-executed tool step as pending under its
+        parent card so it shows live before it completes.  (Approval-gated
+        sub-tools paint via :meth:`approve_tools`.)  The child is already
+        registered via ``note_agent_child``, so ``_enqueue`` stamps
+        ``parent_call_id`` onto this ``tool_pending``."""
+        self._enqueue({"type": "tool_pending", "items": self._serialize_approval_items([item])})
+
+    def begin_agent_scope(self) -> None:
+        """Enter a task agent's execution.  Until the matching
+        :meth:`end_agent_scope`, the web pane drops ``on_info`` lines (the task
+        card carries the sub-agent's visible output, so the info chatter would
+        only escape to the top level).  Depth-counted for the parent's parallel
+        task pool; the session brackets each ``_run_agent`` with this pair."""
+        with self._agent_children_lock:
+            self._agent_scope_depth += 1
+
+    def end_agent_scope(self) -> None:
+        """Leave a task agent's execution (see :meth:`begin_agent_scope`)."""
+        with self._agent_children_lock:
+            self._agent_scope_depth = max(0, self._agent_scope_depth - 1)
 
     def _register_listener(
         self, maxsize: int = _DEFAULT_LISTENER_QUEUE_MAX
@@ -2475,6 +2504,13 @@ class SessionUIBase:
             log.warning("Failed to record usage event", exc_info=True)
 
     def on_info(self, message: str) -> None:
+        # Inside a task agent, progress chatter ("[task done] N chars", a tool's
+        # "fetched N chars, extracting...") carries no call_id, so it can't nest
+        # under the task card — drop it on the web pane rather than let it escape
+        # to the top level.  The card shows the steps + result; the CLI overrides
+        # this method and keeps the lines (no card there).
+        if self._agent_scope_depth > 0:
+            return
         self._enqueue({"type": "info", "message": message})
 
     def on_error(self, message: str) -> None:

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import contextvars
 import copy
 import json
 import math
@@ -43,6 +44,25 @@ log = get_logger(__name__)
 # UI's ``_LISTENER_QUEUE_MAX``. Per-queue cap keeps a slow SSE consumer
 # from bloating memory.
 _DEFAULT_LISTENER_QUEUE_MAX = 500
+
+# Recall: how many finished task agents' projected sub-trajectories to retain
+# in memory for /history card rebuilds.  LRU-bounded so a marathon workstream
+# can't grow it without limit; eviction (and a cold reopen, which starts empty)
+# recalls honestly as "not retained" rather than a fabricated 0-step card.
+_AGENT_TRAJECTORY_CAP = 256
+
+# Sub-agent scope, PER-THREAD.  A task agent's progress chatter reaches the UI as
+# ``on_info`` lines ("[task done] N chars", a tool's "fetched N chars") that
+# carry no call_id — they can't nest under the task card and would escape to the
+# top level, so the web pane drops them while a sub-agent runs.  A contextvar,
+# not a session-global counter, so the suppression follows the sub-agent's OWN
+# thread: a parallel sibling tool running in another pool thread keeps its info
+# lines.  Incremented/decremented by begin_/end_agent_scope around each
+# ``_run_agent``; the CLI overrides ``on_info`` and is unaffected (no card → the
+# lines are its only signal).
+_agent_scope_var: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "turnstone_agent_scope_depth", default=0
+)
 
 
 def _resolve_event_buffer_max() -> int:
@@ -262,16 +282,20 @@ class SessionUIBase:
         # own lock so the hot fan-out path never serializes on ``_listeners_lock``.
         self._agent_children: dict[str, str] = {}
         self._agent_children_lock = threading.Lock()
-        # Sub-agent scope depth.  A task agent's progress chatter reaches the UI
-        # as ``on_info`` lines ("[task done] N chars", a tool's "fetched N
-        # chars, extracting...") that carry no call_id — so they can't nest under
-        # the task card and would escape to the top level.  While any ``_run_agent``
-        # is in flight this is > 0 and the web pane drops those info lines (the
-        # card already shows the steps + result).  A depth, not a flag, so the
-        # parent's 4-wide parallel task pool nests correctly; guarded by
-        # ``_agent_children_lock``.  The CLI overrides ``on_info`` and is
-        # unaffected (it has no card, so the lines are its only signal).
-        self._agent_scope_depth = 0
+        # Recall store: a finished task agent's projected sub-trajectory (step
+        # items: id/name/arguments/output/is_error), keyed by its (parent)
+        # call_id, so /history can rebuild the collapsible card after a fresh
+        # connect / reopen while the workstream is still in memory.  LRU-bounded
+        # (oldest evicted past the cap); IN-MEMORY ONLY — durable persistence is
+        # deferred, so a cold reopen (new session) finds it empty and renders the
+        # flat parent record.  Guarded by ``_agent_children_lock`` (same low-rate
+        # agent-state path).  [[HYPOTHESIS]] the sub-trajectory is the ledger;
+        # an absent one is unknown ("not retained"), never none ("0 steps").
+        self._agent_trajectories: collections.OrderedDict[str, list[dict[str, Any]]] = (
+            collections.OrderedDict()
+        )
+        # (Sub-agent ``on_info`` suppression is per-thread via the module-level
+        # ``_agent_scope_var`` contextvar — no instance field.)
         # Approval blocking — the worker thread calls approve_tools
         # which waits on _approval_event; the /approve endpoint sets
         # it via resolve_approval.
@@ -554,17 +578,40 @@ class SessionUIBase:
 
     def begin_agent_scope(self) -> None:
         """Enter a task agent's execution.  Until the matching
-        :meth:`end_agent_scope`, the web pane drops ``on_info`` lines (the task
-        card carries the sub-agent's visible output, so the info chatter would
-        only escape to the top level).  Depth-counted for the parent's parallel
-        task pool; the session brackets each ``_run_agent`` with this pair."""
-        with self._agent_children_lock:
-            self._agent_scope_depth += 1
+        :meth:`end_agent_scope`, the web pane drops ``on_info`` lines from THIS
+        thread (the task card carries the sub-agent's visible output, so the info
+        chatter would only escape to the top level).  Per-thread via
+        :data:`_agent_scope_var` so a parallel SIBLING tool in another pool
+        thread isn't suppressed; depth-counted for safety though task agents
+        don't nest.  The session brackets each ``_run_agent`` with this pair."""
+        _agent_scope_var.set(_agent_scope_var.get() + 1)
 
     def end_agent_scope(self) -> None:
         """Leave a task agent's execution (see :meth:`begin_agent_scope`)."""
+        _agent_scope_var.set(max(0, _agent_scope_var.get() - 1))
+
+    def stash_agent_trajectory(self, call_id: str, steps: list[dict[str, Any]]) -> None:
+        """Retain a finished task agent's projected sub-trajectory (step items)
+        keyed by its call_id so ``/history`` can rebuild the card on a fresh
+        connect / reopen while the workstream is in memory.  LRU-bounded; the
+        newest write is most-recently-used, oldest evicted past the cap.  See
+        :data:`_AGENT_TRAJECTORY_CAP` and the field comment in ``__init__``."""
+        if not call_id:
+            return
         with self._agent_children_lock:
-            self._agent_scope_depth = max(0, self._agent_scope_depth - 1)
+            self._agent_trajectories[call_id] = steps
+            self._agent_trajectories.move_to_end(call_id)
+            while len(self._agent_trajectories) > _AGENT_TRAJECTORY_CAP:
+                self._agent_trajectories.popitem(last=False)
+
+    def get_agent_trajectory(self, call_id: str) -> list[dict[str, Any]] | None:
+        """Read a stashed sub-trajectory, or ``None`` if not retained (evicted,
+        or a cold reopen with an empty store).  ``None`` is the honest "unknown"
+        signal — the caller renders the flat parent record, never a 0-step card."""
+        if not call_id:
+            return None
+        with self._agent_children_lock:
+            return self._agent_trajectories.get(call_id)
 
     def _register_listener(
         self, maxsize: int = _DEFAULT_LISTENER_QUEUE_MAX
@@ -2504,12 +2551,13 @@ class SessionUIBase:
             log.warning("Failed to record usage event", exc_info=True)
 
     def on_info(self, message: str) -> None:
-        # Inside a task agent, progress chatter ("[task done] N chars", a tool's
-        # "fetched N chars, extracting...") carries no call_id, so it can't nest
-        # under the task card — drop it on the web pane rather than let it escape
-        # to the top level.  The card shows the steps + result; the CLI overrides
-        # this method and keeps the lines (no card there).
-        if self._agent_scope_depth > 0:
+        # Inside a task agent (on THIS thread), progress chatter ("[task done] N
+        # chars", a tool's "fetched N chars") carries no call_id, so it can't
+        # nest under the task card — drop it on the web pane rather than let it
+        # escape to the top level.  Per-thread, so a parallel sibling tool's info
+        # still shows.  The card shows the steps + result; the CLI overrides this
+        # method and keeps the lines (no card there).
+        if _agent_scope_var.get() > 0:
             return
         self._enqueue({"type": "info", "message": message})
 

--- a/turnstone/shared_static/conversation.css
+++ b/turnstone/shared_static/conversation.css
@@ -706,3 +706,126 @@
     font-size: 13px;
   }
 }
+
+/* Task-agent card — a task_agent .conv-row hosts a collapsible body of its
+   sub-tool steps so they nest under the call instead of scattering top-level.
+   Accent rail + inset background read as "inside" the task agent. */
+.conv-agent {
+  margin: 8px 0 2px;
+  border-left: 2px solid color-mix(in srgb, var(--accent) 45%, var(--hair-2));
+  border-radius: var(--r-sm);
+  background: var(--panel-2);
+}
+.conv-agent-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 28px; /* the card's primary control — a real hit target */
+  padding: 4px 10px;
+  background: none;
+  border: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  cursor: pointer;
+  text-align: left;
+}
+.conv-agent-toggle:hover {
+  color: var(--ink-2);
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+}
+.conv-agent-toggle:focus-visible {
+  /* Match the house focus ring (.conv-btn / .conv-verdict-expand); inset
+     because the toggle is full-width, flush to the card edge. */
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: var(--r-sm);
+}
+.conv-agent-caret {
+  display: inline-block;
+  font-size: 11px;
+  color: var(--ink-3);
+  transition: transform 0.12s ease;
+}
+.conv-agent[data-collapsed="true"] .conv-agent-caret {
+  transform: rotate(-90deg); /* ▾ -> ▸, from the one collapse attribute */
+}
+.conv-agent[data-collapsed="true"] .conv-agent-body {
+  display: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .conv-agent-caret {
+    transition: none;
+  }
+}
+.conv-agent-label {
+  letter-spacing: 0;
+  text-transform: none;
+}
+/* Card-level liveness as a NON-colour cue (WCAG 1.4.1): a text suffix, not just
+   a stripe — in a parallel batch the parent rail belongs to the whole group,
+   not to this one task agent. */
+.conv-agent[data-state="running"] .conv-agent-label::after {
+  content: " · running";
+  color: var(--ink-3);
+}
+.conv-agent[data-state="done"] .conv-agent-label::after {
+  content: " · done";
+  color: color-mix(in srgb, var(--ok) 70%, var(--ink-2));
+}
+.conv-agent[data-state="error"] .conv-agent-label::after {
+  content: " · failed";
+  color: var(--err);
+}
+.conv-agent-body {
+  border-top: 1px solid var(--hair);
+}
+.conv-agent-body:empty {
+  border-top: 0; /* no orphan hairline before the first step paints */
+}
+/* Nested step rows read a touch lighter than top-level tool rows. */
+.conv-agent-body .conv-row {
+  padding: 6px 10px;
+  font-size: 11px;
+}
+.conv-agent-body .conv-row + .conv-row {
+  border-top: 1px solid var(--hair);
+}
+/* The card lives inside a .conv-row; in a PARALLEL batch the rail tick + dot
+   (.conv-batch--parallel .conv-row::before/::after) are descendant rules that
+   would re-draw on every nested step, striking through the names.  Suppress
+   them — the card's own accent rail already signals grouping. */
+.conv-agent-body .conv-row::before,
+.conv-agent-body .conv-row::after {
+  content: none;
+}
+.conv-batch--parallel .conv-agent-body .conv-row {
+  padding-left: 10px;
+}
+/* A nested sub-tool's approval gate binds to ITS step, not the whole card:
+   drop the right-floating spacer so Deny/Approve sit under the step's command. */
+.conv-agent-body .conv-actions {
+  align-items: stretch;
+}
+.conv-agent-body .conv-actions .conv-actions-spacer {
+  display: none;
+}
+/* The streaming-output box is a sibling between nested rows; match the card's
+   type scale + rail, and restore the row separators it sits between. */
+.conv-agent-body .tool-output-stream {
+  font-size: 11px;
+  border-left-color: color-mix(in srgb, var(--accent) 45%, var(--hair-2));
+}
+.conv-agent-body .conv-row + .tool-output-stream,
+.conv-agent-body .tool-output-stream + .conv-row {
+  border-top: 1px solid var(--hair);
+}
+@media (max-width: 700px) {
+  .conv-agent-toggle {
+    min-height: 44px; /* WCAG 2.5.5 touch target */
+  }
+}

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -601,3 +601,53 @@ export function buildConvResult(output, opts) {
   block.appendChild(body);
   return block;
 }
+
+// Expandable body for a task_agent row's nested sub-steps (the "agent card").
+// A task agent runs its own sub-tools; this gives that row a collapsible body
+// the pane renders the live step stream into, so the steps nest UNDER the
+// task_agent call instead of scattering at the top level.  The pane appends the
+// returned `wrap` into the task_agent .conv-row and renders step rows (ordinary
+// .conv-row leaves, matched by call_id) into `body`; `label` shows the live
+// step count.  House style: programmatic DOM, textContent only.
+let _agentCardSeq = 0;
+
+export function buildAgentCardBody() {
+  const wrap = document.createElement("div");
+  wrap.className = "conv-agent";
+  // Single source of truth for collapse: the data attribute drives BOTH the
+  // body visibility and the caret rotation (in CSS), so a programmatic toggle
+  // (collapse-by-default here, or the auto-expand-on-approval in the pane) can't
+  // desync caret/aria the way per-node textContent did.
+  //
+  // Collapsed by default: a task agent can run 100+ steps, and the parent often
+  // fans out many in parallel — expanded, that's a wall.  The label carries the
+  // live count + state ("12 steps · running"), so you expand on demand.  The
+  // pane force-expands a card when a nested approval is pending (it's blocking —
+  // it can't hide behind the toggle).
+  wrap.dataset.collapsed = "true";
+  const bodyId = "conv-agent-body-" + (_agentCardSeq += 1);
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.className = "conv-agent-toggle";
+  toggle.setAttribute("aria-expanded", "false");
+  toggle.setAttribute("aria-controls", bodyId);
+  toggle.setAttribute("aria-label", "Show or hide sub-agent steps");
+  const caret = document.createElement("span");
+  caret.className = "conv-agent-caret";
+  caret.setAttribute("aria-hidden", "true");
+  caret.textContent = "▾"; // CSS rotates it when collapsed
+  const label = document.createElement("span");
+  label.className = "conv-agent-label";
+  label.textContent = "0 steps";
+  toggle.append(caret, label);
+  const body = document.createElement("div");
+  body.className = "conv-agent-body";
+  body.id = bodyId;
+  toggle.addEventListener("click", () => {
+    const collapsed = wrap.dataset.collapsed === "true";
+    wrap.dataset.collapsed = collapsed ? "false" : "true";
+    toggle.setAttribute("aria-expanded", collapsed ? "true" : "false");
+  });
+  wrap.append(toggle, body);
+  return { wrap, body, label };
+}

--- a/turnstone/shared_static/interactive.css
+++ b/turnstone/shared_static/interactive.css
@@ -139,6 +139,11 @@
   max-height: 400px;
   animation: stream-pulse 2s ease-in-out infinite;
 }
+@media (prefers-reduced-motion: reduce) {
+  .tool-output-stream {
+    animation: none;
+  }
+}
 
 .tool-output.collapsed {
   max-height: 150px;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -57,6 +57,18 @@ let _paneCounter = 0;
 // so its voice roles come from THAT node's /v1/api/models (base "/node/{id}"),
 // not the console's; standalone panes use base "" and share one fetch.
 const _voiceRolesPromises = {};
+
+// Max child steps held per task agent while its parent row is unpainted (see
+// InteractivePane._bufferAgentOrphan).  A real agent's whole sub-trajectory is
+// well under this; the cap only bounds a pathological never-arriving parent.
+const _AGENT_ORPHAN_CAP = 256;
+
+// Grace window before a child step whose task_agent row never paints (an id-
+// correlation mismatch, or an agent that aborted before its row painted) is
+// escaped to a top-level row so it stays VISIBLE rather than buffered forever.
+// The ordering race the buffer targets resolves within a frame, far inside it.
+const _AGENT_ORPHAN_GRACE_MS = 500;
+
 function getVoiceRoles(base) {
   base = base || "";
   if (!_voiceRolesPromises[base]) {
@@ -441,6 +453,11 @@ class Pane {
           )
         : null;
       if (!target) {
+        // A namespaced sub-agent child id ("<parent>::<id>") whose row hasn't
+        // nested yet must NOT graft its stream onto the last top-level batch —
+        // that mislabels a sub-tool's output as a main-harness tool's.  Its row
+        // arrives via the orphan flush; skip the chunk until then.
+        if (callId && callId.includes("::")) return;
         const blocks = this.messagesEl.querySelectorAll(".conv-batch");
         if (!blocks.length) return;
         const block = blocks[blocks.length - 1];
@@ -1129,7 +1146,14 @@ class Pane {
         break;
 
       case "tool_info":
-        this.showInlineToolBlock(evt.items, true);
+        // A sub-agent's auto-resolved step (policy / "Always" auto-approval, or
+        // a policy block) arrives as a tool_info with parent_call_id stamped —
+        // route it into the task card like tool_pending / approve_request,
+        // instead of painting a duplicate top-level row.  Top-level tool_info
+        // (no parent_call_id) falls through to the normal inline block.
+        if (!this._routeAgentItems(evt.items, "info")) {
+          this.showInlineToolBlock(evt.items, true);
+        }
         break;
 
       case "approve_request":
@@ -2299,6 +2323,7 @@ class Pane {
     });
     this.announcedBlockEl = block;
     this.messagesEl.appendChild(block);
+    this._relinkAgentCards(list);
     this.scrollToBottom(stick);
     toolAnnounce(_toolAnnounceText(list));
   }
@@ -2414,6 +2439,7 @@ class Pane {
     }
 
     if (!announced) this.messagesEl.appendChild(block);
+    this._relinkAgentCards(items);
     this.scrollToBottom(stick);
   }
 
@@ -2475,7 +2501,20 @@ class Pane {
     const parentId = items[0] && items[0].parent_call_id;
     if (!parentId) return false;
     const card = this._ensureAgentCard(parentId);
-    if (!card) return false; // parent row not painted yet — fall back top-level
+    if (!card) {
+      // Parent task_agent row isn't painted yet: under the 4-wide tool pool a
+      // sub-tool's SSE event can be handled before its task_agent row commits.
+      // Buffer the child step keyed by parent so it nests when the parent row
+      // lands (see _flushAgentOrphans), instead of escaping to a top-level row
+      // that looks like the main harness issued it.  An approval prompt is NOT
+      // buffered — it must stay visible to unblock the gate — so "approve"
+      // falls through to the top-level paint.
+      if (mode !== "approve") {
+        this._bufferAgentOrphan(parentId, items, mode);
+        return true;
+      }
+      return false; // parent row not painted yet — fall back top-level
+    }
     if (mode === "approve") {
       // Cards default to collapsed, but a pending approval is BLOCKING — it
       // can't hide behind the toggle or the turn stalls on a prompt the user
@@ -2533,12 +2572,98 @@ class Pane {
     if (!parentRow) return null;
     if (!this._agentCards) this._agentCards = new Map();
     let card = this._agentCards.get(parentCallId);
-    if (card && parentRow.contains(card.wrap)) return card;
+    if (card) {
+      if (parentRow.contains(card.wrap)) return card;
+      if (!card.wrap.isConnected) {
+        // Same-turn row rebuild: showInlineToolBlock's replaceChildren on the
+        // pending->resolved upgrade detached our card.  Re-attach the SAME card
+        // so its already-rendered steps survive the upgrade.
+        parentRow.appendChild(card.wrap);
+        return card;
+      }
+      // The cached card is still attached to a DIFFERENT (earlier) row — a
+      // call_id reused across turns (some local providers recycle ids).  Fall
+      // through to build a fresh card for THIS row rather than stealing the
+      // prior agent's steps.  (Full cross-turn id correctness is the task-agent
+      // id-consistency follow-up.)
+    }
     card = buildAgentCardBody();
     card.wrap.dataset.state = "running";
     parentRow.appendChild(card.wrap);
     this._agentCards.set(parentCallId, card);
     return card;
+  }
+
+  _bufferAgentOrphan(parentId, items, mode) {
+    // Hold a child step whose task_agent row hasn't painted yet, keyed by
+    // parent, so it nests when the row lands (_flushAgentOrphans).  Bounded two
+    // ways so a parent row that never arrives (an id-correlation mismatch, or
+    // an agent aborted before its row painted) can't leak or hide steps: the
+    // per-parent queue is capped (oldest dropped), and a grace timer escapes
+    // the queue to a top-level row (_escapeAgentOrphans) so the steps stay
+    // VISIBLE rather than buffered forever.
+    if (!this._agentOrphans) this._agentOrphans = new Map();
+    const entry = this._agentOrphans.get(parentId) || {
+      queue: [],
+      timer: null,
+    };
+    entry.queue.push({ items, mode });
+    while (entry.queue.length > _AGENT_ORPHAN_CAP) entry.queue.shift();
+    if (entry.timer == null) {
+      entry.timer = setTimeout(
+        () => this._escapeAgentOrphans(parentId),
+        _AGENT_ORPHAN_GRACE_MS,
+      );
+    }
+    this._agentOrphans.set(parentId, entry);
+  }
+
+  _flushAgentOrphans(parentIds) {
+    // Drain buffered child steps for the just-painted parents (their card now
+    // exists) — targeted by parentId so an unrelated tool paint doesn't replay
+    // every parent's queue.  A step that still can't nest re-buffers (with a
+    // fresh grace timer) for the next paint / escape.
+    if (!this._agentOrphans || !this._agentOrphans.size) return;
+    parentIds.forEach((pid) => {
+      const entry = this._agentOrphans.get(pid);
+      if (!entry) return;
+      this._agentOrphans.delete(pid);
+      if (entry.timer != null) clearTimeout(entry.timer);
+      entry.queue.forEach((o) => this._routeAgentItems(o.items, o.mode));
+    });
+  }
+
+  _escapeAgentOrphans(parentId) {
+    // The parent row never painted within the grace window — render the
+    // buffered steps at top-level so they stay visible (the pre-buffer
+    // behaviour) instead of vanishing.  Batched per mode to avoid the
+    // announce-shell churn of one paint per step.
+    const entry = this._agentOrphans && this._agentOrphans.get(parentId);
+    if (!entry) return;
+    this._agentOrphans.delete(parentId);
+    const pending = [];
+    const info = [];
+    entry.queue.forEach((o) =>
+      (o.mode === "info" ? info : pending).push(...o.items),
+    );
+    if (pending.length) this.announceToolBlock(pending);
+    if (info.length) this.showInlineToolBlock(info, true);
+  }
+
+  _relinkAgentCards(items) {
+    // After a top-level tool row is (re)painted: re-attach any agent card the
+    // rebuild detached, then drain buffered child steps for the parents that
+    // just painted.  Closes the parallel-pool ordering race and keeps a task
+    // agent's nested card intact across its parent's pending->resolved upgrade.
+    const paintedIds = [];
+    (items || []).forEach((it) => {
+      if (!it || !it.call_id) return;
+      paintedIds.push(it.call_id);
+      if (this._agentCards && this._agentCards.has(it.call_id)) {
+        this._ensureAgentCard(it.call_id);
+      }
+    });
+    if (paintedIds.length) this._flushAgentOrphans(paintedIds);
   }
 
   _updateAgentLabel(card) {
@@ -2587,6 +2712,11 @@ class Pane {
         )
       : null;
     if (!target) {
+      // A namespaced sub-agent child id ("<parent>::<id>") whose row hasn't
+      // nested yet must NOT graft its output onto the last top-level batch row
+      // — that mislabels a sub-tool's result as a main-harness tool's.  Its row
+      // arrives via the orphan flush; skip until then.
+      if (callId && callId.includes("::")) return;
       const blocks = this.messagesEl.querySelectorAll(".conv-batch");
       if (!blocks.length) return;
       const block = blocks[blocks.length - 1];

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -1979,6 +1979,10 @@ class Pane {
     // Replaces a JSON.stringify→dataset→JSON.parse round-trip with an
     // in-memory map keyed by call_id.
     const pendingAssessments = {};
+    // Task-agent recall: call_id -> card .conv-agent wrap, so the tool-result
+    // branch can flip the card's done/error state from the task's own result
+    // (mirroring the live appendToolOutput), not from sub-step errors.
+    const agentCardWraps = {};
     let lastToolBlock = null;
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i];
@@ -2054,30 +2058,8 @@ class Pane {
             msg.tool_calls.forEach((tc, idx) => {
               // Synthesize the live `item` shape from the stored tool_call so
               // replay renders the SAME .conv-row as the live path.
-              let header = "";
-              try {
-                const args = JSON.parse(tc.arguments);
-                if (tc.name === "bash") {
-                  header = String(Object.values(args)[0] || "");
-                } else {
-                  const parts = [];
-                  const keys = Object.keys(args);
-                  for (let k = 0; k < keys.length; k++) {
-                    const val = args[keys[k]];
-                    let valStr =
-                      val === null || val === undefined ? "null" : String(val);
-                    if (valStr.length > 80)
-                      valStr = valStr.substring(0, 77) + "...";
-                    parts.push(keys[k] + ": " + valStr);
-                  }
-                  header = parts.join("\n");
-                }
-              } catch (e) {
-                header = String(tc.arguments || "").substring(0, 100);
-              }
-              const item = { func_name: tc.name, call_id: tc.id || "", header };
               const row = buildToolDiv(
-                item,
+                synthToolItem(tc),
                 indexLabel(idx, msg.tool_calls.length),
               );
               // Verdict anchored to THIS row; replay verdicts are final.
@@ -2087,6 +2069,13 @@ class Pane {
                 );
               }
               block.appendChild(row);
+              // Task-agent recall: rebuild the collapsible card under this row
+              // from its stashed sub-trajectory (the /history `agent_steps`
+              // overlay).  Absent ⇒ flat parent row (cold / not-retained).
+              if (tc.agent_steps && tc.agent_steps.length) {
+                const wrap = this._replayAgentCard(row, tc.agent_steps);
+                if (tc.id) agentCardWraps[tc.id] = wrap;
+              }
               // Output-guard finding — deferred until the tool result lands so
               // it anchors under the output (mirrors live showOutputWarning).
               if (
@@ -2152,11 +2141,7 @@ class Pane {
             if (media) {
               insertChained(buildMediaEmbed(media, stripped));
             } else {
-              const out = renderToolOutput(stripped, isToolError);
-              if (out.textContent.split("\n").length > 10) {
-                makeCollapsible(out);
-              }
-              insertChained(out);
+              insertChained(renderCollapsibleOutput(stripped, isToolError));
             }
           }
           if (
@@ -2176,6 +2161,14 @@ class Pane {
               insertChained(_buildOutputWarningEl(pending.assessment));
               delete pendingAssessments[msg.tool_call_id];
             }
+          }
+          // Task-agent recall: flip its card done/error from the task's OWN
+          // result (matching the live appendToolOutput) — NOT from sub-step
+          // errors, since a sub-tool can fail and the agent still synthesize.
+          if (msg.tool_call_id && agentCardWraps[msg.tool_call_id]) {
+            agentCardWraps[msg.tool_call_id].dataset.state = msg.is_error
+              ? "error"
+              : "done";
           }
         }
       } else if (msg.role === "system") {
@@ -2553,6 +2546,28 @@ class Pane {
     card.label.textContent = n === 1 ? "1 step" : n + " steps";
   }
 
+  _replayAgentCard(row, steps) {
+    // Rebuild a finished task agent's card from its recalled step items
+    // (/history `agent_steps`), mirroring the live _routeAgentItems nesting so a
+    // reload looks identical: a collapsed body of step rows, each with its
+    // result.  Recall is terminal — no live approval affordances.  Card state
+    // defaults to "done"; the caller flips it to "error" from the task's OWN
+    // result (the role==="tool" branch), matching the live path — sub-step
+    // errors don't decide it (an agent can recover and synthesize fine).
+    const card = buildAgentCardBody();
+    steps.forEach((step) => {
+      card.body.appendChild(buildToolDiv(synthToolItem(step), ""));
+      const out = stripAnsi(String(step.output || "")).trim();
+      if (out) {
+        card.body.appendChild(renderCollapsibleOutput(out, !!step.is_error));
+      }
+    });
+    card.wrap.dataset.state = "done";
+    this._updateAgentLabel(card);
+    row.appendChild(card.wrap);
+    return card.wrap;
+  }
+
   appendToolOutput(callId, name, output, isError) {
     // Capture pin before the streamEl removal + result insertion change
     // scrollHeight — see announceToolBlock.  The result block is the other
@@ -2650,7 +2665,10 @@ class Pane {
       }
     }
 
-    const out = renderToolOutput(stripped, isError);
+    // The media / MCP-error dispatch above both early-return, so by here it's
+    // the plain-output path — the shared helper applies (test_app_js pins that
+    // tryParseMcpError precedes this renderer call).
+    const out = renderCollapsibleOutput(stripped, isError);
 
     // Mark the parent approval block as errored
     if (
@@ -2660,10 +2678,6 @@ class Pane {
     ) {
       parentBlock.classList.add("conv-batch--error");
       appendToolErrorBadge(parentBlock);
-    }
-
-    if (out.textContent.split("\n").length > 10) {
-      makeCollapsible(out);
     }
 
     target.after(out);
@@ -3314,6 +3328,35 @@ function buildToolDiv(item, indexLabel) {
   return row;
 }
 
+// Synthesize the live `item` shape ({func_name, call_id, header}) from a stored
+// tool_call ({name, id, arguments}) so /history replay AND task-agent card
+// recall render the SAME .conv-row as the live path.  Header derivation mirrors
+// the live serialize: bash shows the command; other tools show `key: value`
+// lines, values clipped at 80 chars; unparseable args fall back to a raw clip.
+function synthToolItem(tc) {
+  tc = tc || {};
+  let header = "";
+  try {
+    const args = JSON.parse(tc.arguments);
+    if (tc.name === "bash") {
+      header = String(Object.values(args)[0] || "");
+    } else {
+      const parts = [];
+      const keys = Object.keys(args);
+      for (let k = 0; k < keys.length; k++) {
+        const val = args[keys[k]];
+        let valStr = val === null || val === undefined ? "null" : String(val);
+        if (valStr.length > 80) valStr = valStr.substring(0, 77) + "...";
+        parts.push(keys[k] + ": " + valStr);
+      }
+      header = parts.join("\n");
+    }
+  } catch (e) {
+    header = String(tc.arguments || "").substring(0, 100);
+  }
+  return { func_name: tc.name, call_id: tc.id || "", header };
+}
+
 function renderVerdictBadge(verdict, judgePending) {
   // Thin wrapper over the shared builder (returns a fragment [badge, detail]).
   return buildConvVerdict(verdict, { judgePending });
@@ -3378,6 +3421,16 @@ function renderToolOutput(stripped, isError) {
     }
   }
   out.textContent = _redactApiKeys(stripped);
+  return out;
+}
+
+// Shared recipe: render tool output and auto-collapse past 10 lines.  The one
+// source for the live appendToolOutput's plain-output path, the /history
+// tool-result replay, and the task-agent card recall — so the collapse
+// threshold can't drift between them.
+function renderCollapsibleOutput(stripped, isError) {
+  const out = renderToolOutput(stripped, isError);
+  if (out.textContent.split("\n").length > 10) makeCollapsible(out);
   return out;
 }
 

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -31,6 +31,7 @@ import {
   buildConvWarning,
   buildConvActions,
   buildConvStatus,
+  buildAgentCardBody,
   batchKicker,
   indexLabel,
 } from "./conversation.js";
@@ -1121,7 +1122,10 @@ class Pane {
         // so the operator can Stop in an emergency.  The authoritative
         // tool_info / approve_request that follows upgrades THIS block in
         // place (matched by call_id) rather than appending a duplicate.
-        this.announceToolBlock(evt.items);
+        // A sub-agent's steps (parent_call_id set) nest in the task card.
+        if (!this._routeAgentItems(evt.items, "pending")) {
+          this.announceToolBlock(evt.items);
+        }
         break;
 
       case "tool_info":
@@ -1129,7 +1133,9 @@ class Pane {
         break;
 
       case "approve_request":
-        this.showInlineToolBlock(evt.items, false, evt.judge_pending);
+        if (!this._routeAgentItems(evt.items, "approve", evt.judge_pending)) {
+          this.showInlineToolBlock(evt.items, false, evt.judge_pending);
+        }
         break;
 
       case "intent_verdict":
@@ -2464,11 +2470,101 @@ class Pane {
     this.scrollToBottom(stick);
   }
 
+  // --- Task-agent card: nest a sub-agent's sub-tool steps under its row -----
+  // Child events (tool_pending / approve_request) carry parent_call_id; route
+  // them into the task_agent row's collapsible body.  tool_result /
+  // tool_output_chunk / intent_verdict / output_warning need no special-casing
+  // — their handlers find the row by call_id anywhere under messagesEl,
+  // including inside the card body.  Returns true when handled (the caller then
+  // skips the top-level rendering path).
+  _routeAgentItems(items, mode, judgePending) {
+    if (!items || !items.length) return false;
+    const parentId = items[0] && items[0].parent_call_id;
+    if (!parentId) return false;
+    const card = this._ensureAgentCard(parentId);
+    if (!card) return false; // parent row not painted yet — fall back top-level
+    if (mode === "approve") {
+      // Cards default to collapsed, but a pending approval is BLOCKING — it
+      // can't hide behind the toggle or the turn stalls on a prompt the user
+      // never sees.  Force the card open (sync aria with the data attribute).
+      card.wrap.dataset.collapsed = "false";
+      const toggle = card.wrap.querySelector(".conv-agent-toggle");
+      if (toggle) toggle.setAttribute("aria-expanded", "true");
+    }
+    const stick = this.isNearBottom();
+    items.forEach((item) => {
+      if (!item || !item.parent_call_id) return;
+      const escId = item.call_id ? CSS.escape(item.call_id) : "";
+      let row = escId
+        ? card.body.querySelector('.conv-row[data-call-id="' + escId + '"]')
+        : null;
+      if (!row) {
+        row = buildToolDiv(item, "");
+        card.body.appendChild(row);
+      }
+      if (mode === "approve") {
+        const verdict =
+          item.judge_verdict || item.heuristic_verdict || item.verdict;
+        if (verdict) {
+          row.appendChild(buildConvVerdict(verdict, { judgePending }));
+        }
+        const actions = buildConvActions({
+          kbd: { approve: "y", deny: "n" },
+          glowRec: verdict && verdict.recommendation,
+          withFeedback: true,
+          onApprove: () =>
+            this.resolveApproval(true, false, this.getFeedback()),
+          onDeny: () => this.resolveApproval(false, false, this.getFeedback()),
+        });
+        row.appendChild(actions);
+        // Reuse the session-level approval resolution: the backend's
+        // approve_tools blocks on ONE pending decision, so pointing
+        // approvalBlockEl at this nested row is enough for resolveApproval to
+        // POST /approve and unblock it.
+        this.pendingApproval = true;
+        this.approvalBlockEl = row;
+        this.inputEl.disabled = true;
+        this.sendBtn.disabled = true;
+      }
+    });
+    this._updateAgentLabel(card);
+    this.scrollToBottom(stick);
+    return true;
+  }
+
+  _ensureAgentCard(parentCallId) {
+    const escId = parentCallId ? CSS.escape(parentCallId) : "";
+    const parentRow = escId
+      ? this.messagesEl.querySelector('.conv-row[data-call-id="' + escId + '"]')
+      : null;
+    if (!parentRow) return null;
+    if (!this._agentCards) this._agentCards = new Map();
+    let card = this._agentCards.get(parentCallId);
+    if (card && parentRow.contains(card.wrap)) return card;
+    card = buildAgentCardBody();
+    card.wrap.dataset.state = "running";
+    parentRow.appendChild(card.wrap);
+    this._agentCards.set(parentCallId, card);
+    return card;
+  }
+
+  _updateAgentLabel(card) {
+    const n = card.body.querySelectorAll(".conv-row").length;
+    card.label.textContent = n === 1 ? "1 step" : n + " steps";
+  }
+
   appendToolOutput(callId, name, output, isError) {
     // Capture pin before the streamEl removal + result insertion change
     // scrollHeight — see announceToolBlock.  The result block is the other
     // tall one-shot append in the tool flow (up to 10 lines before collapse).
     const stick = this.isNearBottom();
+    // A task_agent's OWN result completing flips its card running -> done/error
+    // (child sub-tool results carry namespaced ids, never keys of _agentCards).
+    if (this._agentCards && this._agentCards.has(callId)) {
+      this._agentCards.get(callId).wrap.dataset.state = isError
+        ? "error"
+        : "done";
+    }
     const escapedId = callId ? CSS.escape(callId) : "";
     let target = escapedId
       ? this.messagesEl.querySelector(


### PR DESCRIPTION
## What

Modernizes `task_agent` — some of the oldest code in turnstone, and not fully wired into the web UI — onto the canonical `Turn` trajectory, with a nested expandable step card. Four chunks:

1. **Turn-IR sub-harness** — `_run_agent`/`_exec_task` build a neutral `list[Turn]` lowered at the wire boundary (was hand-rolled OpenAI dicts); the cancel ledger reads Turns and folds back an honest disposition (`unknown`, never `none`).
2. **Parent-tagged step events** — a sub-agent's sub-tool events are stamped with their parent task_agent call_id so the UI can nest them; child ids namespaced by parent so the parent's 4-wide parallel pool can't collide.
3. **Expandable card** — sub-tool steps nest under the task_agent row in a collapsible card (replacing the blue `[task turn N]` info legs), approvals shown inline; collapsed by default, auto-expands when a nested approval is pending so the blocking prompt can't hide.
4. **Recall + read isolation** — the card rebuilds from `/history` while the workstream is in memory (cold/evicted → flat parent row, "not retained", never a fabricated 0-step card); per-sub-agent `_read_files` isolation (copy-on-spawn + merge-back) so a pool sibling can't suppress another agent's blind-overwrite guard.

## Notable fix

`task_agent` never emitted its own `tool_result` — the parent tool-loop only reports error/denied results centrally; every other tool self-reports its success result, and `_exec_task` didn't. The new card depended on that event, so the live card stayed "running" and, worse, a **failed** task recorded `is_error=False` in the canonical trajectory (the source of truth mislabelling a sub-harness outcome). `_exec_task` now self-reports on every path — the live card completes and the durable effect record is honest.

## Verification

- ruff + mypy clean; full suite green (7710 passed, 0 failed).
- The real `InteractivePane.handleEvent` driven through `scripts/livepass.py` across live / recall / collapsed / parallel states (a broken card can't screenshot green).
- Two rounds of code review (per-chunk + a whole-stack bug/quality pass); all findings applied.

## Deferred follow-ups

- **Multimodal sub-agent tool output** → a perception sub-harness (vision model → text), its own PR — the current inline `list[dict]` path puts most text-only local models out of distribution.
- **Sub-tool id consistency** — unify the id-correlation schemes onto one globally-unique sub-tool id, so the live card handles a local provider's cross-turn id reuse the way recall already does.
- **Durable persistence** of sub-agent turns (recall is in-memory while the workstream is open).
