### PR TITLE
fix(memory): don't recompose system prefix on memory write

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3874,18 +3874,65 @@ class TestMemoryAccessTouch:
         assert self._access_count("kafka_runbook") == 0
 
     def test_save_action_does_not_touch_access_count(self, tmp_db):
-        """The save action handler itself must not bump ``access_count`` —
-        that counter is read traffic only.  (The recompose a save triggers
-        may surface the row via the composition path; that is exercised by
-        the composition tests.  Suppressed here to isolate the handler.)"""
+        """The save action handler must not bump ``access_count`` — that counter
+        is read traffic only, and save no longer recomposes the system prefix
+        (see ``_exec_memory``), so the saved row is never surfaced as an injected
+        memory by the handler.  Composition-path touches are exercised by the
+        ``test_composition_*`` tests."""
         session = self._empty_session()
         item = session._prepare_memory(
             "call_1",
             {"action": "save", "name": "kafka_runbook", "content": "x", "scope": "global"},
         )
-        with patch.object(session, "_init_system_messages"):
-            session._exec_memory(item)
+        session._exec_memory(item)
         assert self._access_count("kafka_runbook") == 0
+
+    def test_save_through_exec_does_not_recompose_prefix(self, tmp_db):
+        """End-to-end through ``_exec_memory``: a memory(save) must NOT rebuild
+        the system prefix -- injected memories ride in the cached system block,
+        so re-initing on every write would bust the prompt cache.  The write
+        still (a) invalidates the per-turn search cache so an in-turn
+        memory(search) sees the new row, and (b) folds into the prefix at the
+        next natural recompose.  Exercises the real call chain (no patching of
+        ``_init_system_messages``), which the other memory tests stub out."""
+        session = self._empty_session()
+        self._save("kafka_runbook", "restart the kafka broker pods")
+        self._compose_turn(session, "restart kafka broker pods status")
+        before = "\n".join(m["content"] for m in session.system_messages if m["role"] == "system")
+        assert '<memory name="kafka_runbook"' in before  # composition sanity
+
+        # Prime the per-turn search cache with a probe that excludes the
+        # not-yet-saved row, so a stale cache would be observable below.
+        probe = "scale the broker pods cluster"
+        assert "kafka_scaling" not in {m["name"] for m in session._search_visible_memories(probe)}
+
+        item = session._prepare_memory(
+            "call_1",
+            {
+                "action": "save",
+                "name": "kafka_scaling",
+                "content": "restart kafka and scale the broker pods cluster",
+                "scope": "global",
+            },
+        )
+        assert "error" not in item
+        session._exec_memory(item)
+
+        # 1. Prefix byte-for-byte unchanged -> no prompt-cache bust.
+        after = "\n".join(m["content"] for m in session.system_messages if m["role"] == "system")
+        assert after == before
+        assert '<memory name="kafka_scaling"' not in after
+
+        # 2. The save invalidated the search cache: the SAME probe now returns
+        #    the new row (a stale cache would still omit it).
+        assert "kafka_scaling" in {m["name"] for m in session._search_visible_memories(probe)}
+
+        # 3. The next natural recompose folds the new memory into the prefix.
+        self._compose_turn(session, "how do I scale the kafka broker pods cluster")
+        recomposed = "\n".join(
+            m["content"] for m in session.system_messages if m["role"] == "system"
+        )
+        assert '<memory name="kafka_scaling"' in recomposed
 
 
 class TestMetacognitiveBuffers:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -13015,8 +13015,15 @@ class ChatSession:
                     msg = f"Error: failed to save memory '{item['name']}'"
                     self._report_tool_result(call_id, "memory", msg, is_error=True)
                     return call_id, msg
+                # Invalidate the per-turn search cache so an in-turn
+                # memory(search)/(list) reflects this write.  Deliberately do NOT
+                # recompose the system prefix here: injected memories ride in the
+                # cached system block, so re-initing on every save/update busts
+                # the prompt cache (a full system + history re-write) — for a
+                # memory the model already holds via this tool result.  The write
+                # folds into the prefix at the next natural recompose
+                # (skill/model/MCP/resume/compaction) or the next session.
                 self._invalidate_memory_cache()
-                self._init_system_messages()
                 self._audit_memory_event(
                     "memory.update" if old is not None else "memory.save",
                     memory_id,
@@ -14118,7 +14125,10 @@ class ChatSession:
                 value = aliases.get(arg.lower(), arg.lower())
                 if value in valid:
                     self.reasoning_effort = value
-                    self._init_system_messages()
+                    # No system-prefix recompose here: reasoning effort rides in
+                    # request kwargs (output_config / thinking), not the composed
+                    # prompt, so re-initing would only re-pay the compose for an
+                    # identical prefix.
                     self._save_config()
                     self.ui.on_info(f"Reasoning effort set to {cyan(self.reasoning_effort)}")
                 else:


### PR DESCRIPTION
## Problem

Injected memories are composed into the front `{"role": "system"}` block (`build_memory_context` → `dev_parts` → `system_messages`), which the Anthropic/OpenAI providers hoist into the cached prompt prefix. But `_exec_memory` called `_init_system_messages()` on every `memory(save)` / `memory(delete)`, rebuilding that prefix and busting the prompt cache — a full system + history re-write — for a memory the model already holds via its own tool result.

This fires routinely: a model that saves mid-conversation (or saves the same key twice in a turn) pays a full prefix re-cache on the next request.

## Change

- **`memory(save)` no longer recomposes the system prefix.** It still invalidates the per-turn search cache, so an in-turn `memory(search)`/`(list)` reflects the write. The new memory folds into the prefix at the next natural recompose (skill/model/MCP/resume/compaction) or the next session — the writer already has the content via its tool result, so nothing is lost in-session.
- **Drop the redundant `_init_system_messages()` in the `/reason` handler:** reasoning effort rides in request kwargs (`output_config` / thinking), not the composed prompt, so it recomposed to byte-identical output (a wasted recompute, not a cache bust).
- `delete` is intentionally left recomposing for now (rare; promptly drops a deleted memory from the prefix). A follow-up can revisit symmetry.

The hour-rounded timestamp in `_init_system_messages` already exists to keep this same prefix cache-stable; this closes the other routine churn source.

## Tests

- New chain-level test through the real `_exec_memory` → no-recompose path: asserts the prefix is byte-for-byte unchanged after save, the search cache was invalidated (same probe returns the new row), and the next recompose folds the memory in. The prior memory tests drove `_init_system_messages` directly or patched it out, so this path was uncovered.
- `tests/test_session.py`: 255 passed; ruff + mypy clean.
