### PR TITLE
fix(compaction): carry the plan and the ask across compaction verbatim

### DIFF
--- a/tests/test_compaction_crossing.py
+++ b/tests/test_compaction_crossing.py
@@ -1,0 +1,360 @@
+"""Tests for the compaction crossing discipline: what crosses the summary
+boundary VERBATIM (not only as summarizer paraphrase) and how the synthetic
+summary turns are recognized.
+
+- **Provenance tags** — ``_compact_messages`` and
+  ``reconstruct_turns_checkpointed`` mark both synthetic summary turns
+  ``source="compaction"``; ``_find_turn_boundaries`` and ``_generate_title``
+  test the tag, not the ``[Conversation summary]`` content string.  A user
+  who literally types the label therefore stays a REAL turn (previously it
+  was silently treated as synthetic — provenance by spelling).
+- **Carry budget** — ``_carry_budget_chars`` scales the verbatim-carry
+  allowance to ~25% of the window (clamped by the summary output reserve,
+  floored at ``_MIN_CARRY_BUDGET_CHARS``), replacing the fixed 400-char
+  continuation-hint clip; oversize content keeps head + tail around an
+  honest marker.
+- **Wind-down spill** — with ``carry_spill=True`` (the end-of-turn site
+  passes the ``stopped_to_compact`` latch) the final summarized assistant
+  turn's text is copied onto the summary under ``## Wind-down (verbatim)``
+  — shell concatenation, so the model's own plan statement survives the
+  collapse even when the summarizer paraphrases it.
+- The overflow-backstop compact-and-retry passes ``my_generation`` so a
+  stale send cannot compact-and-swap a newer generation's history.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests._session_helpers import make_session
+from turnstone.core.session import COMPACTION_SOURCE, COMPACTION_SUMMARY_LABEL
+from turnstone.core.trajectory import turns_from_dicts
+
+
+@pytest.fixture
+def session(tmp_db, mock_openai_client):
+    """Small-window session: context_window=10_000, compact_max_tokens=100 so
+    the summary output reserve is tiny and the carry budget is easy to compute
+    (reserve=100, margin=500, spare=9_400, budget=min(2_500, 9_400)=2_500
+    tokens → 10_000 chars at the uncalibrated 4.0 chars/token)."""
+    return make_session(
+        client=mock_openai_client,
+        context_window=10_000,
+        compact_max_tokens=100,
+        max_tokens=1_000,
+        tool_timeout=10,
+    )
+
+
+def _stub_summary(text: str = "DENSE"):
+    return SimpleNamespace(content=text, finish_reason="stop")
+
+
+# ---------------------------------------------------------------------------
+# Provenance tags on the synthetic summary turns
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryTurnProvenance:
+    def test_compact_tags_both_summary_turns(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "do the thing"},
+                {"role": "assistant", "content": "did the thing"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True) is True
+
+        label, summary = session.messages[0], session.messages[1]
+        assert label.text == COMPACTION_SUMMARY_LABEL
+        assert label.source == COMPACTION_SOURCE
+        assert summary.source == COMPACTION_SOURCE
+
+    def test_boundaries_exclude_tagged_label_only(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
+                {"role": "assistant", "content": "summary"},
+                {"role": "user", "content": "real follow-up"},
+            ]
+        )
+        assert session._find_turn_boundaries() == [2]
+
+    def test_literal_label_from_user_is_a_real_boundary(self, session):
+        """A user who literally types '[Conversation summary]' is not a
+        compaction artifact — provenance rides the tag, not the spelling."""
+        session.messages = turns_from_dicts([{"role": "user", "content": COMPACTION_SUMMARY_LABEL}])
+        assert session._find_turn_boundaries() == [0]
+
+    def test_title_gen_titles_from_literal_label_user(self, session):
+        """The tag distinction reaches _generate_title: a synthetic label is
+        skipped (pinned in test_cooperative_compaction), but a REAL user
+        message that happens to equal the label is titled from normally."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {"role": "assistant", "content": "an answer"},
+            ]
+        )
+        with (
+            patch.object(
+                session, "_utility_completion", return_value=_stub_summary("A Title")
+            ) as uc,
+            patch.object(session, "ui", new=MagicMock()),
+        ):
+            session._generate_title()
+
+        uc.assert_called_once()
+        prompt = uc.call_args[0][0][-1]["content"]
+        assert COMPACTION_SUMMARY_LABEL in prompt  # titled FROM the real message
+
+
+class TestCheckpointReconstructionProvenance:
+    def test_resume_turns_carry_compaction_source(self, storage_backend):
+        """A reopened session must see the same provenance the live session
+        held: reconstruct_turns_checkpointed tags the synthetic label AND the
+        marker-backed summary turn, while real tail rows stay untagged."""
+        st = storage_backend
+        st.register_workstream("ws1", user_id="u1", title="t", kind="interactive")
+        st.save_message("ws1", "user", "old question")
+        st.save_message("ws1", "assistant", "old answer")
+        watermark = st.get_compaction_watermark("ws1", 0)
+        st.save_message(
+            "ws1",
+            "assistant",
+            "THE SUMMARY",
+            source=COMPACTION_SOURCE,
+            meta=json.dumps({"watermark": watermark}),
+        )
+        st.save_message("ws1", "user", "new question")
+
+        turns = st.load_message_turns("ws1")
+        assert [t.text for t in turns] == [
+            COMPACTION_SUMMARY_LABEL,
+            "THE SUMMARY",
+            "new question",
+        ]
+        assert turns[0].source == COMPACTION_SOURCE
+        assert turns[1].source == COMPACTION_SOURCE
+        assert turns[2].source is None
+
+
+# ---------------------------------------------------------------------------
+# Carry budget — the verbatim-crossing allowance
+# ---------------------------------------------------------------------------
+
+
+class TestCarryBudget:
+    def test_scales_to_quarter_window(self, session):
+        # reserve=100 (compact_max_tokens), margin=500, spare=9_400;
+        # min(10_000 // 4, 9_400) = 2_500 tokens * 4.0 chars/token.
+        assert session._carry_budget_chars() == 10_000
+
+    def test_floors_on_tiny_window(self, tmp_db, mock_openai_client):
+        tiny = make_session(client=mock_openai_client, context_window=1_000, tool_timeout=10)
+        assert tiny._carry_budget_chars() == tiny._MIN_CARRY_BUDGET_CHARS
+
+    @pytest.mark.parametrize("carries", [1, 2])
+    def test_reserve_plus_all_carries_fit_window_at_shipped_defaults(
+        self, tmp_db, mock_openai_client, carries
+    ):
+        """The invariant that prevents a carry-induced overflow, pinned at the
+        SHIPPED defaults (budget bugs hide behind test-sized configs) and for
+        BOTH carry counts: the end-of-turn site fires the spill and the hint
+        together, and sizing each independently stacks reserve + 2·carry +
+        margin past the window."""
+        s = make_session(client=mock_openai_client, tool_timeout=10)
+        reserve = s._summary_output_tokens()
+        per_carry_tokens = s._carry_budget_chars(carries) / s._chars_per_token
+        margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
+        assert reserve + carries * per_carry_tokens + margin <= s.context_window
+
+    def test_double_carry_splits_the_spare(self, tmp_db, mock_openai_client):
+        """At shipped defaults the spare (window − reserve − margin) binds two
+        carries: each gets spare // 2, strictly less than the solo
+        quarter-window allowance."""
+        s = make_session(client=mock_openai_client, tool_timeout=10)
+        reserve = s._summary_output_tokens()
+        margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
+        spare = s.context_window - reserve - margin
+        assert s._carry_budget_chars(2) == int((spare // 2) * s._chars_per_token)
+        assert s._carry_budget_chars(2) < s._carry_budget_chars(1)
+
+
+class TestContinuationHintCarry:
+    def test_long_ask_crosses_verbatim(self, session):
+        """A 3_000-char user message is within the 10_000-char carry budget and
+        must cross whole — the old fixed clip kept 400 chars of it."""
+        ask = "spec line\n" * 300  # 3_000 chars
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": ask},
+                {"role": "assistant", "content": "working on it"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True) is True
+
+        summary_text = session.messages[1].text or ""
+        assert ask.strip() in summary_text  # verbatim, not clipped
+        assert "## Continue" in summary_text
+
+    def test_oversize_ask_keeps_head_and_tail_with_marker(self, session):
+        head_sentinel = "HEAD-OF-SPEC"
+        tail_sentinel = "TAIL-OF-SPEC"
+        ask = head_sentinel + ("x" * 20_000) + tail_sentinel  # over the 10_000 budget
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": ask},
+                {"role": "assistant", "content": "working on it"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True) is True
+
+        summary_text = session.messages[1].text or ""
+        assert head_sentinel in summary_text
+        assert tail_sentinel in summary_text
+        # The marker reports the ORIGINAL size, and the summary tells the
+        # model the full text is retrievable — a truncated carry is a cache
+        # miss with a pointer, not a silent loss.
+        assert f"…[truncated — {len(ask):,} chars total]…" in summary_text
+        assert "the recall tool can retrieve it" in summary_text
+        assert ask not in summary_text  # genuinely truncated
+
+    def test_untruncated_carry_gets_no_recall_pointer(self, session):
+        """The retrievability note appears ONLY when something was cut."""
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "short ask"},
+                {"role": "assistant", "content": "working on it"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True) is True
+        assert "recall tool" not in (session.messages[1].text or "")
+
+
+# ---------------------------------------------------------------------------
+# Wind-down spill — the model's plan statement crosses verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestWindDownSpill:
+    SPILL = (
+        "Goal: finish the migration.\n"
+        "Remaining: backfill rows 300-900, rerun the verifier.\n"
+        "Next step: resume at scripts/backfill.py --from 300."
+    )
+
+    def _compacted_summary(self, session, *, carry_spill: bool) -> str:
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "please migrate the database"},
+                {"role": "assistant", "content": self.SPILL},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True, carry_spill=carry_spill) is True
+        return session.messages[1].text or ""
+
+    def test_spill_copied_verbatim_under_heading(self, session):
+        summary_text = self._compacted_summary(session, carry_spill=True)
+        assert "## Wind-down (verbatim)" in summary_text
+        assert self.SPILL in summary_text  # copied, not paraphrased
+        # Ordering: recorded plan first, then how to resume.
+        assert summary_text.index("## Wind-down (verbatim)") < summary_text.index("## Continue")
+
+    def test_no_spill_without_flag(self, session):
+        summary_text = self._compacted_summary(session, carry_spill=False)
+        assert "## Wind-down (verbatim)" not in summary_text
+
+    def test_no_spill_when_last_summarized_turn_is_not_assistant(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": "next task"},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True, carry_spill=True) is True
+        assert "## Wind-down (verbatim)" not in (session.messages[1].text or "")
+
+    def test_empty_spill_adds_no_heading(self, session):
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": "   "},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True, carry_spill=True) is True
+        assert "## Wind-down (verbatim)" not in (session.messages[1].text or "")
+
+    def test_oversize_spill_truncated_by_carry_budget(self, session):
+        big_spill = "PLAN-HEAD " + ("y" * 20_000) + " PLAN-TAIL"
+        session.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": big_spill},
+            ]
+        )
+        session._msg_tokens = [1, 1]
+        with patch.object(session, "_utility_completion", return_value=_stub_summary()):
+            assert session._compact_messages(auto=True, carry_spill=True) is True
+        summary_text = session.messages[1].text or ""
+        assert "PLAN-HEAD" in summary_text and "PLAN-TAIL" in summary_text
+        assert "…[truncated —" in summary_text
+        assert "the recall tool can retrieve it" in summary_text
+
+    def test_double_carry_shares_the_budget(self, tmp_db, mock_openai_client):
+        """Spill + hint on ONE compaction — the end-of-turn shape — must fit
+        the window together.  At the shipped window defaults each carry gets
+        spare // 2, so two oversize carries land truncated to the shared
+        budget instead of stacking two solo quarter-window allowances on top
+        of the half-window summary reserve."""
+        s = make_session(client=mock_openai_client, tool_timeout=10)
+        per_carry = s._carry_budget_chars(2)
+        ask = "ASK-HEAD " + "a" * (per_carry * 2) + " ASK-TAIL"
+        spill = "PLAN-HEAD " + "b" * (per_carry * 2) + " PLAN-TAIL"
+        s.messages = turns_from_dicts(
+            [
+                {"role": "user", "content": ask},
+                {"role": "assistant", "content": spill},
+            ]
+        )
+        s._msg_tokens = [1, 1]
+        with patch.object(s, "_utility_completion", return_value=_stub_summary()):
+            assert s._compact_messages(auto=True, carry_spill=True) is True
+
+        text = s.messages[1].text or ""
+        assert "## Wind-down (verbatim)" in text and "## Continue" in text
+        for sentinel in ("ASK-HEAD", "ASK-TAIL", "PLAN-HEAD", "PLAN-TAIL"):
+            assert sentinel in text
+        assert text.count("…[truncated —") == 2  # both carries hit the shared cap
+        framing = 700  # headings, hint wording, stub summary, recall pointer
+        assert len(text) <= 2 * per_carry + framing
+
+    def test_do_auto_compact_forwards_carry_spill(self, session):
+        """The end-of-turn site passes carry_spill=stopped_to_compact through
+        _do_auto_compact — pin the forwarding."""
+        with patch.object(session, "_compact_messages", return_value=True) as cm:
+            session._do_auto_compact(my_generation=3, carry_spill=True)
+        assert cm.call_args.kwargs["carry_spill"] is True
+        assert cm.call_args.kwargs["my_generation"] == 3

--- a/tests/test_compaction_crossing.py
+++ b/tests/test_compaction_crossing.py
@@ -154,39 +154,62 @@ class TestCheckpointReconstructionProvenance:
 # ---------------------------------------------------------------------------
 
 
+def _isolate_overhead(s, system_tokens: int = 0) -> None:
+    """Pin the fixed prompt overhead (system + tool defs) for exact budget
+    arithmetic — the real values vary with the composed prompt and registered
+    tools (same isolation pattern as TestRemainingTokenBudget)."""
+    s._system_tokens = system_tokens
+    s._tools = []
+
+
 class TestCarryBudget:
     def test_scales_to_quarter_window(self, session):
-        # reserve=100 (compact_max_tokens), margin=500, spare=9_400;
-        # min(10_000 // 4, 9_400) = 2_500 tokens * 4.0 chars/token.
+        # overhead=0, reserve=100 (compact_max_tokens), margin=500,
+        # spare=9_400; min(10_000 // 4, 9_400) = 2_500 tokens * 4.0 chars/token.
+        _isolate_overhead(session)
         assert session._carry_budget_chars() == 10_000
 
     def test_floors_on_tiny_window(self, tmp_db, mock_openai_client):
         tiny = make_session(client=mock_openai_client, context_window=1_000, tool_timeout=10)
+        _isolate_overhead(tiny)
         assert tiny._carry_budget_chars() == tiny._MIN_CARRY_BUDGET_CHARS
 
     @pytest.mark.parametrize("carries", [1, 2])
-    def test_reserve_plus_all_carries_fit_window_at_shipped_defaults(
+    def test_overhead_reserve_and_carries_fit_window_at_shipped_defaults(
         self, tmp_db, mock_openai_client, carries
     ):
         """The invariant that prevents a carry-induced overflow, pinned at the
-        SHIPPED defaults (budget bugs hide behind test-sized configs) and for
-        BOTH carry counts: the end-of-turn site fires the spill and the hint
-        together, and sizing each independently stacks reserve + 2·carry +
-        margin past the window."""
+        SHIPPED defaults (budget bugs hide behind test-sized configs), for
+        BOTH carry counts, and INCLUDING the fixed prompt overhead: the
+        post-compaction prompt is system + tools + summary + carries, so a
+        budget that ignores the overhead (or sizes carries independently)
+        stacks past the window and the backstop re-compacts the carries
+        away."""
         s = make_session(client=mock_openai_client, tool_timeout=10)
+        _isolate_overhead(s, system_tokens=4_000)  # a chunky composed prompt
         reserve = s._summary_output_tokens()
         per_carry_tokens = s._carry_budget_chars(carries) / s._chars_per_token
         margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
-        assert reserve + carries * per_carry_tokens + margin <= s.context_window
+        assert 4_000 + reserve + carries * per_carry_tokens + margin <= s.context_window
+
+    def test_budget_shrinks_with_prompt_overhead(self, tmp_db, mock_openai_client):
+        """Monotonicity pin: the overhead term is genuinely in the formula —
+        a bigger system prompt leaves less to carry."""
+        s = make_session(client=mock_openai_client, tool_timeout=10)
+        _isolate_overhead(s, system_tokens=0)
+        roomy = s._carry_budget_chars(2)
+        _isolate_overhead(s, system_tokens=8_000)
+        assert s._carry_budget_chars(2) < roomy
 
     def test_double_carry_splits_the_spare(self, tmp_db, mock_openai_client):
-        """At shipped defaults the spare (window − reserve − margin) binds two
-        carries: each gets spare // 2, strictly less than the solo
-        quarter-window allowance."""
+        """At shipped defaults the spare (window − overhead − reserve −
+        margin) binds two carries: each gets spare // 2, strictly less than
+        the solo quarter-window allowance."""
         s = make_session(client=mock_openai_client, tool_timeout=10)
+        _isolate_overhead(s, system_tokens=2_000)
         reserve = s._summary_output_tokens()
         margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
-        spare = s.context_window - reserve - margin
+        spare = s.context_window - reserve - margin - 2_000
         assert s._carry_budget_chars(2) == int((spare // 2) * s._chars_per_token)
         assert s._carry_budget_chars(2) < s._carry_budget_chars(1)
 

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -21,6 +21,7 @@ import pytest
 
 from tests._session_helpers import make_session
 from turnstone.core.session import (
+    COMPACTION_SOURCE,
     COMPACTION_SUMMARY_LABEL,
     GenerationCancelled,
     _CompactionIrreducibleError,
@@ -162,7 +163,9 @@ class TestMidturnCompactionPolicy:
             patch.object(session.ui, "on_info") as on_info,
         ):
             session._do_auto_compact("mid-turn")
-        compact.assert_called_once_with(auto=True, preserve_tail=0, my_generation=0)
+        compact.assert_called_once_with(
+            auto=True, preserve_tail=0, my_generation=0, carry_spill=False
+        )
         msg = on_info.call_args.args[0]
         assert "58%" in msg
         assert "mid-turn" in msg
@@ -582,7 +585,7 @@ class TestPackBlocks:
         batches = session._pack_blocks(blocks, budget_chars=budget)
         flat = [b for batch in batches for b in batch]
         assert flat[0] == "before" and flat[-1] == "after"  # neighbours survive
-        truncated = [b for b in flat if "[truncated]" in b]
+        truncated = [b for b in flat if "[truncated" in b]
         assert len(truncated) == 1
         assert len(truncated[0]) <= budget
         assert truncated[0].startswith("z")  # head preserved
@@ -1036,7 +1039,11 @@ def test_generate_title_skips_synthetic_summary_label(session):
     issuing a model call that titles the conversation '[Conversation summary]'."""
     session.messages = turns_from_dicts(
         [
-            {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+            {
+                "role": "user",
+                "content": COMPACTION_SUMMARY_LABEL,
+                "_source": COMPACTION_SOURCE,
+            },
             {"role": "assistant", "content": "the dense summary"},
         ]
     )
@@ -1179,7 +1186,11 @@ class TestProactivePreSend:
         not a real turn, so _find_turn_boundaries excludes it and no hint is added."""
         session.messages = turns_from_dicts(
             [
-                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
                 {"role": "assistant", "content": "prior dense summary"},
             ]
         )
@@ -1498,7 +1509,11 @@ class TestRetryRewindSkipSummary:
         # Reactive compaction left only [summary_user, summary_asst] — no real turn.
         session.messages = turns_from_dicts(
             [
-                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
                 {"role": "assistant", "content": "the dense summary"},
             ]
         )
@@ -1510,7 +1525,11 @@ class TestRetryRewindSkipSummary:
     def test_rewind_on_bare_summary_is_noop(self, session):
         session.messages = turns_from_dicts(
             [
-                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
                 {"role": "assistant", "content": "the dense summary"},
             ]
         )
@@ -1522,7 +1541,11 @@ class TestRetryRewindSkipSummary:
     def test_retry_targets_real_turn_and_keeps_summary(self, session):
         session.messages = turns_from_dicts(
             [
-                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
                 {"role": "assistant", "content": "the dense summary"},
                 {"role": "user", "content": "a real follow-up"},
                 {"role": "assistant", "content": "the answer"},
@@ -1539,7 +1562,11 @@ class TestRetryRewindSkipSummary:
     def test_rewind_stops_at_summary_boundary(self, session):
         session.messages = turns_from_dicts(
             [
-                {"role": "user", "content": COMPACTION_SUMMARY_LABEL},
+                {
+                    "role": "user",
+                    "content": COMPACTION_SUMMARY_LABEL,
+                    "_source": COMPACTION_SOURCE,
+                },
                 {"role": "assistant", "content": "the dense summary"},
                 {"role": "user", "content": "a real follow-up"},
                 {"role": "assistant", "content": "the answer"},

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -175,7 +175,9 @@ class TestContextOverflowRecovery:
         ):
             session.send("hello")
 
-        compact_mock.assert_called_once_with(auto=True)
+        # my_generation must be the send's own generation — a stale send that
+        # hits overflow must not compact-and-swap a newer generation's history.
+        compact_mock.assert_called_once_with(auto=True, my_generation=session._generation)
         assert call_count == 2
 
     def test_anthropic_prompt_too_long_triggers_compact(self, session):
@@ -206,7 +208,7 @@ class TestContextOverflowRecovery:
         ):
             session.send("hello")
 
-        compact_mock.assert_called_once_with(auto=True)
+        compact_mock.assert_called_once_with(auto=True, my_generation=session._generation)
 
     def test_non_context_error_propagates(self, session):
         session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -2675,7 +2675,11 @@ class ChatSession:
         return used > self.context_window * min(0.95, self.auto_compact_pct + 0.10)
 
     def _do_auto_compact(
-        self, where: str = "", preserve_tail: int = 0, my_generation: int = 0
+        self,
+        where: str = "",
+        preserve_tail: int = 0,
+        my_generation: int = 0,
+        carry_spill: bool = False,
     ) -> bool:
         """Emit the auto-compaction notice, compact, and refresh the status
         line.  Shared by the mid-turn policy (:meth:`_maybe_compact_midturn`)
@@ -2685,7 +2689,9 @@ class ChatSession:
         is forwarded to :meth:`_compact_messages` (e.g. to keep an in-flight
         tool-call turn during compact-before-truncate); ``my_generation`` is
         forwarded so the message swap aborts if a newer send supersedes this one
-        mid-compaction (0 = the manual /compact path, which has no generation).
+        mid-compaction (0 = the manual /compact path, which has no generation);
+        ``carry_spill`` is forwarded so the end-of-turn site can copy the
+        model's wind-down turn onto the summary verbatim.
         Returns whether a summary was actually produced (False if compaction
         bailed) so callers can avoid acting on a compaction that did not happen."""
         qualifier = f" {where}" if where else ""
@@ -2694,7 +2700,10 @@ class ChatSession:
             f"\n[Auto-compacting{qualifier}: prompt exceeds {pct_display}% of context window]"
         )
         compacted = self._compact_messages(
-            auto=True, preserve_tail=preserve_tail, my_generation=my_generation
+            auto=True,
+            preserve_tail=preserve_tail,
+            my_generation=my_generation,
+            carry_spill=carry_spill,
         )
         self._print_status_line()
         return compacted
@@ -2760,11 +2769,11 @@ class ChatSession:
             asst_msg = ""
             for m in list(self.messages):
                 content = m.text  # joins text blocks; multipart attachments contribute none
-                # Skip the synthetic [Conversation summary] turn: after a compaction
-                # it is messages[0], and titling from the bare label yields a
-                # meaningless title (the same summary-turn-as-real-turn hazard
-                # _find_turn_boundaries guards for retry/rewind).
-                if m.role is Role.USER and not user_msg and content != COMPACTION_SUMMARY_LABEL:
+                # Skip the synthetic [Conversation summary] turn (source tag,
+                # not content match — same rule as _find_turn_boundaries):
+                # after a compaction it is messages[0], and titling from the
+                # bare label yields a meaningless title.
+                if m.role is Role.USER and not user_msg and m.source != COMPACTION_SOURCE:
                     user_msg = content[:300]
                 elif m.role is Role.ASSISTANT and not asst_msg:
                     asst_msg = content[:200]
@@ -3983,6 +3992,7 @@ class ChatSession:
     _MAX_SUMMARY_DEPTH = 5  # recursion ceiling before bailing
     _MIN_SUMMARY_BUDGET_CHARS = 2000  # floor so a tiny window still makes progress
     _MIN_SUMMARY_OUTPUT_TOKENS = 512  # floor on summary output even on a tiny window
+    _MIN_CARRY_BUDGET_CHARS = 2000  # floor on verbatim carry (ask quote / wind-down spill)
 
     def _get_health_tracker(self) -> BackendHealthTracker | None:
         """Get the health tracker for this session's current backend.
@@ -4763,7 +4773,12 @@ class ChatSession:
                         # its own thinking start/stop) to avoid nested spinners.
                         self.ui.on_thinking_stop()
                         try:
-                            self._compact_messages(auto=True)
+                            # my_generation: without it a stale send that hits
+                            # overflow here could compact-and-swap the LIVE
+                            # generation's history after a force-cancel started
+                            # a newer one — the same race every other compaction
+                            # site already guards.
+                            self._compact_messages(auto=True, my_generation=my_generation)
                             msgs = self._prepare_wire_messages(self._full_messages())
                             self.ui.on_thinking_start()
                             stream = self._create_stream_with_retry(msgs)
@@ -4849,7 +4864,12 @@ class ChatSession:
                     # consumed above — compact whenever over soft.  None-safe via
                     # _estimated_prompt_tokens(), so no _last_usage guard.
                     if self._over_soft(self._estimated_prompt_tokens()):
-                        compacted = self._do_auto_compact(my_generation=my_generation)
+                        # carry_spill: when the model stopped to let us compact,
+                        # its final turn is the plan spill the advisory asked
+                        # for — copy it across verbatim, don't just paraphrase.
+                        compacted = self._do_auto_compact(
+                            my_generation=my_generation, carry_spill=stopped_to_compact
+                        )
                         # _do_auto_compact's summary call is slow; unlike the
                         # mid-turn siblings this site also PERSISTS the resume
                         # turn, so re-check the generation didn't change during
@@ -5301,14 +5321,15 @@ class ChatSession:
         artifact, not a real turn: as a retry/rewind target it would re-send the
         bare label and regenerate over it (clobbering the summary), and as the
         pre-send ``preserve_tail`` anchor it would preserve the label instead of
-        the real question.  (A user who literally types the label leaves no real
-        boundary — retry/rewind then correctly no-op, and the pre-send caller's
-        own ``else`` fallback keeps the trailing turn.)
+        the real question.  Tested by the ``source`` tag both producers set
+        (:meth:`_compact_messages` in memory, ``reconstruct_turns_checkpointed``
+        on resume), not by content — so a user who literally types the label
+        keeps a real boundary, and retry/rewind treat their message normally.
         """
         return [
             i
             for i, m in enumerate(self.messages)
-            if m.role is Role.USER and (m.text or "") != COMPACTION_SUMMARY_LABEL
+            if m.role is Role.USER and m.source != COMPACTION_SOURCE
         ]
 
     def _persist_truncation(self, removed_count: int) -> None:
@@ -6124,6 +6145,30 @@ class ChatSession:
         window_cap = max(self._MIN_SUMMARY_OUTPUT_TOKENS, self.context_window // 2)
         return min(hard_cap, window_cap)
 
+    def _carry_budget_chars(self, carries: int = 1) -> int:
+        """Per-carry char budget for content carried VERBATIM across a
+        compaction — the continuation hint's quote of the user's last
+        message, and the wind-down spill.
+
+        A quarter of the window per carry, clamped so ALL concurrent carries
+        fit what the window spares after the summary output reserve: the
+        carried text lands in the same post-compaction turn as the summary,
+        so ``reserve + carries·budget + margin ≤ window`` must hold by
+        construction — sizing each carry independently stacks past the
+        window at default config exactly when spill and hint fire together
+        (the end-of-turn site).  Floored at ``_MIN_CARRY_BUDGET_CHARS`` so
+        small windows still carry something meaningful; on a sub-~1200-token
+        window (no shipped model) the floor exceeds the spare deliberately —
+        carrying something beats carrying nothing, and the overflow backstop
+        absorbs the worst case.  Chars via the calibrated
+        ``_chars_per_token``.
+        """
+        reserve = self._summary_output_tokens()
+        margin = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
+        spare = max(0, self.context_window - reserve - margin)
+        budget_tokens = min(self.context_window // 4, spare // max(1, carries))
+        return max(self._MIN_CARRY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token))
+
     def _summary_input_budget_chars(self) -> int:
         """Per-call input budget for a summary completion, in characters.
 
@@ -6158,18 +6203,22 @@ class ChatSession:
 
     @staticmethod
     def _truncate_block(block: str, budget: int) -> str:
-        """Hard-truncate a single oversized block to ``budget`` chars, keeping the
-        head and tail around a ``…[truncated]…`` marker.
+        """Hard-truncate a single oversized block to ``budget`` chars, keeping
+        the head and tail around a marker that reports the ORIGINAL size — the
+        reader (the summarizer, or on the verbatim-carry paths the
+        post-compaction model) sees how much is missing, not just that a cut
+        happened.
 
-        Only used for a lone block that can't fit any batch — the one lossy path
-        in chunked compaction.  The result is always ``<= budget``.
+        Used for a lone block that can't fit any summary batch, and for the
+        verbatim carries (ask quote / wind-down spill).  The result is always
+        ``<= budget``.
         """
         if len(block) <= budget:
             # Already fits — return as-is.  Without this, a budget wider than the
             # block makes the head slice ``block[:head]`` and tail slice
             # ``block[-tail:]`` overlap and DUPLICATE content around the marker.
             return block
-        marker = "\n…[truncated]…\n"
+        marker = f"\n…[truncated — {len(block):,} chars total]…\n"
         if budget <= len(marker):
             return block[:budget]
         keep = budget - len(marker)
@@ -6348,7 +6397,11 @@ class ChatSession:
                     budget = max(self._MIN_SUMMARY_BUDGET_CHARS, budget // 2)
 
     def _compact_messages(
-        self, auto: bool = False, preserve_tail: int = 0, my_generation: int = 0
+        self,
+        auto: bool = False,
+        preserve_tail: int = 0,
+        my_generation: int = 0,
+        carry_spill: bool = False,
     ) -> bool:
         """Compact conversation history by summarizing it into a summary turn.
 
@@ -6359,12 +6412,22 @@ class ChatSession:
         most-recent messages are no longer silently dropped.
 
         When auto=True (triggered by context limit), appends a continuation
-        hint with the last user message so the model can resume seamlessly.
+        hint quoting the last user message — verbatim up to
+        :meth:`_carry_budget_chars` — so the model can resume seamlessly.
 
         ``preserve_tail`` keeps the last N messages verbatim (re-appended after
         the summary) instead of summarizing them — used to keep an in-flight
         assistant tool-call turn so the tool results appended after compaction
         aren't orphaned from their ``tool_use``.
+
+        ``carry_spill`` copies the final summarized assistant turn's text onto
+        the summary under a ``## Wind-down (verbatim)`` heading — shell
+        concatenation, not summarizer output.  The end-of-turn site sets it
+        when the model stopped *because it was advised* to wrap up: that turn
+        holds the goal/remaining-tasks/next-steps the advisory asked it to
+        record, and the plan must cross a compaction copied, not paraphrased —
+        the summarizer also reads the spill, but its paraphrase must not be
+        the only survivor.
         """
         # Clear the cooperative latch on every compaction *attempt*, ahead of
         # the early-return guards below — a bailed compaction (too few/large
@@ -6427,15 +6490,55 @@ class ChatSession:
             self.ui.on_info("Compaction produced an empty summary; keeping history.")
             return False
 
+        # The verbatim carries: the wind-down spill and the continuation-hint
+        # quote of the ask.  Both can fire on the SAME compaction (the
+        # end-of-turn site), so they must share ONE budget — sized per-carry
+        # against each other, the summary reserve stacks past the window at
+        # default config (reserve cw/2 + 2·(cw/4) + margin > cw) and the
+        # overflow backstop would then re-compact WITHOUT the spill,
+        # paraphrasing away exactly what this carries.
+        spill_text = ""
+        if carry_spill and to_summarize:
+            # to_summarize[-1] is the model's final turn only because the
+            # end-of-turn site passes preserve_tail=0; a carry_spill caller
+            # with preserve_tail > 0 must locate the spill ahead of the
+            # preserved tail instead.
+            spill = to_summarize[-1]
+            if spill.role is Role.ASSISTANT:
+                spill_text = (spill.text or "").strip()
+        carries = (1 if spill_text else 0) + (1 if last_user_content else 0)
+        carry_budget = self._carry_budget_chars(carries) if carries else 0
+
+        # Wind-down first, then how to resume — the summary reads: sections,
+        # what the model recorded, then the ask to continue from.
+        carry_truncated = False
+        if spill_text:
+            carry_truncated = len(spill_text) > carry_budget
+            summary += "\n\n## Wind-down (verbatim)\n" + self._truncate_block(
+                spill_text, carry_budget
+            )
+
         # Append continuation hint for auto-compact
         if last_user_content:
-            # Truncate very long user messages
-            if len(last_user_content) > 500:
-                last_user_content = last_user_content[:400] + "..."
+            # The quoted ask crosses verbatim up to the carry budget — the last
+            # user message may BE the task (a pasted spec or diff), so a fixed
+            # few-hundred-char clip amputates it.  Beyond the budget keep head
+            # + tail around an honest marker.
+            carry_truncated = carry_truncated or len(last_user_content) > carry_budget
+            last_user_content = self._truncate_block(last_user_content, carry_budget)
             summary += (
                 f"\n\n## Continue\n"
                 f"The user's last message was: {last_user_content}\n"
                 f"Continue assisting from where we left off."
+            )
+
+        # A truncated carry is a cache miss, not a loss: storage keeps the
+        # full transcript, so tell the model where the rest lives instead of
+        # leaving a bare cut.
+        if carry_truncated:
+            summary += (
+                "\n\nTruncated content above is not lost: the full text remains "
+                "in conversation history and the recall tool can retrieve it."
             )
 
         # Honor a cancel — or a newer generation that superseded this send DURING
@@ -6449,8 +6552,19 @@ class ChatSession:
 
         # Replace messages — summary, then any preserved tail verbatim.
         before_tokens = self._system_tokens + sum(self._msg_tokens) + self._tool_def_tokens()
-        summary_user = {"role": "user", "content": COMPACTION_SUMMARY_LABEL}
-        summary_asst = {"role": "assistant", "content": summary}
+        # Both synthetic turns carry the compaction source tag so consumers
+        # (_find_turn_boundaries, _generate_title) test provenance, not
+        # content — a user who literally types the label stays a real turn.
+        summary_user = {
+            "role": "user",
+            "content": COMPACTION_SUMMARY_LABEL,
+            "_source": COMPACTION_SOURCE,
+        }
+        summary_asst = {
+            "role": "assistant",
+            "content": summary,
+            "_source": COMPACTION_SOURCE,
+        }
         self.messages = turns_from_dicts([summary_user, summary_asst]) + list(preserved)
         # File contents are gone after compaction — force re-read before edit_file
         self._read_files.clear()

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6151,21 +6151,26 @@ class ChatSession:
         message, and the wind-down spill.
 
         A quarter of the window per carry, clamped so ALL concurrent carries
-        fit what the window spares after the summary output reserve: the
-        carried text lands in the same post-compaction turn as the summary,
-        so ``reserve + carries·budget + margin ≤ window`` must hold by
-        construction — sizing each carry independently stacks past the
-        window at default config exactly when spill and hint fire together
-        (the end-of-turn site).  Floored at ``_MIN_CARRY_BUDGET_CHARS`` so
-        small windows still carry something meaningful; on a sub-~1200-token
-        window (no shipped model) the floor exceeds the spare deliberately —
-        carrying something beats carrying nothing, and the overflow backstop
-        absorbs the worst case.  Chars via the calibrated
-        ``_chars_per_token``.
+        fit what the window spares after the summary output reserve AND the
+        fixed prompt overhead (system message + tool definitions — the same
+        terms the ``_estimated_prompt_tokens`` fallback counts, because they
+        ride every request): the carried text lands in the same
+        post-compaction prompt as all of those, so
+        ``overhead + reserve + carries·budget + margin ≤ window`` must hold
+        by construction — sizing carries independently (or ignoring the
+        overhead) stacks past the window at default config exactly when
+        spill and hint fire together, and the overflow backstop would then
+        re-compact WITHOUT the carries.  Floored at
+        ``_MIN_CARRY_BUDGET_CHARS`` so small windows still carry something
+        meaningful; when the floor exceeds the spare (a tiny window, or a
+        system prompt that fills it) the floor wins deliberately — carrying
+        something beats carrying nothing, and the overflow backstop absorbs
+        the worst case.  Chars via the calibrated ``_chars_per_token``.
         """
         reserve = self._summary_output_tokens()
         margin = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
-        spare = max(0, self.context_window - reserve - margin)
+        overhead = self._system_tokens + self._tool_def_tokens()
+        spare = max(0, self.context_window - reserve - margin - overhead)
         budget_tokens = min(self.context_window // 4, spare // max(1, carries))
         return max(self._MIN_CARRY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token))
 

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -1069,10 +1069,13 @@ def reconstruct_turns_checkpointed(
     watermark]`` — the in-memory view the session held when it compacted. The
     summarized prefix and any older markers (id <= watermark) are dropped; the
     full history stays in storage for ``/history``/export/audit. The marker
-    reconstructs as a plain ``assistant`` turn (``reconstruct_turns`` drops
-    ``_source`` for assistant rows), and a synthetic ``[Conversation summary]``
-    user label is prepended to match what ``session._compact_messages`` builds
-    in memory (and to satisfy the leading-user-turn wire contract).
+    reconstructs as an ``assistant`` turn re-tagged ``source="compaction"``
+    (``reconstruct_turns`` drops ``_source`` for assistant rows), and a
+    synthetic ``[Conversation summary]`` user label — tagged likewise — is
+    prepended to match what ``session._compact_messages`` builds in memory
+    (and to satisfy the leading-user-turn wire contract).  The tags keep
+    provenance-testing consumers (``_find_turn_boundaries``, title gen)
+    working identically across a reopen.
 
     Falls back to the full reconstruction when there is no marker or its watermark
     is absent/corrupt, so every pre-checkpoint session loads exactly as before.
@@ -1101,9 +1104,12 @@ def reconstruct_turns_checkpointed(
     # slices separately so the summary leads regardless of row-id ordering (a
     # preserved tail kept verbatim sits at a *lower* id than the marker).
     tail = [r for r in rows if r[0] > watermark and not _is_compaction_marker(r)]
-    label = Turn(Role.USER, _content_blocks(COMPACTION_SUMMARY_LABEL, []))
+    label = Turn(Role.USER, _content_blocks(COMPACTION_SUMMARY_LABEL, []), source=COMPACTION_SOURCE)
+    marker_turns = reconstruct_turns([marker], ws_id, attachments_by_msg)
+    for t in marker_turns:
+        t.source = COMPACTION_SOURCE
     return [
         label,
-        *reconstruct_turns([marker], ws_id, attachments_by_msg),
+        *marker_turns,
         *reconstruct_turns(tail, ws_id, attachments_by_msg),
     ]


### PR DESCRIPTION
## What

Compaction review follow-up: the control-relevant content that crosses a compaction — the model's wind-down plan and the user's standing ask — now crosses **verbatim**, not only as summarizer paraphrase; and the synthetic summary turns carry machine-readable provenance instead of being recognized by their content string.

## Changes

**Wind-down spill crosses copied, not paraphrased.** The cooperative advisory asks the model to record its goal / remaining tasks / next steps before the collapse — and then end-of-turn compaction handed that spill to the summarizer like everything else, so the model resumed from a paraphrase of what it recorded. Now, when the model stopped *because it was advised* (`stopped_to_compact`), `_compact_messages(carry_spill=True)` shell-concatenates the final assistant turn's text onto the summary under `## Wind-down (verbatim)`, ahead of the `## Continue` hint. The summarizer still reads the spill; its paraphrase just isn't the only survivor.

**The ask's carry budget scales with the window.** The continuation hint clipped the user's last message to 400 chars — amputating a pasted spec or diff, which often *is* the task. New `_carry_budget_chars(carries)`: ~25% of the context window per carry, clamped so **all concurrent carries** fit what the window spares after the summary output reserve, the fixed prompt overhead (system message + tool definitions — the same terms `_estimated_prompt_tokens` counts), and the safety margin (`overhead + reserve + carries·budget + margin ≤ window` by construction), floored at 2000 chars. Oversize content keeps head + tail around the honest `…[truncated]…` marker. The per-carry sizing matters: at the end-of-turn site the spill and the hint fire on the *same* compaction, and sizing each independently stacks past the window at default config (`reserve cw/2 + 2·(cw/4) + margin > cw`) — the overflow backstop would then re-compact *without* the spill, paraphrasing away exactly what the feature carries. Both carries now share one budget (`spare // carries`); a review pass on this branch caught the stack-up and the end-to-end double-carry case is pinned in tests.

**Summary turns carry provenance; consumers stop string-matching.** `_compact_messages` and `reconstruct_turns_checkpointed` now tag both synthetic turns `source="compaction"`; `_find_turn_boundaries` and `_generate_title` test the tag instead of comparing content to `[Conversation summary]`. A user who literally types the label is now a real turn (boundary, title source, retry/rewind target) instead of being silently classified as a compaction artifact. This is the same fix the U2 bug family (retry/hint/title treating the synthetic turn as real) needed — made once at the provenance layer instead of once per consumer.

**Truncated carries say what's missing and where the rest lives.** `_truncate_block`'s marker now reports the original size (`…[truncated — N chars total]…`, matching the tool-output and recall precedents), and when a carry was actually cut the summary gains one line telling the model the full text remains in conversation history and is retrievable with the recall tool — a truncated carry is a cache miss with a pointer, not a silent loss.

**Race fix in the overflow backstop.** The send loop's compact-and-retry called `_compact_messages(auto=True)` without `my_generation`, so a stale send hitting context overflow could compact-and-swap the *live* generation's history after a force-cancel started a newer one — the same race every other compaction site already guards. It now passes `my_generation`.

## Tests

`tests/test_compaction_crossing.py`: tag round-trip through `_compact_messages` and through checkpoint reconstruction on the cross-backend fixture; literal-label user message is a real boundary and a valid title source; carry-budget arithmetic (quarter-window, tiny-window floor, the reserve+carries·budget+margin ≤ window invariant pinned at shipped defaults for one AND two carries, spare-splitting for the double carry); long ask crosses verbatim / oversize ask keeps head+tail+marker; spill copied verbatim under its heading, ordering before `## Continue`, absent without the flag / for non-assistant or empty tails, truncated when oversize; end-to-end double-carry (spill + hint together, both truncated to the shared budget); `_do_auto_compact` forwarding. Existing cooperative-compaction and overflow-recovery tests updated for the tagged label turns and the `my_generation` kwarg the producers now emit.
