### PR TITLE
feat(mcp): proactively keep consented OAuth (OBO) tokens fresh for unattended work

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import inspect
 import json
 import time
@@ -2180,6 +2181,13 @@ class TestConnectOneUnreachable:
 
         loop = asyncio.new_event_loop()
         loop.run_until_complete(mgr._connect_all())
+        # _connect_all spawns the long-lived token-freshness sweep task; cancel
+        # it before closing the loop so it isn't destroyed while pending.
+        sweep = mgr._user_token_sweep_task
+        if sweep is not None:
+            sweep.cancel()
+            with contextlib.suppress(BaseException):
+                loop.run_until_complete(sweep)
         loop.close()
 
         bad_state = mgr._static_servers.get("bad")

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -408,6 +408,97 @@ class TestRefreshFailureClassification:
         assert ("user-1", "srv-oauth") not in state.mcp_oauth_refresh_locks
 
 
+class TestObserveOnlyLookup:
+    """``revoke_on_failure=False`` (the background token-freshness sweep): still
+    refresh a healthy token, but on failure NEVER delete a token or mutate the
+    shared streak — a timer must not destroy consent or move a foreground user's
+    revoke threshold. A permanent rejection surfaces as ``refresh_failed`` with
+    the row INTACT; an ambiguous one as transient with the streak untouched."""
+
+    def _lookup(self, state: SimpleNamespace) -> Any:
+        from turnstone.core.mcp_oauth import get_user_access_token_classified
+
+        async def _run() -> Any:
+            with _public_addr_patch():
+                return await get_user_access_token_classified(
+                    app_state=state,
+                    user_id="user-1",
+                    server_name="srv-oauth",
+                    force_refresh=True,
+                    revoke_on_failure=False,
+                )
+
+        return asyncio.run(_run())
+
+    def test_permanent_invalid_grant_does_not_revoke(self, storage: SQLiteBackend) -> None:
+        """The exact contrast to ``test_permanent_invalid_grant_revokes``: same
+        dead-grant signal, but observe-only leaves the row for the lazy path."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(return_value=_mk_response(400, {"error": "invalid_grant"}))
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        result = self._lookup(state)
+
+        assert result.kind == "refresh_failed"
+        assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is not None
+
+    def test_ambiguous_does_not_touch_shared_streak(self, storage: SQLiteBackend) -> None:
+        """Repeated observe-mode ambiguous failures never bump the shared
+        ambiguous_streak, so a later foreground dispatch is not pushed over the
+        escalation edge by background activity (the finding this guards)."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(return_value=_mk_response(400, None))
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        with patch("turnstone.core.mcp_oauth._AMBIGUOUS_ESCALATION_THRESHOLD", 2):
+            for _ in range(5):
+                assert self._lookup(state).kind == "refresh_failed_transient"
+
+        backoff = getattr(state, "mcp_oauth_refresh_backoff", {})
+        entry = backoff.get(("user-1", "srv-oauth"))
+        assert entry is None or entry.ambiguous_streak == 0
+        assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is not None
+
+    def test_expired_no_refresh_does_not_revoke(self, storage: SQLiteBackend) -> None:
+        """An expired token with no refresh token surfaces as a dead grant but is
+        NOT deleted on the observe path."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000, refresh=None)
+
+        result = self._lookup(state)
+
+        assert result.kind == "refresh_failed"
+        assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is not None
+
+    def test_healthy_token_still_refreshes(self, storage: SQLiteBackend) -> None:
+        """Observe mode is not read-only: a near-expiry token is still refreshed
+        (only the destructive failure paths change)."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                200, {"access_token": "fresh-bbb", "expires_in": 3600, "token_type": "Bearer"}
+            )
+        )
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        result = self._lookup(state)
+
+        assert result.kind == "token"
+        assert result.token == "fresh-bbb"
+
+
 # ---------------------------------------------------------------------------
 # Happy paths
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import threading
 import time
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -114,12 +115,13 @@ def running_loop_mgr():
         # handlers don't fire after pytest has torn its handlers down. Mirrors
         # the production ``shutdown()`` shape.
         async def _drain(m: MCPClientManager) -> None:
-            task = m._user_pool_eviction_task
-            if task is not None:
-                task.cancel()
-                with contextlib.suppress(BaseException):
-                    await task
-                m._user_pool_eviction_task = None
+            for attr in ("_user_pool_eviction_task", "_user_token_sweep_task"):
+                task = getattr(m, attr)
+                if task is not None:
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
+                    setattr(m, attr, None)
 
         with contextlib.suppress(Exception):
             asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=2)
@@ -969,3 +971,400 @@ class TestUserIdThreadThrough:
         assert result == "static-output"
         # No pool entries were created.
         assert mgr._user_pool_entries == {}
+
+
+# ---------------------------------------------------------------------------
+# Background token-freshness sweep (oauth_user keep-hot, no connection warming)
+# ---------------------------------------------------------------------------
+
+
+class TestUserTokenFreshnessSweep:
+    """The background sweep that keeps every consented ``oauth_user`` grant hot
+    for unattended / autonomous work: refresh-on-expiry via the canonical path,
+    proactive dead-grant badging, once-only surfacing, and — the load-bearing
+    property — total invisibility to static / no-auth deployments."""
+
+    def _wire(self, mgr: MCPClientManager, storage: SQLiteBackend, cipher: Any) -> None:
+        mgr.set_storage(storage)
+        mgr.set_app_state(_make_app_state(storage, cipher=cipher))
+        mgr._oauth_user_server_names = {"pool-srv"}
+
+    @staticmethod
+    def _classified(kind: str, token: str | None = None):
+        async def _fake(**kwargs: Any) -> Any:
+            return SimpleNamespace(kind=kind, token=token)
+
+        return _fake
+
+    # -- no-auth / static safety: the sweep must be structurally invisible ----
+
+    def test_sweep_noop_without_oauth_servers(self, running_loop_mgr, storage) -> None:
+        """A static-only / no-auth deployment: the OBO gate returns before any
+        DB scan or AS round-trip — the single most important property."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        mgr._oauth_user_server_names = set()  # no oauth_user server configured
+        storage.list_mcp_user_token_reconcile_targets = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=AsyncMock(),
+        ) as classified:
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        storage.list_mcp_user_token_reconcile_targets.assert_not_called()  # no token-table scan
+        classified.assert_not_awaited()  # no AS round-trip
+
+    def test_sweep_noop_before_storage_wired(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._oauth_user_server_names = {"pool-srv"}  # oauth configured but app not wired yet
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=AsyncMock(),
+        ) as classified:
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        classified.assert_not_awaited()
+
+    def test_sweep_skips_server_not_in_oauth_set(self, running_loop_mgr, storage) -> None:
+        """A token row lingering for a since-demoted / renamed server is not
+        reconciled — only pairs whose server is currently ``oauth_user``."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="ghost-srv")
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=AsyncMock(),
+        ) as classified:
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        classified.assert_not_awaited()  # ghost-srv is not in _oauth_user_server_names
+
+    # -- classification branches --------------------------------------------
+
+    def test_healthy_token_no_badge(self, running_loop_mgr, storage) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.upsert_mcp_pending_consent = MagicMock()  # type: ignore[method-assign]
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("token", token="access-aaa"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        storage.upsert_mcp_pending_consent.assert_not_called()
+        assert ("u1", "pool-srv") not in mgr._token_sweep_warned
+
+    def test_dead_grant_badges_once_and_dedups(self, running_loop_mgr, storage, caplog) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.upsert_mcp_pending_consent = MagicMock()  # type: ignore[method-assign]
+
+        with (
+            patch(
+                "turnstone.core.mcp_client.get_user_access_token_classified",
+                new=self._classified("refresh_failed"),
+            ),
+            caplog.at_level(logging.WARNING, logger="turnstone.core.mcp_client"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())  # second tick: no re-badge
+
+        # Badge raised exactly once, proactively, with the dashboard's code.
+        storage.upsert_mcp_pending_consent.assert_called_once()
+        assert (
+            storage.upsert_mcp_pending_consent.call_args.kwargs["error_code"]
+            == "mcp_consent_required"
+        )
+        assert ("u1", "pool-srv") in mgr._token_sweep_warned
+        escalations = [r for r in caplog.records if "needs re-consent" in r.getMessage()]
+        assert len(escalations) == 1  # logged loud-once, not every tick
+
+    def test_decrypt_failure_warns_but_does_not_badge(self, running_loop_mgr, storage) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.upsert_mcp_pending_consent = MagicMock()  # type: ignore[method-assign]
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("decrypt_failure"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        # Operator-actionable (key unknown) — surfaced in the warned set, but NOT
+        # a user-consent badge (outside the dashboard's scope).
+        storage.upsert_mcp_pending_consent.assert_not_called()
+        assert ("u1", "pool-srv") in mgr._token_sweep_warned
+
+    def test_transient_failure_is_silent(self, running_loop_mgr, storage) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.upsert_mcp_pending_consent = MagicMock()  # type: ignore[method-assign]
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("refresh_failed_transient"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        storage.upsert_mcp_pending_consent.assert_not_called()
+        assert ("u1", "pool-srv") not in mgr._token_sweep_warned  # retryable, not surfaced
+
+    def test_recovery_rearms_and_clears_badge(self, running_loop_mgr, storage) -> None:
+        """A dead grant that later returns healthy clears its warned pin AND drops
+        the stale badge — the self-heal for a spurious invalid_grant that has
+        since recovered. Production-reachable now that the observe-only sweep no
+        longer deletes the row on refresh_failed, so the pair keeps enumerating."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.delete_mcp_pending_consent = MagicMock(return_value=True)  # type: ignore[method-assign]
+        key = ("u1", "pool-srv")
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("refresh_failed"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert key in mgr._token_sweep_warned
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("token", token="access-aaa"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert key not in mgr._token_sweep_warned  # recovered → re-armed
+        storage.delete_mcp_pending_consent.assert_called_once_with("u1", "pool-srv")
+
+    def test_dead_grant_not_pinned_when_badge_persist_fails(
+        self, running_loop_mgr, storage
+    ) -> None:
+        """If the badge write fails, the pair is NOT pinned, so the next tick
+        retries — a single failed persist must not permanently lose the only
+        proactive signal for a sweep-detected dead grant."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        storage.upsert_mcp_pending_consent = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("db down")
+        )
+        key = ("u1", "pool-srv")
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("refresh_failed"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+            assert key not in mgr._token_sweep_warned  # not pinned — will retry
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        # Retried on the second tick rather than deduped away by a phantom pin.
+        assert storage.upsert_mcp_pending_consent.call_count == 2
+
+    def test_sweep_uses_non_revoking_observe_mode(self, running_loop_mgr, storage) -> None:
+        """The background sweep MUST call the canonical lookup non-destructively:
+        a timer may never delete a token or move a foreground user's revoke
+        threshold."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        seen_kwargs: list[dict[str, Any]] = []
+
+        async def _spy(**kwargs: Any) -> Any:
+            seen_kwargs.append(kwargs)
+            return SimpleNamespace(kind="token", token="access-aaa")
+
+        with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=_spy):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert seen_kwargs and seen_kwargs[0]["revoke_on_failure"] is False
+        assert seen_kwargs[0]["revoke_ambiguous_escalation"] is False
+
+    # -- keepalive refresh (exercise the refresh token before it idles out) ---
+
+    def test_keepalive_refresh_due_logic(self) -> None:
+        mgr = MCPClientManager({})
+        mgr._user_token_refresh_keepalive_s = 3600.0
+        old = (datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S")
+        recent = (datetime.now(UTC) - timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        assert mgr._keepalive_refresh_due(old) is True  # past the window → force
+        assert mgr._keepalive_refresh_due(recent) is False  # still warm
+        assert mgr._keepalive_refresh_due(None) is True  # unknown → force once, safe
+        assert mgr._keepalive_refresh_due("not-a-date") is True  # unparseable → force
+        mgr._user_token_refresh_keepalive_s = 0.0
+        assert mgr._keepalive_refresh_due(old) is False  # disabled → never force
+
+    def test_keepalive_due_forces_refresh(self, running_loop_mgr, storage) -> None:
+        """A grant whose refresh token has idled past the window is force-refreshed
+        even though its access token may be fresh — the [6] fix: keep the refresh
+        token alive so an unattended run never finds it aged out."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        mgr._user_token_refresh_keepalive_s = 1800.0
+        stale = (datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S")
+        storage.list_mcp_user_token_reconcile_targets = MagicMock(  # type: ignore[method-assign]
+            return_value=[("u1", "pool-srv", stale)]
+        )
+        seen_kwargs: list[dict[str, Any]] = []
+
+        async def _spy(**kwargs: Any) -> Any:
+            seen_kwargs.append(kwargs)
+            return SimpleNamespace(kind="token", token="access-aaa")
+
+        with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=_spy):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert seen_kwargs and seen_kwargs[0]["force_refresh"] is True
+
+    def test_keepalive_not_due_does_not_force(self, running_loop_mgr, storage) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        mgr._user_token_refresh_keepalive_s = 1800.0
+        recent = (datetime.now(UTC) - timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        storage.list_mcp_user_token_reconcile_targets = MagicMock(  # type: ignore[method-assign]
+            return_value=[("u1", "pool-srv", recent)]
+        )
+        seen_kwargs: list[dict[str, Any]] = []
+
+        async def _spy(**kwargs: Any) -> Any:
+            seen_kwargs.append(kwargs)
+            return SimpleNamespace(kind="token", token="access-aaa")
+
+        with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=_spy):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert seen_kwargs and seen_kwargs[0]["force_refresh"] is False  # still warm
+
+    def test_warned_set_pruned_to_consented_pairs(self, running_loop_mgr, storage) -> None:
+        """A warned pair that is no longer consented (row gone) is dropped from
+        the dedup set so it can't grow unbounded across transient dead grants."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        _seed_user_token(storage, cipher, user_id="u1", server_name="pool-srv")
+        mgr._token_sweep_warned = {("gone-user", "pool-srv"), ("u1", "pool-srv")}
+
+        with patch(
+            "turnstone.core.mcp_client.get_user_access_token_classified",
+            new=self._classified("token", token="access-aaa"),
+        ):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert ("gone-user", "pool-srv") not in mgr._token_sweep_warned  # pruned
+        assert ("u1", "pool-srv") not in mgr._token_sweep_warned  # healthy → cleared
+
+    def test_per_pair_failure_isolated(self, running_loop_mgr, storage) -> None:
+        """One pair raising must not starve the rest of the pass."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        self._wire(mgr, storage, cipher)
+        mgr._oauth_user_server_names = {"pool-srv"}
+        _seed_user_token(storage, cipher, user_id="u-bad", server_name="pool-srv")
+        _seed_user_token(storage, cipher, user_id="u-ok", server_name="pool-srv")
+        seen: list[str] = []
+
+        async def _flaky(**kwargs: Any) -> Any:
+            uid = kwargs["user_id"]
+            seen.append(uid)
+            if uid == "u-bad":
+                raise RuntimeError("boom")
+            return SimpleNamespace(kind="token", token="access-aaa")
+
+        with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=_flaky):
+            _run_on_loop(loop, mgr._sweep_user_token_freshness())
+        assert {"u-bad", "u-ok"} <= set(seen)  # both attempted despite one raising
+
+    def test_sweep_loop_cancel_returns_cleanly(self, running_loop_mgr) -> None:
+        """The loop body exits on cancellation without raising (mirrors the
+        eviction loop's teardown contract)."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_token_sweep_s = 999.0  # park in the sleep
+
+        async def _spawn() -> asyncio.Task[None]:
+            return asyncio.ensure_future(mgr._user_token_sweep_loop())
+
+        task = _run_on_loop(loop, _spawn())
+
+        async def _cancel() -> None:
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
+
+        _run_on_loop(loop, _cancel())
+        assert task.cancelled() or task.done()
+
+    def test_connect_all_starts_the_sweep_task(self, running_loop_mgr) -> None:
+        """Wiring guard: ``_connect_all`` must start the sweep once, even with no
+        servers configured — otherwise the whole keep-hot mechanism is dead code."""
+        mgr, loop, _ = running_loop_mgr
+        assert mgr._user_token_sweep_task is None
+
+        _run_on_loop(loop, mgr._connect_all())
+        try:
+            task = mgr._user_token_sweep_task
+            assert task is not None and not task.done()  # live, single instance
+        finally:
+
+            async def _drain() -> None:
+                t = mgr._user_token_sweep_task
+                if t is not None:
+                    t.cancel()
+                    with contextlib.suppress(BaseException):
+                        await t
+                    mgr._user_token_sweep_task = None
+
+            _run_on_loop(loop, _drain())
+
+    def test_disabled_sweep_not_started_by_connect_all(self, running_loop_mgr) -> None:
+        """Cadence <= 0 disables the sweep entirely — no task is spawned."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_token_sweep_s = 0.0
+        _run_on_loop(loop, mgr._connect_all())
+        assert mgr._user_token_sweep_task is None
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            (0, 0.0),  # explicit disable
+            (-5, 0.0),  # negative disables (no busy-loop)
+            (1, 30.0),  # tiny positive floored to _MIN_USER_TOKEN_SWEEP_S
+            (600, 600.0),  # normal value passes through
+        ],
+    )
+    def test_cadence_clamped_or_disabled(self, configured, expected) -> None:
+        """The config cadence is floored (positive) or disabled (<= 0) so an
+        ``asyncio.sleep(0)`` busy-loop is unreachable."""
+        with patch(
+            "turnstone.core.mcp_client.load_config",
+            return_value={"user_token_sweep_seconds": configured},
+        ):
+            mgr = MCPClientManager({})
+        assert mgr._user_token_sweep_s == expected
+
+    # -- storage enumerator --------------------------------------------------
+
+    def test_reconcile_targets_pairs_expiry_unfiltered_with_last_exercised(self, storage) -> None:
+        cipher = make_mcp_token_cipher()
+        # alice consents to two servers → two rows.
+        _seed_user_token(storage, cipher, user_id="alice", server_name="srv-a")
+        _seed_user_token(storage, cipher, user_id="alice", server_name="srv-b")
+        # bob's access token is expired but the refresh token is live — still a
+        # consented, reconcilable grant, so bob must be enumerated.
+        _seed_user_token(
+            storage, cipher, user_id="bob", server_name="srv-a", expires_in_seconds=-999
+        )
+        targets = storage.list_mcp_user_token_reconcile_targets()
+        # (user, server) identity, all three grants present regardless of expiry.
+        assert sorted((u, s) for u, s, _ in targets) == [
+            ("alice", "srv-a"),
+            ("alice", "srv-b"),
+            ("bob", "srv-a"),
+        ]
+        # last_exercised = COALESCE(last_refreshed, created); never-refreshed rows
+        # fall back to created, so it is always populated (drives the keepalive).
+        assert all(last_exercised for _, _, last_exercised in targets)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -690,6 +690,29 @@ class MCPClientManager:
         mcp_cfg = load_config("mcp")
         self._user_pool_idle_ttl_s = float(mcp_cfg.get("user_session_idle_ttl_seconds", 600))
         self._user_pool_lru_max = int(mcp_cfg.get("user_session_lru_max", 200))
+        # Background token-freshness sweep cadence (seconds). Keeps every
+        # consented oauth_user grant hot for unattended / autonomous work. Kept
+        # comfortably under the shortest common access-token lifetime so a token
+        # is refreshed before it lapses; 240 s clears the usual 300 s floor with
+        # margin. A value <= 0 DISABLES the sweep (the task is never started); a
+        # positive value is floored at ``_MIN_USER_TOKEN_SWEEP_S`` so a
+        # fat-fingered tiny cadence can't turn the loop into a CPU/DB/AS
+        # busy-loop (``asyncio.sleep(0)`` yields without delay).
+        raw_sweep_s = float(mcp_cfg.get("user_token_sweep_seconds", 240))
+        self._user_token_sweep_s = (
+            max(self._MIN_USER_TOKEN_SWEEP_S, raw_sweep_s) if raw_sweep_s > 0 else 0.0
+        )
+        # How long a consented grant's refresh token may sit un-exercised before
+        # the sweep FORCE-refreshes it (even while the access token is still
+        # fresh) to keep it alive for a provider that ages out idle refresh
+        # tokens — the exact unattended-work failure the sweep exists to prevent.
+        # <= 0 disables keepalive (only near-expiry refreshes). Must sit safely
+        # under the shortest provider refresh-token idle timeout; 1800s (30m)
+        # clears a ~1h idle window with margin. Effective floor is the sweep
+        # cadence (a grant can't be force-refreshed more than once per tick).
+        self._user_token_refresh_keepalive_s = float(
+            mcp_cfg.get("user_token_refresh_keepalive_seconds", 1800)
+        )
 
         # OAuth integration. ``set_app_state`` wires app_state in after the
         # lifespan has built the token store / OAuth helpers; pool dispatch
@@ -711,6 +734,21 @@ class MCPClientManager:
         # rows exist, so deferring keeps the task count at zero in
         # static-only deployments).
         self._user_pool_eviction_task: asyncio.Task[None] | None = None
+
+        # Token-freshness sweep task handle. Like the eviction task it is a
+        # dedicated handle (not in ``_background_tasks``); UNLIKE it, the sweep
+        # is started once in ``_connect_all`` because a consented grant needs
+        # keeping-hot even before any pool entry exists. Its tick early-returns
+        # when no ``oauth_user`` server is configured, so a static-only / no-auth
+        # deployment pays only a per-tick set-emptiness check — no AS calls, no
+        # token-table scans.
+        self._user_token_sweep_task: asyncio.Task[None] | None = None
+        # ``(user, server)`` pairs whose dead-grant / undecryptable state the
+        # sweep has already surfaced, so it badges + logs ONCE on the transition
+        # rather than every tick. Pruned to the currently-consented set each
+        # pass, so a recovered or re-consented grant re-arms the surfacing.
+        # Loop-only mutation.
+        self._token_sweep_warned: set[tuple[str, str]] = set()
 
         # Strong references to fire-and-forget background tasks (catalog
         # refreshes etc.).  ``create_task`` alone keeps only a weak ref — an
@@ -799,6 +837,16 @@ class MCPClientManager:
 
         self._connected.set()
 
+        # Start the background token-freshness sweep (once, on the mcp-loop).
+        # Keeps every consented oauth_user grant hot for unattended work and
+        # surfaces dead grants proactively. Started here rather than lazily (like
+        # the eviction task) because a grant needs keeping-hot even in a
+        # deployment that has not yet created a pool entry; the tick self-gates
+        # to a no-op when no oauth_user server is configured. Skipped entirely
+        # when disabled via config (cadence <= 0).
+        if self._user_token_sweep_s > 0 and self._user_token_sweep_task is None:
+            self._user_token_sweep_task = asyncio.create_task(self._user_token_sweep_loop())
+
     _CONNECT_TIMEOUT = 30  # seconds — prevents hung connections on broken remotes
     _TCP_PROBE_TIMEOUT = 5  # seconds — fast TCP pre-flight for HTTP transports
 
@@ -812,6 +860,16 @@ class MCPClientManager:
 
     # Pool eviction loop tick interval (per-iteration sleep, seconds).
     _POOL_EVICTION_TICK_S = 30.0
+
+    # Floor for the config-driven token-freshness sweep cadence. A positive
+    # ``user_token_sweep_seconds`` below this is clamped up so a misconfigured
+    # tiny value can't busy-loop the sweep; <= 0 disables it (handled at start).
+    _MIN_USER_TOKEN_SWEEP_S = 30.0
+
+    # Short grace before the FIRST sweep after connect, so a restart surfaces a
+    # grant that died during downtime quickly (rather than after a full cadence)
+    # without hammering a cold cluster the instant every node boots.
+    _USER_TOKEN_SWEEP_STARTUP_GRACE_S = 5.0
 
     # Best-effort lock acquire timeout for the eviction pass; eviction must
     # never block on a contested per-key lock so the next tick retries.
@@ -1882,6 +1940,263 @@ class MCPClientManager:
                 self._priming_keys.discard(key)
 
         await asyncio.gather(*(_prime_one(s) for s in list(self._oauth_user_server_names)))
+
+    # -- background token-freshness sweep (oauth_user grants) -----------------
+
+    async def _user_token_sweep_loop(self) -> None:
+        """Long-running coroutine — keeps every consented ``oauth_user`` grant hot.
+
+        Turnstone's OAuth token refresh is otherwise entirely LAZY: a token is
+        refreshed only when a tool is dispatched or a session binds the acting
+        user, and a dead refresh token (needs re-consent) is discovered only when
+        a dispatch fails. That assumes a human is driving the session — it breaks
+        for unattended / autonomous work, where a scheduled run or an
+        alert-triggered workstream acts on behalf of a user who is NOT present and
+        must find the token already fresh and the grant already known-good.
+
+        This loop closes that gap WITHOUT keeping connections warm and WITHOUT
+        mutating consent state on a timer (:meth:`_reconcile_one_user_token` is
+        observe-only). Each tick it walks every consented ``(user, server)`` pair
+        and runs the canonical refresh path
+        (:func:`get_user_access_token_classified`), which (a) refreshes an access
+        token within the 60s expiry skew AND — via the keepalive gate
+        (:meth:`_keepalive_refresh_due`) — force-refreshes a grant whose refresh
+        token has sat un-exercised past the keepalive window, so a provider that
+        ages out *idle* refresh tokens can't expire one between the user's real
+        sessions even when the access-token TTL is long; and (b) surfaces a dead
+        grant as a proactive re-consent badge, ahead of the work that needs it
+        instead of at dispatch time. Connections stay lazy: one cheap reconnect
+        on first dispatch is fine; a failed or stale-token dispatch is not.
+
+        STRICTLY ``oauth_user``-scoped. :meth:`_sweep_user_token_freshness`
+        early-returns when no ``oauth_user`` server is configured, so a
+        static-only / no-auth deployment does no AS round-trips, no MCP-server
+        calls, and no token-table scans — just a set-emptiness check per tick.
+
+        The FIRST sweep runs after only a short startup grace (not a full
+        cadence) so a restart surfaces a grant that died during downtime within
+        seconds; every subsequent sweep waits the full cadence.
+        """
+        delay = min(self._USER_TOKEN_SWEEP_STARTUP_GRACE_S, self._user_token_sweep_s)
+        while True:
+            try:
+                await asyncio.sleep(delay)
+                await self._sweep_user_token_freshness()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                log.warning("MCP token-freshness sweep iteration failed", exc_info=True)
+            delay = self._user_token_sweep_s  # subsequent sweeps wait the full cadence
+
+    async def _sweep_user_token_freshness(self) -> None:
+        """One pass: refresh + classify every consented ``oauth_user`` grant.
+
+        MUST run on the mcp-loop. The gate below IS the no-auth safety property:
+        with no ``oauth_user`` server, or before storage / app_state are wired,
+        this returns before touching the DB or any AS — a static / no-auth server
+        (whose rows :func:`_db_servers_to_config` strips out, and which never
+        writes a user-token row) is structurally invisible to this pass. Per-pair
+        failures are isolated so one bad grant can't starve the rest.
+        """
+        if self._storage is None or self._app_state is None or not self._oauth_user_server_names:
+            return
+        try:
+            targets = await asyncio.to_thread(self._storage.list_mcp_user_token_reconcile_targets)
+        except Exception:
+            log.debug("MCP token sweep: failed to enumerate consented grants", exc_info=True)
+            return
+        oauth_servers = self._oauth_user_server_names
+        seen: set[tuple[str, str]] = set()
+        for user_id, server_name, last_exercised in targets:
+            if server_name not in oauth_servers:
+                # A token row lingering for a server that is no longer
+                # auth_type=oauth_user (renamed / demoted) — not ours to keep hot.
+                continue
+            key = (user_id, server_name)
+            seen.add(key)
+            try:
+                # Force a refresh when the refresh token has sat un-exercised past
+                # the keepalive window, so a provider that ages out idle refresh
+                # tokens can't expire one between the user's real sessions.
+                await self._reconcile_one_user_token(
+                    key, force_refresh=self._keepalive_refresh_due(last_exercised)
+                )
+            except Exception:
+                log.debug(
+                    "MCP token sweep: reconcile failed user=%s server=%s",
+                    user_id,
+                    server_name,
+                    exc_info=True,
+                )
+        # Prune the once-only surfacing set to pairs still consented this pass, so
+        # a re-consented or revoked-then-recreated grant re-arms (and the set can
+        # never grow unbounded across many transient dead grants).
+        self._token_sweep_warned &= seen
+
+    async def _reconcile_one_user_token(
+        self, key: tuple[str, str], *, force_refresh: bool = False
+    ) -> None:
+        """Refresh-on-expiry + dead-grant classification for one ``(user, server)``.
+
+        OBSERVE-ONLY: runs the canonical lookup with ``revoke_on_failure=False``
+        so a background timer NEVER deletes a token or moves a foreground user's
+        revoke threshold — a dead grant is only *surfaced*, and the authoritative
+        revoke stays on the lazy-dispatch path where a real user action justifies
+        it. NEVER connects to the MCP server: only the token is kept hot. Because
+        the row survives, the pair is re-checked every tick, so a spurious
+        server-wide ``invalid_grant`` (an AS maintenance window) self-heals — the
+        badge is dropped on the tick the grant works again.
+
+        ``force_refresh`` (set by the keepalive gate) exercises the refresh token
+        even while the access token is still fresh, so a provider that ages out
+        idle refresh tokens can't expire one between the user's real sessions.
+
+        Surfacing is once-per-transition (tracked in ``_token_sweep_warned``):
+        ``refresh_failed`` (dead grant) raises the dashboard pending-consent
+        badge — and the pin is set ONLY after a successful persist, so a failed
+        badge write retries next tick rather than being lost forever;
+        ``decrypt_failure`` (operator key issue) is logged but NOT badged (the
+        same split :meth:`_record_pending_consent_best_effort` applies).
+        """
+        user_id, server_name = key
+        lookup = await get_user_access_token_classified(
+            app_state=self._app_state,
+            user_id=user_id,
+            server_name=server_name,
+            revoke_ambiguous_escalation=False,
+            revoke_on_failure=False,
+            force_refresh=force_refresh,
+        )
+        if lookup.kind == "refresh_failed":
+            # Dead grant: only a human re-consent in a browser fixes it. Badge it
+            # proactively so the user sees the affordance ahead of autonomous use.
+            if key not in self._token_sweep_warned:
+                log.warning(
+                    "MCP token sweep: grant for user=%s server=%s needs re-consent "
+                    "(dead refresh token) — surfaced proactively before autonomous use",
+                    user_id,
+                    server_name,
+                )
+                # Pin only on a durable badge — a failed write is retried next
+                # tick (the observe-only row survives to be re-enumerated).
+                if await self._persist_pending_consent_best_effort(user_id, server_name):
+                    self._token_sweep_warned.add(key)
+        elif lookup.kind == "decrypt_failure":
+            # Undecryptable stored token — an operator key issue, not
+            # user-fixable and outside the consent dashboard's scope. Surface it
+            # once; do not badge.
+            if key not in self._token_sweep_warned:
+                self._token_sweep_warned.add(key)
+                log.warning(
+                    "MCP token sweep: stored token for user=%s server=%s is undecryptable "
+                    "(operator key issue) — cannot keep this grant hot",
+                    user_id,
+                    server_name,
+                )
+        elif lookup.kind in ("token", "missing") and key in self._token_sweep_warned:
+            # Usable again (fresh / freshly-refreshed) or gone (de-consented). On
+            # a transition out of a surfaced state, re-arm and drop any stale
+            # badge — the self-heal for a spurious invalid_grant that recovered
+            # (no-op if none was raised, e.g. a decrypt_error).
+            self._token_sweep_warned.discard(key)
+            await self._clear_pending_consent_best_effort(user_id, server_name)
+        # refresh_failed_transient: AS / network blip — the token is retained and
+        # the next tick retries. Not human-actionable, so nothing is surfaced and
+        # the prior warned state (if any) is left intact.
+
+    def _keepalive_refresh_due(self, last_exercised_iso: str | None) -> bool:
+        """True when a grant's refresh token has sat un-exercised past the
+        keepalive window and should be force-refreshed to stay alive.
+
+        Disabled (``_user_token_refresh_keepalive_s <= 0``) → never. An unknown /
+        unparseable timestamp → force once (safe: exercising a live token is
+        harmless; missing the keepalive is the failure we're preventing). The
+        stored timestamp is naive-UTC ISO (``%Y-%m-%dT%H:%M:%S``).
+        """
+        if self._user_token_refresh_keepalive_s <= 0:
+            return False
+        if not last_exercised_iso:
+            return True
+        try:
+            last = datetime.fromisoformat(last_exercised_iso)
+        except (TypeError, ValueError):
+            return True
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=UTC)
+        return (datetime.now(UTC) - last).total_seconds() >= self._user_token_refresh_keepalive_s
+
+    def _write_pending_consent(
+        self, user_id: str, server_name: str, *, error_code: str, scopes_required: str | None
+    ) -> None:
+        """Single source of the deferred-consent upsert call shape (blocking).
+
+        Both best-effort wrappers — the sync dispatch-path
+        :meth:`_record_pending_consent_best_effort` and the loop-path
+        :meth:`_persist_pending_consent_best_effort` — route through here so the
+        7-kwarg ``upsert_mcp_pending_consent`` call and the timestamp format live
+        in ONE place. ``last_ws_id`` / ``last_tool_call_id`` are ``None`` for the
+        proactive (no-dispatch) path; the dispatch path passes its ids through a
+        thin wrapper. Raises on storage error — callers wrap best-effort.
+        """
+        if self._storage is None:
+            return
+        self._storage.upsert_mcp_pending_consent(
+            user_id=user_id,
+            server_name=server_name,
+            error_code=error_code,
+            scopes_required=scopes_required,
+            last_ws_id=None,
+            last_tool_call_id=None,
+            now_iso=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
+        )
+
+    async def _persist_pending_consent_best_effort(self, user_id: str, server_name: str) -> bool:
+        """Raise the dashboard pending-consent badge for a proactively-detected
+        dead grant, off the mcp-loop. Returns True iff the badge was persisted.
+
+        The sweep runs ON the loop, so the blocking storage write goes through
+        :func:`asyncio.to_thread`. Maps to the ``mcp_consent_required`` code the
+        dashboard already renders. Best-effort: a storage failure is logged and
+        returns False (never raised onto the loop) so the caller retries on the
+        next tick rather than pinning a badge that was never written.
+        """
+        if self._storage is None:
+            return False
+        try:
+            await asyncio.to_thread(
+                self._write_pending_consent,
+                user_id,
+                server_name,
+                error_code="mcp_consent_required",
+                scopes_required=None,
+            )
+            return True
+        except Exception:
+            log.warning(
+                "MCP token sweep: pending-consent badge persist failed user=%s server=%s",
+                user_id,
+                server_name,
+                exc_info=True,
+            )
+            return False
+
+    async def _clear_pending_consent_best_effort(self, user_id: str, server_name: str) -> None:
+        """Drop a stale pending-consent badge when a previously-surfaced grant is
+        usable again (real re-consent, or a spurious ``invalid_grant`` that has
+        healed), off the mcp-loop. No-op if no badge was raised. Best-effort: a
+        storage failure is logged, never raised onto the loop.
+        """
+        if self._storage is None:
+            return
+        try:
+            await asyncio.to_thread(self._storage.delete_mcp_pending_consent, user_id, server_name)
+        except Exception:
+            log.debug(
+                "MCP token sweep: pending-consent clear failed user=%s server=%s",
+                user_id,
+                server_name,
+                exc_info=True,
+            )
 
     # -- pool eviction --------------------------------------------------------
 
@@ -3047,6 +3362,15 @@ class MCPClientManager:
         if self._loop is not None and self._loop.is_running():
 
             async def _cancel_background() -> None:
+                # The token-freshness sweep is a dedicated handle (not in
+                # _background_tasks); cancel it here so a deployment that never
+                # creates a pool entry — and thus skips the pool-teardown block
+                # below — still stops it cleanly.
+                if self._user_token_sweep_task is not None:
+                    self._user_token_sweep_task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await self._user_token_sweep_task
+                    self._user_token_sweep_task = None
                 tasks = list(self._background_tasks)
                 for task in tasks:
                     task.cancel()
@@ -3161,6 +3485,8 @@ class MCPClientManager:
         self._user_prompt_map.clear()
         self._user_prompts.clear()
         self._user_pool_eviction_task = None
+        self._user_token_sweep_task = None
+        self._token_sweep_warned.clear()
 
         log.info("MCP client shut down")
 
@@ -4096,14 +4422,8 @@ class MCPClientManager:
         code, scopes = parsed
         scopes_str = " ".join(scopes) if scopes else None
         try:
-            self._storage.upsert_mcp_pending_consent(
-                user_id=user_id,
-                server_name=server_name,
-                error_code=code,
-                scopes_required=scopes_str,
-                last_ws_id=None,
-                last_tool_call_id=None,
-                now_iso=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
+            self._write_pending_consent(
+                user_id, server_name, error_code=code, scopes_required=scopes_str
             )
         except Exception:
             log.warning(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2134,9 +2134,12 @@ class MCPClientManager:
         :meth:`_record_pending_consent_best_effort` and the loop-path
         :meth:`_persist_pending_consent_best_effort` — route through here so the
         7-kwarg ``upsert_mcp_pending_consent`` call and the timestamp format live
-        in ONE place. ``last_ws_id`` / ``last_tool_call_id`` are ``None`` for the
-        proactive (no-dispatch) path; the dispatch path passes its ids through a
-        thin wrapper. Raises on storage error — callers wrap best-effort.
+        in ONE place. ``last_ws_id`` / ``last_tool_call_id`` are always ``None``:
+        neither path captures a triggering ws / tool-call id (the mcp dispatch
+        layer never receives one, and the proactive sweep has no dispatch), and
+        no caller reads those columns today — they are unpopulated schema
+        affordances from migration 054. Raises on storage error — callers wrap
+        best-effort.
         """
         if self._storage is None:
             return

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1506,6 +1506,7 @@ async def get_user_access_token_classified(
     server_name: str,
     force_refresh: bool = False,
     revoke_ambiguous_escalation: bool = True,
+    revoke_on_failure: bool = True,
 ) -> TokenLookupResult:
     """Tagged token lookup with refresh-on-expiry.
 
@@ -1549,6 +1550,18 @@ async def get_user_access_token_classified(
     this session. The streak + cooldown persist, so the authoritative
     escalation-revoke happens on the lazy-dispatch path when the user actually
     invokes the tool.
+
+    ``revoke_on_failure=False`` makes the lookup fully OBSERVE-ONLY: it still
+    refreshes a healthy near-expiry token, but a failure NEVER mutates durable
+    or cross-call state — no token deletion, no ``token_revoked`` audit, and no
+    ambiguous-streak / cooldown bump. A permanent rejection is reported as
+    ``refresh_failed`` and everything else as ``refresh_failed_transient``, but
+    the row is left intact for the authoritative (revoking) lazy-dispatch path.
+    Used by the background token-freshness sweep, which reconciles EVERY
+    consented grant on a timer for users who aren't present: a timer must not be
+    able to delete a token or move a foreground user's revoke threshold, and a
+    spurious server-wide ``invalid_grant`` (e.g. an AS maintenance window) must
+    self-heal on a later tick rather than force a fleet-wide re-consent.
     """
     token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
     if token_store is None:
@@ -1614,6 +1627,9 @@ async def get_user_access_token_classified(
     if not refresh_value:
         # Expired token with no refresh token: genuinely unusable, no
         # misclassification risk (a local check, not an AS response) — revoke.
+        # Observe-only callers surface it as a dead grant without deleting.
+        if not revoke_on_failure:
+            return TokenLookupResult(kind="refresh_failed")
         return await _revoke_after_refresh_failure(
             app_state,
             token_store,
@@ -1669,6 +1685,8 @@ async def get_user_access_token_classified(
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
         refresh_value2 = plain2.get("refresh_token")
         if not refresh_value2:
+            if not revoke_on_failure:
+                return TokenLookupResult(kind="refresh_failed")
             return await _revoke_after_refresh_failure(
                 app_state,
                 token_store,
@@ -1690,6 +1708,16 @@ async def get_user_access_token_classified(
                 existing_scopes=plain2.get("scopes") or "",
             )
         except MCPOAuthRefreshFailed as exc:
+            if not revoke_on_failure:
+                # Observe-only (background sweep): never revoke, never mutate the
+                # shared streak / cooldown. A permanent rejection surfaces as a
+                # dead grant to badge; anything else is a retryable transient the
+                # next tick (or a real dispatch) re-attempts. The 240s sweep
+                # cadence is its own rate limit, so skipping the cooldown here
+                # cannot hammer the AS.
+                if exc.failure_class is _RefreshFailureClass.PERMANENT:
+                    return TokenLookupResult(kind="refresh_failed")
+                return TokenLookupResult(kind="refresh_failed_transient")
             if exc.failure_class is _RefreshFailureClass.PERMANENT:
                 # The AS rejected the grant as dead (invalid_grant / invalid_scope
                 # / an OIDC interaction-required code): a reliable dead-grant

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -4771,6 +4771,24 @@ class PostgreSQLBackend:
                 )
             return out
 
+    def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
+        """Return ``(user_id, server_name, COALESCE(last_refreshed, created))`` per
+        token row — the freshness sweep's drive set + keepalive-refresh signal.
+
+        Unfiltered by expiry: an expired access token with a live refresh token
+        is still a consented grant the sweep must keep hot. Only ``oauth_user``
+        servers write these rows; no ciphertext is projected.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                sa.select(
+                    mcp_user_tokens.c.user_id,
+                    mcp_user_tokens.c.server_name,
+                    sa.func.coalesce(mcp_user_tokens.c.last_refreshed, mcp_user_tokens.c.created),
+                )
+            ).fetchall()
+        return [(row[0], row[1], row[2]) for row in rows]
+
     def delete_mcp_oauth_rows_by_server_name(self, server_name: str) -> int:
         """Purge user tokens + pending OAuth state for *server_name*."""
         with self._conn() as conn:

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -2158,6 +2158,22 @@ class StorageBackend(Protocol):
         """
         ...
 
+    def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
+        """Return ``(user_id, server_name, last_exercised_iso)`` for every MCP
+        user-token row — the drive set for the background freshness sweep.
+
+        ``last_exercised = COALESCE(last_refreshed, created)`` is the last time
+        the grant's refresh token was exercised; the sweep force-refreshes once
+        it exceeds the configured keepalive window, so a provider that ages out
+        an *idle* refresh token can't expire one between a user's real sessions.
+        Deliberately UNFILTERED by ``expires_at``: an expired access token backed
+        by a live refresh token is still a consented, reconcilable grant. Only
+        ``auth_type='oauth_user'`` servers ever write these rows, so a static /
+        no-auth server is structurally absent; ciphertext columns are never
+        touched — only the identity + timestamp cross the wire.
+        """
+        ...
+
     def delete_mcp_oauth_rows_by_server_name(self, server_name: str) -> int:
         """Purge per-(user, server) tokens and pending OAuth states for *server_name*.
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -4942,6 +4942,24 @@ class SQLiteBackend:
                 )
             return out
 
+    def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
+        """Return ``(user_id, server_name, COALESCE(last_refreshed, created))`` per
+        token row — the freshness sweep's drive set + keepalive-refresh signal.
+
+        Unfiltered by expiry: an expired access token with a live refresh token
+        is still a consented grant the sweep must keep hot. Only ``oauth_user``
+        servers write these rows; no ciphertext is projected.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                sa.select(
+                    mcp_user_tokens.c.user_id,
+                    mcp_user_tokens.c.server_name,
+                    sa.func.coalesce(mcp_user_tokens.c.last_refreshed, mcp_user_tokens.c.created),
+                )
+            ).fetchall()
+        return [(row[0], row[1], row[2]) for row in rows]
+
     def delete_mcp_oauth_rows_by_server_name(self, server_name: str) -> int:
         """Purge user tokens + pending OAuth state for *server_name*."""
         with self._conn() as conn:


### PR DESCRIPTION
## Problem

Per-user OAuth (`auth_type=oauth_user`, on-behalf-of) token refresh is entirely **lazy**: a token is refreshed only when a tool is dispatched or a session binds the acting user, and a dead refresh token is discovered only when a dispatch *fails*. That assumes a human is driving the session — which breaks precisely for **autonomous / scheduled work** acting on behalf of an absent user:

- the access token may be expired (first dispatch pays the refresh latency),
- it may be in a transient-failure cooldown (tool unavailable), or
- the grant may be dead, with nobody present to re-consent.

The only periodic MCP-loop task today (idle eviction) actively **tears OBO connections down**; nothing keeps tokens warm or surfaces dead grants ahead of the work that needs them.

## Change

A background token-freshness sweep (`_user_token_sweep_loop`, default 240s) that keeps every consented `oauth_user` grant hot **without keeping connections warm** and **without mutating consent state on a timer**.

- **Strictly `oauth_user`-scoped.** Gates on `_oauth_user_server_names` and drives off `mcp_user_tokens` rows. A static / no-auth server has neither, so it is *structurally* invisible to the sweep — zero DB scans, zero authorization-server round-trips, zero MCP-server calls. Never connects to the MCP server; connections stay lazy (one cheap reconnect on first dispatch).
- **Observe-only.** A new `revoke_on_failure=False` parameter on `get_user_access_token_classified` makes the background path non-destructive: a timer never deletes a token, emits `token_revoked`, or mutates the shared ambiguous-streak / cooldown. A dead grant is only *surfaced* (proactive dashboard pending-consent badge); the authoritative revoke stays on the lazy-dispatch path where a real user action justifies it. Because the row survives, a spurious server-wide `invalid_grant` (an AS maintenance window) **self-heals** — the badge is dropped on the tick the grant works again.
- **Keepalive.** Force-refreshes a grant whose refresh token has sat un-exercised past `user_token_refresh_keepalive_seconds` (default 1800s) even while the access token is still fresh, so a provider that ages out *idle* refresh tokens can't expire one between a user's real sessions.
- **Robust surfacing.** Dead grants are surfaced once per transition, pinning the pair only after a durable badge write so a failed persist retries rather than being lost. The first sweep runs after a short startup grace, so a restart surfaces a grant that died during downtime within seconds.

Cadence `<= 0` disables the sweep; a positive value is floored (30s) so a misconfigured tiny cadence can't busy-loop. The sweep reuses the per-key refresh lock, so a keepalive force can't double-refresh against a concurrent dispatch.

### Storage
Adds `list_mcp_user_token_reconcile_targets()` → `(user_id, server_name, COALESCE(last_refreshed, created))` (expiry-unfiltered, no ciphertext projected) on the protocol, sqlite, and postgres backends.

## Deliberately out of scope
- **Connection pre-warming** (keeping OBO sockets hot for zero first-dispatch latency) — connections re-establish lazily and cheaply; the token is what needs keeping fresh.
- **Static-server auto-reconnect** (self-healing a downed non-OBO server without manual intervention) — a real, separate gap being spiked next.
- **Per-node sharding** of the sweep — a scaling concern only at large fleet sizes; a follow-up if OBO ever scales past low-tens of consented users per node.

## Tests
No-auth invisibility, observe-only non-destruction (token kept + shared streak untouched on a background permanent / ambiguous failure), keepalive gating (due / not-due / disabled / unparseable), badge persist-then-pin retry, self-heal on recovery, cadence clamp / disable, and the storage enumerator. Full MCP / OAuth / storage / session suites pass locally.
