### PR TITLE
fix(judge): full tool arguments for the LLM judges, bounded by their real window

### DIFF
--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -1504,6 +1504,9 @@ def _stub_judge_for_evaluate_intent(monkeypatch, sess):
     fake_judge = MagicMock()
     # judge.evaluate(items, messages, callback=, cancel_event=) → list[verdict]
     fake_judge.evaluate.side_effect = lambda items, *_args, **_kw: [fake_verdict] * len(items)
+    # arg_budget_chars() feeds honest_truncate in the projection loop and must
+    # be a real int, not a MagicMock; large enough that nothing truncates.
+    fake_judge.arg_budget_chars.return_value = 200_000
     monkeypatch.setattr(sess, "_ensure_judge", lambda: fake_judge)
     return fake_judge
 
@@ -1545,7 +1548,10 @@ def test_spawn_batch_evaluate_intent_projects_all_children(coord_session, monkey
 
 def test_spawn_batch_evaluate_intent_truncates_long_messages(coord_session, monkeypatch):
     sess, _coord, _ui = coord_session
-    _stub_judge_for_evaluate_intent(monkeypatch, sess)
+    fake_judge = _stub_judge_for_evaluate_intent(monkeypatch, sess)
+    # Each child's initial_message is truncated to its share of the judge's
+    # arg budget (window-based), not a fixed cap, and the omission is honest.
+    fake_judge.arg_budget_chars.return_value = 300  # 1 child → 300 chars/child
     long_msg = "x" * 500
     item = sess._prepare_tool(
         _tc("spawn_batch", {"children": [{"initial_message": long_msg, "skill": "researcher"}]})
@@ -1554,9 +1560,9 @@ def test_spawn_batch_evaluate_intent_truncates_long_messages(coord_session, monk
 
     children = item["func_args"]["children"]
     assert len(children) == 1
-    # Cap is 200 chars — same shape every other coord-tool projection uses.
-    assert len(children[0]["initial_message"]) == 200
-    assert children[0]["initial_message"] == "x" * 200
+    msg = children[0]["initial_message"]
+    assert msg.startswith("x" * 300)
+    assert "200 of 500 chars omitted" in msg
 
 
 def test_spawn_batch_evaluate_intent_handles_empty_children_defensively(coord_session, monkeypatch):
@@ -1609,10 +1615,15 @@ def test_tasks_update_without_title_evaluates_intent_cleanly(coord_session, monk
     # The crash trigger: item["title"] is None after _prepare_tasks.
     assert item["title"] is None
     sess._evaluate_intent([item])
+    # title collapses None → "" (truncatable text); status is projected so the
+    # judge can see what state is being set; child_ws_id passes through as None
+    # ("unchanged"), never sliced.
     assert item["func_args"] == {
         "action": "update",
         "task_id": "tsk_1",
         "title": "",
+        "status": "in_progress",
+        "child_ws_id": None,
     }
 
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -476,6 +476,65 @@ class TestContextPreparation:
         assert "Conversation context:" in result[1]["content"]
 
 
+class TestArgBudget:
+    """The projected ``func_args`` and the conversation transcript share the
+    judge model's context window; large arguments are honestly truncated to it
+    rather than blind-capped."""
+
+    def test_honest_truncate_verbatim_when_it_fits(self):
+        from turnstone.core.judge import honest_truncate
+
+        assert honest_truncate("short", 100) == "short"
+
+    def test_honest_truncate_reports_exact_omitted_count(self):
+        from turnstone.core.judge import honest_truncate
+
+        out = honest_truncate("A" * 5000, 1000)
+        assert out.startswith("A" * 1000)
+        assert "4,000 of 5,000 chars omitted" in out
+
+    def test_arg_budget_scales_with_context_window_uncapped(self):
+        """The judge-prompt budget scales with the real window and is NOT
+        ceilinged — a big-window judge gets a proportionally big budget so args
+        lower whole; only a genuine overflow truncates."""
+        from turnstone.core.judge import _ARG_CONTEXT_RATIO, _CHARS_PER_TOKEN
+
+        judge = _make_judge()
+        judge._judge_context_window = 40_000
+        small = judge.arg_budget_chars()
+        judge._judge_context_window = 200_000
+        big = judge.arg_budget_chars()
+        assert small == int(40_000 * _ARG_CONTEXT_RATIO * _CHARS_PER_TOKEN)
+        assert big == int(200_000 * _ARG_CONTEXT_RATIO * _CHARS_PER_TOKEN)  # no ceiling
+
+    def test_verdict_record_copy_is_capped_by_oh_crap_backstop(self):
+        """The func_args stored on the verdict (persisted + streamed) is bounded
+        by _VERDICT_ARG_CAP even when the args are enormous — the judge PROMPT
+        is bounded separately by the window, not by this cap."""
+        from turnstone.core.judge import _VERDICT_ARG_CAP, evaluate_heuristic
+
+        v = evaluate_heuristic("write_file", {"content": "Z" * 40_000}, "write_file", "c1")
+        assert len(v.func_args) <= _VERDICT_ARG_CAP + 80  # payload + honest marker
+        assert "chars omitted" in v.func_args
+
+    def test_large_args_shrink_the_history_they_share_the_window_with(self):
+        """A big write/edit must eat into the transcript budget, not push the
+        prompt past the window."""
+        judge = _make_judge()
+        # One anchor user turn (the judge trims to the last user message
+        # onward), then many assistant turns that compete for the budget.
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "anchor"}]
+        messages += [{"role": "assistant", "content": "x" * 1000} for _ in range(50)]
+
+        small = judge._prepare_context(_make_item(func_args={"command": "ls"}), messages)
+        big = judge._prepare_context(
+            _make_item(func_name="write_file", func_args={"content": "Z" * 200_000}), messages
+        )
+        # Each included history turn renders one "ASSISTANT:" line; the
+        # big-argument call fits strictly fewer of them.
+        assert big[1]["content"].count("ASSISTANT:") < small[1]["content"].count("ASSISTANT:")
+
+
 # ---------------------------------------------------------------------------
 # Confidence arbitration
 # ---------------------------------------------------------------------------
@@ -874,6 +933,27 @@ class TestModelAliasResolution:
         assert judge._client_factory_args["base_url"] == "https://alias.example/v1"
         assert judge._client_factory_args["api_key"] == "alias-key"
         assert judge._client_factory_args["provider_name"] == "openai"
+
+    def test_alias_window_comes_from_registry_config_not_provider_caps(self):
+        """The judge window must come from the registry's ModelConfig
+        (cfg.context_window=50_000 here), NOT provider.get_capabilities(), which
+        returns a static 200000 for every local model and would over-budget a
+        small local judge into overflow."""
+        alias_provider = _make_mock_provider()
+        alias_provider.provider_name = "openai"
+        # If the code (wrongly) consulted caps, it'd read this fictitious 200k.
+        alias_provider.get_capabilities = MagicMock(return_value=MagicMock(context_window=200_000))
+        alias_client = MagicMock(base_url="https://alias/v1", api_key="k")
+        registry = self._make_alias_registry("judge-mini", alias_provider, alias_client, "local-9b")
+        judge = IntentJudge(
+            config=JudgeConfig(enabled=True, model="judge-mini"),
+            session_provider=_make_mock_provider(),
+            session_client=MagicMock(base_url="https://s/v1", api_key="s"),
+            session_model="session-model",
+            context_window=100_000,
+            model_registry=registry,
+        )
+        assert judge._judge_context_window == 50_000
 
     def test_unknown_alias_inherits_session_model(self):
         """``judge.model`` is alias-only.  A value that doesn't resolve

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -481,6 +481,15 @@ class TestArgBudget:
     judge model's context window; large arguments are honestly truncated to it
     rather than blind-capped."""
 
+    def test_positive_window_coerces_zero_and_non_int(self):
+        from turnstone.core.judge import _DEFAULT_JUDGE_CONTEXT_WINDOW, _positive_window
+
+        assert _positive_window(50_000) == 50_000
+        assert _positive_window(0, 40_000) == 40_000  # 0 falls through to next
+        assert _positive_window(None, 0, 32_000) == 32_000  # None + 0 fall through
+        assert _positive_window(-5, floor=1_000) == 1_000
+        assert _positive_window(0) == _DEFAULT_JUDGE_CONTEXT_WINDOW  # floor default
+
     def test_honest_truncate_verbatim_when_it_fits(self):
         from turnstone.core.judge import honest_truncate
 
@@ -954,6 +963,27 @@ class TestModelAliasResolution:
             model_registry=registry,
         )
         assert judge._judge_context_window == 50_000
+
+    def test_alias_zero_context_window_falls_back_to_session(self):
+        """config.toml can hand back a ModelConfig with context_window=0 (that
+        path lacks the DB loader's 0→inherit normalization); a 0 window would
+        zero every budget and make honest_truncate drop everything, so it must
+        fall back to the session window."""
+        cfg = MagicMock()
+        cfg.context_window = 0
+        registry = MagicMock()
+        registry.has_alias.side_effect = lambda a: a == "judge-mini"
+        registry.resolve.return_value = (MagicMock(base_url="http://a", api_key="k"), "m", cfg)
+        registry.get_provider.return_value = _make_mock_provider()
+        judge = IntentJudge(
+            config=JudgeConfig(enabled=True, model="judge-mini"),
+            session_provider=_make_mock_provider(),
+            session_client=MagicMock(base_url="http://s", api_key="s"),
+            session_model="session-model",
+            context_window=100_000,
+            model_registry=registry,
+        )
+        assert judge._judge_context_window == 100_000  # session window, not 0
 
     def test_unknown_alias_inherits_session_model(self):
         """``judge.model`` is alias-only.  A value that doesn't resolve

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -330,6 +330,32 @@ class TestLoadModelRegistry:
         _, model, _ = reg.resolve()
         assert model == "gpt-4o"
 
+    def test_config_context_window_zero_inherits_detected(self) -> None:
+        """``context_window = 0`` in a [models.*] entry is the auto-detect
+        sentinel: it must inherit the CLI/detected window, not stay a literal 0
+        (which would zero every downstream budget — judge lowering, session
+        compaction).  The DB loader normalizes 0->inherit; the config path must
+        match it (``.get(k, 0) or context_window``, not ``.get(k, default)``)."""
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "local": {
+                    "base_url": "http://localhost:8000/v1",
+                    "model": "local-model",
+                    "context_window": 0,  # auto-detect
+                },
+            },
+            "model": {"default": "local"},
+        }
+        with patch("turnstone.core.model_registry.load_config", return_value=fake_cfg):
+            reg = load_model_registry(
+                base_url="http://localhost:8000/v1",
+                api_key="dummy",
+                model="local-model",
+                context_window=40_000,  # the CLI-detected window
+            )
+        _, _, cfg = reg.resolve("local")
+        assert cfg.context_window == 40_000  # inherited, not the literal 0
+
     def test_fallback_from_config(self) -> None:
         fake_cfg: dict[str, Any] = {
             "models": {

--- a/tests/test_output_guard_judge.py
+++ b/tests/test_output_guard_judge.py
@@ -279,24 +279,52 @@ class TestOversizeGuard:
         assert not small.evaluate(payload, call_id="c1").succeeded
         assert big.evaluate(payload, call_id="c1").succeeded
 
-    def test_missing_provider_capabilities_falls_back_to_default_window(self) -> None:
-        """If the provider can't report a context window, construction uses the
-        conservative default rather than crashing or an unbounded window."""
+    def test_session_fallback_uses_passed_window_not_provider_caps(self) -> None:
+        """No output_guard_model → the guard keys off the session's real window
+        (passed in), NOT provider.get_capabilities(), which reports 200000 for a
+        local model and would leave the guard blind to overflow."""
+        provider = _make_provider(content='{"risk_level": "none", "flags": []}')
+        # provider caps report the fictitious 200k; the guard must ignore it.
+        provider.get_capabilities = MagicMock(return_value=MagicMock(context_window=200_000))
+        judge = OutputGuardJudge(
+            config=JudgeConfig(output_guard_llm=True),  # no output_guard_model
+            session_provider=provider,
+            session_client=MagicMock(base_url="http://test", api_key="k"),
+            session_model="test-model",
+            context_window=40_000,  # the session's real window
+        )
+        assert judge._judge_context_window == 40_000
+
+    def test_zero_window_coerced_away_on_both_paths(self) -> None:
+        """A config.toml context_window=0 (present but unusable) must not zero
+        the guard: coerce to the session window (alias path) / the default."""
         from turnstone.core.output_guard_judge import _DEFAULT_JUDGE_CONTEXT_WINDOW
 
-        provider = _make_provider(content='{"risk_level": "none", "flags": []}')
-        provider.get_capabilities = MagicMock(side_effect=RuntimeError("no caps"))
-        config = JudgeConfig(output_guard_llm=True)
-        client = MagicMock()
-        client.base_url = "http://test"
-        client.api_key = "k"
-        judge = OutputGuardJudge(
-            config=config,
-            session_provider=provider,
-            session_client=client,
-            session_model="test-model",
+        # Alias path: ModelConfig.context_window == 0 → session window.
+        cfg = MagicMock()
+        cfg.context_window = 0
+        registry = MagicMock()
+        registry.has_alias.return_value = True
+        registry.resolve.return_value = (MagicMock(base_url="http://a", api_key="k"), "m", cfg)
+        registry.get_provider.return_value = _make_provider()
+        alias_judge = OutputGuardJudge(
+            config=JudgeConfig(output_guard_llm=True, output_guard_model="og"),
+            session_provider=_make_provider(),
+            session_client=MagicMock(base_url="http://s", api_key="s"),
+            session_model="m",
+            model_registry=registry,
+            context_window=64_000,
         )
-        assert judge._judge_context_window == _DEFAULT_JUDGE_CONTEXT_WINDOW
+        assert alias_judge._judge_context_window == 64_000
+
+        # Fallback path: no context_window passed → conservative default, not 0.
+        fallback_judge = OutputGuardJudge(
+            config=JudgeConfig(output_guard_llm=True),
+            session_provider=_make_provider(),
+            session_client=MagicMock(base_url="http://s", api_key="s"),
+            session_model="m",
+        )
+        assert fallback_judge._judge_context_window == _DEFAULT_JUDGE_CONTEXT_WINDOW
 
 
 class TestAliasResolution:

--- a/tests/test_output_guard_judge.py
+++ b/tests/test_output_guard_judge.py
@@ -23,6 +23,10 @@ def _make_provider(
     """Build a mock LLMProvider whose create_completion returns the given content."""
     provider = MagicMock()
     provider.provider_name = "openai"
+    # The judge reads context_window at construction for its oversize guard.
+    caps = MagicMock()
+    caps.context_window = 200_000
+    provider.get_capabilities = MagicMock(return_value=caps)
 
     def _create_completion(**_kwargs: Any) -> Any:
         if delay:
@@ -243,6 +247,58 @@ class TestEvaluateFailurePaths:
         assert stragglers == [], f"non-daemon worker survived evaluate(): {stragglers}"
 
 
+class TestOversizeGuard:
+    """A tool output that would overflow the judge model's context window must
+    not silently fall to heuristic-only via an opaque provider 400 — it is
+    detected up front and surfaced as a labelled llm_error the operator sees."""
+
+    def test_oversize_output_skips_llm_and_returns_labeled_error(self) -> None:
+        # ``content`` would parse to a clean verdict IF the provider were
+        # called — so a labelled oversize error proves the call was skipped.
+        judge = _make_judge(content='{"risk_level": "low", "flags": [], "reasoning": "x"}')
+        judge._judge_context_window = 50  # tiny window forces the guard to trip
+        v = judge.evaluate("Z" * 2000, func_name="web_fetch", call_id="c1")
+        assert not v.succeeded
+        assert "output_too_large_for_judge_window" in v.error
+        assert v.judge_model  # model recorded so the audit row is attributable
+
+    def test_output_within_window_is_judged_normally(self) -> None:
+        judge = _make_judge(content='{"risk_level": "low", "flags": [], "reasoning": "x"}')
+        v = judge.evaluate("a small, safe output", func_name="bash", call_id="c1")
+        assert v.succeeded
+        assert "too_large" not in v.error
+
+    def test_guard_threshold_scales_with_resolved_window(self) -> None:
+        """The same output that overflows a tiny window passes a large one —
+        the guard is keyed to the judge model, not a fixed cap."""
+        payload = "Z" * 4000  # assembled prompt overflows a 200-tok window, fits 200k
+        small = _make_judge(content='{"risk_level": "low", "flags": [], "reasoning": "x"}')
+        small._judge_context_window = 200
+        big = _make_judge(content='{"risk_level": "low", "flags": [], "reasoning": "x"}')
+        big._judge_context_window = 200_000
+        assert not small.evaluate(payload, call_id="c1").succeeded
+        assert big.evaluate(payload, call_id="c1").succeeded
+
+    def test_missing_provider_capabilities_falls_back_to_default_window(self) -> None:
+        """If the provider can't report a context window, construction uses the
+        conservative default rather than crashing or an unbounded window."""
+        from turnstone.core.output_guard_judge import _DEFAULT_JUDGE_CONTEXT_WINDOW
+
+        provider = _make_provider(content='{"risk_level": "none", "flags": []}')
+        provider.get_capabilities = MagicMock(side_effect=RuntimeError("no caps"))
+        config = JudgeConfig(output_guard_llm=True)
+        client = MagicMock()
+        client.base_url = "http://test"
+        client.api_key = "k"
+        judge = OutputGuardJudge(
+            config=config,
+            session_provider=provider,
+            session_client=client,
+            session_model="test-model",
+        )
+        assert judge._judge_context_window == _DEFAULT_JUDGE_CONTEXT_WINDOW
+
+
 class TestAliasResolution:
     def test_unknown_alias_falls_back_to_session_model(self) -> None:
         # Registry says alias does not exist; judge should fall back.
@@ -390,14 +446,24 @@ class TestFenceEscape:
         assert "Heuristic stage flagged:" not in prompt
         assert "Heuristic annotations:" not in prompt
 
-    def test_user_prompt_truncates_long_tool_args(self) -> None:
+    def test_user_prompt_does_not_default_truncate_tool_args(self) -> None:
+        """tool_args lowers whole — no default cap.  A pathologically large call
+        is caught by evaluate()'s window backstop, not by clipping a normal
+        argument into a misleading prefix."""
         long_args = '{"query": "' + ("x" * 1000) + '"}'
         prompt = OutputGuardJudge._user_prompt(
             "the output", func_name="search", tool_args=long_args
         )
-        assert "...(truncated)" in prompt
-        # Original full 1000+ chars must not appear.
-        assert long_args not in prompt
+        assert long_args in prompt
+        assert "chars omitted" not in prompt
+
+    def test_user_prompt_never_truncates_the_output_under_review(self) -> None:
+        """The fenced output is the content being judged and must reach the
+        judge whole."""
+        big_output = "Z" * 20_000
+        prompt = OutputGuardJudge._user_prompt(big_output, func_name="web_fetch")
+        assert big_output in prompt
+        assert "chars omitted" not in prompt
 
     def test_user_prompt_skips_heuristic_section_when_clean(self) -> None:
         # risk='none' and empty flags → no "Heuristic stage flagged" line.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,7 +6,7 @@ import json
 import subprocess
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -448,6 +448,7 @@ class TestTaskExec:
         fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
         fake_judge = MagicMock()
         fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        fake_judge.arg_budget_chars.return_value = 200_000
         monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
 
         skill = {"name": "research", "content": "# Research", "enabled": True}
@@ -468,6 +469,7 @@ class TestTaskExec:
         fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
         fake_judge = MagicMock()
         fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        fake_judge.arg_budget_chars.return_value = 200_000
         monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
 
         item = session._prepare_task("c1", {"prompt": "do x"})
@@ -603,6 +605,383 @@ class TestTaskExec:
         event = self._drive_gate(session, monkeypatch, cancel_on_approval=True)
         assert event is not None
         assert event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# func_args projection for the intent judge
+# ---------------------------------------------------------------------------
+
+
+def _project_func_args(item: dict[str, Any], *, budget: int = 200_000) -> Any:
+    """Run *item* through ``_evaluate_intent`` with a stub judge and return the
+    ``func_args`` the judge would be handed — its ENTIRE view of the call's
+    arguments.  ``budget`` stands in for the judge model's context window so
+    truncation behaviour is testable without a live model."""
+    session = _make_session()
+    fake_verdict = MagicMock()
+    fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
+    fake_judge = MagicMock()
+    fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+    fake_judge.arg_budget_chars.return_value = budget
+    session._ensure_judge = lambda: fake_judge  # type: ignore[method-assign]
+    session._evaluate_intent([item])
+    return item.get("func_args", "<<UNSET>>")
+
+
+class TestEvaluateIntentProjection:
+    """The projection block in ``_evaluate_intent`` is the judge's only view of
+    a pending call's arguments.  A narrow projection silently starves the judge:
+    a live 9B judge denied a legitimate multi-edit ``edit_file`` at 95% because
+    it received ``{"path": ...}`` with no ``edits``.  These pin the full risk
+    surface per tool, the None-safety the batch depends on, and the
+    context-window-budgeted honest truncation."""
+
+    # -- the incident: edit_file must carry its edits ----------------------
+
+    def test_edit_file_projects_edits_not_just_path(self) -> None:
+        """Regression for the false-deny incident: the judge must see the
+        old_string/new_string pairs, not a bare path."""
+        item = {
+            "call_id": "c1",
+            "func_name": "edit_file",
+            "needs_approval": True,
+            "path": "/workspace/contextllens/contextllens.py",
+            "edits": [
+                {"old_string": "if first_token_ts", "new_string": "ttft = ...", "near_line": 42},
+            ],
+            "replace_all": False,
+        }
+        fa = _project_func_args(item)
+        assert fa["path"].endswith("contextllens.py")
+        assert fa["edits"][0]["old_string"] == "if first_token_ts"
+        assert fa["edits"][0]["new_string"] == "ttft = ..."
+        assert fa["edits"][0]["near_line"] == 42
+        assert fa["replace_all"] is False
+
+    # -- skills: the dead-assignment bug -----------------------------------
+
+    def test_skills_create_projection_is_not_empty(self) -> None:
+        """``fa`` was built and never assigned — the judge saw ``{}`` for every
+        skills mutation.  It must now carry the full create surface."""
+        item = {
+            "call_id": "c1",
+            "func_name": "skills",
+            "needs_approval": True,
+            "action": "create",
+            "name": "helper",
+            "category": "general",
+            "kind": "any",
+            "description": "does things",
+            "content": "# Helper\nrun stuff",
+            "projected_risk": "medium",
+        }
+        fa = _project_func_args(item)
+        assert fa != {}
+        assert fa["action"] == "create"
+        assert fa["name"] == "helper"
+        assert fa["content"] == "# Helper\nrun stuff"
+        assert fa["projected_risk"] == "medium"
+
+    def test_skills_create_surfaces_self_escalation_signal(self) -> None:
+        """allowed_tools + auto_approve is the skills self-escalation risk the
+        approval card warns on; the judge must see it too."""
+        item = {
+            "call_id": "c1",
+            "func_name": "skills",
+            "needs_approval": True,
+            "action": "create",
+            "name": "sneaky",
+            "content": "x",
+            "projected_risk": "critical",
+            "session_fields": {
+                "allowed_tools": '["bash"]',
+                "auto_approve": True,
+                "activation": "default",
+            },
+        }
+        fa = _project_func_args(item)
+        assert fa["allowed_tools"] == '["bash"]'
+        assert fa["auto_approve"] is True
+        assert fa["activation"] == "default"
+
+    def test_skills_update_projects_updated_fields_and_allowed_tools(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "skills",
+            "needs_approval": True,
+            "action": "update",
+            "name": "helper",
+            "updates": {"content": "new body", "allowed_tools": '["bash"]', "auto_approve": True},
+            "projected_risk": "high",
+            "current_risk": "low",
+        }
+        fa = _project_func_args(item)
+        assert fa["updated_fields"] == ["allowed_tools", "auto_approve", "content"]
+        assert fa["content"] == "new body"
+        assert fa["allowed_tools"] == '["bash"]'
+        assert fa["auto_approve"] is True
+        assert fa["projected_risk"] == "high"
+        assert fa["current_risk"] == "low"
+
+    def test_skills_enable_surfaces_stored_risk_and_auto_approve(self) -> None:
+        """Re-enabling a planted critical/auto_approve skill is the attack —
+        the judge must see WHAT is being re-enabled, not just the name."""
+        item = {
+            "call_id": "c1",
+            "func_name": "skills",
+            "needs_approval": True,
+            "action": "enable",
+            "name": "planted",
+            "risk_level": "critical",
+            "auto_approve": True,
+        }
+        fa = _project_func_args(item)
+        assert fa["action"] == "enable"
+        assert fa["name"] == "planted"
+        assert fa["risk_level"] == "critical"
+        assert fa["auto_approve"] is True
+
+    # -- write_file / bash content and control fields ----------------------
+
+    def test_write_file_projects_content_and_append(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "write_file",
+            "needs_approval": True,
+            "path": "/etc/hosts",
+            "content": "127.0.0.1 evil.example",
+            "append": True,
+        }
+        fa = _project_func_args(item)
+        assert fa["content"] == "127.0.0.1 evil.example"
+        assert fa["append"] is True
+
+    def test_bash_projects_timeout_and_stop_on_error(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "bash",
+            "needs_approval": True,
+            "command": "make build",
+            "timeout": 120,
+            "stop_on_error": True,
+        }
+        fa = _project_func_args(item)
+        assert fa["command"] == "make build"
+        assert fa["timeout"] == 120
+        assert fa["stop_on_error"] is True
+
+    def test_task_agent_projects_model_override(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "task_agent",
+            "needs_approval": True,
+            "prompt": "investigate",
+            "skill": {"name": "research"},
+            "model_override": "gpt-5",
+        }
+        fa = _project_func_args(item)
+        assert fa["model_override"] == "gpt-5"
+        assert fa["skill"] == "research"
+
+    def test_watch_projects_stop_on_and_limits(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "watch",
+            "needs_approval": True,
+            "action": "create",
+            "command": "curl health",
+            "watch_name": "hc",
+            "stop_on": "status==200",
+            "max_polls": 50,
+            "interval_secs": 300,
+        }
+        fa = _project_func_args(item)
+        assert fa["stop_on"] == "status==200"
+        assert fa["max_polls"] == 50
+        assert fa["interval_secs"] == 300
+
+    def test_spawn_workstream_projects_project(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "spawn_workstream",
+            "needs_approval": True,
+            "skill": "x",
+            "initial_message": "go",
+            "target_node": "n1",
+            "name": "w",
+            "model": "m",
+            "project": "proj-42",
+        }
+        fa = _project_func_args(item)
+        assert fa["project"] == "proj-42"
+
+    # -- gated MCP tools: read_resource / use_prompt -----------------------
+
+    def test_read_resource_projects_uri(self) -> None:
+        """The URI is the risk surface (file:///etc/shadow, SSRF-shaped http).
+        Without a branch this reached the judge as {}."""
+        item = {
+            "call_id": "c1",
+            "func_name": "read_resource",
+            "needs_approval": True,
+            "resource_uri": "file:///etc/shadow",
+        }
+        fa = _project_func_args(item)
+        assert fa == {"uri": "file:///etc/shadow"}
+
+    def test_use_prompt_projects_name_and_arguments(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "use_prompt",
+            "needs_approval": True,
+            "prompt_name": "summarize",
+            "prompt_arguments": {"topic": "secrets"},
+        }
+        fa = _project_func_args(item)
+        assert fa["prompt_name"] == "summarize"
+        assert "secrets" in fa["prompt_arguments"]
+
+    # -- tasks: status / child_ws_id / ordering + None-safety --------------
+
+    def test_tasks_add_projects_status_and_child_ws_id(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "tasks",
+            "needs_approval": True,
+            "action": "add",
+            "title": "ship it",
+            "status": "in_progress",
+            "child_ws_id": "ws-9",
+        }
+        fa = _project_func_args(item)
+        assert fa["title"] == "ship it"
+        assert fa["status"] == "in_progress"
+        assert fa["child_ws_id"] == "ws-9"
+
+    def test_tasks_update_passes_none_status_through_without_crashing(self) -> None:
+        """_prepare_tasks stores None for omitted update fields; the projection
+        must not slice them (a single None once cancelled the whole batch)."""
+        item = {
+            "call_id": "c1",
+            "func_name": "tasks",
+            "needs_approval": True,
+            "action": "update",
+            "task_id": "t1",
+            "title": None,
+            "status": None,
+            "child_ws_id": None,
+        }
+        fa = _project_func_args(item)
+        assert fa["task_id"] == "t1"
+        assert fa["title"] == ""  # None → "" (title is truncatable text)
+        assert fa["status"] is None  # passthrough — null == "unchanged"
+        assert fa["child_ws_id"] is None
+
+    def test_tasks_reorder_projects_full_ordering(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "tasks",
+            "needs_approval": True,
+            "action": "reorder",
+            "task_ids": ["t3", "t1", "t2"],
+        }
+        fa = _project_func_args(item)
+        assert fa["task_ids"] == ["t3", "t1", "t2"]
+
+    # -- context-window-budgeted honest truncation -------------------------
+
+    def test_small_content_is_not_truncated(self) -> None:
+        item = {
+            "call_id": "c1",
+            "func_name": "write_file",
+            "needs_approval": True,
+            "path": "/f",
+            "content": "small body",
+        }
+        fa = _project_func_args(item, budget=200_000)
+        assert fa["content"] == "small body"
+        assert "omitted" not in fa["content"]
+
+    def test_large_content_truncated_to_budget_with_honest_marker(self) -> None:
+        body = "A" * 5000
+        item = {
+            "call_id": "c1",
+            "func_name": "write_file",
+            "needs_approval": True,
+            "path": "/f",
+            "content": body,
+        }
+        fa = _project_func_args(item, budget=1000)
+        assert fa["content"].startswith("A" * 1000)
+        # honest about exactly how much was dropped
+        assert "4,000 of 5,000 chars omitted" in fa["content"]
+
+    def test_edit_projection_marks_overflow_when_budget_exhausted(self) -> None:
+        """A batch of huge edits collapses its tail to an honest count rather
+        than silently showing only a prefix of the list."""
+        edits = [
+            {"old_string": "X" * 4000, "new_string": "Y" * 4000, "near_line": None}
+            for _ in range(5)
+        ]
+        item = {
+            "call_id": "c1",
+            "func_name": "edit_file",
+            "needs_approval": True,
+            "path": "/f",
+            "edits": edits,
+            "replace_all": False,
+        }
+        fa = _project_func_args(item, budget=2000)
+        # first edit projected (truncated), tail collapsed to a marker entry
+        assert "old_string" in fa["edits"][0]
+        assert fa["edits"][-1].get("omitted_edits", 0) > 0
+
+    # -- systemic guard: no gated tool may project an empty view -----------
+
+    _GATED_ITEMS: ClassVar[list[dict[str, Any]]] = [
+        {"func_name": "bash", "command": "ls", "needs_approval": True},
+        {"func_name": "write_file", "path": "/f", "content": "c", "needs_approval": True},
+        {
+            "func_name": "edit_file",
+            "path": "/f",
+            "edits": [{"old_string": "a", "new_string": "b"}],
+            "needs_approval": True,
+        },
+        {
+            "func_name": "skills",
+            "action": "create",
+            "name": "s",
+            "content": "c",
+            "needs_approval": True,
+        },
+        {"func_name": "skills", "action": "enable", "name": "s", "needs_approval": True},
+        {"func_name": "task_agent", "prompt": "p", "needs_approval": True},
+        {"func_name": "watch", "action": "create", "command": "c", "needs_approval": True},
+        {"func_name": "spawn_workstream", "skill": "x", "needs_approval": True},
+        {"func_name": "send_to_workstream", "ws_id": "w", "message": "m", "needs_approval": True},
+        {"func_name": "close_workstream", "ws_id": "w", "needs_approval": True},
+        {"func_name": "cancel_workstream", "ws_id": "w", "needs_approval": True},
+        {"func_name": "tasks", "action": "add", "title": "t", "needs_approval": True},
+        {"func_name": "tasks", "action": "reorder", "task_ids": ["a"], "needs_approval": True},
+        # MCP resource read / prompt invocation — gated but set neither mcp_args
+        # nor func_args; without an explicit branch they reached the judge as {}.
+        {"func_name": "read_resource", "resource_uri": "file:///etc/x", "needs_approval": True},
+        {
+            "func_name": "use_prompt",
+            "prompt_name": "p",
+            "prompt_arguments": {},
+            "needs_approval": True,
+        },
+    ]
+
+    def test_no_gated_tool_projects_empty_func_args(self) -> None:
+        """If a gated tool ever projects ``{}`` (a forgotten branch or an
+        unassigned ``fa``), the judge rules on nothing — fail loudly here."""
+        for base in self._GATED_ITEMS:
+            item = {"call_id": "c1", **base}
+            fa = _project_func_args(item)
+            label = f"{base['func_name']}/{base.get('action', '')}"
+            assert isinstance(fa, dict) and fa, f"{label} projected empty func_args: {fa!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -725,10 +725,15 @@ def evaluate_heuristic(
 
     arg_text = _get_arg_text(func_name, func_args)
     arg_snippet = _summarize_args(func_args)
+    # Rule matching runs against the FULL args (arg_text / the func_args dict);
+    # only the copy stored on the verdict — persisted + streamed, frontend-
+    # unread — carries the OH CRAP backstop.  The judge prompt is unaffected.
     try:
-        func_args_json = json.dumps(func_args, ensure_ascii=False, separators=(",", ":"))
+        func_args_json = honest_truncate(
+            json.dumps(func_args, ensure_ascii=False, separators=(",", ":")), _VERDICT_ARG_CAP
+        )
     except (TypeError, ValueError):
-        func_args_json = str(func_args)
+        func_args_json = honest_truncate(str(func_args), _VERDICT_ARG_CAP)
 
     for rule in rules if rules is not None else _HEURISTIC_RULES:
         if _match_rule(rule, func_name, func_args, approval_label, arg_text):
@@ -797,6 +802,48 @@ _JUDGE_MAX_TURNS = 5
 
 # Approximate characters per token for context budget estimation
 _CHARS_PER_TOKEN = 3.5
+
+# Fraction of the judge model's context window given to the pending call's
+# argument surface (``func_args``) in the judge PROMPT.  Args get this slice
+# (0.25); the conversation transcript gets ``max_context_ratio`` (0.5); and
+# ``_prepare_context`` deducts the rendered args from the transcript budget so
+# the two never jointly overrun the window.  Sized so a small-window local
+# judge (a 9B model at ~40k → ~35 KB of args) still sees whole normal arguments
+# and a 200k judge sees whole large file bodies — the budget scales with the
+# model rather than a fixed cap that would starve one and overflow another;
+# truncation happens only on genuine overflow of the real window.
+_ARG_CONTEXT_RATIO = 0.25
+
+# "OH CRAP" backstop on the argument copy that rides the VERDICT — persisted to
+# ``intent_verdicts.func_args`` and streamed over SSE.  This is NOT the judge's
+# view: the judge prompt lowers args whole up to its real context window (see
+# ``arg_budget_chars`` / the projection in ``_evaluate_intent``).  This cap
+# bounds only the record + stream, and only against a model emitting an insane
+# payload — 16 KB is far above any realistic argument; beyond it the frontend
+# never reads the field anyway, and the FULL args remain in the trajectory.
+_VERDICT_ARG_CAP = 16384
+
+
+def honest_truncate(text: str, budget: int) -> str:
+    """Return *text* untouched when it fits *budget* characters, otherwise the
+    leading ``budget`` characters followed by an explicit note of exactly how
+    many characters were dropped.
+
+    The judge reasons about the argument surface it is shown; a silent
+    ``text[:400]`` slice reads to the model as *the whole argument*, which is
+    how a legitimate 5-KB file write gets judged as if it were 400 bytes.  The
+    marker makes the omission legible — the judge knows content continues and
+    can weigh the truncation into its verdict rather than treating the fragment
+    as complete.  Reason-neutral, since the same helper bounds both the judge
+    prompt (fit the window) and the verdict record (the OH CRAP backstop).
+    """
+    if budget < 0:
+        budget = 0
+    if len(text) <= budget:
+        return text
+    omitted = len(text) - budget
+    return f"{text[:budget]}…[{omitted:,} of {len(text):,} chars omitted]"
+
 
 _JUDGE_TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
@@ -927,15 +974,25 @@ class IntentJudge:
         if config.model and model_registry is not None:
             try:
                 if model_registry.has_alias(config.model):
-                    client, model_name, _ = model_registry.resolve(config.model)
+                    client, model_name, model_cfg = model_registry.resolve(config.model)
                     self._provider = model_registry.get_provider(config.model)
                     self._client_factory_args = self._extract_client_config(
                         client,
                         self._provider.provider_name,
                     )
                     self._model = model_name
-                    caps = self._provider.get_capabilities(self._model)
-                    self._judge_context_window = caps.context_window
+                    # Use the registry's per-model context window, NOT
+                    # ``provider.get_capabilities().context_window``: the static
+                    # capability table returns 200000 for every model absent
+                    # from it (i.e. every local / self-hosted judge), so keying
+                    # the budget off it silently over-budgets a small local
+                    # judge into overflow.  ModelConfig.context_window is the
+                    # operator-configured / auto-detected real window.  getattr
+                    # guard: a malformed ModelConfig degrades the window, it must
+                    # not abort resolution.
+                    self._judge_context_window = getattr(
+                        model_cfg, "context_window", context_window
+                    )
                     resolved = True
             except Exception:
                 log.debug("Model alias resolution failed for %r, falling back", config.model)
@@ -1171,10 +1228,15 @@ class IntentJudge:
             except (json.JSONDecodeError, TypeError):
                 func_args = {}
         call_id = item.get("call_id", item.get("tool_call_id", ""))
+        # ``func_args_json`` is the verdict's record copy (persisted + streamed,
+        # frontend-unread) — OH CRAP backstop only.  The judge PROMPT gets the
+        # full window-scaled projection via ``_prepare_context(item, ...)``.
         try:
-            func_args_json = json.dumps(func_args, ensure_ascii=False, separators=(",", ":"))
+            func_args_json = honest_truncate(
+                json.dumps(func_args, ensure_ascii=False, separators=(",", ":")), _VERDICT_ARG_CAP
+            )
         except (TypeError, ValueError):
-            func_args_json = str(func_args)
+            func_args_json = honest_truncate(str(func_args), _VERDICT_ARG_CAP)
 
         # Prepare context
         judge_messages = self._prepare_context(item, messages)
@@ -1381,16 +1443,27 @@ class IntentJudge:
         )
         return None
 
+    def arg_budget_chars(self) -> int:
+        """Character budget for the pending call's projected ``func_args``.
+
+        Scales with the judge model's context window (see
+        :data:`_ARG_CONTEXT_RATIO`) so callers can truncate large argument
+        fields — a file body, a batch of edits — to what *this* judge can
+        actually read, rather than a fixed cap that starves a 200k model and
+        overflows a 4k one.  Used by the session's projection step; the judge
+        re-shares the same window in :meth:`_prepare_context`.  No fixed
+        ceiling: args lower whole up to the judge's real window, and only a
+        genuine window overflow forces an honest, marked truncation — the
+        record/stream copy is bounded separately (see :data:`_VERDICT_ARG_CAP`).
+        """
+        return int(self._judge_context_window * _ARG_CONTEXT_RATIO * _CHARS_PER_TOKEN)
+
     def _prepare_context(
         self,
         item: dict[str, Any],
         messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
         """Build the judge's message list with FIFO-truncated conversation."""
-        # Calculate token budget for conversation history
-        budget_tokens = int(self._judge_context_window * self._config.max_context_ratio)
-        budget_chars = int(budget_tokens * _CHARS_PER_TOKEN)
-
         # Build user message with tool call details
         func_name = item.get("func_name", item.get("name", ""))
         func_args = item.get("func_args", {})
@@ -1407,6 +1480,16 @@ class IntentJudge:
             f"Arguments:\n```json\n"
             f"{json.dumps(func_args, indent=2, ensure_ascii=False)}\n```"
         )
+
+        # Calculate the character budget for conversation history.  The
+        # arguments (``tool_detail``) and the transcript share the same
+        # context slice, so deduct what the arguments already consume — a
+        # large but budgeted write/edit shrinks the history it competes with
+        # instead of pushing the prompt past the window.  Floor keeps at least
+        # a minimal transcript even when the arguments are unusually large.
+        budget_tokens = int(self._judge_context_window * self._config.max_context_ratio)
+        budget_chars = int(budget_tokens * _CHARS_PER_TOKEN)
+        budget_chars = max(budget_chars - len(tool_detail), budget_chars // 5)
 
         # Trim to messages from the last user message onward — the judge
         # only needs the immediate request context, not the full history.

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -823,6 +823,26 @@ _ARG_CONTEXT_RATIO = 0.25
 # never reads the field anyway, and the FULL args remain in the trajectory.
 _VERDICT_ARG_CAP = 16384
 
+# Conservative floor for a judge context window when no sane value resolves.
+_DEFAULT_JUDGE_CONTEXT_WINDOW = 32_768
+
+
+def _positive_window(*candidates: Any, floor: int = _DEFAULT_JUDGE_CONTEXT_WINDOW) -> int:
+    """First positive-int context window among *candidates*, else *floor*.
+
+    A ``context_window`` of 0 or a non-int would zero out every budget and make
+    ``honest_truncate`` drop everything — a silent, total lowering failure.  0
+    is reachable: a config.toml model passes ``context_window`` through without
+    the DB loader's ``0 → inherit`` normalization (model_registry.py:484 vs
+    :400), so the registry can hand back a ModelConfig whose window is 0.  Fall
+    through such values to the next sane candidate (typically the session
+    window), then a conservative floor.
+    """
+    for c in candidates:
+        if isinstance(c, int) and c > 0:
+            return c
+    return floor
+
 
 def honest_truncate(text: str, budget: int) -> str:
     """Return *text* untouched when it fits *budget* characters, otherwise the
@@ -987,11 +1007,14 @@ class IntentJudge:
                     # from it (i.e. every local / self-hosted judge), so keying
                     # the budget off it silently over-budgets a small local
                     # judge into overflow.  ModelConfig.context_window is the
-                    # operator-configured / auto-detected real window.  getattr
-                    # guard: a malformed ModelConfig degrades the window, it must
-                    # not abort resolution.
-                    self._judge_context_window = getattr(
-                        model_cfg, "context_window", context_window
+                    # operator-configured / auto-detected real window.
+                    # ``_positive_window`` guards both a malformed ModelConfig
+                    # (missing attr → the session ``context_window``) and a
+                    # config.toml ``context_window=0`` (present but unusable →
+                    # the session window, then a floor); either must not abort
+                    # resolution or zero out the budgets.
+                    self._judge_context_window = _positive_window(
+                        getattr(model_cfg, "context_window", None), context_window
                     )
                     resolved = True
             except Exception:
@@ -1012,7 +1035,9 @@ class IntentJudge:
                 session_provider.provider_name,
             )
             self._model = session_model
-            self._judge_context_window = context_window
+            # Coerce here too: the session ``context_window`` can itself be a
+            # config.toml 0 if the session model is misconfigured.
+            self._judge_context_window = _positive_window(context_window)
 
     # -- Client lifecycle helpers -------------------------------------------
 

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -831,12 +831,12 @@ def _positive_window(*candidates: Any, floor: int = _DEFAULT_JUDGE_CONTEXT_WINDO
     """First positive-int context window among *candidates*, else *floor*.
 
     A ``context_window`` of 0 or a non-int would zero out every budget and make
-    ``honest_truncate`` drop everything — a silent, total lowering failure.  0
-    is reachable: a config.toml model passes ``context_window`` through without
-    the DB loader's ``0 → inherit`` normalization (model_registry.py:484 vs
-    :400), so the registry can hand back a ModelConfig whose window is 0.  Fall
-    through such values to the next sane candidate (typically the session
-    window), then a conservative floor.
+    ``honest_truncate`` drop everything — a silent, total lowering failure.
+    Defense-in-depth: the registry normalizes the ``0 = auto-detect`` sentinel
+    to the inherited window at load time (both loader paths), so a 0 should not
+    reach here — but a stray non-positive window from any source must never
+    zero a budget.  Fall through such values to the next sane candidate
+    (typically the session window), then a conservative floor.
     """
     for c in candidates:
         if isinstance(c, int) and c > 0:
@@ -1008,11 +1008,10 @@ class IntentJudge:
                     # the budget off it silently over-budgets a small local
                     # judge into overflow.  ModelConfig.context_window is the
                     # operator-configured / auto-detected real window.
-                    # ``_positive_window`` guards both a malformed ModelConfig
-                    # (missing attr → the session ``context_window``) and a
-                    # config.toml ``context_window=0`` (present but unusable →
-                    # the session window, then a floor); either must not abort
-                    # resolution or zero out the budgets.
+                    # ``_positive_window`` is defensive: a malformed ModelConfig
+                    # (missing attr) or any stray non-positive window degrades to
+                    # the session ``context_window`` then a floor, so it neither
+                    # aborts resolution nor zeroes the budgets.
                     self._judge_context_window = _positive_window(
                         getattr(model_cfg, "context_window", None), context_window
                     )
@@ -1035,8 +1034,7 @@ class IntentJudge:
                 session_provider.provider_name,
             )
             self._model = session_model
-            # Coerce here too: the session ``context_window`` can itself be a
-            # config.toml 0 if the session model is misconfigured.
+            # Coerce here too, defensively against a non-positive session window.
             self._judge_context_window = _positive_window(context_window)
 
     # -- Client lifecycle helpers -------------------------------------------

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -481,7 +481,12 @@ def load_model_registry(
             base_url=entry_base_url,
             api_key=_resolve_env_vars(entry.get("api_key", api_key)),
             model=model_name,
-            context_window=entry.get("context_window", context_window),
+            # 0 = auto-detect: inherit the CLI-detected context_window, matching
+            # the DB loader above.  ``.get(k, 0) or context_window`` (NOT
+            # ``.get(k, default)``) is load-bearing — an explicit
+            # ``context_window = 0`` must normalize to the inherited window, not
+            # stay a literal 0 that zeroes every downstream budget.
+            context_window=entry.get("context_window", 0) or context_window,
             provider=_resolve_openai_provider(entry.get("provider", "openai"), entry_base_url),
             capabilities=entry_caps,
             source="config",

--- a/turnstone/core/output_guard_judge.py
+++ b/turnstone/core/output_guard_judge.py
@@ -280,8 +280,9 @@ class OutputGuardJudge:
         # ``provider.get_capabilities()``, which returns a static 200000 for
         # every model absent from its table (i.e. every local / self-hosted
         # judge), so a guard keyed off it would never trip for the small-window
-        # local judges it exists to protect.  ``_positive_window`` also guards a
-        # config.toml ``context_window=0`` (which would zero out the guard).
+        # local judges it exists to protect.  ``_positive_window`` also
+        # defensively coerces any non-positive window (which would zero out the
+        # guard) to the session window, then a floor.
         resolved = False
         if config.output_guard_model and model_registry is not None:
             try:

--- a/turnstone/core/output_guard_judge.py
+++ b/turnstone/core/output_guard_judge.py
@@ -58,6 +58,19 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+# Prompt-size guard.  A tool output large enough to overflow the judge model's
+# context window would come back as an opaque provider 400 and fall silently to
+# heuristic-only; we detect it up front instead (see ``evaluate``).
+# ``_CHARS_PER_TOKEN`` mirrors ``judge._CHARS_PER_TOKEN`` — the same token
+# estimate both judges budget with, duplicated to keep this module free of a
+# runtime judge import; keep the two in sync if either is retuned.  ``0.9``
+# leaves headroom for the 512-token response plus estimation error.  The
+# default window is a conservative fallback used only when the provider can't
+# report capabilities — the resolved model's real window is preferred.
+_CHARS_PER_TOKEN = 3.5
+_MAX_PROMPT_RATIO = 0.9
+_DEFAULT_JUDGE_CONTEXT_WINDOW = 32_768
+
 
 # ---------------------------------------------------------------------------
 # Verdict
@@ -259,17 +272,30 @@ class OutputGuardJudge:
         # Alias resolution mirrors IntentJudge.__init__ at judge.py:917-960.
         # An empty / unset alias falls through to the session model silently;
         # a set-but-unknown alias logs a warning and also falls through.
+        # Judge model's context window drives the oversize-output guard in
+        # ``evaluate``.  On the alias path it comes from the registry's
+        # ModelConfig — NOT ``provider.get_capabilities()``, which returns a
+        # static 200000 for every model absent from its table (i.e. every local
+        # / self-hosted judge), so the guard keyed off it would never trip for
+        # the small-window local judges it exists to protect.
         resolved = False
         if config.output_guard_model and model_registry is not None:
             try:
                 if model_registry.has_alias(config.output_guard_model):
-                    client, model_name, _ = model_registry.resolve(config.output_guard_model)
+                    client, model_name, model_cfg = model_registry.resolve(
+                        config.output_guard_model
+                    )
                     self._provider = model_registry.get_provider(config.output_guard_model)
                     self._client_factory_args = self._extract_client_config(
                         client, self._provider.provider_name
                     )
                     self._model = model_name
                     self._judge_model_alias = config.output_guard_model
+                    # getattr guard: a malformed ModelConfig must not abort
+                    # resolution — degrade the window, keep the model.
+                    self._judge_context_window = getattr(
+                        model_cfg, "context_window", _DEFAULT_JUDGE_CONTEXT_WINDOW
+                    )
                     resolved = True
             except Exception:
                 log.debug(
@@ -292,6 +318,15 @@ class OutputGuardJudge:
             )
             self._model = session_model
             self._judge_model_alias = ""
+            # Session-model fallback: no ModelConfig in hand, so use the static
+            # capability table (correct for commercial models; a conservative
+            # default for anything it doesn't know).
+            try:
+                self._judge_context_window = self._provider.get_capabilities(
+                    self._model
+                ).context_window
+            except Exception:
+                self._judge_context_window = _DEFAULT_JUDGE_CONTEXT_WINDOW
 
         # Lazy-init in _create_client(); reused across evaluate() calls.
         # Session swaps the entire OutputGuardJudge on credential / model
@@ -405,6 +440,33 @@ class OutputGuardJudge:
             },
         ]
 
+        # Oversize guard.  The heuristic stage has already run and its verdict
+        # stands regardless; what's at stake here is only the opted-in LLM tier.
+        # A prompt that overflows the judge window returns an opaque provider
+        # 400, which would fall to heuristic-only with no trace that the LLM was
+        # even attempted.  Detect it up front: skip the doomed call, log a
+        # warning, and return a LABELLED error verdict so the skip surfaces as a
+        # distinct ``llm_error`` audit row (reason = "output_too_large…") the
+        # operator can see, rather than a silent no-op.
+        prompt_chars = sum(len(str(m["content"])) for m in judge_messages)
+        est_tokens = int(prompt_chars / _CHARS_PER_TOKEN)
+        if est_tokens > self._judge_context_window * _MAX_PROMPT_RATIO:
+            log.warning(
+                "output_guard_judge.output_too_large",
+                call_id=call_id,
+                func_name=func_name,
+                output_chars=len(output),
+                est_prompt_tokens=est_tokens,
+                judge_context_window=self._judge_context_window,
+            )
+            return self._error_verdict(
+                verdict_id,
+                call_id,
+                start,
+                f"output_too_large_for_judge_window: ~{est_tokens} tok "
+                f"> {self._judge_context_window} window",
+            )
+
         try:
             client = self._create_client()
         except Exception as e:
@@ -513,9 +575,11 @@ class OutputGuardJudge:
         verdict + heuristic annotations) precede the fence.  The system
         prompt classifies each field's trust level: framework-supplied
         fields are TRUSTED; ``tool_args`` is UNTRUSTED (caller-supplied,
-        may contain injection); fenced output is UNTRUSTED.  Tool args
-        are truncated to 500 chars to bound prompt cost while preserving
-        shape.
+        may contain injection); fenced output is UNTRUSTED.  Neither
+        ``tool_args`` nor the fenced output is truncated here — both lower
+        whole.  A pathologically large call is caught by the window backstop in
+        ``evaluate`` (which skips the LLM tier honestly rather than feeding it a
+        silently-clipped prefix), never by a default cap on a normal argument.
         """
         nonce = fence.mint_nonce()
 
@@ -525,8 +589,7 @@ class OutputGuardJudge:
         if tool_description:
             lines.append(f"Description: {tool_description}")
         if tool_args:
-            truncated = tool_args if len(tool_args) <= 500 else tool_args[:500] + "...(truncated)"
-            lines.append(f"Called with: {truncated}")
+            lines.append(f"Called with: {tool_args}")
         if heuristic_risk != "none" or heuristic_flags:
             flags_str = ", ".join(heuristic_flags) if heuristic_flags else "(none)"
             lines.append(

--- a/turnstone/core/output_guard_judge.py
+++ b/turnstone/core/output_guard_judge.py
@@ -48,6 +48,11 @@ from turnstone.core.deadline import (
     DeadlineExceededError,
     run_with_deadline,
 )
+from turnstone.core.judge import (
+    _CHARS_PER_TOKEN,
+    _DEFAULT_JUDGE_CONTEXT_WINDOW,
+    _positive_window,
+)
 from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
@@ -60,16 +65,11 @@ log = get_logger(__name__)
 
 # Prompt-size guard.  A tool output large enough to overflow the judge model's
 # context window would come back as an opaque provider 400 and fall silently to
-# heuristic-only; we detect it up front instead (see ``evaluate``).
-# ``_CHARS_PER_TOKEN`` mirrors ``judge._CHARS_PER_TOKEN`` — the same token
-# estimate both judges budget with, duplicated to keep this module free of a
-# runtime judge import; keep the two in sync if either is retuned.  ``0.9``
-# leaves headroom for the 512-token response plus estimation error.  The
-# default window is a conservative fallback used only when the provider can't
-# report capabilities — the resolved model's real window is preferred.
-_CHARS_PER_TOKEN = 3.5
+# heuristic-only; we detect it up front instead (see ``evaluate``).  The token
+# estimate, window floor, and coercion are shared with the intent judge
+# (imported above) so the two stay in lockstep.  ``0.9`` leaves headroom for
+# the 512-token response plus estimation error.
 _MAX_PROMPT_RATIO = 0.9
-_DEFAULT_JUDGE_CONTEXT_WINDOW = 32_768
 
 
 # ---------------------------------------------------------------------------
@@ -267,17 +267,21 @@ class OutputGuardJudge:
         session_client: Any,
         session_model: str,
         model_registry: Any | None = None,
+        context_window: int = _DEFAULT_JUDGE_CONTEXT_WINDOW,
     ) -> None:
         self._config = config
         # Alias resolution mirrors IntentJudge.__init__ at judge.py:917-960.
         # An empty / unset alias falls through to the session model silently;
         # a set-but-unknown alias logs a warning and also falls through.
         # Judge model's context window drives the oversize-output guard in
-        # ``evaluate``.  On the alias path it comes from the registry's
-        # ModelConfig — NOT ``provider.get_capabilities()``, which returns a
-        # static 200000 for every model absent from its table (i.e. every local
-        # / self-hosted judge), so the guard keyed off it would never trip for
-        # the small-window local judges it exists to protect.
+        # ``evaluate``.  It comes from the registry's ModelConfig on the alias
+        # path and the session's real window (``context_window``, resolved by
+        # the caller from _get_capabilities) on the fallback path — NEVER
+        # ``provider.get_capabilities()``, which returns a static 200000 for
+        # every model absent from its table (i.e. every local / self-hosted
+        # judge), so a guard keyed off it would never trip for the small-window
+        # local judges it exists to protect.  ``_positive_window`` also guards a
+        # config.toml ``context_window=0`` (which would zero out the guard).
         resolved = False
         if config.output_guard_model and model_registry is not None:
             try:
@@ -291,10 +295,8 @@ class OutputGuardJudge:
                     )
                     self._model = model_name
                     self._judge_model_alias = config.output_guard_model
-                    # getattr guard: a malformed ModelConfig must not abort
-                    # resolution — degrade the window, keep the model.
-                    self._judge_context_window = getattr(
-                        model_cfg, "context_window", _DEFAULT_JUDGE_CONTEXT_WINDOW
+                    self._judge_context_window = _positive_window(
+                        getattr(model_cfg, "context_window", None), context_window
                     )
                     resolved = True
             except Exception:
@@ -318,15 +320,12 @@ class OutputGuardJudge:
             )
             self._model = session_model
             self._judge_model_alias = ""
-            # Session-model fallback: no ModelConfig in hand, so use the static
-            # capability table (correct for commercial models; a conservative
-            # default for anything it doesn't know).
-            try:
-                self._judge_context_window = self._provider.get_capabilities(
-                    self._model
-                ).context_window
-            except Exception:
-                self._judge_context_window = _DEFAULT_JUDGE_CONTEXT_WINDOW
+            # Session-model fallback: use the session's real context window
+            # (the caller resolved it from _get_capabilities, config/registry-
+            # aware) — NOT provider.get_capabilities(), which reports 200000 for
+            # a local session model and would leave the guard blind to overflow,
+            # the very failure this fixes.  Mirrors IntentJudge's fallback.
+            self._judge_context_window = _positive_window(context_window)
 
         # Lazy-init in _create_client(); reused across evaluate() calls.
         # Session swaps the entire OutputGuardJudge on credential / model

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7139,6 +7139,44 @@ class ChatSession:
                 return desc if isinstance(desc, str) else ""
         return ""
 
+    @staticmethod
+    def _project_edits_for_judge(edits: list[Any], budget: int) -> list[dict[str, Any]]:
+        """Project an ``edit_file`` edits list into the judge's argument view,
+        FIFO-truncated to *budget* characters of old/new text.
+
+        Each entry keeps ``old_string`` / ``new_string`` (each honestly
+        truncated when huge) and ``near_line``.  Once the budget is spent, the
+        remaining edits collapse to a single ``{"omitted_edits": N}`` marker so
+        the judge knows more edits follow rather than silently seeing a prefix.
+        The common case — a handful of small edits — fits the budget whole and
+        is projected verbatim, which is the fix for the incident where a
+        legitimate multi-edit call reached the judge as ``{"path": ...}`` alone.
+        """
+        from turnstone.core.judge import honest_truncate
+
+        projected: list[dict[str, Any]] = []
+        remaining = budget
+        for i, e in enumerate(edits):
+            if not isinstance(e, dict):
+                continue
+            # Always project the first edit (truncated if it alone exceeds the
+            # budget); collapse the tail only once the budget is exhausted.
+            if remaining <= 0 and projected:
+                projected.append({"omitted_edits": len(edits) - i})
+                break
+            old = str(e.get("old_string", ""))
+            new = str(e.get("new_string", ""))
+            per = max(remaining // 2, 0)
+            projected.append(
+                {
+                    "old_string": honest_truncate(old, per),
+                    "new_string": honest_truncate(new, per),
+                    "near_line": e.get("near_line"),
+                }
+            )
+            remaining -= len(old) + len(new)
+        return projected
+
     def _evaluate_intent(
         self,
         items: list[dict[str, Any]],
@@ -7168,97 +7206,165 @@ class ChatSession:
         if not pending:
             return None
 
-        # Build func_args from tool-specific item keys so the heuristic
-        # engine can pattern-match on argument content.
+        # Build func_args: the model-visible LOWERING of the pending call's
+        # arguments into the judge's context.  The full args always remain in
+        # the trajectory (the tool call itself); this dict is only the view the
+        # judge reasons over, and it is read by BOTH tiers with different needs
+        # — the heuristic engine regex-matches a narrow field (``_get_arg_text``
+        # reads only ``command`` for bash, ``path`` for write/edit_file), while
+        # the LLM judge sees this dict as its ENTIRE argument view
+        # (``judge._prepare_context`` serialises it straight into the prompt).
+        # Getting the lowering RIGHT is the whole fix: a path-only ``edit_file``
+        # projection made a live judge rule a legitimate multi-edit call
+        # "malformed — missing old_string/new_string" and deny it at 95%.
+        #
+        # Truncation here is a BACKSTOP, not a default.  Args lower whole; a
+        # field is honestly truncated (with a dropped-char marker) only when it
+        # genuinely exceeds ``arg_budget`` — the judge model's real context
+        # window (registry-sourced, not the static 200k caps default).  Normal
+        # args are never clipped; the record/stream copy carries its own OH CRAP
+        # backstop in judge.py, and the untruncated args stay in the trajectory.
+        from turnstone.core.judge import honest_truncate
+
+        arg_budget = judge.arg_budget_chars()
         for it in pending:
             name = it.get("func_name", "")
             if name == "bash":
-                it["func_args"] = {"command": it.get("command", "")}
-            elif name in ("write_file", "edit_file", "read_file"):
+                it["func_args"] = {
+                    "command": it.get("command", ""),
+                    "timeout": it.get("timeout"),
+                    "stop_on_error": bool(it.get("stop_on_error")),
+                }
+            elif name == "write_file":
+                it["func_args"] = {
+                    "path": it.get("path", ""),
+                    "content": honest_truncate(it.get("content") or "", arg_budget),
+                    "append": bool(it.get("append")),
+                }
+            elif name == "edit_file":
+                it["func_args"] = {
+                    "path": it.get("path", ""),
+                    "edits": self._project_edits_for_judge(it.get("edits") or [], arg_budget),
+                    "replace_all": bool(it.get("replace_all")),
+                }
+            elif name == "read_file":
                 it["func_args"] = {"path": it.get("path", "")}
             elif name == "web_fetch":
                 it["func_args"] = {"url": it.get("url", ""), "question": it.get("question", "")}
             elif name == "web_search":
                 it["func_args"] = {"query": it.get("query", ""), "category": it.get("category", "")}
             elif name == "skills":
-                # Projection for judge / audit on the model-facing skills
-                # tool. Mutating actions surface name + action + a snippet
-                # of the proposed content / fields so a heuristic rule can
-                # match on suspicious patterns (e.g. allowed_tools
-                # expansion).  Long fields are capped for verdict-row size.
+                # Projection for the judge / audit on the model-facing skills
+                # tool.  ``fa`` MUST be assigned back to the item at the end of
+                # this branch — an earlier revision built it and never did,
+                # leaving the judge to rule on every skills mutation with an
+                # empty ``{}`` argument view.  find/get/load are read-only
+                # (needs_approval=False) and never reach this loop; the
+                # create/update/enable/disable set does.
                 action_val = it.get("action", "")
                 fa: dict[str, Any] = {"action": action_val, "name": it.get("name", "")}
-                if action_val in ("find", "get"):
-                    pass
-                elif action_val == "load":
-                    pass  # name only — covers the surface
-                elif action_val == "create":
+                if action_val == "create":
                     fa["category"] = it.get("category", "")
                     fa["kind"] = it.get("kind", "")
-                    fa["description"] = (it.get("description") or "")[:200]
-                    fa["content"] = (it.get("content") or "")[:400]
+                    # Both lower whole up to the judge window; the projection
+                    # only truncates when a field genuinely exceeds it.  (The
+                    # two fields sharing the budget is bounded by the window:
+                    # each ≤ window·ratio, and _prepare_context shrinks history
+                    # to fit whatever the args consume.)
+                    fa["description"] = honest_truncate(it.get("description") or "", arg_budget)
+                    fa["content"] = honest_truncate(it.get("content") or "", arg_budget)
                     fa["projected_risk"] = it.get("projected_risk", "")
+                    # allowed_tools + auto_approve are THE self-escalation risk
+                    # signal for a model-authored skill (auto_approve + a tool
+                    # allowlist means those tools auto-fire when the skill later
+                    # loads).  The approval card already warns on it; the judge
+                    # was blind to it.
+                    sf = it.get("session_fields")
+                    if isinstance(sf, dict):
+                        if sf.get("allowed_tools") and sf.get("allowed_tools") != "[]":
+                            fa["allowed_tools"] = sf.get("allowed_tools")
+                        if sf.get("auto_approve"):
+                            fa["auto_approve"] = True
+                        if sf.get("activation"):
+                            fa["activation"] = sf.get("activation")
                 elif action_val == "update":
                     upd = it.get("updates") or {}
                     fa["updated_fields"] = sorted(upd.keys()) if isinstance(upd, dict) else []
-                    if isinstance(upd, dict) and "content" in upd:
-                        fa["content"] = (upd.get("content") or "")[:400]
+                    if isinstance(upd, dict):
+                        if "content" in upd:
+                            fa["content"] = honest_truncate(upd.get("content") or "", arg_budget)
+                        if upd.get("allowed_tools") and upd.get("allowed_tools") != "[]":
+                            fa["allowed_tools"] = upd.get("allowed_tools")
+                        if "auto_approve" in upd:
+                            fa["auto_approve"] = bool(upd.get("auto_approve"))
                     fa["projected_risk"] = it.get("projected_risk", "")
                     fa["current_risk"] = it.get("current_risk", "")
                 elif action_val in ("enable", "disable"):
-                    pass  # name + action is the auditable surface
+                    # Re-enabling a model-planted high/critical skill is the
+                    # attack this projection must expose: surface the existing
+                    # skill's stored risk tier + auto_approve (stashed by
+                    # ``_prepare_skills_toggle``) so the judge weighs WHAT is
+                    # being re-enabled, not just its name.
+                    if it.get("risk_level"):
+                        fa["risk_level"] = it.get("risk_level")
+                    if it.get("auto_approve"):
+                        fa["auto_approve"] = True
+                it["func_args"] = fa
             elif name == "watch":
                 it["func_args"] = {
                     "action": it.get("action", ""),
                     "command": it.get("command", ""),
                     "name": it.get("watch_name", ""),
+                    "stop_on": it.get("stop_on"),
+                    "max_polls": it.get("max_polls"),
+                    "interval_secs": it.get("interval_secs"),
                 }
-            elif name == "notify":
-                it["func_args"] = {"message": (it.get("message") or "")[:200]}
             elif name == "task_agent":
                 # Pending items reach this point already shaped by
                 # ``_prepare_task``, so ``it["skill"]`` is the resolved
                 # skill_data dict (or ``None``), not the raw string the
                 # LLM passed.  Mirror the ``spawn_workstream`` projection
                 # so heuristic ``arg_pattern`` rules can match on skill
-                # name and the judge / audit row sees which persona was
-                # selected.
+                # name and the judge / audit row sees which persona and
+                # model override were selected.
                 skill_dict = it.get("skill") or {}
                 it["func_args"] = {
-                    "prompt": (it.get("prompt") or "")[:200],
+                    "prompt": honest_truncate(it.get("prompt") or "", arg_budget),
                     "skill": skill_dict.get("name", "") if isinstance(skill_dict, dict) else "",
+                    "model_override": it.get("model_override") or "",
                 }
             # Coordinator tool args — only the ``needs_approval=True`` set
             # reaches this point (read-only inspect / list_* / wait
             # tools are filtered above), so this matches the auditable
-            # surface 1:1. Free-form fields capped to keep the verdict
-            # row size bounded.
+            # surface 1:1. Free-form fields truncated to the judge window.
             elif name == "spawn_workstream":
                 it["func_args"] = {
                     "skill": it.get("skill", ""),
-                    "initial_message": (it.get("initial_message") or "")[:200],
+                    "initial_message": honest_truncate(it.get("initial_message") or "", arg_budget),
                     "target_node": it.get("target_node", ""),
                     "name": it.get("name", ""),
                     "model": it.get("model", ""),
+                    "project": it.get("project", ""),
                 }
             elif name == "spawn_batch":
                 # Project every child so the judge sees the full fan-out.
                 # First-child-only projection (the prior shape) hid a
                 # malicious mid-batch entry from both heuristic and LLM
-                # tiers. Tool schema caps ``children`` at 10, so worst
-                # case is ~3 KiB of JSON in the verdict row — comparable
-                # to the existing ``reasoning`` / ``evidence`` fields.
-                # ``name`` (cosmetic) and ``model`` (registry alias)
-                # skipped to keep the payload lean; risk-relevant fields
-                # are skill, initial_message, target_node.
+                # tiers.  The judge window is split evenly across children so
+                # the total stays bounded regardless of child count; each
+                # ``initial_message`` is honestly truncated to its share.
+                # ``name`` (cosmetic) and ``model`` (registry alias) skipped
+                # to keep the payload lean; risk-relevant fields are skill,
+                # initial_message, target_node.
                 children = it.get("children") or []
+                per_child = max(arg_budget // max(len(children), 1), 0)
                 it["func_args"] = {
                     "child_count": len(children),
                     "children": [
                         {
                             "skill": c.get("skill", "") if isinstance(c, dict) else "",
                             "initial_message": (
-                                (c.get("initial_message") or "")[:200]
+                                honest_truncate(c.get("initial_message") or "", per_child)
                                 if isinstance(c, dict)
                                 else ""
                             ),
@@ -7272,31 +7378,55 @@ class ChatSession:
             elif name == "send_to_workstream":
                 it["func_args"] = {
                     "ws_id": it.get("ws_id", ""),
-                    "message": (it.get("message") or "")[:200],
+                    "message": honest_truncate(it.get("message") or "", arg_budget),
                 }
             elif name == "close_workstream":
                 it["func_args"] = {
                     "ws_id": it.get("ws_id", ""),
-                    "reason": (it.get("reason") or "")[:200],
+                    "reason": honest_truncate(it.get("reason") or "", arg_budget),
                 }
             elif name == "close_all_children":
-                it["func_args"] = {"reason": (it.get("reason") or "")[:200]}
+                it["func_args"] = {"reason": honest_truncate(it.get("reason") or "", arg_budget)}
             elif name in ("cancel_workstream", "delete_workstream"):
                 it["func_args"] = {"ws_id": it.get("ws_id", "")}
             elif name == "tasks":
-                # ``title`` is optional on update — _prepare_tasks stores
-                # ``None`` when omitted, so dict.get(x, "") returns None
-                # (not the default) and slicing crashes.  Collapse via
-                # ``or ""`` so absent and explicit-None both fall back to
-                # empty string.  The other projections above use the same
-                # pattern defensively — a future preparer that stores
-                # None for any of these fields shouldn't take down the
-                # whole batch (every sibling tool call gets reported as
-                # cancelled) on a single missing optional field.
+                # ``reorder`` carries the full ordering; add/update/remove carry
+                # a task_id + the fields being set.  ``title``/``status``/
+                # ``child_ws_id`` are optional on update — _prepare_tasks stores
+                # ``None`` when omitted.  Never slice a maybe-None field (a
+                # single missing optional once crashed the whole batch, marking
+                # every sibling call cancelled): title collapses via ``or ""``
+                # before truncation; status/child_ws_id pass through as-is so a
+                # ``null`` honestly reads as "unchanged" rather than "set empty".
+                action_val = it.get("action", "")
+                fa_tasks: dict[str, Any] = {"action": action_val}
+                if action_val == "reorder":
+                    fa_tasks["task_ids"] = it.get("task_ids") or []
+                else:
+                    fa_tasks["task_id"] = it.get("task_id", "")
+                    fa_tasks["title"] = honest_truncate(it.get("title") or "", arg_budget)
+                    if "status" in it:
+                        fa_tasks["status"] = it.get("status")
+                    if "child_ws_id" in it:
+                        fa_tasks["child_ws_id"] = it.get("child_ws_id")
+                it["func_args"] = fa_tasks
+            elif name == "read_resource":
+                # Gated MCP resource read.  The URI is the risk surface
+                # (file:///etc/shadow, an SSRF-shaped http URI) and is what
+                # both tiers must see — without this branch the item carries
+                # only ``resource_uri``/``mcp_user_id`` (no ``mcp_args``), so it
+                # fell past the fallback below and reached the judge as ``{}``.
+                it["func_args"] = {"uri": it.get("resource_uri", "")}
+            elif name == "use_prompt":
+                # Gated MCP prompt invocation.  Name + arguments are the surface
+                # (a prompt can carry injection through its arguments); same
+                # empty-{} starvation as read_resource without this branch.
                 it["func_args"] = {
-                    "action": it.get("action", ""),
-                    "task_id": it.get("task_id", ""),
-                    "title": (it.get("title") or "")[:100],
+                    "prompt_name": it.get("prompt_name", ""),
+                    "prompt_arguments": honest_truncate(
+                        json.dumps(it.get("prompt_arguments") or {}, ensure_ascii=False),
+                        arg_budget,
+                    ),
                 }
             elif it.get("mcp_args"):
                 it["func_args"] = it["mcp_args"]
@@ -11646,6 +11776,11 @@ class ChatSession:
             "action": verb,
             "name": name,
             "template_id": existing["template_id"],
+            # Surfaced to the judge's func_args projection: re-enabling a
+            # model-planted high/critical (or auto_approve) skill is the attack
+            # the intent judge must be able to see, not just the name.
+            "risk_level": existing_risk,
+            "auto_approve": bool(existing.get("auto_approve")),
         }
 
     def _exec_skills_toggle(self, item: dict[str, Any], *, enable: bool) -> tuple[str, str]:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7119,6 +7119,10 @@ class ChatSession:
                 session_client=self.client,
                 session_model=self.model,
                 model_registry=self._registry,
+                # Session's real (config/registry-aware) window, so the oversize
+                # guard is accurate when output_guard_model is unset — same
+                # source IntentJudge gets via _ensure_judge.
+                context_window=self._get_capabilities().context_window,
             )
         except Exception:
             log.warning("output_guard_judge.init_failed", exc_info=True)


### PR DESCRIPTION
The intent- and output-guard judges are learned-kernel calls whose entire view of a pending tool call is what the shell lowers into their prompt. That lowering was too narrow and mis-bounded, producing confident false verdicts and silent tier drops.

## Intent judge — full tool arguments

The `func_args` projection in `_evaluate_intent` lowered only a narrow field per tool: `edit_file` reached the judge as `{path}` with the edits stripped, and skills mutations built their projection and never assigned it, so the judge ruled on `{}`. A small local judge denied a legitimate multi-edit `edit_file` at 95% confidence as "malformed, missing old_string/new_string" on exactly this gap.

Now every gated tool projects its full risk-relevant surface — edits, file content, timeouts, model overrides, skill risk fields, task status/ordering, MCP resource URIs and prompt arguments — with `read_resource` / `use_prompt` branches that previously fell through to `{}`. A parametrized guard test asserts every gated tool projects a non-empty view, so this failure mode fails CI instead of shipping.

## Real context window, not a fictitious cap

Both judges keyed their limits off `get_capabilities().context_window`, which reports a static 200k for every local/self-hosted model — so their budgets and guards never fit the small-window local judges they exist to serve. They now source the real per-model window from the registry config.

## Truncation is a backstop, not a default

Arguments lower whole up to the judge's real window; only a genuine overflow truncates, with an explicit dropped-character marker, and the untruncated arguments always remain in the trajectory. The verdict's persisted/streamed copy carries a separate 16 KB backstop against pathological payloads.

The output-guard judge gained an up-front oversize guard: when the assembled prompt would exceed the window it skips the doomed call and records a labelled `llm_error` the operator sees, instead of the opaque provider error that silently dropped the opted-in LLM tier (the heuristic tier runs first, so its verdict stands).
