### PR TITLE
refactor(skills): persona owns identity, SKILL.md is capability

### DIFF
--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -198,6 +198,23 @@ def test_spawn_prepare_needs_approval(coord_session):
     assert item["skill"] == "s"
 
 
+def test_spawn_prepare_denies_high_risk_skill(coord_session):
+    """Review fix: the high/critical-risk gate that blocks skills(load) also
+    blocks spawn_workstream(skill=…), so a child spawn can't route around it."""
+    sess, _coord, _ui = coord_session
+    with patch("turnstone.core.session.get_storage") as gs:
+        gs.return_value.get_prompt_template_by_name.return_value = {
+            "name": "danger",
+            "risk_level": "critical",
+        }
+        item = sess._prepare_tool(
+            _tc("spawn_workstream", {"initial_message": "go", "skill": "danger"})
+        )
+    assert "error" in item
+    assert "/skill danger" in item["error"]
+    assert item.get("needs_approval") is not True
+
+
 def test_spawn_exec_calls_client_and_returns_summary(coord_session):
     sess, coord, _ui = coord_session
     coord.spawn.return_value = {

--- a/tests/test_persona_guards.py
+++ b/tests/test_persona_guards.py
@@ -521,16 +521,21 @@ class TestSpawnPersona:
 
 
 # ---------------------------------------------------------------------------
-# Guard 7 — task_agent has no persona parameter (sub-agents keep their own
-# identity; persona is a workstream-level concept).
+# Guard 7 — task_agent HAS a persona parameter: a sub-agent's identity comes
+# from a persona (default = the built-in task-agent identity), validated at
+# prep against the interactive kind.  Revises the original "no persona for
+# task agents" stance now that personas are first-class on every path.
 # ---------------------------------------------------------------------------
 
 
-def test_task_agent_schema_has_no_persona_param() -> None:
+def test_task_agent_schema_has_persona_param() -> None:
     from turnstone.core.tools import TOOLS
 
     task_agent = next(t for t in TOOLS if t["function"]["name"] == "task_agent")
-    assert "persona" not in task_agent["function"]["parameters"]["properties"]
+    props = task_agent["function"]["parameters"]["properties"]
+    assert "persona" in props
+    # skill= is capability now — the description frames it that way.
+    assert "capability" in props["skill"]["description"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_templates_runtime.py
+++ b/tests/test_prompt_templates_runtime.py
@@ -88,10 +88,9 @@ def _make_session(**kwargs):
 
 
 def _sys_content(session: ChatSession) -> str:
-    """Extract the system message content."""
-    msgs = [m for m in session.system_messages if m["role"] == "system"]
-    assert msgs
-    return msgs[0]["content"]
+    """Full prompt prefix: identity system message + any skill context message."""
+    assert session.system_messages
+    return "\n".join(m["content"] for m in session.system_messages)
 
 
 def _create_template(db, template_id, name, content, is_default=False, **kwargs):
@@ -187,17 +186,24 @@ class TestDefaultTemplates:
         content = _sys_content(session)
         assert "Not default." not in content
 
-    def test_templates_before_instructions(self, tmp_db):
+    def test_default_template_delivered_as_context_after_identity(self, tmp_db):
+        """Default templates are CAPABILITY context (step 3): delivered in a
+        separate message after the identity system message (which carries user
+        instructions), not interleaved into the identity block."""
         from turnstone.core.storage import get_storage
 
         db = get_storage()
         _create_template(db, "t1", "tpl", "TEMPLATE_CONTENT", is_default=True)
 
         session = _make_session(instructions="USER_INSTRUCTIONS")
-        content = _sys_content(session)
-        tpl_pos = content.index("TEMPLATE_CONTENT")
-        instr_pos = content.index("USER_INSTRUCTIONS")
-        assert tpl_pos < instr_pos
+        msgs = session.system_messages
+        # Instructions live in the identity system message; the template body
+        # does NOT.
+        assert "USER_INSTRUCTIONS" in msgs[0]["content"]
+        assert "TEMPLATE_CONTENT" not in msgs[0]["content"]
+        # Default template content rides the trailing skill capability message.
+        assert msgs[-1]["role"] == "user"
+        assert "TEMPLATE_CONTENT" in msgs[-1]["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_templates_runtime.py
+++ b/tests/test_prompt_templates_runtime.py
@@ -186,10 +186,11 @@ class TestDefaultTemplates:
         content = _sys_content(session)
         assert "Not default." not in content
 
-    def test_default_template_delivered_as_context_after_identity(self, tmp_db):
-        """Default templates are CAPABILITY context (step 3): delivered in a
-        separate message after the identity system message (which carries user
-        instructions), not interleaved into the identity block."""
+    def test_default_template_stays_in_identity_system_message(self, tmp_db):
+        """Default (always-on) templates are the standing baseline and never
+        change mid-session, so they stay in the identity system message (with
+        user instructions) — only a NAMED applied skill moves to a separate
+        context message.  Template guidance still precedes user instructions."""
         from turnstone.core.storage import get_storage
 
         db = get_storage()
@@ -197,13 +198,11 @@ class TestDefaultTemplates:
 
         session = _make_session(instructions="USER_INSTRUCTIONS")
         msgs = session.system_messages
-        # Instructions live in the identity system message; the template body
-        # does NOT.
-        assert "USER_INSTRUCTIONS" in msgs[0]["content"]
-        assert "TEMPLATE_CONTENT" not in msgs[0]["content"]
-        # Default template content rides the trailing skill capability message.
-        assert msgs[-1]["role"] == "user"
-        assert "TEMPLATE_CONTENT" in msgs[-1]["content"]
+        # Both the default template and instructions live in the system message,
+        # template first — and no default triggers a user-role context message.
+        assert all(m["role"] == "system" for m in msgs)
+        content = msgs[0]["content"]
+        assert content.index("TEMPLATE_CONTENT") < content.index("USER_INSTRUCTIONS")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -272,18 +272,19 @@ class TestChatSessionConstruction:
 
 
 # ---------------------------------------------------------------------------
-# Tests — _exec_task (optional skill substitutes the hardcoded identity)
+# Tests — _exec_task (identity from persona/default; skill = capability turn)
 # ---------------------------------------------------------------------------
 
 
 class TestTaskExec:
-    """Tests for _exec_task: optional skill= replaces the default persona,
-    but operating guidance (one-shot, tool-use over narration, no follow-ups)
-    is always preserved."""
+    """Tests for _exec_task: identity comes from ``persona=`` (or the default
+    task-agent identity), NEVER the skill; a ``skill=`` rides a distinct
+    capability turn.  Operating guidance (one-shot, tool-use over narration,
+    no follow-ups) always layers on top."""
 
     @staticmethod
-    def _capture_exec_messages(session, item):
-        """Run _exec_task with _run_agent patched; return system message text."""
+    def _capture_exec_turns(session, item):
+        """Run _exec_task with _run_agent patched; return the turns list."""
         captured: dict = {}
 
         def fake_run_agent(messages, **kwargs):
@@ -292,27 +293,22 @@ class TestTaskExec:
 
         with patch.object(session, "_run_agent", side_effect=fake_run_agent):
             session._exec_task(item)
-        return captured["messages"][0].text
+        return captured["messages"]
 
-    def test_known_skill_renders_into_system_message(self, tmp_db) -> None:
-        """Validated skill content (with template vars resolved) replaces
-        the default '# Task Agent' persona, but the operating guidance
-        (the numbered list) is preserved — those are sub-agent semantics
-        that a persona should layer on top of, not replace.
-
-        Covers the full prepare→exec round-trip so a future regression
-        in either half (skill not stored on the item, or exec ignoring it)
-        is caught."""
+    def test_skill_delivered_as_capability_turn_not_identity(self, tmp_db) -> None:
+        """A skill= is CAPABILITY, not identity: its body (template vars
+        resolved) rides a distinct turn AFTER the system message, while the
+        default '# Task Agent' identity + operating guidance stay in the
+        system message.  Covers the full prepare→exec round-trip."""
         session = _make_session()
         skill = {
             "name": "research",
-            "content": "# Research Agent\nws={{ws_id}} model={{model}} node={{node_id}}",
+            "content": "# Research Skill\nws={{ws_id}} model={{model}} node={{node_id}}",
         }
         with patch("turnstone.core.session.get_skill_by_name", return_value=skill):
             item = session._prepare_task("c1", {"prompt": "investigate X", "skill": "research"})
 
-        # Item carries the minimized projection — name/content/risk_level
-        # only — not the raw prompt_templates row.
+        # Item carries the minimized projection — name/content/risk_level only.
         assert item["skill"] == {
             "name": "research",
             "content": skill["content"],
@@ -321,35 +317,113 @@ class TestTaskExec:
         assert item.get("needs_approval") is True
         assert "skill: research" in item["header"]
 
-        sys_msg = self._capture_exec_messages(session, item)
-        # Skill persona rendered with template vars resolved
-        assert "# Research Agent" in sys_msg
-        assert f"ws={session._ws_id}" in sys_msg
-        assert f"model={session.model}" in sys_msg
-        # Default persona is gone — skill substitutes for it.
-        assert "# Task Agent" not in sys_msg
-        assert "autonomous task agent with full tool access" not in sys_msg
-        # Operating guidance survives regardless of skill.
+        turns = self._capture_exec_turns(session, item)
+        sys_msg = turns[0].text
+        # Identity stays the DEFAULT — the skill does NOT become identity.
+        assert ChatSession._TASK_DEFAULT_IDENTITY in sys_msg
+        assert "# Task Agent" in sys_msg
         assert ChatSession._TASK_OPERATING_GUIDANCE in sys_msg
+        # Skill body is NOT fused into the identity system message.
+        assert "# Research Skill" not in sys_msg
+        # It rides a distinct capability turn, template vars resolved.
+        capability = turns[1].text
+        assert ChatSession._TASK_SKILL_CAPABILITY_PREAMBLE in capability
+        assert "# Research Skill" in capability
+        assert f"ws={session._ws_id}" in capability
+        assert f"model={session.model}" in capability
+        # Task prompt is the final turn.
+        assert turns[-1].text == "investigate X"
 
-    def test_omitted_skill_uses_hardcoded_identity(self, tmp_db) -> None:
-        """Regression guard: without skill=, the default '# Task Agent'
-        persona AND the operating guidance both appear verbatim.
-
-        Pins the no-skill path so the substitution branch can't
-        accidentally swallow the default case."""
+    def test_omitted_skill_uses_default_identity(self, tmp_db) -> None:
+        """Without skill= or persona=, the default '# Task Agent' identity +
+        operating guidance appear in the system message, and there is NO
+        capability turn — just system + prompt."""
         session = _make_session()
         item = session._prepare_task("c1", {"prompt": "do x"})
 
         assert item["skill"] is None
+        assert item["persona"] == ""
         assert "skill:" not in item["header"]
+        assert "persona:" not in item["header"]
 
-        sys_msg = self._capture_exec_messages(session, item)
+        turns = self._capture_exec_turns(session, item)
+        sys_msg = turns[0].text
         assert ChatSession._TASK_DEFAULT_IDENTITY in sys_msg
         assert ChatSession._TASK_OPERATING_GUIDANCE in sys_msg
-        # Default-persona literals also present (sanity check on the constant).
         assert "# Task Agent" in sys_msg
         assert "autonomous task agent with full tool access" in sys_msg
+        # No skill → no capability turn: just system + prompt.
+        assert len(turns) == 2
+        assert turns[-1].text == "do x"
+
+    def test_persona_sets_identity_skill_stays_capability(self, tmp_db) -> None:
+        """persona= sets the sub-agent identity (base prompt) in place of the
+        default; a skill passed alongside stays a capability turn."""
+        session = _make_session()
+        persona_row = {
+            "name": "engineer",
+            "base_prompt": "# Engineer\nYou are an engineer.",
+            "base_prompt_file": None,
+            "tool_allowlist": None,
+            "mcp_enabled": True,
+            "memory_enabled": True,
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        }
+        skill = {"name": "research", "content": "# Research Skill"}
+        with (
+            patch("turnstone.core.session.get_skill_by_name", return_value=skill),
+            patch("turnstone.core.session.get_storage") as gs,
+        ):
+            gs.return_value.get_persona_by_name.return_value = persona_row
+            item = session._prepare_task(
+                "c1", {"prompt": "do x", "skill": "research", "persona": "engineer"}
+            )
+
+        assert item.get("needs_approval") is True
+        assert item["persona"] == "engineer"
+        assert "persona: engineer" in item["header"]
+        assert "skill: research" in item["header"]
+
+        turns = self._capture_exec_turns(session, item)
+        sys_msg = turns[0].text
+        # Identity = persona, not the default and not the skill.
+        assert "# Engineer" in sys_msg
+        assert ChatSession._TASK_DEFAULT_IDENTITY not in sys_msg
+        assert "# Research Skill" not in sys_msg
+        # Operating guidance still layers on the persona identity.
+        assert ChatSession._TASK_OPERATING_GUIDANCE in sys_msg
+        # Skill remains a capability turn.
+        assert "# Research Skill" in turns[1].text
+
+    def test_unknown_persona_returns_error(self, tmp_db) -> None:
+        """Unknown persona name → clean error item, no approval."""
+        session = _make_session()
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = None
+            item = session._prepare_task("c1", {"prompt": "do x", "persona": "ghost"})
+        assert item.get("needs_approval") is False
+        assert "ghost" in item["error"]
+        assert "Omit `persona`" in item["error"]
+
+    def test_persona_wrong_kind_returns_error(self, tmp_db) -> None:
+        """A coordinator-only persona can't serve as a task-agent identity."""
+        session = _make_session()
+        coord_row = {
+            "name": "orchestrator",
+            "base_prompt": "# Orchestrator",
+            "base_prompt_file": None,
+            "tool_allowlist": None,
+            "mcp_enabled": True,
+            "memory_enabled": True,
+            "enabled": True,
+            "applies_to_kinds": ["coordinator"],
+        }
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = coord_row
+            item = session._prepare_task("c1", {"prompt": "do x", "persona": "orchestrator"})
+        assert item.get("needs_approval") is False
+        assert "interactive" in item["error"]
 
     @pytest.mark.parametrize("skill_value", ["", "   ", "\t\n"])
     def test_prepare_task_empty_or_whitespace_skill_treated_as_omitted(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -425,6 +425,195 @@ class TestTaskExec:
         assert item.get("needs_approval") is False
         assert "interactive" in item["error"]
 
+    def test_persona_tool_allowlist_restricts_sub_agent_tools(self, tmp_db) -> None:
+        """A restrictive persona caps the sub-agent's TOOLS (Principle 7 /
+        review fix), not just its identity text — stated identity must match
+        granted authority."""
+        session = _make_session()
+        session._task_tools = [
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "write_file"}},
+            {"function": {"name": "bash"}},
+        ]
+        persona_row = {
+            "name": "readonly",
+            "base_prompt": "# Readonly reviewer",
+            "base_prompt_file": None,
+            "tool_allowlist": ["read_file", "search"],  # excludes write_file/bash
+            "mcp_enabled": True,
+            "memory_enabled": True,
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        }
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = persona_row
+            item = session._prepare_task("c1", {"prompt": "edit auth", "persona": "readonly"})
+        assert item["persona_tools"] == frozenset({"read_file", "search"})
+
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured.update(kwargs)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        tool_names = {t["function"]["name"] for t in captured["tools"]}
+        # write_file + bash dropped by the persona; read_file kept (search was
+        # never in the task tool set to begin with).
+        assert tool_names == {"read_file"}
+
+    def test_no_persona_keeps_full_task_tools(self, tmp_db) -> None:
+        session = _make_session()
+        session._task_tools = [
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "bash"}},
+        ]
+        item = session._prepare_task("c1", {"prompt": "do x"})
+        assert item["persona_tools"] is None
+
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured.update(kwargs)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        assert {t["function"]["name"] for t in captured["tools"]} == {"read_file", "bash"}
+
+    def test_parent_persona_caps_sub_agent_tools(self, tmp_db) -> None:
+        """A restricted PARENT session must not escalate authority by spawning:
+        the sub-agent's tools are capped by the parent's own persona grant even
+        with NO child persona (Principle 7 — delegation narrows, never widens;
+        whole-PR review fix)."""
+        session = _make_session()
+        session._tool_search = None
+        session._task_tools = [
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "write_file"}},
+            {"function": {"name": "bash"}},
+        ]
+        # Parent runs under a read-only persona.
+        session._persona_tools = frozenset({"read_file", "search"})
+
+        item = session._prepare_task("c1", {"prompt": "edit auth"})
+        assert item["persona_tools"] is None  # no CHILD persona
+
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured.update(kwargs)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        # Parent's read-only grant caps the sub-agent: write_file + bash dropped.
+        assert {t["function"]["name"] for t in captured["tools"]} == {"read_file"}
+
+    def test_child_persona_mcp_off_drops_mcp_tools(self, tmp_db) -> None:
+        """A child persona with mcp_enabled=False hides MCP tools (``mcp__*`` and
+        the MCP-access read_resource / use_prompt) from the sub-agent, even when
+        tool_allowlist is null (unrestricted native tools) — the mcp lever must
+        not silently no-op on the task_agent path (whole-PR review fix)."""
+        session = _make_session()
+        session._tool_search = None
+        session._task_tools = [
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "read_resource"}},
+            {"function": {"name": "use_prompt"}},
+            {"function": {"name": "mcp__github__search"}},
+        ]
+        persona_row = {
+            "name": "sandboxed",
+            "base_prompt": "# Sandboxed",
+            "base_prompt_file": None,
+            "tool_allowlist": None,  # null = unrestricted native tools
+            "mcp_enabled": False,  # but MCP is OFF
+            "memory_enabled": True,
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        }
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = persona_row
+            item = session._prepare_task("c1", {"prompt": "do x", "persona": "sandboxed"})
+        assert item["persona_mcp"] is False
+        assert item["persona_tools"] is None
+
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured.update(kwargs)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        # MCP tools shed; native read_file kept.
+        assert {t["function"]["name"] for t in captured["tools"]} == {"read_file"}
+
+    def test_child_persona_memory_off_drops_memory_tool(self, tmp_db) -> None:
+        """A child persona with memory_enabled=False drops the memory tool from
+        the sub-agent's hands (lever 4), matching a main session under the same
+        persona (whole-PR review fix)."""
+        session = _make_session()
+        session._tool_search = None
+        session._task_tools = [
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "memory"}},
+        ]
+        persona_row = {
+            "name": "nomem",
+            "base_prompt": "# No memory",
+            "base_prompt_file": None,
+            "tool_allowlist": None,
+            "mcp_enabled": True,
+            "memory_enabled": False,
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        }
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = persona_row
+            item = session._prepare_task("c1", {"prompt": "do x", "persona": "nomem"})
+        assert item["persona_memory"] is False
+
+        captured: dict = {}
+
+        def fake_run_agent(messages, **kwargs):
+            captured.update(kwargs)
+            return "done"
+
+        with patch.object(session, "_run_agent", side_effect=fake_run_agent):
+            session._exec_task(item)
+        assert {t["function"]["name"] for t in captured["tools"]} == {"read_file"}
+
+    def test_evaluate_intent_projects_persona_for_task_agent(self, tmp_db, monkeypatch) -> None:
+        """Judge/audit projection includes the persona name (review fix): a
+        persona-driven identity shift must be visible to policy + audit, like
+        spawn_workstream."""
+        session = _make_session()
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "tier": "heuristic"}
+        fake_judge = MagicMock()
+        fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        fake_judge.arg_budget_chars.return_value = 200_000
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        persona_row = {
+            "name": "engineer",
+            "base_prompt": "# Engineer",
+            "base_prompt_file": None,
+            "tool_allowlist": None,
+            "mcp_enabled": True,
+            "memory_enabled": True,
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        }
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_persona_by_name.return_value = persona_row
+            item = session._prepare_task("c1", {"prompt": "do x", "persona": "engineer"})
+        session._evaluate_intent([item])
+        assert item["func_args"]["persona"] == "engineer"
+
     @pytest.mark.parametrize("skill_value", ["", "   ", "\t\n"])
     def test_prepare_task_empty_or_whitespace_skill_treated_as_omitted(
         self, tmp_db, skill_value
@@ -471,12 +660,11 @@ class TestTaskExec:
         # tell them apart at recovery time.
         assert "unknown skill" not in item["error"]
 
-    def test_prepare_task_high_risk_skill_surfaces_in_header(self, tmp_db, caplog) -> None:
-        """High/critical risk skills surface the tier in the approval header
-        and emit a structured warning, mirroring the signal ``_load_skills``
-        emits for session-level skills (session.py:1336)."""
-        import logging
-
+    def test_prepare_task_denies_high_risk_skill(self, tmp_db) -> None:
+        """High/critical-risk skills are PRINCIPAL-load-only: task_agent(skill=…)
+        DENIES them — the same gate skills(load) / spawn_* enforce, so a model
+        cannot route around it by delegating activation to a sub-agent
+        (whole-PR review fix — task_agent was the un-gated surface)."""
         session = _make_session()
         risky_skill = {
             "name": "danger",
@@ -484,16 +672,15 @@ class TestTaskExec:
             "enabled": True,
             "risk_level": "critical",
         }
-        with (
-            caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
-            patch("turnstone.core.session.get_skill_by_name", return_value=risky_skill),
-        ):
+        with patch("turnstone.core.session.get_skill_by_name", return_value=risky_skill):
             item = session._prepare_task("c1", {"prompt": "do x", "skill": "danger"})
-        assert item.get("needs_approval") is True
-        assert "skill: danger" in item["header"]
-        assert "risk: critical" in item["header"]
-        warning_seen = any("high_risk_skill" in r.getMessage() for r in caplog.records)
-        assert warning_seen, "expected task_agent.high_risk_skill warning"
+        assert item.get("needs_approval") is False
+        assert "principal-load-only" in item["header"]
+        assert "/skill danger" in item["error"]
+        # Distinct from the unknown/disabled errors so the model's recovery
+        # path can tell them apart.
+        assert "unknown skill" not in item["error"]
+        assert "disabled" not in item["error"]
 
     def test_prepare_task_normal_risk_skill_omits_tier_from_header(self, tmp_db) -> None:
         """Header only surfaces high/critical — low/medium/safe skills don't

--- a/tests/test_skill_resource_materialization.py
+++ b/tests/test_skill_resource_materialization.py
@@ -135,9 +135,8 @@ def _create_skill(db: Any, skill_id: str, name: str, content: str, **kw: Any) ->
 
 
 def _sys_content(session: ChatSession) -> str:
-    msgs = [m for m in session.system_messages if m["role"] == "system"]
-    assert msgs
-    return msgs[0]["content"]
+    assert session.system_messages
+    return "\n".join(m["content"] for m in session.system_messages)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skill_substitution_unification.py
+++ b/tests/test_skill_substitution_unification.py
@@ -1,0 +1,226 @@
+"""Skill substitution unification (SKILL.md subsystem refactor, step 1).
+
+Pins the invariant that skill-body placeholder substitution is IDENTICAL
+across every invocation context.  Interactive load, default skills, and
+``task_agent`` sub-agents all route through
+``ChatSession._render_skill_body`` — so a skill reading ``$ARGUMENTS`` or
+``${TURNSTONE_EFFORT}`` resolves the same everywhere, rather than
+rendering literally on the ``task_agent`` path (which previously ran
+``_render_template`` alone).
+
+Also covers the two behaviours the unified path newly guarantees:
+
+* ``${TURNSTONE_*}`` env vars (canonical) and their ``${CLAUDE_*}``
+  back-compat aliases both resolve.
+* ``${TURNSTONE_SKILL_DIR}`` resolves to the concrete materialized bundle
+  path in the rendered body, because resources are materialized BEFORE
+  substitution (the ordering fix).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from tests._session_helpers import make_session
+from turnstone.core.storage._registry import get_storage
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _create_skill(db: Any, skill_id: str, name: str, content: str, **kw: Any) -> None:
+    db.create_prompt_template(
+        template_id=skill_id,
+        name=name,
+        category=kw.get("category", "general"),
+        content=content,
+        variables="[]",
+        is_default=kw.get("is_default", False),
+        org_id="",
+        created_by="test",
+        origin="manual",
+        mcp_server="",
+        readonly=False,
+        description="",
+        tags="[]",
+        source_url="",
+        version="1.0.0",
+        author="",
+        activation=kw.get("activation", "named"),
+        token_estimate=0,
+        model="",
+        auto_approve=False,
+        temperature=None,
+        reasoning_effort="",
+        max_tokens=None,
+        token_budget=0,
+        agent_max_turns=None,
+        notify_on_complete="{}",
+        enabled=True,
+        allowed_tools="[]",
+        priority=0,
+    )
+
+
+class TestRenderSkillBodySharedPath:
+    """``_render_skill_body`` is the single substitution path — the one
+    ``task_agent`` now calls.  Assert it resolves the spec forms that the
+    old ``_render_template``-only ``task_agent`` path left literal."""
+
+    def test_env_vars_resolve(self, tmp_db: str) -> None:
+        session = make_session(reasoning_effort="high")
+        try:
+            out = session._render_skill_body(
+                "id ${TURNSTONE_SESSION_ID} effort ${TURNSTONE_EFFORT}"
+            )
+            assert out == f"id {session._ws_id} effort high"
+        finally:
+            session.close()
+
+    def test_claude_aliases_resolve(self, tmp_db: str) -> None:
+        session = make_session(reasoning_effort="low")
+        try:
+            out = session._render_skill_body("id ${CLAUDE_SESSION_ID} effort ${CLAUDE_EFFORT}")
+            assert out == f"id {session._ws_id} effort low"
+        finally:
+            session.close()
+
+    def test_bare_arguments_clears_to_empty(self, tmp_db: str) -> None:
+        # A ``task_agent`` gets its task via the prompt, not invocation
+        # args, so the shared path is called with ``arguments_str=""`` —
+        # the bare ``$ARGUMENTS`` placeholder clears to empty (spawn-child
+        # semantics), NOT the literal string it was before unification.
+        session = make_session()
+        try:
+            assert session._render_skill_body("before $ARGUMENTS after") == "before  after"
+        finally:
+            session.close()
+
+    def test_curly_and_spec_passes_both_apply(self, tmp_db: str) -> None:
+        # Legacy ``{{model}}`` AND spec ``${TURNSTONE_EFFORT}`` in one body —
+        # both passes run through the shared path.
+        session = make_session(model="my-model", reasoning_effort="high")
+        try:
+            out = session._render_skill_body("model {{model}} effort ${TURNSTONE_EFFORT}")
+            assert out == "model my-model effort high"
+        finally:
+            session.close()
+
+    def test_positional_tokens_clear_without_args(self, tmp_db: str) -> None:
+        # A sub-agent supplies no invocation args, so every positional form
+        # ($N / $0 / $ARGUMENTS[N]) — like bare $ARGUMENTS — resolves to
+        # empty, identical to the defaults and spawn-child paths.  Pinned so
+        # this deliberate unification isn't mistaken for silent corruption:
+        # the old _render_template-only path left these tokens verbatim.
+        session = make_session()
+        try:
+            out = session._render_skill_body("step $1 / $0 / $ARGUMENTS[2] done")
+            assert out == "step  /  /  done"
+        finally:
+            session.close()
+
+    def test_skill_dir_literal_on_sub_agent_path(self, tmp_db: str) -> None:
+        # task_agent calls _render_skill_body with no skill_dir (sub-agent
+        # bundles aren't materialized yet), so ${TURNSTONE_SKILL_DIR} stays
+        # literal on this path — unchanged from before, resolved in a later
+        # step.  The env vars that DO have values still resolve.
+        session = make_session(reasoning_effort="high")
+        try:
+            out = session._render_skill_body(
+                "dir ${TURNSTONE_SKILL_DIR} effort ${TURNSTONE_EFFORT}"
+            )
+            assert out == "dir ${TURNSTONE_SKILL_DIR} effort high"
+        finally:
+            session.close()
+
+
+class TestSkillDirResolvesInBody:
+    """Materialize-before-substitute: ``${TURNSTONE_SKILL_DIR}`` in a skill
+    body resolves to the concrete on-disk bundle path after a full load."""
+
+    def test_turnstone_skill_dir_in_body(self, tmp_db: str) -> None:
+        db = get_storage()
+        _create_skill(db, "s1", "dir-skill", "Scripts under ${TURNSTONE_SKILL_DIR}/scripts.")
+        db.create_skill_resource("r1", "s1", "scripts/go.py", "print('x')")
+
+        session = make_session(skill="dir-skill")
+        try:
+            base = session._skill_resources_dir
+            assert base is not None
+            assert session._skill_content == f"Scripts under {base}/scripts."
+        finally:
+            session.close()
+
+    def test_claude_skill_dir_alias_in_body(self, tmp_db: str) -> None:
+        db = get_storage()
+        _create_skill(db, "s1", "dir-alias-skill", "Bundle at ${CLAUDE_SKILL_DIR}")
+        db.create_skill_resource("r1", "s1", "references/a.md", "# a")
+
+        session = make_session(skill="dir-alias-skill")
+        try:
+            base = session._skill_resources_dir
+            assert base is not None
+            assert session._skill_content == f"Bundle at {base}"
+        finally:
+            session.close()
+
+    def test_skill_dir_literal_without_resources(self, tmp_db: str) -> None:
+        # No bundled resources → no dir → placeholder stays literal
+        # (graceful degradation), not an empty path.
+        db = get_storage()
+        _create_skill(db, "s1", "no-res-skill", "Path ${TURNSTONE_SKILL_DIR} here.")
+
+        session = make_session(skill="no-res-skill")
+        try:
+            assert session._skill_resources_dir is None
+            assert session._skill_content == "Path ${TURNSTONE_SKILL_DIR} here."
+        finally:
+            session.close()
+
+
+class TestSkillResourceEnvAliases:
+    """Bash env exposes the materialized bundle dir under turnstone-owned
+    names unconditionally, and under the foreign ``CLAUDE_SKILL_DIR`` alias
+    only when the host hasn't already set it (no shadowing when turnstone
+    runs as a node inside Claude Code)."""
+
+    def test_turnstone_owned_aliases_always_present(
+        self, tmp_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLAUDE_SKILL_DIR", raising=False)
+        db = get_storage()
+        _create_skill(db, "s1", "env-alias-skill", "content")
+        db.create_skill_resource("r1", "s1", "scripts/t.py", "code")
+
+        session = make_session(skill="env-alias-skill")
+        try:
+            env = session._skill_resource_env()
+            d = session._skill_resources_dir
+            assert env["SKILL_RESOURCES_DIR"] == d
+            assert env["TURNSTONE_SKILL_DIR"] == d
+            # Host hasn't set it → turnstone supplies the portability alias.
+            assert env["CLAUDE_SKILL_DIR"] == d
+        finally:
+            session.close()
+
+    def test_host_claude_skill_dir_not_shadowed(
+        self, tmp_db: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # turnstone as a node inside Claude Code: the host's CLAUDE_SKILL_DIR
+        # must survive.  turnstone only injects its own names and leaves
+        # CLAUDE_SKILL_DIR out of the extra-env so scrubbed_env's passthrough
+        # keeps the host value.
+        monkeypatch.setenv("CLAUDE_SKILL_DIR", "/host/claude/skill")
+        db = get_storage()
+        _create_skill(db, "s1", "env-host-skill", "content")
+        db.create_skill_resource("r1", "s1", "scripts/t.py", "code")
+
+        session = make_session(skill="env-host-skill")
+        try:
+            env = session._skill_resource_env()
+            d = session._skill_resources_dir
+            assert env["TURNSTONE_SKILL_DIR"] == d
+            assert env["SKILL_RESOURCES_DIR"] == d
+            assert "CLAUDE_SKILL_DIR" not in env
+        finally:
+            session.close()

--- a/tests/test_skill_substitution_unification.py
+++ b/tests/test_skill_substitution_unification.py
@@ -64,8 +64,11 @@ def _create_skill(db: Any, skill_id: str, name: str, content: str, **kw: Any) ->
 
 class TestRenderSkillBodySharedPath:
     """``_render_skill_body`` is the single substitution path — the one
-    ``task_agent`` now calls.  Assert it resolves the spec forms that the
-    old ``_render_template``-only ``task_agent`` path left literal."""
+    ``task_agent`` now calls.  With ``substitute_args=True`` (arg-capable
+    invocations: interactive /skill, skills(load)) the spec arg forms
+    resolve; with ``substitute_args=False`` (capability contexts: defaults,
+    task_agent) literal ``$N``/``$ARGUMENTS`` are left untouched.  Env vars
+    resolve either way."""
 
     def test_env_vars_resolve(self, tmp_db: str) -> None:
         session = make_session(reasoning_effort="high")
@@ -85,11 +88,9 @@ class TestRenderSkillBodySharedPath:
         finally:
             session.close()
 
-    def test_bare_arguments_clears_to_empty(self, tmp_db: str) -> None:
-        # A ``task_agent`` gets its task via the prompt, not invocation
-        # args, so the shared path is called with ``arguments_str=""`` —
-        # the bare ``$ARGUMENTS`` placeholder clears to empty (spawn-child
-        # semantics), NOT the literal string it was before unification.
+    def test_arg_capable_path_clears_bare_arguments_when_no_args(self, tmp_db: str) -> None:
+        # Arg-capable invocation (interactive /skill, skills(load)) with no
+        # args → bare $ARGUMENTS clears to empty, per the SKILL.md spec.
         session = make_session()
         try:
             assert session._render_skill_body("before $ARGUMENTS after") == "before  after"
@@ -106,16 +107,27 @@ class TestRenderSkillBodySharedPath:
         finally:
             session.close()
 
-    def test_positional_tokens_clear_without_args(self, tmp_db: str) -> None:
-        # A sub-agent supplies no invocation args, so every positional form
-        # ($N / $0 / $ARGUMENTS[N]) — like bare $ARGUMENTS — resolves to
-        # empty, identical to the defaults and spawn-child paths.  Pinned so
-        # this deliberate unification isn't mistaken for silent corruption:
-        # the old _render_template-only path left these tokens verbatim.
+    def test_arg_capable_path_clears_positional_tokens_when_no_args(self, tmp_db: str) -> None:
+        # Arg-capable path with no args → positional forms clear to empty (spec).
         session = make_session()
         try:
             out = session._render_skill_body("step $1 / $0 / $ARGUMENTS[2] done")
             assert out == "step  /  /  done"
+        finally:
+            session.close()
+
+    def test_capability_context_preserves_literal_arg_tokens(self, tmp_db: str) -> None:
+        # Capability contexts (task_agent, defaults) never receive invocation
+        # args, so substitute_args=False leaves literal $ARGUMENTS/$N/$name
+        # untouched (they are prose/shell text) while env vars still resolve.
+        # Pins the review fix that stopped blanking such tokens for sub-agents.
+        session = make_session(reasoning_effort="high")
+        try:
+            out = session._render_skill_body(
+                "run ./deploy.sh $1 $2 at ${TURNSTONE_EFFORT}; process $ARGUMENTS",
+                substitute_args=False,
+            )
+            assert out == "run ./deploy.sh $1 $2 at high; process $ARGUMENTS"
         finally:
             session.close()
 
@@ -151,16 +163,25 @@ class TestSkillDirResolvesInBody:
         finally:
             session.close()
 
-    def test_claude_skill_dir_alias_in_body(self, tmp_db: str) -> None:
+    def test_claude_skill_dir_not_aliased_in_body(self, tmp_db: str) -> None:
+        # CLAUDE_SKILL_DIR is NOT a turnstone-owned alias: it stays a literal
+        # placeholder even with a materialized bundle (that name belongs to the
+        # host in bash; turnstone claims neither surface).  The canonical
+        # TURNSTONE_SKILL_DIR does resolve.
         db = get_storage()
-        _create_skill(db, "s1", "dir-alias-skill", "Bundle at ${CLAUDE_SKILL_DIR}")
+        _create_skill(
+            db,
+            "s1",
+            "dir-alias-skill",
+            "Bundle at ${CLAUDE_SKILL_DIR} vs ${TURNSTONE_SKILL_DIR}",
+        )
         db.create_skill_resource("r1", "s1", "references/a.md", "# a")
 
         session = make_session(skill="dir-alias-skill")
         try:
             base = session._skill_resources_dir
             assert base is not None
-            assert session._skill_content == f"Bundle at {base}"
+            assert session._skill_content == f"Bundle at ${{CLAUDE_SKILL_DIR}} vs {base}"
         finally:
             session.close()
 
@@ -180,11 +201,11 @@ class TestSkillDirResolvesInBody:
 
 class TestSkillResourceEnvAliases:
     """Bash env exposes the materialized bundle dir under turnstone-owned
-    names unconditionally, and under the foreign ``CLAUDE_SKILL_DIR`` alias
-    only when the host hasn't already set it (no shadowing when turnstone
-    runs as a node inside Claude Code)."""
+    names (``TURNSTONE_SKILL_DIR`` / ``SKILL_RESOURCES_DIR``) unconditionally,
+    and never under the foreign ``CLAUDE_SKILL_DIR`` — that name is the host's,
+    so turnstone leaves it untouched whether or not the host has set it."""
 
-    def test_turnstone_owned_aliases_always_present(
+    def test_turnstone_owned_names_present_claude_absent(
         self, tmp_db: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("CLAUDE_SKILL_DIR", raising=False)
@@ -198,18 +219,18 @@ class TestSkillResourceEnvAliases:
             d = session._skill_resources_dir
             assert env["SKILL_RESOURCES_DIR"] == d
             assert env["TURNSTONE_SKILL_DIR"] == d
-            # Host hasn't set it → turnstone supplies the portability alias.
-            assert env["CLAUDE_SKILL_DIR"] == d
+            # turnstone never supplies CLAUDE_SKILL_DIR (the host's namespace),
+            # even when the host hasn't set it.
+            assert "CLAUDE_SKILL_DIR" not in env
         finally:
             session.close()
 
-    def test_host_claude_skill_dir_not_shadowed(
+    def test_host_claude_skill_dir_untouched(
         self, tmp_db: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # turnstone as a node inside Claude Code: the host's CLAUDE_SKILL_DIR
-        # must survive.  turnstone only injects its own names and leaves
-        # CLAUDE_SKILL_DIR out of the extra-env so scrubbed_env's passthrough
-        # keeps the host value.
+        # must survive.  turnstone never injects CLAUDE_SKILL_DIR into the
+        # extra-env, so scrubbed_env's passthrough keeps the host value.
         monkeypatch.setenv("CLAUDE_SKILL_DIR", "/host/claude/skill")
         db = get_storage()
         _create_skill(db, "s1", "env-host-skill", "content")

--- a/tests/test_skill_substitution_unification.py
+++ b/tests/test_skill_substitution_unification.py
@@ -224,3 +224,51 @@ class TestSkillResourceEnvAliases:
             assert "CLAUDE_SKILL_DIR" not in env
         finally:
             session.close()
+
+
+class TestSkillContextPlacement:
+    """Step 3: an applied skill's body rides its own capability context
+    message (user role), separate from the identity system message — so it
+    never occupies the cached identity prefix or reads as identity, and it
+    does not leak into the task_agent base."""
+
+    def test_skill_body_in_context_message_not_identity(self, tmp_db: str) -> None:
+        db = get_storage()
+        _create_skill(db, "s1", "place-skill", "PLACEMENT_MARKER body text")
+
+        session = make_session(skill="place-skill")
+        try:
+            msgs = session.system_messages
+            # Identity system message is first, role=system, and skill-free.
+            assert msgs[0]["role"] == "system"
+            assert "PLACEMENT_MARKER" not in msgs[0]["content"]
+            # Skill rides exactly one separate user-role capability message.
+            skill_msgs = [m for m in msgs if m["role"] == "user"]
+            assert len(skill_msgs) == 1
+            assert "PLACEMENT_MARKER" in skill_msgs[0]["content"]
+            # The intro names the active skill so the model knows what it is.
+            assert "place-skill" in skill_msgs[0]["content"]
+        finally:
+            session.close()
+
+    def test_no_skill_no_context_message(self, tmp_db: str) -> None:
+        # No applied skill and no defaults → only the identity system message.
+        session = make_session()
+        try:
+            assert all(m["role"] == "system" for m in session.system_messages)
+        finally:
+            session.close()
+
+    def test_agent_prefix_excludes_skill_context(self, tmp_db: str) -> None:
+        # task_agent base = the identity system block only; the parent's
+        # applied skill does NOT leak into the sub-agent prefix.
+        db = get_storage()
+        _create_skill(db, "s1", "leak-skill", "SHOULD_NOT_LEAK body")
+
+        session = make_session(skill="leak-skill")
+        try:
+            assert len(session._agent_system_messages) == 1
+            assert session._agent_system_messages[0]["role"] == "system"
+            assert "SHOULD_NOT_LEAK" not in session._agent_system_messages[0]["content"]
+        finally:
+            session.close()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -111,10 +111,9 @@ def _make_session(**kwargs):
 
 
 def _sys_content(session: ChatSession) -> str:
-    """Extract the system message content."""
-    msgs = [m for m in session.system_messages if m["role"] == "system"]
-    assert msgs
-    return msgs[0]["content"]
+    """Full prompt prefix: identity system message + any skill context message."""
+    assert session.system_messages
+    return "\n".join(m["content"] for m in session.system_messages)
 
 
 def _create_template(db, template_id, name, content, **kwargs):

--- a/tests/test_skills_tool.py
+++ b/tests/test_skills_tool.py
@@ -1497,3 +1497,35 @@ class TestSkillsLoadRiskGate:
             gs.return_value.get_prompt_template_by_name.return_value = None
             item = session._prepare_skills("c1", {"action": "load", "name": "ghost"})
         assert item.get("needs_approval") is True
+
+    def test_shared_helper_denies_high_and_critical_only(self) -> None:
+        # The one shared gate used by skills(load) AND the spawn paths, so a
+        # child spawn cannot route around it.
+        session = _make_session()
+        for tier in ("high", "critical"):
+            with patch("turnstone.core.session.get_storage") as gs:
+                gs.return_value.get_prompt_template_by_name.return_value = {
+                    "name": "x",
+                    "risk_level": tier,
+                }
+                assert "/skill x" in session._high_risk_skill_denied("x")
+        for row in (
+            {"name": "y", "risk_level": "low"},
+            {"name": "y", "risk_level": ""},
+            None,
+        ):
+            with patch("turnstone.core.session.get_storage") as gs:
+                gs.return_value.get_prompt_template_by_name.return_value = row
+                assert session._high_risk_skill_denied("y") == ""
+
+    def test_risk_gate_fails_closed_on_storage_error(self) -> None:
+        # A risk gate that can't read the row must DENY, never wave the skill
+        # through (fail closed).  Returning a denial (not "") also keeps
+        # spawn_batch's per-row partial-success intact under a storage blip.
+        session = _make_session()
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_prompt_template_by_name.side_effect = RuntimeError("db down")
+            denial = session._high_risk_skill_denied("z")
+        assert denial != ""
+        assert "z" in denial
+        assert "/skill z" in denial

--- a/tests/test_skills_tool.py
+++ b/tests/test_skills_tool.py
@@ -1529,3 +1529,13 @@ class TestSkillsLoadRiskGate:
         assert denial != ""
         assert "z" in denial
         assert "/skill z" in denial
+
+    def test_risk_gate_fails_closed_on_no_storage(self) -> None:
+        # Storage-unavailable (get_storage() is None) is treated the same as a
+        # lookup fault — DENY, not allow.  A gate that can't verify the risk
+        # tier must not wave the skill through (Copilot review nit).
+        session = _make_session()
+        with patch("turnstone.core.session.get_storage", return_value=None):
+            denial = session._high_risk_skill_denied("z")
+        assert denial != ""
+        assert "/skill z" in denial

--- a/tests/test_skills_tool.py
+++ b/tests/test_skills_tool.py
@@ -1444,3 +1444,56 @@ class TestSkillCatalogDisclosure:
         # human-facing path); the tool-facing path is the new
         # ``skills(action='find')`` flow.
         assert "/skill" in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — model-initiated load risk gate (design §5.5 / Principle 7)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsLoadRiskGate:
+    """A high/critical-risk skill is PRINCIPAL-load-only: the model cannot
+    activate it through skills(action='load') — that path is denied outright,
+    forcing an explicit operator /skill.  Lower-risk skills load as before.
+    The scanner-computed risk_level is the gate signal (it already escalates
+    for the auto_approve + allowed_tools authority the create path warns about),
+    so no new schema is needed.  The principal path (set_skill via /skill or
+    cli --skill) is not routed through _prepare_skills_load and is not gated."""
+
+    @staticmethod
+    def _load_item(session, name: str, risk: str):
+        row = {"name": name, "risk_level": risk, "enabled": True, "content": "x"}
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_prompt_template_by_name.return_value = row
+            return session._prepare_skills("c1", {"action": "load", "name": name})
+
+    def test_high_risk_load_denied_for_model(self) -> None:
+        item = self._load_item(_make_session(), "danger", "high")
+        assert item.get("needs_approval") is False
+        assert "/skill danger" in item["error"]
+        assert "high" in item["error"]
+
+    def test_critical_risk_load_denied_for_model(self) -> None:
+        item = self._load_item(_make_session(), "nuke", "critical")
+        assert item.get("needs_approval") is False
+        assert "critical" in item["error"]
+
+    def test_low_risk_load_allowed_for_model(self) -> None:
+        item = self._load_item(_make_session(), "safe", "low")
+        assert item.get("needs_approval") is True
+        assert item["action"] == "load"
+        assert item["name"] == "safe"
+
+    def test_no_risk_load_allowed_for_model(self) -> None:
+        item = self._load_item(_make_session(), "plain", "")
+        assert item.get("needs_approval") is True
+
+    def test_missing_skill_falls_through_to_exec_not_found(self) -> None:
+        # Unknown name → the gate finds no row and passes through; the
+        # not-found error is the exec path's job, so prep still asks for
+        # approval rather than erroring on the gate.
+        session = _make_session()
+        with patch("turnstone.core.session.get_storage") as gs:
+            gs.return_value.get_prompt_template_by_name.return_value = None
+            item = session._prepare_skills("c1", {"action": "load", "name": "ghost"})
+        assert item.get("needs_approval") is True

--- a/tests/test_substitute_skill_args.py
+++ b/tests/test_substitute_skill_args.py
@@ -2,12 +2,13 @@
 substitution applied to skill bodies at load time.
 
 Covers every placeholder form Turnstone implements — including the
-``${TURNSTONE_*}`` canonical env vars and their ``${CLAUDE_*}``
-back-compat aliases, and ``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}``
-resolution when the caller supplies a materialized bundle path — plus the
-spec's "append ARGUMENTS at end if no placeholder" rule and the
-single-pass guarantee against re-expansion of user-supplied values that
-happen to contain placeholder syntax.
+``${TURNSTONE_*}`` canonical env vars and the ``${CLAUDE_SESSION_ID}`` /
+``${CLAUDE_EFFORT}`` back-compat aliases (there is deliberately NO
+``CLAUDE_SKILL_DIR`` alias), ``${TURNSTONE_SKILL_DIR}`` resolution when the
+caller supplies a materialized bundle path, plus the spec's "append
+ARGUMENTS at end if no placeholder" rule and the single-pass guarantee
+against re-expansion of user-supplied values that happen to contain
+placeholder syntax.
 """
 
 from __future__ import annotations
@@ -159,10 +160,11 @@ class TestEnvironmentAliases:
 
 
 class TestSkillDir:
-    """``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}`` resolve to the
-    materialized bundle path when the caller supplies one (it materializes
-    resources BEFORE substituting), and degrade to a literal placeholder
-    when the skill bundles no resources."""
+    """``${TURNSTONE_SKILL_DIR}`` resolves to the materialized bundle path when
+    the caller supplies one (it materializes resources BEFORE substituting) and
+    degrades to a literal placeholder when the skill bundles no resources.
+    ``${CLAUDE_SKILL_DIR}`` is NOT a turnstone alias — it always stays literal
+    (that name is the host's in bash; turnstone claims neither surface)."""
 
     def test_turnstone_skill_dir_resolves(self) -> None:
         out = _substitute_skill_args(
@@ -175,7 +177,10 @@ class TestSkillDir:
         )
         assert out == "cd /tmp/skill-xyz/scripts"
 
-    def test_claude_skill_dir_alias_resolves(self) -> None:
+    def test_claude_skill_dir_not_aliased(self) -> None:
+        # Even with a materialized bundle, ${CLAUDE_SKILL_DIR} is left literal:
+        # turnstone owns TURNSTONE_SKILL_DIR only, so the two never diverge from
+        # the bash env (which likewise never sets CLAUDE_SKILL_DIR).
         out = _substitute_skill_args(
             "cd ${CLAUDE_SKILL_DIR}",
             arguments_str="",
@@ -184,7 +189,7 @@ class TestSkillDir:
             effort="high",
             skill_dir="/tmp/skill-xyz",
         )
-        assert out == "cd /tmp/skill-xyz"
+        assert out == "cd ${CLAUDE_SKILL_DIR}"
 
     def test_skill_dir_left_literal_when_unset(self) -> None:
         # Default skill_dir="" → placeholder stays literal (graceful),
@@ -234,3 +239,45 @@ class TestIntegration:
             "Named: 123 resolved on main.\n"
             "Full: 123 main"
         )
+
+
+class TestSubstituteArgsToggle:
+    """``substitute_args=False`` (capability contexts: defaults, task_agent)
+    leaves every invocation-arg form LITERAL while still resolving env vars,
+    so literal ``$1`` / ``$ARGUMENTS`` prose or shell text isn't blanked."""
+
+    def test_arg_forms_left_literal(self) -> None:
+        out = _substitute_skill_args(
+            "run $0 $1 $ARGUMENTS $ARGUMENTS[2] $named",
+            arguments_str="a b c",  # present, but ignored under substitute_args=False
+            arg_names=["named"],
+            ws_id="ws-abc",
+            effort="high",
+            substitute_args=False,
+        )
+        assert out == "run $0 $1 $ARGUMENTS $ARGUMENTS[2] $named"
+
+    def test_env_still_resolves(self) -> None:
+        out = _substitute_skill_args(
+            "id ${TURNSTONE_SESSION_ID} at ${TURNSTONE_EFFORT} in ${TURNSTONE_SKILL_DIR}",
+            arguments_str="",
+            arg_names=[],
+            ws_id="ws-abc",
+            effort="high",
+            skill_dir="/tmp/skill-x",
+            substitute_args=False,
+        )
+        assert out == "id ws-abc at high in /tmp/skill-x"
+
+    def test_no_append_when_args_disabled(self) -> None:
+        # The append-ARGUMENTS-at-end rule must not fire when arg substitution
+        # is off, even if arguments_str is non-empty.
+        out = _substitute_skill_args(
+            "body with no placeholder",
+            arguments_str="x y",
+            arg_names=[],
+            ws_id="ws-abc",
+            effort="high",
+            substitute_args=False,
+        )
+        assert out == "body with no placeholder"

--- a/tests/test_substitute_skill_args.py
+++ b/tests/test_substitute_skill_args.py
@@ -1,10 +1,13 @@
 """Unit tests for ``_substitute_skill_args`` — SKILL.md spec placeholder
 substitution applied to skill bodies at load time.
 
-Covers every placeholder form Turnstone implements (``${CLAUDE_SKILL_DIR}``
-is deferred — see #572) plus the spec's "append ARGUMENTS at end if no
-placeholder" rule and the single-pass guarantee against re-expansion of
-user-supplied values that happen to contain placeholder syntax.
+Covers every placeholder form Turnstone implements — including the
+``${TURNSTONE_*}`` canonical env vars and their ``${CLAUDE_*}``
+back-compat aliases, and ``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}``
+resolution when the caller supplies a materialized bundle path — plus the
+spec's "append ARGUMENTS at end if no placeholder" rule and the
+single-pass guarantee against re-expansion of user-supplied values that
+happen to contain placeholder syntax.
 """
 
 from __future__ import annotations
@@ -134,6 +137,60 @@ class TestEnvironment:
 
     def test_unknown_env_left_as_literal(self) -> None:
         assert _sub("${CLAUDE_UNKNOWN_FOO}") == "${CLAUDE_UNKNOWN_FOO}"
+
+
+class TestEnvironmentAliases:
+    """``TURNSTONE_*`` is the canonical, vendor-neutral spelling;
+    ``CLAUDE_*`` is a permanent back-compat alias so skills imported from
+    Claude Code / skills.sh keep resolving.  Both map to one value."""
+
+    def test_turnstone_session_id(self) -> None:
+        assert _sub("session ${TURNSTONE_SESSION_ID}") == "session ws-abc"
+
+    def test_turnstone_effort(self) -> None:
+        assert _sub("effort ${TURNSTONE_EFFORT}") == "effort high"
+
+    def test_canonical_and_alias_agree(self) -> None:
+        assert _sub("${CLAUDE_SESSION_ID}") == _sub("${TURNSTONE_SESSION_ID}") == "ws-abc"
+        assert _sub("${CLAUDE_EFFORT}") == _sub("${TURNSTONE_EFFORT}") == "high"
+
+    def test_unknown_turnstone_var_left_as_literal(self) -> None:
+        assert _sub("${TURNSTONE_UNKNOWN_FOO}") == "${TURNSTONE_UNKNOWN_FOO}"
+
+
+class TestSkillDir:
+    """``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}`` resolve to the
+    materialized bundle path when the caller supplies one (it materializes
+    resources BEFORE substituting), and degrade to a literal placeholder
+    when the skill bundles no resources."""
+
+    def test_turnstone_skill_dir_resolves(self) -> None:
+        out = _substitute_skill_args(
+            "cd ${TURNSTONE_SKILL_DIR}/scripts",
+            arguments_str="",
+            arg_names=[],
+            ws_id="ws-abc",
+            effort="high",
+            skill_dir="/tmp/skill-xyz",
+        )
+        assert out == "cd /tmp/skill-xyz/scripts"
+
+    def test_claude_skill_dir_alias_resolves(self) -> None:
+        out = _substitute_skill_args(
+            "cd ${CLAUDE_SKILL_DIR}",
+            arguments_str="",
+            arg_names=[],
+            ws_id="ws-abc",
+            effort="high",
+            skill_dir="/tmp/skill-xyz",
+        )
+        assert out == "cd /tmp/skill-xyz"
+
+    def test_skill_dir_left_literal_when_unset(self) -> None:
+        # Default skill_dir="" → placeholder stays literal (graceful),
+        # not an empty path.
+        assert _sub("${TURNSTONE_SKILL_DIR}") == "${TURNSTONE_SKILL_DIR}"
+        assert _sub("${CLAUDE_SKILL_DIR}") == "${CLAUDE_SKILL_DIR}"
 
 
 class TestSinglePassGuarantee:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -786,6 +786,18 @@ def _without_tool(tools: list[dict[str, Any]], name: str) -> list[dict[str, Any]
     return [t for t in tools if t.get("function", {}).get("name") != name]
 
 
+def _is_mcp_surface_tool(name: str) -> bool:
+    """Whether *name* is an MCP-surfaced tool an mcp-off persona should not see.
+
+    Covers both a server tool (``mcp__{server}__{tool}`` — see
+    ``mcp_client`` naming) and the MCP-access native tools (``read_resource`` /
+    ``use_prompt``).  An mcp-off main session sheds these by nulling its client;
+    a sub-agent, which reuses the parent's ``_task_tools``, sheds them by this
+    name filter instead.
+    """
+    return name.startswith("mcp__") or name in ("read_resource", "use_prompt")
+
+
 def _render_template(content: str, context: dict[str, str]) -> str:
     """Replace ``{{variable}}`` placeholders in a single pass.
 
@@ -807,8 +819,16 @@ def _substitute_skill_args(
     ws_id: str,
     effort: str,
     skill_dir: str = "",
+    substitute_args: bool = True,
 ) -> str:
     """Apply SKILL.md spec placeholder substitution.
+
+    When *substitute_args* is False the invocation-arg forms
+    (``$ARGUMENTS`` / ``$ARGUMENTS[N]`` / ``$N`` / ``$<name>``) are left
+    LITERAL and only the ``${…}`` env vars resolve — for capability
+    contexts (defaults, ``task_agent``) that are never invoked with args,
+    where a literal ``$1`` or ``$ARGUMENTS`` in the body is prose or shell
+    text, not a placeholder to blank.
 
     Handles every spec placeholder form:
 
@@ -825,11 +845,15 @@ def _substitute_skill_args(
       back-compat alias so skills imported from Claude Code / skills.sh
       keep resolving.  Both map to the same value.
     * ``${TURNSTONE_EFFORT}`` / ``${CLAUDE_EFFORT}`` — reasoning_effort
-    * ``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}`` — absolute
-      path of the materialized resource bundle, resolved when *skill_dir*
-      is supplied (the caller materializes resources BEFORE substituting)
-      and left literal otherwise, so a skill that bundles no resources
-      degrades gracefully rather than emitting an empty path.
+    * ``${TURNSTONE_SKILL_DIR}`` — absolute path of the materialized
+      resource bundle, resolved when *skill_dir* is supplied (the caller
+      materializes resources BEFORE substituting) and left literal
+      otherwise, so a skill that bundles no resources degrades gracefully
+      rather than emitting an empty path.  Unlike the session/effort vars
+      there is deliberately NO ``CLAUDE_SKILL_DIR`` alias: that name also
+      lives in bash, where turnstone-as-a-node-inside-Claude-Code must not
+      shadow the host's value — so turnstone claims it in neither surface
+      and leaves the foreign name entirely to the host.
 
     Single-pass: a value containing a placeholder token (e.g.
     ``$0='$ARGUMENTS'``) does not get re-expanded.  Matches the
@@ -864,18 +888,25 @@ def _substitute_skill_args(
         "CLAUDE_EFFORT": effort,
     }
     if skill_dir:
+        # TURNSTONE_SKILL_DIR only — NO CLAUDE_SKILL_DIR alias.  That name is
+        # the host's in bash (see _skill_resource_env), so turnstone claims it
+        # in neither surface to avoid a prompt-vs-bash divergence.
         env["TURNSTONE_SKILL_DIR"] = skill_dir
-        env["CLAUDE_SKILL_DIR"] = skill_dir
 
     def _at(idx_str: str) -> str:
         idx = int(idx_str)  # regex guarantees digits
         return positional[idx] if 0 <= idx < len(positional) else ""
 
     def _replace(m: re.Match[str]) -> str:
-        if m.group("idx_bracket") is not None:
-            return _at(m.group("idx_bracket"))
         if m.group("env") is not None:
             return env.get(m.group("env"), m.group(0))
+        if not substitute_args:
+            # Capability contexts never receive invocation args, so a literal
+            # $ARGUMENTS/$N/$name is prose or shell text — leave it untouched
+            # rather than blanking it.  Only the env vars above resolve.
+            return m.group(0)
+        if m.group("idx_bracket") is not None:
+            return _at(m.group("idx_bracket"))
         if m.group("idx_short") is not None:
             return _at(m.group("idx_short"))
         if m.group("named") is not None:
@@ -887,11 +918,17 @@ def _substitute_skill_args(
         # Match is the bare $ARGUMENTS literal (no named groups).
         return arguments_str or ""
 
-    had_literal_arguments = bool(_SPEC_ARGUMENTS_LITERAL_RE.search(content))
     rendered = _SPEC_PLACEHOLDER_RE.sub(_replace, content)
 
-    if arguments_str and not had_literal_arguments:
-        rendered = f"{rendered}\n\nARGUMENTS: {arguments_str}"
+    # The spec's append-ARGUMENTS-at-end rule only applies when args are being
+    # substituted at all — capability contexts (substitute_args=False) ignore
+    # invocation args entirely, so they must not append them either.  The
+    # literal-$ARGUMENTS scan is only consumed on that path, so defer it behind
+    # the guard rather than scanning every default / task_agent capability body.
+    if substitute_args and arguments_str:
+        had_literal_arguments = bool(_SPEC_ARGUMENTS_LITERAL_RE.search(content))
+        if not had_literal_arguments:
+            rendered = f"{rendered}\n\nARGUMENTS: {arguments_str}"
 
     return rendered
 
@@ -2132,6 +2169,7 @@ class ChatSession:
         arguments_str: str = "",
         arg_names: list[str] | None = None,
         skill_dir: str | None = None,
+        substitute_args: bool = True,
     ) -> str:
         """Render one skill body through the single substitution path.
 
@@ -2146,8 +2184,11 @@ class ChatSession:
 
         Every invocation context routes through here — interactive load,
         default skills, and ``task_agent`` sub-agents — so a skill reading
-        ``${TURNSTONE_EFFORT}`` or ``$ARGUMENTS`` resolves identically
-        wherever it runs, instead of rendering literally in some paths.
+        ``${TURNSTONE_EFFORT}`` resolves identically wherever it runs.
+        *substitute_args* is False for capability contexts that never
+        receive invocation args (defaults, ``task_agent``): there a literal
+        ``$1`` / ``$ARGUMENTS`` is prose or shell text and is left
+        untouched, while env vars still resolve.
         """
         context = {
             "model": self.model,
@@ -2163,6 +2204,7 @@ class ChatSession:
             ws_id=self._ws_id,
             effort=effort,
             skill_dir=skill_dir or "",
+            substitute_args=substitute_args,
         )
 
     def _load_skills(self) -> None:
@@ -2223,7 +2265,9 @@ class ChatSession:
                 # subs (``${TURNSTONE_SESSION_ID}`` / ``${TURNSTONE_EFFORT}``)
                 # still resolve.  Defaults carry no per-skill resource bundle,
                 # so ``skill_dir`` is omitted.
-                parts = [self._render_skill_body(t["content"]) for t in defaults]
+                parts = [
+                    self._render_skill_body(t["content"], substitute_args=False) for t in defaults
+                ]
                 self._skill_content = "\n\n".join(parts)
             else:
                 self._skill_content = None
@@ -2359,11 +2403,11 @@ class ChatSession:
         The bundle dir is exported as canonical ``TURNSTONE_SKILL_DIR`` and
         the original ``SKILL_RESOURCES_DIR`` (back-compat for existing skills
         and the ``$SKILL_RESOURCES_DIR`` disclosure hint), both pointing at
-        the same directory.  ``CLAUDE_SKILL_DIR`` is added as a portability
-        alias for imported Claude Code / skills.sh skills, but ONLY when the
-        host hasn't already set it: ``CLAUDE_SKILL_DIR`` is another vendor's
-        namespace, and turnstone running as a node inside Claude Code must
-        not shadow the host's real value.
+        the same directory.  There is deliberately NO ``CLAUDE_SKILL_DIR``:
+        that is another vendor's namespace, and turnstone running as a node
+        inside Claude Code must leave the host's value untouched — so turnstone
+        neither exports it here nor substitutes it in the prompt (see
+        ``_substitute_skill_args``), keeping the two surfaces in agreement.
         """
         if not self._skill_resources_dir:
             return {}
@@ -2371,8 +2415,6 @@ class ChatSession:
             "SKILL_RESOURCES_DIR": self._skill_resources_dir,
             "TURNSTONE_SKILL_DIR": self._skill_resources_dir,
         }
-        if "CLAUDE_SKILL_DIR" not in os.environ:
-            env["CLAUDE_SKILL_DIR"] = self._skill_resources_dir
         scripts_dir = os.path.join(self._skill_resources_dir, "scripts")
         if os.path.isdir(scripts_dir):
             current_path = os.environ.get("PATH")
@@ -3519,54 +3561,59 @@ class ChatSession:
                     "to invoke the prompts listed above."
                 )
                 dev_parts.append("\n".join(lines))
-        # Applied-skill body is CAPABILITY context, not identity — build it
-        # into its own block, delivered below as a separate (user-role)
-        # message rather than concatenated into the identity system prefix.
-        # Keeping it off that prefix means skills(load) no longer busts the
-        # cached identity block, and the skill never reads as who-the-agent-is.
-        # PRE-MERGE GATE: the model-adherence eval this vs main (design §7 Q1)
-        # is NOT run in-tree — it must clear before this branch merges.
+        # Applied-skill body is CAPABILITY context, not identity.  A NAMED
+        # applied skill (loaded via /skill or skills(load)) is the only
+        # mid-session-changeable skill and thus the only one that would bust the
+        # cached identity block, so its body is delivered below as a separate
+        # (user-role) message, off the identity system prefix — it never reads
+        # as who-the-agent-is and no longer invalidates the identity cache.
+        # DEFAULT (always-on) skills are set at init, never change mid-session,
+        # and are the standing baseline, so they stay in the identity system
+        # message where their guidance keeps system-level weight.
+        # PRE-MERGE GATE: the §7 Q1 model-adherence eval (this branch vs main)
+        # covers ONLY the named-skill move; it is not run in-tree and must clear
+        # before this branch merges.
         skill_context = ""
         if self._skill_content:
             tpl = self._skill_content
             if len(tpl) > _MAX_SKILL_CONTENT:
                 log.warning("skill_content.truncated", length=len(tpl))
                 tpl = tpl[:_MAX_SKILL_CONTENT]
-            if self._skill_name:
+            if not self._skill_name:
+                # Default (always-on) skills: keep in the identity system prefix.
+                dev_parts.append("")
+                dev_parts.append(tpl)
+            else:
                 intro = (
                     f"The following is the guidance for your active skill "
                     f"'{self._skill_name}'. Apply it throughout this session."
                 )
-            else:
-                intro = (
-                    "The following is your active skill guidance. Apply it throughout this session."
-                )
-            skill_parts = [intro, "", tpl]
-            if self._skill_resources:
-                lines = ["<skill-resources>"]
-                total_size = 0
-                for rpath, rcontent in sorted(self._skill_resources.items()):
-                    size_kb = f"{len(rcontent) / 1024:.1f}KB"
-                    total_size += len(rcontent)
-                    lines.append(f"- {rpath} ({size_kb})")
-                if total_size <= 8192:
+                skill_parts = [intro, "", tpl]
+                if self._skill_resources:
+                    lines = ["<skill-resources>"]
+                    total_size = 0
                     for rpath, rcontent in sorted(self._skill_resources.items()):
-                        lines.append(f"\n--- {rpath} ---")
-                        lines.append(rcontent)
-                else:
-                    lines.append(
-                        "Resource content omitted (total exceeds 8KB). "
-                        "Resource files are listed above by path and size."
-                    )
-                if self._skill_resources_dir:
-                    lines.append(
-                        "\nResource files are materialized on disk. "
-                        "Scripts in scripts/ are on PATH and can be run by name. "
-                        "All files are under $SKILL_RESOURCES_DIR."
-                    )
-                lines.append("</skill-resources>")
-                skill_parts.append("\n".join(lines))
-            skill_context = "\n".join(skill_parts)
+                        size_kb = f"{len(rcontent) / 1024:.1f}KB"
+                        total_size += len(rcontent)
+                        lines.append(f"- {rpath} ({size_kb})")
+                    if total_size <= 8192:
+                        for rpath, rcontent in sorted(self._skill_resources.items()):
+                            lines.append(f"\n--- {rpath} ---")
+                            lines.append(rcontent)
+                    else:
+                        lines.append(
+                            "Resource content omitted (total exceeds 8KB). "
+                            "Resource files are listed above by path and size."
+                        )
+                    if self._skill_resources_dir:
+                        lines.append(
+                            "\nResource files are materialized on disk. "
+                            "Scripts in scripts/ are on PATH and can be run by name. "
+                            "All files are under $SKILL_RESOURCES_DIR."
+                        )
+                    lines.append("</skill-resources>")
+                    skill_parts.append("\n".join(lines))
+                skill_context = "\n".join(skill_parts)
         # Skill catalog: disclose search-activated skills so the model
         # knows they exist (Agent Skills standard progressive disclosure).
         try:
@@ -3601,11 +3648,12 @@ class ChatSession:
             # Composed against a real user-message query at least once; send()
             # uses this to know the deferred first-turn recompose is done.
             self._system_composed_with_context = True
-        # Persona lever 4 (own hands only): memory-off suppresses recalled-
-        # memory injection here, the nudges at their producer sites, and the
-        # memory tool via the visibility filter.  Task agents keep their own
-        # memory tool (``_task_tools`` is not persona-filtered), and
-        # compaction spill/markers are session mechanics — never gated.
+        # Persona lever 4: memory-off suppresses recalled-memory injection
+        # here, the nudges at their producer sites, and the memory tool via the
+        # visibility filter.  Sub-agents (task_agent) are persona-filtered at
+        # the delegation edge too now (see _exec_task), so a memory-off persona
+        # drops their memory tool as well; compaction spill/markers are session
+        # mechanics — never gated.
         visible_mems, candidate_source = (
             self._select_memory_candidates(context) if self._persona_memory else ([], "")
         )
@@ -7662,6 +7710,9 @@ class ChatSession:
                 it["func_args"] = {
                     "prompt": honest_truncate(it.get("prompt") or "", arg_budget),
                     "skill": skill_dict.get("name", "") if isinstance(skill_dict, dict) else "",
+                    # Persona swaps the sub-agent's identity/authority — the
+                    # judge and audit row must see it, mirroring spawn_workstream.
+                    "persona": it.get("persona") or "",
                     "model_override": it.get("model_override") or "",
                 }
             # Coordinator tool args — only the ``needs_approval=True`` set
@@ -9600,6 +9651,22 @@ class ChatSession:
                         "Use skills(action='find', query='...') to find available names."
                     ),
                 }
+            # Risk gate: high/critical-risk skills are PRINCIPAL-load-only — the
+            # same bar skills(load) / spawn_workstream / spawn_batch enforce via
+            # _high_risk_skill_denied.  task_agent is a model-initiated
+            # activation surface too, so a sub-agent must not route around it.
+            # Enforced on the row we ALREADY fetched (no re-query, no drift
+            # between get_skill_by_name and get_prompt_template_by_name).
+            risk_tier = skill_data.get("risk_level", "")
+            if risk_tier in ("high", "critical"):
+                return {
+                    "call_id": call_id,
+                    "func_name": "task_agent",
+                    "header": f"✗ task_agent: skill '{skill_arg}' is principal-load-only",
+                    "preview": "",
+                    "needs_approval": False,
+                    "error": f"Error: {self._principal_load_only_msg(skill_arg, risk_tier)}",
+                }
             # ``get_skill_by_name`` returns the full prompt_templates row
             # (~30 columns including ``scan_report``, ``installed_by``,
             # ``source_url``, etc.).  Project to the minimal field set
@@ -9611,45 +9678,63 @@ class ChatSession:
                 "content": skill_data["content"],
                 "risk_level": skill_data.get("risk_level", ""),
             }
-        # Persona = the sub-agent's identity (system prompt).  Validated at
-        # prep against the interactive kind (the general-purpose personas a
-        # worker can adopt) so an invalid name becomes a clean tool error the
-        # model can react to, not a mid-exec surprise.  The resolved BASE text
-        # is frozen into the item; ``_exec_task`` never re-reads storage.
-        # Omitted → the default autonomous task-agent identity.
+        # Persona = the sub-agent's identity AND its authority envelope.
+        # Validated at prep against the interactive kind (the general-purpose
+        # personas a worker can adopt) so an invalid name becomes a clean tool
+        # error the model can react to, not a mid-exec surprise.  All four
+        # levers — prompt (identity), tools + mcp + memory (authority) — are
+        # frozen into the item; ``_exec_task`` never re-reads storage.  A
+        # restrictive persona must actually restrict the sub-agent (Principle 7
+        # attenuation), not merely relabel its identity.  Omitted → default
+        # identity, full tools.
         persona_arg = (args.get("persona") or "").strip()
         persona_prompt = ""
+        persona_tools: frozenset[str] | None = None
+        persona_mcp = True
+        persona_memory = True
         if persona_arg:
-            row, perr = resolve_persona_for_kind(get_storage(), persona_arg, "interactive")
-            if perr or row is None:
-                detail = perr or f"unknown persona {persona_arg!r}"
+            try:
+                row, perr = resolve_persona_for_kind(get_storage(), persona_arg, "interactive")
+                if perr or row is None:
+                    detail = perr or f"unknown persona {persona_arg!r}"
+                    return {
+                        "call_id": call_id,
+                        "func_name": "task_agent",
+                        "header": f"✗ task_agent: {detail}",
+                        "preview": "",
+                        "needs_approval": False,
+                        "error": (
+                            f"Error: {detail}. Omit `persona` for the default task-agent identity."
+                        ),
+                    }
+                snap = snapshot_from_persona(row)
+            except Exception:
+                # Match the spawn path's defensive posture
+                # (_validate_child_persona): a storage blip or a drifted
+                # base_prompt file becomes a clean tool error the model can
+                # react to, not an opaque "internal error preparing task_agent".
+                log.debug("task_agent.persona_resolve_failed", persona=persona_arg, exc_info=True)
                 return {
                     "call_id": call_id,
                     "func_name": "task_agent",
-                    "header": f"✗ task_agent: {detail}",
+                    "header": f"✗ task_agent: could not resolve persona '{persona_arg}'",
                     "preview": "",
                     "needs_approval": False,
                     "error": (
-                        f"Error: {detail}. Omit `persona` for the default task-agent identity."
+                        f"Error: could not resolve persona '{persona_arg}' (storage "
+                        "unavailable). Retry, or omit `persona` for the default identity."
                     ),
                 }
-            persona_prompt = snapshot_from_persona(row).prompt
+            persona_prompt = snap.prompt
+            persona_tools = snap.tools
+            persona_mcp = snap.mcp
+            persona_memory = snap.memory
         preview_text = prompt[:300] + ("..." if len(prompt) > 300 else "")
         header = "\u2699 task_agent (autonomous agent"
         if skill_data:
+            # High/critical skills were denied above (principal-load-only), so a
+            # skill that reaches here is safe-tier — just name it in the header.
             header += f", skill: {skill_data['name']}"
-            # Surface high/critical risk at approval time so the operator
-            # sees the same signal ``_load_skills`` emits for session-level
-            # skills (session.py:1336).  Log mirrors that path's structured
-            # event for forensic continuity.
-            risk_tier = skill_data.get("risk_level", "")
-            if risk_tier in ("high", "critical"):
-                header += f", risk: {risk_tier}"
-                log.warning(
-                    "task_agent.high_risk_skill",
-                    skill=skill_data["name"],
-                    risk_level=risk_tier,
-                )
         if persona_arg:
             header += f", persona: {persona_arg}"
         header += ")"
@@ -9666,6 +9751,9 @@ class ChatSession:
             "skill": skill_data,
             "persona": persona_arg,
             "persona_prompt": persona_prompt,
+            "persona_tools": persona_tools,
+            "persona_mcp": persona_mcp,
+            "persona_memory": persona_memory,
         }
 
     def _resolve_scope_id(self, scope: str) -> str:
@@ -10393,6 +10481,12 @@ class ChatSession:
             persona_err = self._validate_child_persona(persona)
             if persona_err:
                 return self._coord_tool_error(call_id, "spawn_workstream", persona_err)
+        if skill:
+            # Same principal-load-only gate as skills(load): a high/critical-risk
+            # skill must not be model-activated by handing it to a child.
+            skill_err = self._high_risk_skill_denied(skill)
+            if skill_err:
+                return self._coord_tool_error(call_id, "spawn_workstream", skill_err)
         if initial_message:
             first_line = initial_message.splitlines()[0]
             preview_line = first_line[:120] + ("..." if len(first_line) > 120 else "")
@@ -10539,6 +10633,7 @@ class ChatSession:
         # Persona prechecks hit storage; a fan-out batch usually repeats one
         # persona across all children, so memoize per prepare call.
         persona_verdicts: dict[str, str] = {}
+        skill_verdicts: dict[str, str] = {}
         for idx, raw in enumerate(raw_children):
             if not isinstance(raw, dict):
                 normalised.append({"idx": idx, "_error": "child spec must be an object"})
@@ -10570,6 +10665,14 @@ class ChatSession:
                     persona_verdicts[persona] = self._validate_child_persona(persona)
                 if persona_verdicts[persona]:
                     spec["_error"] = persona_verdicts[persona]
+            if skill and not spec.get("_error"):
+                # Same principal-load-only risk gate as spawn_workstream,
+                # surfaced per-row (partial-success) rather than failing the
+                # whole batch.  Memoized: a fan-out usually repeats one skill.
+                if skill not in skill_verdicts:
+                    skill_verdicts[skill] = self._high_risk_skill_denied(skill)
+                if skill_verdicts[skill]:
+                    spec["_error"] = skill_verdicts[skill]
             normalised.append(spec)
             if spec.get("_error"):
                 preview_rows.append(f"  {idx}. [invalid — {spec['_error']}]")
@@ -11616,6 +11719,57 @@ class ChatSession:
 
     # -- load -------------------------------------------------------------------
 
+    @staticmethod
+    def _principal_load_only_msg(name: str, tier: str) -> str:
+        """The canonical denial wording for a principal-load-only skill.
+
+        Single-sourced so every activation surface (skills(load), spawn_*,
+        task_agent) speaks with one voice — the model keys its recovery path
+        off this text, so it must not drift between callers.
+        """
+        return (
+            f"skill '{name}' has risk tier '{tier}' and can only be "
+            f"activated by the operator. Ask the user to run /skill {name} — the "
+            f"model cannot load or assign it."
+        )
+
+    def _high_risk_skill_denied(self, name: str) -> str:
+        """Return a denial message when *name* is a high/critical-risk skill the
+        model may not activate, else ``""``.
+
+        Design §5.5 / HYPOTHESIS Principle 7: such a skill is PRINCIPAL-load-only
+        — the model must not activate it through any tools path (an injection-
+        steerable lane that would widen authority behind a rubber-stampable
+        approval; the scanner escalates risk precisely for the auto_approve +
+        allowed_tools authority the create path warns about).  The operator
+        loads it explicitly with ``/skill`` (handle_command / cli --skill call
+        set_skill directly and bypass this gate).  This is the shared check for
+        the model-initiated activation surfaces that resolve the row by name —
+        skills(load) AND spawn_workstream / spawn_batch(skill=…) — so the gate
+        cannot be routed around by delegating activation to a spawned child.
+        ``task_agent`` enforces the same bar inline on the row it already
+        fetched (see ``_prepare_task``).  Narrowing-only: it can DENY, never
+        widen, so it is safe by construction.
+        """
+        storage = get_storage()
+        if storage is None:
+            return ""
+        try:
+            row = storage.get_prompt_template_by_name(name)
+        except Exception:
+            # Fail CLOSED: a risk gate that can't read the row must DENY, never
+            # wave the skill through.  Denying (not returning "") also keeps
+            # spawn_batch's per-row partial-success intact — one child's lookup
+            # fault denies only that child, not the whole batch.
+            log.warning("skill.risk_gate_lookup_failed", skill=name, exc_info=True)
+            return (
+                f"skill '{name}' could not be risk-checked (storage unavailable) "
+                f"and was not activated. Retry, or ask the operator to run /skill {name}."
+            )
+        if row and row.get("risk_level") in ("high", "critical"):
+            return self._principal_load_only_msg(name, row["risk_level"])
+        return ""
+
     def _prepare_skills_load(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         # Both kinds can ``load`` — interactive sessions replace their own
         # persona, coordinator sessions do the same for their orchestrator.
@@ -11632,26 +11786,12 @@ class ChatSession:
         name = self._coord_str_arg(args, "name").strip()
         if not name:
             return self._coord_tool_error(call_id, "skills", "load: 'name' is required")
-        # Risk gate (design §5.5 / HYPOTHESIS Principle 7): a high/critical-risk
-        # skill is PRINCIPAL-load-only.  The model must not activate it through
-        # the tools path — an injection-steerable lane that would widen
-        # authority behind a rubber-stampable approval (the scanner escalates
-        # risk precisely for the auto_approve + allowed_tools authority the
-        # create path warns about).  The operator loads such a skill explicitly
-        # with ``/skill``; that path (handle_command / cli --skill) calls
-        # set_skill directly and bypasses this gate.  A narrowing check — it can
-        # only DENY, never widen — so it is safe by construction.
-        storage = get_storage()
-        if storage is not None:
-            row = storage.get_prompt_template_by_name(name)
-            if row and row.get("risk_level") in ("high", "critical"):
-                return self._coord_tool_error(
-                    call_id,
-                    "skills",
-                    f"load: skill '{name}' has risk tier '{row['risk_level']}' and can "
-                    f"only be activated by the operator. Ask the user to run "
-                    f"/skill {name} if they want it — the model cannot load it.",
-                )
+        # Risk gate: a high/critical-risk skill is principal-load-only.  Shared
+        # with the spawn paths (see _high_risk_skill_denied) so delegating
+        # activation to a child cannot route around it.
+        block = self._high_risk_skill_denied(name)
+        if block:
+            return self._coord_tool_error(call_id, "skills", f"load: {block}")
         # SKILL.md spec ``$ARGUMENTS`` payload — optional.  Mirror
         # the spec's free-form string shape (``/skill-name a b "c d"``)
         # rather than a list, so the model can pass quoted positional
@@ -14342,7 +14482,7 @@ class ChatSession:
             # defaults and spawn-child paths) and ``${TURNSTONE_*}`` env vars
             # resolve; ``skill_dir`` is unset (sub-agent bundles aren't
             # materialized yet), leaving ``${TURNSTONE_SKILL_DIR}`` literal.
-            skill_body = self._render_skill_body(skill_data["content"])
+            skill_body = self._render_skill_body(skill_data["content"], substitute_args=False)
             if len(skill_body) > _MAX_SKILL_CONTENT:
                 log.warning(
                     "skill_content.truncated",
@@ -14353,6 +14493,36 @@ class ChatSession:
                 skill_body = skill_body[:_MAX_SKILL_CONTENT]
             agent_turns.append(Turn.user(self._TASK_SKILL_CAPABILITY_PREAMBLE + skill_body))
         agent_turns.append(Turn.user(prompt))
+        # Attenuate the sub-agent's tools (Principle 7): authority narrows down
+        # a delegation edge, never widens.  TWO envelopes apply, both narrowing
+        # (filtering the available set is sufficient — a tool absent from the
+        # list can't be called, so it can't be auto-approved whatever
+        # ``auto_tools`` says):
+        #   1. the PARENT session's own persona grant — a restricted principal
+        #      must not escalate by spawning.  ``_apply_persona_visibility`` is a
+        #      no-op when the parent has no restrictive persona, and already
+        #      honours the parent's tools + memory levers (parent mcp-off is
+        #      reflected in ``_task_tools`` at construction).
+        #   2. the CHILD persona (``task_agent persona=…``) — its tools, mcp,
+        #      and memory levers confine the sub-agent exactly as they would a
+        #      main session that adopted the persona.
+        task_tools = self._apply_persona_visibility(self._task_tools)
+        persona_tools = item.get("persona_tools")
+        if persona_tools is not None:
+            task_tools = [
+                t for t in task_tools if t.get("function", {}).get("name") in persona_tools
+            ]
+        if not item.get("persona_mcp", True):
+            # Child persona mcp-off: shed MCP server tools + MCP-access tools,
+            # mirroring how an mcp-off main session sheds them (nulled client).
+            task_tools = [
+                t
+                for t in task_tools
+                if not _is_mcp_surface_tool(t.get("function", {}).get("name", ""))
+            ]
+        if not item.get("persona_memory", True):
+            # Child persona memory-off: drop the memory tool from its hands.
+            task_tools = [t for t in task_tools if t.get("function", {}).get("name") != "memory"]
         self._begin_agent_scope()
         # Per-sub-agent file-read tracking.  COPY the parent's current set in (so
         # the agent can edit a file the parent already read for it — no spurious
@@ -14364,7 +14534,7 @@ class ChatSession:
             result = self._run_agent(
                 agent_turns,
                 label="task",
-                tools=self._task_tools,
+                tools=task_tools,
                 auto_tools=TASK_AUTO_TOOLS,
                 agent_alias=item.get("model_override"),
                 parent_call_id=call_id,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -3519,13 +3519,29 @@ class ChatSession:
                     "to invoke the prompts listed above."
                 )
                 dev_parts.append("\n".join(lines))
+        # Applied-skill body is CAPABILITY context, not identity — build it
+        # into its own block, delivered below as a separate (user-role)
+        # message rather than concatenated into the identity system prefix.
+        # Keeping it off that prefix means skills(load) no longer busts the
+        # cached identity block, and the skill never reads as who-the-agent-is.
+        # PRE-MERGE GATE: the model-adherence eval this vs main (design §7 Q1)
+        # is NOT run in-tree — it must clear before this branch merges.
+        skill_context = ""
         if self._skill_content:
             tpl = self._skill_content
             if len(tpl) > _MAX_SKILL_CONTENT:
                 log.warning("skill_content.truncated", length=len(tpl))
                 tpl = tpl[:_MAX_SKILL_CONTENT]
-            dev_parts.append("")
-            dev_parts.append(tpl)
+            if self._skill_name:
+                intro = (
+                    f"The following is the guidance for your active skill "
+                    f"'{self._skill_name}'. Apply it throughout this session."
+                )
+            else:
+                intro = (
+                    "The following is your active skill guidance. Apply it throughout this session."
+                )
+            skill_parts = [intro, "", tpl]
             if self._skill_resources:
                 lines = ["<skill-resources>"]
                 total_size = 0
@@ -3549,7 +3565,8 @@ class ChatSession:
                         "All files are under $SKILL_RESOURCES_DIR."
                     )
                 lines.append("</skill-resources>")
-                dev_parts.append("\n".join(lines))
+                skill_parts.append("\n".join(lines))
+            skill_context = "\n".join(skill_parts)
         # Skill catalog: disclose search-activated skills so the model
         # knows they exist (Agent Skills standard progressive disclosure).
         try:
@@ -3626,10 +3643,18 @@ class ChatSession:
                     "Use memory(action='search') or memory(action='list') for more."
                 )
         new_system_messages.append({"role": "system", "content": "\n".join(dev_parts)})
+        # Agent prefix: the identity system block only (snapshotted BEFORE the
+        # skill block below) — a task_agent supplies its own persona identity
+        # and any skill as capability (see _exec_task), so the parent's applied
+        # skill no longer leaks into the sub-agent base.
+        self._agent_system_messages = list(new_system_messages)
+        # Applied-skill body rides its own capability message, off the cached
+        # identity prefix (see skill_context above).  PRE-MERGE GATE: the
+        # model-adherence eval this-vs-main (design §7 Q1) is not run in-tree.
+        if skill_context:
+            new_system_messages.append({"role": "user", "content": skill_context})
         # Atomic swap — readers see either old or new, never partial
         self.system_messages = new_system_messages
-        # Agent prefix: system + developer only (no memories)
-        self._agent_system_messages = list(new_system_messages)
 
     def _full_messages(self) -> list[dict[str, Any]]:
         """System messages + conversation history as wire dicts.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -119,6 +119,7 @@ from turnstone.core.personas import (
     PersonaSnapshot,
     resolve_persona_for_kind,
     snapshot_from_config,
+    snapshot_from_persona,
 )
 from turnstone.core.providers import create_provider
 from turnstone.core.ratelimit import TokenBucket
@@ -9585,6 +9586,29 @@ class ChatSession:
                 "content": skill_data["content"],
                 "risk_level": skill_data.get("risk_level", ""),
             }
+        # Persona = the sub-agent's identity (system prompt).  Validated at
+        # prep against the interactive kind (the general-purpose personas a
+        # worker can adopt) so an invalid name becomes a clean tool error the
+        # model can react to, not a mid-exec surprise.  The resolved BASE text
+        # is frozen into the item; ``_exec_task`` never re-reads storage.
+        # Omitted → the default autonomous task-agent identity.
+        persona_arg = (args.get("persona") or "").strip()
+        persona_prompt = ""
+        if persona_arg:
+            row, perr = resolve_persona_for_kind(get_storage(), persona_arg, "interactive")
+            if perr or row is None:
+                detail = perr or f"unknown persona {persona_arg!r}"
+                return {
+                    "call_id": call_id,
+                    "func_name": "task_agent",
+                    "header": f"✗ task_agent: {detail}",
+                    "preview": "",
+                    "needs_approval": False,
+                    "error": (
+                        f"Error: {detail}. Omit `persona` for the default task-agent identity."
+                    ),
+                }
+            persona_prompt = snapshot_from_persona(row).prompt
         preview_text = prompt[:300] + ("..." if len(prompt) > 300 else "")
         header = "\u2699 task_agent (autonomous agent"
         if skill_data:
@@ -9601,6 +9625,8 @@ class ChatSession:
                     skill=skill_data["name"],
                     risk_level=risk_tier,
                 )
+        if persona_arg:
+            header += f", persona: {persona_arg}"
         header += ")"
         return {
             "call_id": call_id,
@@ -9613,6 +9639,8 @@ class ChatSession:
             "prompt": prompt,
             "model_override": model_override,
             "skill": skill_data,
+            "persona": persona_arg,
+            "persona_prompt": persona_prompt,
         }
 
     def _resolve_scope_id(self, scope: str) -> str:
@@ -14224,61 +14252,62 @@ class ChatSession:
         "3. **Complete the task fully.** Do not ask follow-up "
         "questions — execute the work as described in the prompt."
     )
+    # Framing for a skill delivered to a sub-agent as capability context
+    # (a distinct turn), keeping it clearly separate from the agent's
+    # persona identity.
+    _TASK_SKILL_CAPABILITY_PREAMBLE = (
+        "The following skill provides capability and procedure for the task "
+        "below. Apply it as reference for how to do the work — it is not your "
+        "identity.\n\n"
+    )
 
     def _exec_task(self, item: dict[str, Any]) -> tuple[str, str]:
         """Delegate to a general-purpose autonomous sub-agent."""
         call_id, prompt = item["call_id"], item["prompt"]
         skill_data = item.get("skill")
+        # Identity comes from the persona (resolved at prep) or the default
+        # autonomous task-agent identity — NEVER the skill.  The one-shot,
+        # tool-over-narration operating guidance always layers on top: these
+        # are sub-agent semantics a persona builds on, not replaces.
+        identity = item.get("persona_prompt") or self._TASK_DEFAULT_IDENTITY
+        identity = identity + "\n\n" + self._TASK_OPERATING_GUIDANCE
+        # Task agent gets the base system prompt (tool patterns) merged with
+        # its identity in a single system message. No conversation history —
+        # it's an autonomous sub-agent. Merged to avoid multi-system-message
+        # errors on models like Qwen.
+        base = self._agent_system_messages[0]["content"] if self._agent_system_messages else ""
+        agent_turns: list[Turn] = [Turn.system(base + "\n\n" + identity)]
         if skill_data:
-            # Structured forensic record naming the skill the LLM ran
-            # under.  The approval row captures the choice at consent
-            # time; this log captures it at exec time so post-incident
-            # search ("which sessions ran skill X?") doesn't have to
-            # cross-walk approval and exec tables.
+            # Structured forensic record naming the skill the LLM ran under.
+            # The approval row captures the choice at consent time; this log
+            # captures it at exec time so post-incident search ("which
+            # sessions ran skill X?") doesn't have to cross-walk approval and
+            # exec tables.
             log.info(
                 "task_agent.skill_invoked",
                 skill=skill_data["name"],
                 risk_level=skill_data.get("risk_level", ""),
                 ws_id=self._ws_id,
             )
-            # Route through the shared skill substitution path so a
-            # ``task_agent`` skill resolves ``${TURNSTONE_*}`` env vars
-            # exactly like interactive and spawn loads (previously this ran
-            # ``_render_template`` alone, leaving every ``$``/``${…}`` form
-            # literal — the substitution asymmetry across invocation
-            # contexts).
-            #
-            # A sub-agent gets its task via the prompt, not invocation args,
-            # so ``arguments_str`` is empty: bare ``$ARGUMENTS`` and every
-            # positional ``$N`` / ``$ARGUMENTS[N]`` form resolve to empty —
-            # deliberately identical to the defaults and spawn-child paths,
-            # not the verbatim passthrough the old shortcut happened to give.
-            # ``skill_dir`` is likewise unset here (sub-agent resource
-            # bundles aren't materialized yet), so ``${TURNSTONE_SKILL_DIR}``
-            # stays literal on this path — unchanged from before; a later
-            # step adds sub-agent materialization and a persona-owned
-            # identity so this body becomes pure capability context.
-            skill_identity = self._render_skill_body(skill_data["content"])
-            if len(skill_identity) > _MAX_SKILL_CONTENT:
+            # A skill applied to a task_agent is CAPABILITY, not identity:
+            # delivered as a distinct context turn ahead of the task, never
+            # fused into the system identity.  Substituted through the shared
+            # pipeline — a sub-agent has no invocation args, so ``$ARGUMENTS``
+            # and positional ``$N`` forms resolve to empty (identical to the
+            # defaults and spawn-child paths) and ``${TURNSTONE_*}`` env vars
+            # resolve; ``skill_dir`` is unset (sub-agent bundles aren't
+            # materialized yet), leaving ``${TURNSTONE_SKILL_DIR}`` literal.
+            skill_body = self._render_skill_body(skill_data["content"])
+            if len(skill_body) > _MAX_SKILL_CONTENT:
                 log.warning(
                     "skill_content.truncated",
-                    length=len(skill_identity),
+                    length=len(skill_body),
                     agent="task",
                     skill=skill_data.get("name", ""),
                 )
-                skill_identity = skill_identity[:_MAX_SKILL_CONTENT]
-        else:
-            skill_identity = self._TASK_DEFAULT_IDENTITY
-        identity = skill_identity + "\n\n" + self._TASK_OPERATING_GUIDANCE
-        # Task agent gets the base system prompt (tool patterns) merged
-        # with its own identity in a single system message. No conversation
-        # history — it's an autonomous sub-agent. Merged to avoid
-        # multi-system-message errors on models like Qwen.
-        base = self._agent_system_messages[0]["content"] if self._agent_system_messages else ""
-        agent_turns: list[Turn] = [
-            Turn.system(base + "\n\n" + identity),
-            Turn.user(prompt),
-        ]
+                skill_body = skill_body[:_MAX_SKILL_CONTENT]
+            agent_turns.append(Turn.user(self._TASK_SKILL_CAPABILITY_PREAMBLE + skill_body))
+        agent_turns.append(Turn.user(prompt))
         self._begin_agent_scope()
         # Per-sub-agent file-read tracking.  COPY the parent's current set in (so
         # the agent can edit a file the parent already read for it — no spurious

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -711,7 +711,7 @@ _SPEC_PLACEHOLDER_RE = re.compile(
     r"""
     \$ARGUMENTS\[(?P<idx_bracket>\d+)\]            # $ARGUMENTS[N]
     | \$ARGUMENTS\b(?!\[)                             # $ARGUMENTS (bare)
-    | \$\{(?P<env>CLAUDE_[A-Z_]+)\}                   # ${CLAUDE_*}
+    | \$\{(?P<env>(?:CLAUDE|TURNSTONE)_[A-Z_]+)\}     # ${TURNSTONE_*} / ${CLAUDE_*}
     | \$(?P<idx_short>\d+)\b                          # $N
     | \$(?P<named>[A-Za-z_][A-Za-z0-9_]*)\b           # $name
     """,
@@ -805,12 +805,11 @@ def _substitute_skill_args(
     arg_names: list[str],
     ws_id: str,
     effort: str,
+    skill_dir: str = "",
 ) -> str:
     """Apply SKILL.md spec placeholder substitution.
 
-    Handles every spec form except ``${CLAUDE_SKILL_DIR}`` (which
-    requires a filesystem-shaped skill layout Turnstone doesn't have
-    yet — see #572 for the deferral note):
+    Handles every spec placeholder form:
 
     * ``$ARGUMENTS`` — full argument string as the user typed it
     * ``$ARGUMENTS[N]`` / ``$N`` — Nth positional arg (0-indexed),
@@ -819,8 +818,17 @@ def _substitute_skill_args(
     * ``$<name>`` — named arg from the SKILL.md ``arguments:``
       frontmatter list, paired with the positional arg at the same
       index
-    * ``${CLAUDE_SESSION_ID}`` — current workstream id
-    * ``${CLAUDE_EFFORT}`` — current reasoning_effort
+    * ``${TURNSTONE_SESSION_ID}`` / ``${CLAUDE_SESSION_ID}`` — current
+      workstream id.  ``TURNSTONE_`` is canonical (Turnstone is
+      multi-provider); the ``CLAUDE_`` spelling is a permanent
+      back-compat alias so skills imported from Claude Code / skills.sh
+      keep resolving.  Both map to the same value.
+    * ``${TURNSTONE_EFFORT}`` / ``${CLAUDE_EFFORT}`` — reasoning_effort
+    * ``${TURNSTONE_SKILL_DIR}`` / ``${CLAUDE_SKILL_DIR}`` — absolute
+      path of the materialized resource bundle, resolved when *skill_dir*
+      is supplied (the caller materializes resources BEFORE substituting)
+      and left literal otherwise, so a skill that bundles no resources
+      degrades gracefully rather than emitting an empty path.
 
     Single-pass: a value containing a placeholder token (e.g.
     ``$0='$ARGUMENTS'``) does not get re-expanded.  Matches the
@@ -847,7 +855,16 @@ def _substitute_skill_args(
         positional = arguments_str.split() if arguments_str else []
 
     name_to_idx = {name: i for i, name in enumerate(arg_names)}
-    env = {"CLAUDE_SESSION_ID": ws_id, "CLAUDE_EFFORT": effort}
+    # ``TURNSTONE_*`` canonical + ``CLAUDE_*`` back-compat alias, same value.
+    env = {
+        "TURNSTONE_SESSION_ID": ws_id,
+        "CLAUDE_SESSION_ID": ws_id,
+        "TURNSTONE_EFFORT": effort,
+        "CLAUDE_EFFORT": effort,
+    }
+    if skill_dir:
+        env["TURNSTONE_SKILL_DIR"] = skill_dir
+        env["CLAUDE_SKILL_DIR"] = skill_dir
 
     def _at(idx_str: str) -> str:
         idx = int(idx_str)  # regex guarantees digits
@@ -2107,81 +2124,108 @@ class ChatSession:
             config.update(snap.to_config())
         save_workstream_config(self._ws_id, config)
 
-    def _load_skills(self) -> None:
-        """Load skills from storage.  Called once at init and on /skill."""
+    def _render_skill_body(
+        self,
+        content: str,
+        *,
+        arguments_str: str = "",
+        arg_names: list[str] | None = None,
+        skill_dir: str | None = None,
+    ) -> str:
+        """Render one skill body through the single substitution path.
+
+        Two passes, order load-bearing: legacy ``{{var}}`` first (against
+        the immutable skill source), then the SKILL.md spec pass
+        (``$ARGUMENTS`` / ``${TURNSTONE_*}``).  Rendering ``{{…}}`` first
+        means a user-supplied arg value that happens to contain
+        ``{{model}}`` cannot be re-expanded against the live context; the
+        spec pass writes its substituted values in last, and
+        :func:`_substitute_skill_args` is itself single-pass, so those
+        values are never swept again.
+
+        Every invocation context routes through here — interactive load,
+        default skills, and ``task_agent`` sub-agents — so a skill reading
+        ``${TURNSTONE_EFFORT}`` or ``$ARGUMENTS`` resolves identically
+        wherever it runs, instead of rendering literally in some paths.
+        """
         context = {
             "model": self.model,
             "ws_id": self._ws_id,
             "node_id": self._node_id or "",
         }
         effort = getattr(self, "reasoning_effort", "") or ""
+        rendered = _render_template(content, context)
+        return _substitute_skill_args(
+            rendered,
+            arguments_str=arguments_str,
+            arg_names=arg_names or [],
+            ws_id=self._ws_id,
+            effort=effort,
+            skill_dir=skill_dir or "",
+        )
+
+    def _load_skills(self) -> None:
+        """Load the active skill (or defaults) from storage into context.
+
+        Called once at init and on ``/skill``.  Resources are loaded and
+        materialized to disk BEFORE the body is substituted, so
+        ``${TURNSTONE_SKILL_DIR}`` resolves to the concrete on-disk path
+        rather than a dangling placeholder.  All bodies go through
+        :meth:`_render_skill_body` — the one substitution path, shared
+        with ``task_agent``.
+        """
+        skill_data: dict[str, Any] | None = None
         if self._skill_name:
             skill_data = get_skill_by_name(self._skill_name)
             if skill_data:
-                # Two-pass render — legacy ``{{model}}`` first, spec
-                # ``$ARGUMENTS`` second.  Order is load-bearing: user-
-                # supplied arg values may legitimately contain
-                # ``{{...}}`` patterns (literal text the model wanted to
-                # quote), and running ``_render_template`` AFTER the
-                # spec substitution would silently re-expand them
-                # against the live context.  Running it FIRST resolves
-                # the curly-brace placeholders against the immutable
-                # skill source, then the spec pass writes substituted
-                # values in last — those values can't be re-expanded
-                # because the curly-brace renderer has already
-                # finished.
-                arg_names = self._skill_arg_names(skill_data)
-                content = _render_template(skill_data["content"], context)
-                self._skill_content = _substitute_skill_args(
-                    content,
-                    arguments_str=self._skill_arguments,
-                    arg_names=arg_names,
-                    ws_id=self._ws_id,
-                    effort=effort,
-                )
-                self._check_skill_budget(skill_data)
                 self._skill_resources = self._load_skill_resources(
                     skill_data.get("template_id", "")
                 )
-                if skill_data.get("risk_level") in ("high", "critical"):
-                    risk_tier = skill_data["risk_level"]
-                    log.warning(
-                        "skill.high_risk_loaded",
-                        skill=skill_data["name"],
-                        risk_level=risk_tier,
-                    )
-                    self.ui.on_info(
-                        f"⚠ Skill '{skill_data['name']}' has risk level: {risk_tier}. "
-                        f"Review scan report in admin panel before enabling in production."
-                    )
             else:
                 log.warning("skill.not_found", name=self._skill_name)
-                self._skill_content = None
                 self._skill_resources = {}
+        else:
+            self._skill_resources = {}
+
+        # Materialize first: the body substitution below reads
+        # ``self._skill_resources_dir`` to resolve ``${TURNSTONE_SKILL_DIR}``.
+        # A no-op that clears any stale dir on the not-found / defaults /
+        # no-skill paths.
+        self._materialize_skill_resources()
+
+        if skill_data:
+            self._skill_content = self._render_skill_body(
+                skill_data["content"],
+                arguments_str=self._skill_arguments,
+                arg_names=self._skill_arg_names(skill_data),
+                skill_dir=self._skill_resources_dir,
+            )
+            self._check_skill_budget(skill_data)
+            if skill_data.get("risk_level") in ("high", "critical"):
+                risk_tier = skill_data["risk_level"]
+                log.warning(
+                    "skill.high_risk_loaded",
+                    skill=skill_data["name"],
+                    risk_level=risk_tier,
+                )
+                self.ui.on_info(
+                    f"⚠ Skill '{skill_data['name']}' has risk level: {risk_tier}. "
+                    f"Review scan report in admin panel before enabling in production."
+                )
+        elif self._skill_name:
+            # Named skill not found — resources already cleared above.
+            self._skill_content = None
         else:
             defaults = list_default_skills()
             if defaults:
-                # ``arg_names`` and ``arguments_str`` are empty for the
-                # default-skill path — defaults are always-on and don't
-                # take user-supplied invocation args — but env subs
-                # (``${CLAUDE_SESSION_ID}`` / ``${CLAUDE_EFFORT}``)
-                # still resolve.  Same render-then-substitute order as
-                # the explicit-skill branch (see comment above).
-                parts = [
-                    _substitute_skill_args(
-                        _render_template(t["content"], context),
-                        arguments_str="",
-                        arg_names=[],
-                        ws_id=self._ws_id,
-                        effort=effort,
-                    )
-                    for t in defaults
-                ]
+                # Defaults are always-on and take no invocation args, but env
+                # subs (``${TURNSTONE_SESSION_ID}`` / ``${TURNSTONE_EFFORT}``)
+                # still resolve.  Defaults carry no per-skill resource bundle,
+                # so ``skill_dir`` is omitted.
+                parts = [self._render_skill_body(t["content"]) for t in defaults]
                 self._skill_content = "\n\n".join(parts)
             else:
                 self._skill_content = None
-            self._skill_resources = {}
-        self._materialize_skill_resources()
         self._validate_skill_resources()
 
     @staticmethod
@@ -2309,10 +2353,25 @@ class ChatSession:
         )
 
     def _skill_resource_env(self) -> dict[str, str]:
-        """Return extra env vars for bash when skill resources are materialized."""
+        """Return extra env vars for bash when skill resources are materialized.
+
+        The bundle dir is exported as canonical ``TURNSTONE_SKILL_DIR`` and
+        the original ``SKILL_RESOURCES_DIR`` (back-compat for existing skills
+        and the ``$SKILL_RESOURCES_DIR`` disclosure hint), both pointing at
+        the same directory.  ``CLAUDE_SKILL_DIR`` is added as a portability
+        alias for imported Claude Code / skills.sh skills, but ONLY when the
+        host hasn't already set it: ``CLAUDE_SKILL_DIR`` is another vendor's
+        namespace, and turnstone running as a node inside Claude Code must
+        not shadow the host's real value.
+        """
         if not self._skill_resources_dir:
             return {}
-        env: dict[str, str] = {"SKILL_RESOURCES_DIR": self._skill_resources_dir}
+        env: dict[str, str] = {
+            "SKILL_RESOURCES_DIR": self._skill_resources_dir,
+            "TURNSTONE_SKILL_DIR": self._skill_resources_dir,
+        }
+        if "CLAUDE_SKILL_DIR" not in os.environ:
+            env["CLAUDE_SKILL_DIR"] = self._skill_resources_dir
         scripts_dir = os.path.join(self._skill_resources_dir, "scripts")
         if os.path.isdir(scripts_dir):
             current_path = os.environ.get("PATH")
@@ -14182,12 +14241,24 @@ class ChatSession:
                 risk_level=skill_data.get("risk_level", ""),
                 ws_id=self._ws_id,
             )
-            context = {
-                "model": self.model,
-                "ws_id": self._ws_id,
-                "node_id": self._node_id or "",
-            }
-            skill_identity = _render_template(skill_data["content"], context)
+            # Route through the shared skill substitution path so a
+            # ``task_agent`` skill resolves ``${TURNSTONE_*}`` env vars
+            # exactly like interactive and spawn loads (previously this ran
+            # ``_render_template`` alone, leaving every ``$``/``${…}`` form
+            # literal — the substitution asymmetry across invocation
+            # contexts).
+            #
+            # A sub-agent gets its task via the prompt, not invocation args,
+            # so ``arguments_str`` is empty: bare ``$ARGUMENTS`` and every
+            # positional ``$N`` / ``$ARGUMENTS[N]`` form resolve to empty —
+            # deliberately identical to the defaults and spawn-child paths,
+            # not the verbatim passthrough the old shortcut happened to give.
+            # ``skill_dir`` is likewise unset here (sub-agent resource
+            # bundles aren't materialized yet), so ``${TURNSTONE_SKILL_DIR}``
+            # stays literal on this path — unchanged from before; a later
+            # step adds sub-agent materialization and a persona-owned
+            # identity so this body becomes pure capability context.
+            skill_identity = self._render_skill_body(skill_data["content"])
             if len(skill_identity) > _MAX_SKILL_CONTENT:
                 log.warning(
                     "skill_content.truncated",

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -11632,6 +11632,26 @@ class ChatSession:
         name = self._coord_str_arg(args, "name").strip()
         if not name:
             return self._coord_tool_error(call_id, "skills", "load: 'name' is required")
+        # Risk gate (design §5.5 / HYPOTHESIS Principle 7): a high/critical-risk
+        # skill is PRINCIPAL-load-only.  The model must not activate it through
+        # the tools path — an injection-steerable lane that would widen
+        # authority behind a rubber-stampable approval (the scanner escalates
+        # risk precisely for the auto_approve + allowed_tools authority the
+        # create path warns about).  The operator loads such a skill explicitly
+        # with ``/skill``; that path (handle_command / cli --skill) calls
+        # set_skill directly and bypasses this gate.  A narrowing check — it can
+        # only DENY, never widen — so it is safe by construction.
+        storage = get_storage()
+        if storage is not None:
+            row = storage.get_prompt_template_by_name(name)
+            if row and row.get("risk_level") in ("high", "critical"):
+                return self._coord_tool_error(
+                    call_id,
+                    "skills",
+                    f"load: skill '{name}' has risk tier '{row['risk_level']}' and can "
+                    f"only be activated by the operator. Ask the user to run "
+                    f"/skill {name} if they want it — the model cannot load it.",
+                )
         # SKILL.md spec ``$ARGUMENTS`` payload — optional.  Mirror
         # the spec's free-form string shape (``/skill-name a b "c d"``)
         # rather than a list, so the model can pass quoted positional

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -11752,16 +11752,22 @@ class ChatSession:
         widen, so it is safe by construction.
         """
         storage = get_storage()
+        row = None
+        lookup_failed = False
         if storage is None:
-            return ""
-        try:
-            row = storage.get_prompt_template_by_name(name)
-        except Exception:
+            lookup_failed = True
+        else:
+            try:
+                row = storage.get_prompt_template_by_name(name)
+            except Exception:
+                log.warning("skill.risk_gate_lookup_failed", skill=name, exc_info=True)
+                lookup_failed = True
+        if lookup_failed:
             # Fail CLOSED: a risk gate that can't read the row must DENY, never
-            # wave the skill through.  Denying (not returning "") also keeps
+            # wave the skill through — for storage-unavailable (None) AND a
+            # lookup fault alike.  Denying (not returning "") also keeps
             # spawn_batch's per-row partial-success intact — one child's lookup
             # fault denies only that child, not the whole batch.
-            log.warning("skill.risk_gate_lookup_failed", skill=name, exc_info=True)
             return (
                 f"skill '{name}' could not be risk-checked (storage unavailable) "
                 f"and was not activated. Retry, or ask the operator to run /skill {name}."

--- a/turnstone/tools/skills.json
+++ b/turnstone/tools/skills.json
@@ -23,7 +23,7 @@
       },
       "arguments": {
         "type": "string",
-        "description": "For `load`: optional invocation arguments for SKILL.md `$ARGUMENTS` / `$N` / `$<name>` substitution in the skill body. Free-form string parsed with shell-style quoting via `shlex.split` — quotes are stripped, so `\"hello world\" second` yields $0=hello world, $1=second (no surrounding quotes in the substituted value). Skills declaring `arguments: [issue, branch]` in their frontmatter expose `$issue` and `$branch` bound by position. Omit or pass an empty string when the skill has no `$ARGUMENTS`/`$N`/`$<name>` placeholders; `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` env-var substitution still runs regardless."
+        "description": "For `load`: optional invocation arguments for SKILL.md `$ARGUMENTS` / `$N` / `$<name>` substitution in the skill body. Free-form string parsed with shell-style quoting via `shlex.split` — quotes are stripped, so `\"hello world\" second` yields $0=hello world, $1=second (no surrounding quotes in the substituted value). Skills declaring `arguments: [issue, branch]` in their frontmatter expose `$issue` and `$branch` bound by position. Omit or pass an empty string when the skill has no `$ARGUMENTS`/`$N`/`$<name>` placeholders; `${TURNSTONE_SESSION_ID}` / `${TURNSTONE_EFFORT}` env-var substitution (with `${CLAUDE_*}` accepted as a back-compat alias) still runs regardless."
       },
       "query": {
         "type": "string",

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -1,6 +1,6 @@
 {
   "name": "task_agent",
-  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, or task_agent — it cannot save memories, search conversation history, set up watches, switch skills mid-task, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to run the sub-agent under a specific skill framing (fixed at invocation, cannot be changed mid-task); use `skill(action='search', query='...')` to find an appropriate name first. An empty `skill` value is acceptable — the sub-agent runs as a competent general-purpose task helper.",
+  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, or task_agent — it cannot save memories, search conversation history, set up watches, switch skills mid-task, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to give the sub-agent capability and procedure for the task (reference material, fixed at invocation), and/or `persona=<name>` to set its identity; use `skill(action='search', query='...')` to find a skill name first. Both are optional — the sub-agent runs as a competent general-purpose task helper by default.",
   "parameters": {
     "type": "object",
     "properties": {
@@ -10,7 +10,11 @@
       },
       "skill": {
         "type": "string",
-        "description": "Optional skill name. Sub-agent runs with this skill's content as its system identity. Use `skill(action='search', query='...')` to discover available names. An empty value is acceptable and yields a competent general-purpose task helper."
+        "description": "Optional skill name providing capability and procedure (reference material) the sub-agent applies to the task — NOT its identity. Use `skill(action='search', query='...')` to discover available names. An empty value is acceptable and yields a competent general-purpose task helper."
+      },
+      "persona": {
+        "type": "string",
+        "description": "Optional persona name setting the sub-agent's identity (base system prompt), resolved against interactive-kind personas. Omit for the default autonomous task-agent identity."
       },
       "model": {
         "type": "string",

--- a/turnstone/tools/task_agent.json
+++ b/turnstone/tools/task_agent.json
@@ -1,6 +1,6 @@
 {
   "name": "task_agent",
-  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, or task_agent — it cannot save memories, search conversation history, set up watches, switch skills mid-task, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to give the sub-agent capability and procedure for the task (reference material, fixed at invocation), and/or `persona=<name>` to set its identity; use `skill(action='search', query='...')` to find a skill name first. Both are optional — the sub-agent runs as a competent general-purpose task helper by default.",
+  "description": "Delegate a general-purpose task to an autonomous sub-agent. The agent can read, write, edit, search, and run commands but does NOT have access to memory, recall, watch, skill, or task_agent — it cannot save memories, search conversation history, set up watches, switch skills mid-task, or delegate further. All context must be in the prompt. Provide a clear, self-contained task description. Optionally pass `skill=<name>` to give the sub-agent capability and procedure for the task (reference material, fixed at invocation), and/or `persona=<name>` to set its identity; use `skills(action='find', query='...')` to find a skill name first. Both are optional — the sub-agent runs as a competent general-purpose task helper by default.",
   "parameters": {
     "type": "object",
     "properties": {
@@ -10,7 +10,7 @@
       },
       "skill": {
         "type": "string",
-        "description": "Optional skill name providing capability and procedure (reference material) the sub-agent applies to the task — NOT its identity. Use `skill(action='search', query='...')` to discover available names. An empty value is acceptable and yields a competent general-purpose task helper."
+        "description": "Optional skill name providing capability and procedure (reference material) the sub-agent applies to the task — NOT its identity. Use `skills(action='find', query='...')` to discover available names. An empty value is acceptable and yields a competent general-purpose task helper."
       },
       "persona": {
         "type": "string",


### PR DESCRIPTION
## What & why

Turnstone "skills" were two eras welded together: the 008-era **prompt-templates** system (a template *is an identity* → goes in the system message) and the later **agentskills.io SKILL.md** feature (a skill is a *capability*). They shared one table, one loader, and one destination. This branch draws the line the standard intends — **identity comes from a persona; a skill is capability, never identity** — and unifies skill substitution so a skill behaves the same wherever it is invoked.

## Changes (5 commits, in build order)

1. **Substitution unification** (`aedf35ff`) — one `_render_skill_body` path across interactive load, defaults, and `task_agent`. Previously `task_agent` ran `_render_template` only, leaving `$ARGUMENTS`/`${…}` literal on that path. Adds `${TURNSTONE_*}` as the canonical vendor-neutral env spelling, with `${CLAUDE_SESSION_ID}`/`${CLAUDE_EFFORT}` as back-compat aliases so imported Claude Code / skills.sh skills keep resolving; materialize-before-substitute so `${TURNSTONE_SKILL_DIR}` resolves in-body. (The `${CLAUDE_SKILL_DIR}` alias was dropped in commit 5 — see Review — because that name collides with the host's bash namespace.)
2. **task_agent persona** (`9b6c56a6`) — `task_agent` gains `persona=` (identity, validated against the interactive kind, resolved and frozen at approval prep). The skill becomes capability delivered as a distinct context turn, never the sub-agent's identity. `_TASK_DEFAULT_IDENTITY` stays the no-persona default.
3. **Skills → context** (`24e5f517`) — a **named** applied skill's body leaves the identity system message for a separate user-role context message. Default (always-on) skills stay in the system message — they never change mid-session, so they aren't the cache-bust source and keep their system-level weight. ⚠️ **See Merge gate.**
4. **Risk gate** (`2c1b1410`) — the model cannot activate a high/critical-risk skill through the tools path; those become principal-load-only (`/skill`). Uses the scanner-computed `risk_level`, no schema.
5. **Review fixes** (`609dacfa`) — folds the fixes from **two** independent multi-agent reviews of commits 1–4 (high, then max effort). *First round:* closed a gate **bypass** via `spawn_workstream`/`spawn_batch(skill=)`; a restrictive `persona=` **attenuates the sub-agent's tools** (Principle 7), not just its identity text; stopped `$N`/`$ARGUMENTS` blanking on capability skills; added `persona` to the judge/audit projection. *Max round — task_agent was the surface lagging its siblings:* the high/critical risk gate now covers **`task_agent(skill=)`** too (it was the one un-gated model-activation lane); `task_agent` now honors **all four** persona levers — mcp-off and memory-off drop MCP (`mcp__*` + `read_resource`/`use_prompt`) and memory tools, not just the tool allowlist — and the sub-agent is also capped by the **parent** session's own grant (a restricted principal can't escalate by spawning); the risk gate **fails closed** on a storage fault (deny, not wave-through, preserving batch partial-success); persona-resolution errors degrade to a clean tool error instead of an opaque internal error.

## ⚠️ Merge gate

Change 3 moves the **named** applied-skill body from the system message to a user-role context message. A **model-adherence eval (this branch vs `main`)** should confirm the model follows a named skill as well from a context message as from the system message before this merges. Mechanical structure is fully covered by tests; behavioral adherence is not (not runnable in CI). Scope is the named-skill move only — default skills are unchanged from `main`.

## Deferred (with rationale)

- **Storage `type` discriminator** — `origin` (`manual`/`mcp`/`source`) already discriminates skill/mcp/registry today and every consumer works with it; nothing needs a `type` column. Its shape also depends on an open question — should MCP prompts be a `prompt_templates` tenant at all? Deferred rather than land a speculative migration.
- **`disable-model-invocation` persistence**, **`variables`→`arguments` consolidation**, **sub-agent skill-resource materialization** — captured with rationale and entry points. The `variables` consolidation in particular is not a mechanical rename (it would switch on `$<name>` substitution for MCP-synced prompts), so it's held pending the MCP-tenancy decision above.

## Testing

`ruff` + `mypy` clean; ~1400 targeted tests green across skills / persona / session / coordinator / provider / wire / compaction. New coverage: `tests/test_skill_substitution_unification.py` (substitution parity, context-message placement) plus, from the reviews, risk-gate + fail-closed tests in `tests/test_skills_tool.py` and `task_agent` tests in `tests/test_session.py` — high/critical-skill denial, parent-persona tool cap, and child-persona mcp-off / memory-off tool attenuation.

## Review

Reviewed by independent multi-agent passes (high, then max effort) over the full branch diff; all confirmed findings addressed. The max pass's headline — `task_agent` bypassing the very high/critical-risk gate its sibling activation surfaces enforce — is fixed, along with the persona-lever, parent-grant, and fail-closed gaps it surfaced, and a `${CLAUDE_SKILL_DIR}` prompt-vs-bash divergence (resolved by dropping that alias entirely — canonical `${TURNSTONE_SKILL_DIR}` only; the `${CLAUDE_SESSION_ID}` / `${CLAUDE_EFFORT}` prompt aliases remain, as they have no bash-namespace collision).

**One finding is deferred to a follow-up branch:** the sub-agent persona `base_prompt` is currently *appended* to, rather than *replacing*, the default BASE identity — so a `task_agent(persona=…)` sub-agent reads two identities. Tool *authority* is correctly attenuated (the persona/parent tool-lever fixes landed here), so only identity *framing* is diluted; the proper fix recomposes the sub-agent system message via `base_override` and is best validated by the same model-adherence eval that already gates the branch (see Merge gate).

## Breaking changes

Breaking-tolerant by design (no transitional flags): `task_agent` skills are now capability, not identity — a skill previously passed to `task_agent` as its system identity now rides a capability turn with a persona (or the default) owning identity. Skill bodies using `$N`/`$ARGUMENTS` as literal text on capability paths are now preserved rather than blanked. `${TURNSTONE_*}` is canonical; `${CLAUDE_SESSION_ID}`/`${CLAUDE_EFFORT}` remain supported aliases, but `${CLAUDE_SKILL_DIR}` is **not** honored (that name is left to the host — use `${TURNSTONE_SKILL_DIR}`).
