### PR TITLE
ci(claude): grant write permission so Claude reviews/replies can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # post the review + inline comments
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # post comments/reviews when @-mentioned on a PR
+      issues: write # post comments when @-mentioned on an issue
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Symptom

`claude-review` (the auto-reviewer in `claude-code-review.yml`) runs **green** on PRs but posts **no review** — e.g. on #735 it ran ~3m, logged `permission_denials_count: 3` + `No buffered inline comments`, and left nothing on the PR. (The separate `claude` check that shows *"skipping"* is the `@claude` mention-responder — that's by design, not the reviewer.)

## Cause

The runtime token is read-only:

```
GITHUB_TOKEN Permissions
  PullRequests: read
```

So Claude reviews the diff but is permission-denied when it tries to post the review / inline comments; the job treats the posting-denial as non-fatal, so it goes green while posting nothing.

## Fix

- `claude-code-review.yml`: `pull-requests: read` → **`write`** (post the review + inline comments).
- `claude.yml` (the `@claude` responder): `pull-requests` + `issues` → **`write`** — it had the same read-only block, so an `@claude` reply would also silently fail to post.

`contents` stays `read` — no repo-push capability is granted. Both workflows remain gated to trusted triggers (reviewer: same-repo PRs via `head.repo.full_name == github.repository`; responder: `@claude` from OWNER/MEMBER/COLLABORATOR), so the write scope only applies in already-trusted contexts. Permissions-only change — no new `run:` steps, no untrusted-input interpolation.
