### PR TITLE
Fix/mcp dead transport followup

### DIFF
--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -1936,3 +1936,27 @@ class TestInternalMcpStatusEndpoint:
         r = c.get("/v1/api/_internal/mcp-status")
         assert r.status_code == 200
         assert r.json() == {"servers": {}}
+
+    def test_status_aggregate_gated_on_admin_mcp_permission(self, storage: SQLiteBackend) -> None:
+        """oauth_user status is cross-user-aggregated ONLY for callers holding
+        admin.mcp (the console cluster-health view). A read/approve user without
+        it gets aggregate=False — strictly their own pool, the leak guard."""
+
+        def _aggregate_arg(middleware_cls: type) -> Any:
+            mgr = MagicMock()
+            mgr.get_all_server_status.return_value = {}
+            app = Starlette(
+                routes=_routes_with_internal(),
+                middleware=[Middleware(middleware_cls)],
+            )
+            app.state.auth_storage = storage
+            app.state.mcp_client = mgr
+            client = TestClient(app, raise_server_exceptions=False)
+            assert client.get("/v1/api/_internal/mcp-status").status_code == 200
+            return mgr.get_all_server_status.call_args
+
+        admin_call = _aggregate_arg(_InjectAuthMiddleware)
+        assert admin_call.kwargs.get("aggregate") is True
+
+        user_call = _aggregate_arg(_InjectAuthNoMcpMiddleware)
+        assert user_call.kwargs.get("aggregate") is False

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2742,13 +2742,19 @@ class TestIsDeadTransport:
             McpError(ErrorData(code=-32603, message="Backend session not found"))
         )
 
-    def test_app_session_terminated_superstring_is_not_dead(self):
-        """#2 regression: only the SDK's EXACT 'Session terminated' message (or
-        its 32600 code) is transport death — an application message that merely
-        CONTAINS those words stays a protocol rejection."""
+    def test_app_session_terminated_message_is_not_dead(self):
+        """#8 regression: the message is application-controlled and is NOT matched
+        — only the SDK's synthesized code 32600 is. A healthy session-owning
+        server that returns a protocol error whose message is EXACTLY 'Session
+        terminated' (or a superstring) with a normal code stays breaker-safe."""
         from mcp import McpError
         from mcp.types import ErrorData
 
+        # Exact SDK message but an app protocol code (not 32600) — must NOT be dead.
+        assert not _is_dead_transport(
+            McpError(ErrorData(code=-32603, message="Session terminated"))
+        )
+        # Superstring likewise.
         assert not _is_dead_transport(
             McpError(ErrorData(code=-32603, message="Player session terminated by host"))
         )
@@ -2768,10 +2774,15 @@ class TestIsDeadTransport:
         assert not issubclass(httpx.ReadTimeout, TimeoutError)  # premise guard
         assert _is_dead_transport(httpx.ReadTimeout("read timed out"))
 
-    def test_httpx_pool_timeout_is_dead(self):
+    def test_httpx_pool_timeout_is_not_dead(self):
+        """PoolTimeout is connection-pool saturation, NOT a dead connection:
+        evicting the session can't relieve pool pressure and would trip the
+        shared breaker for all users under transient load. The Connect/Read/Write
+        timeouts (a dead/hung connection) stay dead."""
         import httpx
 
-        assert _is_dead_transport(httpx.PoolTimeout("pool timed out"))
+        assert not _is_dead_transport(httpx.PoolTimeout("pool exhausted"))
+        assert _is_dead_transport(httpx.WriteTimeout("write timed out"))
 
     def test_httpx_read_error_is_dead(self):
         """#8: a connection that dies mid-read surfaces as httpx.ReadError (a

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -17,6 +17,7 @@ from tests.conftest import _seed_static_state
 from turnstone.core.mcp_client import (
     MCPClientManager,
     _db_servers_to_config,
+    _is_dead_transport,
     _mcp_to_openai,
     load_mcp_config,
 )
@@ -2613,6 +2614,188 @@ class TestCircuitBreaker:
             assert outcome == "error:ClosedResourceError"
 
         asyncio.run(_run())
+
+    def test_read_resource_sync_dead_transport_evicts_and_trips_circuit(self):
+        """Regression (follow-up): read_resource_sync kept the old
+        BrokenPipe/ConnectionReset/EOF-only guard, so a dead streamable-http
+        transport surfacing as McpError(CONNECTION_CLOSED) reused the corpse
+        session forever — the exact restart-hang call_tool_sync already fixes.
+        It must now evict the session AND trip the breaker."""
+        from mcp import McpError
+        from mcp.types import CONNECTION_CLOSED, ErrorData
+
+        mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
+        mock_session = MagicMock()
+        _seed_static_state(mgr, "test", session=mock_session)
+        mgr._loop = MagicMock()
+        mgr._resource_map = {"file:///x": ("test", "file:///x")}
+        mock_future = MagicMock()
+        mock_future.result.side_effect = McpError(
+            ErrorData(code=CONNECTION_CLOSED, message="connection closed")
+        )
+        with (
+            patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
+            pytest.raises(McpError),
+        ):
+            mgr.read_resource_sync("file:///x", timeout=5)
+        assert mgr._static_servers["test"].session is None
+        assert mgr._consecutive_failures.get("test", 0) == 1
+
+    def test_read_resource_sync_protocol_mcperror_does_not_evict(self):
+        """A healthy protocol rejection (resource not found) must NOT evict the
+        session or trip the breaker on the resource path."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
+        mock_session = MagicMock()
+        _seed_static_state(mgr, "test", session=mock_session)
+        mgr._loop = MagicMock()
+        mgr._resource_map = {"file:///x": ("test", "file:///x")}
+        mock_future = MagicMock()
+        mock_future.result.side_effect = McpError(
+            ErrorData(code=-32602, message="resource not found")
+        )
+        with (
+            patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
+            pytest.raises(McpError),
+        ):
+            mgr.read_resource_sync("file:///x", timeout=5)
+        assert mgr._static_servers["test"].session is mock_session
+        assert mgr._consecutive_failures.get("test", 0) == 0
+
+    def test_get_prompt_sync_dead_transport_evicts_and_trips_circuit(self):
+        """Regression (follow-up): get_prompt_sync had the same corpse-reuse
+        bug as read_resource_sync. A dead transport (anyio.ClosedResourceError)
+        must evict the session AND trip the breaker."""
+        import anyio
+
+        mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
+        mock_session = MagicMock()
+        _seed_static_state(mgr, "test", session=mock_session)
+        mgr._loop = MagicMock()
+        mgr._prompt_map = {"mcp__test__p": ("test", "p")}
+        mock_future = MagicMock()
+        mock_future.result.side_effect = anyio.ClosedResourceError()
+        with (
+            patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
+            pytest.raises(anyio.ClosedResourceError),
+        ):
+            mgr.get_prompt_sync("mcp__test__p", timeout=5)
+        assert mgr._static_servers["test"].session is None
+        assert mgr._consecutive_failures.get("test", 0) == 1
+
+    def test_get_prompt_sync_protocol_mcperror_does_not_evict(self):
+        """A healthy protocol rejection must NOT evict on the prompt path."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
+        mock_session = MagicMock()
+        _seed_static_state(mgr, "test", session=mock_session)
+        mgr._loop = MagicMock()
+        mgr._prompt_map = {"mcp__test__p": ("test", "p")}
+        mock_future = MagicMock()
+        mock_future.result.side_effect = McpError(
+            ErrorData(code=-32602, message="prompt not found")
+        )
+        with (
+            patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
+            pytest.raises(McpError),
+        ):
+            mgr.get_prompt_sync("mcp__test__p", timeout=5)
+        assert mgr._static_servers["test"].session is mock_session
+        assert mgr._consecutive_failures.get("test", 0) == 0
+
+
+class TestIsDeadTransport:
+    """Direct unit tests for ``_is_dead_transport`` — the single shared gate
+    that decides 'tear down and rebuild the session' vs 'healthy protocol
+    rejection' across every session-use site."""
+
+    def test_connection_closed_is_dead(self):
+        from mcp import McpError
+        from mcp.types import CONNECTION_CLOSED, ErrorData
+
+        assert _is_dead_transport(
+            McpError(ErrorData(code=CONNECTION_CLOSED, message="connection closed"))
+        )
+
+    def test_sdk_session_terminated_is_dead(self):
+        """The streamable-http SDK synthesizes EXACTLY code=32600 /
+        'Session terminated' when a held mcp-session-id 404s after a server
+        restart — keyed off the code so it survives a message reword."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        assert _is_dead_transport(McpError(ErrorData(code=32600, message="Session terminated")))
+
+    def test_app_session_not_found_is_not_dead(self):
+        """#2 regression: a HEALTHY session-owning MCP server (game/shell)
+        rejecting a stale id with 'session not found' is a protocol error, NOT
+        transport death. The old bare-substring match wrongly evicted the live
+        session and tripped the shared breaker for every user."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        assert not _is_dead_transport(
+            McpError(ErrorData(code=-32603, message="Backend session not found"))
+        )
+
+    def test_app_session_terminated_superstring_is_not_dead(self):
+        """#2 regression: only the SDK's EXACT 'Session terminated' message (or
+        its 32600 code) is transport death — an application message that merely
+        CONTAINS those words stays a protocol rejection."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        assert not _is_dead_transport(
+            McpError(ErrorData(code=-32603, message="Player session terminated by host"))
+        )
+
+    def test_plain_protocol_mcperror_is_not_dead(self):
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        assert not _is_dead_transport(McpError(ErrorData(code=-32601, message="method not found")))
+
+    def test_httpx_read_timeout_is_dead(self):
+        """#7: an idle read timeout on a long-lived streamable-http stream is
+        the dominant idle-death mode — and is NOT a builtin TimeoutError, so it
+        must be caught here or it falls through to a healthy 'other'."""
+        import httpx
+
+        assert not issubclass(httpx.ReadTimeout, TimeoutError)  # premise guard
+        assert _is_dead_transport(httpx.ReadTimeout("read timed out"))
+
+    def test_httpx_pool_timeout_is_dead(self):
+        import httpx
+
+        assert _is_dead_transport(httpx.PoolTimeout("pool timed out"))
+
+    def test_httpx_read_error_is_dead(self):
+        """#8: a connection that dies mid-read surfaces as httpx.ReadError (a
+        NetworkError sibling of the already-handled ConnectError)."""
+        import httpx
+
+        assert _is_dead_transport(httpx.ReadError("peer reset"))
+
+    def test_httpx_write_error_is_dead(self):
+        import httpx
+
+        assert _is_dead_transport(httpx.WriteError("broken pipe"))
+
+    def test_httpx_local_protocol_error_is_not_dead(self):
+        """LocalProtocolError is OUR bug (a malformed request we built), not a
+        dead peer — it must NOT be mistaken for transport death."""
+        import httpx
+
+        assert not _is_dead_transport(httpx.LocalProtocolError("bad header"))
+
+    def test_anyio_closed_resource_is_dead(self):
+        import anyio
+
+        assert _is_dead_transport(anyio.ClosedResourceError())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1695,18 +1695,20 @@ class TestPoolPrimingAndTokenRotation:
         assert store.get_user_token("user-1", "pool-srv") is not None
 
     @pytest.mark.anyio
-    async def test_non_destructive_resolve_keeps_dead_grant_default_revokes(
+    async def test_prime_revokes_permanent_but_defers_ambiguous_escalation(
         self, storage: SQLiteBackend
     ) -> None:
-        """Priming resolves with revoke_on_dead_grant=False, so a PERMANENT refresh
-        rejection (invalid_grant) must KEEP the token — the authoritative revoke is
-        deferred to lazy dispatch. Drives the REAL get_user_access_token_classified
-        (only the AS round-trip is stubbed), pinning both directions of the gate the
-        prior prime test left mocked-out."""
+        """Priming resolves with revoke_ambiguous_escalation=False. A PERMANENT
+        rejection (invalid_grant — a reliable dead-grant signal) is STILL revoked
+        so the catalog isn't stranded cold behind a phantom 'consented' token;
+        only a sustained-UNCLASSIFIABLE (ambiguous) escalation is deferred to lazy
+        dispatch. Drives the REAL resolver (only the AS round-trip is stubbed)."""
         from unittest.mock import patch
 
         from turnstone.core.mcp_oauth import (
+            _AMBIGUOUS_ESCALATION_THRESHOLD,
             MCPOAuthRefreshFailed,
+            _refresh_backoff_state,
             _RefreshFailureClass,
             get_user_access_token_classified,
         )
@@ -1714,41 +1716,74 @@ class TestPoolPrimingAndTokenRotation:
         cipher = make_mcp_token_cipher()
         _seed_oauth_server(storage, name="srv-oauth")
         state = _make_app_state(storage, cipher=cipher)
-        # Expired token WITH a refresh token → reaches the refresh path (not the
-        # expired-no-refresh shortcut), where a PERMANENT failure would revoke.
-        _seed_user_token(
-            storage, cipher, user_id="user-1", server_name="srv-oauth", expires_in_seconds=-10
-        )
         store = MCPTokenStore(storage, cipher, node_id="test")
 
-        async def _permanent_fail(**_kwargs: Any) -> tuple[str, str | None, str | None]:
-            raise MCPOAuthRefreshFailed(
-                "invalid_grant", failure_class=_RefreshFailureClass.PERMANENT
+        def _raiser(cls: _RefreshFailureClass) -> Any:
+            async def _f(**_kwargs: Any) -> tuple[str, str | None, str | None]:
+                raise MCPOAuthRefreshFailed("boom", failure_class=cls)
+
+            return _f
+
+        def _seed(uid: str) -> None:
+            # Expired-with-refresh so each resolve reaches the refresh path.
+            _seed_user_token(
+                storage, cipher, user_id=uid, server_name="srv-oauth", expires_in_seconds=-10
             )
 
-        with patch("turnstone.core.mcp_oauth._refresh_and_persist", side_effect=_permanent_fail):
-            kept = await get_user_access_token_classified(
+        # (1) PERMANENT during prime → REVOKED (genuinely dead → clean re-consent).
+        _seed("perm-user")
+        with patch(
+            "turnstone.core.mcp_oauth._refresh_and_persist",
+            side_effect=_raiser(_RefreshFailureClass.PERMANENT),
+        ):
+            perm = await get_user_access_token_classified(
                 app_state=state,
-                user_id="user-1",
+                user_id="perm-user",
                 server_name="srv-oauth",
-                revoke_on_dead_grant=False,
+                revoke_ambiguous_escalation=False,
             )
-        assert kept.kind == "refresh_failed_transient"
-        assert store.get_user_token("user-1", "srv-oauth") is not None, (
-            "non-destructive prime must NOT delete a grant on a permanent refresh "
-            "failure — the revoke is deferred to lazy dispatch"
+        assert perm.kind == "refresh_failed"
+        assert store.get_user_token("perm-user", "srv-oauth") is None, (
+            "prime must revoke a PERMANENT (reliably-dead) grant, not strand it cold"
         )
 
-        # Control: the DEFAULT (lazy-dispatch) resolve still revokes the same grant.
-        with patch("turnstone.core.mcp_oauth._refresh_and_persist", side_effect=_permanent_fail):
-            revoked = await get_user_access_token_classified(
+        # (2) AMBIGUOUS escalation during prime → DEFERRED (token KEPT).
+        _seed("amb-user")
+        _refresh_backoff_state(state, "amb-user", "srv-oauth").ambiguous_streak = (
+            _AMBIGUOUS_ESCALATION_THRESHOLD - 1
+        )
+        with patch(
+            "turnstone.core.mcp_oauth._refresh_and_persist",
+            side_effect=_raiser(_RefreshFailureClass.AMBIGUOUS),
+        ):
+            amb = await get_user_access_token_classified(
                 app_state=state,
-                user_id="user-1",
+                user_id="amb-user",
+                server_name="srv-oauth",
+                revoke_ambiguous_escalation=False,
+            )
+        assert amb.kind == "refresh_failed_transient"
+        assert store.get_user_token("amb-user", "srv-oauth") is not None, (
+            "prime must DEFER (not revoke) a sustained-ambiguous escalation"
+        )
+
+        # (3) Control: lazy dispatch (default) DOES escalate-revoke the same.
+        _seed("amb-lazy")
+        _refresh_backoff_state(state, "amb-lazy", "srv-oauth").ambiguous_streak = (
+            _AMBIGUOUS_ESCALATION_THRESHOLD - 1
+        )
+        with patch(
+            "turnstone.core.mcp_oauth._refresh_and_persist",
+            side_effect=_raiser(_RefreshFailureClass.AMBIGUOUS),
+        ):
+            lazy = await get_user_access_token_classified(
+                app_state=state,
+                user_id="amb-lazy",
                 server_name="srv-oauth",
             )
-        assert revoked.kind == "refresh_failed"
-        assert store.get_user_token("user-1", "srv-oauth") is None, (
-            "default (lazy-dispatch) resolve must still revoke a permanently-dead grant"
+        assert lazy.kind == "refresh_failed"
+        assert store.get_user_token("amb-lazy", "srv-oauth") is None, (
+            "lazy dispatch must still escalate-revoke a sustained-ambiguous grant"
         )
 
     def test_prime_user_pools_skips_already_connected(
@@ -2041,6 +2076,22 @@ class TestOAuthUserServerStatus:
 
         # Non-aggregate stays strictly per-user (no cross-user disclosure).
         assert mgr.get_server_status("pool-srv", user_id="user-B")["connected"] is False
+
+    def test_public_server_status_uses_aggregate_for_operator_endpoints(self) -> None:
+        """#1 regression: the approve-scoped operator refresh/reconnect endpoints
+        (_public_server_status) must report a warm oauth_user server as connected
+        via the aggregate view — not the per-user default (user_id=None), which
+        would render every in-use oauth_user server disconnected/empty right after
+        a successful refresh."""
+        from turnstone.server import _public_server_status
+
+        mgr = MCPClientManager({})
+        mgr._oauth_user_server_names = {"pool-srv"}
+        self._warm(mgr, "user-A", "pool-srv", n_tools=2)
+
+        status = _public_server_status(mgr, "pool-srv")
+        assert status["connected"] is True
+        assert status["tools"] == 2
 
 
 # Suppress unused-import warning for AsyncMock.

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1953,34 +1953,71 @@ class TestPoolPrimingAndTokenRotation:
 
 
 class TestOAuthUserServerStatus:
-    """``get_server_status`` for ``auth_type='oauth_user'`` servers reflects
-    per-user pool warmth instead of a permanent global "connecting" — so the
-    console pill flips to connected once a pool is primed (the third leg of the
-    OBO fix set)."""
+    """``get_server_status`` for ``auth_type='oauth_user'`` servers reflects the
+    REQUESTING user's pool warmth (scoped by user_id), never another user's — so
+    the console pill flips to connected once that user's pool is primed, without
+    leaking one user's catalog to another."""
 
-    def test_oauth_user_status_connected_when_pool_warm(self) -> None:
+    @staticmethod
+    def _warm(mgr: MCPClientManager, user_id: str, server: str, n_tools: int = 1) -> None:
         from turnstone.core.mcp_client import PoolEntryState
 
+        entry = PoolEntryState(key=(user_id, server), open_lock=MagicMock())
+        entry.session = MagicMock()
+        entry.tools = [{"function": {"name": f"mcp__{server}__t{i}"}} for i in range(n_tools)]
+        mgr._user_pool_entries[(user_id, server)] = entry
+
+    def test_oauth_user_status_connected_for_own_warm_pool(self) -> None:
         mgr = MCPClientManager({})
         mgr._oauth_user_server_names = {"pool-srv"}
-        entry = PoolEntryState(key=("user-1", "pool-srv"), open_lock=MagicMock())
-        entry.session = MagicMock()
-        entry.tools = [{"function": {"name": "mcp__pool-srv__do"}}]
-        mgr._user_pool_entries[("user-1", "pool-srv")] = entry
+        self._warm(mgr, "user-1", "pool-srv", n_tools=1)
 
-        st = mgr.get_server_status("pool-srv")
+        st = mgr.get_server_status("pool-srv", user_id="user-1")
         assert st["connected"] is True
         assert st["tools"] == 1
         assert st["auth_type"] == "oauth_user"
         assert st["user_pools"] == 1
         # Also surfaced in the all-servers map (oauth_user is absent from
         # _server_configs, so this exercises the explicit union).
-        assert "pool-srv" in mgr.get_all_server_status()
+        assert "pool-srv" in mgr.get_all_server_status(user_id="user-1")
+
+    def test_oauth_user_status_does_not_leak_other_users_pool(self) -> None:
+        """#4 regression: user B must NOT see user A's warm pool — neither the
+        connected flag nor the catalog count. Before scoping, status was derived
+        from warm[0] (an arbitrary user), leaking A's catalog size to B over the
+        read-scoped /mcp-status endpoint."""
+        mgr = MCPClientManager({})
+        mgr._oauth_user_server_names = {"pool-srv"}
+        self._warm(mgr, "user-A", "pool-srv", n_tools=5)
+
+        own = mgr.get_server_status("pool-srv", user_id="user-A")
+        assert own["connected"] is True
+        assert own["tools"] == 5
+
+        other = mgr.get_server_status("pool-srv", user_id="user-B")
+        assert other["connected"] is False, "user B must not see user A's pool as connected"
+        assert other["tools"] == 0, "user B must not see user A's catalog size"
+        assert other["user_pools"] == 0
+
+    def test_oauth_user_status_no_user_context_is_not_connected(self) -> None:
+        """A request with no user context (user_id falsy — e.g. an operator
+        refresh/reconnect) reports not-connected rather than an arbitrary
+        user's pool."""
+        mgr = MCPClientManager({})
+        mgr._oauth_user_server_names = {"pool-srv"}
+        self._warm(mgr, "user-A", "pool-srv", n_tools=3)
+
+        for uid in (None, ""):
+            st = mgr.get_server_status("pool-srv", user_id=uid)
+            assert st["connected"] is False, f"user_id={uid!r} must not see a pool"
+            assert st["tools"] == 0
+            assert st["user_pools"] == 0
+            assert st["auth_type"] == "oauth_user"
 
     def test_oauth_user_status_connecting_when_no_warm_pool(self) -> None:
         mgr = MCPClientManager({})
         mgr._oauth_user_server_names = {"pool-srv"}
-        st = mgr.get_server_status("pool-srv")
+        st = mgr.get_server_status("pool-srv", user_id="user-1")
         assert st["connected"] is False
         assert st["tools"] == 0
         assert st["user_pools"] == 0

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -2023,6 +2023,25 @@ class TestOAuthUserServerStatus:
         assert st["user_pools"] == 0
         assert st["auth_type"] == "oauth_user"
 
+    def test_oauth_user_status_aggregate_sees_any_user_pool(self) -> None:
+        """Admin cluster-health view (aggregate=True, gated on admin.mcp at the
+        endpoint): connected + a representative catalog reflect ANY user's warm
+        pool, so the operator "in use by anyone" pill works — while a non-admin
+        caller (aggregate=False) still sees only their own pool."""
+        mgr = MCPClientManager({})
+        mgr._oauth_user_server_names = {"pool-srv"}
+        self._warm(mgr, "user-A", "pool-srv", n_tools=4)
+
+        # Aggregate: a different (or absent) user still sees the server in use.
+        agg = mgr.get_server_status("pool-srv", user_id="user-B", aggregate=True)
+        assert agg["connected"] is True
+        assert agg["tools"] == 4
+        assert agg["user_pools"] == 1
+        assert mgr.get_server_status("pool-srv", user_id=None, aggregate=True)["connected"] is True
+
+        # Non-aggregate stays strictly per-user (no cross-user disclosure).
+        assert mgr.get_server_status("pool-srv", user_id="user-B")["connected"] is False
+
 
 # Suppress unused-import warning for AsyncMock.
 _ = AsyncMock

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1687,8 +1687,69 @@ class TestPoolPrimingAndTokenRotation:
 
         assert primed == [], "transient refresh failure must not warm the pool"
         # The token row must survive — priming must never revoke on a transient blip.
+        # NOTE: the resolver is stubbed here, so this only covers _prime_user_pools'
+        # handling of a transient result; the actual revoke-vs-keep decision under
+        # the flag prime passes is exercised by
+        # test_non_destructive_resolve_keeps_dead_grant_default_revokes below.
         store = MCPTokenStore(storage, cipher, node_id="test")
         assert store.get_user_token("user-1", "pool-srv") is not None
+
+    @pytest.mark.anyio
+    async def test_non_destructive_resolve_keeps_dead_grant_default_revokes(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Priming resolves with revoke_on_dead_grant=False, so a PERMANENT refresh
+        rejection (invalid_grant) must KEEP the token — the authoritative revoke is
+        deferred to lazy dispatch. Drives the REAL get_user_access_token_classified
+        (only the AS round-trip is stubbed), pinning both directions of the gate the
+        prior prime test left mocked-out."""
+        from unittest.mock import patch
+
+        from turnstone.core.mcp_oauth import (
+            MCPOAuthRefreshFailed,
+            _RefreshFailureClass,
+            get_user_access_token_classified,
+        )
+
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="srv-oauth")
+        state = _make_app_state(storage, cipher=cipher)
+        # Expired token WITH a refresh token → reaches the refresh path (not the
+        # expired-no-refresh shortcut), where a PERMANENT failure would revoke.
+        _seed_user_token(
+            storage, cipher, user_id="user-1", server_name="srv-oauth", expires_in_seconds=-10
+        )
+        store = MCPTokenStore(storage, cipher, node_id="test")
+
+        async def _permanent_fail(**_kwargs: Any) -> tuple[str, str | None, str | None]:
+            raise MCPOAuthRefreshFailed(
+                "invalid_grant", failure_class=_RefreshFailureClass.PERMANENT
+            )
+
+        with patch("turnstone.core.mcp_oauth._refresh_and_persist", side_effect=_permanent_fail):
+            kept = await get_user_access_token_classified(
+                app_state=state,
+                user_id="user-1",
+                server_name="srv-oauth",
+                revoke_on_dead_grant=False,
+            )
+        assert kept.kind == "refresh_failed_transient"
+        assert store.get_user_token("user-1", "srv-oauth") is not None, (
+            "non-destructive prime must NOT delete a grant on a permanent refresh "
+            "failure — the revoke is deferred to lazy dispatch"
+        )
+
+        # Control: the DEFAULT (lazy-dispatch) resolve still revokes the same grant.
+        with patch("turnstone.core.mcp_oauth._refresh_and_persist", side_effect=_permanent_fail):
+            revoked = await get_user_access_token_classified(
+                app_state=state,
+                user_id="user-1",
+                server_name="srv-oauth",
+            )
+        assert revoked.kind == "refresh_failed"
+        assert store.get_user_token("user-1", "srv-oauth") is None, (
+            "default (lazy-dispatch) resolve must still revoke a permanently-dead grant"
+        )
 
     def test_prime_user_pools_skips_already_connected(
         self, running_loop_mgr, storage: SQLiteBackend

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -147,15 +147,16 @@ _PRIME_MAX_CONCURRENCY = 4
 
 
 # ``mcp.client.streamable_http._send_session_terminated_error`` synthesizes this
-# (non-standard, POSITIVE) JSON-RPC code + message *client-side* when a held
+# (non-standard, POSITIVE) JSON-RPC code *client-side* when a held
 # ``mcp-session-id`` 404s after the MCP server restarted and dropped its session
 # map. It is NOT a documented MCP constant, and the SDK deliberately discards the
-# server's own 404 body ("Session not found", code ``-32600``) — so both are
-# pinned here, greppable for the next SDK bump. No spec-compliant server emits a
-# POSITIVE 32600, which is exactly what makes the code a safe dead-transport
-# signal to key off.
+# server's own 404 body ("Session not found", code ``-32600``) — so it is pinned
+# here, greppable for the next SDK bump. No spec-compliant server emits a POSITIVE
+# 32600, which is what makes the code a safe, deterministic dead-transport signal
+# to key off. The application-controlled message is NOT matched: a healthy
+# session-owning server can legitimately return a protocol error whose message is
+# "Session terminated".
 _SDK_SESSION_TERMINATED_CODE = 32600
-_SDK_SESSION_TERMINATED_MSG = "session terminated"
 
 
 def _is_dead_transport(exc: BaseException) -> bool:
@@ -174,20 +175,22 @@ def _is_dead_transport(exc: BaseException) -> bool:
     2. **Transport-swallowed** — the SDK's ``post_writer`` swallows the upstream
        error and the caller sees ``McpError(CONNECTION_CLOSED)`` (-32000); or the
        underlying httpx connection is gone / unrecoverable mid-exchange. Every
-       ``httpx.NetworkError`` ({Connect,Read,Write,Close}Error),
-       ``httpx.TimeoutException`` ({Connect,Read,Write,Pool}Timeout) and
-       ``httpx.RemoteProtocolError`` qualifies — notably a read/idle timeout on a
-       long-lived stream, which is NOT a builtin ``TimeoutError`` and would
-       otherwise be misread as a healthy "other" failure and left in place.
+       ``httpx.NetworkError`` ({Connect,Read,Write,Close}Error), the Connect/Read/
+       Write timeouts, and ``httpx.RemoteProtocolError`` qualify — notably a
+       read/idle timeout on a long-lived stream, which is NOT a builtin
+       ``TimeoutError`` and would otherwise be misread as a healthy "other"
+       failure. ``httpx.PoolTimeout`` is deliberately EXCLUDED: it means
+       connection-pool saturation, not a dead connection — evicting the session
+       wouldn't relieve the pressure and would trip the shared breaker for all
+       users on transient load.
     3. **Server-side session lost** — the MCP server RESTARTED and dropped its
        session map, so our held ``mcp-session-id`` is unknown. The server returns
        HTTP 404 and the SDK synthesizes ``McpError(code=32600, "Session
        terminated")`` (see ``streamable_http._send_session_terminated_error``),
-       discarding the server's own 404 body. Keyed off that exact synthesized
-       code (a positive 32600 no compliant server emits), with the exact message
-       as a forward-compat fallback — NOT a bare substring, so a healthy
-       session-owning server's "...session not found" rejection stays a
-       breaker-safe protocol error rather than a forced teardown.
+       discarding the server's own 404 body. Keyed off that synthesized code
+       ALONE (a positive 32600 no compliant server emits); the message is
+       application-controlled, so a healthy session-owning server that returns a
+       protocol error reading "Session terminated" stays breaker-safe.
 
     The raw-socket variants (``BrokenPipeError`` / ``ConnectionResetError`` /
     ``EOFError``) are kept for the stdio transport and defense-in-depth.
@@ -199,12 +202,15 @@ def _is_dead_transport(exc: BaseException) -> bool:
         | BrokenPipeError
         | ConnectionResetError
         | EOFError
-        # NetworkError == {Connect,Read,Write,Close}Error; TimeoutException ==
-        # {Connect,Read,Write,Pool}Timeout. RemoteProtocolError (peer broke the
-        # framing) is dead too; LocalProtocolError (our own bug) is deliberately
-        # excluded by naming RemoteProtocolError rather than the shared base.
+        # NetworkError == {Connect,Read,Write,Close}Error (connection gone). The
+        # Connect/Read/Write timeouts mean a dead/hung connection; PoolTimeout is
+        # EXCLUDED (pool saturation, not a dead session — eviction can't relieve
+        # it and would trip the shared breaker under load). RemoteProtocolError
+        # (peer broke framing) is dead; LocalProtocolError (our bug) stays out.
         | httpx.NetworkError
-        | httpx.TimeoutException
+        | httpx.ConnectTimeout
+        | httpx.ReadTimeout
+        | httpx.WriteTimeout
         | httpx.RemoteProtocolError,
     ):
         return True
@@ -213,19 +219,16 @@ def _is_dead_transport(exc: BaseException) -> bool:
         code = getattr(err, "code", None)
         if code == mcp_types.CONNECTION_CLOSED:
             return True
-        # Server-restarted-session loss: match the SDK's deterministic
-        # synthesized code, with its EXACT message as a forward-compat fallback.
-        # Exact-match (not substring) is deliberate: a bare "session terminated"
-        # / "session not found" substring also matches a healthy session-owning
-        # server's application-level stale-id rejection, which must stay a
-        # breaker-safe protocol error — evicting it would tear down a live
-        # session and trip the shared per-server breaker for every user. The
-        # client never sees "session not found" for a real dead transport (the
-        # SDK discards the server's 404 body), so exact-match loses no coverage.
-        if (
-            code == _SDK_SESSION_TERMINATED_CODE
-            or (getattr(err, "message", "") or "").strip().lower() == _SDK_SESSION_TERMINATED_MSG
-        ):
+        # Server-restarted-session loss: match the SDK's deterministic synthesized
+        # code ALONE. The message is application-controlled — a healthy
+        # session-owning server (e.g. a game/shell MCP server) can legitimately
+        # reject a stale id with a protocol error whose message is
+        # "Session terminated" / "session not found", and matching on it would
+        # tear down that live session and trip the shared per-server breaker for
+        # every user. The client never sees those messages for a REAL dead
+        # transport (the SDK discards the server's 404 body and synthesizes code
+        # 32600), so keying off the code loses no coverage.
+        if code == _SDK_SESSION_TERMINATED_CODE:
             return True
     return False
 
@@ -1839,19 +1842,20 @@ class MCPClientManager:
             try:
                 async with sem:
                     try:
-                        # Non-destructive resolve: refreshes an expired/near-expiry
-                        # token and persists it, but NEVER revokes a grant here
-                        # (revoke_on_dead_grant=False). Priming runs for every
-                        # consented server, so a single (possibly misclassified) AS
-                        # hiccup must not strand one the user may not even be using
-                        # this session; a dead grant is deferred to the lazy-dispatch
-                        # path, which revokes when the user actually invokes the
-                        # tool. Only kind == "token" warms the pool.
+                        # Resolve via the guarded refresh state machine, but with
+                        # revoke_ambiguous_escalation=False: a genuinely-dead grant
+                        # (permanent AS rejection / expired-no-refresh) is still
+                        # revoked so the catalog isn't left cold behind a phantom
+                        # "consented" token, but a sustained-UNCLASSIFIABLE rejection
+                        # is deferred to lazy dispatch — priming runs for every
+                        # consented server, so an AS hiccup we can't classify must
+                        # not revoke consent for one the user may not be using this
+                        # session. Only kind == "token" warms the pool.
                         lookup = await get_user_access_token_classified(
                             app_state=self._app_state,
                             user_id=user_id,
                             server_name=server_name,
-                            revoke_on_dead_grant=False,
+                            revoke_ambiguous_escalation=False,
                         )
                         if lookup.kind != "token" or not lookup.token:
                             return  # not consented / undecryptable / refresh failed — lazy paths handle it
@@ -3844,6 +3848,28 @@ class MCPClientManager:
         self._loop.call_soon_threadsafe(_schedule_refresh)
         return session
 
+    def _record_and_evict_on_dead_transport(self, server_name: str, exc: BaseException) -> None:
+        """Shared static-dispatch failure handling for ``call_tool_sync`` /
+        ``read_resource_sync`` / ``get_prompt_sync`` (call from their ``except``,
+        then re-raise).
+
+        Protocol errors (``McpError`` from a healthy connection that rejected the
+        request) do NOT trip the breaker. A dead transport — anyio
+        Closed/BrokenResourceError, the SDK-swallowed ``McpError(CONNECTION_CLOSED)``,
+        a server-restarted session, or a gone httpx connection — IS a transport
+        failure even when it is an ``McpError``, so it trips the breaker AND evicts
+        the session (leaving stack/streams for ``_connect_one``'s stale-and-stack
+        guard to reap). Eviction is what lets the next dispatch's ``session is
+        None`` check fire ``_cb_auto_reconnect`` instead of re-using the corpse.
+        """
+        dead = _is_dead_transport(exc)
+        if dead or not isinstance(exc, McpError):
+            self._cb_record_failure(server_name)
+        if dead:
+            evict = self._static_servers.get(server_name)
+            if evict is not None:
+                evict.session = None
+
     def call_tool_sync(
         self,
         func_name: str,
@@ -3921,24 +3947,7 @@ class MCPClientManager:
             self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP tool call timed out after {timeout}s") from None
         except Exception as exc:
-            # Protocol errors (McpError) come from a healthy connection that
-            # rejected the request — only transport errors trip the breaker.
-            # A dead transport (anyio Closed/BrokenResourceError, or the
-            # SDK-swallowed McpError(CONNECTION_CLOSED)) IS a transport failure
-            # even though it is an McpError, so it must trip the breaker AND
-            # evict the session.
-            dead = _is_dead_transport(exc)
-            if dead or not isinstance(exc, McpError):
-                self._cb_record_failure(server_name)
-            if dead:
-                # Evict the session only — leave stack/streams behind so the
-                # stale-session-and-stack guard in _connect_one cleans them up
-                # on the next connect attempt. Eviction is what lets the next
-                # dispatch's ``session is None`` check fire _cb_auto_reconnect
-                # instead of re-using the corpse forever.
-                evict = self._static_servers.get(server_name)
-                if evict is not None:
-                    evict.session = None
+            self._record_and_evict_on_dead_transport(server_name, exc)
             raise
 
         self._cb_record_success(server_name)
@@ -5338,22 +5347,7 @@ class MCPClientManager:
             self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP resource read timed out after {timeout}s") from None
         except Exception as exc:
-            # A dead transport (anyio Closed/BrokenResourceError, the SDK-
-            # swallowed McpError(CONNECTION_CLOSED), a server-restarted session,
-            # or a gone httpx connection) IS a transport failure even when it is
-            # an McpError, so it must trip the breaker AND evict the corpse
-            # session — otherwise read_resource_sync re-probes the same dead
-            # session forever, the restart-hang call_tool_sync already fixes.
-            dead = _is_dead_transport(exc)
-            if dead or not isinstance(exc, McpError):
-                self._cb_record_failure(server_name)
-            if dead:
-                # Evict the session only — leave stack/streams behind so the
-                # stale-session-and-stack guard in _connect_one cleans them up
-                # on the next connect attempt.
-                evict = self._static_servers.get(server_name)
-                if evict is not None:
-                    evict.session = None
+            self._record_and_evict_on_dead_transport(server_name, exc)
             raise
 
         self._cb_record_success(server_name)
@@ -5447,22 +5441,7 @@ class MCPClientManager:
             self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP prompt retrieval timed out after {timeout}s") from None
         except Exception as exc:
-            # A dead transport (anyio Closed/BrokenResourceError, the SDK-
-            # swallowed McpError(CONNECTION_CLOSED), a server-restarted session,
-            # or a gone httpx connection) IS a transport failure even when it is
-            # an McpError, so it must trip the breaker AND evict the corpse
-            # session — otherwise get_prompt_sync re-probes the same dead
-            # session forever, the restart-hang call_tool_sync already fixes.
-            dead = _is_dead_transport(exc)
-            if dead or not isinstance(exc, McpError):
-                self._cb_record_failure(server_name)
-            if dead:
-                # Evict the session only — leave stack/streams behind so the
-                # stale-session-and-stack guard in _connect_one cleans them up
-                # on the next connect attempt.
-                evict = self._static_servers.get(server_name)
-                if evict is not None:
-                    evict.session = None
+            self._record_and_evict_on_dead_transport(server_name, exc)
             raise
 
         self._cb_record_success(server_name)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -3367,15 +3367,20 @@ class MCPClientManager:
         clean = msg.replace("\n", " ").replace("\r", "")
         self._last_error[name] = clean[: self._MAX_ERROR_LEN]
 
-    def get_server_status(self, name: str) -> dict[str, Any]:
-        """Return live status for a single server, including config details."""
+    def get_server_status(self, name: str, user_id: str | None = None) -> dict[str, Any]:
+        """Return live status for a single server, including config details.
+
+        For ``auth_type='oauth_user'`` servers the result is scoped to *user_id*
+        (see :meth:`_oauth_user_server_status`). ``user_id`` is ignored for
+        static servers, whose session is process-global.
+        """
         # auth_type='oauth_user' servers hold NO process-global session — they
         # are warmed per-user into the pool — so the static-session check below
-        # would always report them "connecting". Derive their status from warm
-        # per-user pool entries instead, so the console pill reflects real
-        # per-user reachability once a pool is primed.
+        # would always report them "connecting". Derive their status from the
+        # REQUESTING user's warm pool entry instead, so the console pill reflects
+        # that user's real reachability once their pool is primed.
         if name in self._oauth_user_server_names:
-            return self._oauth_user_server_status(name)
+            return self._oauth_user_server_status(name, user_id)
         state = self._static_servers.get(name)
         connected = state is not None and state.session is not None
         cfg = self._server_configs.get(name, {})
@@ -3404,26 +3409,33 @@ class MCPClientManager:
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
         }
 
-    def _oauth_user_server_status(self, name: str) -> dict[str, Any]:
-        """Live status for an ``auth_type='oauth_user'`` server.
+    def _oauth_user_server_status(self, name: str, user_id: str | None) -> dict[str, Any]:
+        """Live status for an ``auth_type='oauth_user'`` server, scoped to *user_id*.
 
         These have no global session (stripped from ``_server_configs`` /
         ``_static_servers``); they connect per-user into ``_user_pool_entries``.
-        Report ``connected=True`` when at least one user has a warm pool entry,
-        with a representative catalog count and the number of warm user pools —
-        so the console stops showing a permanent "connecting"/``---`` for a
-        server that is in fact reachable and in use.
+        ``connected`` and the catalog counts reflect ONLY the requesting user's
+        warm pool entry — never another user's. The per-user pool is per-user
+        data, and ``connected`` / ``tools`` / ``resources`` / ``prompts`` reach
+        read-scoped callers over the wire, so deriving them from an arbitrary
+        other user's pool would leak that user's catalog (and its existence) to
+        anyone with read scope. A request with no user context (``user_id``
+        falsy, e.g. an operator refresh/reconnect) reports ``connected=False``.
         """
         # Snapshot with list(): the mcp-loop thread mutates _user_pool_entries
         # (prime insert / idle eviction) concurrently with status polls from the
         # console/server thread, and iterating a live dict that changes size
         # raises RuntimeError mid-comprehension. The sibling get_all_server_status
         # and the eviction loop snapshot the same way.
-        warm = [
-            entry
-            for (uid, sname), entry in list(self._user_pool_entries.items())
-            if sname == name and entry.session is not None
-        ]
+        warm = (
+            [
+                entry
+                for (uid, sname), entry in list(self._user_pool_entries.items())
+                if sname == name and uid == user_id and entry.session is not None
+            ]
+            if user_id
+            else []
+        )
         rep = warm[0] if warm else None
         cb_deadline = self._circuit_open_until.get(name)
         cb_open = cb_deadline is not None and time.monotonic() < cb_deadline
@@ -3445,19 +3457,20 @@ class MCPClientManager:
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
         }
 
-    def get_all_server_status(self) -> dict[str, dict[str, Any]]:
+    def get_all_server_status(self, user_id: str | None = None) -> dict[str, dict[str, Any]]:
         """Return live status for all configured servers.
 
         Includes ``oauth_user`` servers (which are absent from
         ``_server_configs``) so the console list reports their real per-user
         pool status instead of falling back to a DB-only "connecting" default.
+        Their status is scoped to *user_id* (see :meth:`get_server_status`).
         """
         result: dict[str, dict[str, Any]] = {}
         for name in list(self._server_configs):
-            result[name] = self.get_server_status(name)
+            result[name] = self.get_server_status(name, user_id)
         for name in list(self._oauth_user_server_names):
             if name not in result:
-                result[name] = self.get_server_status(name)
+                result[name] = self.get_server_status(name, user_id)
         return result
 
     def reconcile_sync(self, storage: Any, timeout: int = 30) -> dict[str, Any]:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1839,14 +1839,19 @@ class MCPClientManager:
             try:
                 async with sem:
                     try:
-                        # Guarded resolve: refreshes an expired/near-expiry token
-                        # and persists it, but a transient failure keeps the token
-                        # (kind=refresh_failed_transient) so priming can never
-                        # revoke a live grant. Only kind == "token" warms the pool.
+                        # Non-destructive resolve: refreshes an expired/near-expiry
+                        # token and persists it, but NEVER revokes a grant here
+                        # (revoke_on_dead_grant=False). Priming runs for every
+                        # consented server, so a single (possibly misclassified) AS
+                        # hiccup must not strand one the user may not even be using
+                        # this session; a dead grant is deferred to the lazy-dispatch
+                        # path, which revokes when the user actually invokes the
+                        # tool. Only kind == "token" warms the pool.
                         lookup = await get_user_access_token_classified(
                             app_state=self._app_state,
                             user_id=user_id,
                             server_name=server_name,
+                            revoke_on_dead_grant=False,
                         )
                         if lookup.kind != "token" or not lookup.token:
                             return  # not consented / undecryptable / refresh failed — lazy paths handle it

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -146,6 +146,18 @@ _MAX_PROMPTS_PER_SERVER = 1000
 _PRIME_MAX_CONCURRENCY = 4
 
 
+# ``mcp.client.streamable_http._send_session_terminated_error`` synthesizes this
+# (non-standard, POSITIVE) JSON-RPC code + message *client-side* when a held
+# ``mcp-session-id`` 404s after the MCP server restarted and dropped its session
+# map. It is NOT a documented MCP constant, and the SDK deliberately discards the
+# server's own 404 body ("Session not found", code ``-32600``) — so both are
+# pinned here, greppable for the next SDK bump. No spec-compliant server emits a
+# POSITIVE 32600, which is exactly what makes the code a safe dead-transport
+# signal to key off.
+_SDK_SESSION_TERMINATED_CODE = 32600
+_SDK_SESSION_TERMINATED_MSG = "session terminated"
+
+
 def _is_dead_transport(exc: BaseException) -> bool:
     """True when *exc* means the MCP session's transport is dead and the
     session must be torn down and rebuilt (vs a protocol-level rejection
@@ -161,15 +173,21 @@ def _is_dead_transport(exc: BaseException) -> bool:
        :class:`anyio.ClosedResourceError` / :class:`anyio.BrokenResourceError`.
     2. **Transport-swallowed** — the SDK's ``post_writer`` swallows the upstream
        error and the caller sees ``McpError(CONNECTION_CLOSED)`` (-32000); or the
-       underlying httpx connection is simply gone (server down / peer closed
-       mid-response → ``httpx.ConnectError`` / ``httpx.RemoteProtocolError``).
+       underlying httpx connection is gone / unrecoverable mid-exchange. Every
+       ``httpx.NetworkError`` ({Connect,Read,Write,Close}Error),
+       ``httpx.TimeoutException`` ({Connect,Read,Write,Pool}Timeout) and
+       ``httpx.RemoteProtocolError`` qualifies — notably a read/idle timeout on a
+       long-lived stream, which is NOT a builtin ``TimeoutError`` and would
+       otherwise be misread as a healthy "other" failure and left in place.
     3. **Server-side session lost** — the MCP server RESTARTED and dropped its
        session map, so our held ``mcp-session-id`` is unknown. The server returns
-       HTTP 404 and the SDK surfaces ``McpError(code=32600, "Session terminated")``
-       (see ``streamable_http._send_session_terminated_error``). The session-id is
-       dead server-side; only a fresh ``initialize`` (full reconnect) recovers it —
-       reusing it 404s forever (the restart-hang). Matched by message because the
-       SDK's code (32600) is not a documented MCP constant.
+       HTTP 404 and the SDK synthesizes ``McpError(code=32600, "Session
+       terminated")`` (see ``streamable_http._send_session_terminated_error``),
+       discarding the server's own 404 body. Keyed off that exact synthesized
+       code (a positive 32600 no compliant server emits), with the exact message
+       as a forward-compat fallback — NOT a bare substring, so a healthy
+       session-owning server's "...session not found" rejection stays a
+       breaker-safe protocol error rather than a forced teardown.
 
     The raw-socket variants (``BrokenPipeError`` / ``ConnectionResetError`` /
     ``EOFError``) are kept for the stdio transport and defense-in-depth.
@@ -181,17 +199,33 @@ def _is_dead_transport(exc: BaseException) -> bool:
         | BrokenPipeError
         | ConnectionResetError
         | EOFError
-        | httpx.ConnectError
-        | httpx.ConnectTimeout
+        # NetworkError == {Connect,Read,Write,Close}Error; TimeoutException ==
+        # {Connect,Read,Write,Pool}Timeout. RemoteProtocolError (peer broke the
+        # framing) is dead too; LocalProtocolError (our own bug) is deliberately
+        # excluded by naming RemoteProtocolError rather than the shared base.
+        | httpx.NetworkError
+        | httpx.TimeoutException
         | httpx.RemoteProtocolError,
     ):
         return True
     if isinstance(exc, McpError):
         err = exc.error
-        if getattr(err, "code", None) == mcp_types.CONNECTION_CLOSED:
+        code = getattr(err, "code", None)
+        if code == mcp_types.CONNECTION_CLOSED:
             return True
-        msg = (getattr(err, "message", "") or "").lower()
-        if "session terminated" in msg or "session not found" in msg:
+        # Server-restarted-session loss: match the SDK's deterministic
+        # synthesized code, with its EXACT message as a forward-compat fallback.
+        # Exact-match (not substring) is deliberate: a bare "session terminated"
+        # / "session not found" substring also matches a healthy session-owning
+        # server's application-level stale-id rejection, which must stay a
+        # breaker-safe protocol error — evicting it would tear down a live
+        # session and trip the shared per-server breaker for every user. The
+        # client never sees "session not found" for a real dead transport (the
+        # SDK discards the server's 404 body), so exact-match loses no coverage.
+        if (
+            code == _SDK_SESSION_TERMINATED_CODE
+            or (getattr(err, "message", "") or "").strip().lower() == _SDK_SESSION_TERMINATED_MSG
+        ):
             return True
     return False
 
@@ -3375,9 +3409,14 @@ class MCPClientManager:
         so the console stops showing a permanent "connecting"/``---`` for a
         server that is in fact reachable and in use.
         """
+        # Snapshot with list(): the mcp-loop thread mutates _user_pool_entries
+        # (prime insert / idle eviction) concurrently with status polls from the
+        # console/server thread, and iterating a live dict that changes size
+        # raises RuntimeError mid-comprehension. The sibling get_all_server_status
+        # and the eviction loop snapshot the same way.
         warm = [
             entry
-            for (uid, sname), entry in self._user_pool_entries.items()
+            for (uid, sname), entry in list(self._user_pool_entries.items())
             if sname == name and entry.session is not None
         ]
         rep = warm[0] if warm else None
@@ -5262,9 +5301,16 @@ class MCPClientManager:
             self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP resource read timed out after {timeout}s") from None
         except Exception as exc:
-            if not isinstance(exc, McpError):
+            # A dead transport (anyio Closed/BrokenResourceError, the SDK-
+            # swallowed McpError(CONNECTION_CLOSED), a server-restarted session,
+            # or a gone httpx connection) IS a transport failure even when it is
+            # an McpError, so it must trip the breaker AND evict the corpse
+            # session — otherwise read_resource_sync re-probes the same dead
+            # session forever, the restart-hang call_tool_sync already fixes.
+            dead = _is_dead_transport(exc)
+            if dead or not isinstance(exc, McpError):
                 self._cb_record_failure(server_name)
-            if isinstance(exc, (BrokenPipeError, ConnectionResetError, EOFError)):
+            if dead:
                 # Evict the session only — leave stack/streams behind so the
                 # stale-session-and-stack guard in _connect_one cleans them up
                 # on the next connect attempt.
@@ -5364,9 +5410,16 @@ class MCPClientManager:
             self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP prompt retrieval timed out after {timeout}s") from None
         except Exception as exc:
-            if not isinstance(exc, McpError):
+            # A dead transport (anyio Closed/BrokenResourceError, the SDK-
+            # swallowed McpError(CONNECTION_CLOSED), a server-restarted session,
+            # or a gone httpx connection) IS a transport failure even when it is
+            # an McpError, so it must trip the breaker AND evict the corpse
+            # session — otherwise get_prompt_sync re-probes the same dead
+            # session forever, the restart-hang call_tool_sync already fixes.
+            dead = _is_dead_transport(exc)
+            if dead or not isinstance(exc, McpError):
                 self._cb_record_failure(server_name)
-            if isinstance(exc, (BrokenPipeError, ConnectionResetError, EOFError)):
+            if dead:
                 # Evict the session only — leave stack/streams behind so the
                 # stale-session-and-stack guard in _connect_one cleans them up
                 # on the next connect attempt.

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -3367,12 +3367,15 @@ class MCPClientManager:
         clean = msg.replace("\n", " ").replace("\r", "")
         self._last_error[name] = clean[: self._MAX_ERROR_LEN]
 
-    def get_server_status(self, name: str, user_id: str | None = None) -> dict[str, Any]:
+    def get_server_status(
+        self, name: str, user_id: str | None = None, *, aggregate: bool = False
+    ) -> dict[str, Any]:
         """Return live status for a single server, including config details.
 
-        For ``auth_type='oauth_user'`` servers the result is scoped to *user_id*
-        (see :meth:`_oauth_user_server_status`). ``user_id`` is ignored for
-        static servers, whose session is process-global.
+        For ``auth_type='oauth_user'`` servers the result is scoped to *user_id*,
+        or aggregated across all users when ``aggregate=True`` (see
+        :meth:`_oauth_user_server_status`). Both are ignored for static servers,
+        whose session is process-global.
         """
         # auth_type='oauth_user' servers hold NO process-global session — they
         # are warmed per-user into the pool — so the static-session check below
@@ -3380,7 +3383,7 @@ class MCPClientManager:
         # REQUESTING user's warm pool entry instead, so the console pill reflects
         # that user's real reachability once their pool is primed.
         if name in self._oauth_user_server_names:
-            return self._oauth_user_server_status(name, user_id)
+            return self._oauth_user_server_status(name, user_id, aggregate=aggregate)
         state = self._static_servers.get(name)
         connected = state is not None and state.session is not None
         cfg = self._server_configs.get(name, {})
@@ -3409,7 +3412,9 @@ class MCPClientManager:
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
         }
 
-    def _oauth_user_server_status(self, name: str, user_id: str | None) -> dict[str, Any]:
+    def _oauth_user_server_status(
+        self, name: str, user_id: str | None, *, aggregate: bool = False
+    ) -> dict[str, Any]:
         """Live status for an ``auth_type='oauth_user'`` server, scoped to *user_id*.
 
         These have no global session (stripped from ``_server_configs`` /
@@ -3421,21 +3426,32 @@ class MCPClientManager:
         other user's pool would leak that user's catalog (and its existence) to
         anyone with read scope. A request with no user context (``user_id``
         falsy, e.g. an operator refresh/reconnect) reports ``connected=False``.
+
+        ``aggregate=True`` is the admin cluster-health view: ``connected`` and a
+        representative catalog count reflect ANY user's warm pool. It is gated at
+        the endpoint on the ``admin.mcp`` permission, whose holders already see
+        cross-user MCP state (consent counts, server config), so it is not a new
+        disclosure — it restores the "in use by anyone" pill for operators
+        without exposing one user's pool to another read-scoped user.
         """
         # Snapshot with list(): the mcp-loop thread mutates _user_pool_entries
         # (prime insert / idle eviction) concurrently with status polls from the
         # console/server thread, and iterating a live dict that changes size
         # raises RuntimeError mid-comprehension. The sibling get_all_server_status
         # and the eviction loop snapshot the same way.
-        warm = (
-            [
-                entry
-                for (uid, sname), entry in list(self._user_pool_entries.items())
-                if sname == name and uid == user_id and entry.session is not None
+        entries = list(self._user_pool_entries.items())
+        if aggregate:
+            warm = [e for (uid, sname), e in entries if sname == name and e.session is not None]
+        elif user_id:
+            warm = [
+                e
+                for (uid, sname), e in entries
+                if sname == name and uid == user_id and e.session is not None
             ]
-            if user_id
-            else []
-        )
+        else:
+            warm = []
+        # rep is the first warm entry (insertion order): the requester's own pool
+        # when scoped, or a representative catalog for the aggregate operator view.
         rep = warm[0] if warm else None
         cb_deadline = self._circuit_open_until.get(name)
         cb_open = cb_deadline is not None and time.monotonic() < cb_deadline
@@ -3457,20 +3473,23 @@ class MCPClientManager:
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
         }
 
-    def get_all_server_status(self, user_id: str | None = None) -> dict[str, dict[str, Any]]:
+    def get_all_server_status(
+        self, user_id: str | None = None, *, aggregate: bool = False
+    ) -> dict[str, dict[str, Any]]:
         """Return live status for all configured servers.
 
         Includes ``oauth_user`` servers (which are absent from
         ``_server_configs``) so the console list reports their real per-user
         pool status instead of falling back to a DB-only "connecting" default.
-        Their status is scoped to *user_id* (see :meth:`get_server_status`).
+        Their status is scoped to *user_id*, or aggregated across users when
+        ``aggregate=True`` (see :meth:`get_server_status`).
         """
         result: dict[str, dict[str, Any]] = {}
         for name in list(self._server_configs):
-            result[name] = self.get_server_status(name, user_id)
+            result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
         for name in list(self._oauth_user_server_names):
             if name not in result:
-                result[name] = self.get_server_status(name, user_id)
+                result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
         return result
 
     def reconcile_sync(self, storage: Any, timeout: int = 30) -> dict[str, Any]:

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1505,7 +1505,7 @@ async def get_user_access_token_classified(
     user_id: str,
     server_name: str,
     force_refresh: bool = False,
-    revoke_on_dead_grant: bool = True,
+    revoke_ambiguous_escalation: bool = True,
 ) -> TokenLookupResult:
     """Tagged token lookup with refresh-on-expiry.
 
@@ -1537,15 +1537,18 @@ async def get_user_access_token_classified(
     the second caller sees ``last_refreshed > t_lock_request_started``
     and reuses the freshly-refreshed token.
 
-    ``revoke_on_dead_grant=False`` makes the lookup NON-DESTRUCTIVE: a grant the
-    classifier would otherwise delete (permanent rejection / ambiguous-streak
-    escalation / expired-with-no-refresh) is instead reported as
-    ``refresh_failed_transient`` with the token left in place. Used by
-    session-start pool priming, which runs for EVERY consented server and must
-    never let a single (possibly misclassified) AS hiccup revoke a grant for a
-    server the user may not even be using this session — the authoritative
-    revoke stays on the lazy-dispatch path, where the user actually invokes the
-    tool.
+    ``revoke_ambiguous_escalation=False`` narrows revocation for background
+    session-start priming. A genuinely-dead grant is STILL revoked so it is
+    cleaned up and the user gets a re-consent affordance: a PERMANENT AS
+    rejection (``invalid_grant`` / ``invalid_scope`` — a reliable dead-grant
+    signal per RFC 6749 §5.2) and an expired-with-no-refresh token both revoke
+    unconditionally. Only the *sustained-ambiguous* escalation — an
+    unclassifiable 400/401 the heuristic would treat as dead after a streak — is
+    deferred: priming runs for EVERY consented server, so an unclassifiable AS
+    hiccup must not revoke consent for a server the user may not even be using
+    this session. The streak + cooldown persist, so the authoritative
+    escalation-revoke happens on the lazy-dispatch path when the user actually
+    invokes the tool.
     """
     token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
     if token_store is None:
@@ -1607,23 +1610,18 @@ async def get_user_access_token_classified(
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
     server_id_for_audit = str(server_row.get("server_id") or "")
 
-    async def _dead_grant(reason: str) -> TokenLookupResult:
-        # Non-destructive priming: with revoke_on_dead_grant=False we NEVER
-        # delete a grant here. A misclassified transient (e.g. invalid_grant
-        # emitted during an AS key-rotation window) must not strand a server the
-        # user may not even be using this session. The authoritative revoke is
-        # deferred to the lazy-dispatch path (revoke_on_dead_grant=True), where
-        # the user is actually invoking the tool. Reported as the transient kind
-        # so the token (and its per-key refresh lock) is kept intact.
-        if not revoke_on_dead_grant:
-            return TokenLookupResult(kind="refresh_failed_transient")
-        return await _revoke_after_refresh_failure(
-            app_state, token_store, user_id, server_name, server_id_for_audit, reason=reason
-        )
-
     refresh_value = plain.get("refresh_token")
     if not refresh_value:
-        return await _dead_grant(reason="expired_no_refresh")
+        # Expired token with no refresh token: genuinely unusable, no
+        # misclassification risk (a local check, not an AS response) — revoke.
+        return await _revoke_after_refresh_failure(
+            app_state,
+            token_store,
+            user_id,
+            server_name,
+            server_id_for_audit,
+            reason="expired_no_refresh",
+        )
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
     pg_lock = await _acquire_pg_refresh_lock(storage, user_id, server_name)
@@ -1671,7 +1669,14 @@ async def get_user_access_token_classified(
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
         refresh_value2 = plain2.get("refresh_token")
         if not refresh_value2:
-            return await _dead_grant(reason="expired_no_refresh")
+            return await _revoke_after_refresh_failure(
+                app_state,
+                token_store,
+                user_id,
+                server_name,
+                server_id_for_audit,
+                reason="expired_no_refresh",
+            )
 
         try:
             new_access, _new_refresh, _new_expires_at = await _refresh_and_persist(
@@ -1687,9 +1692,18 @@ async def get_user_access_token_classified(
         except MCPOAuthRefreshFailed as exc:
             if exc.failure_class is _RefreshFailureClass.PERMANENT:
                 # The AS rejected the grant as dead (invalid_grant / invalid_scope
-                # / an OIDC interaction-required code) — revoke and re-consent
-                # (deferred to lazy dispatch when revoke_on_dead_grant=False).
-                return await _dead_grant(reason="refresh_failed")
+                # / an OIDC interaction-required code): a reliable dead-grant
+                # signal (RFC 6749 §5.2), so revoke unconditionally — even under
+                # background priming. Deferring it would strand the catalog cold
+                # with the token still reading "consented" and no re-consent path.
+                return await _revoke_after_refresh_failure(
+                    app_state,
+                    token_store,
+                    user_id,
+                    server_name,
+                    server_id_for_audit,
+                    reason="refresh_failed",
+                )
             # Transient or ambiguous: keep the token (a blip must never revoke a
             # user's consent) and arm the cooldown so a down AS isn't hit on
             # every later dispatch.
@@ -1703,14 +1717,35 @@ async def get_user_access_token_classified(
                     # non-standard shape. Escalate to re-consent so the user
                     # isn't stranded on a retryable error forever. (Infra
                     # transients never reach here, so an outage can't escalate.)
+                    if revoke_ambiguous_escalation:
+                        log.warning(
+                            "mcp_server.oauth.refresh_ambiguous_escalated",
+                            user_id=user_id,
+                            server_name=server_name,
+                            streak=backoff.ambiguous_streak,
+                            error=str(exc),
+                        )
+                        return await _revoke_after_refresh_failure(
+                            app_state,
+                            token_store,
+                            user_id,
+                            server_name,
+                            server_id_for_audit,
+                            reason="refresh_failed_ambiguous_escalated",
+                        )
+                    # Background priming: an UNCLASSIFIABLE sustained rejection is
+                    # exactly where a bulk prime of servers the user may not be
+                    # using must not revoke consent. Defer the escalation-revoke to
+                    # lazy dispatch — the streak + armed cooldown persist, so it
+                    # escalates on the user's next real call. Falls through to the
+                    # transient return below (token kept, lock retained).
                     log.warning(
-                        "mcp_server.oauth.refresh_ambiguous_escalated",
+                        "mcp_server.oauth.refresh_ambiguous_escalation_deferred",
                         user_id=user_id,
                         server_name=server_name,
                         streak=backoff.ambiguous_streak,
                         error=str(exc),
                     )
-                    return await _dead_grant(reason="refresh_failed_ambiguous_escalated")
             else:
                 # A clean infra/operator-fixable transient breaks any ambiguous
                 # run — only an uninterrupted streak escalates.

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1500,7 +1500,12 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
 
 
 async def get_user_access_token_classified(
-    *, app_state: Any, user_id: str, server_name: str, force_refresh: bool = False
+    *,
+    app_state: Any,
+    user_id: str,
+    server_name: str,
+    force_refresh: bool = False,
+    revoke_on_dead_grant: bool = True,
 ) -> TokenLookupResult:
     """Tagged token lookup with refresh-on-expiry.
 
@@ -1531,6 +1536,16 @@ async def get_user_access_token_classified(
     callers still collapse to one round-trip via the dual-layer lock:
     the second caller sees ``last_refreshed > t_lock_request_started``
     and reuses the freshly-refreshed token.
+
+    ``revoke_on_dead_grant=False`` makes the lookup NON-DESTRUCTIVE: a grant the
+    classifier would otherwise delete (permanent rejection / ambiguous-streak
+    escalation / expired-with-no-refresh) is instead reported as
+    ``refresh_failed_transient`` with the token left in place. Used by
+    session-start pool priming, which runs for EVERY consented server and must
+    never let a single (possibly misclassified) AS hiccup revoke a grant for a
+    server the user may not even be using this session — the authoritative
+    revoke stays on the lazy-dispatch path, where the user actually invokes the
+    tool.
     """
     token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
     if token_store is None:
@@ -1592,16 +1607,23 @@ async def get_user_access_token_classified(
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
     server_id_for_audit = str(server_row.get("server_id") or "")
 
+    async def _dead_grant(reason: str) -> TokenLookupResult:
+        # Non-destructive priming: with revoke_on_dead_grant=False we NEVER
+        # delete a grant here. A misclassified transient (e.g. invalid_grant
+        # emitted during an AS key-rotation window) must not strand a server the
+        # user may not even be using this session. The authoritative revoke is
+        # deferred to the lazy-dispatch path (revoke_on_dead_grant=True), where
+        # the user is actually invoking the tool. Reported as the transient kind
+        # so the token (and its per-key refresh lock) is kept intact.
+        if not revoke_on_dead_grant:
+            return TokenLookupResult(kind="refresh_failed_transient")
+        return await _revoke_after_refresh_failure(
+            app_state, token_store, user_id, server_name, server_id_for_audit, reason=reason
+        )
+
     refresh_value = plain.get("refresh_token")
     if not refresh_value:
-        return await _revoke_after_refresh_failure(
-            app_state,
-            token_store,
-            user_id,
-            server_name,
-            server_id_for_audit,
-            reason="expired_no_refresh",
-        )
+        return await _dead_grant(reason="expired_no_refresh")
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
     pg_lock = await _acquire_pg_refresh_lock(storage, user_id, server_name)
@@ -1649,14 +1671,7 @@ async def get_user_access_token_classified(
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
         refresh_value2 = plain2.get("refresh_token")
         if not refresh_value2:
-            return await _revoke_after_refresh_failure(
-                app_state,
-                token_store,
-                user_id,
-                server_name,
-                server_id_for_audit,
-                reason="expired_no_refresh",
-            )
+            return await _dead_grant(reason="expired_no_refresh")
 
         try:
             new_access, _new_refresh, _new_expires_at = await _refresh_and_persist(
@@ -1672,15 +1687,9 @@ async def get_user_access_token_classified(
         except MCPOAuthRefreshFailed as exc:
             if exc.failure_class is _RefreshFailureClass.PERMANENT:
                 # The AS rejected the grant as dead (invalid_grant / invalid_scope
-                # / an OIDC interaction-required code) — revoke and re-consent.
-                return await _revoke_after_refresh_failure(
-                    app_state,
-                    token_store,
-                    user_id,
-                    server_name,
-                    server_id_for_audit,
-                    reason="refresh_failed",
-                )
+                # / an OIDC interaction-required code) — revoke and re-consent
+                # (deferred to lazy dispatch when revoke_on_dead_grant=False).
+                return await _dead_grant(reason="refresh_failed")
             # Transient or ambiguous: keep the token (a blip must never revoke a
             # user's consent) and arm the cooldown so a down AS isn't hit on
             # every later dispatch.
@@ -1701,14 +1710,7 @@ async def get_user_access_token_classified(
                         streak=backoff.ambiguous_streak,
                         error=str(exc),
                     )
-                    return await _revoke_after_refresh_failure(
-                        app_state,
-                        token_store,
-                        user_id,
-                        server_name,
-                        server_id_for_audit,
-                        reason="refresh_failed_ambiguous_escalated",
-                    )
+                    return await _dead_grant(reason="refresh_failed_ambiguous_escalated")
             else:
                 # A clean infra/operator-fixable transient breaks any ambiguous
                 # run — only an uninterrupted streak escalates.

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3169,7 +3169,12 @@ def _strip_server_status_for_read(full: dict[str, Any]) -> dict[str, Any]:
 
 def _public_server_status(mcp_mgr: Any, name: str) -> dict[str, Any]:
     """Strip ``command``/``url`` from ``get_server_status`` before returning over the wire."""
-    return _strip_server_status(mcp_mgr.get_server_status(name))
+    # aggregate=True: the operator refresh/reconnect endpoints are approve-scoped
+    # cluster actions with no single requesting user, so oauth_user servers report
+    # the any-user warm-pool view (matching the admin console) rather than the
+    # per-user default — which, with user_id=None, would render a warm, in-use
+    # server as disconnected/empty right after a successful refresh.
+    return _strip_server_status(mcp_mgr.get_server_status(name, aggregate=True))
 
 
 def internal_mcp_status(request: Request) -> JSONResponse:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3188,11 +3188,15 @@ def internal_mcp_status(request: Request) -> JSONResponse:
     if mcp_mgr is None:
         return JSONResponse({"servers": {}})
 
+    # Scope oauth_user server status to the requesting user — their per-user pool
+    # catalog (and its existence) must not leak to other read-scoped callers.
+    # _auth_user_id returns "" when unauthenticated, which the manager treats as
+    # "no user context" (oauth_user servers then report not-connected).
+    all_status = mcp_mgr.get_all_server_status(_auth_user_id(request))
     return JSONResponse(
         {
             "servers": {
-                name: _strip_server_status_for_read(status)
-                for name, status in mcp_mgr.get_all_server_status().items()
+                name: _strip_server_status_for_read(status) for name, status in all_status.items()
             }
         }
     )

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3191,8 +3191,14 @@ def internal_mcp_status(request: Request) -> JSONResponse:
     # Scope oauth_user server status to the requesting user — their per-user pool
     # catalog (and its existence) must not leak to other read-scoped callers.
     # _auth_user_id returns "" when unauthenticated, which the manager treats as
-    # "no user context" (oauth_user servers then report not-connected).
-    all_status = mcp_mgr.get_all_server_status(_auth_user_id(request))
+    # "no user context" (oauth_user servers then report not-connected). Callers
+    # holding admin.mcp (the console cluster-health view, whose proxy forwards
+    # the admin's permissions) get the cross-user aggregate instead — they are
+    # already trusted to see consent counts + server config, so it is no new
+    # disclosure and it keeps the operator "in use by anyone" pill working.
+    auth_result = getattr(getattr(request, "state", None), "auth_result", None)
+    is_admin = auth_result is not None and auth_result.has_permission("admin.mcp")
+    all_status = mcp_mgr.get_all_server_status(_auth_user_id(request), aggregate=is_admin)
     return JSONResponse(
         {
             "servers": {


### PR DESCRIPTION
This pull request introduces comprehensive improvements and regression tests for MCP client/server session handling, especially around session liveness, error classification, and user pool isolation for OAuth-based servers. The changes focus on ensuring robust detection and handling of dead transports, preventing cross-user information leaks in server status, and refining token refresh/revocation logic during ambiguous or permanent failures.

Key changes include:

### MCP Client Dead Transport Detection and Session Handling

* Added and thoroughly tested the `_is_dead_transport` function, which centralizes the logic to determine when an MCP session's transport is dead (across stdio, HTTP, and anyio transports). This ensures sessions are only evicted and breakers tripped for genuine transport failures, not protocol errors or transient load issues. The function now keys off specific error codes (including a positive 32600 synthesized by the SDK) and excludes pool saturation errors. [[1]](diffhunk://#diff-5f0ae188a9cf555f834ac99aeb613d9801a26a9e2bf1a688b8bd158d67847a77R149-R161) [[2]](diffhunk://#diff-5f0ae188a9cf555f834ac99aeb613d9801a26a9e2bf1a688b8bd158d67847a77L164-R193) [[3]](diffhunk://#diff-11516fcbcb8d8428f12c2ab8218a8f92d6b17749b23e924c206bb10d688547ecR20) [[4]](diffhunk://#diff-11516fcbcb8d8428f12c2ab8218a8f92d6b17749b23e924c206bb10d688547ecR2618-R2810)

* Added regression tests for `read_resource_sync` and `get_prompt_sync` to verify that dead transports evict sessions and trip breakers, while healthy protocol rejections do not.

### OAuth User Pool Status and Isolation

* Updated `get_server_status` for `auth_type='oauth_user'` servers to always reflect the requesting user's pool warmth, never another user's, preventing cross-user catalog size leaks. Added tests to verify correct per-user isolation and aggregate (admin-only) views.

* Ensured that admin endpoints (with `admin.mcp` permission) can aggregate status across users, while regular users see only their own pool status. Added endpoint and permission-gating tests for this behavior. [[1]](diffhunk://#diff-cc3b6487a1a345ffe4b2a9e66178b47ea21e58bc206bbe89dca4c5287ba9cdd3R1939-R1962) [[2]](diffhunk://#diff-af2173b789c82691f2def34154a37c355e3890c9a8f0e260889172291f9aaed1L1895-R2095)

### Token Refresh and Revocation Logic

* Improved token priming logic to revoke tokens only on permanent failures, while ambiguous failures defer revocation until lazy dispatch. Added tests to verify that ambiguous escalation does not prematurely revoke tokens, but permanent failures do.

### Test and Documentation Enhancements

* Expanded and clarified test coverage for session management, error classification, and user pool status, including edge cases and regression scenarios. [[1]](diffhunk://#diff-11516fcbcb8d8428f12c2ab8218a8f92d6b17749b23e924c206bb10d688547ecR2618-R2810) [[2]](diffhunk://#diff-af2173b789c82691f2def34154a37c355e3890c9a8f0e260889172291f9aaed1R1690-R1788) [[3]](diffhunk://#diff-af2173b789c82691f2def34154a37c355e3890c9a8f0e260889172291f9aaed1L1895-R2095)
* Improved inline documentation for dead transport detection and error handling logic. [[1]](diffhunk://#diff-5f0ae188a9cf555f834ac99aeb613d9801a26a9e2bf1a688b8bd158d67847a77R149-R161) [[2]](diffhunk://#diff-5f0ae188a9cf555f834ac99aeb613d9801a26a9e2bf1a688b8bd158d67847a77L164-R193)

These changes significantly harden the MCP client/server interaction layer, improving reliability, security, and correctness in multi-user and error-prone environments.