### PR TITLE
fix(ci): gate workflow_run publishing to same-repo tag pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,9 @@ on:
 
 concurrency:
   group: docker-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  # Never cancel mid-push: an interrupted multi-tag push can leave the
+  # registry with a partial tag set (e.g. :latest moved, :stable not).
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -19,15 +21,24 @@ env:
 
 jobs:
   docker:
+    # Same gate as publish.yml: workflow_run fires for every CI completion
+    # (including fork and same-repo PR runs) with this repo's token and
+    # packages:write.  Only same-repo tag pushes may publish images; CI's
+    # push trigger matches main/stable/* and v* tags, so a head_branch
+    # starting with "v" is necessarily a tag run.
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          # The docker build only reads the tree; keep the token out of it.
+          persist-credentials: false
 
       - name: Resolve release tag
         id: tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,9 @@ on:
 
 concurrency:
   group: publish-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  # Never cancel a publish mid-upload: a half-uploaded release (sdist up,
+  # wheel missing) cannot be re-run cleanly because PyPI rejects duplicates.
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -15,7 +17,16 @@ permissions:
 
 jobs:
   publish:
-    if: github.event.workflow_run.conclusion == 'success'
+    # workflow_run fires for EVERY CI completion — including CI runs for
+    # pull_requests from forks — and always executes here with this repo's
+    # secrets, tokens, and the pypi environment.  Gate to same-repo tag
+    # pushes only: CI's push trigger matches branches main/stable/* and
+    # tags v*, so a head_branch starting with "v" is necessarily a tag run.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     environment: pypi
     steps:
@@ -23,6 +34,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          # python -m build executes the tree's build backend; don't leave
+          # the contents:write token sitting in .git/config while it runs.
+          persist-credentials: false
 
       - name: Resolve release tag
         id: tag

--- a/.github/workflows/vendor-js.yml
+++ b/.github/workflows/vendor-js.yml
@@ -25,18 +25,30 @@ permissions:
 
 jobs:
   vendor-js:
-    if: github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch'
+    # Same-repo PRs only: this job checks out the PR head and pushes to it
+    # with contents:write, so it must never act on a fork's branch.
+    # Gate on the PR author (immutable), not github.actor (names whoever
+    # caused the latest event, which can be someone else re-running it).
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login == 'renovate[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR head ref
         id: ref
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Branch names may contain shell metacharacters; pass via env,
+          # never interpolate ${{ }} into the script body.
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            ref=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            ref=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName -q .headRefName)
           else
-            ref="${{ github.head_ref }}"
+            ref="$HEAD_REF"
           fi
           echo "head_ref=${ref}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/vendor-js.yml
+++ b/.github/workflows/vendor-js.yml
@@ -46,7 +46,16 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            ref=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName -q .headRefName)
+            # The dispatch input is an arbitrary PR number; refuse fork PRs.
+            # A fork's headRefName is a bare branch name that may collide
+            # with a branch in this repo, and checkout+push would then hit
+            # that unrelated branch ("same-repo PRs only" applies here too).
+            pr_json=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName,isCrossRepository)
+            if [[ "$(jq -r '.isCrossRepository' <<< "$pr_json")" != "false" ]]; then
+              echo "::error::PR #${PR_NUMBER} head is not a branch in this repository; refusing to complete it."
+              exit 1
+            fi
+            ref=$(jq -r '.headRefName' <<< "$pr_json")
           else
             ref="$HEAD_REF"
           fi


### PR DESCRIPTION
## Problem

`publish.yml` and `docker-publish.yml` trigger on `workflow_run` of CI, which fires for **every** CI completion — including CI runs for pull requests from forks — and always executes in this repo's context with its secrets, `contents: write`, `id-token: write`, and the `pypi` environment. The only gate was `conclusion == 'success'`.

Observed consequences:

- ~25 publish runs in 48h, almost all triggered by PR CI completions (renovate branches, feature branches) — each a full-clone privileged job that resolved no tag and skipped.
- Run [28468804960](https://github.com/turnstonelabs/turnstone/actions/runs/28468804960) was triggered by a fork PR's CI run and attempted to check out the fork's commit inside the publish-privileged job. The only stop was `actions/checkout@v7`'s built-in refusal to check out fork code from a `workflow_run` workflow.
- Residual path to a real upload: a fork PR whose head commit is an upstream-tagged commit (fork, branch at an existing `v*` tag, open PR) passes the `git tag --points-at HEAD` check and reaches the upload with **valid** OIDC — trusted publishing can't distinguish it, because `workflow_run` jobs run as this repo with the `pypi` environment. The GitHub-release step would also run with `contents: write`.

## Fix

**`publish.yml`, `docker-publish.yml`** — the job now requires all of:

1. CI concluded successfully,
2. CI was triggered by a `push` event (excludes all PR runs, fork or same-repo),
3. the head repository is this repository,
4. `head_branch` starts with `v`.

Clause 4 pins publishing to tag-push CI runs: for tag runs `head_branch` is the tag name (verified against existing run data: the `v1.7.0a6` CI run reports `head_branch: v1.7.0a6`), and CI's push trigger only matches `main`/`stable/*`/`v*`, so nothing else starts with `v`.

Also:
- `persist-credentials: false` on both checkouts — `python -m build` / the docker build execute the tree's build code and don't need a git-writable token in `.git/config`.
- `cancel-in-progress: false` — a publish cancelled mid-upload leaves a half-uploaded release that can't be re-run cleanly (PyPI rejects duplicate files); an interrupted multi-tag docker push can leave a partial tag set.

**`vendor-js.yml`** (same pass; it pushes commits with `contents: write` while executing a script from the PR head):
- gate on the immutable PR author (`pull_request.user.login`) instead of `github.actor` (names whoever caused the latest event),
- require a same-repo head,
- pass `github.head_ref` via `env:` instead of interpolating `${{ }}` into the script body (branch names may contain shell metacharacters).

Validated with zizmor; remaining findings on these files are the categorical `workflow_run`-trigger warning (mitigated by the gates above — the trigger is what provides publish-only-after-CI-passes) and vendor-js's persisted credentials (required: it pushes).

## Follow-ups (repo settings, not in this PR)

- The `pypi` environment currently has no protection rules; a required reviewer would add a human gate per release.
- Fork-PR approval policy is `first_time_contributors`; `all_external_contributors` is the stricter option.
- Verify the PyPI trusted publisher pins both `publish.yml` and the `pypi` environment.

## Behavior change for releases

Publishing now happens from exactly one run per release — the one triggered by the `v*` tag push. Pushing `main` alone no longer spins up publish jobs at all. First live exercise will be the next tag.