### PR TITLE
Project sharing gaps: acting-user MCP credentials, private-project visibility, project surfaces

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -531,6 +531,58 @@ class TestCollectorDelta:
         assert event["type"] == "ws_closed"
         assert "ws1" not in c._nodes["node-a"].workstreams
 
+    def test_reconcile_additions_event_carries_tenancy_fields(self):
+        """The poll-diff ws_created must carry user_id + project_id — the
+        console's per-connection tenancy filter gates on them, and a
+        missing field fails open (private leak) or over-hides (creator
+        shortcut can't fire)."""
+        c = _make_collector()
+        node = NodeSnapshot(node_id="node-a", server_url="http://a:8080")
+        c._nodes["node-a"] = node
+
+        pending = c._reconcile_node(
+            "node-a",
+            node,
+            [
+                {
+                    "id": "ws1",
+                    "name": "n",
+                    "state": "idle",
+                    "kind": "interactive",
+                    "user_id": "alice",
+                    "project_id": "p1",
+                }
+            ],
+        )
+
+        created = [e for e in pending if e["type"] == "ws_created"]
+        assert len(created) == 1
+        assert created[0]["user_id"] == "alice"
+        assert created[0]["project_id"] == "p1"
+
+    def test_emit_console_ws_created_carries_project(self):
+        """Console pseudo-node coordinator rows + their ws_created must
+        carry project_id or private-project coordinators leak on the
+        SSE surface (the REST lane filters via _coordinator_rows)."""
+        c = _make_collector()
+        q: queue.Queue[dict] = queue.Queue()
+        c.register_listener(q)
+
+        c.emit_console_ws_created(
+            "cws1",
+            name="C",
+            user_id="alice",
+            kind="coordinator",
+            project_id="p1",
+        )
+
+        event = q.get_nowait()
+        assert event["type"] == "ws_created"
+        assert event["user_id"] == "alice"
+        assert event["project_id"] == "p1"
+        row = c._nodes[c.CONSOLE_PSEUDO_NODE_ID].workstreams["cws1"]
+        assert row["project_id"] == "p1"
+
     def test_apply_delta_ws_rename(self):
         c = _make_collector()
         c._nodes["node-a"] = NodeSnapshot(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import queue
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -1046,6 +1046,8 @@ class TestConsoleHTTPEndpoints:
             page=1,
             per_page=25,
             extra_rows=[],
+            # Per-request private-project tenancy closure — identity varies.
+            row_filter=ANY,
         )
 
     def test_get_workstreams_per_page_capped(self, client, mock_collector):

--- a/tests/test_coordinator_adapter.py
+++ b/tests/test_coordinator_adapter.py
@@ -73,7 +73,7 @@ def _make_ws(**overrides: Any) -> Workstream:
 
 def test_emit_created_calls_collector_with_coord_fields() -> None:
     adapter, collector = _make_adapter()
-    ws = _make_ws()
+    ws = _make_ws(project_id="p1")
     adapter.emit_created(ws)
     collector.emit_console_ws_created.assert_called_once_with(
         "coord-1",
@@ -82,6 +82,8 @@ def test_emit_created_calls_collector_with_coord_fields() -> None:
         kind=WorkstreamKind.COORDINATOR.value,
         state=WorkstreamState.IDLE.value,
         parent_ws_id=None,
+        # Tenancy-load-bearing: the console SSE filter gates on this.
+        project_id="p1",
     )
 
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -520,6 +520,7 @@ def test_active_list_row_shape_includes_unified_fields(storage):
         "kind",
         "parent_ws_id",
         "user_id",
+        "project_id",
     }
     assert row["name"] == "lifted-coord"
     assert row["kind"] == "coordinator"

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -25,6 +25,7 @@ from turnstone.server import (
     get_project_endpoint,
     list_project_members_endpoint,
     list_projects,
+    project_resources_endpoint,
     remove_project_member_endpoint,
     update_project_endpoint,
 )
@@ -103,6 +104,10 @@ def client(storage: SQLiteBackend) -> Iterator[TestClient]:
                         "/api/projects/{project_id}/members/{user_id}",
                         remove_project_member_endpoint,
                         methods=["DELETE"],
+                    ),
+                    Route(
+                        "/api/projects/{project_id}/resources",
+                        project_resources_endpoint,
                     ),
                 ],
             ),
@@ -194,3 +199,51 @@ class TestProjectApi:
     def test_get_missing_404(self, client: TestClient) -> None:
         r = client.get("/v1/api/projects/nope")
         assert r.status_code == 404
+
+
+class TestProjectResources:
+    def _seed(self, client: TestClient, storage: SQLiteBackend) -> str:
+        pid: str = client.post("/v1/api/projects", json={"name": "R"}).json()["project_id"]
+        storage.register_workstream("ws-a", name="alpha", user_id="alice", project_id=pid)
+        storage.register_workstream("ws-b", name="beta", user_id="alice", project_id=pid)
+        storage.register_workstream("ws-x", name="other", user_id="alice")
+        mid = storage.save_message("ws-a", "user", "see attached")
+        storage.save_attachment("a" * 64, "notes.txt", "text/plain", 5, "text", b"hello")
+        storage.set_message_attachments("ws-a", mid, ["a" * 64])
+        storage.create_structured_memory("m1", "fact", "d", "general", "project", pid, "body")
+        return pid
+
+    def test_resources_aggregate(self, client: TestClient, storage: SQLiteBackend) -> None:
+        pid = self._seed(client, storage)
+        r = client.get(f"/v1/api/projects/{pid}/resources")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["project_id"] == pid
+        assert body["name"] == "R"
+        ws_ids = [w["ws_id"] for w in body["workstreams"]]
+        assert set(ws_ids) == {"ws-a", "ws-b"}  # ws-x is not in the project
+        atts = body["attachments"]
+        assert len(atts) == 1
+        assert atts[0]["attachment_id"] == "a" * 64
+        assert atts[0]["filename"] == "notes.txt"
+        assert atts[0]["ws_id"] == "ws-a"
+        assert "content" not in atts[0]  # metadata only — never the blob
+        assert body["memory_count"] == 1
+
+    def test_resources_empty_project(self, client: TestClient) -> None:
+        pid = client.post("/v1/api/projects", json={"name": "E"}).json()["project_id"]
+        body = client.get(f"/v1/api/projects/{pid}/resources").json()
+        assert body["workstreams"] == []
+        assert body["attachments"] == []
+        assert body["memory_count"] == 0
+
+    def test_resources_missing_404(self, client: TestClient) -> None:
+        assert client.get("/v1/api/projects/nope/resources").status_code == 404
+
+    def test_resources_private_non_member_403(
+        self, client: TestClient, storage: SQLiteBackend
+    ) -> None:
+        # Owned by someone else, private — alice holds project.read but no
+        # membership, so the per-project ACL denies.
+        storage.create_project("p-zed", "Z", "zed")
+        assert client.get("/v1/api/projects/p-zed/resources").status_code == 403

--- a/tests/test_project_storage.py
+++ b/tests/test_project_storage.py
@@ -230,17 +230,22 @@ class TestMemoryScopeLabels:
 
 class TestProjectResourceQueries:
     def test_list_workstreams_for_project_scoped_and_ordered(self, backend: Any) -> None:
+        import sqlalchemy as sa
+
         backend.create_project("p1", "A", "u1")
         backend.register_workstream("w-old", name="old", user_id="u1", project_id="p1")
         backend.register_workstream("w-new", name="new", user_id="u1", project_id="p1")
         backend.register_workstream("w-out", name="out", user_id="u1")
-        # Force a deterministic updated ordering.
-        backend.update_workstream_title("w-new", "bump")
+        # Force a deterministic ``updated`` ordering directly — same-second
+        # registration timestamps would otherwise make ORDER BY updated
+        # DESC a coin flip and the ordering assertion vacuous.
+        with backend._engine.connect() as conn:  # noqa: SLF001
+            conn.execute(
+                sa.text("UPDATE workstreams SET updated = '2020-01-01' WHERE ws_id = 'w-old'")
+            )
+            conn.commit()
         rows = backend.list_workstreams_for_project("p1")
-        assert [r["ws_id"] for r in rows][: 2] == ["w-new", "w-old"] or {
-            r["ws_id"] for r in rows
-        } == {"w-new", "w-old"}
-        assert all(r["ws_id"] != "w-out" for r in rows)
+        assert [r["ws_id"] for r in rows] == ["w-new", "w-old"]
         assert {"ws_id", "name", "title", "state", "kind", "updated", "node_id", "user_id"} <= set(
             rows[0]
         )

--- a/tests/test_project_storage.py
+++ b/tests/test_project_storage.py
@@ -226,3 +226,51 @@ class TestMemoryScopeLabels:
         ]
         labels = [r["scope_label"] for r in _enrich_memory_scope_labels(rows, backend)]
         assert labels == ["Research", "alice", "alice", "planning chat", "", "gone"]
+
+
+class TestProjectResourceQueries:
+    def test_list_workstreams_for_project_scoped_and_ordered(self, backend: Any) -> None:
+        backend.create_project("p1", "A", "u1")
+        backend.register_workstream("w-old", name="old", user_id="u1", project_id="p1")
+        backend.register_workstream("w-new", name="new", user_id="u1", project_id="p1")
+        backend.register_workstream("w-out", name="out", user_id="u1")
+        # Force a deterministic updated ordering.
+        backend.update_workstream_title("w-new", "bump")
+        rows = backend.list_workstreams_for_project("p1")
+        assert [r["ws_id"] for r in rows][: 2] == ["w-new", "w-old"] or {
+            r["ws_id"] for r in rows
+        } == {"w-new", "w-old"}
+        assert all(r["ws_id"] != "w-out" for r in rows)
+        assert {"ws_id", "name", "title", "state", "kind", "updated", "node_id", "user_id"} <= set(
+            rows[0]
+        )
+
+    def test_list_project_attachments_dedupes_to_first_ws(self, backend: Any) -> None:
+        backend.create_project("p1", "A", "u1")
+        backend.register_workstream("w1", user_id="u1", project_id="p1")
+        backend.register_workstream("w2", user_id="u1", project_id="p1")
+        backend.save_attachment("a" * 64, "one.txt", "text/plain", 3, "text", b"abc")
+        backend.save_attachment("b" * 64, "two.png", "image/png", 4, "image", b"pngx")
+        m1 = backend.save_message("w1", "user", "first")
+        backend.set_message_attachments("w1", m1, ["a" * 64])
+        # Same blob referenced again from w2 + a second blob.
+        m2 = backend.save_message("w2", "user", "second")
+        backend.set_message_attachments("w2", m2, ["a" * 64, "b" * 64])
+        atts = backend.list_project_attachments("p1")
+        by_id = {a["attachment_id"]: a for a in atts}
+        assert set(by_id) == {"a" * 64, "b" * 64}
+        assert by_id["a" * 64]["ws_id"] == "w1"  # first reference wins
+        assert by_id["b" * 64]["ws_id"] == "w2"
+        assert by_id["a" * 64]["filename"] == "one.txt"
+        assert "content" not in by_id["a" * 64]
+
+    def test_list_project_attachments_skips_pruned_blob(self, backend: Any) -> None:
+        backend.create_project("p1", "A", "u1")
+        backend.register_workstream("w1", user_id="u1", project_id="p1")
+        m1 = backend.save_message("w1", "user", "ref to a gone blob")
+        backend.set_message_attachments("w1", m1, ["c" * 64])  # never saved
+        assert backend.list_project_attachments("p1") == []
+
+    def test_list_project_attachments_empty_project(self, backend: Any) -> None:
+        backend.create_project("p1", "A", "u1")
+        assert backend.list_project_attachments("p1") == []

--- a/tests/test_project_workstream_visibility.py
+++ b/tests/test_project_workstream_visibility.py
@@ -292,3 +292,253 @@ class TestSavedListFilter:
 
         rows_alice = await _collect_saved_rows(cfg, _request_for("alice"))
         assert {r["ws_id"] for r in rows_alice} == {"ws-plain", "ws-priv", "ws-pub", "ws-own"}
+
+
+class TestTriStateVisibility:
+    def test_undetermined_on_storage_error(self) -> None:
+        storage = MagicMock()
+        storage.get_project.side_effect = RuntimeError("db down")
+        vis = WorkstreamProjectVisibility("bob", storage=storage)
+        assert vis.ws_visibility("p1") is None
+        # The boolean form stays fail-closed.
+        assert vis.ws_visible("p1") is False
+
+    def test_definitive_verdicts(self) -> None:
+        assert (
+            WorkstreamProjectVisibility("bob", storage=_fake_storage(visibility="public"))
+            .ws_visibility("p1")
+            is True
+        )
+        assert WorkstreamProjectVisibility("bob", storage=_fake_storage()).ws_visibility("p1") is False
+
+
+class _ScriptedVis:
+    """ws_visibility stub: per-pid verdict, or a list consumed per call."""
+
+    def __init__(self, verdicts: dict, bypass: bool = False) -> None:
+        self.verdicts = dict(verdicts)
+        self.bypass = bypass
+        self.calls = 0
+
+    def ws_visibility(self, pid, ws_owner=""):
+        self.calls += 1
+        v = self.verdicts.get(pid or "", True)
+        if isinstance(v, list):
+            return v.pop(0) if len(v) > 1 else v[0]
+        return v
+
+
+class TestClusterTenancyFilter:
+    def _snap(self):
+        return {
+            "nodes": [
+                {
+                    "node_id": "node-a",
+                    "workstreams": [
+                        {"ws_id": "w-vis", "state": "running", "project_id": "", "user_id": "a"},
+                        {"ws_id": "w-priv", "state": "running", "project_id": "ph", "user_id": "a"},
+                    ],
+                }
+            ],
+            "overview": {
+                "nodes": 1,
+                "workstreams": 2,
+                "states": {"running": 2, "thinking": 0, "idle": 0},
+            },
+        }
+
+    def test_snapshot_filters_rows_and_rederives_overview(self) -> None:
+        from turnstone.console.server import _ClusterTenancyFilter
+
+        filt = _ClusterTenancyFilter(_ScriptedVis({"ph": False}))
+        snap = filt.filter_snapshot(self._snap())
+        assert [w["ws_id"] for w in snap["nodes"][0]["workstreams"]] == ["w-vis"]
+        # Overview no longer leaks the hidden row's existence or state.
+        assert snap["overview"]["workstreams"] == 1
+        assert snap["overview"]["states"] == {"running": 1, "thinking": 0, "idle": 0}
+        # Later sparse events for the hidden ws are suppressed.
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w-priv"}) is False
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w-vis"}) is True
+
+    def test_bypass_leaves_snapshot_untouched(self) -> None:
+        from turnstone.console.server import _ClusterTenancyFilter
+
+        filt = _ClusterTenancyFilter(_ScriptedVis({"ph": False}, bypass=True))
+        snap = filt.filter_snapshot(self._snap())
+        assert len(snap["nodes"][0]["workstreams"]) == 2
+        assert snap["overview"]["workstreams"] == 2  # collector aggregate preserved
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w-priv"}) is True
+        assert filt.event_touches_storage({"type": "ws_created", "ws_id": "x"}) is False
+
+    def test_ws_created_judged_and_closed_cleans_up(self) -> None:
+        from turnstone.console.server import _ClusterTenancyFilter
+
+        filt = _ClusterTenancyFilter(_ScriptedVis({"ph": False}))
+        created = {"type": "ws_created", "ws_id": "w1", "project_id": "ph", "user_id": "b"}
+        assert filt.event_visible(created) is False
+        assert filt.event_visible({"type": "ws_rename", "ws_id": "w1"}) is False
+        # The close of a never-shown workstream is itself suppressed…
+        assert filt.event_visible({"type": "ws_closed", "ws_id": "w1"}) is False
+        # …and the state is cleaned, so an unrelated later event passes.
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w1"}) is True
+
+    def test_undetermined_suppresses_then_retries(self) -> None:
+        from turnstone.console.server import _ClusterTenancyFilter
+
+        vis = _ScriptedVis({"pu": [None, True]})
+        filt = _ClusterTenancyFilter(vis)
+        created = {"type": "ws_created", "ws_id": "w1", "project_id": "pu", "user_id": "b"}
+        # Storage blip: suppressed but NOT pinned hidden.
+        assert filt.event_visible(created) is False
+        assert "w1" in filt._unresolved
+        # Within the retry interval later events stay suppressed without
+        # re-hitting storage.
+        calls_before = vis.calls
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w1"}) is False
+        assert vis.calls == calls_before
+        # Past the interval the row is re-judged and recovers.
+        filt._RETRY_INTERVAL_S = 0.0
+        filt._retry_after["w1"] = 0.0
+        assert filt.event_touches_storage({"type": "cluster_state", "ws_id": "w1"}) is True
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w1"}) is True
+        assert "w1" not in filt._unresolved
+
+    def test_denied_verdict_pins_hidden(self) -> None:
+        from turnstone.console.server import _ClusterTenancyFilter
+
+        vis = _ScriptedVis({"pu": [None, False]})
+        filt = _ClusterTenancyFilter(vis)
+        filt._RETRY_INTERVAL_S = 0.0
+        assert (
+            filt.event_visible(
+                {"type": "ws_created", "ws_id": "w1", "project_id": "pu", "user_id": "b"}
+            )
+            is False
+        )
+        filt._retry_after["w1"] = 0.0
+        assert filt.event_visible({"type": "cluster_state", "ws_id": "w1"}) is False
+        assert "w1" in filt._hidden and "w1" not in filt._unresolved
+
+
+class TestCreateValidatorProjectGate:
+    """The interactive create validator's attach gate: explicit ids are
+    strict, inherited ids tolerate a deleted project (real ephemeral DB)."""
+
+    async def test_inherited_dangling_project_is_stripped(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.server import _interactive_create_validate_request
+
+        register_workstream(
+            "coord-1", user_id="alice", kind="coordinator", project_id="p-gone"
+        )
+        body: dict = {"kind": "interactive", "parent_ws_id": "coord-1"}
+        err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
+        assert err is None
+        assert (body.get("project_id") or "") == ""
+
+    async def test_explicit_unknown_project_still_400s(self, tmp_db: str) -> None:
+        from turnstone.server import _interactive_create_validate_request
+
+        body: dict = {"kind": "interactive", "project_id": "nope"}
+        err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
+        assert err is not None and err.status_code == 400
+
+    async def test_inherited_private_revoked_membership_403s(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.core.storage import get_storage
+        from turnstone.server import _interactive_create_validate_request
+
+        get_storage().create_project("p-priv", "P", "zed")
+        register_workstream(
+            "coord-2", user_id="alice", kind="coordinator", project_id="p-priv"
+        )
+        body: dict = {"kind": "interactive", "parent_ws_id": "coord-2"}
+        err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
+        assert err is not None and err.status_code == 403
+
+    async def test_inherited_accessible_project_passes(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.core.storage import get_storage
+        from turnstone.server import _interactive_create_validate_request
+
+        storage = get_storage()
+        storage.create_project("p-ok", "P", "zed")
+        storage.add_project_member("p-ok", "alice")
+        register_workstream("coord-3", user_id="alice", kind="coordinator", project_id="p-ok")
+        body: dict = {"kind": "interactive", "parent_ws_id": "coord-3"}
+        err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
+        assert err is None
+        assert body["project_id"] == "p-ok"
+
+
+class TestSavedListPagination:
+    """The saved-list collector pages past invisible rows instead of
+    letting a post-SQL filter shrink the window."""
+
+    def _row(self, i: int, project_id: str | None) -> tuple:
+        return (
+            f"ws-{i:03d}",
+            None,
+            None,
+            f"n{i}",
+            "2026-01-01T00:00:00",
+            f"{99999 - i}",  # updated: descending with i
+            1,
+            "node-a",
+            "idle",
+            "interactive",
+            None,
+            None,
+            0,
+            0,
+            None,
+            project_id,
+            "alice",
+        )
+
+    def _cfg(self):
+        from turnstone.core.session_routes import SessionEndpointConfig
+        from turnstone.core.workstream import WorkstreamKind
+
+        return SessionEndpointConfig(
+            permission_gate=None,
+            manager_lookup=lambda request: (None, None),
+            tenant_check=None,
+            not_found_label="Workstream not found",
+            audit_action_prefix="workstream",
+            list_kind=WorkstreamKind.INTERACTIVE,
+            saved_state_filter=None,
+            saved_loaded_lookup=None,
+        )
+
+    def _patch(self, monkeypatch: pytest.MonkeyPatch, rows: list) -> None:
+        def _fake(limit=20, *, kind=None, user_id=None, state=None, offset=0):
+            return rows[offset : offset + limit]
+
+        monkeypatch.setattr("turnstone.core.memory.list_workstreams_with_history", _fake)
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage())  # denies any pid
+        monkeypatch.setattr(
+            WorkstreamProjectVisibility,
+            "for_request",
+            classmethod(lambda cls, request, storage=None: vis),
+        )
+
+    async def test_pages_past_invisible_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from turnstone.core.session_routes import _collect_saved_rows
+
+        rows = [self._row(i, "ph") for i in range(60)] + [
+            self._row(i, None) for i in range(60, 130)
+        ]
+        self._patch(monkeypatch, rows)
+        result = await _collect_saved_rows(self._cfg(), MagicMock())
+        assert len(result) == 50
+        assert result[0]["ws_id"] == "ws-060"
+        assert result[-1]["ws_id"] == "ws-109"
+
+    async def test_scan_cap_terminates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from turnstone.core.session_routes import _collect_saved_rows
+
+        rows = [self._row(i, "ph") for i in range(5000)]
+        self._patch(monkeypatch, rows)
+        result = await _collect_saved_rows(self._cfg(), MagicMock())
+        assert result == []

--- a/tests/test_project_workstream_visibility.py
+++ b/tests/test_project_workstream_visibility.py
@@ -305,11 +305,14 @@ class TestTriStateVisibility:
 
     def test_definitive_verdicts(self) -> None:
         assert (
-            WorkstreamProjectVisibility("bob", storage=_fake_storage(visibility="public"))
-            .ws_visibility("p1")
+            WorkstreamProjectVisibility(
+                "bob", storage=_fake_storage(visibility="public")
+            ).ws_visibility("p1")
             is True
         )
-        assert WorkstreamProjectVisibility("bob", storage=_fake_storage()).ws_visibility("p1") is False
+        assert (
+            WorkstreamProjectVisibility("bob", storage=_fake_storage()).ws_visibility("p1") is False
+        )
 
 
 class _ScriptedVis:
@@ -428,9 +431,7 @@ class TestCreateValidatorProjectGate:
         from turnstone.core.memory import register_workstream
         from turnstone.server import _interactive_create_validate_request
 
-        register_workstream(
-            "coord-1", user_id="alice", kind="coordinator", project_id="p-gone"
-        )
+        register_workstream("coord-1", user_id="alice", kind="coordinator", project_id="p-gone")
         body: dict = {"kind": "interactive", "parent_ws_id": "coord-1"}
         err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
         assert err is None
@@ -449,9 +450,7 @@ class TestCreateValidatorProjectGate:
         from turnstone.server import _interactive_create_validate_request
 
         get_storage().create_project("p-priv", "P", "zed")
-        register_workstream(
-            "coord-2", user_id="alice", kind="coordinator", project_id="p-priv"
-        )
+        register_workstream("coord-2", user_id="alice", kind="coordinator", project_id="p-priv")
         body: dict = {"kind": "interactive", "parent_ws_id": "coord-2"}
         err = await _interactive_create_validate_request(MagicMock(), body, "alice", [])
         assert err is not None and err.status_code == 403

--- a/tests/test_project_workstream_visibility.py
+++ b/tests/test_project_workstream_visibility.py
@@ -1,0 +1,294 @@
+"""Private-project workstream visibility enforcement.
+
+Covers the tenancy predicate (:class:`WorkstreamProjectVisibility`), the
+create-time attach gate (:func:`ensure_project_attachable`), the row-access
+gate in :func:`resolve_workstream_owner`, and the saved-list filter in
+``_collect_saved_rows`` — the choke points that keep workstreams attached
+to a private project out of non-members' listings and 403 their direct
+access.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from turnstone.core.auth import (
+    WorkstreamProjectVisibility,
+    ensure_project_attachable,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _fake_storage(
+    *,
+    visibility: str = "private",
+    owner: str = "alice",
+    members: tuple[str, ...] = (),
+    missing: bool = False,
+) -> MagicMock:
+    storage = MagicMock()
+    if missing:
+        storage.get_project.return_value = None
+    else:
+        storage.get_project.return_value = {
+            "project_id": "p1",
+            "name": "P1",
+            "owner_id": owner,
+            "visibility": visibility,
+            "state": "active",
+        }
+    storage.is_project_member.side_effect = lambda pid, uid: uid in members
+    return storage
+
+
+class _FakeAuth:
+    def __init__(
+        self,
+        user_id: str,
+        scopes: tuple[str, ...] = (),
+        permissions: tuple[str, ...] = (),
+    ) -> None:
+        self.user_id = user_id
+        self._scopes = set(scopes)
+        self._permissions = set(permissions)
+
+    def has_scope(self, scope: str) -> bool:
+        return scope in self._scopes
+
+    def has_permission(self, permission: str) -> bool:
+        return permission in self._permissions
+
+
+def _request_for(
+    uid: str,
+    scopes: tuple[str, ...] = (),
+    permissions: tuple[str, ...] = (),
+) -> Any:
+    return SimpleNamespace(state=SimpleNamespace(auth_result=_FakeAuth(uid, scopes, permissions)))
+
+
+class TestWsVisiblePredicate:
+    def test_no_project_always_visible(self) -> None:
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage())
+        assert vis.ws_visible(None)
+        assert vis.ws_visible("")
+
+    def test_dangling_project_visible(self) -> None:
+        # Project deletion leaves ws links behind — no row, no privacy.
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage(missing=True))
+        assert vis.ws_visible("p1")
+
+    def test_public_project_visible_to_anyone(self) -> None:
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage(visibility="public"))
+        assert vis.ws_visible("p1")
+
+    def test_private_hidden_from_non_member(self) -> None:
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage())
+        assert not vis.ws_visible("p1")
+
+    def test_private_visible_to_project_owner(self) -> None:
+        vis = WorkstreamProjectVisibility("alice", storage=_fake_storage())
+        assert vis.ws_visible("p1")
+
+    def test_private_visible_to_member(self) -> None:
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage(members=("bob",)))
+        assert vis.ws_visible("p1")
+
+    def test_private_visible_to_ws_creator(self) -> None:
+        # A workstream's own creator never loses sight of it, even after
+        # a membership revoke leaves a legacy private-project link.
+        vis = WorkstreamProjectVisibility("bob", storage=_fake_storage())
+        assert vis.ws_visible("p1", ws_owner="bob")
+
+    def test_private_hidden_from_anonymous(self) -> None:
+        vis = WorkstreamProjectVisibility("", storage=_fake_storage())
+        assert not vis.ws_visible("p1")
+
+    def test_bypass_sees_everything(self) -> None:
+        vis = WorkstreamProjectVisibility("bob", bypass=True, storage=_fake_storage())
+        assert vis.ws_visible("p1")
+
+    def test_storage_error_fails_closed(self) -> None:
+        storage = MagicMock()
+        storage.get_project.side_effect = RuntimeError("db down")
+        vis = WorkstreamProjectVisibility("bob", storage=storage)
+        assert not vis.ws_visible("p1")
+
+    def test_project_rows_memoized(self) -> None:
+        storage = _fake_storage(visibility="public")
+        vis = WorkstreamProjectVisibility("bob", storage=storage)
+        assert vis.ws_visible("p1")
+        assert vis.ws_visible("p1")
+        assert storage.get_project.call_count == 1
+
+    def test_for_request_bypass_rules(self) -> None:
+        assert WorkstreamProjectVisibility.for_request(
+            _request_for("bob", scopes=("service",))
+        )._bypass
+        assert WorkstreamProjectVisibility.for_request(
+            _request_for("bob", permissions=("admin.cluster.inspect",))
+        )._bypass
+        assert not WorkstreamProjectVisibility.for_request(_request_for("bob"))._bypass
+
+
+class TestEnsureProjectAttachable:
+    def test_no_project_allowed(self) -> None:
+        assert ensure_project_attachable("bob", "", storage=_fake_storage()) is None
+
+    def test_unknown_project_is_400(self) -> None:
+        denied = ensure_project_attachable("bob", "p1", storage=_fake_storage(missing=True))
+        assert denied is not None and denied[0] == 400
+
+    def test_public_project_allowed(self) -> None:
+        assert (
+            ensure_project_attachable("bob", "p1", storage=_fake_storage(visibility="public"))
+            is None
+        )
+
+    def test_private_member_and_owner_allowed(self) -> None:
+        assert (
+            ensure_project_attachable("bob", "p1", storage=_fake_storage(members=("bob",))) is None
+        )
+        assert ensure_project_attachable("alice", "p1", storage=_fake_storage()) is None
+
+    def test_private_non_member_is_403(self) -> None:
+        denied = ensure_project_attachable("bob", "p1", storage=_fake_storage())
+        assert denied is not None and denied[0] == 403
+
+    def test_anonymous_private_is_403(self) -> None:
+        denied = ensure_project_attachable("", "p1", storage=_fake_storage())
+        assert denied is not None and denied[0] == 403
+
+    def test_storage_error_fails_closed(self) -> None:
+        storage = MagicMock()
+        storage.get_project.side_effect = RuntimeError("db down")
+        denied = ensure_project_attachable("bob", "p1", storage=storage)
+        assert denied is not None and denied[0] == 403
+
+
+class TestResolveWorkstreamOwnerProjectGate:
+    """Integration against the real (ephemeral) storage: the row-access
+    gate every interactive ws-scoped verb inherits via tenant_check."""
+
+    def _seed(self, *, member: bool) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.core.storage import get_storage
+
+        storage = get_storage()
+        storage.create_project("p1", "Secret", "alice")
+        if member:
+            storage.add_project_member("p1", "bob")
+        register_workstream("ws-priv", user_id="alice", project_id="p1")
+
+    def test_non_member_gets_403(self, tmp_db: str) -> None:
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        self._seed(member=False)
+        owner, err = resolve_workstream_owner(_request_for("bob"), "ws-priv")
+        assert err is not None and err.status_code == 403
+
+    def test_member_resolves_owner(self, tmp_db: str) -> None:
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        self._seed(member=True)
+        owner, err = resolve_workstream_owner(_request_for("bob"), "ws-priv")
+        assert err is None
+        assert owner == "alice"
+
+    def test_ws_creator_bypasses(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.core.storage import get_storage
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        storage = get_storage()
+        storage.create_project("p1", "Secret", "alice")
+        # bob created a ws in alice's private project, then lost access —
+        # bob still reaches his own workstream.
+        register_workstream("ws-bob", user_id="bob", project_id="p1")
+        owner, err = resolve_workstream_owner(_request_for("bob"), "ws-bob")
+        assert err is None
+        assert owner == "bob"
+
+    def test_admin_inspect_bypasses(self, tmp_db: str) -> None:
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        self._seed(member=False)
+        owner, err = resolve_workstream_owner(
+            _request_for("bob", permissions=("admin.cluster.inspect",)), "ws-priv"
+        )
+        assert err is None
+        assert owner == "alice"
+
+    def test_missing_ws_still_404s(self, tmp_db: str) -> None:
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        owner, err = resolve_workstream_owner(_request_for("bob"), "nope")
+        assert err is not None and err.status_code == 404
+
+    def test_public_project_ws_resolves(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream
+        from turnstone.core.storage import get_storage
+        from turnstone.core.web_helpers import resolve_workstream_owner
+
+        storage = get_storage()
+        storage.create_project("p1", "Open", "alice")
+        storage.update_project("p1", visibility="public")
+        register_workstream("ws-pub", user_id="alice", project_id="p1")
+        owner, err = resolve_workstream_owner(_request_for("bob"), "ws-pub")
+        assert err is None
+        assert owner == "alice"
+
+
+class TestSavedListFilter:
+    """The saved-sessions collector drops private-project rows server-side
+    and carries project_id on surviving rows (real ephemeral DB)."""
+
+    async def test_saved_rows_filtered_and_carry_project_id(self, tmp_db: str) -> None:
+        from turnstone.core.memory import register_workstream, save_message
+        from turnstone.core.session_routes import (
+            SessionEndpointConfig,
+            _collect_saved_rows,
+        )
+        from turnstone.core.storage import get_storage
+        from turnstone.core.workstream import WorkstreamKind
+
+        storage = get_storage()
+        storage.create_project("p1", "Secret", "alice")
+        storage.create_project("p2", "Open", "alice")
+        storage.update_project("p2", visibility="public")
+
+        register_workstream("ws-plain", user_id="alice")
+        register_workstream("ws-priv", user_id="alice", project_id="p1")
+        register_workstream("ws-pub", user_id="alice", project_id="p2")
+        register_workstream("ws-own", user_id="bob", project_id="p1")
+        for wid in ("ws-plain", "ws-priv", "ws-pub", "ws-own"):
+            save_message(wid, "user", "hello")
+
+        cfg = SessionEndpointConfig(
+            permission_gate=None,
+            manager_lookup=lambda request: (None, None),
+            tenant_check=None,
+            not_found_label="Workstream not found",
+            audit_action_prefix="workstream",
+            list_kind=WorkstreamKind.INTERACTIVE,
+            saved_state_filter=None,
+            saved_loaded_lookup=None,
+        )
+
+        rows = await _collect_saved_rows(cfg, _request_for("bob"))
+        ids = {r["ws_id"] for r in rows}
+        # bob: no membership in p1 — alice's private ws is dropped; the
+        # public-project ws, the project-less ws, and bob's own
+        # private-project ws all survive.
+        assert ids == {"ws-plain", "ws-pub", "ws-own"}
+        by_id = {r["ws_id"]: r for r in rows}
+        assert by_id["ws-pub"]["project_id"] == "p2"
+        assert by_id["ws-plain"]["project_id"] is None
+
+        rows_alice = await _collect_saved_rows(cfg, _request_for("alice"))
+        assert {r["ws_id"] for r in rows_alice} == {"ws-plain", "ws-priv", "ws-pub", "ws-own"}

--- a/tests/test_saved_handler_unified.py
+++ b/tests/test_saved_handler_unified.py
@@ -137,12 +137,16 @@ def _patch_storage(
         kind: Any = None,
         user_id: Any = None,
         state: Any = None,
+        offset: int = 0,
     ) -> list[tuple[Any, ...]]:
         calls.append({"kind": kind, "state": state, "user_id": user_id, "limit": limit})
+        # Honour limit/offset like the real query — the collector pages
+        # with OFFSET until it fills its visibility window, so a fake
+        # that ignored them would return the same batch forever.
         if kind == WorkstreamKind.COORDINATOR:
-            return coord_rows
+            return coord_rows[offset : offset + limit]
         if kind == WorkstreamKind.INTERACTIVE:
-            return interactive_rows
+            return interactive_rows[offset : offset + limit]
         return []
 
     # The handler imports the symbol from turnstone.core.memory at call

--- a/tests/test_saved_handler_unified.py
+++ b/tests/test_saved_handler_unified.py
@@ -6,7 +6,7 @@ for its L-shell dashboard, plus a regression guard for the single-kind
 :func:`turnstone.core.session_routes._collect_saved_rows`.
 
 Storage is mocked (``list_workstreams_with_history`` is patched to
-return synthetic 15-tuples) — no real or dev database is touched. The
+return synthetic 17-tuples) — no real or dev database is touched. The
 request is a :class:`unittest.mock.MagicMock`, matching how the
 body-level coordinator endpoint tests build request stubs; the saved
 path only reads ``request`` to pass it to ``saved_loaded_lookup`` /
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.anyio
 # Column order from list_workstreams_with_history (keep in sync with the
 # storage SELECT): ws_id, alias, title, name, created, updated,
 # message_count, node_id, state, kind, model_alias, launch_skill,
-# child_count, context_tokens, context_window.
+# child_count, context_tokens, context_window, project_id, owner.
 def _row(
     ws_id: str,
     *,
@@ -49,8 +49,10 @@ def _row(
     kind: str,
     state: str = "closed",
     name: str | None = None,
+    project_id: str | None = None,
+    owner: str | None = None,
 ) -> tuple[Any, ...]:
-    """Build a synthetic storage row (15-tuple) for one workstream."""
+    """Build a synthetic storage row (17-tuple) for one workstream."""
     return (
         ws_id,
         None,  # alias
@@ -67,6 +69,8 @@ def _row(
         0,  # child_count
         1000,  # context_tokens
         4000,  # context_window
+        project_id,  # project_id
+        owner,  # owner user_id
     )
 
 
@@ -343,6 +347,7 @@ async def test_single_kind_saved_unchanged(monkeypatch: pytest.MonkeyPatch) -> N
         "child_count",
         "context_tokens",
         "context_ratio",
+        "project_id",
     }
 
 

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -646,6 +646,7 @@ class TestListWorkstreamsTrustedTeamVisibility:
             "kind",
             "parent_ws_id",
             "user_id",
+            "project_id",
         }
         assert row["kind"] == "interactive"
         assert row["user_id"] == "user-shape"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1191,3 +1191,147 @@ class TestMCPToolGating:
         # session's ``user_id`` (sanity-check on the wiring).
         mcp_client.resource_count_for_user.assert_any_call("pool-only-user")
         mcp_client.prompt_count_for_user.assert_any_call("pool-only-user")
+
+
+class TestMCPActingUserBinding:
+    """Per-user MCP credentials follow the acting user on shared workstreams.
+
+    The workstream owner is the fallback identity; an authenticated send
+    rebinds credential resolution (dispatch + catalogs + listeners) to the
+    sender. Prepared tool items pin the identity at prepare time so a
+    pending approval can't execute under a later sender's credentials.
+    """
+
+    def _make(self, mock_openai_client, owner="alice"):
+        mcp_client = MagicMock()
+        mcp_client.get_tools.return_value = []
+        mcp_client.call_tool_sync.return_value = "ok"
+        session = ChatSession(
+            client=mock_openai_client,
+            model="local-model",
+            ui=MagicMock(),
+            instructions=None,
+            temperature=0.5,
+            max_tokens=1000,
+            tool_timeout=10,
+            mcp_client=mcp_client,
+            user_id=owner,
+        )
+        # Capture instead of persisting — same stub idiom as
+        # test_session_mcp_dispatch_error.
+        session._report_tool_result = MagicMock()  # type: ignore[method-assign]
+        return session, mcp_client
+
+    def test_effective_identity_defaults_to_owner(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        assert session._mcp_effective_user_id == "alice"
+        item = session._prepare_mcp_tool("c1", "mcp__srv__tool", {})
+        session._exec_mcp_tool(item)
+        assert mcp_client.call_tool_sync.call_args.kwargs["user_id"] == "alice"
+
+    def test_bind_rebinds_dispatch_catalog_listeners_and_prime(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        mcp_client.reset_mock()
+
+        session.bind_acting_user("bob")
+
+        # Dispatch identity follows the acting user.
+        item = session._prepare_mcp_tool("c1", "mcp__srv__tool", {})
+        session._exec_mcp_tool(item)
+        assert mcp_client.call_tool_sync.call_args.kwargs["user_id"] == "bob"
+        # Listener registrations swapped from owner to acting user for
+        # all three catalog kinds — identity is the (user_id, callback)
+        # pair, so the remove must name the OLD uid and the add the new.
+        mcp_client.remove_listener.assert_called_once_with(session._mcp_refresh_cb, user_id="alice")
+        mcp_client.add_listener.assert_called_once_with(session._mcp_refresh_cb, user_id="bob")
+        mcp_client.remove_resource_listener.assert_called_once_with(
+            session._mcp_resource_cb, user_id="alice"
+        )
+        mcp_client.add_resource_listener.assert_called_once_with(
+            session._mcp_resource_cb, user_id="bob"
+        )
+        mcp_client.remove_prompt_listener.assert_called_once_with(
+            session._mcp_prompt_cb, user_id="alice"
+        )
+        mcp_client.add_prompt_listener.assert_called_once_with(
+            session._mcp_prompt_cb, user_id="bob"
+        )
+        # The acting user's oauth_user pools are warmed so their tools
+        # surface without a manual reconnect.
+        mcp_client.prime_user_pools.assert_called_once_with("bob")
+        # Merged tool list rebuilt under the new identity.
+        mcp_client.get_tools.assert_any_call(user_id="bob")
+
+    def test_prepared_item_pins_identity_across_rebind(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        session.bind_acting_user("bob")
+        item = session._prepare_mcp_tool("c1", "mcp__srv__tool", {})
+        # A different user takes over the session while the item is
+        # pending approval — execution must stay under the requester.
+        session.bind_acting_user("carol")
+        session._exec_mcp_tool(item)
+        assert mcp_client.call_tool_sync.call_args.kwargs["user_id"] == "bob"
+
+    def test_resource_and_prompt_items_pin_identity(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        session.bind_acting_user("bob")
+        res_item = session._prepare_read_resource("c1", {"uri": "res://x"})
+        mcp_client.is_mcp_prompt.return_value = True
+        prompt_item = session._prepare_use_prompt("c2", {"name": "p"})
+        session.bind_acting_user("carol")
+        assert res_item["mcp_user_id"] == "bob"
+        assert prompt_item["mcp_user_id"] == "bob"
+        # And the prompt-existence gate consults the CURRENT effective
+        # identity (carol) for new preparations.
+        session._prepare_use_prompt("c3", {"name": "p"})
+        assert mcp_client.is_mcp_prompt.call_args.kwargs["user_id"] == "carol"
+
+    def test_bind_noops_on_empty_and_same_user(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        mcp_client.reset_mock()
+        session.bind_acting_user("")
+        session.bind_acting_user("alice")  # same as owner
+        mcp_client.remove_listener.assert_not_called()
+        mcp_client.add_listener.assert_not_called()
+        mcp_client.prime_user_pools.assert_not_called()
+        assert session._mcp_effective_user_id == "alice"
+
+    def test_send_kwarg_binds_before_turn_starts(self, tmp_db, mock_openai_client):
+        import pytest
+
+        session, _mcp_client = self._make(mock_openai_client)
+
+        class _SentinelError(Exception):
+            pass
+
+        # ``bind_acting_user`` runs before ``_refresh_model_from_registry``
+        # at the top of send() — abort there to prove the ordering without
+        # driving the full agent loop.
+        session._refresh_model_from_registry = MagicMock(  # type: ignore[method-assign]
+            side_effect=_SentinelError
+        )
+        with pytest.raises(_SentinelError):
+            session.send("hi", acting_user_id="bob")
+        assert session._acting_user_id == "bob"
+
+    def test_close_removes_listeners_under_rebound_identity(self, tmp_db, mock_openai_client):
+        session, mcp_client = self._make(mock_openai_client)
+        session.bind_acting_user("bob")
+        refresh_cb = session._mcp_refresh_cb
+        mcp_client.reset_mock()
+        session.close()
+        mcp_client.remove_listener.assert_called_once_with(refresh_cb, user_id="bob")
+
+    def test_bind_without_mcp_client_only_records(self, tmp_db, mock_openai_client):
+        session = ChatSession(
+            client=mock_openai_client,
+            model="local-model",
+            ui=MagicMock(),
+            instructions=None,
+            temperature=0.5,
+            max_tokens=1000,
+            tool_timeout=10,
+            user_id="alice",
+        )
+        session.bind_acting_user("bob")
+        assert session._mcp_effective_user_id == "bob"

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -441,6 +441,7 @@ class SavedWorkstreamInfo(BaseModel):
     child_count: int = 0
     context_tokens: int = 0
     context_ratio: float = 0.0
+    project_id: str | None = None
 
 
 class ListSavedWorkstreamsResponse(BaseModel):

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -540,6 +540,9 @@ class ClusterCollector:
                     "kind": WorkstreamKind.from_raw(ws.get("kind")),
                     "parent_ws_id": ws.get("parent_ws_id"),
                     "project_id": ws.get("project_id", "") or "",
+                    # Mirror the SSE-relay path: the tenancy filter's
+                    # ws-creator shortcut reads this.
+                    "user_id": ws.get("user_id", "") or "",
                 }
             )
         # Removals
@@ -1170,6 +1173,7 @@ class ClusterCollector:
         kind: str,
         state: str = "idle",
         parent_ws_id: str | None = None,
+        project_id: str | None = None,
     ) -> None:
         """Record a new coordinator row on the console pseudo-node + fan out.
 
@@ -1201,6 +1205,9 @@ class ClusterCollector:
                     "kind": kind,
                     "parent_ws_id": parent_ws_id,
                     "user_id": user_id or "",
+                    # Tenancy-load-bearing: the per-connection SSE filter
+                    # gates on this — a missing project_id fails open.
+                    "project_id": project_id or "",
                     "updated": now,
                 }
             pending.append(
@@ -1213,6 +1220,7 @@ class ClusterCollector:
                     "kind": kind,
                     "parent_ws_id": parent_ws_id,
                     "user_id": user_id or "",
+                    "project_id": project_id or "",
                 }
             )
         for event in pending:

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -932,6 +932,7 @@ class ClusterCollector:
         page: int = 1,
         per_page: int = 50,
         extra_rows: list[dict[str, Any]] | None = None,
+        row_filter: Callable[[dict[str, Any]], bool] | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Return filtered, sorted, paginated workstreams + total count.
 
@@ -939,6 +940,10 @@ class ClusterCollector:
         filter / sort / paginate — used by callers that contribute
         console-local rows (e.g. coordinator workstreams) that aren't
         tracked on any node's SSE stream.
+
+        ``row_filter`` (when provided) runs against the merged,
+        UNPAGINATED pool so dropped rows never skew ``total`` or page
+        boundaries — the private-project tenancy filter rides here.
         """
         with self._lock:
             all_ws = []
@@ -954,6 +959,10 @@ class ClusterCollector:
                     all_ws.append(dict(ws))
             if extra_rows:
                 all_ws.extend(dict(r) for r in extra_rows)
+
+        # Row-level tenancy filter first — before pagination math.
+        if row_filter is not None:
+            all_ws = [ws for ws in all_ws if row_filter(ws)]
 
         # Filter
         if state:

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -161,6 +161,7 @@ class CoordinatorAdapter:
                 kind=ws.kind.value,
                 state=ws.state.value,
                 parent_ws_id=None,
+                project_id=ws.project_id,
             )
         except Exception:
             log.debug("coord_adapter.created_fanout_failed ws=%s", ws.id[:8], exc_info=True)
@@ -505,6 +506,7 @@ class CoordinatorAdapter:
                     kind=WorkstreamKind.COORDINATOR.value,
                     state=ws.state.value,
                     parent_ws_id=None,
+                    project_id=ws.project_id,
                 )
             except Exception:
                 log.debug(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1578,12 +1578,137 @@ def _collector_scope_error(request: Request) -> JSONResponse | None:
     return None
 
 
+class _ClusterTenancyFilter:
+    """Per-connection/request private-project tenancy for cluster payloads.
+
+    Wraps a :class:`WorkstreamProjectVisibility` with the state the
+    cluster surfaces need: the snapshot carries full rows (project_id +
+    user_id) but follow-up SSE events are sparse (usually just ws_id),
+    so invisible workstreams are recorded in ``_hidden`` at
+    snapshot/ws_created time and every later event naming them is
+    swallowed. A row whose project lookup fails transiently lands in
+    ``_unresolved`` instead — suppressed but re-judged (rate-limited) on
+    its later events, so a DB blip neither leaks a private workstream
+    nor pins a public one invisible until reconnect. Access changes
+    (membership grant/revoke) still take effect on reconnect — same
+    resolve-once precedent as session construction. The visibility
+    instance memoizes project rows, so the steady-state per-event cost
+    is a set lookup.
+    """
+
+    _RETRY_INTERVAL_S = 5.0
+
+    def __init__(self, visibility: Any) -> None:
+        self._vis = visibility
+        # Bypass principals (service scope / admin.cluster.inspect) get
+        # the payload UNTOUCHED — no row drops, and crucially no
+        # overview recompute (their header should reflect the
+        # collector's own aggregates).
+        self._bypass = bool(getattr(visibility, "bypass", False))
+        self._hidden: set[str] = set()
+        # wid -> (project_id, ws_owner) awaiting a definitive verdict.
+        self._unresolved: dict[str, tuple[str, str]] = {}
+        self._retry_after: dict[str, float] = {}
+
+    @staticmethod
+    def _row_ws_id(ws: dict[str, Any]) -> str:
+        return str(ws.get("ws_id") or ws.get("id") or "")
+
+    def _judge(self, wid: str, project_id: str, ws_owner: str) -> bool:
+        """Tri-state check folded into the connection state.
+
+        Undetermined (storage blip) suppresses the row/event but leaves
+        it re-judgeable; definitive verdicts settle into shown/hidden.
+        """
+        verdict = self._vis.ws_visibility(project_id, ws_owner=ws_owner)
+        if verdict is None:
+            if wid:
+                self._unresolved[wid] = (project_id, ws_owner)
+                self._retry_after[wid] = time.monotonic() + self._RETRY_INTERVAL_S
+            return False
+        if wid:
+            self._unresolved.pop(wid, None)
+            self._retry_after.pop(wid, None)
+            if verdict:
+                self._hidden.discard(wid)
+            else:
+                self._hidden.add(wid)
+        return bool(verdict)
+
+    def filter_snapshot(self, snap: dict[str, Any]) -> dict[str, Any]:
+        """Drop invisible rows from every node list and re-derive the
+        overview aggregates the collector computed over the UNFILTERED
+        rows — otherwise the header count/state histogram leaks the
+        existence and lifecycle of hidden workstreams."""
+        if self._bypass:
+            return snap
+        total = 0
+        states: dict[str, int] = {}
+        for node in snap.get("nodes", []):
+            kept: list[dict[str, Any]] = []
+            for ws in node.get("workstreams", []):
+                wid = self._row_ws_id(ws)
+                if self._judge(wid, ws.get("project_id") or "", ws.get("user_id") or ""):
+                    kept.append(ws)
+                    state = str(ws.get("state") or "idle")
+                    states[state] = states.get(state, 0) + 1
+                    total += 1
+            node["workstreams"] = kept
+        overview = snap.get("overview")
+        if isinstance(overview, dict):
+            overview["workstreams"] = total
+            prior_states = overview.get("states")
+            if isinstance(prior_states, dict):
+                rebuilt = dict.fromkeys(prior_states, 0)
+                rebuilt.update(states)
+                overview["states"] = rebuilt
+        return snap
+
+    def event_visible(self, event: dict[str, Any]) -> bool:
+        if self._bypass:
+            return True
+        etype = event.get("type")
+        wid = str(event.get("ws_id") or "")
+        if etype == "ws_created":
+            return self._judge(wid, event.get("project_id") or "", event.get("user_id") or "")
+        if etype == "ws_closed" and wid:
+            was_suppressed = wid in self._hidden or wid in self._unresolved
+            self._hidden.discard(wid)
+            self._unresolved.pop(wid, None)
+            self._retry_after.pop(wid, None)
+            return not was_suppressed
+        if wid and wid in self._unresolved:
+            if time.monotonic() >= self._retry_after.get(wid, 0.0):
+                pid, owner = self._unresolved[wid]
+                return self._judge(wid, pid, owner)
+            return False
+        return not (wid and wid in self._hidden)
+
+    def event_touches_storage(self, event: dict[str, Any]) -> bool:
+        """True when judging this event may perform a project lookup —
+        the caller offloads those to the executor."""
+        if self._bypass:
+            return False
+        wid = str(event.get("ws_id") or "")
+        return event.get("type") == "ws_created" or wid in self._unresolved
+
+
 async def cluster_snapshot(request: Request) -> JSONResponse:
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
     err = _collector_scope_error(request)
     if err is not None:
         return err
     collector: ClusterCollector = request.app.state.collector
-    return JSONResponse(collector.get_snapshot())
+    # Same tenancy treatment as the SSE snapshot and the cluster list —
+    # this endpoint served the raw collector state and was the one
+    # remaining unfiltered window into private-project workstreams.
+    tenancy = _ClusterTenancyFilter(WorkstreamProjectVisibility.for_request(request))
+
+    def _collect() -> dict[str, Any]:
+        return tenancy.filter_snapshot(collector.get_snapshot())
+
+    return JSONResponse(await asyncio.to_thread(_collect))
 
 
 async def cluster_events_sse(request: Request) -> Response:
@@ -1595,52 +1720,8 @@ async def cluster_events_sse(request: Request) -> Response:
     collector: ClusterCollector = request.app.state.collector
     client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=2000)
 
-    # Per-connection private-project tenancy. The snapshot carries full
-    # rows (project_id + user_id); follow-up events are sparse (usually
-    # just ws_id), so invisible workstreams are recorded in ``hidden``
-    # at snapshot/ws_created time and every later event naming them is
-    # swallowed. Access changes (membership grant/revoke) take effect
-    # on reconnect — same resolve-once precedent as session
-    # construction. The visibility instance memoizes project rows, so
-    # the steady-state per-event cost is a set lookup.
-    visibility = WorkstreamProjectVisibility.for_request(request)
-    hidden: set[str] = set()
-
-    def _row_ws_id(ws: dict[str, Any]) -> str:
-        return str(ws.get("ws_id") or ws.get("id") or "")
-
-    def _filter_snapshot(snap: dict[str, Any]) -> dict[str, Any]:
-        for node in snap.get("nodes", []):
-            kept: list[dict[str, Any]] = []
-            for ws in node.get("workstreams", []):
-                if visibility.ws_visible(
-                    ws.get("project_id") or "", ws_owner=ws.get("user_id") or ""
-                ):
-                    kept.append(ws)
-                else:
-                    wid = _row_ws_id(ws)
-                    if wid:
-                        hidden.add(wid)
-            node["workstreams"] = kept
-        return snap
-
-    def _event_visible(event: dict[str, Any]) -> bool:
-        etype = event.get("type")
-        wid = str(event.get("ws_id") or "")
-        if etype == "ws_created":
-            if not visibility.ws_visible(
-                event.get("project_id") or "", ws_owner=event.get("user_id") or ""
-            ):
-                if wid:
-                    hidden.add(wid)
-                return False
-            hidden.discard(wid)
-            return True
-        if wid and wid in hidden:
-            if etype == "ws_closed":
-                hidden.discard(wid)
-            return False
-        return True
+    # Per-connection private-project tenancy — see _ClusterTenancyFilter.
+    tenancy = _ClusterTenancyFilter(WorkstreamProjectVisibility.for_request(request))
 
     async def event_generator() -> AsyncGenerator[dict[str, str], None]:
         loop = asyncio.get_running_loop()
@@ -1652,7 +1733,7 @@ async def cluster_events_sse(request: Request) -> Response:
             snap["type"] = "snapshot"
             # Executor: the snapshot filter resolves project rows from
             # storage — never block the event loop on DB I/O.
-            snap = await loop.run_in_executor(None, _filter_snapshot, snap)
+            snap = await loop.run_in_executor(None, tenancy.filter_snapshot, snap)
             yield {"data": json.dumps(snap)}
 
             while True:
@@ -1660,13 +1741,14 @@ async def cluster_events_sse(request: Request) -> Response:
                     event = await loop.run_in_executor(
                         None, functools.partial(client_queue.get, timeout=5)
                     )
-                    # Only ws_created can touch storage (project lookup);
-                    # every other event type is a pure set-membership
-                    # check and stays on the loop.
-                    if event.get("type") == "ws_created":
-                        visible = await loop.run_in_executor(None, _event_visible, event)
+                    # Judgments that may hit storage (ws_created, or a
+                    # retry of an unresolved row) run on the executor;
+                    # everything else is a pure set-membership check and
+                    # stays on the loop.
+                    if tenancy.event_touches_storage(event):
+                        visible = await loop.run_in_executor(None, tenancy.event_visible, event)
                     else:
-                        visible = _event_visible(event)
+                        visible = tenancy.event_visible(event)
                     if visible:
                         yield {"data": json.dumps(event)}
                 except queue.Empty:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1007,7 +1007,10 @@ async def cluster_workstreams(request: Request) -> JSONResponse:
     per_page = _parse_int(params, "per_page", 50, minimum=1, maximum=200)
     extra_rows = _coordinator_rows(request)
     visibility = WorkstreamProjectVisibility.for_request(request)
-    ws_list, total = collector.get_workstreams(
+    # Executor: the tenancy row_filter resolves project rows from storage,
+    # so the whole collect+filter+paginate runs off the event loop.
+    ws_list, total = await asyncio.to_thread(
+        collector.get_workstreams,
         state=state,
         node=node,
         search=search,
@@ -1523,12 +1526,17 @@ async def cluster_node_detail(request: Request) -> JSONResponse:
     if not detail:
         return JSONResponse({"error": "Node not found"}, status_code=404)
     # Private-project tenancy — same predicate as the cluster list.
+    # Executor: the predicate resolves project rows from storage.
     visibility = WorkstreamProjectVisibility.for_request(request)
-    detail["workstreams"] = [
-        ws
-        for ws in detail.get("workstreams", [])
-        if visibility.ws_visible(ws.get("project_id") or "", ws_owner=ws.get("user_id") or "")
-    ]
+
+    def _filter_ws_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            ws
+            for ws in rows
+            if visibility.ws_visible(ws.get("project_id") or "", ws_owner=ws.get("user_id") or "")
+        ]
+
+    detail["workstreams"] = await asyncio.to_thread(_filter_ws_rows, detail.get("workstreams", []))
 
     # Attach metadata if available
     import json as _nd_json
@@ -13110,6 +13118,7 @@ def create_app(
         get_project_endpoint,
         list_project_members_endpoint,
         list_projects,
+        project_resources_endpoint,
         remove_project_member_endpoint,
         update_project_endpoint,
     )
@@ -13525,6 +13534,10 @@ def create_app(
                         "/api/projects/{project_id}",
                         delete_project_endpoint,
                         methods=["DELETE"],
+                    ),
+                    Route(
+                        "/api/projects/{project_id}/resources",
+                        project_resources_endpoint,
                     ),
                     Route(
                         "/api/projects/{project_id}/members",

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -995,6 +995,8 @@ def _coordinator_rows(request: Request) -> list[dict[str, Any]]:
 
 
 async def cluster_workstreams(request: Request) -> JSONResponse:
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
     collector: ClusterCollector = request.app.state.collector
     params = dict(request.query_params)
     state = params.get("state")
@@ -1004,6 +1006,7 @@ async def cluster_workstreams(request: Request) -> JSONResponse:
     page = _parse_int(params, "page", 1, minimum=1)
     per_page = _parse_int(params, "per_page", 50, minimum=1, maximum=200)
     extra_rows = _coordinator_rows(request)
+    visibility = WorkstreamProjectVisibility.for_request(request)
     ws_list, total = collector.get_workstreams(
         state=state,
         node=node,
@@ -1012,6 +1015,9 @@ async def cluster_workstreams(request: Request) -> JSONResponse:
         page=page,
         per_page=per_page,
         extra_rows=extra_rows,
+        row_filter=lambda ws: visibility.ws_visible(
+            ws.get("project_id") or "", ws_owner=ws.get("user_id") or ""
+        ),
     )
     pages = math.ceil(total / per_page) if per_page > 0 else 0
     return JSONResponse(
@@ -1506,6 +1512,8 @@ async def cluster_ws_live_bulk(request: Request) -> JSONResponse:
 
 
 async def cluster_node_detail(request: Request) -> JSONResponse:
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
     collector: ClusterCollector = request.app.state.collector
     node_id = request.path_params["node_id"]
     nv = _validate_node_id(node_id)
@@ -1514,6 +1522,13 @@ async def cluster_node_detail(request: Request) -> JSONResponse:
     detail = collector.get_node_detail(node_id)
     if not detail:
         return JSONResponse({"error": "Node not found"}, status_code=404)
+    # Private-project tenancy — same predicate as the cluster list.
+    visibility = WorkstreamProjectVisibility.for_request(request)
+    detail["workstreams"] = [
+        ws
+        for ws in detail.get("workstreams", [])
+        if visibility.ws_visible(ws.get("project_id") or "", ws_owner=ws.get("user_id") or "")
+    ]
 
     # Attach metadata if available
     import json as _nd_json
@@ -1564,11 +1579,60 @@ async def cluster_snapshot(request: Request) -> JSONResponse:
 
 
 async def cluster_events_sse(request: Request) -> Response:
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
     err = _collector_scope_error(request)
     if err is not None:
         return err
     collector: ClusterCollector = request.app.state.collector
     client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=2000)
+
+    # Per-connection private-project tenancy. The snapshot carries full
+    # rows (project_id + user_id); follow-up events are sparse (usually
+    # just ws_id), so invisible workstreams are recorded in ``hidden``
+    # at snapshot/ws_created time and every later event naming them is
+    # swallowed. Access changes (membership grant/revoke) take effect
+    # on reconnect — same resolve-once precedent as session
+    # construction. The visibility instance memoizes project rows, so
+    # the steady-state per-event cost is a set lookup.
+    visibility = WorkstreamProjectVisibility.for_request(request)
+    hidden: set[str] = set()
+
+    def _row_ws_id(ws: dict[str, Any]) -> str:
+        return str(ws.get("ws_id") or ws.get("id") or "")
+
+    def _filter_snapshot(snap: dict[str, Any]) -> dict[str, Any]:
+        for node in snap.get("nodes", []):
+            kept: list[dict[str, Any]] = []
+            for ws in node.get("workstreams", []):
+                if visibility.ws_visible(
+                    ws.get("project_id") or "", ws_owner=ws.get("user_id") or ""
+                ):
+                    kept.append(ws)
+                else:
+                    wid = _row_ws_id(ws)
+                    if wid:
+                        hidden.add(wid)
+            node["workstreams"] = kept
+        return snap
+
+    def _event_visible(event: dict[str, Any]) -> bool:
+        etype = event.get("type")
+        wid = str(event.get("ws_id") or "")
+        if etype == "ws_created":
+            if not visibility.ws_visible(
+                event.get("project_id") or "", ws_owner=event.get("user_id") or ""
+            ):
+                if wid:
+                    hidden.add(wid)
+                return False
+            hidden.discard(wid)
+            return True
+        if wid and wid in hidden:
+            if etype == "ws_closed":
+                hidden.discard(wid)
+            return False
+        return True
 
     async def event_generator() -> AsyncGenerator[dict[str, str], None]:
         loop = asyncio.get_running_loop()
@@ -1578,6 +1642,9 @@ async def cluster_events_sse(request: Request) -> Response:
                 None, collector.get_snapshot_and_register, client_queue
             )
             snap["type"] = "snapshot"
+            # Executor: the snapshot filter resolves project rows from
+            # storage — never block the event loop on DB I/O.
+            snap = await loop.run_in_executor(None, _filter_snapshot, snap)
             yield {"data": json.dumps(snap)}
 
             while True:
@@ -1585,7 +1652,15 @@ async def cluster_events_sse(request: Request) -> Response:
                     event = await loop.run_in_executor(
                         None, functools.partial(client_queue.get, timeout=5)
                     )
-                    yield {"data": json.dumps(event)}
+                    # Only ws_created can touch storage (project lookup);
+                    # every other event type is a pure set-membership
+                    # check and stays on the loop.
+                    if event.get("type") == "ws_created":
+                        visible = await loop.run_in_executor(None, _event_visible, event)
+                    else:
+                        visible = _event_visible(event)
+                    if visible:
+                        yield {"data": json.dumps(event)}
                 except queue.Empty:
                     pass  # poll timeout, retry
                 if await request.is_disconnected():
@@ -3393,6 +3468,19 @@ async def _coord_create_validate_request(
     """
     if not uid:
         return JSONResponse({"error": "authentication required"}, status_code=401)
+    # Project attach gate — same rule as the interactive validator: a
+    # private project accepts new workstreams only from its owner or
+    # members, and a nonexistent project_id 400s rather than minting a
+    # dangling link.
+    project_raw = body.get("project_id")
+    attach_pid = (project_raw.strip() if isinstance(project_raw, str) else "") or ""
+    if attach_pid:
+        from turnstone.core.auth import ensure_project_attachable
+
+        denied = ensure_project_attachable(uid, attach_pid)
+        if denied is not None:
+            status, message = denied
+            return JSONResponse({"error": message}, status_code=status)
     return None
 
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -2522,10 +2522,11 @@ function _renderProjects(projects) {
     const p = projects[i];
     const archived = p.state === "archived";
     html +=
-      '<div class="admin-row" role="listitem" data-project-id="' +
+      '<div class="admin-row" role="listitem" data-expandable data-project-id="' +
       escapeHtml(p.project_id) +
-      '">' +
+      '" tabindex="0" aria-expanded="false">' +
       '<span class="admin-col admin-col-username">' +
+      '<span class="admin-expand-indicator" aria-hidden="true">▸</span>' +
       escapeHtml(p.name) +
       "</span>" +
       '<span class="admin-col admin-col-name">' +
@@ -2597,6 +2598,197 @@ function _bindProjectRowActions(container) {
         this.getAttribute("data-project-name"),
       );
     });
+  });
+  // Expandable per-project resources panel (workstreams / attachments /
+  // memory) — same interaction contract as the Users tab's OIDC panel.
+  container
+    .querySelectorAll(".admin-row[data-expandable]")
+    .forEach(function (row) {
+      const _expand = function () {
+        _toggleProjectPanel(row.getAttribute("data-project-id"), row);
+      };
+      row.addEventListener("click", function (e) {
+        // Clicks on the row's kebab menu must not also toggle the panel.
+        if (
+          e.target.closest(".admin-kebab") ||
+          e.target.closest(".admin-btn-danger") ||
+          e.target.closest(".admin-btn-action")
+        )
+          return;
+        _expand();
+      });
+      row.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          _expand();
+        }
+      });
+    });
+}
+
+function _toggleProjectPanel(projectId, rowEl) {
+  const existing = rowEl.nextElementSibling;
+  if (existing && existing.classList.contains("proj-detail-panel")) {
+    // Collapse
+    existing.style.maxHeight = "0";
+    const indicator = rowEl.querySelector(".admin-expand-indicator");
+    if (indicator) indicator.classList.remove("expanded");
+    rowEl.setAttribute("aria-expanded", "false");
+    setTimeout(function () {
+      if (existing.parentNode) existing.remove();
+    }, 160);
+    return;
+  }
+  // Collapse any other open panel first (single-open accordion).
+  const openPanels = document.querySelectorAll(
+    "#admin-projects-table .proj-detail-panel",
+  );
+  for (let i = 0; i < openPanels.length; i++) {
+    openPanels[i].style.maxHeight = "0";
+    const prevRow = openPanels[i].previousElementSibling;
+    if (prevRow) {
+      const ind = prevRow.querySelector(".admin-expand-indicator");
+      if (ind) ind.classList.remove("expanded");
+      prevRow.setAttribute("aria-expanded", "false");
+    }
+    (function (panel) {
+      setTimeout(function () {
+        if (panel.parentNode) panel.remove();
+      }, 160);
+    })(openPanels[i]);
+  }
+  const indicator = rowEl.querySelector(".admin-expand-indicator");
+  if (indicator) indicator.classList.add("expanded");
+  rowEl.setAttribute("aria-expanded", "true");
+  const panel = document.createElement("div");
+  panel.className = "proj-detail-panel";
+  panel.setAttribute("role", "none");
+  setSafeHtml(
+    panel,
+    '<div class="proj-detail-inner">' +
+      '<div class="proj-detail-body"><span class="proj-detail-empty">Loading…</span></div>' +
+      "</div>",
+  );
+  rowEl.after(panel);
+  requestAnimationFrame(function () {
+    panel.style.maxHeight = panel.scrollHeight + "px";
+  });
+  authFetch("/v1/api/projects/" + encodeURIComponent(projectId) + "/resources")
+    .then(function (r) {
+      if (!r.ok) throw new Error("Failed");
+      return r.json();
+    })
+    .then(function (data) {
+      _renderProjectResources(panel, data);
+    })
+    .catch(function () {
+      const body = panel.querySelector(".proj-detail-body");
+      if (body)
+        setSafeHtml(
+          body,
+          '<span class="proj-detail-empty">Failed to load</span>',
+        );
+    });
+}
+
+const _PROJ_ATT_ICONS = { image: "\u{1f5bc}", audio: "\u{1f3b5}" };
+
+function _projAttachmentHref(att) {
+  // Content serving is ws-scoped and node-local: interactive workstreams
+  // route through the console's transparent node proxy; coordinator
+  // workstreams (no node_id recorded on the attachment's ws row here)
+  // serve from the console's own coord attachment routes.
+  const tail =
+    "v1/api/workstreams/" +
+    encodeURIComponent(att.ws_id) +
+    "/attachments/" +
+    encodeURIComponent(att.attachment_id) +
+    "/content";
+  return att.node_id
+    ? "/node/" + encodeURIComponent(att.node_id) + "/" + tail
+    : "/" + tail;
+}
+
+function _projFmtSize(n) {
+  if (typeof n !== "number" || n < 0) return "";
+  if (n < 1024) return n + " B";
+  if (n < 1048576) return (n / 1024).toFixed(1) + " KB";
+  return (n / 1048576).toFixed(1) + " MB";
+}
+
+function _renderProjectResources(panel, data) {
+  const body = panel.querySelector(".proj-detail-body");
+  if (!body) return;
+  const wss = data.workstreams || [];
+  // node_id lives on the workstream rows; the attachment rows carry only
+  // their first-referencing ws_id — join here for download URLs.
+  const nodeByWs = {};
+  for (let i = 0; i < wss.length; i++) nodeByWs[wss[i].ws_id] = wss[i].node_id;
+  let html =
+    '<div class="proj-detail-header">Workstreams (' + wss.length + ")</div>";
+  if (!wss.length) {
+    html += '<span class="proj-detail-empty">No workstreams</span>';
+  } else {
+    for (let i = 0; i < wss.length; i++) {
+      const w = wss[i];
+      html +=
+        '<div class="proj-detail-row">' +
+        '<span class="proj-detail-main">' +
+        escapeHtml(w.title || w.name || w.ws_id.substring(0, 12)) +
+        "</span>" +
+        '<span class="proj-detail-dim">' +
+        escapeHtml(String(w.kind || "")) +
+        " · " +
+        escapeHtml(String(w.state || "")) +
+        " · " +
+        escapeHtml(String(w.updated || "").slice(0, 10)) +
+        " · " +
+        escapeHtml(w.ws_id.substring(0, 7)) +
+        "</span>" +
+        "</div>";
+    }
+  }
+  const atts = data.attachments || [];
+  html +=
+    '<div class="proj-detail-header">Attachments (' + atts.length + ")</div>";
+  if (!atts.length) {
+    html += '<span class="proj-detail-empty">No attachments</span>';
+  } else {
+    for (let i = 0; i < atts.length; i++) {
+      const a = atts[i];
+      const icon = _PROJ_ATT_ICONS[a.kind] || "\u{1f4c4}";
+      a.node_id = nodeByWs[a.ws_id] || "";
+      html +=
+        '<div class="proj-detail-row">' +
+        '<span class="proj-detail-main">' +
+        '<span aria-hidden="true">' +
+        icon +
+        "</span> " +
+        '<a class="proj-detail-link" target="_blank" rel="noopener" href="' +
+        escapeHtml(_projAttachmentHref(a)) +
+        '">' +
+        escapeHtml(a.filename || a.attachment_id.substring(0, 12)) +
+        "</a>" +
+        "</span>" +
+        '<span class="proj-detail-dim">' +
+        escapeHtml(_projFmtSize(a.size_bytes)) +
+        " · " +
+        escapeHtml(String(a.created || "").slice(0, 10)) +
+        "</span>" +
+        "</div>";
+    }
+  }
+  html +=
+    '<div class="proj-detail-header">Memory</div>' +
+    '<div class="proj-detail-row"><span class="proj-detail-main">' +
+    String(data.memory_count || 0) +
+    " project-scoped memor" +
+    (data.memory_count === 1 ? "y" : "ies") +
+    "</span></div>";
+  setSafeHtml(body, html);
+  // Re-measure after content lands so the animated max-height fits.
+  requestAnimationFrame(function () {
+    panel.style.maxHeight = panel.scrollHeight + "px";
   });
 }
 

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1899,6 +1899,7 @@ function _initSavedCoordTable() {
         return s.kind || "";
       },
     },
+    SavedColumns.project(),
     SavedColumns.model(),
     SavedColumns.count("child_count", "CHILDREN", "92px"),
     SavedColumns.ctx(),
@@ -2010,6 +2011,13 @@ function _initSavedCoordTable() {
       },
     },
   });
+  // The PROJECT column resolves names from the shared projects cache,
+  // which fills asynchronously — re-render once names arrive.
+  if (window.TurnstoneProjects) {
+    window.TurnstoneProjects.onProjectsChange(function () {
+      if (_coordTable) _coordTable.render();
+    });
+  }
 }
 
 // HTML inline-onclick wrappers — keep the global names the markup binds

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -3233,20 +3233,23 @@ h3.skill-spec-heading {
 /* ==========================================================================
    OIDC detail panel (inline expansion below user row)
    ========================================================================== */
-.oidc-detail-panel {
+.oidc-detail-panel,
+.proj-detail-panel {
   max-height: 0;
   overflow: hidden;
   transition: max-height 150ms ease;
   margin: 0 8px 0 24px;
 }
-.oidc-detail-inner {
+.oidc-detail-inner,
+.proj-detail-inner {
   border: 1px dashed var(--border);
   border-radius: var(--radius-sm);
   padding: 12px 16px;
   margin-bottom: 8px;
   background: var(--row-alt);
 }
-.oidc-detail-header {
+.oidc-detail-header,
+.proj-detail-header {
   font-family: var(--font-ui);
   font-size: 10px;
   text-transform: uppercase;
@@ -3254,9 +3257,45 @@ h3.skill-spec-heading {
   color: var(--fg-dim);
   margin-bottom: 8px;
 }
-.oidc-detail-header::before {
+.oidc-detail-header::before,
+.proj-detail-header::before {
   content: "\25c6 ";
   color: var(--accent);
+}
+/* Per-project resources panel rows: name/link left, dim meta right. */
+.proj-detail-header + .proj-detail-header,
+.proj-detail-row + .proj-detail-header {
+  margin-top: 12px;
+}
+.proj-detail-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+  font-size: 12px;
+  align-items: baseline;
+}
+.proj-detail-row + .proj-detail-row {
+  border-top: 1px solid var(--border);
+}
+.proj-detail-main {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.proj-detail-dim {
+  color: var(--fg-dim);
+  font-size: 11px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.proj-detail-link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+}
+.proj-detail-link:hover {
+  text-decoration-color: var(--accent);
 }
 .oidc-identity-row {
   display: grid;
@@ -3300,7 +3339,8 @@ h3.skill-spec-heading {
 .oidc-identity-actions .admin-btn-danger {
   font-size: 11px;
 }
-.oidc-detail-empty {
+.oidc-detail-empty,
+.proj-detail-empty {
   color: var(--fg-dim);
   font-size: 12px;
   font-style: italic;
@@ -3340,7 +3380,8 @@ h3.skill-spec-heading {
   .oidc-identity-time {
     display: none;
   }
-  .oidc-detail-panel {
+  .oidc-detail-panel,
+  .proj-detail-panel {
     margin-left: 8px;
   }
 }
@@ -3540,6 +3581,7 @@ h3.skill-spec-heading {
     animation: none;
   }
   .oidc-detail-panel,
+  .proj-detail-panel,
   .admin-expand-indicator {
     transition: none;
   }

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -306,6 +306,13 @@ class WorkstreamProjectVisibility:
         )
         return cls(uid, bypass=bypass, storage=storage)
 
+    @property
+    def bypass(self) -> bool:
+        """True when this principal sees everything (service scope /
+        ``admin.cluster.inspect``) — callers that transform payloads
+        (not just drop rows) use this to leave them untouched."""
+        return self._bypass
+
     def _resolve_storage(self) -> Any:
         if self._storage is None:
             from turnstone.core.storage._registry import get_storage
@@ -329,14 +336,36 @@ class WorkstreamProjectVisibility:
             )
         return self._member[project_id]
 
-    def ws_visible(self, project_id: str | None, ws_owner: str = "") -> bool:
-        """Apply the class rules to one workstream row."""
+    def _project_grants(self, project: dict[str, Any]) -> bool:
+        """The tenancy rule for one already-fetched project row.
+
+        THE single statement of who may see a project's workstreams —
+        :meth:`ws_visibility` and :func:`ensure_project_attachable` both
+        route through here so the security decision cannot diverge.
+        """
+        if (project.get("visibility") or "private") != "private":
+            return True
+        if not self._user_id:
+            return False
+        if project.get("owner_id") == self._user_id:
+            return True
+        return self._is_member(str(project.get("project_id") or ""))
+
+    def ws_visibility(self, project_id: str | None, ws_owner: str = "") -> bool | None:
+        """Tri-state form of :meth:`ws_visible`.
+
+        ``True`` visible, ``False`` denied, ``None`` undetermined — the
+        project could not be resolved (storage failure). Callers that
+        can retry later (the SSE event filter) use this to avoid pinning
+        a verdict on a transient blip; everything else goes through
+        :meth:`ws_visible`, which maps ``None`` to fail-closed.
+        """
         if self._bypass:
             return True
         # Only a real string can name a project — anything else (None,
         # a test double, a corrupted row) means "no project link", not
-        # "private". Keeps the fail-closed branch for genuine lookup
-        # failures rather than type noise.
+        # "private". Keeps the undetermined/fail-closed branch for
+        # genuine lookup failures rather than type noise.
         if not project_id or not isinstance(project_id, str):
             return True
         pid = project_id.strip()
@@ -348,20 +377,22 @@ class WorkstreamProjectVisibility:
             project = self._project(pid)
             if project is None:
                 return True
-            if (project.get("visibility") or "private") != "private":
-                return True
-            if not self._user_id:
-                return False
-            if project.get("owner_id") == self._user_id:
-                return True
-            return self._is_member(pid)
+            return self._project_grants(project)
         except Exception:
             log.warning(
-                "workstream project-visibility check failed user=%s project=%s — failing closed",
+                "workstream project-visibility check undetermined user=%s project=%s",
                 self._user_id,
                 pid,
             )
-            return False
+            return None
+
+    def ws_visible(self, project_id: str | None, ws_owner: str = "") -> bool:
+        """Apply the class rules to one workstream row (fail-closed).
+
+        An undetermined verdict (storage failure) hides the row rather
+        than leaking on a blip.
+        """
+        return self.ws_visibility(project_id, ws_owner=ws_owner) is True
 
 
 def ensure_project_attachable(
@@ -397,11 +428,12 @@ def ensure_project_attachable(
         project = storage.get_project(pid)
         if project is None:
             return (400, "unknown project_id")
-        if (project.get("visibility") or "private") != "private":
-            return None
-        if user_id and (
-            project.get("owner_id") == user_id or bool(storage.is_project_member(pid, user_id))
-        ):
+        # One tenancy rule, one place: reuse the visibility predicate's
+        # core (same-module private access; the fetched row is seeded
+        # into the memo so this costs no second get_project).
+        vis = WorkstreamProjectVisibility(user_id, storage=storage)
+        vis._projects[pid] = project
+        if vis._project_grants(project):
             return None
         return (403, "cannot attach a workstream to a private project you don't belong to")
     except Exception:

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -253,6 +253,156 @@ def user_can_access_project(
     return acc.can_write if write else acc.can_read
 
 
+class WorkstreamProjectVisibility:
+    """Per-request memoized visibility predicate for project-scoped workstreams.
+
+    Answers "may *user_id* see a workstream attached to *project_id*?" for
+    listing filters and the row-access gate. Distinct from
+    :func:`user_can_access_project` on purpose: that composes the RBAC
+    capability (``project.read``, admin-default) with the ACL and gates the
+    project *management* surfaces, whereas workstream visibility is a
+    tenancy question — an explicit ``project_members`` row (or ownership)
+    IS the grant, no capability required, or members without ``project.read``
+    would lose sight of their own shared workstreams.
+
+    Rules (first match wins):
+
+    * ``bypass`` instances see everything — service-scope callers (the
+      collector and other cluster machinery must never be blinded at the
+      node edge; user-facing filtering happens at the console edge) and
+      holders of ``admin.cluster.inspect`` (the existing cluster-wide
+      workstream-inspect surface).
+    * No / dangling ``project_id`` → visible (a deleted project leaves the
+      link behind by design — no row, no privacy to enforce).
+    * Non-private visibility → visible (trusted-team default).
+    * Private → the workstream's own creator, the project owner, or a
+      project member; anonymous callers fail closed.
+    * A storage failure while resolving a project fails closed (treated
+      as private-and-not-a-member) rather than leaking on a blip.
+
+    Project rows and membership verdicts are memoized per instance —
+    construct one per request/connection, not per row.
+    """
+
+    def __init__(self, user_id: str, *, bypass: bool = False, storage: Any = None) -> None:
+        self._user_id = user_id or ""
+        self._bypass = bypass
+        self._storage = storage
+        self._projects: dict[str, dict[str, Any] | None] = {}
+        self._member: dict[str, bool] = {}
+
+    @classmethod
+    def for_request(cls, request: Any, *, storage: Any = None) -> WorkstreamProjectVisibility:
+        """Build a filter for an HTTP request's authenticated principal.
+
+        Service-scoped tokens and ``admin.cluster.inspect`` holders get a
+        bypass instance; everyone else filters as themselves.
+        """
+        auth: AuthResult | None = getattr(getattr(request, "state", None), "auth_result", None)
+        uid = str(getattr(auth, "user_id", "") or "")
+        bypass = bool(
+            auth is not None
+            and (auth.has_scope("service") or auth.has_permission("admin.cluster.inspect"))
+        )
+        return cls(uid, bypass=bypass, storage=storage)
+
+    def _resolve_storage(self) -> Any:
+        if self._storage is None:
+            from turnstone.core.storage._registry import get_storage
+
+            self._storage = get_storage()
+        return self._storage
+
+    def _project(self, project_id: str) -> dict[str, Any] | None:
+        if project_id not in self._projects:
+            storage = self._resolve_storage()
+            if storage is None:
+                raise RuntimeError("storage unavailable for project visibility check")
+            self._projects[project_id] = storage.get_project(project_id)
+        return self._projects[project_id]
+
+    def _is_member(self, project_id: str) -> bool:
+        if project_id not in self._member:
+            storage = self._resolve_storage()
+            self._member[project_id] = bool(
+                storage is not None and storage.is_project_member(project_id, self._user_id)
+            )
+        return self._member[project_id]
+
+    def ws_visible(self, project_id: str | None, ws_owner: str = "") -> bool:
+        """Apply the class rules to one workstream row."""
+        if self._bypass:
+            return True
+        pid = (project_id or "").strip()
+        if not pid:
+            return True
+        if ws_owner and ws_owner == self._user_id:
+            return True
+        try:
+            project = self._project(pid)
+            if project is None:
+                return True
+            if (project.get("visibility") or "private") != "private":
+                return True
+            if not self._user_id:
+                return False
+            if project.get("owner_id") == self._user_id:
+                return True
+            return self._is_member(pid)
+        except Exception:
+            log.warning(
+                "workstream project-visibility check failed user=%s project=%s — failing closed",
+                self._user_id,
+                pid,
+            )
+            return False
+
+
+def ensure_project_attachable(
+    user_id: str,
+    project_id: str,
+    *,
+    storage: Any = None,
+) -> tuple[int, str] | None:
+    """Gate attaching a NEW workstream to *project_id* at create time.
+
+    Returns ``None`` when the attach is allowed, else ``(status_code,
+    message)`` for the handler to surface. Stricter than
+    :meth:`WorkstreamProjectVisibility.ws_visible` in one way — a
+    nonexistent project is a 400 (a dangling link on an EXISTING row is
+    tolerated because project deletion leaves links behind, but minting
+    a fresh dangling link is a caller error) — and shares its tenancy
+    rule: private projects accept workstreams only from their owner or
+    members; public/active-or-archived projects accept from anyone
+    (memory writes stay member-gated at the session layer).
+
+    Fail-closed: empty ``user_id`` or a storage failure denies with 403.
+    """
+    pid = (project_id or "").strip()
+    if not pid:
+        return None
+    if storage is None:
+        from turnstone.core.storage._registry import get_storage
+
+        storage = get_storage()
+    if storage is None:
+        return (403, "project access could not be verified")
+    try:
+        project = storage.get_project(pid)
+        if project is None:
+            return (400, "unknown project_id")
+        if (project.get("visibility") or "private") != "private":
+            return None
+        if user_id and (
+            project.get("owner_id") == user_id or bool(storage.is_project_member(pid, user_id))
+        ):
+            return None
+        return (403, "cannot attach a workstream to a private project you don't belong to")
+    except Exception:
+        log.warning("project attach check failed user=%s project=%s — failing closed", user_id, pid)
+        return (403, "project access could not be verified")
+
+
 def _permissions_to_scopes(permissions: set[str]) -> frozenset[str]:
     """Derive legacy scopes from a granular permission set."""
     scopes: set[str] = set()

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -333,7 +333,13 @@ class WorkstreamProjectVisibility:
         """Apply the class rules to one workstream row."""
         if self._bypass:
             return True
-        pid = (project_id or "").strip()
+        # Only a real string can name a project — anything else (None,
+        # a test double, a corrupted row) means "no project link", not
+        # "private". Keeps the fail-closed branch for genuine lookup
+        # failures rather than type noise.
+        if not project_id or not isinstance(project_id, str):
+            return True
+        pid = project_id.strip()
         if not pid:
             return True
         if ws_owner and ws_owner == self._user_id:

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -318,6 +318,7 @@ def list_workstreams_with_history(
     kind: WorkstreamKind | str | None = None,
     user_id: str | None = None,
     state: str | None = None,
+    offset: int = 0,
 ) -> list[Any]:
     """List workstreams that have conversation messages.
 
@@ -342,6 +343,7 @@ def list_workstreams_with_history(
             kind=kind,
             user_id=user_id,
             state=state,
+            offset=offset,
         )
     except Exception:
         log.warning("Failed to list workstreams with history", exc_info=True)

--- a/turnstone/core/memory.py
+++ b/turnstone/core/memory.py
@@ -614,6 +614,20 @@ def get_workstream_owner(ws_id: str) -> str | None:
         return None
 
 
+def get_workstream_row(ws_id: str) -> dict[str, Any] | None:
+    """Return the full workstreams row dict, or None when missing/unreadable.
+
+    Same fail-soft shape as :func:`get_workstream_owner` — access gates
+    treat ``None`` as not-found, so a storage blip degrades to a 404
+    rather than a 500.
+    """
+    try:
+        return get_storage().get_workstream(ws_id)
+    except Exception:
+        log.warning("Failed to get workstream row ws=%s", ws_id, exc_info=True)
+        return None
+
+
 def update_workstream_title(ws_id: str, title: str) -> None:
     """Set or update the auto-generated title for a workstream."""
     try:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1174,6 +1174,18 @@ class ChatSession:
         # Listener identity, catalog merge, and dispatch all consume
         # this through ``_mcp_user_id``.
         self._mcp_user_id: str | None = user_id or None
+        # Acting user for per-user MCP credential resolution on SHARED
+        # workstreams: the authenticated principal who most recently
+        # initiated a turn (bound by ``bind_acting_user`` from the send
+        # path). Empty until the first authenticated send, and empty
+        # forever on CLI / eval / scheduled sessions — every consumer
+        # goes through ``_mcp_effective_user_id``, which falls back to
+        # the session owner. Rebinding also swaps the user-scoped MCP
+        # listeners; ``_mcp_listener_user_id`` tracks the identity the
+        # current registrations were made under (listener identity is
+        # the ``(user_id, callback)`` pair).
+        self._acting_user_id: str = ""
+        self._mcp_listener_user_id: str | None = user_id or None
         self._username = username
         self._client_type = client_type
         # Whether the user is online to complete an in-flight OAuth
@@ -2210,11 +2222,12 @@ class ChatSession:
         # is fixed at COORDINATOR_TOOLS.  Ignore MCP server changes.
         if self._kind == WorkstreamKind.COORDINATOR:
             return
-        # Phase 7: pass session-bound user_id so the merged tool list
-        # includes this user's pool catalog. The static path is included
-        # by ``get_tools`` regardless; ``user_id=None`` would silently
-        # drop pool tools that the LLM is allowed to call.
-        mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
+        # Pass the effective user_id (acting user on shared workstreams,
+        # owner otherwise) so the merged tool list includes that user's
+        # pool catalog. The static path is included by ``get_tools``
+        # regardless; ``user_id=None`` would silently drop pool tools
+        # that the LLM is allowed to call.
+        mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_effective_user_id)
         self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
         self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
         self._render_agent_tool_descriptions()
@@ -2447,20 +2460,26 @@ class ChatSession:
         if self._mcp_client and self._mcp_refresh_cb:
             # ``user_id`` MUST match the value used at registration —
             # the listener identity is ``(user_id, callback)``, not
-            # callback alone. ``self._user_id`` is set once in
-            # ``__init__`` and never mutated, so identity is stable.
-            self._mcp_client.remove_listener(self._mcp_refresh_cb, user_id=self._mcp_user_id)
+            # callback alone. ``bind_acting_user`` may have re-scoped
+            # the registrations since construction, so the tracked
+            # ``_mcp_listener_user_id`` (not ``_mcp_user_id``) is the
+            # registration identity.
+            self._mcp_client.remove_listener(
+                self._mcp_refresh_cb, user_id=self._mcp_listener_user_id
+            )
             self._mcp_refresh_cb = None
         if self._mcp_client and self._mcp_resource_cb:
             # ``user_id`` MUST mirror the value passed at registration —
             # the listener identity is ``(user_id, callback)`` and an
             # unscoped removal would leave the registration in place.
             self._mcp_client.remove_resource_listener(
-                self._mcp_resource_cb, user_id=self._mcp_user_id
+                self._mcp_resource_cb, user_id=self._mcp_listener_user_id
             )
             self._mcp_resource_cb = None
         if self._mcp_client and self._mcp_prompt_cb:
-            self._mcp_client.remove_prompt_listener(self._mcp_prompt_cb, user_id=self._mcp_user_id)
+            self._mcp_client.remove_prompt_listener(
+                self._mcp_prompt_cb, user_id=self._mcp_listener_user_id
+            )
             self._mcp_prompt_cb = None
         if self._watch_runner:
             self._watch_runner.remove_dispatch_fn(self._ws_id)
@@ -3113,9 +3132,10 @@ class ChatSession:
             )
         # MCP resource catalog (lets the model know what's available for read_resource)
         if self._mcp_client:
-            # Per-user merge: pool entries for ``self._mcp_user_id`` are
-            # included; other users' pool resources are not.
-            all_resources = self._mcp_client.get_resources(user_id=self._mcp_user_id)
+            # Per-user merge: pool entries for the effective user (acting
+            # user on shared workstreams, owner otherwise) are included;
+            # other users' pool resources are not.
+            all_resources = self._mcp_client.get_resources(user_id=self._mcp_effective_user_id)
             concrete = [r for r in all_resources if not r.get("template")]
             templates = [r for r in all_resources if r.get("template")]
             if concrete or templates:
@@ -3140,9 +3160,10 @@ class ChatSession:
                 dev_parts.append("\n".join(lines))
         # MCP prompt catalog (lets the model know what's available for use_prompt)
         if self._mcp_client:
-            # Per-user merge: pool entries for ``self._mcp_user_id`` are
-            # included; other users' pool prompts are not.
-            prompts = self._mcp_client.get_prompts(user_id=self._mcp_user_id)
+            # Per-user merge: pool entries for the effective user (acting
+            # user on shared workstreams, owner otherwise) are included;
+            # other users' pool prompts are not.
+            prompts = self._mcp_client.get_prompts(user_id=self._mcp_effective_user_id)
             if prompts:
                 lines = ["<mcp-prompts>"]
                 for p in prompts[:30]:
@@ -3931,9 +3952,13 @@ class ChatSession:
         # connected. Per-user variants (scope decision 0.2) keep the
         # tool visible for a pool-only user even when the static catalog
         # is empty.
-        if not self._mcp_client or not self._mcp_client.resource_count_for_user(self._mcp_user_id):
+        if not self._mcp_client or not self._mcp_client.resource_count_for_user(
+            self._mcp_effective_user_id
+        ):
             tools = _without_tool(tools, "read_resource")
-        if not self._mcp_client or not self._mcp_client.prompt_count_for_user(self._mcp_user_id):
+        if not self._mcp_client or not self._mcp_client.prompt_count_for_user(
+            self._mcp_effective_user_id
+        ):
             tools = _without_tool(tools, "use_prompt")
 
         return tools
@@ -4463,6 +4488,81 @@ class ChatSession:
 
     # -- Main generation loop ------------------------------------------------
 
+    @property
+    def _mcp_effective_user_id(self) -> str | None:
+        """Identity for per-user MCP (oauth_user) credential resolution.
+
+        The acting user — the authenticated principal who last initiated
+        a turn on this session — when one is bound; otherwise the session
+        owner. On a shared workstream this makes MCP tool calls run under
+        the credentials (and catalog) of whoever is actually driving,
+        rather than whoever created the workstream. Falls back to the
+        owner for CLI / eval / scheduled / internal turns, preserving the
+        pre-existing single-user behaviour.
+        """
+        return self._acting_user_id or self._mcp_user_id
+
+    def bind_acting_user(self, user_id: str) -> None:
+        """Bind the authenticated initiator of the current turn.
+
+        Called from the HTTP send path with the caller's authenticated
+        user id. No-ops when ``user_id`` is empty (unauthenticated lanes
+        keep the owner fallback) or unchanged. On a genuine change this
+        re-scopes the session's MCP view to the new acting user:
+
+        - swaps the user-scoped tool/resource/prompt listeners so pool
+          catalog changes for the acting user reach this session
+          (listener identity is the ``(user_id, callback)`` pair);
+        - fire-and-forget primes the acting user's oauth_user pools so
+          their tools surface without a manual reconnect;
+        - rebuilds the merged tool list and catalog-dependent state via
+          the same callbacks a pool notification would fire.
+
+        The binding is sticky — it persists until the next authenticated
+        send — so wake nudges and auto-resume continuations keep running
+        under the user whose turn they continue. It intentionally does
+        NOT rebind mid-turn: queued interjections fold into the current
+        turn under the initiator's identity, and prepared tool items pin
+        the identity at prepare time (see ``_prepare_mcp_tool``).
+        """
+        if not user_id or user_id == (self._acting_user_id or self._user_id):
+            self._acting_user_id = self._acting_user_id or user_id
+            return
+        self._acting_user_id = user_id
+        mcp = self._mcp_client
+        if not mcp or self._kind == WorkstreamKind.COORDINATOR:
+            return
+        old_listener_uid = self._mcp_listener_user_id
+        new_listener_uid: str | None = self._mcp_effective_user_id
+        if new_listener_uid != old_listener_uid:
+            if self._mcp_refresh_cb:
+                mcp.remove_listener(self._mcp_refresh_cb, user_id=old_listener_uid)
+                mcp.add_listener(self._mcp_refresh_cb, user_id=new_listener_uid)
+            if self._mcp_resource_cb:
+                mcp.remove_resource_listener(self._mcp_resource_cb, user_id=old_listener_uid)
+                mcp.add_resource_listener(self._mcp_resource_cb, user_id=new_listener_uid)
+            if self._mcp_prompt_cb:
+                mcp.remove_prompt_listener(self._mcp_prompt_cb, user_id=old_listener_uid)
+                mcp.add_prompt_listener(self._mcp_prompt_cb, user_id=new_listener_uid)
+            self._mcp_listener_user_id = new_listener_uid
+        if new_listener_uid and hasattr(mcp, "prime_user_pools"):
+            try:
+                mcp.prime_user_pools(new_listener_uid)
+            except Exception:
+                log.debug(
+                    "mcp prime_user_pools scheduling failed user=%s",
+                    new_listener_uid,
+                    exc_info=True,
+                )
+        # Rebuild the merged tool list and resource/prompt-dependent
+        # state under the new identity NOW — the prime above completes
+        # asynchronously and only notifies on catalog changes, while
+        # already-warm pool entries for this user produce no
+        # notification at all.
+        self._on_mcp_tools_changed()
+        self._on_mcp_resources_changed()
+        self._on_mcp_prompts_changed()
+
     def send(
         self,
         user_input: str,
@@ -4470,6 +4570,7 @@ class ChatSession:
         send_id: str | None = None,
         *,
         from_wake: bool = False,
+        acting_user_id: str | None = None,
     ) -> None:
         """Send user input and handle the response loop (including tool calls).
 
@@ -4483,7 +4584,15 @@ class ChatSession:
         ``send_id`` is an end-to-end tracking token only; it no longer gates a
         DB reservation (the upload buffer is the pending store, and the bytes
         in ``attachments`` were already drained/peeked from it by the caller).
+
+        ``acting_user_id`` is the authenticated caller who initiated this
+        turn (HTTP send / retry paths). It rebinds per-user MCP credential
+        resolution to that user for this and subsequent turns — see
+        :meth:`bind_acting_user`. ``None`` (internal callers: wake nudges,
+        auto-resume, CLI) leaves the current binding untouched.
         """
+        if acting_user_id is not None:
+            self.bind_acting_user(acting_user_id)
         self._refresh_model_from_registry()
         # Token budget approval gate
         if self._budget_exhausted:
@@ -7640,13 +7749,13 @@ class ChatSession:
         }
         preparer = preparers.get(func_name)
         if not preparer:
-            # Check if this is an MCP tool. Phase 7: pass session-bound
-            # ``user_id`` so per-user pool tools become reachable here —
-            # without this kwarg the gate stays static-only and pool
-            # dispatch is structurally unreachable from
-            # ``ChatSession._prepare_tool`` (RFC §3, invariant 8).
+            # Check if this is an MCP tool. Pass the effective ``user_id``
+            # (acting user on shared workstreams) so per-user pool tools
+            # become reachable here — without this kwarg the gate stays
+            # static-only and pool dispatch is structurally unreachable
+            # from ``ChatSession._prepare_tool`` (RFC §3, invariant 8).
             if self._mcp_client and self._mcp_client.is_mcp_tool(
-                func_name, user_id=self._mcp_user_id
+                func_name, user_id=self._mcp_effective_user_id
             ):
                 return self._prepare_mcp_tool(call_id, func_name, args)
             self.ui.on_error(f"Model called unknown tool: {func_name!r}")
@@ -7655,7 +7764,7 @@ class ChatSession:
                 available.extend(
                     sorted(
                         t["function"]["name"]
-                        for t in self._mcp_client.get_tools(user_id=self._mcp_user_id)
+                        for t in self._mcp_client.get_tools(user_id=self._mcp_effective_user_id)
                     )
                 )
             return {
@@ -11783,6 +11892,10 @@ class ChatSession:
             "execute": self._exec_mcp_tool,
             "mcp_func_name": func_name,
             "mcp_args": args,
+            # Pin the credential identity at prepare time: an item that
+            # sits pending approval must execute under the user whose
+            # turn requested it, not whoever binds the session later.
+            "mcp_user_id": self._mcp_effective_user_id,
         }
 
     def _exec_mcp_tool(self, item: dict[str, Any]) -> tuple[str, str]:
@@ -11799,7 +11912,7 @@ class ChatSession:
             output = self._mcp_client.call_tool_sync(
                 func_name,
                 args,
-                user_id=self._mcp_user_id,
+                user_id=item.get("mcp_user_id", self._mcp_effective_user_id),
                 timeout=self.tool_timeout,
                 is_interactive_for_consent=self._is_interactive_for_consent,
             )
@@ -11873,6 +11986,8 @@ class ChatSession:
             "approval_label": f"mcp_resource__{self._normalize_resource_uri(uri)}",
             "execute": self._exec_read_resource,
             "resource_uri": uri,
+            # Pinned at prepare time — see _prepare_mcp_tool.
+            "mcp_user_id": self._mcp_effective_user_id,
         }
 
     def _exec_read_resource(self, item: dict[str, Any]) -> tuple[str, str]:
@@ -11891,7 +12006,7 @@ class ChatSession:
             # static path runs byte-identical (invariant 1).
             output = self._mcp_client.read_resource_sync(
                 uri,
-                user_id=self._mcp_user_id,
+                user_id=item.get("mcp_user_id", self._mcp_effective_user_id),
                 timeout=self.tool_timeout,
                 is_interactive_for_consent=self._is_interactive_for_consent,
             )
@@ -11934,7 +12049,7 @@ class ChatSession:
                 "needs_approval": False,
                 "error": "No MCP servers configured",
             }
-        if not self._mcp_client.is_mcp_prompt(name, user_id=self._mcp_user_id):
+        if not self._mcp_client.is_mcp_prompt(name, user_id=self._mcp_effective_user_id):
             return {
                 "call_id": call_id,
                 "func_name": "use_prompt",
@@ -11968,6 +12083,8 @@ class ChatSession:
             "execute": self._exec_use_prompt,
             "prompt_name": name,
             "prompt_arguments": arguments,
+            # Pinned at prepare time — see _prepare_mcp_tool.
+            "mcp_user_id": self._mcp_effective_user_id,
         }
 
     def _exec_use_prompt(self, item: dict[str, Any]) -> tuple[str, str]:
@@ -11988,7 +12105,7 @@ class ChatSession:
             messages = self._mcp_client.get_prompt_sync(
                 name,
                 arguments or None,
-                user_id=self._mcp_user_id,
+                user_id=item.get("mcp_user_id", self._mcp_effective_user_id),
                 timeout=self.tool_timeout,
                 is_interactive_for_consent=self._is_interactive_for_consent,
             )
@@ -14419,12 +14536,12 @@ class ChatSession:
             elif arg and arg.split()[0] == "refresh":
                 self._handle_mcp_refresh(arg)
             else:
-                # Phase 7 + 7b: pass session-bound user_id so the /mcp
+                # Phase 7 + 7b: pass the effective user_id so the /mcp
                 # listing surfaces this user's pool tools, resources,
                 # and prompts alongside the static catalog.
-                tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
-                resources = self._mcp_client.get_resources(user_id=self._mcp_user_id)
-                prompts = self._mcp_client.get_prompts(user_id=self._mcp_user_id)
+                tools = self._mcp_client.get_tools(user_id=self._mcp_effective_user_id)
+                resources = self._mcp_client.get_resources(user_id=self._mcp_effective_user_id)
+                prompts = self._mcp_client.get_prompts(user_id=self._mcp_effective_user_id)
                 mcp_lines = []
                 if tools:
                     mcp_lines.append(f"MCP tools ({len(tools)}):")

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2704,15 +2704,54 @@ async def _collect_saved_rows(
     """
     import asyncio
 
+    from turnstone.core.auth import WorkstreamProjectVisibility
     from turnstone.core.memory import list_workstreams_with_history
 
-    rows = await asyncio.to_thread(
-        list_workstreams_with_history,
-        limit=50,
-        kind=cfg.list_kind,
-        user_id=None,
-        state=cfg.saved_state_filter,
-    )
+    visibility = WorkstreamProjectVisibility.for_request(request)
+
+    def _fetch_visible_rows() -> list[Any]:
+        """Page through storage until 50 visible rows (or exhaustion).
+
+        The visibility filter runs post-SQL, so a plain LIMIT-then-filter
+        would silently shrink the window whenever recently-updated rows
+        belong to private projects the caller can't see — their own rows
+        at position 51+ would never surface. Paging with OFFSET restores
+        the 'top-50 most-recent VISIBLE' contract. Runs entirely in the
+        worker thread: both the query and the per-row project lookups
+        are storage I/O. Bounded at 20 pages (1000 rows scanned) as a
+        runaway guard; hitting it is logged, not silent.
+        """
+        visible: list[Any] = []
+        offset = 0
+        page = 50
+        max_pages = 20
+        for _ in range(max_pages):
+            batch = list_workstreams_with_history(
+                limit=page,
+                kind=cfg.list_kind,
+                user_id=None,
+                state=cfg.saved_state_filter,
+                offset=offset,
+            )
+            for row in batch:
+                # project_id / owner are the SELECT tail — see the column
+                # order comment below.
+                if visibility.ws_visible(row[15], ws_owner=row[16] or ""):
+                    visible.append(row)
+                    if len(visible) >= 50:
+                        return visible
+            if len(batch) < page:
+                return visible
+            offset += page
+        log.info(
+            "ws.saved.visibility_scan_capped kind=%s scanned=%d visible=%d",
+            cfg.list_kind,
+            max_pages * page,
+            len(visible),
+        )
+        return visible
+
+    rows = await asyncio.to_thread(_fetch_visible_rows)
 
     # Coord-only: exclude ws_ids currently in the warm pool.
     loaded: set[str] = set()
@@ -2739,10 +2778,6 @@ async def _collect_saved_rows(
     # aliases absent from model_definitions (e.g. config.toml-only
     # models), so context_ratio degrades to 0.0 there rather than
     # reporting a bogus occupancy.
-    from turnstone.core.auth import WorkstreamProjectVisibility
-
-    visibility = WorkstreamProjectVisibility.for_request(request)
-
     result: list[dict[str, Any]] = []
     for row in rows:
         (
@@ -2765,10 +2800,6 @@ async def _collect_saved_rows(
             owner,
         ) = row
         if wid in loaded:
-            continue
-        # Private-project tenancy: rows the requester may not see are
-        # dropped server-side, not hidden client-side.
-        if not visibility.ws_visible(project_id, ws_owner=owner or ""):
             continue
         ctx_tokens = context_tokens or 0
         context_ratio = (

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1540,6 +1540,16 @@ def make_retry_handler(
                     ui._enqueue({"type": "busy_error", "message": "Cannot retry while processing."})
                 return JSONResponse({"status": "busy"})
 
+        # A retry is a fresh turn initiated by the authenticated caller —
+        # rebind per-user MCP credential resolution to them before the
+        # re-send dispatches (the per-kind ``dispatch_retry`` closure
+        # calls ``send()`` without identity kwargs).
+        from turnstone.core.web_helpers import auth_user_id
+
+        acting_uid = auth_user_id(request)
+        if acting_uid:
+            session.bind_acting_user(acting_uid)
+
         retry_msg = session.retry()
 
         if hasattr(ui, "_enqueue"):
@@ -3620,7 +3630,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
 
     from turnstone.core import session_worker
     from turnstone.core.session import AttachmentsNotQueueableError, GenerationCancelled
-    from turnstone.core.web_helpers import read_json_or_400
+    from turnstone.core.web_helpers import auth_user_id, read_json_or_400
 
     async def send(request: Request) -> Response:
         if cfg.permission_gate is not None:
@@ -3652,6 +3662,14 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         ui = ws.ui
         if ui is None:
             return JSONResponse({"error": "session UI not available"}, status_code=409)
+
+        # The authenticated sender: threaded into the fresh-turn dispatch
+        # below so per-user MCP credentials follow whoever is actually
+        # driving a shared workstream. Deliberately NOT applied on the
+        # live-worker queue path — an interjection folds into the current
+        # turn under the initiator's identity (no mid-turn credential
+        # switch); the next fresh turn rebinds.
+        acting_uid = auth_user_id(request)
 
         # ----- Attachment resolution (from the per-node upload buffer) -----
         send_id = ""
@@ -3758,6 +3776,8 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     kwargs["attachments"] = resolved_atts
                 if send_id:
                     kwargs["send_id"] = send_id
+                if acting_uid:
+                    kwargs["acting_user_id"] = acting_uid
                 session.send(message, **kwargs)
             except GenerationCancelled:
                 # Safety net — send() normally handles this internally.

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2646,12 +2646,20 @@ def make_list_handler(cfg: SessionEndpointConfig) -> Handler:
         resolve_titles = cfg.list_resolve_titles
 
         def _build_rows() -> list[dict[str, Any]]:
+            from turnstone.core.auth import WorkstreamProjectVisibility
+
+            visibility = WorkstreamProjectVisibility.for_request(request)
             wss = mgr.list_all()
             titles: dict[str, str | None] = {}
             if resolve_titles is not None and wss:
                 titles = resolve_titles([ws.id for ws in wss])
             rows: list[dict[str, Any]] = []
             for ws in wss:
+                project_id = getattr(ws, "project_id", "") or ""
+                # Private-project tenancy — drop rows the requester may
+                # not see (same predicate as the saved list).
+                if not visibility.ws_visible(project_id, ws_owner=ws.user_id or ""):
+                    continue
                 title = titles.get(ws.id) or ws.name
                 rows.append(
                     {
@@ -2661,6 +2669,7 @@ def make_list_handler(cfg: SessionEndpointConfig) -> Handler:
                         "kind": ws.kind,
                         "parent_ws_id": ws.parent_ws_id,
                         "user_id": ws.user_id,
+                        "project_id": project_id or None,
                     }
                 )
             return rows
@@ -2720,12 +2729,17 @@ async def _collect_saved_rows(
     # Column order from list_workstreams_with_history (keep in sync with
     # the storage SELECT): ws_id, alias, title, name, created, updated,
     # message_count, node_id, state, kind, model_alias, launch_skill,
-    # child_count, context_tokens, context_window.  The occupancy ratio
-    # is derived here (Python float division) rather than in SQL so the
-    # NULL / zero-window cases stay obvious and identical across backends.
-    # context_window is NULL for model aliases absent from
-    # model_definitions (e.g. config.toml-only models), so context_ratio
-    # degrades to 0.0 there rather than reporting a bogus occupancy.
+    # child_count, context_tokens, context_window, project_id, owner.
+    # The occupancy ratio is derived here (Python float division) rather
+    # than in SQL so the NULL / zero-window cases stay obvious and
+    # identical across backends.  context_window is NULL for model
+    # aliases absent from model_definitions (e.g. config.toml-only
+    # models), so context_ratio degrades to 0.0 there rather than
+    # reporting a bogus occupancy.
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
+    visibility = WorkstreamProjectVisibility.for_request(request)
+
     result: list[dict[str, Any]] = []
     for row in rows:
         (
@@ -2744,8 +2758,14 @@ async def _collect_saved_rows(
             child_count,
             context_tokens,
             context_window,
+            project_id,
+            owner,
         ) = row
         if wid in loaded:
+            continue
+        # Private-project tenancy: rows the requester may not see are
+        # dropped server-side, not hidden client-side.
+        if not visibility.ws_visible(project_id, ws_owner=owner or ""):
             continue
         ctx_tokens = context_tokens or 0
         context_ratio = (
@@ -2768,6 +2788,7 @@ async def _collect_saved_rows(
                 "child_count": child_count or 0,
                 "context_tokens": ctx_tokens,
                 "context_ratio": context_ratio,
+                "project_id": project_id or None,
             }
         )
     return result

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -1543,12 +1543,14 @@ def make_retry_handler(
         # A retry is a fresh turn initiated by the authenticated caller —
         # rebind per-user MCP credential resolution to them before the
         # re-send dispatches (the per-kind ``dispatch_retry`` closure
-        # calls ``send()`` without identity kwargs).
+        # calls ``send()`` without identity kwargs). getattr-guarded so
+        # per-kind session stubs without the method keep working.
         from turnstone.core.web_helpers import auth_user_id
 
         acting_uid = auth_user_id(request)
-        if acting_uid:
-            session.bind_acting_user(acting_uid)
+        bind_acting = getattr(session, "bind_acting_user", None)
+        if acting_uid and callable(bind_acting):
+            bind_acting(acting_uid)
 
         retry_msg = session.retry()
 
@@ -2655,7 +2657,8 @@ def make_list_handler(cfg: SessionEndpointConfig) -> Handler:
                 titles = resolve_titles([ws.id for ws in wss])
             rows: list[dict[str, Any]] = []
             for ws in wss:
-                project_id = getattr(ws, "project_id", "") or ""
+                raw_pid = getattr(ws, "project_id", "")
+                project_id = raw_pid if isinstance(raw_pid, str) else ""
                 # Private-project tenancy — drop rows the requester may
                 # not see (same predicate as the saved list).
                 if not visibility.ws_visible(project_id, ws_owner=ws.user_id or ""):
@@ -3797,8 +3800,14 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     kwargs["attachments"] = resolved_atts
                 if send_id:
                     kwargs["send_id"] = send_id
-                if acting_uid:
-                    kwargs["acting_user_id"] = acting_uid
+                # Fresh turn: rebind per-user MCP credentials to the
+                # authenticated sender. Bound here (not via a send()
+                # kwarg) so per-kind session stubs with explicit send
+                # signatures keep working; getattr-guarded for the same
+                # reason. The queue path above never rebinds.
+                bind = getattr(session, "bind_acting_user", None)
+                if acting_uid and callable(bind):
+                    bind(acting_uid)
                 session.send(message, **kwargs)
             except GenerationCancelled:
                 # Safety net — send() normally handles this internally.

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -593,9 +593,10 @@ class PostgreSQLBackend:
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
         state: str | None = None,
+        offset: int = 0,
     ) -> list[Any]:
         # See SQLite sibling for the rationale on the kind / user_id / state filters.
-        params: dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {"limit": limit, "offset": max(0, offset)}
         kind_clause = ""
         user_clause = ""
         state_clause = ""
@@ -634,7 +635,7 @@ class PostgreSQLBackend:
                         f"{kind_clause}"
                         f"{user_clause}"
                         f"{state_clause}"
-                        "ORDER BY w.updated DESC LIMIT :limit"
+                        "ORDER BY w.updated DESC LIMIT :limit OFFSET :offset"
                     ),
                     params,
                 ).fetchall()
@@ -5216,31 +5217,37 @@ class PostgreSQLBackend:
                         first_ws[aid] = ws_id
             if not first_ws:
                 return []
-            meta_rows = conn.execute(
-                sa.select(
-                    workstream_attachments.c.attachment_id,
-                    workstream_attachments.c.filename,
-                    workstream_attachments.c.mime_type,
-                    workstream_attachments.c.size_bytes,
-                    workstream_attachments.c.kind,
-                    workstream_attachments.c.created,
-                ).where(workstream_attachments.c.attachment_id.in_(list(first_ws)))
-            ).fetchall()
-            meta = {r[0]: r for r in meta_rows}
+            # Chunk the IN() — a project can reference more distinct
+            # blobs than the driver's bind-parameter cap.
+            meta: dict[str, Any] = {}
+            ids = list(first_ws)
+            for i in range(0, len(ids), 500):
+                meta_rows = conn.execute(
+                    sa.select(
+                        workstream_attachments.c.attachment_id,
+                        workstream_attachments.c.filename,
+                        workstream_attachments.c.mime_type,
+                        workstream_attachments.c.size_bytes,
+                        workstream_attachments.c.kind,
+                        workstream_attachments.c.created,
+                    ).where(workstream_attachments.c.attachment_id.in_(ids[i : i + 500]))
+                ).fetchall()
+                for r in meta_rows:
+                    meta[r[0]] = r
             out: list[dict[str, Any]] = []
             for aid, ws_id in first_ws.items():
-                r = meta.get(aid)
-                if r is None:
+                m = meta.get(aid)
+                if m is None:
                     # Ref-list names a pruned blob (refcount GC) — skip.
                     continue
                 out.append(
                     {
-                        "attachment_id": r[0],
-                        "filename": r[1],
-                        "mime_type": r[2],
-                        "size_bytes": r[3],
-                        "kind": r[4],
-                        "created": r[5],
+                        "attachment_id": m[0],
+                        "filename": m[1],
+                        "mime_type": m[2],
+                        "size_bytes": m[3],
+                        "kind": m[4],
+                        "created": m[5],
                         "ws_id": ws_id,
                     }
                 )

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -622,7 +622,7 @@ class PostgreSQLBackend:
                         "(SELECT ue.prompt_tokens FROM usage_events ue "
                         " WHERE ue.ws_id = w.ws_id "
                         " ORDER BY ue.timestamp DESC LIMIT 1), "
-                        "md.context_window "
+                        "md.context_window, w.project_id, w.user_id "
                         "FROM workstreams w "
                         "LEFT JOIN workstream_config wcm "
                         "  ON wcm.ws_id = w.ws_id AND wcm.key = 'model_alias' "

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -5157,6 +5157,95 @@ class PostgreSQLBackend:
             ).scalar()
         return result is not None
 
+    def list_workstreams_for_project(self, project_id: str) -> list[dict[str, Any]]:
+        # See SQLite sibling for the projection rationale.
+        with self._conn() as conn:
+            rows = conn.execute(
+                sa.select(
+                    workstreams.c.ws_id,
+                    workstreams.c.name,
+                    workstreams.c.title,
+                    workstreams.c.state,
+                    workstreams.c.kind,
+                    workstreams.c.updated,
+                    workstreams.c.node_id,
+                    workstreams.c.user_id,
+                )
+                .where(workstreams.c.project_id == project_id)
+                .order_by(workstreams.c.updated.desc())
+            ).fetchall()
+            return [
+                {
+                    "ws_id": r[0],
+                    "name": r[1],
+                    "title": r[2],
+                    "state": r[3],
+                    "kind": r[4],
+                    "updated": r[5],
+                    "node_id": r[6],
+                    "user_id": r[7],
+                }
+                for r in rows
+            ]
+
+    def list_project_attachments(self, project_id: str) -> list[dict[str, Any]]:
+        # See SQLite sibling: metadata-only (never the content blob), each
+        # id paired with its first referencing ws_id for URL construction.
+        with self._conn() as conn:
+            ref_rows = conn.execute(
+                sa.select(conversations.c.ws_id, conversations.c.attachments)
+                .select_from(
+                    conversations.join(workstreams, workstreams.c.ws_id == conversations.c.ws_id)
+                )
+                .where(
+                    workstreams.c.project_id == project_id,
+                    conversations.c.attachments.is_not(None),
+                )
+                .order_by(conversations.c.id)
+            ).fetchall()
+            first_ws: dict[str, str] = {}
+            for ws_id, raw in ref_rows:
+                try:
+                    ids = json.loads(raw) if raw else []
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(ids, list):
+                    continue
+                for aid in ids:
+                    if isinstance(aid, str) and aid and aid not in first_ws:
+                        first_ws[aid] = ws_id
+            if not first_ws:
+                return []
+            meta_rows = conn.execute(
+                sa.select(
+                    workstream_attachments.c.attachment_id,
+                    workstream_attachments.c.filename,
+                    workstream_attachments.c.mime_type,
+                    workstream_attachments.c.size_bytes,
+                    workstream_attachments.c.kind,
+                    workstream_attachments.c.created,
+                ).where(workstream_attachments.c.attachment_id.in_(list(first_ws)))
+            ).fetchall()
+            meta = {r[0]: r for r in meta_rows}
+            out: list[dict[str, Any]] = []
+            for aid, ws_id in first_ws.items():
+                r = meta.get(aid)
+                if r is None:
+                    # Ref-list names a pruned blob (refcount GC) — skip.
+                    continue
+                out.append(
+                    {
+                        "attachment_id": r[0],
+                        "filename": r[1],
+                        "mime_type": r[2],
+                        "size_bytes": r[3],
+                        "kind": r[4],
+                        "created": r[5],
+                        "ws_id": ws_id,
+                    }
+                )
+            return out
+
     # -- OIDC identity ---------------------------------------------------------
 
     def create_oidc_user(

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -362,8 +362,13 @@ class StorageBackend(Protocol):
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
         state: str | None = None,
+        offset: int = 0,
     ) -> list[Any]:
         """List workstreams that have messages, ordered by updated DESC.
+
+        ``offset`` skips that many rows before applying ``limit`` — the
+        saved-list collector pages through with it so a post-SQL
+        visibility filter can keep fetching until it fills its window.
 
         ``kind`` filters at the SQL layer — pass ``WorkstreamKind.INTERACTIVE``
         from the interactive "saved workstreams" sidebar so coordinator rows

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -2319,6 +2319,17 @@ class StorageBackend(Protocol):
         """Return True if user_id is a member of project_id."""
         ...
 
+    def list_workstreams_for_project(self, project_id: str) -> list[dict[str, Any]]:
+        """Return the project's workstreams (ws_id, name, title, state, kind,
+        updated, node_id, user_id), newest-updated first."""
+        ...
+
+    def list_project_attachments(self, project_id: str) -> list[dict[str, Any]]:
+        """Committed attachments referenced by any turn in the project's
+        workstreams — metadata only, each with the first referencing ws_id
+        (content serving is ws-scoped)."""
+        ...
+
     # -- Prompt policies -------------------------------------------------------
 
     def list_prompt_policies(self, org_id: str = "") -> list[dict[str, Any]]:

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -686,6 +686,7 @@ class SQLiteBackend:
         kind: WorkstreamKind | str | None = None,
         user_id: str | None = None,
         state: str | None = None,
+        offset: int = 0,
     ) -> list[Any]:
         # ``kind`` filter applied at the SQL layer so coordinator rows
         # (which persist conversation history the same way interactive
@@ -699,7 +700,7 @@ class SQLiteBackend:
         # ``state`` filter — coordinator-saved surface passes "closed"
         # so deleted / currently-active rows don't end up in the saved
         # cards (which would 404 on click or duplicate the active list).
-        params: dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {"limit": limit, "offset": max(0, offset)}
         kind_clause = ""
         user_clause = ""
         state_clause = ""
@@ -738,7 +739,7 @@ class SQLiteBackend:
                         f"{kind_clause}"
                         f"{user_clause}"
                         f"{state_clause}"
-                        "ORDER BY w.updated DESC LIMIT :limit"
+                        "ORDER BY w.updated DESC LIMIT :limit OFFSET :offset"
                     ),
                     params,
                 ).fetchall()
@@ -5381,31 +5382,37 @@ class SQLiteBackend:
                         first_ws[aid] = ws_id
             if not first_ws:
                 return []
-            meta_rows = conn.execute(
-                sa.select(
-                    workstream_attachments.c.attachment_id,
-                    workstream_attachments.c.filename,
-                    workstream_attachments.c.mime_type,
-                    workstream_attachments.c.size_bytes,
-                    workstream_attachments.c.kind,
-                    workstream_attachments.c.created,
-                ).where(workstream_attachments.c.attachment_id.in_(list(first_ws)))
-            ).fetchall()
-            meta = {r[0]: r for r in meta_rows}
+            # Chunk the IN() — a project can reference more distinct
+            # blobs than the driver's bind-parameter cap.
+            meta: dict[str, Any] = {}
+            ids = list(first_ws)
+            for i in range(0, len(ids), 500):
+                meta_rows = conn.execute(
+                    sa.select(
+                        workstream_attachments.c.attachment_id,
+                        workstream_attachments.c.filename,
+                        workstream_attachments.c.mime_type,
+                        workstream_attachments.c.size_bytes,
+                        workstream_attachments.c.kind,
+                        workstream_attachments.c.created,
+                    ).where(workstream_attachments.c.attachment_id.in_(ids[i : i + 500]))
+                ).fetchall()
+                for r in meta_rows:
+                    meta[r[0]] = r
             out: list[dict[str, Any]] = []
             for aid, ws_id in first_ws.items():
-                r = meta.get(aid)
-                if r is None:
+                m = meta.get(aid)
+                if m is None:
                     # Ref-list names a pruned blob (refcount GC) — skip.
                     continue
                 out.append(
                     {
-                        "attachment_id": r[0],
-                        "filename": r[1],
-                        "mime_type": r[2],
-                        "size_bytes": r[3],
-                        "kind": r[4],
-                        "created": r[5],
+                        "attachment_id": m[0],
+                        "filename": m[1],
+                        "mime_type": m[2],
+                        "size_bytes": m[3],
+                        "kind": m[4],
+                        "created": m[5],
                         "ws_id": ws_id,
                     }
                 )

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -726,7 +726,7 @@ class SQLiteBackend:
                         "(SELECT ue.prompt_tokens FROM usage_events ue "
                         " WHERE ue.ws_id = w.ws_id "
                         " ORDER BY ue.timestamp DESC LIMIT 1), "
-                        "md.context_window "
+                        "md.context_window, w.project_id, w.user_id "
                         "FROM workstreams w "
                         "LEFT JOIN workstream_config wcm "
                         "  ON wcm.ws_id = w.ws_id AND wcm.key = 'model_alias' "

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -5320,6 +5320,97 @@ class SQLiteBackend:
             ).scalar()
         return result is not None
 
+    def list_workstreams_for_project(self, project_id: str) -> list[dict[str, Any]]:
+        with self._conn() as conn:
+            rows = conn.execute(
+                sa.select(
+                    workstreams.c.ws_id,
+                    workstreams.c.name,
+                    workstreams.c.title,
+                    workstreams.c.state,
+                    workstreams.c.kind,
+                    workstreams.c.updated,
+                    workstreams.c.node_id,
+                    workstreams.c.user_id,
+                )
+                .where(workstreams.c.project_id == project_id)
+                .order_by(workstreams.c.updated.desc())
+            ).fetchall()
+            return [
+                {
+                    "ws_id": r[0],
+                    "name": r[1],
+                    "title": r[2],
+                    "state": r[3],
+                    "kind": r[4],
+                    "updated": r[5],
+                    "node_id": r[6],
+                    "user_id": r[7],
+                }
+                for r in rows
+            ]
+
+    def list_project_attachments(self, project_id: str) -> list[dict[str, Any]]:
+        """Committed attachments referenced by any turn in the project's
+        workstreams — metadata only (never the content blob), each with the
+        first referencing ws_id (content serving is ws-scoped, so the caller
+        needs a ws to build a download URL against).
+        """
+        with self._conn() as conn:
+            ref_rows = conn.execute(
+                sa.select(conversations.c.ws_id, conversations.c.attachments)
+                .select_from(
+                    conversations.join(workstreams, workstreams.c.ws_id == conversations.c.ws_id)
+                )
+                .where(
+                    workstreams.c.project_id == project_id,
+                    conversations.c.attachments.is_not(None),
+                )
+                .order_by(conversations.c.id)
+            ).fetchall()
+            first_ws: dict[str, str] = {}
+            for ws_id, raw in ref_rows:
+                try:
+                    ids = json.loads(raw) if raw else []
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(ids, list):
+                    continue
+                for aid in ids:
+                    if isinstance(aid, str) and aid and aid not in first_ws:
+                        first_ws[aid] = ws_id
+            if not first_ws:
+                return []
+            meta_rows = conn.execute(
+                sa.select(
+                    workstream_attachments.c.attachment_id,
+                    workstream_attachments.c.filename,
+                    workstream_attachments.c.mime_type,
+                    workstream_attachments.c.size_bytes,
+                    workstream_attachments.c.kind,
+                    workstream_attachments.c.created,
+                ).where(workstream_attachments.c.attachment_id.in_(list(first_ws)))
+            ).fetchall()
+            meta = {r[0]: r for r in meta_rows}
+            out: list[dict[str, Any]] = []
+            for aid, ws_id in first_ws.items():
+                r = meta.get(aid)
+                if r is None:
+                    # Ref-list names a pruned blob (refcount GC) — skip.
+                    continue
+                out.append(
+                    {
+                        "attachment_id": r[0],
+                        "filename": r[1],
+                        "mime_type": r[2],
+                        "size_bytes": r[3],
+                        "kind": r[4],
+                        "created": r[5],
+                        "ws_id": ws_id,
+                    }
+                )
+            return out
+
     # -- OIDC identity ---------------------------------------------------------
 
     def create_oidc_user(

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -330,8 +330,14 @@ def resolve_workstream_owner(
 
     When ``mgr`` is provided and the workstream is live in memory,
     trust its cached ``user_id`` / ``project_id`` instead of
-    round-tripping storage — keeps in-memory-only handlers functional
-    during transient DB outages and trims the hot-path by one query.
+    round-tripping storage for the ROW — but note the project gate
+    itself may still hit storage (one memoized ``get_project`` +
+    membership lookup when the row names a project), and it fails
+    CLOSED: during a transient DB outage a project-attached workstream
+    403s rather than risking a leak. That is a deliberate trade — a
+    DB outage already degrades sends/persistence, and failing open on
+    a private-tenancy check is the worse failure. Project-less
+    workstreams keep the zero-storage fast path.
 
     ``not_found_label`` is the message body the 404 carries — the
     interactive surface uses "Workstream not found"; coord uses

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -349,7 +349,8 @@ def resolve_workstream_owner(
         ws_mem = mgr.get(ws_id)
         if ws_mem is not None:
             owner = ws_mem.user_id or ""
-            project_id = getattr(ws_mem, "project_id", "") or ""
+            raw_pid = getattr(ws_mem, "project_id", "")
+            project_id = raw_pid if isinstance(raw_pid, str) else ""
 
     if owner is None:
         # Not in memory — storage resolves persisted-but-not-loaded rows.

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -333,11 +333,22 @@ def resolve_workstream_owner(
     round-tripping storage for the ROW — but note the project gate
     itself may still hit storage (one memoized ``get_project`` +
     membership lookup when the row names a project), and it fails
-    CLOSED: during a transient DB outage a project-attached workstream
-    403s rather than risking a leak. That is a deliberate trade — a
-    DB outage already degrades sends/persistence, and failing open on
-    a private-tenancy check is the worse failure. Project-less
+    CLOSED: a project-attached workstream 403s when that lookup fails
+    rather than risking a leak. That is a deliberate trade — a DB
+    outage already degrades sends/persistence, and failing open on a
+    private-tenancy check is the worse failure. Project-less
     workstreams keep the zero-storage fast path.
+
+    Failure-mode map, precisely: which error a storage outage produces
+    depends on where it strikes. The ROW lookup is fail-soft
+    (:func:`turnstone.core.memory.get_workstream_row` degrades an
+    exception to ``None``), so a storage-path row fetch that fails
+    surfaces as this function's 404 — pre-existing behaviour shared
+    with the old owner lookup. Only once a row IS resolved (from the
+    manager or storage) does the project gate run, and THAT failure is
+    the fail-closed 403 above. In-memory workstreams therefore 403 on
+    a project-gate blip; not-loaded ones typically 404 at the row
+    fetch first.
 
     ``not_found_label`` is the message body the 404 carries — the
     interactive surface uses "Workstream not found"; coord uses

--- a/turnstone/core/web_helpers.py
+++ b/turnstone/core/web_helpers.py
@@ -316,17 +316,22 @@ def resolve_workstream_owner(
     """Resolve ``ws_id`` to its owner; 404 when the row doesn't exist.
 
     Turnstone is a trusted-team tool: scope-level auth (e.g.
-    ``admin.workstreams`` / ``admin.coordinator``) is the only gate;
-    row-level ownership is not enforced here. Returns
+    ``admin.coordinator``) is the primary gate and row-level OWNERSHIP
+    is still not enforced here. The one row-level check this performs
+    is PROJECT tenancy: a workstream attached to a *private* project is
+    only reachable by the project's owner/members, the workstream's own
+    creator, service-scope callers, and ``admin.cluster.inspect``
+    holders — everyone else gets a 403 (see
+    :class:`turnstone.core.auth.WorkstreamProjectVisibility`). Returns
     ``(owner_user_id, None)`` on success — the persisted owner id,
     which attachments should be filed under so existing storage shape
     is preserved. Falls back to the caller's own uid when the row has
     no recorded owner.
 
     When ``mgr`` is provided and the workstream is live in memory,
-    trust its cached ``user_id`` instead of round-tripping storage —
-    keeps in-memory-only handlers functional during transient DB
-    outages and trims the hot-path by one query.
+    trust its cached ``user_id`` / ``project_id`` instead of
+    round-tripping storage — keeps in-memory-only handlers functional
+    during transient DB outages and trims the hot-path by one query.
 
     ``not_found_label`` is the message body the 404 carries — the
     interactive surface uses "Workstream not found"; coord uses
@@ -334,20 +339,36 @@ def resolve_workstream_owner(
     """
     from starlette.responses import JSONResponse as _JSONResponse
 
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
     caller = auth_user_id(request)
+    owner: str | None = None
+    project_id = ""
 
     if mgr is not None:
         ws_mem = mgr.get(ws_id)
         if ws_mem is not None:
-            return ws_mem.user_id or caller, None
-        # Not in memory — fall through to storage so persisted-but-not-
-        # loaded rows still resolve.
+            owner = ws_mem.user_id or ""
+            project_id = getattr(ws_mem, "project_id", "") or ""
 
-    from turnstone.core.memory import get_workstream_owner
-
-    owner = get_workstream_owner(ws_id)
     if owner is None:
-        return "", _JSONResponse({"error": not_found_label}, status_code=404)
+        # Not in memory — storage resolves persisted-but-not-loaded rows.
+        from turnstone.core.memory import get_workstream_row
+
+        row = get_workstream_row(ws_id)
+        if row is None:
+            return "", _JSONResponse({"error": not_found_label}, status_code=404)
+        owner = row.get("user_id") or ""
+        project_id = row.get("project_id") or ""
+
+    if project_id:
+        visibility = WorkstreamProjectVisibility.for_request(request)
+        if not visibility.ws_visible(project_id, ws_owner=owner):
+            return "", _JSONResponse(
+                {"error": "Forbidden: workstream belongs to a private project"},
+                status_code=403,
+            )
+
     return owner or caller, None
 
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1071,13 +1071,19 @@ async def dashboard(request: Request) -> JSONResponse:
     mgr: SessionManager = request.app.state.workstreams
     # No per-user OWNER filter (trusted-team deployment shape) — but
     # private-project rows are dropped for non-members, same predicate
-    # as every other listing surface.
+    # as every other listing surface. Executor: the predicate resolves
+    # project rows from storage, so the filter must not run on the
+    # event loop.
     visibility = WorkstreamProjectVisibility.for_request(request)
-    wss = [
-        ws
-        for ws in mgr.list_all()
-        if visibility.ws_visible(getattr(ws, "project_id", "") or "", ws_owner=ws.user_id or "")
-    ]
+
+    def _visible_wss() -> list[Workstream]:
+        return [
+            ws
+            for ws in mgr.list_all()
+            if visibility.ws_visible(getattr(ws, "project_id", "") or "", ws_owner=ws.user_id or "")
+        ]
+
+    wss = await asyncio.to_thread(_visible_wss)
     total_tokens = 0
     total_tool_calls = 0
     active_count = 0
@@ -1917,6 +1923,7 @@ async def _interactive_create_validate_request(
             },
             status_code=400,
         )
+    inherited_pid = False
     body_parent = body.get("parent_ws_id") or None
     if body_parent is not None:
         from turnstone.core.storage._registry import get_storage as _get_storage_for_parent
@@ -1943,12 +1950,17 @@ async def _interactive_create_validate_request(
         # (which forwards the body verbatim).
         if not (body.get("project_id") or "") and parent_row.get("project_id"):
             body["project_id"] = parent_row.get("project_id")
+            inherited_pid = True
     # Project attach gate (explicit or parent-inherited): a private
     # project accepts new workstreams only from its owner/members, and a
-    # nonexistent project_id is a caller error rather than a silent
-    # dangling link. Re-checking the inherited value is deliberate — a
-    # coordinator owner whose membership was revoked fails the child
+    # nonexistent EXPLICIT project_id is a caller error rather than a
+    # silent dangling link. Re-checking the inherited value is deliberate
+    # — a coordinator owner whose membership was revoked fails the child
     # spawn loudly here instead of minting rows they can no longer see.
+    # The one asymmetry: an INHERITED project that no longer exists is
+    # not the spawner's error — project deletion leaves the parent's
+    # link dangling by design and must not disable spawn_workstream, so
+    # the child simply isn't attached.
     attach_pid = str(body.get("project_id") or "")
     if attach_pid:
         from turnstone.core.auth import ensure_project_attachable
@@ -1956,7 +1968,10 @@ async def _interactive_create_validate_request(
         denied = ensure_project_attachable(uid, attach_pid)
         if denied is not None:
             status, message = denied
-            return JSONResponse({"error": message}, status_code=status)
+            if inherited_pid and status == 400:
+                body["project_id"] = ""
+            else:
+                return JSONResponse({"error": message}, status_code=status)
     notify_targets_raw = body.get("notify_targets", "[]")
     if isinstance(notify_targets_raw, list):
         notify_targets_raw = json.dumps(notify_targets_raw)
@@ -2083,6 +2098,12 @@ async def _interactive_create_post_install(
                 # isolation — a coordinator must never receive
                 # child_ws_* events for workstreams it doesn't own.
                 "user_id": ws.user_id,
+                # Project id likewise: the console's per-connection SSE
+                # tenancy filter gates ws_created on it — omitting it
+                # here made freshly-created private-project workstreams
+                # fail open on live cluster views (its open/resume and
+                # node-snapshot siblings already carry it).
+                "project_id": ws.project_id,
             }
         )
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2777,8 +2777,6 @@ async def project_resources_endpoint(request: Request) -> JSONResponse:
     Same access gate as ``get_project_endpoint``: ``project.read`` plus the
     per-project ACL.
     """
-    import asyncio
-
     from turnstone.core.auth import require_permission, user_can_access_project
     from turnstone.core.storage import get_storage
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1065,12 +1065,19 @@ async def global_events_sse(request: Request) -> Response:
 
 async def dashboard(request: Request) -> JSONResponse:
     """GET /v1/api/dashboard — enriched workstream data + aggregate stats."""
+    from turnstone.core.auth import WorkstreamProjectVisibility
     from turnstone.core.memory import get_workstream_display_name
 
     mgr: SessionManager = request.app.state.workstreams
-    # No per-user filter — see list_workstreams above for the rationale
-    # (trusted-team deployment shape; mutations stay owner-gated).
-    wss = mgr.list_all()
+    # No per-user OWNER filter (trusted-team deployment shape) — but
+    # private-project rows are dropped for non-members, same predicate
+    # as every other listing surface.
+    visibility = WorkstreamProjectVisibility.for_request(request)
+    wss = [
+        ws
+        for ws in mgr.list_all()
+        if visibility.ws_visible(getattr(ws, "project_id", "") or "", ws_owner=ws.user_id or "")
+    ]
     total_tokens = 0
     total_tool_calls = 0
     active_count = 0
@@ -1936,6 +1943,20 @@ async def _interactive_create_validate_request(
         # (which forwards the body verbatim).
         if not (body.get("project_id") or "") and parent_row.get("project_id"):
             body["project_id"] = parent_row.get("project_id")
+    # Project attach gate (explicit or parent-inherited): a private
+    # project accepts new workstreams only from its owner/members, and a
+    # nonexistent project_id is a caller error rather than a silent
+    # dangling link. Re-checking the inherited value is deliberate — a
+    # coordinator owner whose membership was revoked fails the child
+    # spawn loudly here instead of minting rows they can no longer see.
+    attach_pid = str(body.get("project_id") or "")
+    if attach_pid:
+        from turnstone.core.auth import ensure_project_attachable
+
+        denied = ensure_project_attachable(uid, attach_pid)
+        if denied is not None:
+            status, message = denied
+            return JSONResponse({"error": message}, status_code=status)
     notify_targets_raw = body.get("notify_targets", "[]")
     if isinstance(notify_targets_raw, list):
         notify_targets_raw = json.dumps(notify_targets_raw)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2747,6 +2747,49 @@ async def get_project_endpoint(request: Request) -> JSONResponse:
     return JSONResponse(_project_view(row))
 
 
+async def project_resources_endpoint(request: Request) -> JSONResponse:
+    """GET /v1/api/projects/{project_id}/resources — the project's contents.
+
+    Workstreams, referenced attachments (metadata + a ws_id to build the
+    ws-scoped download URL against), and the project-scoped memory count —
+    the aggregate view behind the manage → governance → Projects shelf.
+    Same access gate as ``get_project_endpoint``: ``project.read`` plus the
+    per-project ACL.
+    """
+    import asyncio
+
+    from turnstone.core.auth import require_permission, user_can_access_project
+    from turnstone.core.storage import get_storage
+
+    err = require_permission(request, "project.read")
+    if err:
+        return err
+    uid, uerr = _project_request_uid(request)
+    if uerr:
+        return uerr
+    project_id = request.path_params["project_id"]
+    storage = get_storage()
+    row = storage.get_project(project_id) if storage else None
+    if row is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+    if not user_can_access_project(uid, project_id, write=False, storage=storage):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    def _collect() -> dict[str, Any]:
+        # The attachment scan walks every conversation row in the
+        # project's workstreams — keep the whole collection off the
+        # event loop.
+        return {
+            "project_id": project_id,
+            "name": row.get("name", ""),
+            "workstreams": storage.list_workstreams_for_project(project_id),
+            "attachments": storage.list_project_attachments(project_id),
+            "memory_count": storage.count_structured_memories(scope="project", scope_id=project_id),
+        }
+
+    return JSONResponse(await asyncio.to_thread(_collect))
+
+
 async def update_project_endpoint(request: Request) -> JSONResponse:
     """PATCH /v1/api/projects/{project_id} — rename / re-visibility / archive."""
     from turnstone.core.auth import require_permission, user_can_access_project
@@ -4267,6 +4310,10 @@ def create_app(
                         "/api/projects/{project_id}",
                         delete_project_endpoint,
                         methods=["DELETE"],
+                    ),
+                    Route(
+                        "/api/projects/{project_id}/resources",
+                        project_resources_endpoint,
                     ),
                     Route(
                         "/api/projects/{project_id}/members",

--- a/turnstone/shared_static/cards.js
+++ b/turnstone/shared_static/cards.js
@@ -59,6 +59,16 @@ function _ctxCell(sess) {
 
 /* NAME cell: ellipsised title + an optional skill chip when the workstream
    launched with a non-default skill (empty for "Use defaults"). */
+/* Resolve a project_id to its display name via the shared projects data
+   layer (window bridge — cards.js also loads in the classic bundles).
+   Unknown / inaccessible ids render empty so callers can show "—". */
+function _projectName(projectId) {
+  if (!projectId) return "";
+  var tp = window.TurnstoneProjects;
+  if (!tp || typeof tp.projectName !== "function") return "";
+  return tp.projectName(projectId) || "";
+}
+
 function _nameCell(sess) {
   var wrap = document.createElement("div");
   wrap.className = "scell-name";
@@ -109,6 +119,20 @@ export var SavedColumns = {
       },
       sort: function (s) {
         return (s.model_alias || "").toLowerCase();
+      },
+    };
+  },
+  project: function () {
+    return {
+      key: "project",
+      label: "PROJECT",
+      width: "120px",
+      hideBelow: true,
+      cell: function (s) {
+        return _projectName(s.project_id) || "—";
+      },
+      sort: function (s) {
+        return (_projectName(s.project_id) || "").toLowerCase();
       },
     };
   },
@@ -279,6 +303,8 @@ export function createSavedTable(opts) {
       (sess.title || "") +
       " " +
       (sess.name || "") +
+      " " +
+      (_projectName(sess.project_id) || "") +
       " " +
       sess.ws_id
     ).toLowerCase();

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -849,6 +849,7 @@ let _wsTable = null;
 function _initSavedWsTable() {
   const WS_COLUMNS = [
     SavedColumns.name(),
+    SavedColumns.project(),
     SavedColumns.model(),
     SavedColumns.count("message_count", "MSGS"),
     SavedColumns.ctx(),
@@ -884,6 +885,13 @@ function _initSavedWsTable() {
       },
     },
   });
+  // The PROJECT column resolves names from the shared projects cache,
+  // which fills asynchronously — re-render once names arrive.
+  if (window.TurnstoneProjects) {
+    window.TurnstoneProjects.onProjectsChange(function () {
+      if (_wsTable) _wsTable.render();
+    });
+  }
 }
 
 // HTML inline-onclick wrappers — keep the global names the existing markup


### PR DESCRIPTION
First real-world use of shared project workstreams (#724) exposed three gaps: MCP tool calls on a shared workstream ran under the workstream *creator's* OAuth credentials regardless of who was driving; workstreams attached to a private project were visible and reachable to every authenticated user; and neither the dashboard saved-sessions list nor the governance Projects view showed what belongs to a project. This PR closes all three, plus the findings from a max-effort review pass over the branch.

### Acting-user MCP credential resolution

* Per-user MCP (`oauth_user`) credential resolution was bound once at session construction to the persisted workstream owner. The authenticated initiator of each turn (send + retry paths) is now bound as the session's acting user: dispatch, tool/resource/prompt catalogs, visibility gates, and consent flows follow whoever is actually driving, with the owner as fallback for CLI / eval / scheduled / internal turns.
* Rebinding swaps the user-scoped MCP listeners (identity is the `(user_id, callback)` pair), primes the acting user's pools fire-and-forget, and rebuilds the merged tool list. Prepared tool items pin the identity at prepare time, so an item awaiting approval executes under the user whose turn requested it — never whoever binds the session later. Mid-turn queued interjections deliberately do not rebind (no credential switch inside a tool batch).
* The binding survives compaction and auto-resume (same session object); it resets to the owner on rehydration — sender identity is not persisted.

### Private-project workstream visibility

* New tenancy predicate (`WorkstreamProjectVisibility`): a private project's workstreams are visible only to the project owner, its members, the workstream's own creator, service-scope callers, and `admin.cluster.inspect` holders. Public projects, dangling links (deleted projects), and project-less workstreams keep the trusted-team default. Membership itself is the grant — deliberately not gated on the `project.read` capability, which guards the management API.
* Enforced at every listing surface: saved sessions (the projection now carries `project_id` + owner), active list, node dashboard, console cluster list (pre-pagination via a collector `row_filter` so totals stay honest), node detail, `cluster_snapshot`, and the console tier-1 SSE stream (per-connection snapshot filtering with re-derived overview aggregates, plus a hidden-set for sparse follow-up events).
* Row-level access enforced in `resolve_workstream_owner` (403), covering every interactive ws-scoped verb via `tenant_check`; the console coordinator lane stays on its privileged `admin.coordinator` gate.
* Create-time attach gate: explicit unknown `project_id` is a 400, private non-member a 403; a parent-inherited project that was since deleted is dropped rather than failing coordinator child spawns.

### Project surfaces

* `SavedWorkstreamInfo` gains `project_id`; both saved-session tables (webui + console) grow a sortable, filterable PROJECT column that re-renders when the async project-name cache fills.
* New `GET /v1/api/projects/{id}/resources` (project.read + per-project ACL): the project's workstreams, referenced attachments (metadata only — never content blobs — each with a ws-scoped download link through the console node proxy), and the project-scoped memory count. Backed by `list_workstreams_for_project` (first consumer of `idx_workstreams_project`) and `list_project_attachments` (conversation ref-list walk, first-referencing ws per blob, `IN()` chunked).
* Manage → governance → Projects rows are now expandable into that resources panel (same interaction contract as the Users tab's OIDC detail panel).

### Review-pass hardening

A 35-agent review over the branch surfaced 15 confirmed findings, all addressed: the emitters that never carried `project_id`/`user_id` (console pseudo-node coordinator rows, interactive-create and poll-diff `ws_created` events) now do — with emitter-shape tests; SSE overview counts are computed post-filter; the saved list pages with OFFSET until it fills its window instead of filtering after the LIMIT; a storage blip suppresses an SSE row without pinning it hidden until reconnect (rate-limited re-judge); bypass principals get payloads untouched; visibility checks run off the event loop everywhere; and both security gates share a single `_project_grants` predicate. The one accepted trade: project-attached row access fails closed (403) during a transient DB outage rather than risking a leak — documented at the gate.

Full non-live suite: 7865 passed. Both storage backends exercised for the new queries.