### PR TITLE
chore(ci): allow Renovate PRs through Claude Code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,7 @@ jobs:
         uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'renovate[bot]' # let Renovate PRs get reviewed
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Add `renovate[bot]` to `allowed_bots` in `claude-code-review.yml` so Renovate's dependency-bump PRs get reviewed by Claude Code instead of being silently skipped by the default human-actor check.

## Test plan
- [ ] Open/update a Renovate PR and confirm the Claude Code Review workflow runs and posts a review.