### PR TITLE
fix(compaction): recover from context overflow on resume across providers

### DIFF
--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -996,6 +996,21 @@ def test_is_ctx_overflow_detection(message, expected):
     assert _is_ctx_overflow(RuntimeError(message)) is expected
 
 
+def test_is_ctx_overflow_excludes_recognized_rate_limit_class():
+    """A 429 RateLimitError whose token-quota text contains an overflow phrase must
+    NOT be classified as overflow.  _stop_retrying calls _is_ctx_overflow with no
+    class gate of its own, so without this a retryable rate-limit ("… maximum number
+    of tokens allowed per minute …") would be made non-retryable.  The SAME text in
+    an unrecognized class is still overflow — proving it's the class gate at work."""
+
+    class RateLimitError(Exception):  # name is in _BACKEND_RATE_LIMIT_EXC_NAMES
+        pass
+
+    msg = "exceeds the maximum number of tokens allowed per minute"
+    assert _is_ctx_overflow(RateLimitError(msg)) is False  # retryable, not overflow
+    assert _is_ctx_overflow(RuntimeError(msg)) is True  # unknown class → text decides
+
+
 def test_format_backend_error_renders_overflow(session):
     """The text-first overflow branch in _format_backend_error renders a clear
     "Context window exceeded" message (with a raw tail) for an exception class

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -15,11 +15,17 @@ the harness collapses the transcript:
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests._session_helpers import make_session
+from turnstone.core.session import (
+    COMPACTION_SUMMARY_LABEL,
+    GenerationCancelled,
+    _CompactionIrreducibleError,
+    _is_ctx_overflow,
+)
 from turnstone.core.trajectory import dicts_from_turns, turns_from_dicts
 
 
@@ -128,8 +134,9 @@ class TestMidturnCompactionPolicy:
             patch.object(session, "_do_auto_compact") as compact,
             patch.object(session, "_append_system_turn") as advise,
         ):
-            session._maybe_compact_midturn()
-        compact.assert_called_once_with("mid-turn")
+            session._maybe_compact_midturn(my_generation=7)
+        # my_generation threads through so the compaction swap stays generation-guarded.
+        compact.assert_called_once_with("mid-turn", my_generation=7)
         advise.assert_not_called()
 
     def test_hard_ceiling_compacts_without_advisory(self, session):
@@ -141,8 +148,8 @@ class TestMidturnCompactionPolicy:
             patch.object(session, "_do_auto_compact") as compact,
             patch.object(session, "_append_system_turn") as advise,
         ):
-            session._maybe_compact_midturn()
-        compact.assert_called_once_with("mid-turn")
+            session._maybe_compact_midturn(my_generation=7)
+        compact.assert_called_once_with("mid-turn", my_generation=7)
         advise.assert_not_called()
 
     def test_do_auto_compact_rounds_percentage(self, session):
@@ -155,7 +162,7 @@ class TestMidturnCompactionPolicy:
             patch.object(session.ui, "on_info") as on_info,
         ):
             session._do_auto_compact("mid-turn")
-        compact.assert_called_once_with(auto=True, preserve_tail=0)
+        compact.assert_called_once_with(auto=True, preserve_tail=0, my_generation=0)
         msg = on_info.call_args.args[0]
         assert "58%" in msg
         assert "mid-turn" in msg
@@ -263,7 +270,11 @@ class TestEndOfTurnAutoResume:
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
             patch.object(session, "_emit_state") as emit_state,
-            patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
+            # Over soft (8000) but UNDER hard (9000): isolates the end-of-turn
+            # trigger this test targets.  A value over hard would ALSO trip the
+            # proactive pre-send compaction (covered by TestProactivePreSend),
+            # double-counting the mocked compactor.
+            patch.object(session, "_estimated_prompt_tokens", return_value=8_500),
             patch.object(session, "_do_auto_compact") as compact,
             patch.object(session, "_append_user_turn") as resume,
             patch("turnstone.core.session.save_message"),
@@ -690,13 +701,10 @@ class TestChunkedCompaction:
         """q-3: the ``depth >= _MAX_SUMMARY_DEPTH`` recursion backstop bails to
         False (the "too large" path) without fabricating a summary.
 
-        Distinct from ``test_irreducible_input_bails_to_false`` (which bails at
-        depth 0 via the ``len(batches) >= len(blocks)`` arm before any model
-        call): here depth 0 packs into several batches AND reduces, so the level
-        succeeds and recurses; depth 1 still has >1 batch but a strictly smaller
-        count (so the len arm is False), and ``depth >= 1`` fires the bail.  That
-        the depth-0 calls ran first is proven by ``_utility_completion`` being
-        called (≥1) despite the False return.
+        depth 0 packs into several batches and recurses; depth 1 still has >1
+        batch, and ``depth >= 1`` fires the bail.  That the depth-0 calls ran
+        first is proven by ``_utility_completion`` being called (≥1) despite the
+        False return.
         """
         session.context_window = 5_000
         session.compact_max_tokens = 4_000  # squeezes the input budget
@@ -705,7 +713,7 @@ class TestChunkedCompaction:
         budget = session._summary_input_budget_chars()
 
         # ~30 messages, each block bigger than 1/6 of the budget → depth 0 packs
-        # into several batches (and len(batches) < len(blocks), so it recurses).
+        # into several batches and recurses (depth 0 < MAX).
         session.messages = turns_from_dicts(
             [
                 {
@@ -719,8 +727,7 @@ class TestChunkedCompaction:
         before = list(session.messages)
 
         # Each depth-0 partial is 0.4*budget chars: two pack per batch but not
-        # three, so depth 1 reduces the batch count without collapsing to one —
-        # the len arm stays False and the depth ceiling is what bails.
+        # three, so depth 1 still has >1 batch and the depth ceiling bails.
         partial = "P" * ((budget * 2) // 5)
         summary = SimpleNamespace(content=partial, finish_reason="stop")
 
@@ -729,19 +736,16 @@ class TestChunkedCompaction:
 
         assert result is False
         assert session.messages == before  # untouched on the bail
-        assert uc.call_count >= 1  # depth-0 ran (depth arm), not the len arm
+        assert uc.call_count >= 1  # depth-0 ran before the depth-ceiling bail
 
     def test_irreducible_input_bails_to_false(self, session):
-        """A genuinely irreducible case still bails to False (the "too large"
-        path) rather than fabricate, and without burning a model call.
+        """A genuinely irreducible case — where even a floor-truncated lone block
+        still overflows the window — bails to False (the "too large" path) rather
+        than fabricate a summary, leaving the history untouched.
 
-        Needs a *tiny* window now that Fix 1 keeps the budget healthy on normal
-        windows: at context_window=900 the output reserve + compactor prompt +
-        safety already exceed the window, so the true input capacity is negative
-        and ``_summary_input_budget_chars`` caps the budget to 0.  Each ~5000-char
-        message head+tail-caps to ~1525, far over the 0/1-char budget, so
-        ``_pack_blocks`` truncates each into its own batch:
-        ``len(batches) == len(blocks)`` → irreducible bail at depth 0, no model call.
+        With per-block splitting the chunker no longer bails on packing alone; it
+        bails only when a block truncated to ``_MIN_SUMMARY_BUDGET_CHARS`` STILL
+        overflows the model — i.e. no body is small enough to summarize.
         """
         session.context_window = 900
         session.compact_max_tokens = 900
@@ -755,11 +759,15 @@ class TestChunkedCompaction:
         session._msg_tokens = [1, 1]
         before = list(session.messages)
 
-        with patch.object(session, "_utility_completion") as uc:
+        # Every summary call overflows — even a floor-truncated lone block — so no
+        # body is ever small enough to summarize: bail irreducible, history intact.
+        def always_overflow(*_a, **_k):
+            raise RuntimeError("maximum context length is 900 tokens")
+
+        with patch.object(session, "_utility_completion", side_effect=always_overflow):
             result = session._compact_messages(auto=True)
 
         assert result is False
-        uc.assert_not_called()  # no reduction at depth 0 → bail before any call
         assert session.messages == before  # untouched
 
     def test_default_config_summary_call_fits_window(self, session):
@@ -940,3 +948,593 @@ def test_compaction_advisory_is_registered():
     turn = make_system_turn("compaction_pending", text)
     assert turn["role"] == "system"
     assert turn["_source"] == "compaction_pending"
+
+
+# ---------------------------------------------------------------------------
+# Context-overflow handling: detection, proactive pre-send compaction (Layer A),
+# and the closed-loop adaptive chunker — the resume-rehydration overflow fix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        # Real overflow messages (vLLM / OpenAI / Anthropic) — must match.
+        ("This model's maximum context length is 524288 tokens", True),
+        (
+            "maximum context length is 524288 tokens ... your prompt contains at "
+            "least 523777 input tokens",
+            True,
+        ),
+        ("prompt is too long: 200000 > 100000", True),
+        ("the input is too long for this model", True),
+        ("Please reduce the length of the input prompt", True),
+        ("request exceeds the context window", True),
+        # Anthropic (input + max_tokens) and Google/Gemini wordings — match NONE of
+        # the old phrase set; regression guard for the centralized detector.
+        (
+            "input length and max_tokens exceed context limit: 9000 + 4000 > 8000, "
+            "decrease input length or max_tokens and try again",
+            True,
+        ),
+        (
+            "The input token count (29000) exceeds the maximum number of tokens allowed (28000)",
+            True,
+        ),
+        # Retryable / unrelated — must NOT match (esp. token-quota 429s, which a
+        # bare "input tokens" substring would false-match into a hard failure).
+        ("rate limit exceeded: 40000 input tokens per minute", False),
+        ("This request would exceed your organization's rate limit", False),
+        ("Connection refused", False),
+        ("invalid api key", False),
+    ],
+)
+def test_is_ctx_overflow_detection(message, expected):
+    """Overflow is detected by text, not exception class: vLLM returns the same
+    condition as a 400 ``BadRequestError`` on /v1/chat/completions but a 500
+    ``InternalServerError`` on /v1/messages."""
+    assert _is_ctx_overflow(RuntimeError(message)) is expected
+
+
+def test_format_backend_error_renders_overflow(session):
+    """The text-first overflow branch in _format_backend_error renders a clear
+    "Context window exceeded" message (with a raw tail) for an exception class
+    OUTSIDE _BACKEND_KNOWN_EXC_NAMES — the anthropic-compat 500 case — and a
+    non-overflow unknown class still falls through to None."""
+
+    class InternalServerError(Exception):  # not in _BACKEND_KNOWN_EXC_NAMES
+        pass
+
+    msg = session._format_backend_error(
+        InternalServerError("This model's maximum context length is 524288 tokens")
+    )
+    assert msg is not None
+    assert "Context window exceeded" in msg
+    assert "raw=" in msg
+    assert session._format_backend_error(InternalServerError("boom")) is None
+
+
+def test_generate_title_skips_synthetic_summary_label(session):
+    """After a compaction the first 'user' turn is the synthetic [Conversation
+    summary] label; _generate_title must not title from it — with no real user
+    message it skips regeneration and rebroadcasts the current title, instead of
+    issuing a model call that titles the conversation '[Conversation summary]'."""
+    session.messages = turns_from_dicts(
+        [
+            {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+            {"role": "assistant", "content": "the dense summary"},
+        ]
+    )
+    with (
+        patch.object(session, "_utility_completion") as uc,
+        patch.object(session, "ui", new=MagicMock()) as ui_mock,
+    ):
+        session._generate_title("Existing Title")
+
+    uc.assert_not_called()  # no real user message → no title model call
+    ui_mock.on_rename.assert_called_once_with("Existing Title")  # current title rebroadcast
+
+
+class TestProactivePreSend:
+    """Layer A: a send whose history already exceeds the window (e.g. a
+    rehydrated resume) compacts BEFORE the first stream call, so an over-window
+    payload is never put on the wire."""
+
+    def test_proactive_pre_send_compaction_runs_before_stream(self, session):
+        session.messages = turns_from_dicts([{"role": "user", "content": "task"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+        session._compaction_advised = False
+        order: list[str] = []
+        forwarded: dict[str, object] = {}
+
+        def fake_compact(*args, **kwargs):
+            where = args[0] if args else ""
+            order.append(f"compact:{where}")
+            if where == "pre-send":  # capture only the Layer-A call, not end-of-turn
+                forwarded["preserve_tail"] = kwargs.get("preserve_tail")
+            return True
+
+        def fake_stream(*_args, **_kwargs):
+            order.append("stream")
+            return iter([])
+
+        with (
+            # 9999 > hard (9000) → compaction is owed at send time.
+            patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
+            patch.object(session, "_check_metacognitive_nudge", return_value=None),
+            patch.object(session, "_do_auto_compact", side_effect=fake_compact),
+            patch.object(session, "_create_stream_with_retry", side_effect=fake_stream),
+            patch.object(
+                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        assert order[0] == "compact:pre-send", order
+        assert "stream" in order
+        # End-to-end through send(): the pre-existing "task" turn + the just-sent
+        # "go" turn, last USER boundary at index 1 → preserve exactly the trailing
+        # "go" turn (no nudge fired), pinning len(messages) - boundaries[-1].
+        assert forwarded["preserve_tail"] == 1
+
+    def test_pre_send_preserves_user_turn_past_trailing_nudge(self, session):
+        """The just-sent user message survives compaction verbatim even when a
+        system nudge was appended after it — pre-send preserves from the last USER
+        boundary, not messages[-1]."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+                {"role": "user", "content": "THE ACTUAL QUESTION"},
+                {"role": "system", "_source": "output_guard", "content": "a trailing nudge"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1, 1]
+        summary = SimpleNamespace(content="SUMMARY", finish_reason="stop")
+
+        # The real pre-send preserve computation, then the real _compact_messages.
+        boundaries = session._find_turn_boundaries()
+        preserve = len(session.messages) - boundaries[-1]
+        # Pin the formula: last USER turn at index 2 → preserve the user msg AND the
+        # trailing nudge (indices 2,3), i.e. exactly 2 — not 1 (which would drop the
+        # user turn under the nudge) and not the whole history.
+        assert preserve == 2
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._do_auto_compact("pre-send", preserve_tail=preserve) is True
+
+        texts = [m.text or "" for m in session.messages]
+        assert any("THE ACTUAL QUESTION" in t for t in texts)  # user msg verbatim
+        assert any("a trailing nudge" in t for t in texts)  # trailing nudge kept too
+        assert not any("old answer" in t for t in texts)  # older turns summarized away
+
+    def test_continuation_hint_references_last_summarized_user_message(self, session):
+        """When the last user turn is summarized away (reactive, preserve_tail=0),
+        the summary carries a ``## Continue`` hint quoting that message so the model
+        knows where to resume."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "FIRST question"},
+                {"role": "assistant", "content": "first reply"},
+                {"role": "user", "content": "LASTQ the recent ask"},
+                {"role": "assistant", "content": "second reply"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1, 1]
+        summary = SimpleNamespace(content="DENSE SUMMARY", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._do_auto_compact("reactive", preserve_tail=0) is True
+
+        summ = session.messages[1].text or ""  # the summary_asst turn
+        assert "## Continue" in summ
+        assert "LASTQ the recent ask" in summ
+
+    def test_continuation_hint_skipped_when_last_user_preserved(self, session):
+        """When preserve_tail keeps the last user turn verbatim (the pre-send path),
+        NO continuation hint is added — the preserved tail already carries the
+        message, so a hint would duplicate it and reframe a fresh ask as 'continue
+        where we left off'."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "FIRST question"},
+                {"role": "assistant", "content": "first reply"},
+                {"role": "user", "content": "LASTQ the recent ask"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1]
+        preserve = len(session.messages) - session._find_turn_boundaries()[-1]  # == 1
+        summary = SimpleNamespace(content="DENSE SUMMARY", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._do_auto_compact("pre-send", preserve_tail=preserve) is True
+
+        summ = session.messages[1].text or ""  # the summary_asst turn
+        assert "## Continue" not in summ  # last user turn preserved, not summarized
+        # The preserved tail carries the message — exactly once across the transcript.
+        texts = [m.text or "" for m in session.messages]
+        assert sum("LASTQ the recent ask" in t for t in texts) == 1
+
+    def test_continuation_hint_skips_synthetic_summary_label(self, session):
+        """Re-compacting an already-bare [Conversation summary] history must not quote
+        the synthetic label as 'the user's last message' — it's a compaction artifact,
+        not a real turn, so _find_turn_boundaries excludes it and no hint is added."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "prior dense summary"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        summary = SimpleNamespace(content="NEW SUMMARY", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._do_auto_compact("reactive", preserve_tail=0) is True
+
+        summ = session.messages[1].text or ""  # the new summary_asst turn
+        assert summ == "NEW SUMMARY"  # bare summary, no hint quoting the label
+        assert "## Continue" not in summ
+
+
+class TestChunkerOverflowSplit:
+    """The chunker recovers from a char-budget under-estimate by splitting an
+    over-window batch into per-block summaries — chunking, not truncation, and
+    without re-summarizing completed siblings.  These drive the real
+    _summarize_blocks / _summarize_batch / _pack_blocks path (only the leaf
+    _summarize_once model call is mocked, by body size)."""
+
+    def test_overflowing_batch_subdivides_then_merges(self, session):
+        # All blocks pack into one batch (huge char budget), but the combined body
+        # overflows the *token* window while smaller sub-batches fit.
+        blocks = ["A" * 4000, "B" * 4000, "C" * 4000]
+        bodies: list[int] = []
+
+        def fake_once(_system_prompt, body):
+            bodies.append(len(body))
+            if len(body) > 6_000:  # a multi-block body overflows the token window
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return "S"
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+            patch.object(session, "_summarize_once", side_effect=fake_once),
+        ):
+            result = session._summarize_blocks(blocks)
+
+        assert result == "S"  # produced a summary, never raised _CompactionIrreducible
+        assert any(n > 6_000 for n in bodies)  # the combined batch overflowed…
+        # …then it was halved until the pieces fit and merged (no whole-list re-run).
+        assert sum(1 for n in bodies if n <= 6_000) >= 3
+
+    def test_overflow_subdivides_not_per_block(self, session):
+        """An over-window batch is halved (binary subdivision), NOT summarized one
+        call per block — so a wide batch costs ~log2(N) calls, not N.  Regression
+        guard for the per-block grind (a ~1000-block batch becoming ~1000 serial
+        summary calls stuck in 'part 1/2')."""
+        # 8 blocks packed into one batch; the model overflows only when a body holds
+        # 5+ blocks, so the 8-block batch must subdivide but 4-block halves fit.
+        blocks = [f"b{i:02d} " + "z" * 500 for i in range(8)]
+        calls: list[str] = []
+
+        def fake_once(_system_prompt, body):
+            calls.append(body)
+            if body.count("\n\n") >= 4:  # a body of 5+ blocks overflows the window
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return "S"
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=1_000_000),
+            patch.object(session, "_summarize_once", side_effect=fake_once),
+        ):
+            result = session._summarize_blocks(blocks)
+
+        assert result == "S"
+        # Binary subdivision: [8] → two [4] halves that both fit — a handful of calls,
+        # nowhere near 8 (per-block split would be ≥8 leaf calls).
+        assert len(calls) <= 5, len(calls)
+        # It never descended to single blocks (every summarized body is multi-block);
+        # per-block split would have produced 8 single-block bodies.
+        assert all("\n\n" in body for body in calls)
+
+    def test_lone_oversized_block_floored_then_succeeds(self, session):
+        # A single block that overflows even by itself is head/tail-truncated to
+        # the floor and retried once — not bailed.
+        floor = session._MIN_SUMMARY_BUDGET_CHARS
+        calls: list[int] = []
+
+        def fake_once(_system_prompt, body):
+            calls.append(len(body))
+            if len(body) > floor:
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return "S"
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=50_000),
+            patch.object(session, "_summarize_once", side_effect=fake_once),
+        ):
+            result = session._summarize_blocks(["Z" * 20_000])
+
+        assert result == "S"  # floored block summarized, not bailed
+        assert any(n > floor for n in calls)  # the over-floor call overflowed…
+        assert any(n <= floor for n in calls)  # …then the floored retry fit
+
+    def test_lone_block_shrinks_progressively_not_straight_to_floor(self, session):
+        """A lone over-window block is shrunk by halving (keeping as much as fits),
+        NOT slammed straight to the 2 000-char floor — so when a mid-size truncation
+        already fits the window, far more of the message survives than a floor jump
+        would keep (the single-block analogue of the multi-block binary subdivision)."""
+        floor = session._MIN_SUMMARY_BUDGET_CHARS
+        calls: list[int] = []
+
+        def fake_once(_system_prompt, body):
+            calls.append(len(body))
+            if len(body) > 9_000:  # only bodies well above the floor overflow
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return "S"
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=50_000),
+            patch.object(session, "_summarize_once", side_effect=fake_once),
+        ):
+            result = session._summarize_blocks(["Z" * 16_000])
+
+        assert result == "S"
+        # First shrink budget is len//2 == 8 000 (< the 9 000 overflow line), so it
+        # fits on the FIRST halving — the surviving body stays far above the floor,
+        # which a straight-to-floor jump (~2 000) would have discarded.
+        fitted = [n for n in calls if n <= 9_000]
+        assert fitted and min(fitted) > 2 * floor
+
+    def test_non_shrinking_merge_bails_at_depth_not_recursionerror(self, session):
+        """If per-block summaries never compress (the merge keeps overflowing),
+        recursion is bounded by the depth ceiling and bails to
+        _CompactionIrreducibleError — NOT an unbounded recurse into RecursionError.
+        Regression for the depth-check-only-on-the-multi-batch-path bug."""
+
+        def no_shrink(_system_prompt, body):
+            if "\n\n" in body:  # any multi-block body overflows the window
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return body  # a single-block 'summary' is the block itself — no shrink
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+            patch.object(session, "_summarize_once", side_effect=no_shrink),
+            pytest.raises(_CompactionIrreducibleError),
+        ):
+            session._summarize_blocks(["A" * 4000, "B" * 4000, "C" * 4000])
+
+    def test_later_batch_overflow_keeps_completed_siblings(self, session):
+        """A later batch overflowing and splitting does NOT re-summarize earlier
+        completed batches — siblings are retained in the accumulator."""
+        # budget ~4500 packs the 4 blocks into two 2-block batches; only the batch
+        # holding 'C' overflows-and-splits, so the first batch's summary stands.
+        blocks = ["A" * 2000, "B" * 2000, "C" * 2000, "D" * 2000]
+        bodies: list[str] = []
+
+        def fake_once(_system_prompt, body):
+            bodies.append(body)
+            if "CC" in body and "\n\n" in body:  # the multi-block batch holding C
+                raise RuntimeError("maximum context length is 524288 tokens")
+            return "S"
+
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=4_500),
+            patch.object(session, "_summarize_once", side_effect=fake_once),
+        ):
+            result = session._summarize_blocks(blocks)
+
+        assert result == "S"
+        # The first batch (A+B) was summarized exactly once, never recomputed after
+        # the later (C+D) batch overflowed and split.
+        assert sum(1 for b in bodies if "AAA" in b and "BBB" in b) == 1
+
+    def test_cancel_mid_compaction_aborts_and_leaves_history(self, session):
+        """A cancel observed during compaction raises GenerationCancelled (a
+        BaseException) out of _summarize_batch before the message-swap, so the
+        history is left untouched and the cancel propagates (not swallowed)."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "u " + "x" * 3000},
+                {"role": "assistant", "content": "a " + "y" * 3000},
+                {"role": "user", "content": "u2 " + "z" * 3000},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1]
+        before = list(session.messages)
+
+        def cancel_then_summarize(*_a, **_k):
+            # The owner cancels after the first summary call lands.
+            session._cancel_event.set()
+            return SimpleNamespace(content="SUMMARY", finish_reason="stop")
+
+        try:
+            with (
+                patch.object(session, "_summary_input_budget_chars", return_value=3_500),
+                patch.object(session, "_utility_completion", side_effect=cancel_then_summarize),
+                pytest.raises(GenerationCancelled),
+            ):
+                session._compact_messages(auto=True)
+            assert session.messages == before  # history untouched
+        finally:
+            session._cancel_event.clear()
+
+    def test_cancel_during_single_summary_call_aborts_before_swap(self, session):
+        """A cancel that lands DURING the one-and-only summary call is honored by
+        the pre-swap cancel-check — the per-batch check ran before the call, so it
+        could not see it.  Regression guard for a single-batch compaction swapping
+        despite a mid-call cancel."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "small u"},
+                {"role": "assistant", "content": "small a"},
+                {"role": "user", "content": "small u2"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1]
+        before = list(session.messages)
+
+        def cancel_during_call(*_a, **_k):
+            session._cancel_event.set()  # cancel lands while the single call runs
+            return SimpleNamespace(content="SUMMARY", finish_reason="stop")
+
+        try:
+            with (
+                # Huge budget → all blocks pack into ONE batch → exactly one call.
+                patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+                patch.object(session, "_utility_completion", side_effect=cancel_during_call),
+                pytest.raises(GenerationCancelled),
+            ):
+                session._compact_messages(auto=True)
+            assert session.messages == before  # swap skipped, history intact
+        finally:
+            session._cancel_event.clear()
+
+    def test_manual_compact_does_not_disarm_concurrent_cancel(self, session):
+        """A manual /compact must NOT reset _cancel_event.  If a cancel is already in
+        flight for a concurrent send worker (the /command handler runs on a separate
+        thread with no worker gate), resetting it would silently disarm the cancel —
+        the worker would never see it and run to completion.  Instead /compact
+        observes the set event and aborts itself, leaving the cancel intact."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "u one"},
+                {"role": "assistant", "content": "a one"},
+                {"role": "user", "content": "u two"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1]
+        session._cancel_event.set()  # a concurrent send is mid-cancel
+        before = list(session.messages)
+        try:
+            with (
+                patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+                patch.object(session, "_utility_completion") as uc,
+                pytest.raises(GenerationCancelled),
+            ):
+                session._compact_messages(auto=False)
+            assert session._cancel_event.is_set()  # cancel left INTACT, not disarmed
+            assert session.messages == before  # no swap
+            uc.assert_not_called()  # bailed before issuing a summary call
+        finally:
+            session._cancel_event.clear()
+
+    def test_send_clears_its_cancel_event_on_exit(self, session):
+        """send() consumes its own generation's cancel signal in its finally, so a
+        cancel that targeted a now-finished send can't later block an unrelated idle
+        manual /compact.  A cancel is raised mid-stream here; after send() returns the
+        event is clear."""
+        session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
+        session._msg_tokens = [1]
+        session._title_generated = True
+
+        def cancel_midstream(*_a, **_k):
+            session._cancel_event.set()
+            raise GenerationCancelled()
+
+        with (
+            patch.object(session, "_estimated_prompt_tokens", return_value=10),  # under hard
+            patch.object(session, "_check_metacognitive_nudge", return_value=None),
+            patch.object(session, "_create_stream_with_retry", side_effect=cancel_midstream),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch("turnstone.core.session.save_message"),
+        ):
+            session.send("go")
+
+        assert not session._cancel_event.is_set()  # finally consumed this gen's cancel
+
+    def test_compaction_aborts_swap_when_generation_superseded(self, session):
+        """A stale send thread (a newer generation already started during the slow
+        summary call) must NOT swap history — the pre-swap _check_cancelled(
+        my_generation) raises so self.messages is left intact for the live
+        generation.  Guards the history-corruption hole the pre-send layer opened by
+        sitting ahead of the loop-top generation check."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "u one"},
+                {"role": "assistant", "content": "a one"},
+                {"role": "user", "content": "u two"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1]
+        session._generation = 5  # a newer send is the live generation
+        before = list(session.messages)
+        summary = SimpleNamespace(content="SUMMARY", finish_reason="stop")
+        with (
+            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+            patch.object(session, "_utility_completion", return_value=summary),
+            pytest.raises(GenerationCancelled),
+        ):
+            # This thread belongs to the OLD generation 3 (superseded by 5).
+            session._compact_messages(auto=True, my_generation=3)
+        assert session.messages == before  # swap skipped — history intact for gen 5
+
+
+class TestRetryRewindSkipSummary:
+    """retry()/rewind() must treat the synthetic ``[Conversation summary]`` user
+    turn as a non-target: it is a compaction artifact, not a real turn, so
+    targeting it would re-send the bare label and regenerate over the summary."""
+
+    def test_retry_on_bare_summary_is_noop(self, session):
+        # Reactive compaction left only [summary_user, summary_asst] — no real turn.
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "the dense summary"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        before = list(session.messages)
+        assert session.retry() is None  # nothing real to retry
+        assert session.messages == before  # summary left intact
+
+    def test_rewind_on_bare_summary_is_noop(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "the dense summary"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        before = list(session.messages)
+        assert session.rewind(1) == 0
+        assert session.messages == before  # summary left intact
+
+    def test_retry_targets_real_turn_and_keeps_summary(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "the dense summary"},
+                {"role": "user", "content": "a real follow-up"},
+                {"role": "assistant", "content": "the answer"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1, 1]
+        assert session.retry() == "a real follow-up"
+        # Dropped from the real user turn onward; the summary prefix survives.
+        assert [m.text for m in session.messages] == [
+            COMPACTION_SUMMARY_LABEL,
+            "the dense summary",
+        ]
+
+    def test_rewind_stops_at_summary_boundary(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "the dense summary"},
+                {"role": "user", "content": "a real follow-up"},
+                {"role": "assistant", "content": "the answer"},
+            ]
+        )
+        session._msg_tokens = [1, 1, 1, 1]
+        # Even an over-deep rewind can't cross into the summary.
+        removed = session.rewind(5)
+        assert removed == 2  # only the one real turn (user + assistant)
+        assert [m.text for m in session.messages] == [
+            COMPACTION_SUMMARY_LABEL,
+            "the dense summary",
+        ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1537,6 +1537,59 @@ class TestAgentOutputGuard:
             assert args[1] == prior
             assert args[2] == "plan_agent_synthesis"
 
+    def test_non_overflow_terminal_error_salvages_partial_work(self):
+        """A NON-overflow terminal API error must still salvage the sub-agent's
+        partial assistant work — regression guard: narrowing the salvage gate to
+        overflow-only discarded a completed synthesis when the final call died on a
+        persistent non-overflow error (e.g. a 5xx/timeout after retries)."""
+        from turnstone.core.judge import JudgeConfig
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        session = _make_session(judge_config=JudgeConfig(output_guard=True))
+        session._provider = OpenAIChatCompletionsProvider()
+        session._MAX_RETRIES = 0  # fail fast, no backoff
+
+        prior = "Substantial partial synthesis before the backend died."
+
+        with patch.object(
+            session, "_evaluate_output", wraps=lambda cid, o, fn: (o, None)
+        ) as mock_eval:
+
+            def fake_create(**_kwargs):
+                raise RuntimeError("upstream connect error or disconnect/reset (503)")
+
+            session.client.chat.completions.create = fake_create
+            result = session._run_agent(
+                [Turn.user("test"), Turn.assistant(prior)],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+                label="task",
+            )
+
+            assert result == prior  # partial work salvaged, not discarded
+            mock_eval.assert_called_once()
+            assert mock_eval.call_args[0][1] == prior
+
+    def test_non_overflow_terminal_error_without_partial_work_reraises(self):
+        """With no partial assistant work to salvage, a non-overflow terminal error
+        re-raises so the real failure surfaces to the coordinator rather than being
+        masked as an empty success."""
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        session = _make_session()
+        session._provider = OpenAIChatCompletionsProvider()
+        session._MAX_RETRIES = 0
+
+        def fake_create(**_kwargs):
+            raise RuntimeError("upstream connect error or disconnect/reset (503)")
+
+        session.client.chat.completions.create = fake_create
+        with pytest.raises(RuntimeError, match="503"):
+            session._run_agent(
+                [Turn.user("test")],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+                label="task",
+            )
+
     def test_turn_limit_forced_synthesis_is_guarded(self):
         """When max_tool_turns is exhausted, the forced synthesis call's
         content flows through the guard."""

--- a/tests/test_session_backend_error_format.py
+++ b/tests/test_session_backend_error_format.py
@@ -157,6 +157,19 @@ def test_rate_limit_message():
     assert "limit exceeded" in msg
 
 
+def test_rate_limit_with_overflow_phrasing_is_not_mislabeled_overflow():
+    """A recognized RateLimitError whose quota text happens to contain a
+    context-overflow phrase must still render as rate-limited — the text-based
+    overflow branch is gated on 'not a known class', so it can't hijack a
+    recognized error and mark a transient 429 as a hard 'Context window exceeded'."""
+    msg = _format(
+        _stub(), RateLimitError("exceeds the maximum number of tokens allowed per minute")
+    )
+    assert msg is not None
+    assert "Backend rate-limited" in msg
+    assert "Context window exceeded" not in msg
+
+
 # ---------------------------------------------------------------------------
 # Fall-through + degradation behaviour
 # ---------------------------------------------------------------------------

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -873,22 +873,31 @@ _BACKEND_KNOWN_EXC_NAMES: frozenset[str] = (
 def _is_ctx_overflow(exc: BaseException) -> bool:
     """True when *exc* looks like a context-window overflow from any backend.
 
-    Detection is by message *text*, not exception class: vLLM surfaces the SAME
-    overflow as HTTP 400 ``BadRequestError`` on the OpenAI endpoint but HTTP 500
-    ``InternalServerError`` on the Anthropic (``/v1/messages``) endpoint, so
-    class-based matching would miss one of them.  A free function (not a method)
-    so the fatal-error formatter — which is unit-tested with a stand-in ``self``
-    — and the per-call retry gates, the send-loop recovery, and the chunker can
-    all share one definition.
+    Detection is by message *text* AMONG classes that aren't already a recognized
+    backend error: vLLM surfaces the SAME overflow as HTTP 400 ``BadRequestError``
+    on the OpenAI endpoint but HTTP 500 ``InternalServerError`` on the Anthropic
+    (``/v1/messages``) endpoint — neither is in ``_BACKEND_KNOWN_EXC_NAMES`` — so
+    text matching is what unifies them.  The class gate is the safety rail: an
+    overflow is never a recognized error, so excluding known classes can't suppress
+    a real overflow, but it keeps a retryable 429 ``RateLimitError`` — whose
+    token-quota text can read "… maximum number of tokens allowed per minute …" —
+    from being misread as a deterministic overflow.  That matters because EVERY
+    caller (the retry gates via ``_stop_retrying``, the send-loop recovery, the
+    chunker, the task_agent loop, the fatal-error formatter) routes an overflow to
+    a non-retryable / compaction path; a false positive on a 429 would turn a
+    transient rate-limit into a hard failure.  Centralizing the gate here keeps all
+    those callers consistent without each re-checking the class.
 
-    The phrases are deliberately overflow-*specific* and cover the core providers
+    A free function (not a method) so the fatal-error formatter — unit-tested with
+    a stand-in ``self`` — and the other callers can share one definition.
+
+    The phrases are deliberately overflow-specific and cover the core providers
     (OpenAI/vLLM "maximum context length"; Anthropic "exceed context limit,
     decrease input length"; Google/Gemini "exceeds the maximum number of tokens
-    allowed").  They must NOT match a retryable rate-limit, whose body can mention
-    token quotas ("… input tokens per minute …") — these gates make a match
-    non-retryable, so a false positive would turn a transient 429 into a hard,
-    mislabeled failure (hence no bare "input tokens" / "too many tokens").
+    allowed").
     """
+    if type(exc).__name__ in _BACKEND_KNOWN_EXC_NAMES:
+        return False
     text = str(exc).lower()
     return any(
         s in text
@@ -3679,15 +3688,13 @@ class ChatSession:
 
         name = type(exc).__name__
 
-        # Context overflow — matched by text, not class, because it arrives as
-        # BadRequestError (OpenAI 400) OR InternalServerError (Anthropic-compat 500),
-        # which would otherwise render as an opaque class name with no hint that the
-        # prompt was simply too large.  Gated on "not a known class" so a recognized
-        # error (e.g. a RateLimitError whose quota text happens to mention a token
-        # maximum) still falls through to its own specific message below rather than
-        # being mislabeled as overflow.  The overflow classes are not in
-        # ``_BACKEND_KNOWN_EXC_NAMES``, so this still catches them.
-        if name not in _BACKEND_KNOWN_EXC_NAMES and _is_ctx_overflow(exc):
+        # Context overflow — matched by text, because it arrives as BadRequestError
+        # (OpenAI 400) OR InternalServerError (Anthropic-compat 500), which would
+        # otherwise render as an opaque class name with no hint that the prompt was
+        # simply too large.  _is_ctx_overflow self-gates on "not a known class", so a
+        # recognized error (e.g. a RateLimitError whose quota text mentions a token
+        # maximum) returns False here and falls through to its own specific message.
+        if _is_ctx_overflow(exc):
             return (
                 f"Context window exceeded for model={model_label}: the conversation "
                 f"is too large to send. Auto-compaction should shrink it and retry; "

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -870,6 +870,41 @@ _BACKEND_KNOWN_EXC_NAMES: frozenset[str] = (
 )
 
 
+def _is_ctx_overflow(exc: BaseException) -> bool:
+    """True when *exc* looks like a context-window overflow from any backend.
+
+    Detection is by message *text*, not exception class: vLLM surfaces the SAME
+    overflow as HTTP 400 ``BadRequestError`` on the OpenAI endpoint but HTTP 500
+    ``InternalServerError`` on the Anthropic (``/v1/messages``) endpoint, so
+    class-based matching would miss one of them.  A free function (not a method)
+    so the fatal-error formatter — which is unit-tested with a stand-in ``self``
+    — and the per-call retry gates, the send-loop recovery, and the chunker can
+    all share one definition.
+
+    The phrases are deliberately overflow-*specific* and cover the core providers
+    (OpenAI/vLLM "maximum context length"; Anthropic "exceed context limit,
+    decrease input length"; Google/Gemini "exceeds the maximum number of tokens
+    allowed").  They must NOT match a retryable rate-limit, whose body can mention
+    token quotas ("… input tokens per minute …") — these gates make a match
+    non-retryable, so a false positive would turn a transient 429 into a hard,
+    mislabeled failure (hence no bare "input tokens" / "too many tokens").
+    """
+    text = str(exc).lower()
+    return any(
+        s in text
+        for s in (
+            "context length",
+            "maximum context",
+            "context window",
+            "context limit",
+            "prompt is too long",
+            "input is too long",
+            "reduce the length of the input",
+            "maximum number of tokens",
+        )
+    )
+
+
 class SessionUI(Protocol):
     def on_turn_start(self) -> None: ...
     def on_turn_committed(self) -> None: ...
@@ -2551,7 +2586,7 @@ class ChatSession:
         safety_margin = int(self.context_window * 0.05)
         return max(0, self.context_window - used - response_reserve - safety_margin)
 
-    def _maybe_compact_midturn(self) -> None:
+    def _maybe_compact_midturn(self, my_generation: int = 0) -> None:
         """Cooperative mid-turn compaction policy.
 
         Reads the provider-anchored fullness estimate (the same measure
@@ -2572,7 +2607,7 @@ class ChatSession:
         """
         est = self._estimated_prompt_tokens()
         if self._compaction_owed(est):
-            self._do_auto_compact("mid-turn")
+            self._do_auto_compact("mid-turn", my_generation=my_generation)
         elif self._over_soft(est):
             self._append_system_turn("compaction_pending", format_nudge("compaction_pending"))
             self._compaction_advised = True
@@ -2589,8 +2624,7 @@ class ChatSession:
         """
         if used is None:
             used = self._estimated_prompt_tokens()
-        hard = self.context_window * min(0.95, self.auto_compact_pct + 0.10)
-        return used > hard or (self._over_soft(used) and self._compaction_advised)
+        return self._over_hard(used) or (self._over_soft(used) and self._compaction_advised)
 
     def _over_soft(self, used: int) -> bool:
         """True when ``used`` tokens exceed the soft auto-compaction threshold.
@@ -2601,22 +2635,39 @@ class ChatSession:
         """
         return used > self.context_window * self.auto_compact_pct
 
-    def _do_auto_compact(self, where: str = "", preserve_tail: int = 0) -> bool:
+    def _over_hard(self, used: int) -> bool:
+        """True when ``used`` tokens exceed the hard ceiling — a band above the
+        soft threshold (capped at 95%).
+
+        The "compact now, no turn to spare" line.  Single source shared by
+        :meth:`_compaction_owed` and the proactive pre-send guard; the latter uses
+        it ALONE (not ``_compaction_owed``, whose advised-soft arm belongs to the
+        cooperative mid/end-of-turn wind-down, not to a pre-send emergency).
+        """
+        return used > self.context_window * min(0.95, self.auto_compact_pct + 0.10)
+
+    def _do_auto_compact(
+        self, where: str = "", preserve_tail: int = 0, my_generation: int = 0
+    ) -> bool:
         """Emit the auto-compaction notice, compact, and refresh the status
         line.  Shared by the mid-turn policy (:meth:`_maybe_compact_midturn`)
         and the end-of-turn check so the notice wording, the percentage, and
         the post-compaction status refresh stay in lockstep.  ``where`` is an
         optional qualifier for the notice (e.g. ``"mid-turn"``); ``preserve_tail``
         is forwarded to :meth:`_compact_messages` (e.g. to keep an in-flight
-        tool-call turn during compact-before-truncate).  Returns whether a
-        summary was actually produced (False if compaction bailed) so callers
-        can avoid acting on a compaction that did not happen."""
+        tool-call turn during compact-before-truncate); ``my_generation`` is
+        forwarded so the message swap aborts if a newer send supersedes this one
+        mid-compaction (0 = the manual /compact path, which has no generation).
+        Returns whether a summary was actually produced (False if compaction
+        bailed) so callers can avoid acting on a compaction that did not happen."""
         qualifier = f" {where}" if where else ""
         pct_display = round(self.auto_compact_pct * 100)
         self.ui.on_info(
             f"\n[Auto-compacting{qualifier}: prompt exceeds {pct_display}% of context window]"
         )
-        compacted = self._compact_messages(auto=True, preserve_tail=preserve_tail)
+        compacted = self._compact_messages(
+            auto=True, preserve_tail=preserve_tail, my_generation=my_generation
+        )
         self._print_status_line()
         return compacted
 
@@ -2681,7 +2732,11 @@ class ChatSession:
             asst_msg = ""
             for m in list(self.messages):
                 content = m.text  # joins text blocks; multipart attachments contribute none
-                if m.role is Role.USER and not user_msg:
+                # Skip the synthetic [Conversation summary] turn: after a compaction
+                # it is messages[0], and titling from the bare label yields a
+                # meaningless title (the same summary-turn-as-real-turn hazard
+                # _find_turn_boundaries guards for retry/rewind).
+                if m.role is Role.USER and not user_msg and content != COMPACTION_SUMMARY_LABEL:
                     user_msg = content[:300]
                 elif m.role is Role.ASSISTANT and not asst_msg:
                     asst_msg = content[:200]
@@ -3598,8 +3653,10 @@ class ChatSession:
 
         Returns ``None`` for exceptions outside the recognised set so the
         caller falls back to the bare ``f"{type(exc).__name__}: {exc}"``
-        shape.  Matching is by class name (see the
-        ``_BACKEND_*_EXC_NAMES`` sets above) so the same helper covers
+        shape.  A context-window overflow is matched first by message *text* (it
+        can arrive as several exception classes); everything else is matched by
+        class name (see the ``_BACKEND_*_EXC_NAMES`` sets above) so the same
+        helper covers
         httpx ``ReadTimeout`` / ``ConnectError``, OpenAI SDK
         ``APITimeoutError`` / ``APIConnectionError`` /
         ``NotFoundError`` / ``RateLimitError`` / ``AuthenticationError``,
@@ -3612,7 +3669,31 @@ class ChatSession:
         :func:`sanitize_error_text` in the caller, so credentials in the
         base URL are redacted before display / persist.
         """
+        # Backend identity shared by every branch — model label + raw tail.
+        # Hoisted so the context-overflow branch and the class-name branches use
+        # one derivation.  self.model/_model_alias are plain __init__ attributes
+        # (always set), so reading them here can't raise on the fatal path.
+        model_label = self.model or self._model_alias or "?"
+        raw_msg = str(exc).strip()
+        raw_tail = f" raw={raw_msg!r}" if raw_msg else ""
+
         name = type(exc).__name__
+
+        # Context overflow — matched by text, not class, because it arrives as
+        # BadRequestError (OpenAI 400) OR InternalServerError (Anthropic-compat 500),
+        # which would otherwise render as an opaque class name with no hint that the
+        # prompt was simply too large.  Gated on "not a known class" so a recognized
+        # error (e.g. a RateLimitError whose quota text happens to mention a token
+        # maximum) still falls through to its own specific message below rather than
+        # being mislabeled as overflow.  The overflow classes are not in
+        # ``_BACKEND_KNOWN_EXC_NAMES``, so this still catches them.
+        if name not in _BACKEND_KNOWN_EXC_NAMES and _is_ctx_overflow(exc):
+            return (
+                f"Context window exceeded for model={model_label}: the conversation "
+                f"is too large to send. Auto-compaction should shrink it and retry; "
+                f"seeing this means compaction could not reduce it enough.{raw_tail}"
+            )
+
         if name not in _BACKEND_KNOWN_EXC_NAMES:
             return None
 
@@ -3637,14 +3718,6 @@ class ChatSession:
             )
         except Exception:
             log.debug("session.fatal.provider_lookup_failed", exc_info=True)
-        model_label = self.model or self._model_alias or "?"
-        # Original exception text (often empty for httpx.ReadTimeout —
-        # the message is on the class name alone) — included as a
-        # "raw=" tail so operators reading logs can still grep the
-        # underlying SDK error.
-        raw_msg = str(exc).strip()
-        raw_tail = f" raw={raw_msg!r}" if raw_msg else ""
-
         if name in _BACKEND_TIMEOUT_EXC_NAMES:
             return (
                 f"Backend timeout ({name}): no response from {provider_label} "
@@ -3971,6 +4044,17 @@ class ChatSession:
             self.ui.on_info(f"[Fallback {alias} also failed: {fb_err}]")
             return None
 
+    def _stop_retrying(self, exc: BaseException, attempt: int, provider: LLMProvider) -> bool:
+        """Terminal-retry predicate shared by every API retry loop (stream, summary,
+        task_agent): stop on a non-retryable error class, a deterministic
+        context-overflow (retrying an identical oversized payload is pointless), or
+        retry exhaustion."""
+        return (
+            type(exc).__name__ not in provider.retryable_error_names
+            or _is_ctx_overflow(exc)
+            or attempt == self._MAX_RETRIES
+        )
+
     def _try_stream(
         self,
         client: Any,
@@ -4051,7 +4135,10 @@ class ChatSession:
                     self._MAX_RETRIES + 1,
                     exc_info=True,
                 )
-                if ename not in prov.retryable_error_names or attempt == self._MAX_RETRIES:
+                if self._stop_retrying(e, attempt, prov):
+                    # Non-retryable class, deterministic overflow (the send-loop
+                    # compact-and-retry handles it), or retries exhausted — raise
+                    # immediately rather than burn backoff sleeps.
                     raise
                 last_err = e
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
@@ -4477,6 +4564,41 @@ class ChatSession:
             self._init_system_messages()
 
         try:
+            # Bail an orphaned/superseded send BEFORE the pre-send compaction below
+            # can mutate history.  The old code's first in-try act was the loop-top
+            # _check_cancelled(my_generation); the new pre-send layer sits ahead of
+            # the loop, so without this guard a stale thread (a newer send already
+            # bumped _generation and installed a fresh, clear cancel event) would
+            # sail past the event-only checks inside compaction and compact-and-swap
+            # the live generation's history.  A stale thread raises here and the
+            # except-GenerationCancelled handler returns without touching state.
+            self._check_cancelled(my_generation)
+
+            # Proactive pre-send compaction (Layer A): a rehydrated resume — or a
+            # session that never compacted under a larger-window model before a
+            # switch to a smaller one — can arrive already over the window before
+            # the FIRST send.  The mid-turn and end-of-turn triggers only fire AFTER
+            # a successful call, so without this the first post-resume send goes out
+            # blind.  Gate on the HARD ceiling alone (NOT _compaction_owed, whose
+            # advised-soft arm is the cooperative wind-down the model must still get
+            # to act on), run it ONCE here, and preserve from the last USER turn to
+            # the end — the just-sent message plus any nudge _emit_pending_user_nudges
+            # appended after it — so it isn't summarized out from under its own reply.
+            # Sits INSIDE the try so a raise (or a cooperative cancel) lands in the
+            # fatal/cancel handlers like every other compaction site.  Passes
+            # my_generation so the swap inside compaction also aborts if a newer send
+            # starts DURING the (slow) summary call.  Best-effort prevention, not a
+            # guarantee: the char-based estimate under-counts dense/CJK history on an
+            # uncalibrated resume, so the send-loop compact-and-retry below stays the
+            # backstop.
+            if self._over_hard(self._estimated_prompt_tokens()):
+                boundaries = self._find_turn_boundaries()
+                preserve = len(self.messages) - boundaries[-1] if boundaries else 1
+                self._do_auto_compact(
+                    "pre-send", preserve_tail=preserve, my_generation=my_generation
+                )
+                if self._generation != my_generation:
+                    return
             while True:
                 self._check_cancelled(my_generation)
                 msgs = self._prepare_wire_messages(self._full_messages())
@@ -4500,18 +4622,7 @@ class ChatSession:
                         # Context overflow recovery: if the API rejects the
                         # request due to exceeding the context window, compact
                         # the conversation and retry once.
-                        err_text = str(ctx_err).lower()
-                        is_ctx_overflow = any(
-                            s in err_text
-                            for s in (
-                                "context length",
-                                "maximum context",
-                                "too many tokens",
-                                "prompt is too long",
-                                "input tokens",
-                            )
-                        )
-                        if not is_ctx_overflow:
+                        if not _is_ctx_overflow(ctx_err):
                             raise
                         log.warning(
                             "Context overflow detected (%s), compacting and retrying",
@@ -4608,7 +4719,7 @@ class ChatSession:
                     # consumed above — compact whenever over soft.  None-safe via
                     # _estimated_prompt_tokens(), so no _last_usage guard.
                     if self._over_soft(self._estimated_prompt_tokens()):
-                        compacted = self._do_auto_compact()
+                        compacted = self._do_auto_compact(my_generation=my_generation)
                         # _do_auto_compact's summary call is slow; unlike the
                         # mid-turn siblings this site also PERSISTS the resume
                         # turn, so re-check the generation didn't change during
@@ -4680,7 +4791,7 @@ class ChatSession:
                 # orphaned thread can't replace history under the active one.
                 pre_attempted_compact = False
                 if self._generation == my_generation and self._compaction_owed():
-                    self._do_auto_compact("mid-turn", preserve_tail=1)
+                    self._do_auto_compact("mid-turn", preserve_tail=1, my_generation=my_generation)
                     pre_attempted_compact = True
                 truncation_budget = self._remaining_token_budget()
                 _truncated: dict[str, str] = {}
@@ -4882,7 +4993,7 @@ class ChatSession:
                 # bounded the batch, and the next iteration / end-of-turn
                 # re-checks.
                 if not pre_attempted_compact:
-                    self._maybe_compact_midturn()
+                    self._maybe_compact_midturn(my_generation)
         except GenerationCancelled:
             # If a newer send() has started (force cancel), this thread is
             # orphaned — skip all message mutations and state changes.
@@ -4959,6 +5070,15 @@ class ChatSession:
             # an idle session until the next send.  Restores the "None outside a
             # send" invariant on every exit (success, cancel, or error).
             self._wire_part_cache = None
+            # Consume this generation's cancel signal on exit so a cancel that
+            # targeted THIS send can't later abort an unrelated idle operation
+            # (e.g. a manual /compact between sends would otherwise inherit the
+            # still-set event).  Only when still the active generation — a newer
+            # send owns a fresh event we must not clear out from under it.  This is
+            # why a manual /compact no longer needs to reset the event itself
+            # (which would have disarmed a cancel aimed at a concurrent send).
+            if self._generation == my_generation:
+                self._cancel_event.clear()
 
     def _drain_pending_advisories(self) -> None:
         """Drop every pending nudge regardless of channel.
@@ -5044,8 +5164,22 @@ class ChatSession:
     # -- Rewind / retry -------------------------------------------------------
 
     def _find_turn_boundaries(self) -> list[int]:
-        """Return indices of user messages in self.messages (turn start positions)."""
-        return [i for i, m in enumerate(self.messages) if m.role is Role.USER]
+        """Return indices of real user messages in self.messages (turn starts).
+
+        Excludes the synthetic ``[Conversation summary]`` user turn that
+        :meth:`_compact_messages` injects ahead of a summary.  It is a compaction
+        artifact, not a real turn: as a retry/rewind target it would re-send the
+        bare label and regenerate over it (clobbering the summary), and as the
+        pre-send ``preserve_tail`` anchor it would preserve the label instead of
+        the real question.  (A user who literally types the label leaves no real
+        boundary — retry/rewind then correctly no-op, and the pre-send caller's
+        own ``else`` fallback keeps the trailing turn.)
+        """
+        return [
+            i
+            for i, m in enumerate(self.messages)
+            if m.role is Role.USER and (m.text or "") != COMPACTION_SUMMARY_LABEL
+        ]
 
     def _persist_truncation(self, removed_count: int) -> None:
         """Mirror a rewind/retry tail-trim into storage, compaction-safe.
@@ -5900,6 +6034,11 @@ class ChatSession:
         Only used for a lone block that can't fit any batch — the one lossy path
         in chunked compaction.  The result is always ``<= budget``.
         """
+        if len(block) <= budget:
+            # Already fits — return as-is.  Without this, a budget wider than the
+            # block makes the head slice ``block[:head]`` and tail slice
+            # ``block[-tail:]`` overlap and DUPLICATE content around the marker.
+            return block
         marker = "\n…[truncated]…\n"
         if budget <= len(marker):
             return block[:budget]
@@ -5967,10 +6106,9 @@ class ChatSession:
                 break
             except Exception as e:
                 ename = type(e).__name__
-                if (
-                    ename not in self._provider.retryable_error_names
-                    or attempt == self._MAX_RETRIES
-                ):
+                if self._stop_retrying(e, attempt, self._provider):
+                    # Overflow is deterministic — let _summarize_batch subdivide
+                    # instead of retrying an identical oversized call.
                     raise
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
                 self.ui.on_info(f"[Compact retrying in {delay:.0f}s: {ename}]")
@@ -5984,46 +6122,111 @@ class ChatSession:
 
     def _summarize_blocks(self, blocks: list[str], *, depth: int = 0) -> str:
         """Summarize ``blocks`` into one dense summary, chunking + recursing so no
-        single model call exceeds :meth:`_summary_input_budget_chars`.
+        single model call exceeds the model window.
 
-        Base case (everything fits one batch) is a single :meth:`_summarize_once`
-        call — exactly today's behavior, so the common case stays one model call.
-        Otherwise each batch is summarized individually (a partial summary) and the
-        partials are recursively merged one level deeper, until they collapse to a
-        single batch.
+        Blocks are packed to the char budget (:meth:`_summary_input_budget_chars`)
+        and each batch is summarized; the partials are recursively merged one level
+        deeper until they collapse to a single summary.  That char budget is only an
+        *estimate* — it divides by the uncalibrated ``_chars_per_token`` (which sits
+        at an optimistic 4.0 on resume) — so a batch that fits by chars can still
+        overflow the *token* window.  :meth:`_summarize_batch` absorbs that: an
+        over-window multi-block batch is split in half and each half summarized
+        (recursing as needed), then the partials merged (chunking, not truncation),
+        and only a lone block that overflows by itself is head/tail-truncated.
 
-        Raises :class:`_CompactionIrreducibleError` when a level fails to reduce the
-        block count (``len(batches) >= len(blocks)``) or recursion would exceed
-        ``_MAX_SUMMARY_DEPTH`` — the caller turns that into a ``return False`` bail
-        rather than fabricate a summary.
+        Bails with :class:`_CompactionIrreducibleError` only at the recursion
+        ceiling ``_MAX_SUMMARY_DEPTH`` (or when a floored lone block still overflows)
+        — the caller turns that into a ``return False`` rather than fabricate a
+        summary.
         """
-        batches = self._pack_blocks(blocks, self._summary_input_budget_chars())
         system_prompt = (
             self._COMPACTOR_SYSTEM_PROMPT if depth == 0 else self._COMPACTOR_MERGE_SYSTEM_PROMPT
         )
-        if len(batches) == 1:
-            return self._summarize_once(system_prompt, "\n\n".join(batches[0]))
-
-        # More than one batch: bail rather than loop or over-recurse when this
-        # level can't shrink the count (each block is its own batch) or we've gone
-        # too deep.
-        if len(batches) >= len(blocks) or depth >= self._MAX_SUMMARY_DEPTH:
+        # Recursion ceiling FIRST — before packing and the single-batch base case —
+        # so it also bounds the per-block-split merge, which can re-pack into one
+        # batch and would otherwise recurse without ever consulting the ceiling.
+        if depth >= self._MAX_SUMMARY_DEPTH:
             raise _CompactionIrreducibleError
+        batches = self._pack_blocks(blocks, self._summary_input_budget_chars())
+        if len(batches) == 1:
+            return self._summarize_batch(system_prompt, batches[0], depth)
 
+        # More than one batch: recurse-merge the per-batch summaries.  A block-count
+        # guard would be wrong here — _summarize_batch's binary subdivision can
+        # legitimately leave one batch per block — so termination rides the depth
+        # ceiling above plus the progressive-shrink-to-floor bail in _summarize_batch.
         total = len(batches)
         summaries: list[str] = []
         for k, batch in enumerate(batches, start=1):
             self.ui.on_info(f"[compacting part {k}/{total}…]")
-            summaries.append(self._summarize_once(system_prompt, "\n\n".join(batch)))
+            summaries.append(self._summarize_batch(system_prompt, batch, depth))
         return self._summarize_blocks(summaries, depth=depth + 1)
 
-    def _compact_messages(self, auto: bool = False, preserve_tail: int = 0) -> bool:
+    def _summarize_batch(self, system_prompt: str, batch: list[str], depth: int) -> str:
+        """Summarize one packed batch, subdividing on a token-window overflow.
+
+        The char budget that produced ``batch`` is only an estimate, so the model
+        call can overflow the real token window.  When a multi-block batch overflows,
+        it is split in HALF and each half summarized (recursing if a half still
+        overflows), then the two partials merged — binary subdivision, so an
+        over-window batch of N blocks costs ~log2(N) levels and a near-optimal number
+        of leaf calls, NOT N per-block calls (which on a wide rehydrated resume meant
+        hundreds of serial summaries).  A lone block that overflows even by itself is
+        head/tail-truncated progressively (halving the budget down to the floor, the
+        single-block analogue of the binary subdivision above) so it keeps as much as
+        the window allows; only if even the floor still overflows is the window too
+        small to compact anything and we bail irreducible.
+        """
+        # Cooperative cancellation: a cancel mid-compaction aborts here.  It raises
+        # GenerationCancelled (a BaseException), so _compact_messages' ``except
+        # Exception`` can't swallow it and the message-swap below never runs — the
+        # history is left untouched.
+        self._check_cancelled()
+        try:
+            return self._summarize_once(system_prompt, "\n\n".join(batch))
+        except Exception as e:
+            if not _is_ctx_overflow(e):
+                raise
+            if len(batch) > 1:
+                # Token-overflow despite the char budget: split the batch in HALF
+                # and summarize each (each half recurses + halves again if it still
+                # overflows), then merge.  Binary subdivision keeps each leaf as full
+                # as fits — a wide over-window batch costs ~log2(N) calls, not one
+                # model call per block.
+                mid = len(batch) // 2
+                left = self._summarize_batch(system_prompt, batch[:mid], depth)
+                right = self._summarize_batch(system_prompt, batch[mid:], depth)
+                return self._summarize_blocks([left, right], depth=depth + 1)
+            # A lone block overflows by itself: the char budget over-estimated how
+            # many tokens it holds.  Shrink progressively — halve the truncation
+            # budget and retry, keeping as much of the message as the real window
+            # allows — mirroring the multi-block binary subdivision above rather than
+            # slamming straight to the 2 000-char floor (which would discard far more
+            # than the window actually forces).  Bail irreducible only once even the
+            # floor still overflows.
+            budget = max(self._MIN_SUMMARY_BUDGET_CHARS, len(batch[0]) // 2)
+            while True:
+                try:
+                    return self._summarize_once(
+                        system_prompt, self._truncate_block(batch[0], budget)
+                    )
+                except Exception as e2:
+                    if not _is_ctx_overflow(e2):
+                        raise
+                    if budget <= self._MIN_SUMMARY_BUDGET_CHARS:
+                        raise _CompactionIrreducibleError from e2
+                    budget = max(self._MIN_SUMMARY_BUDGET_CHARS, budget // 2)
+
+    def _compact_messages(
+        self, auto: bool = False, preserve_tail: int = 0, my_generation: int = 0
+    ) -> bool:
         """Compact conversation history by summarizing it into a summary turn.
 
-        Summarizes the whole selection via :meth:`_summarize_blocks`, which chunks
-        and recursively merges so no single summary call exceeds the model's own
-        window (:meth:`_summary_input_budget_chars`) — the summary call can't
-        overflow, and the most-recent messages are no longer silently dropped.
+        Summarizes the whole selection via :meth:`_summarize_blocks`, which packs
+        to the char-budget estimate and, when a batch still overflows the real token
+        window, binary-subdivides it (:meth:`_summarize_batch`) — so the summary call
+        recovers from an under-estimate by chunking rather than overflowing, and the
+        most-recent messages are no longer silently dropped.
 
         When auto=True (triggered by context limit), appends a continuation
         hint with the last user message so the model can resume seamlessly.
@@ -6042,20 +6245,28 @@ class ChatSession:
             self.ui.on_info("Not enough messages to compact.")
             return False
 
-        # Find the last user message for the continuation hint
-        last_user_content = None
-        if auto:
-            for m in reversed(self.messages):
-                if m.role is Role.USER:
-                    last_user_content = m.text or ""
-                    break
-
         # Optionally keep the last ``preserve_tail`` messages verbatim — e.g. an
-        # in-flight assistant tool-call whose results are about to be appended —
-        # so compacting them away can't orphan a tool result.  Re-appended after
-        # the summary, below.
+        # in-flight assistant tool-call whose results are about to be appended, or
+        # the just-sent user turn on the pre-send path — so compacting them away
+        # can't orphan a tool result or drop the current question.  Re-appended
+        # after the summary, below.
         preserved = self.messages[-preserve_tail:] if preserve_tail > 0 else []
         to_summarize = self.messages[:-preserve_tail] if preserve_tail > 0 else self.messages
+
+        # Continuation hint: re-inject the user's last REAL message ONLY when it is
+        # being summarized away.  When preserve_tail keeps it verbatim (the pre-send
+        # path), the preserved tail already carries it — adding the hint would
+        # duplicate the message and frame a fresh ask as "continue where we left
+        # off".  Use _find_turn_boundaries so the synthetic [Conversation summary]
+        # turn is excluded: when an already-compacted history is re-compacted, the
+        # last "user" turn is that label, and quoting it would hand the model a
+        # content-free "The user's last message was: [Conversation summary]".
+        last_user_content = None
+        if auto:
+            split = len(to_summarize)  # preserved == self.messages[split:]
+            real_users = self._find_turn_boundaries()
+            if real_users and real_users[-1] < split:  # summarized, not preserved
+                last_user_content = self.messages[real_users[-1]].text or ""
 
         # Build summary blocks from ALL of to_summarize (per-message), then
         # summarize via chunked/hierarchical compaction.  Sizing by the actual
@@ -6096,6 +6307,15 @@ class ChatSession:
                 f"The user's last message was: {last_user_content}\n"
                 f"Continue assisting from where we left off."
             )
+
+        # Honor a cancel — or a newer generation that superseded this send DURING
+        # the (possibly only, possibly slow) summary call — before we mutate state.
+        # GenerationCancelled is a BaseException, so it propagates past the
+        # except-clauses above and leaves self.messages untouched.  Passing
+        # my_generation here is what stops an orphaned send from swapping the live
+        # generation's history after its summary call returns (the event arm alone
+        # can't see it: a newer send installed a fresh, clear event).
+        self._check_cancelled(my_generation)
 
         # Replace messages — summary, then any preserved tail verbatim.
         before_tokens = self._system_tokens + sum(self._msg_tokens) + self._tool_def_tokens()
@@ -12538,10 +12758,9 @@ class ChatSession:
                     return agent_result
                 except Exception as e:
                     ename = type(e).__name__
-                    if (
-                        ename not in agent_provider.retryable_error_names
-                        or attempt == self._MAX_RETRIES
-                    ):
+                    if self._stop_retrying(e, attempt, agent_provider):
+                        # Overflow is deterministic — raise straight to the
+                        # context-limit handler below, no backoff.
                         raise
                     last_err = e
                     delay = self._RETRY_BASE_DELAY * (2**attempt)
@@ -12556,15 +12775,26 @@ class ChatSession:
             try:
                 result = _api_call(agent_turns)
             except Exception as e:
-                # Context-exceeded or other non-retryable API error.
-                # Return what we have so far rather than crashing.
-                err_str = str(e).lower()
-                if "context" in err_str or "token" in err_str:
+                # Terminal API error: overflow, or any non-retryable error that
+                # escaped the retry loop above.  Salvage the sub-agent's partial work
+                # rather than crash the whole task — losing a substantial synthesis to
+                # a late failure is worse than returning it with a note.  (This must
+                # NOT be narrowed to overflow only: a non-overflow terminal error used
+                # to be salvaged too, via the old "context"/"token" text gate, and
+                # narrowing it discarded partial work on e.g. a persistent timeout.)
+                # GenerationCancelled is a BaseException, so a real cancel still
+                # propagates past this ``except Exception``.
+                overflow = _is_ctx_overflow(e)
+                note = "context limit reached" if overflow else f"error ({type(e).__name__})"
+                for t in reversed(agent_turns):
+                    if t.role is Role.ASSISTANT and t.text:
+                        self.ui.on_info(f"[{label}] {note}, returning partial work")
+                        return self._guard_subagent_synthesis(t.text, label)
+                # No partial work to salvage: surface overflow as a calm stop message,
+                # but re-raise any other terminal error so the real failure isn't
+                # masked as an empty success.
+                if overflow:
                     self.ui.on_info(f"[{label}] context limit reached, stopping early")
-                    # Find the last assistant content we have
-                    for t in reversed(agent_turns):
-                        if t.role is Role.ASSISTANT and t.text:
-                            return self._guard_subagent_synthesis(t.text, label)
                     return f"({label} stopped: context limit exceeded)"
                 raise
 
@@ -14143,7 +14373,13 @@ class ChatSession:
                     self.ui.on_info(f"Invalid. Choose from: {', '.join(valid)}")
 
         elif cmd == "/compact":
-            self._compact_messages()
+            try:
+                self._compact_messages()
+            except GenerationCancelled:
+                # Ctrl-C during a manual compaction aborts cleanly — the message
+                # swap never ran (the cancel-check precedes it), so history is
+                # intact, exactly like cancelling a send.
+                self.ui.on_info("Compaction cancelled.")
 
         elif cmd == "/creative":
             self.creative_mode = not self.creative_mode


### PR DESCRIPTION
## Problem

You can't resume an openai-compatible session on an anthropic-compatible model: a session created under the openai-compatible provider and resumed under the anthropic-compatible provider (same vLLM model) failed with an opaque `InternalError` instead of recovering.

**Root cause (verified live against vLLM, deepseek-v4-flash):** a context-window overflow is returned as **HTTP 400 `BadRequestError` on `/v1/chat/completions`** but **HTTP 500 `InternalServerError` on `/v1/messages`**. On resume the rehydrated payload overflowed the window; the 500 was retried four times (because `InternalServerError` is in the retryable set) and then surfaced as a bare class name with no hint that the prompt was simply too large. On the openai-compatible path the same overflow is a clean 400, which is why it only blew up on the anthropic-compatible path.

This is the proactive-pre-send companion to #731 (which fixed the resume rehydration deadlock via a persisted compaction checkpoint).

## What changed (`turnstone/core/session.py`)

- **Status-agnostic overflow detection** — `_is_ctx_overflow` matches by message *text*, not exception class, so the same overflow is recognized whether it arrives as a 400 or a 500. Single definition shared across the fatal-error formatter, both stream-retry gates, the send-loop recovery, the chunker, and the task_agent loop. Overflow is treated as non-retryable (deterministic — no point burning backoff). Phrasing is overflow-specific so a token-quota rate-limit isn't misclassified.
- **Proactive pre-send compaction (Layer A)** — when a send is already over the hard ceiling (e.g. a rehydrated resume, or a switch to a smaller-context model with no prior compaction), compact once before the first stream so the request doesn't go out blind. Generation-guarded end to end so an orphaned/superseded send can never swap the live generation's history.
- **Binary-subdivision chunker** — an over-window summary batch is split in half and the partials merged (~log2(N) calls, not one per block, which on a wide resume meant hundreds of serial summaries). A lone over-window block is truncated progressively down to a floor before bailing irreducible.
- **Cooperative cancellation** through compaction; `send()` consumes its own generation's cancel signal on exit, so a stale cancel can't block a later idle `/compact` and a live cancel is never disarmed.
- **Clearer fatal message** — `_format_backend_error` surfaces "Context window exceeded …" instead of an opaque `InternalServerError`, and only for unrecognized exception classes.
- **Synthetic summary turn is never targeted** — retry, rewind, the continuation hint, and title generation all exclude the `[Conversation summary]` turn so they can't re-send or title from the bare label.
- **task_agent partial-work salvage** — a sub-agent's partial work is returned on any terminal error (not overflow only), re-raising only when there is nothing to salvage.

## Testing

- New/expanded coverage in `tests/test_cooperative_compaction.py`, `tests/test_session.py`, and `tests/test_session_backend_error_format.py`: overflow detection, the binary-subdivision and progressive-shrink chunker paths, pre-send preserve-tail, the generation-guarded swap (history-corruption regression guard), cooperative cancellation, the manual-`/compact` cancel lifecycle, retry/rewind/hint/title summary-turn exclusion, and the task_agent salvage paths.
- 899 relevant tests pass (cooperative, backend-error, session, rewind/retry, compaction-checkpoint, tool-truncation, providers, cancel, coordinator); ruff + mypy clean.
- Live-verified against vLLM: a real overflow is detected and recovered; a rate-limit is not misclassified.

## Review

Five remediation rounds, including three workflow-backed max-effort reviews. The last round caught and fixed a history-corruption regression (the pre-send layer initially sat ahead of the generation guard), a cancel-disarm in manual `/compact`, two more consumers of the summary-turn label, and a narrowed task_agent salvage gate — each now has a regression test.
