### PR TITLE
fix(memory): atomic single-statement upsert for memory save/update

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3934,6 +3934,72 @@ class TestMemoryAccessTouch:
         )
         assert '<memory name="kafka_scaling"' in recomposed
 
+    def test_save_through_tool_preserves_omitted_overwrites_explicit(self, tmp_db):
+        """The None-sentinel flows through _prepare_memory -> _exec_memory: a
+        content-only re-save keeps the stored type/description, while an
+        explicit field overwrites it.  Guards the _prepare_memory omit->None
+        logic that the storage-level tests don't exercise."""
+        from turnstone.core.memory import get_structured_memory_by_name
+
+        session = self._empty_session()
+        item = session._prepare_memory(
+            "c1",
+            {
+                "action": "save",
+                "name": "digest",
+                "content": "v1",
+                "type": "reference",
+                "description": "daily digest",
+                "scope": "global",
+            },
+        )
+        assert "error" not in item
+        session._exec_memory(item)
+
+        # Content-only re-save (omits type/description) -> both preserved.
+        item2 = session._prepare_memory(
+            "c2", {"action": "save", "name": "digest", "content": "v2", "scope": "global"}
+        )
+        session._exec_memory(item2)
+        mem = get_structured_memory_by_name("digest", "global", "")
+        assert mem is not None
+        assert mem["content"] == "v2"
+        assert mem["type"] == "reference"
+        assert mem["description"] == "daily digest"
+
+        # An invalid/typo'd type is treated as unset -> stored type preserved,
+        # not silently downgraded to "general".
+        item_bad = session._prepare_memory(
+            "c2b",
+            {
+                "action": "save",
+                "name": "digest",
+                "content": "v2b",
+                "type": "nonsense",
+                "scope": "global",
+            },
+        )
+        session._exec_memory(item_bad)
+        mem = get_structured_memory_by_name("digest", "global", "")
+        assert mem is not None
+        assert mem["type"] == "reference"  # invalid type ignored, not downgraded
+
+        # An explicit field -> overwrites (the behaviour the None-sentinel enables).
+        item3 = session._prepare_memory(
+            "c3",
+            {
+                "action": "save",
+                "name": "digest",
+                "content": "v3",
+                "type": "general",
+                "scope": "global",
+            },
+        )
+        session._exec_memory(item3)
+        mem = get_structured_memory_by_name("digest", "global", "")
+        assert mem is not None
+        assert mem["type"] == "general"
+
 
 class TestMetacognitiveBuffers:
     """Nudges drain through advisory channels, not the system message."""

--- a/tests/test_structured_memory.py
+++ b/tests/test_structured_memory.py
@@ -13,15 +13,17 @@ from turnstone.core.memory import (
 
 class TestSaveStructuredMemory:
     def test_save_new(self, tmp_db):
-        mid, old = save_structured_memory("test_key", "hello world")
-        assert mid != ""
-        assert old is None
+        row, was_update = save_structured_memory("test_key", "hello world")
+        assert row and row["memory_id"]
+        assert was_update is False
 
     def test_save_upsert(self, tmp_db):
-        save_structured_memory("test_key", "first")
-        mid, old = save_structured_memory("test_key", "second")
-        assert old == "first"
-        assert mid != ""
+        row1, was_update1 = save_structured_memory("test_key", "first")
+        row2, was_update2 = save_structured_memory("test_key", "second")
+        assert was_update1 is False
+        assert was_update2 is True
+        assert row2 and row1 and row2["memory_id"] == row1["memory_id"]  # same row
+        assert row2["content"] == "second"
 
     def test_save_normalizes_key(self, tmp_db):
         save_structured_memory("My-Key", "value")

--- a/tests/test_structured_memory_storage.py
+++ b/tests/test_structured_memory_storage.py
@@ -28,29 +28,80 @@ class TestCreateAndGet:
         assert w["content"] == "w"
 
 
-class TestUpdate:
-    def test_update_content(self, backend):
-        backend.create_structured_memory("m1", "k", "d", "general", "global", "", "old")
-        assert backend.update_structured_memory("m1", content="new")
-        mem = backend.get_structured_memory("m1")
-        assert mem["content"] == "new"
+class TestSaveUpsert:
+    """``save_structured_memory`` upserts by (name, scope, scope_id).
 
-    def test_update_nonexistent(self, backend):
-        assert not backend.update_structured_memory("nope", content="x")
+    A second save of the same key must UPDATE in place, not surface the
+    ``uq_smem_name_scope`` unique-constraint violation.  These run on whichever
+    backend ``--storage-backend`` selects, so the PostgreSQL path is covered in
+    CI -- the session-level memory tests only exercise SQLite (via ``tmp_db``),
+    which is where this path previously had no cross-backend coverage.
+    """
 
-    def test_update_no_fields(self, backend):
-        backend.create_structured_memory("m1", "k", "d", "general", "global", "", "data")
-        assert not backend.update_structured_memory("m1", bogus="val")
+    def test_duplicate_create_raises_integrity_error(self, backend):
+        """The unique constraint the upsert's ON CONFLICT targets actually fires."""
+        import pytest
+        import sqlalchemy as sa
 
-    def test_update_bumps_timestamp(self, backend):
-        backend.create_structured_memory("m1", "k", "d", "general", "global", "", "data")
-        old = backend.get_structured_memory("m1")["updated"]
-        import time
+        backend.create_structured_memory("m1", "dup", "", "general", "global", "", "a")
+        with pytest.raises(sa.exc.IntegrityError):
+            backend.create_structured_memory("m2", "dup", "", "general", "global", "", "b")
 
-        time.sleep(0.01)
-        backend.update_structured_memory("m1", content="new")
-        new = backend.get_structured_memory("m1")["updated"]
-        assert new >= old
+    def test_save_same_key_updates_in_place(self, backend):
+        from turnstone.core.memory import save_structured_memory
+
+        row1, was_update1 = save_structured_memory("upsert_key", "v1", scope="global")
+        assert row1 and was_update1 is False  # inserted
+
+        row2, was_update2 = save_structured_memory("upsert_key", "v2", scope="global")
+        assert row2 and was_update2 is True  # updated in place
+        assert row2["memory_id"] == row1["memory_id"]  # same row, not a duplicate
+        assert row2["content"] == "v2"
+        names = [r["name"] for r in backend.list_structured_memories(scope="global")]
+        assert names.count("upsert_key") == 1
+
+    def test_save_same_key_preserves_description_and_type_on_default_resave(self, backend):
+        from turnstone.core.memory import save_structured_memory
+
+        save_structured_memory(
+            "meta_key", "c1", description="orig desc", mem_type="fact", scope="global"
+        )
+        # A re-save that omits description/type (defaults) must not clobber them.
+        save_structured_memory("meta_key", "c2", scope="global")
+        row = backend.get_structured_memory_by_name("meta_key", "global", "")
+        assert row["content"] == "c2"
+        assert row["description"] == "orig desc"
+        assert row["type"] == "fact"
+
+    def test_upsert_method_updates_in_place_no_raise(self, backend):
+        """The atomic storage primitive updates in place on a key conflict and
+        returns (row, was_update) carrying the existing row's id -- no
+        IntegrityError (which a second create_structured_memory would raise)."""
+        backend.create_structured_memory("m1", "k", "desc", "fact", "global", "", "v1")
+        row, was_update = backend.upsert_structured_memory(
+            "m2", "k", "newdesc", "note", "global", "", "v2"
+        )
+        assert was_update is True
+        assert row["memory_id"] == "m1"  # existing row id, not the supplied "m2"
+        assert row["content"] == "v2"
+        assert row["description"] == "newdesc"
+        assert row["type"] == "note"
+        names = [r["name"] for r in backend.list_structured_memories(scope="global")]
+        assert names.count("k") == 1
+
+    def test_upsert_none_preserves_explicit_overwrites(self, backend):
+        """None description/type keep the stored value on conflict; an explicit
+        value (including "" / "general") overwrites it."""
+        backend.create_structured_memory("m1", "k", "keepdesc", "fact", "global", "", "v1")
+        # None -> preserve stored description/type (a content-only save).
+        row, _ = backend.upsert_structured_memory("m2", "k", None, None, "global", "", "v2")
+        assert row["content"] == "v2"
+        assert row["description"] == "keepdesc"
+        assert row["type"] == "fact"
+        # Explicit "" / "general" -> overwrite.
+        row2, _ = backend.upsert_structured_memory("m3", "k", "", "general", "global", "", "v3")
+        assert row2["description"] == ""
+        assert row2["type"] == "general"
 
 
 class TestDelete:

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import sqlalchemy as sa
-
 from turnstone.core.log import get_logger
 from turnstone.core.storage import get_storage
 from turnstone.core.workstream import WorkstreamKind
@@ -651,44 +649,34 @@ def search_history_recent(limit: int = 20) -> list[Any]:
 def save_structured_memory(
     name: str,
     content: str,
-    description: str = "",
-    mem_type: str = "general",
+    description: str | None = None,
+    mem_type: str | None = None,
     scope: str = "global",
     scope_id: str = "",
-) -> tuple[str, str | None]:
-    """Save a structured memory (upsert by name+scope+scope_id).
+) -> tuple[dict[str, str] | None, bool]:
+    """Save a structured memory as a single atomic upsert by name+scope+scope_id.
 
-    Returns (memory_id, old_content_or_None).  Uses create-first to
-    avoid TOCTOU races under concurrent access.
+    Returns ``(row, was_update)`` where ``row`` is the full saved record (or
+    ``None`` on failure).  The write is exactly one
+    ``INSERT ... ON CONFLICT DO UPDATE ... RETURNING`` statement (see
+    :meth:`StorageBackend.upsert_structured_memory`) -- no preceding read, no
+    IntegrityError round-trip, no TOCTOU window.  ``(row, was_update)`` comes
+    straight from that upsert (this passes a fresh ``memory_id``, so a differing
+    returned id means an existing row was updated in place).  A ``None``
+    description / ``mem_type`` means "leave unset" -- the column default applies
+    on insert and the stored value is kept on conflict.
     """
     import uuid
 
     name = normalize_key(name)
     try:
-        storage = get_storage()
-        # Try create first — if it hits the unique constraint, fall back to update
-        memory_id = str(uuid.uuid4())
-        try:
-            storage.create_structured_memory(
-                memory_id, name, description, mem_type, scope, scope_id, content
-            )
-            return memory_id, None
-        except sa.exc.IntegrityError:
-            # Unique constraint violation — row already exists, update it
-            existing = storage.get_structured_memory_by_name(name, scope, scope_id)
-            if existing:
-                old_content = existing["content"]
-                updates: dict[str, str] = {"content": content}
-                if description:
-                    updates["description"] = description
-                if mem_type != "general":
-                    updates["type"] = mem_type
-                storage.update_structured_memory(existing["memory_id"], **updates)
-                return existing["memory_id"], old_content
-            return "", None
+        row, was_update = get_storage().upsert_structured_memory(
+            str(uuid.uuid4()), name, description, mem_type, scope, scope_id, content
+        )
+        return (row, was_update) if row else (None, False)
     except Exception:
         log.warning("Failed to save structured memory name=%s", name, exc_info=True)
-        return "", None
+        return None, False
 
 
 def get_structured_memory_by_name(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -11250,10 +11250,20 @@ class ChatSession:
                     "needs_approval": False,
                     "error": f"Error: content exceeds {self._mem_cfg.max_content} character limit",
                 }
-            description = (args.get("description") or "").strip()
-            mem_type = (args.get("type") or "general").strip().lower()
-            if mem_type not in ("user", "general", "feedback", "reference"):
-                mem_type = "general"
+            # None (field omitted) means "leave unset": the upsert keeps the
+            # stored value on update and defaults on insert; an explicit value
+            # (including "" / "general") overwrites.
+            description = args.get("description")
+            if description is not None:
+                description = str(description).strip()
+            mem_type = args.get("type")
+            if mem_type is not None:
+                mem_type = str(mem_type).strip().lower()
+                if mem_type not in ("user", "general", "feedback", "reference"):
+                    # An unrecognized type (e.g. a typo) is treated as unset
+                    # (preserve the stored type on update / default on insert)
+                    # rather than silently overwriting it with "general".
+                    mem_type = None
             # Default scope is kind-aware: coord sessions default to
             # ``coordinator`` (their only writable scope); IC sessions
             # default to ``global`` (matches pre-fix behaviour).
@@ -13003,7 +13013,7 @@ class ChatSession:
 
         try:
             if action == "save":
-                memory_id, old = save_structured_memory(
+                row, was_update = save_structured_memory(
                     item["name"],
                     item["content"],
                     description=item["description"],
@@ -13011,7 +13021,7 @@ class ChatSession:
                     scope=item["scope"],
                     scope_id=item["scope_id"],
                 )
-                if not memory_id:
+                if not row:
                     msg = f"Error: failed to save memory '{item['name']}'"
                     self._report_tool_result(call_id, "memory", msg, is_error=True)
                     return call_id, msg
@@ -13025,17 +13035,15 @@ class ChatSession:
                 # (skill/model/MCP/resume/compaction) or the next session.
                 self._invalidate_memory_cache()
                 self._audit_memory_event(
-                    "memory.update" if old is not None else "memory.save",
-                    memory_id,
-                    name=item["name"],
-                    scope=item["scope"],
-                    scope_id=item["scope_id"],
-                    mem_type=item["mem_type"],
+                    "memory.update" if was_update else "memory.save",
+                    row["memory_id"],
+                    name=row["name"],
+                    scope=row["scope"],
+                    scope_id=row["scope_id"],
+                    mem_type=row["type"],
                 )
-                if old is not None:
-                    msg = f"Updated memory '{item['name']}' (type={item['mem_type']}, scope={item['scope']})"
-                else:
-                    msg = f"Saved memory '{item['name']}' (type={item['mem_type']}, scope={item['scope']})"
+                verb = "Updated" if was_update else "Saved"
+                msg = f"{verb} memory '{row['name']}' (type={row['type']}, scope={row['scope']})"
                 self._report_tool_result(call_id, "memory", msg)
                 return call_id, msg
 

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -111,9 +111,6 @@ from turnstone.core.storage._utils import (
     SKILL_MUTABLE as _SKILL_MUTABLE,
 )
 from turnstone.core.storage._utils import (
-    STRUCTURED_MEMORY_MUTABLE as _SMEM_MUTABLE,
-)
-from turnstone.core.storage._utils import (
     VERDICT_MUTABLE as _VERDICT_MUTABLE,
 )
 from turnstone.core.storage._utils import (
@@ -3996,6 +3993,56 @@ class PostgreSQLBackend:
             )
             conn.commit()
 
+    def upsert_structured_memory(
+        self,
+        memory_id: str,
+        name: str,
+        description: str | None,
+        mem_type: str | None,
+        scope: str,
+        scope_id: str,
+        content: str,
+    ) -> tuple[dict[str, str], bool]:
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        insert_stmt = pg_insert(structured_memories).values(
+            memory_id=memory_id,
+            name=name,
+            description="" if description is None else description,
+            type="general" if mem_type is None else mem_type,
+            scope=scope,
+            scope_id=scope_id,
+            content=content,
+            created=now,
+            updated=now,
+            last_accessed=now,
+            access_count=0,
+        )
+        # On conflict, refresh content + timestamps.  description/type are
+        # overwritten only when the caller supplied them; None means "unset" ->
+        # keep the stored value.  created and access_count are left untouched.
+        set_: dict[str, Any] = {
+            "content": insert_stmt.excluded.content,
+            "updated": now,
+            "last_accessed": now,
+        }
+        if description is not None:
+            set_["description"] = insert_stmt.excluded.description
+        if mem_type is not None:
+            set_["type"] = insert_stmt.excluded.type
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["name", "scope", "scope_id"],
+            set_=set_,
+        ).returning(structured_memories)
+        with self._conn() as conn:
+            row = conn.execute(stmt).fetchone()
+            conn.commit()
+            if row is None:  # unreachable: ON CONFLICT DO UPDATE returns one row
+                return {}, False
+            result = dict(row._mapping)
+            return result, result["memory_id"] != memory_id
+
     def get_structured_memory(self, memory_id: str) -> dict[str, str] | None:
         with self._conn() as conn:
             row = conn.execute(
@@ -4017,22 +4064,6 @@ class PostgreSQLBackend:
                 )
             ).fetchone()
             return dict(row._mapping) if row else None
-
-    def update_structured_memory(self, memory_id: str, **fields: str) -> bool:
-        fields = {k: v for k, v in fields.items() if k in _SMEM_MUTABLE}
-        if not fields:
-            return False
-        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
-        fields["updated"] = now
-        fields["last_accessed"] = now
-        with self._conn() as conn:
-            result = conn.execute(
-                sa.update(structured_memories)
-                .where(structured_memories.c.memory_id == memory_id)
-                .values(**fields)
-            )
-            conn.commit()
-            return result.rowcount > 0
 
     def delete_structured_memory(
         self, name: str, scope: str = "global", scope_id: str = ""

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -496,8 +496,9 @@ class StorageBackend(Protocol):
 
         Returns ``(row, was_update)`` (like Django's ``update_or_create``): the
         full saved row, and ``True`` when an existing row was updated rather
-        than inserted.  ``was_update`` is the supplied ``memory_id`` differing
-        from the returned row's id, so pass a fresh unique id to detect inserts.
+        than inserted.  Callers MUST supply a fresh unique ``memory_id`` — it is
+        compared against the returned row's id to tell INSERT from UPDATE, so a
+        reused id would report ``was_update=False`` on a real update.
         """
         ...
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -474,6 +474,33 @@ class StorageBackend(Protocol):
         """Create a structured memory record."""
         ...
 
+    def upsert_structured_memory(
+        self,
+        memory_id: str,
+        name: str,
+        description: str | None,
+        mem_type: str | None,
+        scope: str,
+        scope_id: str,
+        content: str,
+    ) -> tuple[dict[str, str], bool]:
+        """Insert a structured memory, or update it in place on a
+        ``(name, scope, scope_id)`` conflict.
+
+        Atomic ``INSERT ... ON CONFLICT DO UPDATE ... RETURNING`` — no
+        IntegrityError round-trip, race-safe under concurrent saves of the same
+        key.  ``description`` / ``mem_type`` of ``None`` mean "unset": the
+        column default ("" / "general") is used on insert and the stored value
+        is kept on conflict; a non-``None`` value (including "" or "general") is
+        written.
+
+        Returns ``(row, was_update)`` (like Django's ``update_or_create``): the
+        full saved row, and ``True`` when an existing row was updated rather
+        than inserted.  ``was_update`` is the supplied ``memory_id`` differing
+        from the returned row's id, so pass a fresh unique id to detect inserts.
+        """
+        ...
+
     def get_structured_memory(self, memory_id: str) -> dict[str, str] | None:
         """Return structured memory dict or None."""
         ...
@@ -482,10 +509,6 @@ class StorageBackend(Protocol):
         self, name: str, scope: str = "global", scope_id: str = ""
     ) -> dict[str, str] | None:
         """Lookup structured memory by (name, scope, scope_id). Returns dict or None."""
-        ...
-
-    def update_structured_memory(self, memory_id: str, **fields: str) -> bool:
-        """Update specified fields on a structured memory. Returns True if found."""
         ...
 
     def delete_structured_memory(

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -111,9 +111,6 @@ from turnstone.core.storage._utils import (
     SKILL_MUTABLE as _SKILL_MUTABLE,
 )
 from turnstone.core.storage._utils import (
-    STRUCTURED_MEMORY_MUTABLE as _SMEM_MUTABLE,
-)
-from turnstone.core.storage._utils import (
     VERDICT_MUTABLE as _VERDICT_MUTABLE,
 )
 from turnstone.core.storage._utils import (
@@ -4178,6 +4175,56 @@ class SQLiteBackend:
             )
             conn.commit()
 
+    def upsert_structured_memory(
+        self,
+        memory_id: str,
+        name: str,
+        description: str | None,
+        mem_type: str | None,
+        scope: str,
+        scope_id: str,
+        content: str,
+    ) -> tuple[dict[str, str], bool]:
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        insert_stmt = sqlite_insert(structured_memories).values(
+            memory_id=memory_id,
+            name=name,
+            description="" if description is None else description,
+            type="general" if mem_type is None else mem_type,
+            scope=scope,
+            scope_id=scope_id,
+            content=content,
+            created=now,
+            updated=now,
+            last_accessed=now,
+            access_count=0,
+        )
+        # On conflict, refresh content + timestamps.  description/type are
+        # overwritten only when the caller supplied them; None means "unset" ->
+        # keep the stored value.  created and access_count are left untouched.
+        set_: dict[str, Any] = {
+            "content": insert_stmt.excluded.content,
+            "updated": now,
+            "last_accessed": now,
+        }
+        if description is not None:
+            set_["description"] = insert_stmt.excluded.description
+        if mem_type is not None:
+            set_["type"] = insert_stmt.excluded.type
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["name", "scope", "scope_id"],
+            set_=set_,
+        ).returning(structured_memories)
+        with self._conn() as conn:
+            row = conn.execute(stmt).fetchone()
+            conn.commit()
+            if row is None:  # unreachable: ON CONFLICT DO UPDATE returns one row
+                return {}, False
+            result = dict(row._mapping)
+            return result, result["memory_id"] != memory_id
+
     def get_structured_memory(self, memory_id: str) -> dict[str, str] | None:
         with self._conn() as conn:
             row = conn.execute(
@@ -4199,22 +4246,6 @@ class SQLiteBackend:
                 )
             ).fetchone()
             return dict(row._mapping) if row else None
-
-    def update_structured_memory(self, memory_id: str, **fields: str) -> bool:
-        fields = {k: v for k, v in fields.items() if k in _SMEM_MUTABLE}
-        if not fields:
-            return False
-        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
-        fields["updated"] = now
-        fields["last_accessed"] = now
-        with self._conn() as conn:
-            result = conn.execute(
-                sa.update(structured_memories)
-                .where(structured_memories.c.memory_id == memory_id)
-                .values(**fields)
-            )
-            conn.commit()
-            return result.rowcount > 0
 
     def delete_structured_memory(
         self, name: str, scope: str = "global", scope_id: str = ""

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -590,7 +590,6 @@ SKILL_MUTABLE = frozenset(
         "argument_hint",
     }
 )
-STRUCTURED_MEMORY_MUTABLE = frozenset({"content", "description", "type"})
 # ``oauth_client_secret_ct`` is intentionally absent from this set.  It has
 # its own dedicated writer (``StorageBackend.set_mcp_oauth_client_secret_ct``)
 # so the encrypt/None-to-clear semantics — owned by

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2529,11 +2529,15 @@ async def save_memory(request: Request) -> JSONResponse:
             {"error": f"content exceeds {_MAX_MEMORY_CONTENT} character limit"},
             status_code=400,
         )
-    description = str(body.get("description", ""))
-    mem_type = str(body.get("type", "general"))
+    # None (field omitted) means "leave unset": the upsert keeps the stored
+    # value on update and defaults on insert; an explicit value overwrites.
+    raw_desc = body.get("description")
+    description = None if raw_desc is None else str(raw_desc)
+    raw_type = body.get("type")
+    mem_type = None if raw_type is None else str(raw_type)
     scope = str(body.get("scope", "global"))
     scope_id = str(body.get("scope_id", ""))
-    if mem_type not in _VALID_MEMORY_TYPES:
+    if mem_type is not None and mem_type not in _VALID_MEMORY_TYPES:
         return JSONResponse(
             {"error": f"invalid type: {mem_type}; must be one of {sorted(_VALID_MEMORY_TYPES)}"},
             status_code=400,
@@ -2550,26 +2554,13 @@ async def save_memory(request: Request) -> JSONResponse:
     err = _validate_scope_scope_id(scope, scope_id, require_scope_id=True)
     if err:
         return err
-    # save_structured_memory normalises the name internally
-    from turnstone.core.memory import normalize_key
-
-    normalized_name = normalize_key(name)
-    memory_id, old_content = save_structured_memory(
+    # The upsert RETURNINGs the full saved row, so no follow-up read is needed.
+    row, was_update = save_structured_memory(
         name, content, description=description, mem_type=mem_type, scope=scope, scope_id=scope_id
     )
-    if not memory_id:
+    if not row:
         return JSONResponse({"error": "Failed to save memory"}, status_code=500)
-    from turnstone.core.storage._registry import get_storage
-
-    storage = get_storage()
-    mem = storage.get_structured_memory(memory_id) if storage else None
-    if not mem:
-        return JSONResponse(
-            {"memory_id": memory_id, "name": normalized_name, "status": "saved"},
-            status_code=201,
-        )
-    status_code = 200 if old_content is not None else 201
-    return JSONResponse(mem, status_code=status_code)
+    return JSONResponse(row, status_code=200 if was_update else 201)
 
 
 async def search_memories(request: Request) -> JSONResponse:


### PR DESCRIPTION
## Problem

`save_structured_memory` upserted by *try INSERT → catch `IntegrityError` → SELECT + UPDATE*. On PostgreSQL, a model that saves the same key twice in a turn makes the second INSERT hit `uq_smem_name_scope`:

```
ERROR:  duplicate key value violates unique constraint "uq_smem_name_scope"
DETAIL:  Key (name, scope, scope_id)=(morning_tech_digest, global, ) already exists.
```

Postgres logs that at ERROR even when the fallback catches it, and the pattern threw + caught an exception on every update.

## Change

A new `StorageBackend.upsert_structured_memory` on both backends emits one atomic statement:

```sql
INSERT INTO structured_memories (...) VALUES (...)
ON CONFLICT (name, scope, scope_id)
DO UPDATE SET content = ..., description = ..., type = ..., updated = ..., last_accessed = ...
RETURNING <all columns>
```

- Returns `(row, was_update)` — the full saved row and whether an existing row was updated — like Django's `update_or_create`. `was_update` is the supplied (fresh) `memory_id` differing from the returned id. `save_structured_memory` is a thin wrapper over it.
- **Field semantics:** `description`/`mem_type` of `None` mean "leave unset" — the column default applies on insert and the stored value is kept on conflict; an explicit value (incl. `""` / `"general"`) overwrites. So clearing a description or setting type back to `"general"` now persists, where the prior `if mem_type != "general"` / `if description` semantics silently dropped it. An unrecognized type (a typo) is treated as unset (preserve) rather than coerced-and-written.
- The memory tool and the memories HTTP endpoint pass `None` for omitted fields and read effective `type`/`scope` from the returned row; the HTTP endpoint returns that row directly (one query — no follow-up SELECT).
- Removes the now-unused `update_structured_memory` primitive and its dead `STRUCTURED_MEMORY_MUTABLE` constant.

No `IntegrityError` round-trip, no constraint-violation log noise, race-safe under concurrent saves of the same key; `created` / `access_count` are preserved on conflict.

## Tests

- `tests/test_structured_memory_storage.py`: upsert-in-place (no raise, returns existing id), None-preserve vs explicit-overwrite, run on whichever backend `--storage-backend` selects — the save-over-existing path was previously SQLite-only (`tmp_db`).
- `tests/test_structured_memory.py`: facade `(row, was_update)` contract.
- `tests/test_session.py`: tool-path test (`_prepare_memory` → `_exec_memory`) — omit preserves, explicit overwrites, typo'd type preserved.
- mypy + ruff clean; full memory/storage/session/api suite green.

## Review

Reviewed via the multi-stage pipeline (bug / security / performance / quality finders + an earlier xhigh workflow pass). Security / performance / quality came back clean; one minor correctness finding — a typo'd `type` silently downgrading a stored type — was fixed and regression-tested.
