### PR TITLE
feat(mcp): autonomous reconnect + liveness for static MCP servers

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -3827,7 +3827,9 @@ class TestStaticHealthLoop:
         attempt) must not advance the breaker — the server was never proven
         unreachable. The breaker is owned by _ensure_static_connected."""
         mgr, loop, _ = running_loop_mgr
-        mgr._CONNECT_TIMEOUT = 1  # instance shadow: sync-boundary wait, fast test
+        # Instance-shadow the sync-boundary wait (now the caller-timeout constant,
+        # not _CONNECT_TIMEOUT) so the held-lock contention path resolves fast.
+        mgr._STATIC_RECONNECT_CALLER_TIMEOUT_S = 1.0
         _seed_static_state(mgr, "srv", session=None)
 
         async def _hold() -> asyncio.Lock:
@@ -3995,6 +3997,62 @@ class TestEnsureStaticConnected:
         assert out2 is sess
         assert cm.await_count == 1
 
+    def test_dispatch_does_not_defer_when_busy(self, running_loop_mgr) -> None:
+        """Round-4 [3]: a DISPATCH (defer_if_busy=False) reconnects even with an
+        in-flight sibling — it needs the session now — rather than hard-failing a
+        reachable server. The autonomous default still defers (test above)."""
+        mgr, loop, _ = running_loop_mgr
+        state = _seed_static_state(mgr, "srv", session=None)
+        state.in_flight = 1
+        sess = MagicMock()
+
+        async def _connect(name: str, _cfg: dict[str, Any]) -> None:
+            _seed_static_state(mgr, name, session=sess)
+
+        with patch.object(mgr, "_connect_one_locked", side_effect=_connect) as cm:
+            out = _run_hl(
+                loop,
+                mgr._ensure_static_connected(
+                    "srv", mgr._server_configs["srv"], defer_if_busy=False
+                ),
+            )
+        assert out is sess  # reconnected despite in_flight > 0
+        assert cm.await_count == 1
+
+    def test_cancelled_attempt_cleans_up_partial_session_and_records(
+        self, running_loop_mgr
+    ) -> None:
+        """Round-4 [0]/[1]: a bare CancelledError delivered mid-connect (a caller
+        sync-boundary giving up, or shutdown) must NOT leave a half-discovered
+        session installed and must record the failed attempt — the handler is
+        `except BaseException`, not `except Exception`."""
+        mgr, loop, _ = running_loop_mgr
+        state = _seed_static_state(mgr, "srv", session=None)
+
+        async def _handshake_then_cancel(name: str, _cfg: dict[str, Any]) -> None:
+            state.session = MagicMock()  # handshake OK, session installed
+            raise asyncio.CancelledError()  # discovery cancelled by a caller giving up
+
+        with (
+            patch.object(mgr, "_connect_one_locked", side_effect=_handshake_then_cancel),
+            # run_coroutine_threadsafe surfaces a re-raised asyncio.CancelledError
+            # as concurrent.futures.CancelledError at the .result() boundary.
+            pytest.raises((asyncio.CancelledError, concurrent.futures.CancelledError)),
+        ):
+            _run_hl(loop, mgr._ensure_static_connected("srv", mgr._server_configs["srv"]))
+        assert mgr._static_servers["srv"].session is None  # partial session dropped
+        assert mgr._consecutive_failures.get("srv") == 1  # breaker recorded
+
+    def test_timeout_hierarchy_caller_exceeds_attempt(self) -> None:
+        """The systemic round-4 fix: the caller wait must exceed the inner attempt
+        bound so the inner asyncio.timeout fires first (clean TimeoutError), never
+        a bare cancel escaping — and the attempt must cover a full handshake."""
+        assert (
+            MCPClientManager._STATIC_RECONNECT_CALLER_TIMEOUT_S
+            > MCPClientManager._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S
+            > MCPClientManager._CONNECT_TIMEOUT
+        )
+
     def test_failure_records_one_breaker_failure_and_raises(self, running_loop_mgr) -> None:
         mgr, loop, _ = running_loop_mgr
         _seed_static_state(mgr, "srv", session=None)
@@ -4053,6 +4111,34 @@ class TestEnsureStaticConnected:
             assert mgr._static_servers["srv"].session is sess
 
         asyncio.run(_run())
+
+    def test_remove_server_sync_cancels_on_timeout_and_reports_failure(
+        self, running_loop_mgr
+    ) -> None:
+        """Round-4 [2]: if teardown can't finish within the caller timeout (a slow
+        reconnect holding the per-name lock), remove_server_sync CANCELS the
+        pending _remove — so it can't later pop a re-added entry — and returns
+        False rather than a false 'removed'."""
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=MagicMock())
+
+        async def _hang(_name: str) -> None:
+            await asyncio.sleep(10)  # teardown wedged (stands in for lock contention)
+
+        with patch.object(mgr, "_teardown_static_session", side_effect=_hang):
+            result = mgr.remove_server_sync("srv", timeout=0.2)
+        assert result is False  # not a false success
+        assert "srv" not in mgr._server_configs  # config still popped (won't reconnect)
+
+    def test_schedule_next_ping_sets_and_returns_fresh_deadline(self) -> None:
+        """Round-4 [5]: the extracted ping-scheduling helper stores and returns
+        the same fresh deadline (was a copy-pasted triplet in 3 branches)."""
+        mgr = MCPClientManager({})
+        mgr._static_health_check_s = 30.0
+        before = time.monotonic()
+        due = mgr._schedule_next_ping("srv")
+        assert mgr._static_next_ping["srv"] == due
+        assert before + 30.0 <= due <= time.monotonic() + 30.0
 
 
 class TestTeardownStaticSession:

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2188,6 +2188,13 @@ class TestConnectOneUnreachable:
             sweep.cancel()
             with contextlib.suppress(BaseException):
                 loop.run_until_complete(sweep)
+        # _connect_all spawns the long-lived static health task; cancel it before
+        # closing the loop so it isn't destroyed while pending.
+        health = mgr._static_health_task
+        if health is not None:
+            health.cancel()
+            with suppress(BaseException):
+                loop.run_until_complete(health)
         loop.close()
 
         bad_state = mgr._static_servers.get("bad")
@@ -3163,3 +3170,200 @@ class TestCBAutoReconnectRefresh:
         exc = warn_calls[0].kwargs.get("exc_info")
         assert isinstance(exc, RuntimeError)
         assert "catalog fetch broke" in str(exc)
+
+
+def _run_hl(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
+    """Submit *coro* to the running fixture loop and wait (5s)."""
+    return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=5)
+
+
+class TestStaticHealthLoop:
+    """Autonomous static-server reconnect + liveness.
+
+    The SDK gives up reconnecting after 2 attempts on one transport and never on
+    the others (verified: mcp 1.28.1), and every other Turnstone reconnect path
+    is dispatch- or operator-driven — so a static server that dies while idle
+    stays dead. This loop is the missing autonomous trigger: it reconnects
+    disconnected servers on a capped, jittered, forever backoff and pings
+    connected ones, evicting a dead-but-idle session (which nothing else would
+    notice) so it is reconnected.
+    """
+
+    # -- backoff policy ------------------------------------------------------
+
+    def test_reconnect_delay_capped_and_jittered(self) -> None:
+        mgr = MCPClientManager({})
+        # attempt 0: ceiling = base (1s); every draw within [0, base].
+        assert all(
+            0.0 <= mgr._static_reconnect_delay(0) <= mgr._STATIC_RECONNECT_BASE_S
+            for _ in range(200)
+        )
+        # large / unbounded attempt: never exceeds the cap (no overflow, forever).
+        assert all(
+            0.0 <= mgr._static_reconnect_delay(a) <= mgr._STATIC_RECONNECT_MAX_S
+            for a in (10, 100, 10_000)
+        )
+        # jitter actually varies (not a fixed value).
+        assert len({round(mgr._static_reconnect_delay(8), 6) for _ in range(50)}) > 1
+
+    # -- reconnect (layer 1) -------------------------------------------------
+
+    def test_reconnect_one_success_resets_backoff_and_closes_breaker(
+        self, running_loop_mgr
+    ) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "down", session=None)
+        mgr._static_reconnect_attempt["down"] = 4  # pretend we'd been failing
+        mgr._cb_record_failure("down")
+
+        async def _fake_connect(name: str, _cfg: dict[str, Any]) -> None:
+            _seed_static_state(mgr, name, session=MagicMock())
+
+        with (
+            patch.object(mgr, "_connect_one", side_effect=_fake_connect),
+            patch.object(mgr, "_refresh_server", new=AsyncMock()),
+        ):
+            _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+
+        assert mgr._static_servers["down"].session is not None
+        assert "down" not in mgr._static_reconnect_attempt  # reset
+        assert "down" not in mgr._consecutive_failures  # breaker closed
+
+    def test_reconnect_one_retries_forever_with_growing_backoff(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "down", session=None)
+
+        async def _boom(name: str, _cfg: dict[str, Any]) -> None:
+            raise RuntimeError("still down")
+
+        with patch.object(mgr, "_connect_one", side_effect=_boom):
+            for expected in range(1, 7):
+                mgr._static_reconnect_next.pop("down", None)  # force it due
+                due = _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+                assert mgr._static_reconnect_attempt["down"] == expected  # no cap
+                assert due > time.monotonic() - 1  # next attempt scheduled
+
+    def test_reconnect_one_skips_when_connect_already_in_flight(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "down", session=None)
+
+        async def _scenario() -> float:
+            lock = mgr._static_connect_lock_for("down")
+            await lock.acquire()  # simulate a dispatch reconnect in progress
+            try:
+                return await mgr._static_reconnect_one("down", time.monotonic())
+            finally:
+                lock.release()
+
+        with patch.object(mgr, "_connect_one", new=AsyncMock()) as cm:
+            _run_hl(loop, _scenario())
+        cm.assert_not_awaited()  # did not pile a second reconnect on the held lock
+
+    def test_connect_one_serializes_concurrent_reconnects(self, running_loop_mgr) -> None:
+        """The per-name lock prevents two concurrent ``_connect_one`` for one
+        server from interleaving teardown/rebuild on the shared state."""
+        mgr, loop, _ = running_loop_mgr
+        active = 0
+        max_active = 0
+
+        async def _inner(name: str, _cfg: dict[str, Any]) -> None:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.02)
+            active -= 1
+
+        async def _two() -> None:
+            with patch.object(mgr, "_connect_one_locked", side_effect=_inner):
+                await asyncio.gather(mgr._connect_one("x", {}), mgr._connect_one("x", {}))
+
+        _run_hl(loop, _two())
+        assert max_active == 1  # serialized, never overlapping
+
+    # -- liveness ping (layer 2 — the idle-dead detection) -------------------
+
+    def test_ping_one_healthy_keeps_session(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock()
+        _seed_static_state(mgr, "up", session=sess)
+        due = _run_hl(loop, mgr._static_ping_one("up", time.monotonic()))
+        sess.send_ping.assert_awaited_once()
+        assert mgr._static_servers["up"].session is sess  # kept
+        assert due > time.monotonic()  # next ping scheduled
+
+    def test_ping_one_dead_session_evicts_for_reconnect(self, running_loop_mgr) -> None:
+        """The Understone case: a connected-but-dead session that nothing else
+        would notice is detected by the ping and evicted so the next tick
+        reconnects it."""
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock(side_effect=ConnectionResetError("peer gone"))
+        _seed_static_state(mgr, "up", session=sess)
+        now = time.monotonic()
+        _run_hl(loop, mgr._static_ping_one("up", now))
+        assert mgr._static_servers["up"].session is None  # evicted
+        assert mgr._static_reconnect_next["up"] <= now + 0.01  # reconnect asap
+        assert "up" in mgr._consecutive_failures  # breaker recorded a failure
+
+    def test_ping_one_timeout_evicts(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._STATIC_HEALTH_PING_TIMEOUT_S = 0.05  # instance shadow for a fast test
+
+        async def _hang() -> None:
+            await asyncio.sleep(10)
+
+        sess = MagicMock()
+        sess.send_ping = _hang
+        _seed_static_state(mgr, "up", session=sess)
+        _run_hl(loop, mgr._static_ping_one("up", time.monotonic()))
+        assert mgr._static_servers["up"].session is None  # a hung ping = down
+
+    # -- tick scope + lifecycle ---------------------------------------------
+
+    def test_tick_skips_oauth_user_servers(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["pool"] = {"type": "http", "url": "https://x/mcp"}
+        mgr._oauth_user_server_names = {"pool"}
+        now = time.monotonic()
+        with (
+            patch.object(mgr, "_static_ping_one", new=AsyncMock(return_value=now)) as ping,
+            patch.object(mgr, "_static_reconnect_one", new=AsyncMock(return_value=now)) as recon,
+        ):
+            _run_hl(loop, mgr._static_health_tick())
+        for call in ping.await_args_list + recon.await_args_list:
+            assert call.args[0] != "pool"  # oauth_user pools are managed separately
+
+    def test_connect_all_starts_health_task_and_disable_gates_it(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {}
+        _run_hl(loop, mgr._connect_all())
+        assert mgr._static_health_task is not None  # started
+
+        mgr2 = MCPClientManager({})
+        mgr2._loop = loop
+        mgr2._server_configs = {}
+        mgr2._static_health_check_s = 0  # disabled
+        _run_hl(loop, mgr2._connect_all())
+        assert mgr2._static_health_task is None  # not started
+
+    def test_health_loop_cancel_returns_cleanly(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {}  # nothing to do → parks in the sleep
+
+        task = _run_hl(loop, _spawn_task(mgr._static_health_loop()))
+
+        async def _cancel() -> None:
+            task.cancel()
+            with suppress(BaseException):
+                await task
+
+        _run_hl(loop, _cancel())
+        assert task.cancelled() or task.done()
+
+
+async def _spawn_task(coro: Any) -> asyncio.Task[Any]:
+    return asyncio.ensure_future(coro)

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -3240,7 +3240,7 @@ class TestStaticHealthLoop:
             patch.object(mgr, "_connect_one_locked", side_effect=_fake_connect),
             patch.object(mgr, "_refresh_server", new=AsyncMock()),
         ):
-            _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+            _run_hl(loop, mgr._static_reconnect_one("down"))
 
         assert mgr._static_servers["down"].session is not None
         assert "down" not in mgr._static_reconnect_attempt  # health backoff reset
@@ -3261,7 +3261,7 @@ class TestStaticHealthLoop:
         with patch.object(mgr, "_connect_one_locked", side_effect=_boom):
             for expected in range(1, 7):
                 mgr._static_reconnect_next.pop("down", None)  # force it due
-                due = _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+                due = _run_hl(loop, mgr._static_reconnect_one("down"))
                 assert mgr._static_reconnect_attempt["down"] == expected  # no cap
                 assert due > time.monotonic() - 1  # next attempt scheduled
 
@@ -3278,7 +3278,7 @@ class TestStaticHealthLoop:
         async def _scenario() -> float:
             lock = mgr._static_connect_lock_for("down")
             await lock.acquire()  # a dispatch reconnect in progress
-            recon = asyncio.ensure_future(mgr._static_reconnect_one("down", time.monotonic()))
+            recon = asyncio.ensure_future(mgr._static_reconnect_one("down"))
             await asyncio.sleep(0.05)
             assert not recon.done()  # queued on the lock, not skipped/failed
             mgr._static_servers["down"].session = sess  # the holder's connect lands
@@ -3328,7 +3328,7 @@ class TestStaticHealthLoop:
         assert due > time.monotonic()  # next ping scheduled
 
     def test_ping_one_dead_session_evicts_for_reconnect(self, running_loop_mgr) -> None:
-        """The Understone case: a connected-but-dead session that nothing else
+        """The Turnstone case: a connected-but-dead session that nothing else
         would notice is detected by the ping and evicted so the next tick
         reconnects it."""
         mgr, loop, _ = running_loop_mgr
@@ -3504,7 +3504,7 @@ class TestStaticHealthLoop:
 
         # Patch the LOCKED body so the real ``_connect_one`` still takes the lock.
         with patch.object(mgr, "_connect_one_locked", side_effect=_wedge_locked):
-            due = _run_hl(loop, mgr._static_reconnect_one("wedge", time.monotonic()))
+            due = _run_hl(loop, mgr._static_reconnect_one("wedge"))
         assert mgr._static_reconnect_attempt["wedge"] == 1  # failed attempt
         assert not mgr._static_connect_lock_for("wedge").locked()  # lock released
         assert due > time.monotonic() - 1  # backoff scheduled
@@ -3552,15 +3552,15 @@ class TestStaticHealthLoop:
         mgr._server_configs = {"srv": {"type": "stdio", "command": "echo"}}
         _seed_static_state(mgr, "srv", session=None)
 
-        async def _slow_reconnect(name: str, now: float) -> float:
+        async def _slow_reconnect(name: str) -> float:
             await asyncio.sleep(0.3)  # burn real time during the pass
-            return now + 1.0  # next-due 1s from the TICK-START clock
+            return time.monotonic() + 1.0  # due in ~1s from now
 
         with patch.object(mgr, "_static_reconnect_one", side_effect=_slow_reconnect):
             sleep_s = _run_hl(loop, mgr._static_health_tick())
-        # Stale-clock sleep would be ~1.0 (due - tick_start_now). Fresh-clock
-        # subtracts the ~0.3s the pass elapsed, so it is well under 0.9.
-        assert 0.5 <= sleep_s < 0.9
+        # The reconnect returns "due ~1s from post-sleep clock", and the tick
+        # subtracts its own fresh after-clock — the result should be near 1.0.
+        assert 0.7 <= sleep_s <= 1.3
 
     def test_tick_skips_double_underscore_names(self, running_loop_mgr) -> None:
         """A ``__``-containing server can never connect (reserved delimiter); the
@@ -3595,6 +3595,40 @@ class TestStaticHealthLoop:
             result = mgr.reconnect_sync("srv")
         assert result["connected"] is True
         assert held == [True]  # the lock was held while rebuilding
+
+    def test_reconnect_sync_timeout_cleans_catalog(self, running_loop_mgr) -> None:
+        """The inner ``asyncio.timeout`` in ``reconnect_sync``'s ``_reconnect``
+        fires before the caller-side ``future.result(timeout=...)``, triggers the
+        catalog cleanup (empty tools/resources/prompts so the merged maps don't
+        advertise entries with no live session), nulls the stale session, and
+        returns an error dict."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["srv"] = {"type": "stdio", "command": "echo"}
+        mgr._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S = 0.1  # fire quickly
+        _seed_static_state(mgr, "srv", session=MagicMock())
+        state = mgr._static_servers["srv"]
+        state.tools = [{"name": "ghost_tool"}]
+        state.resources = [{"uri": "ghost://resource"}]
+        state.prompts = [{"name": "ghost_prompt"}]
+
+        async def _stall(name: str, _cfg: dict[str, Any]) -> None:
+            await asyncio.sleep(3600)  # never completes — timeout fires first
+
+        with (
+            patch.object(mgr, "_connect_one_locked", side_effect=_stall),
+            patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
+        ):
+            result = mgr.reconnect_sync("srv")
+
+        assert result["connected"] is False
+        assert "timed out" in result["error"].lower()
+        assert result["tools"] == 0
+        assert result["resources"] == 0
+        assert result["prompts"] == 0
+        # Stale session was nulled after the timeout
+        assert mgr._static_servers["srv"].session is None
+        # Lock was released after the timeout + cleanup
+        assert not mgr._static_connect_lock_for("srv").locked()
 
     def test_cb_auto_reconnect_reuses_existing_session(self, running_loop_mgr) -> None:
         """If a session is already live (a health reconnect established it), a
@@ -3634,12 +3668,12 @@ class TestStaticHealthLoop:
         lock = asyncio.run_coroutine_threadsafe(_acquire_hold(), loop).result(timeout=5)
 
         result: dict[str, Any] = {}
-        error: dict[str, BaseException] = {}
+        error: dict[str, Exception] = {}
 
         def _dispatch() -> None:
             try:
                 result["session"] = mgr._cb_auto_reconnect("srv")
-            except BaseException as exc:  # noqa: BLE001 - surfaced to the test
+            except Exception as exc:
                 error["exc"] = exc
 
         with (
@@ -3729,7 +3763,7 @@ class TestStaticHealthLoop:
         state.in_flight = 1  # a call_tool still draining on the evicted stack
         before = time.monotonic()
         with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
-            due = _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+            due = _run_hl(loop, mgr._static_reconnect_one("down"))
         cm.assert_not_awaited()  # no teardown-under-dispatch
         assert before < due <= time.monotonic() + 1.5  # ~1s recheck, not backoff
         assert "down" not in mgr._static_reconnect_attempt  # not a failed attempt
@@ -3747,10 +3781,9 @@ class TestStaticHealthLoop:
         async def _boom(name: str, _cfg: dict[str, Any]) -> None:
             raise RuntimeError("still down")
 
-        stale_now = time.monotonic() - 45.0  # tick "started" 45s ago
         with patch.object(mgr, "_connect_one_locked", side_effect=_boom):
             before = time.monotonic()
-            due = _run_hl(loop, mgr._static_reconnect_one("down", stale_now))
+            due = _run_hl(loop, mgr._static_reconnect_one("down"))
         assert due >= before  # future-dated, not tick-start-relative
         assert mgr._static_reconnect_next["down"] == due
 
@@ -3776,7 +3809,7 @@ class TestStaticHealthLoop:
         mgr._server_configs = {"srv": {"type": "stdio", "command": "echo"}}
         _seed_static_state(mgr, "srv", session=None)
 
-        async def _stray(name: str, now: float) -> float:
+        async def _stray(name: str) -> float:
             raise asyncio.CancelledError
 
         with patch.object(mgr, "_static_reconnect_one", side_effect=_stray):
@@ -3886,12 +3919,12 @@ class TestStaticHealthLoop:
             return lock
 
         lock = asyncio.run_coroutine_threadsafe(_hold(), loop).result(timeout=5)
-        error: dict[str, BaseException] = {}
+        error: dict[str, Exception] = {}
 
         def _dispatch() -> None:
             try:
                 mgr._cb_auto_reconnect("srv")
-            except BaseException as exc:  # noqa: BLE001 - surfaced to the test
+            except Exception as exc:
                 error["exc"] = exc
 
         with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
@@ -4019,13 +4052,13 @@ class TestEnsureStaticConnected:
         assert out is sess  # reconnected despite in_flight > 0
         assert cm.await_count == 1
 
-    def test_cancelled_attempt_cleans_up_partial_session_and_records(
+    def test_cancelled_attempt_cleans_up_partial_session_and_no_breaker_record(
         self, running_loop_mgr
     ) -> None:
-        """Round-4 [0]/[1]: a bare CancelledError delivered mid-connect (a caller
+        """A bare CancelledError delivered mid-connect (a caller
         sync-boundary giving up, or shutdown) must NOT leave a half-discovered
-        session installed and must record the failed attempt — the handler is
-        `except BaseException`, not `except Exception`."""
+        session installed but must NOT record a breaker failure — CancelledError
+        proves nothing about the server."""
         mgr, loop, _ = running_loop_mgr
         state = _seed_static_state(mgr, "srv", session=None)
 
@@ -4041,7 +4074,7 @@ class TestEnsureStaticConnected:
         ):
             _run_hl(loop, mgr._ensure_static_connected("srv", mgr._server_configs["srv"]))
         assert mgr._static_servers["srv"].session is None  # partial session dropped
-        assert mgr._consecutive_failures.get("srv") == 1  # breaker recorded
+        assert "srv" not in mgr._consecutive_failures  # CancelledError is NOT a server failure
 
     def test_timeout_hierarchy_caller_exceeds_attempt(self) -> None:
         """The systemic round-4 fix: the caller wait must exceed the inner attempt

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2940,7 +2940,8 @@ class TestReconnectSync:
         assert "srv" in mgr._circuit_open_until
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_fake_connect_one),
+            # reconnect_sync holds the per-name lock and calls the LOCKED body.
+            patch.object(mgr, "_connect_one_locked", side_effect=_fake_connect_one),
             patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
         ):
             result = mgr.reconnect_sync("srv")
@@ -2962,7 +2963,7 @@ class TestReconnectSync:
             order.append("safe_close")
             assert stack is old_stack
 
-        async def _connect_one(name: str, _cfg: dict[str, Any]) -> None:
+        async def _connect_one_locked(name: str, _cfg: dict[str, Any]) -> None:
             order.append("connect_one")
             _seed_static_state(mgr, name, session=MagicMock())
 
@@ -2978,7 +2979,7 @@ class TestReconnectSync:
         with (
             patch.object(mgr, "_pre_close_streams", side_effect=_pre_close),
             patch.object(mgr, "_safe_close_stack", side_effect=_safe_close),
-            patch.object(mgr, "_connect_one", side_effect=_connect_one),
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one_locked),
         ):
             result = mgr.reconnect_sync("srv")
         assert result["connected"] is True
@@ -2989,11 +2990,11 @@ class TestReconnectSync:
     def test_reconnect_failure_returns_error_dict(self, running_loop_mgr):
         mgr, _loop, _thread = running_loop_mgr
 
-        async def _connect_one(name: str, _cfg: dict[str, Any]) -> None:
+        async def _connect_one_locked(name: str, _cfg: dict[str, Any]) -> None:
             raise RuntimeError("handshake failed")
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_connect_one),
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one_locked),
             patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
         ):
             result = mgr.reconnect_sync("srv")
@@ -3018,11 +3019,11 @@ class TestReconnectSync:
         mgr._rebuild_resources()
         mgr._rebuild_prompts()
 
-        async def _connect_one(name: str, _cfg: dict[str, Any]) -> None:
+        async def _connect_one_locked(name: str, _cfg: dict[str, Any]) -> None:
             raise RuntimeError("handshake failed")
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_connect_one),
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one_locked),
             patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
         ):
             result = mgr.reconnect_sync("srv")
@@ -3047,7 +3048,7 @@ class TestReconnectSync:
             _seed_static_state(mgr, name, session=MagicMock())
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_first_connect),
+            patch.object(mgr, "_connect_one_locked", side_effect=_first_connect),
             patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
         ):
             mgr.reconnect_sync("srv")
@@ -3064,7 +3065,7 @@ class TestReconnectSync:
             _seed_static_state(mgr, name, session=MagicMock())
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_reconnect),
+            patch.object(mgr, "_connect_one_locked", side_effect=_reconnect),
             patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
         ):
             result = mgr.reconnect_sync("srv")
@@ -3104,7 +3105,9 @@ class TestCBAutoReconnectRefresh:
             return [], []
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_connect_one),
+            # _cb_auto_reconnect coordinates via the per-name lock and calls the
+            # LOCKED connect body directly.
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one),
             patch.object(mgr, "_refresh_server", side_effect=_refresh),
         ):
             session = mgr._cb_auto_reconnect("srv")
@@ -3139,7 +3142,7 @@ class TestCBAutoReconnectRefresh:
             raise RuntimeError("catalog fetch broke")
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_connect_one),
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one),
             patch.object(mgr, "_refresh_server", side_effect=_refresh_failing),
             patch("turnstone.core.mcp_client.log") as mock_log,
         ):
@@ -3208,14 +3211,17 @@ class TestStaticHealthLoop:
 
     # -- reconnect (layer 1) -------------------------------------------------
 
-    def test_reconnect_one_success_resets_backoff_and_closes_breaker(
+    def test_reconnect_one_success_closes_open_circuit_but_keeps_failure_count(
         self, running_loop_mgr
     ) -> None:
         mgr, loop, _ = running_loop_mgr
         mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
         _seed_static_state(mgr, "down", session=None)
         mgr._static_reconnect_attempt["down"] = 4  # pretend we'd been failing
-        mgr._cb_record_failure("down")
+        # Trip the breaker OPEN (3 failures) so there is a deadline to clear.
+        for _ in range(3):
+            mgr._cb_record_failure("down")
+        assert "down" in mgr._circuit_open_until
 
         async def _fake_connect(name: str, _cfg: dict[str, Any]) -> None:
             _seed_static_state(mgr, name, session=MagicMock())
@@ -3227,8 +3233,12 @@ class TestStaticHealthLoop:
             _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
 
         assert mgr._static_servers["down"].session is not None
-        assert "down" not in mgr._static_reconnect_attempt  # reset
-        assert "down" not in mgr._consecutive_failures  # breaker closed
+        assert "down" not in mgr._static_reconnect_attempt  # health backoff reset
+        # A transport reconnect closes the OPEN CIRCUIT (dispatch can flow) ...
+        assert "down" not in mgr._circuit_open_until
+        # ... but leaves the failure COUNT for a real dispatch to confirm/reset,
+        # so a connect-ok / calls-fail server still escalates to a trip.
+        assert mgr._consecutive_failures.get("down", 0) >= 1
 
     def test_reconnect_one_retries_forever_with_growing_backoff(self, running_loop_mgr) -> None:
         mgr, loop, _ = running_loop_mgr
@@ -3309,7 +3319,11 @@ class TestStaticHealthLoop:
         assert mgr._static_reconnect_next["up"] <= now + 0.01  # reconnect asap
         assert "up" in mgr._consecutive_failures  # breaker recorded a failure
 
-    def test_ping_one_timeout_evicts(self, running_loop_mgr) -> None:
+    def test_ping_one_timeout_does_not_evict(self, running_loop_mgr) -> None:
+        """A ping TIMEOUT means 'slow', not 'dead': the session is kept and the
+        ping rescheduled. A strict ping timeout must not churn a heavy-but-
+        working server every cycle (only a ``_is_dead_transport`` failure evicts).
+        """
         mgr, loop, _ = running_loop_mgr
         mgr._STATIC_HEALTH_PING_TIMEOUT_S = 0.05  # instance shadow for a fast test
 
@@ -3319,8 +3333,324 @@ class TestStaticHealthLoop:
         sess = MagicMock()
         sess.send_ping = _hang
         _seed_static_state(mgr, "up", session=sess)
+        now = time.monotonic()
+        due = _run_hl(loop, mgr._static_ping_one("up", now))
+        assert mgr._static_servers["up"].session is sess  # kept — timeout != dead
+        assert "up" not in mgr._consecutive_failures  # breaker NOT tripped
+        assert due > now  # next ping rescheduled, not "reconnect asap"
+
+    def test_ping_one_mcp_error_does_not_evict(self, running_loop_mgr) -> None:
+        """A protocol ``McpError`` from a healthy connection (server gates/omits
+        ``ping``) must NOT evict or trip the breaker — only a dead transport does
+        (mirrors ``_record_and_evict_on_dead_transport``)."""
+        from mcp import McpError
+        from mcp.types import ErrorData
+
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock(
+            side_effect=McpError(ErrorData(code=-32601, message="method not found"))
+        )
+        _seed_static_state(mgr, "up", session=sess)
+        now = time.monotonic()
+        due = _run_hl(loop, mgr._static_ping_one("up", now))
+        assert mgr._static_servers["up"].session is sess  # kept — protocol != dead
+        assert "up" not in mgr._consecutive_failures  # breaker untouched
+        assert due > now  # rescheduled, not "reconnect asap"
+
+    def test_ping_one_pool_timeout_does_not_evict(self, running_loop_mgr) -> None:
+        """``httpx.PoolTimeout`` is pool saturation, not a dead session — evicting
+        wouldn't relieve it and would trip the shared breaker under load; the ping
+        rescheduled instead (``_is_dead_transport`` deliberately excludes it)."""
+        import httpx
+
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock(side_effect=httpx.PoolTimeout("pool saturated"))
+        _seed_static_state(mgr, "up", session=sess)
+        now = time.monotonic()
+        due = _run_hl(loop, mgr._static_ping_one("up", now))
+        assert mgr._static_servers["up"].session is sess  # kept — pool != dead
+        assert "up" not in mgr._consecutive_failures
+        assert due > now
+
+    def test_ping_one_skips_busy_server(self, running_loop_mgr) -> None:
+        """A server with an in-flight dispatch (``in_flight`` > 0) is demonstrably
+        alive; the ping is skipped and it is NEVER evicted — the interlock that
+        keeps a long-running ``call_tool`` from being torn down under itself."""
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock(side_effect=AssertionError("busy server pinged"))
+        state = _seed_static_state(mgr, "up", session=sess)
+        state.in_flight = 1  # a call_tool is in flight
+        now = time.monotonic()
+        due = _run_hl(loop, mgr._static_ping_one("up", now))
+        sess.send_ping.assert_not_awaited()  # skipped entirely
+        assert mgr._static_servers["up"].session is sess  # not evicted
+        assert "up" not in mgr._consecutive_failures
+        assert due > now  # rescheduled
+
+    def test_ping_one_does_not_clobber_concurrent_reconnect(self, running_loop_mgr) -> None:
+        """A reconnect that installs a FRESH session during the ping's await
+        window must not be undone: the failure handler only nulls the session it
+        actually pinged (session-identity check)."""
+        mgr, loop, _ = running_loop_mgr
+        fresh = MagicMock()  # S2, installed mid-ping by a concurrent reconnect
+
+        async def _die_after_swap() -> None:
+            # Model the race: a concurrent reconnect swaps in a fresh session,
+            # THEN this stale (S1) ping fails with a dead transport.
+            mgr._static_servers["up"].session = fresh
+            raise ConnectionResetError("S1 transport died")
+
+        stale = MagicMock()  # S1
+        stale.send_ping = _die_after_swap
+        _seed_static_state(mgr, "up", session=stale)
         _run_hl(loop, mgr._static_ping_one("up", time.monotonic()))
-        assert mgr._static_servers["up"].session is None  # a hung ping = down
+        # S1's failure handler must NOT have nulled the freshly-installed S2.
+        assert mgr._static_servers["up"].session is fresh
+
+    # -- in-flight interlock (dispatch side) --------------------------------
+
+    def test_session_op_increments_in_flight_around_op(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        state = _seed_static_state(mgr, "srv", session=MagicMock())
+        seen: list[int] = []
+
+        async def _op() -> str:
+            seen.append(state.in_flight)  # observed WHILE in flight
+            return "ok"
+
+        assert _run_hl(loop, mgr._static_session_op("srv", _op())) == "ok"
+        assert seen == [1]  # bumped for the duration of the op
+        assert state.in_flight == 0  # decremented in finally
+
+    def test_session_op_decrements_in_flight_on_error(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        state = _seed_static_state(mgr, "srv", session=MagicMock())
+
+        async def _boom() -> None:
+            raise RuntimeError("dead transport")
+
+        with pytest.raises(RuntimeError, match="dead transport"):
+            _run_hl(loop, mgr._static_session_op("srv", _boom()))
+        assert state.in_flight == 0  # finally ran even on failure
+
+    def test_ping_skips_while_session_op_in_flight(self, running_loop_mgr) -> None:
+        """End-to-end interlock: while a ``_static_session_op`` is mid-flight the
+        concurrent liveness ping skips and leaves the session intact."""
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock(side_effect=AssertionError("busy server pinged"))
+        _seed_static_state(mgr, "up", session=sess)
+
+        async def _scenario() -> None:
+            release = asyncio.Event()
+
+            async def _op() -> str:
+                await release.wait()
+                return "done"
+
+            op_task = asyncio.ensure_future(mgr._static_session_op("up", _op()))
+            await asyncio.sleep(0)  # let the op start and bump in_flight
+            assert mgr._static_servers["up"].in_flight == 1
+            due = await mgr._static_ping_one("up", time.monotonic())
+            assert mgr._static_servers["up"].session is sess  # not evicted
+            assert due > time.monotonic()  # rescheduled
+            release.set()
+            assert await op_task == "done"
+            assert mgr._static_servers["up"].in_flight == 0  # decremented
+
+        _run_hl(loop, _scenario())
+        sess.send_ping.assert_not_awaited()
+
+    # -- loop robustness (bounded / concurrent / fresh clock) ---------------
+
+    def test_reconnect_one_bounded_when_connect_wedges(self, running_loop_mgr) -> None:
+        """A connect that handshakes then stalls its (unbounded) discovery must
+        not wedge the single loop coroutine or hold the per-name lock forever: the
+        caller-side timeout bounds it, it counts as a failed attempt (backoff),
+        and the ``async with`` lock is released on the cancellation."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S = 0.05  # shrink for a fast test
+        mgr._server_configs["wedge"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "wedge", session=None)
+
+        async def _wedge_locked(name: str, _cfg: dict[str, Any]) -> None:
+            await asyncio.sleep(3600)  # handshake ok, then hangs forever
+
+        # Patch the LOCKED body so the real ``_connect_one`` still takes the lock.
+        with patch.object(mgr, "_connect_one_locked", side_effect=_wedge_locked):
+            due = _run_hl(loop, mgr._static_reconnect_one("wedge", time.monotonic()))
+        assert mgr._static_reconnect_attempt["wedge"] == 1  # failed attempt
+        assert not mgr._static_connect_lock_for("wedge").locked()  # lock released
+        assert due > time.monotonic() - 1  # backoff scheduled
+
+    def test_health_tick_processes_servers_concurrently(self, running_loop_mgr) -> None:
+        """One server stalling its reconnect must not block another server's ping
+        in the same tick — per-server work runs concurrently."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {
+            "slow": {"type": "stdio", "command": "echo"},
+            "fast": {"type": "stdio", "command": "echo"},
+        }
+        _seed_static_state(mgr, "slow", session=None)  # disconnected → reconnect
+        fast_sess = MagicMock()
+        _seed_static_state(mgr, "fast", session=fast_sess)  # connected → ping
+
+        async def _scenario() -> None:
+            slow_in_connect = asyncio.Event()
+            fast_pinged = asyncio.Event()
+
+            async def _slow_connect(name: str, _cfg: dict[str, Any]) -> None:
+                slow_in_connect.set()
+                await asyncio.sleep(3600)  # would block the WHOLE tick if serial
+
+            async def _fast_ping() -> None:
+                fast_pinged.set()
+
+            fast_sess.send_ping = _fast_ping
+            with patch.object(mgr, "_connect_one", side_effect=_slow_connect):
+                tick = asyncio.ensure_future(mgr._static_health_tick())
+                # Sequential-with-slow-first would never reach 'fast'; concurrency
+                # means 'fast' is pinged while 'slow' is still stuck connecting.
+                await asyncio.wait_for(slow_in_connect.wait(), timeout=2)
+                await asyncio.wait_for(fast_pinged.wait(), timeout=2)
+                tick.cancel()
+                with suppress(BaseException):
+                    await tick
+
+        _run_hl(loop, _scenario())
+
+    def test_health_tick_sleep_uses_fresh_clock(self, running_loop_mgr) -> None:
+        """The returned sleep is computed against a FRESH clock, so a tick whose
+        per-server work burned real time doesn't over-sleep by that elapsed time."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {"srv": {"type": "stdio", "command": "echo"}}
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _slow_reconnect(name: str, now: float) -> float:
+            await asyncio.sleep(0.3)  # burn real time during the pass
+            return now + 1.0  # next-due 1s from the TICK-START clock
+
+        with patch.object(mgr, "_static_reconnect_one", side_effect=_slow_reconnect):
+            sleep_s = _run_hl(loop, mgr._static_health_tick())
+        # Stale-clock sleep would be ~1.0 (due - tick_start_now). Fresh-clock
+        # subtracts the ~0.3s the pass elapsed, so it is well under 0.9.
+        assert 0.5 <= sleep_s < 0.9
+
+    def test_tick_skips_double_underscore_names(self, running_loop_mgr) -> None:
+        """A ``__``-containing server can never connect (reserved delimiter); the
+        tick skips it entirely rather than retrying forever + spamming log.error."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {"bad__name": {"type": "stdio", "command": "echo"}}
+        with (
+            patch.object(mgr, "_static_reconnect_one", new=AsyncMock()) as recon,
+            patch.object(mgr, "_static_ping_one", new=AsyncMock()) as ping,
+        ):
+            sleep_s = _run_hl(loop, mgr._static_health_tick())
+        recon.assert_not_awaited()  # never even attempted
+        ping.assert_not_awaited()
+        assert sleep_s == mgr._static_health_check_s  # nothing due → full cadence
+
+    # -- cross-path coordination (operator / dispatch) ----------------------
+
+    def test_reconnect_sync_holds_connect_lock(self, running_loop_mgr) -> None:
+        """Operator ``reconnect_sync`` must hold the per-name connect lock across
+        teardown+rebuild so an autonomous health reconnect can't interleave."""
+        mgr, loop, _ = running_loop_mgr
+        held: list[bool] = []
+
+        async def _connect_locked(name: str, _cfg: dict[str, Any]) -> None:
+            held.append(mgr._static_connect_lock_for(name).locked())
+            _seed_static_state(mgr, name, session=MagicMock())
+
+        with (
+            patch.object(mgr, "_connect_one_locked", side_effect=_connect_locked),
+            patch.object(mgr, "_pre_close_streams", new=AsyncMock()),
+        ):
+            result = mgr.reconnect_sync("srv")
+        assert result["connected"] is True
+        assert held == [True]  # the lock was held while rebuilding
+
+    def test_cb_auto_reconnect_reuses_existing_session(self, running_loop_mgr) -> None:
+        """If a session is already live (a health reconnect established it), a
+        dispatch's ``_cb_auto_reconnect`` REUSES it — no second reconnect, no
+        spurious breaker failure."""
+        mgr, loop, _ = running_loop_mgr
+        existing = MagicMock()
+        _seed_static_state(mgr, "srv", session=existing)  # already up
+
+        with (
+            patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as connect,
+            patch.object(mgr, "_refresh_server", new=AsyncMock()),
+        ):
+            session = mgr._cb_auto_reconnect("srv")
+        assert session is existing  # reused
+        connect.assert_not_awaited()  # did NOT reconnect
+        assert "srv" not in mgr._consecutive_failures  # no spurious failure
+
+    def test_cb_auto_reconnect_reuses_session_established_under_lock(
+        self, running_loop_mgr
+    ) -> None:
+        """A health reconnect that finishes while the dispatch waits for the lock
+        is reused: ``_cb_auto_reconnect`` re-checks the session AFTER acquiring
+        the lock and does not reconnect again or record a spurious failure."""
+        import threading as _threading
+
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["srv"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "srv", session=None)  # down at the first check
+        fresh = MagicMock()
+
+        async def _acquire_hold() -> asyncio.Lock:
+            lock = mgr._static_connect_lock_for("srv")
+            await lock.acquire()  # stand in for an in-progress health reconnect
+            return lock
+
+        lock = asyncio.run_coroutine_threadsafe(_acquire_hold(), loop).result(timeout=5)
+
+        result: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def _dispatch() -> None:
+            try:
+                result["session"] = mgr._cb_auto_reconnect("srv")
+            except BaseException as exc:  # noqa: BLE001 - surfaced to the test
+                error["exc"] = exc
+
+        with (
+            patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as connect,
+            patch.object(mgr, "_refresh_server", new=AsyncMock()),
+        ):
+            worker = _threading.Thread(target=_dispatch)
+            worker.start()
+            try:
+                time.sleep(0.2)  # let the dispatch reach the lock wait
+
+                async def _finish() -> None:
+                    mgr._static_servers["srv"].session = fresh  # reconnect finished
+                    lock.release()
+
+                asyncio.run_coroutine_threadsafe(_finish(), loop).result(timeout=5)
+                worker.join(timeout=5)
+            finally:
+                # Never leak the worker (conftest thread guard): if it is still
+                # blocked, release the lock on the loop and let it drain.
+                if worker.is_alive():
+
+                    async def _emergency() -> None:
+                        if lock.locked():
+                            lock.release()
+
+                    asyncio.run_coroutine_threadsafe(_emergency(), loop).result(timeout=5)
+                    worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert "exc" not in error, error.get("exc")
+        assert result["session"] is fresh  # reused the under-lock session
+        connect.assert_not_awaited()  # did NOT reconnect again
+        assert "srv" not in mgr._consecutive_failures  # no spurious failure
 
     # -- tick scope + lifecycle ---------------------------------------------
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1199,7 +1199,9 @@ class TestLastRefreshTracking:
             async def _raise(*_a: object, **_kw: object) -> None:
                 raise ConnectionError("reconnect failed")
 
-            mgr._connect_one = _raise  # type: ignore[assignment]
+            # The reconnect branch routes through _ensure_static_connected,
+            # which calls the LOCKED connect body.
+            mgr._connect_one_locked = _raise  # type: ignore[assignment]
 
             await mgr._refresh_all("srv")
 
@@ -2951,23 +2953,29 @@ class TestReconnectSync:
         assert "srv" not in mgr._consecutive_failures
 
     def test_reconnect_closes_old_session_then_calls_connect_one(self, running_loop_mgr):
+        """The FORCE-rebuild teardown lives in ``_connect_one_locked``'s
+        stale-guard (the one canonical ``_teardown_static_session`` sequence) —
+        ``reconnect_sync`` no longer carries its own copy. Drive the REAL locked
+        body via a no-command stdio cfg: the stale-guard runs, then the connect
+        early-returns, so the ordering is observable without a live server."""
         mgr, _loop, _thread = running_loop_mgr
+        mgr._server_configs["srv"] = {"type": "stdio"}  # no command → early return
 
         order: list[str] = []
         old_stack = MagicMock(spec=AsyncExitStack)
 
         async def _pre_close(name: str) -> None:
             order.append("pre_close")
+            # Session must already be nulled when streams close (canonical order).
+            assert mgr._static_servers["srv"].session is None
 
         async def _safe_close(stack: Any) -> None:
-            order.append("safe_close")
+            # Only the OLD stack is closed on this path (the fresh connect
+            # stack is aclose()d directly by the no-command early return).
             assert stack is old_stack
+            order.append("safe_close")
 
-        async def _connect_one_locked(name: str, _cfg: dict[str, Any]) -> None:
-            order.append("connect_one")
-            _seed_static_state(mgr, name, session=MagicMock())
-
-        # Seed the old session/stack/streams that the guard should clear.
+        # Seed the old session/stack/streams that the stale-guard should clear.
         _seed_static_state(
             mgr,
             "srv",
@@ -2979,13 +2987,13 @@ class TestReconnectSync:
         with (
             patch.object(mgr, "_pre_close_streams", side_effect=_pre_close),
             patch.object(mgr, "_safe_close_stack", side_effect=_safe_close),
-            patch.object(mgr, "_connect_one_locked", side_effect=_connect_one_locked),
         ):
             result = mgr.reconnect_sync("srv")
-        assert result["connected"] is True
-        assert order == ["pre_close", "safe_close", "connect_one"]
-        # The old stack reference should have been cleared from state.
-        assert mgr._static_servers["srv"].stack is not old_stack
+        assert order == ["pre_close", "safe_close"]  # teardown ran, in order
+        assert result["connected"] is False  # no command — nothing to rebuild
+        state = mgr._static_servers["srv"]
+        assert state.session is None
+        assert state.stack is not old_stack  # old stack cleared from state
 
     def test_reconnect_failure_returns_error_dict(self, running_loop_mgr):
         mgr, _loop, _thread = running_loop_mgr
@@ -3227,7 +3235,9 @@ class TestStaticHealthLoop:
             _seed_static_state(mgr, name, session=MagicMock())
 
         with (
-            patch.object(mgr, "_connect_one", side_effect=_fake_connect),
+            # The driver routes through _ensure_static_connected, which calls
+            # the LOCKED connect body under the per-name lock.
+            patch.object(mgr, "_connect_one_locked", side_effect=_fake_connect),
             patch.object(mgr, "_refresh_server", new=AsyncMock()),
         ):
             _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
@@ -3248,29 +3258,41 @@ class TestStaticHealthLoop:
         async def _boom(name: str, _cfg: dict[str, Any]) -> None:
             raise RuntimeError("still down")
 
-        with patch.object(mgr, "_connect_one", side_effect=_boom):
+        with patch.object(mgr, "_connect_one_locked", side_effect=_boom):
             for expected in range(1, 7):
                 mgr._static_reconnect_next.pop("down", None)  # force it due
                 due = _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
                 assert mgr._static_reconnect_attempt["down"] == expected  # no cap
                 assert due > time.monotonic() - 1  # next attempt scheduled
 
-    def test_reconnect_one_skips_when_connect_already_in_flight(self, running_loop_mgr) -> None:
+    def test_reconnect_one_queued_behind_connect_reuses_its_session(self, running_loop_mgr) -> None:
+        """While another driver holds the per-name connect lock, a health
+        reconnect QUEUES on it (no ``.locked()`` skip anymore) and then REUSES
+        the session the holder installed — never a second ``_connect_one_locked``
+        pile-on tearing down the fresh session."""
         mgr, loop, _ = running_loop_mgr
         mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
         _seed_static_state(mgr, "down", session=None)
+        sess = MagicMock()
 
         async def _scenario() -> float:
             lock = mgr._static_connect_lock_for("down")
-            await lock.acquire()  # simulate a dispatch reconnect in progress
-            try:
-                return await mgr._static_reconnect_one("down", time.monotonic())
-            finally:
-                lock.release()
+            await lock.acquire()  # a dispatch reconnect in progress
+            recon = asyncio.ensure_future(mgr._static_reconnect_one("down", time.monotonic()))
+            await asyncio.sleep(0.05)
+            assert not recon.done()  # queued on the lock, not skipped/failed
+            mgr._static_servers["down"].session = sess  # the holder's connect lands
+            lock.release()
+            return await asyncio.wait_for(recon, timeout=5)
 
-        with patch.object(mgr, "_connect_one", new=AsyncMock()) as cm:
-            _run_hl(loop, _scenario())
-        cm.assert_not_awaited()  # did not pile a second reconnect on the held lock
+        with (
+            patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm,
+            patch.object(mgr, "_refresh_server", new=AsyncMock()),
+        ):
+            due = _run_hl(loop, _scenario())
+        cm.assert_not_awaited()  # reused the holder's session; no second connect
+        assert mgr._static_servers["down"].session is sess  # never torn down
+        assert due > time.monotonic() - 1  # success cadence scheduled
 
     def test_connect_one_serializes_concurrent_reconnects(self, running_loop_mgr) -> None:
         """The per-name lock prevents two concurrent ``_connect_one`` for one
@@ -3316,7 +3338,8 @@ class TestStaticHealthLoop:
         now = time.monotonic()
         _run_hl(loop, mgr._static_ping_one("up", now))
         assert mgr._static_servers["up"].session is None  # evicted
-        assert mgr._static_reconnect_next["up"] <= now + 0.01  # reconnect asap
+        # "Reconnect asap": the (fresh-clock) deadline is already due.
+        assert now <= mgr._static_reconnect_next["up"] <= time.monotonic()
         assert "up" in mgr._consecutive_failures  # breaker recorded a failure
 
     def test_ping_one_timeout_does_not_evict(self, running_loop_mgr) -> None:
@@ -3510,7 +3533,7 @@ class TestStaticHealthLoop:
                 fast_pinged.set()
 
             fast_sess.send_ping = _fast_ping
-            with patch.object(mgr, "_connect_one", side_effect=_slow_connect):
+            with patch.object(mgr, "_connect_one_locked", side_effect=_slow_connect):
                 tick = asyncio.ensure_future(mgr._static_health_tick())
                 # Sequential-with-slow-first would never reach 'fast'; concurrency
                 # means 'fast' is pinged while 'slow' is still stuck connecting.
@@ -3693,6 +3716,378 @@ class TestStaticHealthLoop:
 
         _run_hl(loop, _cancel())
         assert task.cancelled() or task.done()
+
+    # -- unified reconnect coordination (round 3) ----------------------------
+
+    def test_reconnect_one_defers_while_sibling_in_flight(self, running_loop_mgr) -> None:
+        """The health loop DEFERS (short recheck; no backoff bump, no breaker)
+        while a sibling dispatch still runs on the old evicted stack — tearing
+        down now would abort that call mid-flight (review finding [0])."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
+        state = _seed_static_state(mgr, "down", session=None)
+        state.in_flight = 1  # a call_tool still draining on the evicted stack
+        before = time.monotonic()
+        with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
+            due = _run_hl(loop, mgr._static_reconnect_one("down", time.monotonic()))
+        cm.assert_not_awaited()  # no teardown-under-dispatch
+        assert before < due <= time.monotonic() + 1.5  # ~1s recheck, not backoff
+        assert "down" not in mgr._static_reconnect_attempt  # not a failed attempt
+        assert "down" not in mgr._consecutive_failures  # breaker untouched
+
+    def test_reconnect_one_failure_deadline_uses_fresh_clock(self, running_loop_mgr) -> None:
+        """A failed attempt's next-due is written from a FRESH clock — scheduling
+        from a stale tick-start ``now`` (a slow sibling op ran first in the same
+        gather) lands the deadline in the past and collapses the backoff into an
+        every-tick retry storm (review finding [3])."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs["down"] = {"type": "stdio", "command": "echo"}
+        _seed_static_state(mgr, "down", session=None)
+
+        async def _boom(name: str, _cfg: dict[str, Any]) -> None:
+            raise RuntimeError("still down")
+
+        stale_now = time.monotonic() - 45.0  # tick "started" 45s ago
+        with patch.object(mgr, "_connect_one_locked", side_effect=_boom):
+            before = time.monotonic()
+            due = _run_hl(loop, mgr._static_reconnect_one("down", stale_now))
+        assert due >= before  # future-dated, not tick-start-relative
+        assert mgr._static_reconnect_next["down"] == due
+
+    def test_ping_one_deadline_uses_fresh_clock(self, running_loop_mgr) -> None:
+        """The next-ping deadline is written from a FRESH clock — a stale
+        tick-start ``now`` would schedule the next ping in the past and re-ping
+        the server on every tick (review finding [3])."""
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        sess.send_ping = AsyncMock()
+        _seed_static_state(mgr, "up", session=sess)
+        stale_now = time.monotonic() - 45.0
+        before = time.monotonic()
+        due = _run_hl(loop, mgr._static_ping_one("up", stale_now))
+        assert due >= before + mgr._static_health_check_s - 1.0
+        assert mgr._static_next_ping["up"] == due
+
+    def test_health_tick_isolates_per_server_cancelled_error(self, running_loop_mgr) -> None:
+        """A CancelledError in the gather RESULTS is per-server fallout, not
+        shutdown — a genuine shutdown cancels the ``await gather`` itself and
+        never lands in the results list. Re-raising it killed the whole loop."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._server_configs = {"srv": {"type": "stdio", "command": "echo"}}
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _stray(name: str, now: float) -> float:
+            raise asyncio.CancelledError
+
+        with patch.object(mgr, "_static_reconnect_one", side_effect=_stray):
+            sleep_s = _run_hl(loop, mgr._static_health_tick())
+        # Returned a sleep instead of re-raising; the server was rescheduled
+        # on the normal cadence.
+        assert 0.5 <= sleep_s <= mgr._static_health_check_s + 1.0
+
+    def test_health_loop_absorbs_stray_cancel_and_stops_on_real_cancel(
+        self, running_loop_mgr
+    ) -> None:
+        """A stray CancelledError escaping the tick (no pending cancel request
+        on the task) must not kill the loop; a genuine ``task.cancel()`` still
+        stops it promptly."""
+        import threading as _threading
+
+        mgr, loop, _ = running_loop_mgr
+        mgr._static_health_check_s = 0.05  # instance shadow for a fast test
+        survived = _threading.Event()
+        calls = 0
+
+        async def _tick() -> float:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise asyncio.CancelledError  # stray — the task was NOT cancelled
+            survived.set()
+            return 3600.0  # park until the genuine cancel below
+
+        with patch.object(mgr, "_static_health_tick", side_effect=_tick):
+            task = _run_hl(loop, _spawn_task(mgr._static_health_loop()))
+            assert survived.wait(timeout=5), "loop died on a stray per-server cancel"
+            assert not task.done()
+
+            async def _cancel() -> None:
+                task.cancel()
+                with suppress(BaseException):
+                    await task
+
+            _run_hl(loop, _cancel())
+        assert task.done()
+
+    def test_dispatch_reconnect_lock_contention_records_no_breaker_failure(
+        self, running_loop_mgr
+    ) -> None:
+        """Review finding [1]: a dispatch reconnect that times out while merely
+        QUEUED on the per-name lock (held by a longer-bounded health-loop
+        attempt) must not advance the breaker — the server was never proven
+        unreachable. The breaker is owned by _ensure_static_connected."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._CONNECT_TIMEOUT = 1  # instance shadow: sync-boundary wait, fast test
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _hold() -> asyncio.Lock:
+            lock = mgr._static_connect_lock_for("srv")
+            await lock.acquire()  # stand in for a health-loop reconnect
+            return lock
+
+        lock = asyncio.run_coroutine_threadsafe(_hold(), loop).result(timeout=5)
+        try:
+            with (
+                patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm,
+                pytest.raises(RuntimeError, match="reconnect timed out"),
+            ):
+                mgr._cb_auto_reconnect("srv")
+        finally:
+
+            async def _release() -> None:
+                if lock.locked():
+                    lock.release()
+
+            asyncio.run_coroutine_threadsafe(_release(), loop).result(timeout=5)
+        cm.assert_not_awaited()
+        assert "srv" not in mgr._consecutive_failures  # lock wait != failure
+
+    def test_dispatch_reconnect_real_failure_records_breaker_once(self, running_loop_mgr) -> None:
+        """A REAL connect failure through the dispatch path advances the breaker
+        exactly ONCE — recorded inside _ensure_static_connected; the sync
+        boundary must not double-record the same outcome."""
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _boom(name: str, _cfg: dict[str, Any]) -> None:
+            raise ConnectionError("refused")
+
+        with (
+            patch.object(mgr, "_connect_one_locked", side_effect=_boom),
+            pytest.raises(RuntimeError, match="reconnect failed"),
+        ):
+            mgr._cb_auto_reconnect("srv")
+        assert mgr._consecutive_failures.get("srv") == 1
+
+    def test_dispatch_reconnect_does_not_resurrect_removed_server(self, running_loop_mgr) -> None:
+        """Review finding [2]: a dispatch racing remove_server_sync must not
+        rebuild the server from its pre-lock cfg snapshot once the config is
+        gone — _ensure_static_connected re-checks under the lock."""
+        import threading as _threading
+
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _hold() -> asyncio.Lock:
+            lock = mgr._static_connect_lock_for("srv")
+            await lock.acquire()
+            return lock
+
+        lock = asyncio.run_coroutine_threadsafe(_hold(), loop).result(timeout=5)
+        error: dict[str, BaseException] = {}
+
+        def _dispatch() -> None:
+            try:
+                mgr._cb_auto_reconnect("srv")
+            except BaseException as exc:  # noqa: BLE001 - surfaced to the test
+                error["exc"] = exc
+
+        with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
+            worker = _threading.Thread(target=_dispatch)
+            worker.start()
+            try:
+                time.sleep(0.2)  # let the dispatch queue on the lock
+
+                async def _remove_and_release() -> None:
+                    mgr._server_configs.pop("srv", None)  # the remove wins the race
+                    lock.release()
+
+                asyncio.run_coroutine_threadsafe(_remove_and_release(), loop).result(timeout=5)
+                worker.join(timeout=5)
+            finally:
+                # Never leak the worker (conftest thread guard).
+                if worker.is_alive():
+
+                    async def _emergency() -> None:
+                        if lock.locked():
+                            lock.release()
+
+                    asyncio.run_coroutine_threadsafe(_emergency(), loop).result(timeout=5)
+                    worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        cm.assert_not_awaited()  # no rebuild from the stale cfg
+        assert isinstance(error.get("exc"), RuntimeError)  # failed cleanly
+        assert "unavailable" in str(error["exc"])
+        assert "srv" not in mgr._consecutive_failures  # not a breaker failure
+
+
+class TestEnsureStaticConnected:
+    """The ONE lazy-connect primitive every autonomous driver routes through
+    (health loop, dispatch _cb_auto_reconnect, _refresh_all). Operator
+    reconnect_sync deliberately stays a force rebuild outside it."""
+
+    def test_concurrent_drivers_collapse_to_single_connect(self, running_loop_mgr) -> None:
+        """The reconnect STORM fix: N concurrent callers for one server queue on
+        the per-name lock and collapse to a SINGLE _connect_one_locked; everyone
+        else reuses the installed session (never tears it down to rebuild)."""
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=None)
+        sess = MagicMock()
+        connects = 0
+
+        async def _connect(name: str, _cfg: dict[str, Any]) -> None:
+            nonlocal connects
+            connects += 1
+            await asyncio.sleep(0.05)  # hold the lock so siblings queue
+            _seed_static_state(mgr, name, session=sess)
+
+        async def _storm() -> list[Any]:
+            cfg = mgr._server_configs["srv"]
+            return await asyncio.gather(
+                *(mgr._ensure_static_connected("srv", cfg) for _ in range(5))
+            )
+
+        with patch.object(mgr, "_connect_one_locked", side_effect=_connect):
+            sessions = _run_hl(loop, _storm())
+        assert connects == 1  # queued callers reused, not rebuilt
+        assert all(s is sess for s in sessions)
+
+    def test_reuses_live_session_without_teardown(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        sess = MagicMock()
+        _seed_static_state(mgr, "srv", session=sess)
+        with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
+            out = _run_hl(loop, mgr._ensure_static_connected("srv", mgr._server_configs["srv"]))
+        assert out is sess
+        cm.assert_not_awaited()
+
+    def test_returns_none_for_removed_server(self, running_loop_mgr) -> None:
+        """Config re-check under the lock: a concurrently-removed server is not
+        resurrected from the caller's pre-lock cfg snapshot."""
+        mgr, loop, _ = running_loop_mgr
+        cfg = {"type": "stdio", "command": "echo"}  # caller's stale snapshot
+        assert "gone" not in mgr._server_configs
+        with patch.object(mgr, "_connect_one_locked", new=AsyncMock()) as cm:
+            out = _run_hl(loop, mgr._ensure_static_connected("gone", cfg))
+        assert out is None
+        cm.assert_not_awaited()
+        assert "gone" not in mgr._static_servers  # nothing rebuilt
+
+    def test_defers_when_sibling_call_in_flight(self, running_loop_mgr) -> None:
+        """session None + in_flight > 0 → defer (None) without teardown; once
+        the sibling call drains, the next call reconnects."""
+        mgr, loop, _ = running_loop_mgr
+        state = _seed_static_state(mgr, "srv", session=None, stack=MagicMock(spec=AsyncExitStack))
+        state.in_flight = 1
+        sess = MagicMock()
+
+        async def _connect(name: str, _cfg: dict[str, Any]) -> None:
+            _seed_static_state(mgr, name, session=sess)
+
+        cfg = mgr._server_configs["srv"]
+        with patch.object(mgr, "_connect_one_locked", side_effect=_connect) as cm:
+            out = _run_hl(loop, mgr._ensure_static_connected("srv", cfg))
+            assert out is None
+            assert cm.await_count == 0  # no teardown-under-dispatch
+            state.in_flight = 0  # the sibling call finished
+            out2 = _run_hl(loop, mgr._ensure_static_connected("srv", cfg))
+        assert out2 is sess
+        assert cm.await_count == 1
+
+    def test_failure_records_one_breaker_failure_and_raises(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=None)
+
+        async def _boom(name: str, _cfg: dict[str, Any]) -> None:
+            raise ConnectionError("refused")
+
+        with (
+            patch.object(mgr, "_connect_one_locked", side_effect=_boom),
+            pytest.raises(ConnectionError),
+        ):
+            _run_hl(loop, mgr._ensure_static_connected("srv", mgr._server_configs["srv"]))
+        assert mgr._consecutive_failures.get("srv") == 1
+
+    def test_success_clears_only_open_circuit_deadline(self, running_loop_mgr) -> None:
+        """Finding-13 semantics, now owned by the primitive: success re-opens
+        dispatch (deadline cleared) but keeps _consecutive_failures so a
+        connect-ok / calls-fail server still escalates to a trip."""
+        mgr, loop, _ = running_loop_mgr
+        _seed_static_state(mgr, "srv", session=None)
+        for _ in range(3):
+            mgr._cb_record_failure("srv")
+        assert "srv" in mgr._circuit_open_until
+        sess = MagicMock()
+
+        async def _connect(name: str, _cfg: dict[str, Any]) -> None:
+            _seed_static_state(mgr, name, session=sess)
+
+        with patch.object(mgr, "_connect_one_locked", side_effect=_connect):
+            out = _run_hl(loop, mgr._ensure_static_connected("srv", mgr._server_configs["srv"]))
+        assert out is sess
+        assert "srv" not in mgr._circuit_open_until  # dispatch flows again
+        assert mgr._consecutive_failures.get("srv", 0) >= 3  # count kept
+
+    def test_refresh_all_reconnect_keeps_breaker_failure_count(self) -> None:
+        """_refresh_all's reconnect branch routes through the primitive: only
+        the open-circuit deadline clears — the old full _cb_record_success
+        reset let a connect-ok / calls-fail server oscillate 0->1->0 below the
+        breaker threshold forever."""
+
+        async def _run() -> None:
+            mgr = MCPClientManager({})
+            mgr._server_configs["srv"] = {"type": "stdio", "command": "x"}
+            mgr._consecutive_failures["srv"] = 2
+            sess = MagicMock()
+
+            async def _connect(name: str, _cfg: dict[str, Any]) -> None:
+                _seed_static_state(mgr, name, session=sess)
+
+            with patch.object(mgr, "_connect_one_locked", side_effect=_connect):
+                results = await mgr._refresh_all("srv")
+
+            assert results["srv"] == ([], [])  # reconnected; no tools seeded
+            assert mgr._last_refresh["srv"][1] == "ok"
+            assert mgr._consecutive_failures.get("srv") == 2  # NOT reset
+            assert mgr._static_servers["srv"].session is sess
+
+        asyncio.run(_run())
+
+
+class TestTeardownStaticSession:
+    """The one canonical teardown sequence (shared by _connect_one_locked's
+    stale-guard and remove_server_sync)."""
+
+    def test_teardown_order_and_state_cleared(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        order: list[str] = []
+        old_stack = MagicMock(spec=AsyncExitStack)
+
+        async def _pre_close(name: str) -> None:
+            order.append("pre_close")
+            # Session nulled FIRST so concurrent dispatch reads see
+            # "disconnected", not a corpse.
+            assert mgr._static_servers["srv"].session is None
+
+        async def _safe_close(stack: Any) -> None:
+            order.append("safe_close")
+            assert stack is old_stack
+
+        _seed_static_state(mgr, "srv", session=MagicMock(), stack=old_stack)
+        with (
+            patch.object(mgr, "_pre_close_streams", side_effect=_pre_close),
+            patch.object(mgr, "_safe_close_stack", side_effect=_safe_close),
+        ):
+            _run_hl(loop, mgr._teardown_static_session("srv"))
+        assert order == ["pre_close", "safe_close"]
+        state = mgr._static_servers["srv"]
+        assert state.session is None
+        assert state.stack is None
+
+    def test_teardown_missing_server_is_noop(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        _run_hl(loop, mgr._teardown_static_session("nope"))  # must not raise
 
 
 async def _spawn_task(coro: Any) -> asyncio.Task[Any]:

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1033,7 +1033,9 @@ class TestStaticPathUnchanged:
 
         from turnstone.core import mcp_client
 
-        source = inspect.getsource(mcp_client.MCPClientManager._connect_one)
+        # The connect body (incl. the streamablehttp_client call site) lives in
+        # ``_connect_one_locked``; ``_connect_one`` is now a per-name-lock wrapper.
+        source = inspect.getsource(mcp_client.MCPClientManager._connect_one_locked)
 
         # The static path's streamablehttp_client invocation should NOT
         # mention ``httpx_client_factory``. Pool path keeps it.

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1274,16 +1274,20 @@ class MCPClientManager:
             try:
                 async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
                     await self._connect_one_locked(name, cfg)
-            except BaseException:
+            except BaseException as exc:
                 # ANY non-success exit — an ``except Exception`` connect error,
                 # the converted inner TimeoutError, or a bare CancelledError (a
                 # caller's sync boundary giving up early, or a genuine shutdown)
-                # — must not leave a half-discovered session installed, and
-                # records the failed attempt so the breaker can trip. Recording
-                # on a shutdown cancel is harmless; the cleanup is synchronous
-                # (no await), so it is safe under an active cancellation. We hold
+                # — must not leave a half-discovered session installed. We hold
                 # the lock, so no concurrent driver installed a fresh session.
-                self._cb_record_failure(name)
+                #
+                # A CancelledError proves nothing about the server (the caller
+                # may have given up before the connect completed) — skip the
+                # breaker record so a spurious cancel doesn't inflate the
+                # failure count for a healthy server. The caller provides its
+                # own accounting (or doesn't — shutdown state is discarded).
+                if not isinstance(exc, asyncio.CancelledError):
+                    self._cb_record_failure(name)
                 st = self._static_servers.get(name)
                 if st is not None:
                     st.session = None
@@ -3846,16 +3850,28 @@ class MCPClientManager:
             # live session (unlike the lazy ``_ensure_static_connected`` path).
             async with self._static_connect_lock_for(name):
                 try:
-                    await self._connect_one_locked(name, cfg)
-                except Exception:
+                    # Bounded connect — mirrors ``_ensure_static_connected``'s
+                    # inner timeout. The attempt bound covers discovery (the
+                    # one phase ``_connect_one_locked``'s handshake-only
+                    # ``_CONNECT_TIMEOUT`` does not cover), fires strictly
+                    # before the caller-side ``future.result(timeout=...)``,
+                    # and converts to ``TimeoutError`` inside the lock so the
+                    # catalog cleanup below runs instead of the connect being
+                    # externally cancelled mid-flight.
+                    async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
+                        await self._connect_one_locked(name, cfg)
+                except BaseException:
                     # Connect failed mid-reconnect — drop the stale per-server
                     # catalog so the merged tool/resource/prompt maps don't keep
-                    # advertising entries with no live session behind them.
+                    # advertising entries with no live session behind them, and
+                    # null the session so a later health-loop check doesn't see
+                    # a live (but tool-less) session.
                     fail_state = self._static_servers.get(name)
                     if fail_state is not None:
                         fail_state.tools = []
                         fail_state.resources = []
                         fail_state.prompts = []
+                        fail_state.session = None
                     self._rebuild_tools()
                     self._rebuild_resources()
                     self._rebuild_prompts()
@@ -4465,7 +4481,8 @@ class MCPClientManager:
         exception isolation. The returned sleep is against a FRESHLY-read clock —
         the per-server work can take seconds, so the tick-start ``now`` is stale
         by return — computed from the soonest per-server monotonic deadline and
-        clamped so the loop neither busy-spins nor sleeps through a short backoff.
+        clamped at 0.5s minimum to avoid busy-spinning (a deadline shorter
+        than 0.5s adds at most 0.5s latency before the next tick re-checks).
         """
         now = time.monotonic()
         names = [
@@ -4511,7 +4528,7 @@ class MCPClientManager:
         state = self._static_servers.get(name)
         if state is not None and state.session is not None:
             return await self._static_ping_one(name, now)
-        return await self._static_reconnect_one(name, now)
+        return await self._static_reconnect_one(name)
 
     def _static_reconnect_delay(self, attempt: int) -> float:
         """Full-jitter capped-exponential backoff: ``uniform(0, min(CAP, BASE*2^n))``.
@@ -4525,7 +4542,7 @@ class MCPClientManager:
         )
         return random.uniform(0.0, ceiling)
 
-    async def _static_reconnect_one(self, name: str, now: float) -> float:
+    async def _static_reconnect_one(self, name: str) -> float:
         """Reconnect a disconnected static server if its backoff has elapsed.
 
         Returns the monotonic deadline of the next attempt so the loop can
@@ -4535,14 +4552,12 @@ class MCPClientManager:
         shared state; the primitive also owns the attempt bound and the breaker
         (a failure here only advances the health loop's OWN backoff clock).
 
-        Clock discipline: *now* is the tick-start time and can be tens of
-        seconds stale after a slow sibling op in the same gather — it may gate
-        "is it due?", but every WRITTEN/RETURNED deadline uses a fresh
-        ``time.monotonic()`` (a stale base lands deadlines in the past and
-        collapses the backoff into an every-tick retry storm).
+        Uses a FRESH monotonic clock internally (not a caller-passed tick-start
+        snapshot that could be stale after a slow sibling ``gather``).
         """
-        due = self._static_reconnect_next.get(name, now)
-        if now < due:
+        fresh_now = time.monotonic()
+        due = self._static_reconnect_next.get(name, fresh_now)
+        if fresh_now < due:
             return due
         cfg = self._server_configs.get(name)
         if not cfg:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -4511,7 +4511,11 @@ class MCPClientManager:
                 # shutdown path. A CancelledError IN the results is per-server
                 # fallout (a stray anyio cancel-scope poison from a wedged
                 # transport) — re-raising it here killed the whole loop.
-                log.debug("MCP static health: server '%s' pass failed", name, exc_info=res)
+                log.debug(
+                    "MCP static health: server '%s' pass failed",
+                    name,
+                    exc_info=(type(res), res, res.__traceback__),
+                )
                 due = after + self._static_health_check_s
             else:
                 due = res

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -4668,7 +4668,12 @@ class MCPClientManager:
             # stops via its ``except asyncio.CancelledError: return``.
             if not ping_timeout.expired() and isinstance(exc, asyncio.CancelledError):
                 raise
-            dead = (not ping_timeout.expired()) and _is_dead_transport(exc)
+            if ping_timeout.expired():
+                dead = False
+            elif isinstance(exc, BaseExceptionGroup):
+                dead = any(_is_dead_transport(e) for e in exc.exceptions)
+            else:
+                dead = _is_dead_transport(exc)
             # Re-check in-flight under this synchronous handler: a dispatch may
             # have started during the ping window; never evict a busy server.
             # Session-identity: only act on the session we actually PINGED — a

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -938,6 +938,22 @@ class MCPClientManager:
 
     # -- circuit breaker (per-server) -----------------------------------------
 
+    @staticmethod
+    def _capped_exponential(base: float, cap: float, attempt: int) -> float:
+        """``min(cap, base * 2**attempt)`` with the exponent clamped.
+
+        The ONE capped-exponential formula — shared by the circuit-breaker
+        cooldown (:meth:`_cb_record_failure`) and the health loop's reconnect
+        ceiling (:meth:`_static_reconnect_delay`) — so cap/exponent policy
+        can't drift between the two. ``attempt`` is unbounded on the health
+        path (retry forever); the clamp keeps ``2**n`` from exploding into a
+        bignum before ``min`` discards it. Jitter policy stays with the
+        callers (full jitter on the health path, name-seeded 10% on the
+        breaker).
+        """
+        ceiling: float = min(cap, base * (2 ** min(attempt, 32)))
+        return ceiling
+
     def _cb_check(self, name: str) -> tuple[bool, bool]:
         """Check circuit breaker state for *name*.
 
@@ -963,7 +979,9 @@ class MCPClientManager:
         # already >= threshold).
         if count >= self._CB_FAILURE_THRESHOLD and name not in self._circuit_open_until:
             trips = self._circuit_trip_count.get(name, 0)
-            cooldown = min(self._CB_BASE_COOLDOWN * (2**trips), self._CB_MAX_COOLDOWN)
+            cooldown = self._capped_exponential(
+                self._CB_BASE_COOLDOWN, self._CB_MAX_COOLDOWN, trips
+            )
             # Per-server jitter seeded from server name (varies across process
             # restarts via PYTHONHASHSEED, which is desirable — each cluster
             # node gets different jitter to avoid thundering herd).
@@ -1112,6 +1130,29 @@ class MCPClientManager:
         await self._pre_close_streams(key)
         await self._safe_close_stack(stack)
 
+    async def _teardown_static_session(self, name: str) -> None:
+        """Tear down a static server's session/stack (the ONE canonical order).
+
+        Shared by :meth:`_connect_one_locked`'s stale-guard and
+        :meth:`remove_server_sync` so a future ordering fix lands in one place:
+        null the session FIRST (concurrent dispatch reads see "disconnected",
+        not a corpse), pre-close the transport streams (unblocks anyio tasks
+        stuck on zero-buffer ``send()`` — SDK #2147), then close the captured
+        stack. MUST run under the per-name connect lock. Callers decide WHEN
+        teardown is safe — live-session reuse and the ``in_flight`` interlock
+        are enforced by :meth:`_ensure_static_connected`, not here. No-op when
+        the server has no state.
+        """
+        state = self._static_servers.get(name)
+        if state is None:
+            return
+        state.session = None
+        await self._pre_close_streams(name)
+        old_stack = state.stack
+        state.stack = None
+        if old_stack is not None:
+            await self._safe_close_stack(old_stack)
+
     def _static_connect_lock_for(self, name: str) -> asyncio.Lock:
         """Return the per-server connect lock for ``name`` (lazily created).
 
@@ -1139,6 +1180,101 @@ class MCPClientManager:
         async with self._static_connect_lock_for(name):
             await self._connect_one_locked(name, cfg)
 
+    async def _ensure_static_connected(self, name: str, cfg: dict[str, Any]) -> Any:
+        """Idempotently (re)connect static server *name* — the ONE lazy path.
+
+        Every lazy/autonomous reconnect driver — the health loop
+        (:meth:`_static_reconnect_one`), a dispatch's :meth:`_cb_auto_reconnect`,
+        and :meth:`_refresh_all`'s reconnect branch — routes through here so the
+        per-name lock / session-reuse / ``in_flight`` / config-recheck / breaker
+        decisions live in exactly one place. The operator's
+        :meth:`reconnect_sync` deliberately does NOT: that is a FORCE rebuild
+        which tears down even a live session by design.
+
+        MUST run on the mcp-loop. All decisions are made UNDER the per-name
+        connect lock (concurrent callers QUEUE, then land in the reuse branch):
+
+        1. **Config re-check** — a concurrent :meth:`remove_server_sync` pops
+           the config (and retires the lock object) before tearing down;
+           rebuilding from the caller's pre-lock ``cfg`` snapshot would
+           resurrect the removed server. The freshest config wins — *cfg* is
+           the caller's eligibility proof, superseded here.
+        2. **Reuse-if-live** — another driver already (re)connected while we
+           queued; a live session is NEVER torn down and rebuilt here.
+        3. **``in_flight`` guard** — ``session is None`` with ``in_flight > 0``
+           means a sibling call is still running on the old (evicted-but-open)
+           stack; :meth:`_connect_one_locked`'s stale-guard teardown would
+           abort it mid-flight. Defer — the next driver pass reconnects once
+           it drains (mirrors the pool path's ``_close_pool_entry_if_idle``).
+        4. **Bounded connect** — :meth:`_connect_one_locked` under
+           ``_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S`` from the caller side
+           (invariant: never edit its connect internals; its own bounds cover
+           only the handshake, not discovery).
+
+        The circuit breaker is OWNED here for connect outcomes — callers must
+        not record the connect again. Success clears only the OPEN-CIRCUIT
+        DEADLINE (dispatch flows again) and deliberately NOT
+        ``_consecutive_failures``: a connect-ok / calls-fail server must still
+        escalate to a trip; a real dispatch success is what resets the count
+        (:meth:`_cb_record_success`). Failure records one breaker failure and
+        re-raises.
+
+        Returns the session on success or reuse; ``None`` on a deliberate skip
+        (server removed, or busy with an in-flight call); raises on a real
+        connect failure. A genuine task cancellation propagates untouched — no
+        breaker record, since a cancelled attempt proves nothing about the
+        server.
+        """
+        if "__" in name:
+            # Mirrors _connect_one's reserved-delimiter guard: such a name can
+            # never connect; treat as a deliberate skip.
+            log.error("MCP server name '%s' contains '__' (reserved delimiter), skipping", name)
+            return None
+        lock = self._static_connect_lock_for(name)
+        async with lock:
+            # (1) Config re-check. The lock-identity check closes the
+            # remove -> re-add race: remove_server_sync retires the lock object
+            # after teardown, so a waiter still holding the OLD lock must not
+            # connect concurrently with a NEW-lock holder after a re-add.
+            fresh_cfg = self._server_configs.get(name)
+            if fresh_cfg is None or self._static_connect_locks.get(name) is not lock:
+                return None
+            cfg = fresh_cfg
+            state = self._static_servers.get(name)
+            # (2) Reuse-if-live.
+            if state is not None and state.session is not None:
+                return state.session
+            # (3) in_flight guard.
+            if state is not None and state.in_flight > 0:
+                return None
+            # (4) Bounded connect; the breaker is owned here. On expiry the
+            # CancelledError unwinds _connect_one_locked (its cancelling()
+            # checks see a pending cancel and re-raise) and asyncio.timeout
+            # converts it to TimeoutError inside the lock.
+            try:
+                async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
+                    await self._connect_one_locked(name, cfg)
+            except Exception:
+                self._cb_record_failure(name)
+                # Drop a partially-initialized session (handshake OK but a
+                # timed-out ``list_tools`` can leave ``state.session`` set) so
+                # the next attempt reconnects cleanly; leave the stack for the
+                # stale-guard to reap. We hold the lock, so no concurrent
+                # driver can have installed a fresh session to clobber.
+                st = self._static_servers.get(name)
+                if st is not None:
+                    st.session = None
+                raise
+            state = self._static_servers.get(name)
+            if state is None or state.session is None:
+                # e.g. a stdio config with no command "connects" without a
+                # session — a real failure for a reconnect driver.
+                self._cb_record_failure(name)
+                raise RuntimeError(f"MCP server '{name}' reconnect produced no session")
+            # Finding-13 semantics: clear only the open-circuit deadline.
+            self._circuit_open_until.pop(name, None)
+            return state.session
+
     async def _connect_one_locked(self, name: str, cfg: dict[str, Any]) -> None:
         """Connect to a single MCP server and discover its tools.
 
@@ -1149,17 +1285,11 @@ class MCPClientManager:
         # touch the same instance (PR #296 invariant 5: identity stability).
         state = self._ensure_static_state(name)
 
-        # Guard: tear down stale session/stack so we don't leak.  Checks both
-        # session and stack because transport errors in the sync dispatch
-        # methods evict the session but leave the stack behind.  On a brand
-        # new entry both fields are None, so this branch is skipped.
-        if state.session is not None or state.stack is not None:
-            state.session = None
-            await self._pre_close_streams(name)
-            old_stack = state.stack
-            state.stack = None
-            if old_stack is not None:
-                await self._safe_close_stack(old_stack)
+        # Guard: tear down stale session/stack so we don't leak.  Transport
+        # errors in the sync dispatch methods evict the session but leave the
+        # stack behind; ``_teardown_static_session`` clears both (and is a
+        # no-op on a brand new entry).
+        await self._teardown_static_session(name)
 
         # Per-server exit stack for clean per-server lifecycle management
         stack = AsyncExitStack()
@@ -2918,12 +3048,22 @@ class MCPClientManager:
             try:
                 state = self._static_servers.get(name)
                 if state is None or state.session is None:
-                    # Attempt reconnect
+                    # Attempt reconnect via the shared lazy primitive — it owns
+                    # the per-name lock, live-session reuse, the in_flight
+                    # deferral, and the breaker (so no separate
+                    # ``_cb_record_success`` here: only the open-circuit
+                    # deadline is cleared; a real dispatch resets the count).
                     cfg = self._server_configs.get(name)
                     if cfg:
                         log.info("Reconnecting MCP server '%s'", name)
-                        await self._connect_one(name, cfg)
-                        self._cb_record_success(name)
+                        session = await self._ensure_static_connected(name, cfg)
+                        if session is None:
+                            # Deliberate skip: removed concurrently, or a
+                            # sibling call is still in flight on the old
+                            # stack. Not a failure — the next refresh or
+                            # health tick retries.
+                            results[name] = ([], [])
+                            continue
                         post = self._static_servers.get(name)
                         new_names = (
                             [t["function"]["name"] for t in post.tools] if post is not None else []
@@ -3669,21 +3809,17 @@ class MCPClientManager:
 
         async def _reconnect() -> None:
             self._cb_clear(name)
-            # Hold the per-name connect lock across teardown AND rebuild so an
-            # autonomous health-loop reconnect can never interleave its own
-            # teardown/rebuild on the shared ``StaticServerState`` mid-flight
-            # (delivering the ``_connect_one`` docstring's "operator refresh can
-            # never interleave" claim). Call the LOCKED body directly — we hold
-            # the lock, and ``_connect_one`` would deadlock re-acquiring it.
+            # Hold the per-name connect lock across the FORCE rebuild so an
+            # autonomous health-loop / dispatch reconnect can never interleave
+            # its own teardown/rebuild on the shared ``StaticServerState``
+            # mid-flight (delivering the ``_connect_one`` docstring's "operator
+            # refresh can never interleave" claim). Call the LOCKED body
+            # directly — we hold the lock, and ``_connect_one`` would deadlock
+            # re-acquiring it. No explicit pre-teardown: ``_connect_one_locked``'s
+            # stale-guard runs the identical ``_teardown_static_session`` first
+            # thing, and an operator reconnect deliberately rebuilds even a
+            # live session (unlike the lazy ``_ensure_static_connected`` path).
             async with self._static_connect_lock_for(name):
-                state = self._static_servers.get(name)
-                if state is not None:
-                    state.session = None
-                    await self._pre_close_streams(name)
-                    old_stack = state.stack
-                    state.stack = None
-                    if old_stack is not None:
-                        await self._safe_close_stack(old_stack)
                 try:
                     await self._connect_one_locked(name, cfg)
                 except Exception:
@@ -3758,14 +3894,7 @@ class MCPClientManager:
                 # against one already in flight).
                 async with self._static_connect_lock_for(name):
                     # Close session + transport via per-server stack
-                    state = self._static_servers.get(name)
-                    if state is not None:
-                        state.session = None
-                        await self._pre_close_streams(name)
-                        stack = state.stack
-                        state.stack = None
-                        if stack is not None:
-                            await self._safe_close_stack(stack)
+                    await self._teardown_static_session(name)
                     # Clean up per-server state (on the event loop thread)
                     self._static_servers.pop(name, None)
                     self._last_error.pop(name, None)
@@ -4268,13 +4397,25 @@ class MCPClientManager:
         rather than blocking on the forever-retry). The loop keeps breaker state
         in sync so an open breaker closes once it reconnects. Static-only:
         ``oauth_user`` pools are managed by their own paths.
+
+        Cancellation policy: only a GENUINE shutdown (``shutdown()`` cancelling
+        this task) stops the loop. A stray per-server ``CancelledError`` that
+        escapes the tick (a wedged anyio transport surfacing a cancel-scope
+        poison) must not silently kill the only autonomous reconnect driver —
+        ``Task.cancelling()`` is the discriminator, because a real cancel
+        request bumps the task's pending-cancel count before the
+        ``CancelledError`` is delivered.
         """
         while True:
             try:
                 sleep_s = await self._static_health_tick()
                 await asyncio.sleep(sleep_s)
             except asyncio.CancelledError:
-                return
+                task = asyncio.current_task()
+                if task is None or task.cancelling():
+                    return  # genuine shutdown
+                log.warning("MCP static health: stray cancellation absorbed; continuing")
+                await asyncio.sleep(self._static_health_check_s)
             except Exception:
                 log.warning("MCP static health iteration failed", exc_info=True)
                 await asyncio.sleep(self._static_health_check_s)
@@ -4304,16 +4445,22 @@ class MCPClientManager:
             *(self._static_health_one(name, now) for name in names),
             return_exceptions=True,
         )
-        soonest = now + self._static_health_check_s
+        # FRESH clock for every deadline computed after the gather — the
+        # per-server work above can burn tens of seconds, so ``now`` is stale.
+        after = time.monotonic()
+        soonest = after + self._static_health_check_s
         for name, res in zip(names, results, strict=True):
             if isinstance(res, BaseException):
-                # A genuine external cancel (loop shutdown) must propagate so
-                # ``_static_health_loop``'s shutdown path returns; only per-server
-                # errors are isolated.
-                if isinstance(res, asyncio.CancelledError):
-                    raise res
+                # Per-server exception isolation — INCLUDING CancelledError. A
+                # genuine shutdown cancels the ``await gather`` itself, which
+                # raises CancelledError at the await directly (an outer cancel
+                # never lands in the results list, ``return_exceptions``
+                # notwithstanding) and propagates to ``_static_health_loop``'s
+                # shutdown path. A CancelledError IN the results is per-server
+                # fallout (a stray anyio cancel-scope poison from a wedged
+                # transport) — re-raising it here killed the whole loop.
                 log.debug("MCP static health: server '%s' pass failed", name, exc_info=res)
-                due = now + self._static_health_check_s
+                due = after + self._static_health_check_s
             else:
                 due = res
             soonest = min(soonest, due)
@@ -4332,60 +4479,49 @@ class MCPClientManager:
     def _static_reconnect_delay(self, attempt: int) -> float:
         """Full-jitter capped-exponential backoff: ``uniform(0, min(CAP, BASE*2^n))``.
 
-        Retry forever — ``attempt`` is unbounded, so the exponent is clamped
-        before ``2**n`` explodes; past the cap every attempt draws from the same
-        ``[0, CAP]`` window.
+        Retry forever — ``attempt`` is unbounded; :meth:`_capped_exponential`
+        clamps the exponent before ``2**n`` explodes, so past the cap every
+        attempt draws from the same ``[0, CAP]`` window.
         """
-        exp = min(attempt, 32)
-        ceiling = min(self._STATIC_RECONNECT_MAX_S, self._STATIC_RECONNECT_BASE_S * (2**exp))
+        ceiling = self._capped_exponential(
+            self._STATIC_RECONNECT_BASE_S, self._STATIC_RECONNECT_MAX_S, attempt
+        )
         return random.uniform(0.0, ceiling)
 
     async def _static_reconnect_one(self, name: str, now: float) -> float:
         """Reconnect a disconnected static server if its backoff has elapsed.
 
-        Returns the monotonic deadline of the next attempt so the loop can sleep
-        until then. Skips (re-checks shortly) when a connect for this server is
-        already in flight — the per-name lock is the arbiter; piling on would just
-        queue a redundant reconnect.
+        Returns the monotonic deadline of the next attempt so the loop can
+        sleep until then. Routes through :meth:`_ensure_static_connected` — if
+        another driver is mid-connect we queue briefly on the per-name lock and
+        then REUSE its session instead of piling a redundant rebuild on the
+        shared state; the primitive also owns the attempt bound and the breaker
+        (a failure here only advances the health loop's OWN backoff clock).
+
+        Clock discipline: *now* is the tick-start time and can be tens of
+        seconds stale after a slow sibling op in the same gather — it may gate
+        "is it due?", but every WRITTEN/RETURNED deadline uses a fresh
+        ``time.monotonic()`` (a stale base lands deadlines in the past and
+        collapses the backoff into an every-tick retry storm).
         """
         due = self._static_reconnect_next.get(name, now)
         if now < due:
             return due
-        if self._static_connect_lock_for(name).locked():
-            return now + 1.0  # another path is (re)connecting right now
         cfg = self._server_configs.get(name)
         if not cfg:
-            return now + self._static_health_check_s
+            return time.monotonic() + self._static_health_check_s
         try:
             log.info("MCP static health: reconnecting '%s'", name)
-            # Bound the whole attempt from the OUTSIDE (invariant: never edit
-            # ``_connect_one_locked``'s connect internals). ``_connect_one_locked``
-            # bounds only the handshake; its post-handshake discovery is unbounded,
-            # so a server that handshakes then stalls ``list_tools`` would wedge
-            # this single loop coroutine and hold the per-name lock forever. On
-            # timeout the CancelledError unwinds through ``_connect_one``'s
-            # ``async with`` lock (released) and is converted to ``TimeoutError``,
-            # handled below as a failed attempt.
-            async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
-                await self._connect_one(name, cfg)
-            state = self._static_servers.get(name)
-            if state is None or state.session is None:
-                raise RuntimeError("reconnect produced no session")
+            session = await self._ensure_static_connected(name, cfg)
         except Exception as exc:
-            self._cb_record_failure(name)
-            # Drop any partially-initialized session (e.g. handshake OK but a
-            # timed-out ``list_tools`` left ``state.session`` set) so the next
-            # tick reconnects cleanly — respecting the backoff below — instead of
-            # pinging a half-open session. Mirrors ``_record_and_evict_on_dead_
-            # transport``: null the session, leave the stack for ``_connect_one``'s
-            # stale-and-stack guard to reap.
-            st = self._static_servers.get(name)
-            if st is not None:
-                st.session = None
+            # The primitive already recorded the breaker failure and dropped
+            # any partially-initialized session; only the health loop's own
+            # backoff state advances here.
             attempt = self._static_reconnect_attempt.get(name, 0) + 1
             self._static_reconnect_attempt[name] = attempt
             delay = self._static_reconnect_delay(attempt)
-            self._static_reconnect_next[name] = now + delay
+            next_due = time.monotonic() + delay
+            self._static_reconnect_next[name] = next_due
             # Loud on the first few failures, then decays to debug so a long /
             # permanent outage doesn't spam the log on every forever-retry.
             log_fn = log.warning if attempt <= self._CB_FAILURE_THRESHOLD else log.debug
@@ -4396,28 +4532,29 @@ class MCPClientManager:
                 delay,
                 exc,
             )
-            return self._static_reconnect_next[name]
+            return next_due
+        if session is None:
+            # Deliberate skip — removed from config mid-flight, or a sibling
+            # dispatch is still in flight on the old (evicted) stack. Not a
+            # failure: no backoff bump, no breaker; re-check shortly.
+            return time.monotonic() + 1.0
         # Success — reset the health-loop's own backoff, schedule the first ping,
         # and reconcile catalog drift off the critical path (mirrors
-        # ``_cb_auto_reconnect``: the session is usable immediately).
-        #
-        # Breaker: clear only the OPEN-CIRCUIT DEADLINE, not the whole failure
-        # count. A transport reconnect proves the transport recovered, so dispatch
-        # should flow (not be fast-failed) — but for a connect-OK / calls-FAIL
-        # server, resetting ``_consecutive_failures`` here (as ``_cb_record_success``
-        # would) means the count oscillates 0->1->0 and the breaker never trips.
-        # Leaving the count lets a genuine call-failure pattern still escalate to
-        # the threshold; a real dispatch SUCCESS is what resets it.
-        self._circuit_open_until.pop(name, None)
+        # ``_cb_auto_reconnect``: the session is usable immediately). Breaker
+        # state was already settled by ``_ensure_static_connected``: only the
+        # open-circuit deadline cleared, the failure count kept so a
+        # connect-OK / calls-FAIL server still escalates to a trip — a real
+        # dispatch SUCCESS is what resets it.
         self._static_reconnect_attempt.pop(name, None)
         self._static_reconnect_next.pop(name, None)
-        self._static_next_ping[name] = now + self._static_health_check_s
+        next_ping = time.monotonic() + self._static_health_check_s
+        self._static_next_ping[name] = next_ping
         self._spawn_background(
             self._refresh_server(name),
             f"catalog refresh after static health reconnect '{name}'",
         )
         log.info("MCP static health: reconnected '%s'", name)
-        return now + self._static_health_check_s
+        return next_ping
 
     async def _static_ping_one(self, name: str, now: float) -> float:
         """Liveness-ping a connected static server; evict a dead-but-idle one.
@@ -4436,6 +4573,11 @@ class MCPClientManager:
             answer a ping mid-call, and tearing it down would abort that call
             (the ``StaticServerState`` in-flight interlock, mirroring the pool
             path's ``_close_pool_entry_if_idle``).
+
+        Clock discipline: the tick-start *now* may gate "is it due?", but every
+        WRITTEN/RETURNED deadline uses a fresh ``time.monotonic()`` — after a
+        slow sibling op in the same gather a stale base lands the next ping in
+        the past and collapses the cadence into an every-tick re-ping.
         """
         # Recovered-server hygiene: a live session means any stale health-loop
         # backoff (left by a dispatch/operator reconnect the loop didn't drive)
@@ -4450,11 +4592,13 @@ class MCPClientManager:
         state = self._static_servers.get(name)
         session = state.session if state is not None else None
         if session is None:
-            return now  # raced an eviction — reconnect path handles it next tick
+            # Raced an eviction — due now; the reconnect path handles it next tick.
+            return time.monotonic()
         if state is not None and state.in_flight > 0:
             # Busy serving a dispatch → demonstrably alive; skip ping + evict.
-            self._static_next_ping[name] = now + self._static_health_check_s
-            return self._static_next_ping[name]
+            next_ping = time.monotonic() + self._static_health_check_s
+            self._static_next_ping[name] = next_ping
+            return next_ping
         try:
             # invariant-18: ``asyncio.timeout`` (NOT ``wait_for``) so ``send_ping``
             # runs in THIS task and anyio cancel-scope exit stays same-task.
@@ -4482,14 +4626,15 @@ class MCPClientManager:
             if dead and evict is not None and not busy and evict.session is session:
                 self._cb_record_failure(name)
                 evict.session = None
-                self._static_reconnect_next[name] = now  # reconnect asap
+                asap = time.monotonic()
+                self._static_reconnect_next[name] = asap  # reconnect asap
                 self._static_reconnect_attempt.pop(name, None)
                 log.info(
                     "MCP static health: '%s' failed liveness ping (%s); evicting to reconnect",
                     name,
                     type(exc).__name__,
                 )
-                return now
+                return asap
             # Slow / protocol / pool-saturation / busy / swapped-session: not an
             # actionable death — reschedule, don't evict, don't trip the breaker.
             log.debug(
@@ -4497,60 +4642,59 @@ class MCPClientManager:
                 name,
                 type(exc).__name__,
             )
-            self._static_next_ping[name] = now + self._static_health_check_s
-            return self._static_next_ping[name]
-        self._static_next_ping[name] = now + self._static_health_check_s
-        return self._static_next_ping[name]
+            next_ping = time.monotonic() + self._static_health_check_s
+            self._static_next_ping[name] = next_ping
+            return next_ping
+        next_ping = time.monotonic() + self._static_health_check_s
+        self._static_next_ping[name] = next_ping
+        return next_ping
 
     def _cb_auto_reconnect(self, server_name: str) -> Any:
         """Attempt reconnection for a disconnected server during half-open probe.
 
-        Returns the new session on success, or raises on failure. Coordinates
-        with the per-name connect lock so it does not race — or blindly re-do —
-        an autonomous health-loop reconnect for the same server: if a health
-        reconnect already established (or, while we wait for the lock, just
-        establishes) a session, it is REUSED rather than torn down and rebuilt,
-        and no spurious breaker failure is recorded for what was merely lock
-        contention on a reachable server.
+        Returns the new (or concurrently re-established) session on success, or
+        raises on failure. Routes through :meth:`_ensure_static_connected`, so
+        the per-name lock, live-session reuse, config re-check, and the
+        ``in_flight`` deferral are shared with the health loop and
+        ``_refresh_all`` — a dispatch can never tear down, resurrect, or
+        blindly re-do a reconnect another driver already made.
+
+        Breaker ownership: connect outcomes are recorded INSIDE the primitive
+        only. The sync-boundary ``result(timeout=...)`` below deliberately
+        records NOTHING — its expiry usually means the per-name lock was merely
+        contended (a concurrent health-loop attempt is bounded at
+        ``_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S``, above this wait), and counting
+        lock-wait as a server failure trips the breaker for a reachable server.
+        A cancelled attempt proves nothing; the next real connect outcome is
+        recorded where it is observed.
         """
         cfg = self._server_configs.get(server_name)
         if not cfg or self._loop is None:
             raise RuntimeError(f"MCP server '{server_name}' is not connected")
 
         async def _reconnect_for_dispatch() -> Any:
-            # A health-loop reconnect may already have re-established the session
-            # while this dispatch was being scheduled — reuse it, don't pile a
-            # second reconnect on the shared state.
-            state = self._static_servers.get(server_name)
-            if state is not None and state.session is not None:
-                return state.session
-            # Take the per-name lock so teardown/rebuild can't interleave with a
-            # concurrent health-loop / operator reconnect (call the LOCKED body
-            # directly — we already hold the lock, and ``_connect_one`` would
-            # deadlock re-acquiring it).
-            async with self._static_connect_lock_for(server_name):
-                # Re-check under the lock: a health reconnect we queued BEHIND
-                # may have just finished and installed a fresh session. Reuse it.
-                state = self._static_servers.get(server_name)
-                if state is not None and state.session is not None:
-                    return state.session
-                await self._connect_one_locked(server_name, cfg)
-                state = self._static_servers.get(server_name)
-                return state.session if state is not None else None
+            return await self._ensure_static_connected(server_name, cfg)
 
+        # A fresh coroutine/task per attempt: a timed-out attempt is cancelled
+        # below, and the next dispatch starts clean instead of re-entering a
+        # half-cancelled anyio scope.
         reconnect_future = asyncio.run_coroutine_threadsafe(_reconnect_for_dispatch(), self._loop)
         try:
             session = reconnect_future.result(timeout=self._CONNECT_TIMEOUT)
         except concurrent.futures.TimeoutError:
             reconnect_future.cancel()
-            self._cb_record_failure(server_name)
+            # No breaker record: see docstring — lock contention is not a
+            # server failure, and this boundary cannot tell the two apart.
             raise RuntimeError(f"MCP server '{server_name}' reconnect timed out") from None
         except Exception as exc:
-            self._cb_record_failure(server_name)
+            # Real connect failures were already recorded by the primitive;
+            # recording here again would double-count one outcome.
             raise RuntimeError(f"MCP server '{server_name}' reconnect failed: {exc}") from None
         if session is None:
-            self._cb_record_failure(server_name)
-            raise RuntimeError(f"MCP server '{server_name}' reconnect produced no session")
+            # Deliberate skip: the server was removed while we queued, or a
+            # sibling call is still in flight on the old (evicted) stack. Fail
+            # this dispatch cleanly; not a breaker-worthy server failure.
+            raise RuntimeError(f"MCP server '{server_name}' is unavailable (removed or busy)")
 
         # Schedule catalog refresh on the loop without blocking the caller.
         # The reconnected session is valid for the imminent dispatch; catalog

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -916,6 +916,16 @@ class MCPClientManager:
     # handshake plus fast discovery.
     _STATIC_RECONNECT_ATTEMPT_TIMEOUT_S = float(_CONNECT_TIMEOUT + 15)
 
+    # Caller-side wait for a reconnect routed through ``_ensure_static_connected``
+    # (a dispatch's ``_cb_auto_reconnect``, operator ``reconnect_sync`` /
+    # ``remove_server_sync``). MUST exceed ``_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S``
+    # so the primitive's inner bound always fires FIRST — surfacing a clean
+    # ``TimeoutError`` the primitive converts, cleans up, and records on the
+    # breaker — instead of the caller cancelling mid-attempt and leaving a
+    # half-discovered session installed with no breaker record, or an operator
+    # teardown silently timing out behind a slow reconnect that holds the lock.
+    _STATIC_RECONNECT_CALLER_TIMEOUT_S = _STATIC_RECONNECT_ATTEMPT_TIMEOUT_S + 10.0
+
     # Notification debounce
     _NOTIFICATION_DEBOUNCE = 5.0  # seconds between refreshes per server
 
@@ -1180,7 +1190,9 @@ class MCPClientManager:
         async with self._static_connect_lock_for(name):
             await self._connect_one_locked(name, cfg)
 
-    async def _ensure_static_connected(self, name: str, cfg: dict[str, Any]) -> Any:
+    async def _ensure_static_connected(
+        self, name: str, cfg: dict[str, Any], *, defer_if_busy: bool = True
+    ) -> Any:
         """Idempotently (re)connect static server *name* — the ONE lazy path.
 
         Every lazy/autonomous reconnect driver — the health loop
@@ -1244,23 +1256,34 @@ class MCPClientManager:
             # (2) Reuse-if-live.
             if state is not None and state.session is not None:
                 return state.session
-            # (3) in_flight guard.
-            if state is not None and state.in_flight > 0:
+            # (3) in_flight guard — AUTONOMOUS callers only (``defer_if_busy``).
+            # A sibling call is still draining on the old (evicted-but-open)
+            # stack; a rebuild's stale-guard teardown would abort it. The health
+            # loop and ``_refresh_all`` defer (they retry on their own schedule);
+            # a DISPATCH is a deliberate user action that NEEDS the session now,
+            # so it does not defer — it reconnects (the pre-unification behavior),
+            # accepting it may tear a sibling down rather than hard-fail a
+            # reachable server.
+            if defer_if_busy and state is not None and state.in_flight > 0:
                 return None
-            # (4) Bounded connect; the breaker is owned here. On expiry the
-            # CancelledError unwinds _connect_one_locked (its cancelling()
-            # checks see a pending cancel and re-raise) and asyncio.timeout
-            # converts it to TimeoutError inside the lock.
+            # (4) Bounded connect; the breaker is owned here. The inner bound is
+            # STRICTLY below every caller's wait (``_STATIC_RECONNECT_CALLER_
+            # TIMEOUT_S``), so it fires first and asyncio.timeout converts the
+            # cancel to TimeoutError inside the lock — the caller never cancels a
+            # live attempt out from under us.
             try:
                 async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
                     await self._connect_one_locked(name, cfg)
-            except Exception:
+            except BaseException:
+                # ANY non-success exit — an ``except Exception`` connect error,
+                # the converted inner TimeoutError, or a bare CancelledError (a
+                # caller's sync boundary giving up early, or a genuine shutdown)
+                # — must not leave a half-discovered session installed, and
+                # records the failed attempt so the breaker can trip. Recording
+                # on a shutdown cancel is harmless; the cleanup is synchronous
+                # (no await), so it is safe under an active cancellation. We hold
+                # the lock, so no concurrent driver installed a fresh session.
                 self._cb_record_failure(name)
-                # Drop a partially-initialized session (handshake OK but a
-                # timed-out ``list_tools`` can leave ``state.session`` set) so
-                # the next attempt reconnects cleanly; leave the stack for the
-                # stale-guard to reap. We hold the lock, so no concurrent
-                # driver can have installed a fresh session to clobber.
                 st = self._static_servers.get(name)
                 if st is not None:
                     st.session = None
@@ -3780,7 +3803,9 @@ class MCPClientManager:
             "error": "",
         }
 
-    def reconnect_sync(self, name: str, timeout: int = 30) -> dict[str, Any]:
+    def reconnect_sync(
+        self, name: str, timeout: float = _STATIC_RECONNECT_CALLER_TIMEOUT_S
+    ) -> dict[str, Any]:
         """Force a fresh connection to an MCP server (blocks the calling thread).
 
         Tears down the current session/transport (if any), clears the circuit
@@ -3860,7 +3885,9 @@ class MCPClientManager:
             "error": "",
         }
 
-    def remove_server_sync(self, name: str, timeout: int = 15) -> bool:
+    def remove_server_sync(
+        self, name: str, timeout: float = _STATIC_RECONNECT_CALLER_TIMEOUT_S
+    ) -> bool:
         """Disconnect and remove an MCP server at runtime (blocks the calling thread).
 
         All state mutations run on the MCP event loop thread to avoid races
@@ -3916,8 +3943,18 @@ class MCPClientManager:
             future = asyncio.run_coroutine_threadsafe(_remove(), self._loop)
             try:
                 future.result(timeout=timeout)
+            except concurrent.futures.TimeoutError:
+                # A slow reconnect held the per-name lock past our wait. CANCEL
+                # the pending ``_remove`` so it can't later pop a re-added entry
+                # (or its new lock) and corrupt state; report failure rather than
+                # a false "removed" (the default timeout exceeds the reconnect
+                # bound, so this is an edge — a caller passing a short timeout).
+                future.cancel()
+                log.warning("MCP server '%s' removal timed out; cancelled", name)
+                return False
             except Exception:
                 log.warning("Error removing MCP server '%s'", name, exc_info=True)
+                return False
         else:
             # No event loop (tests / pre-start) — mutate directly
             self._static_servers.pop(name, None)
@@ -4556,6 +4593,12 @@ class MCPClientManager:
         log.info("MCP static health: reconnected '%s'", name)
         return next_ping
 
+    def _schedule_next_ping(self, name: str) -> float:
+        """Set and return the next liveness-ping deadline (fresh monotonic clock)."""
+        next_ping = time.monotonic() + self._static_health_check_s
+        self._static_next_ping[name] = next_ping
+        return next_ping
+
     async def _static_ping_one(self, name: str, now: float) -> float:
         """Liveness-ping a connected static server; evict a dead-but-idle one.
 
@@ -4596,9 +4639,7 @@ class MCPClientManager:
             return time.monotonic()
         if state is not None and state.in_flight > 0:
             # Busy serving a dispatch → demonstrably alive; skip ping + evict.
-            next_ping = time.monotonic() + self._static_health_check_s
-            self._static_next_ping[name] = next_ping
-            return next_ping
+            return self._schedule_next_ping(name)
         try:
             # invariant-18: ``asyncio.timeout`` (NOT ``wait_for``) so ``send_ping``
             # runs in THIS task and anyio cancel-scope exit stays same-task.
@@ -4642,12 +4683,8 @@ class MCPClientManager:
                 name,
                 type(exc).__name__,
             )
-            next_ping = time.monotonic() + self._static_health_check_s
-            self._static_next_ping[name] = next_ping
-            return next_ping
-        next_ping = time.monotonic() + self._static_health_check_s
-        self._static_next_ping[name] = next_ping
-        return next_ping
+            return self._schedule_next_ping(name)
+        return self._schedule_next_ping(name)
 
     def _cb_auto_reconnect(self, server_name: str) -> Any:
         """Attempt reconnection for a disconnected server during half-open probe.
@@ -4673,14 +4710,17 @@ class MCPClientManager:
             raise RuntimeError(f"MCP server '{server_name}' is not connected")
 
         async def _reconnect_for_dispatch() -> Any:
-            return await self._ensure_static_connected(server_name, cfg)
+            # defer_if_busy=False: a dispatch NEEDS the session now and may tear
+            # down a sibling call rather than hard-fail a reachable server (the
+            # in_flight defer is for autonomous drivers that retry on their own).
+            return await self._ensure_static_connected(server_name, cfg, defer_if_busy=False)
 
         # A fresh coroutine/task per attempt: a timed-out attempt is cancelled
         # below, and the next dispatch starts clean instead of re-entering a
         # half-cancelled anyio scope.
         reconnect_future = asyncio.run_coroutine_threadsafe(_reconnect_for_dispatch(), self._loop)
         try:
-            session = reconnect_future.result(timeout=self._CONNECT_TIMEOUT)
+            session = reconnect_future.result(timeout=self._STATIC_RECONNECT_CALLER_TIMEOUT_S)
         except concurrent.futures.TimeoutError:
             reconnect_future.cancel()
             # No breaker record: see docstring — lock contention is not a

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1288,9 +1288,7 @@ class MCPClientManager:
                 # own accounting (or doesn't — shutdown state is discarded).
                 if not isinstance(exc, asyncio.CancelledError):
                     self._cb_record_failure(name)
-                st = self._static_servers.get(name)
-                if st is not None:
-                    st.session = None
+                await self._teardown_static_session(name)
                 raise
             state = self._static_servers.get(name)
             if state is None or state.session is None:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -713,6 +713,14 @@ class MCPClientManager:
         self._user_token_refresh_keepalive_s = float(
             mcp_cfg.get("user_token_refresh_keepalive_seconds", 1800)
         )
+        # Static-server health loop: liveness-ping cadence (seconds). Each tick
+        # pings every connected static server (evicting a dead-but-idle one so it
+        # is reconnected) and retries any disconnected one on a capped, jittered,
+        # forever backoff. The SDK gives up reconnecting after 2 attempts with no
+        # backoff (verified: mcp 1.28.1) and never for other transports, so this
+        # is Turnstone's own reconnect — nothing upstream to lean on. <= 0
+        # disables the loop entirely.
+        self._static_health_check_s = float(mcp_cfg.get("static_health_check_seconds", 30))
 
         # OAuth integration. ``set_app_state`` wires app_state in after the
         # lifespan has built the token store / OAuth helpers; pool dispatch
@@ -749,6 +757,22 @@ class MCPClientManager:
         # pass, so a recovered or re-consented grant re-arms the surfacing.
         # Loop-only mutation.
         self._token_sweep_warned: set[tuple[str, str]] = set()
+        # Static-server health loop handle (started once in ``_connect_all``).
+        self._static_health_task: asyncio.Task[None] | None = None
+        # Per-server connect serialization. ``_connect_one`` tears down and
+        # rebuilds the SHARED ``StaticServerState``; two concurrent reconnects
+        # for one server (health loop + a dispatch's ``_cb_auto_reconnect``, or
+        # an operator refresh) would interleave that teardown and corrupt the
+        # entry. This per-name lock serializes them. Lazily created on the
+        # mcp-loop (the asyncio.Lock allocation invariant).
+        self._static_connect_locks: dict[str, asyncio.Lock] = {}
+        # Per-server reconnect backoff state (health loop only, loop-bound):
+        # consecutive-failure ``attempt`` count and the monotonic time of the
+        # next allowed reconnect attempt. Capped + jittered, no attempt limit.
+        self._static_reconnect_attempt: dict[str, int] = {}
+        self._static_reconnect_next: dict[str, float] = {}
+        # Per-server next liveness-ping deadline (monotonic).
+        self._static_next_ping: dict[str, float] = {}
 
         # Strong references to fire-and-forget background tasks (catalog
         # refreshes etc.).  ``create_task`` alone keeps only a weak ref — an
@@ -847,6 +871,14 @@ class MCPClientManager:
         if self._user_token_sweep_s > 0 and self._user_token_sweep_task is None:
             self._user_token_sweep_task = asyncio.create_task(self._user_token_sweep_loop())
 
+        # Start the static-server health loop (once, on the mcp-loop). Self-heals
+        # static connections that the SDK's bounded reconnect / other transports
+        # abandon — the autonomous trigger Turnstone otherwise lacks (all other
+        # reconnect paths are dispatch- or operator-driven). Skipped when disabled
+        # via config (cadence <= 0).
+        if self._static_health_check_s > 0 and self._static_health_task is None:
+            self._static_health_task = asyncio.create_task(self._static_health_loop())
+
     _CONNECT_TIMEOUT = 30  # seconds — prevents hung connections on broken remotes
     _TCP_PROBE_TIMEOUT = 5  # seconds — fast TCP pre-flight for HTTP transports
 
@@ -854,6 +886,18 @@ class MCPClientManager:
     _CB_FAILURE_THRESHOLD = 3
     _CB_BASE_COOLDOWN = 30.0  # seconds
     _CB_MAX_COOLDOWN = 300.0  # 5 minutes
+
+    # Static-server reconnect backoff (health loop). Capped exponential + full
+    # jitter, retry FOREVER (no attempt limit): a server that returns after a
+    # long outage reconnects within ~a minute, and a permanently-misconfigured
+    # one costs at most one attempt per ``_STATIC_RECONNECT_MAX_S``. The cap is
+    # deliberately tighter than ``_CB_MAX_COOLDOWN`` (which gates dispatch
+    # fail-fast, a different clock) so recovery is prompt.
+    _STATIC_RECONNECT_BASE_S = 1.0
+    _STATIC_RECONNECT_MAX_S = 60.0
+    # Liveness-ping timeout: a static server that can't answer a ping in this
+    # long is treated as down (evict → reconnect).
+    _STATIC_HEALTH_PING_TIMEOUT_S = 5.0
 
     # Notification debounce
     _NOTIFICATION_DEBOUNCE = 5.0  # seconds between refreshes per server
@@ -1051,12 +1095,38 @@ class MCPClientManager:
         await self._pre_close_streams(key)
         await self._safe_close_stack(stack)
 
+    def _static_connect_lock_for(self, name: str) -> asyncio.Lock:
+        """Return the per-server connect lock for ``name`` (lazily created).
+
+        MUST be called on the mcp-loop — the asyncio.Lock allocation invariant.
+        """
+        lock = self._static_connect_locks.get(name)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._static_connect_locks[name] = lock
+        return lock
+
     async def _connect_one(self, name: str, cfg: dict[str, Any]) -> None:
-        """Connect to a single MCP server and discover its tools."""
+        """Connect to a single MCP server, serialized per server.
+
+        Wraps :meth:`_connect_one_locked` in the per-name connect lock so a
+        health-loop reconnect, a dispatch ``_cb_auto_reconnect``, and an operator
+        refresh can never interleave teardown/rebuild on the shared
+        ``StaticServerState`` (which would corrupt the entry or leak a stack).
+        No caller holds the lock before calling in, and the body never re-enters
+        ``_connect_one`` for the same name, so there is no reentrancy risk.
+        """
         if "__" in name:
             log.error("MCP server name '%s' contains '__' (reserved delimiter), skipping", name)
             return
+        async with self._static_connect_lock_for(name):
+            await self._connect_one_locked(name, cfg)
 
+    async def _connect_one_locked(self, name: str, cfg: dict[str, Any]) -> None:
+        """Connect to a single MCP server and discover its tools.
+
+        MUST run under the per-server connect lock (see :meth:`_connect_one`).
+        """
         # Operate on a single state object throughout: get-or-create up front
         # so the stale-entry guard and the post-handshake field assignments
         # touch the same instance (PR #296 invariant 5: identity stability).
@@ -3367,6 +3437,14 @@ class MCPClientManager:
                     with contextlib.suppress(BaseException):
                         await self._user_token_sweep_task
                     self._user_token_sweep_task = None
+                # Static health loop is a dedicated handle (not in
+                # _background_tasks); cancel it here so a static-only deployment
+                # — which skips the pool-teardown block below — still stops it.
+                if self._static_health_task is not None:
+                    self._static_health_task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await self._static_health_task
+                    self._static_health_task = None
                 tasks = list(self._background_tasks)
                 for task in tasks:
                     task.cancel()
@@ -3483,6 +3561,11 @@ class MCPClientManager:
         self._user_pool_eviction_task = None
         self._user_token_sweep_task = None
         self._token_sweep_warned.clear()
+        self._static_health_task = None
+        self._static_connect_locks.clear()
+        self._static_reconnect_attempt.clear()
+        self._static_reconnect_next.clear()
+        self._static_next_ping.clear()
 
         log.info("MCP client shut down")
 
@@ -4122,6 +4205,167 @@ class MCPClientManager:
 
         task.add_done_callback(_done)
         return task
+
+    # -- static-server health loop (autonomous reconnect + liveness) ----------
+
+    async def _static_health_loop(self) -> None:
+        """Long-running coroutine — keeps static MCP servers connected.
+
+        The autonomous reconnect Turnstone otherwise lacks. Every other reconnect
+        path is lazy (a tool dispatch, an operator refresh, a config edit), and
+        the SDK's own reconnect is a bounded 2-attempt burst on the
+        streamable-http GET stream ONLY (verified: mcp 1.28.1) — no backoff,
+        nothing for the other transports. So a static server that goes down and
+        comes back while nobody is dispatching to it stays dead until someone
+        acts. Each tick, on the mcp-loop:
+
+          * a DISCONNECTED server (``session is None``) is reconnected on a
+            capped, jittered, forever backoff (:meth:`_static_reconnect_delay`);
+          * a CONNECTED server is liveness-pinged (:meth:`_static_ping_one`) and a
+            dead-but-idle one — which the SDK leaves as a non-None session with
+            closed streams, so nothing else notices until a dispatch fails — is
+            evicted so the next tick reconnects it.
+
+        Backoff is the health loop's OWN clock; the circuit breaker stays the
+        DISPATCH fail-fast gate (a tool call to a down server errors immediately
+        rather than blocking on the forever-retry). The loop keeps breaker state
+        in sync so an open breaker closes once it reconnects. Static-only:
+        ``oauth_user`` pools are managed by their own paths.
+        """
+        while True:
+            try:
+                sleep_s = await self._static_health_tick()
+                await asyncio.sleep(sleep_s)
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                log.warning("MCP static health iteration failed", exc_info=True)
+                await asyncio.sleep(self._static_health_check_s)
+
+    async def _static_health_tick(self) -> float:
+        """One health pass. Returns seconds to sleep until the next due event.
+
+        MUST run on the mcp-loop. Per-server failures are isolated. The returned
+        sleep is the soonest per-server deadline (next reconnect attempt for a
+        down server, next ping for a connected one), clamped so the loop neither
+        busy-spins nor sleeps through a short backoff.
+        """
+        now = time.monotonic()
+        soonest = now + self._static_health_check_s
+        for name in list(self._server_configs.keys()):
+            if name in self._oauth_user_server_names:
+                continue  # per-user pools are managed separately
+            state = self._static_servers.get(name)
+            connected = state is not None and state.session is not None
+            try:
+                if connected:
+                    due = await self._static_ping_one(name, now)
+                else:
+                    due = await self._static_reconnect_one(name, now)
+            except Exception:
+                log.debug("MCP static health: server '%s' pass failed", name, exc_info=True)
+                due = now + self._static_health_check_s
+            soonest = min(soonest, due)
+        return max(0.5, soonest - now)
+
+    def _static_reconnect_delay(self, attempt: int) -> float:
+        """Full-jitter capped-exponential backoff: ``uniform(0, min(CAP, BASE*2^n))``.
+
+        Retry forever — ``attempt`` is unbounded, so the exponent is clamped
+        before ``2**n`` explodes; past the cap every attempt draws from the same
+        ``[0, CAP]`` window.
+        """
+        exp = min(attempt, 32)
+        ceiling = min(self._STATIC_RECONNECT_MAX_S, self._STATIC_RECONNECT_BASE_S * (2**exp))
+        return random.uniform(0.0, ceiling)
+
+    async def _static_reconnect_one(self, name: str, now: float) -> float:
+        """Reconnect a disconnected static server if its backoff has elapsed.
+
+        Returns the monotonic deadline of the next attempt so the loop can sleep
+        until then. Skips (re-checks shortly) when a connect for this server is
+        already in flight — the per-name lock is the arbiter; piling on would just
+        queue a redundant reconnect.
+        """
+        due = self._static_reconnect_next.get(name, now)
+        if now < due:
+            return due
+        if self._static_connect_lock_for(name).locked():
+            return now + 1.0  # another path is (re)connecting right now
+        cfg = self._server_configs.get(name)
+        if not cfg:
+            return now + self._static_health_check_s
+        try:
+            log.info("MCP static health: reconnecting '%s'", name)
+            await self._connect_one(name, cfg)
+            state = self._static_servers.get(name)
+            if state is None or state.session is None:
+                raise RuntimeError("reconnect produced no session")
+        except Exception as exc:
+            self._cb_record_failure(name)
+            attempt = self._static_reconnect_attempt.get(name, 0) + 1
+            self._static_reconnect_attempt[name] = attempt
+            delay = self._static_reconnect_delay(attempt)
+            self._static_reconnect_next[name] = now + delay
+            # Loud on the first few failures, then decays to debug so a long /
+            # permanent outage doesn't spam the log on every forever-retry.
+            log_fn = log.warning if attempt <= self._CB_FAILURE_THRESHOLD else log.debug
+            log_fn(
+                "MCP static health: reconnect '%s' failed (attempt %d), next in %.0fs: %s",
+                name,
+                attempt,
+                delay,
+                exc,
+            )
+            return self._static_reconnect_next[name]
+        # Success — reset backoff, close the breaker, schedule the first ping,
+        # and reconcile catalog drift off the critical path (mirrors
+        # ``_cb_auto_reconnect``: the session is usable immediately).
+        self._cb_record_success(name)
+        self._static_reconnect_attempt.pop(name, None)
+        self._static_reconnect_next.pop(name, None)
+        self._static_next_ping[name] = now + self._static_health_check_s
+        self._spawn_background(
+            self._refresh_server(name),
+            f"catalog refresh after static health reconnect '{name}'",
+        )
+        log.info("MCP static health: reconnected '%s'", name)
+        return now + self._static_health_check_s
+
+    async def _static_ping_one(self, name: str, now: float) -> float:
+        """Liveness-ping a connected static server; evict a dead-but-idle one.
+
+        Returns the monotonic deadline of the next ping. A server that fails a
+        ping — a dead transport, or no answer within the timeout — is evicted
+        (``session = None``) so the next tick reconnects it, and its breaker
+        records a failure so dispatch fails fast in the meantime. ``ping`` is a
+        core-protocol request every healthy server answers, so a failure is
+        unambiguous; we don't try to distinguish protocol from transport.
+        """
+        due = self._static_next_ping.get(name, now)
+        if now < due:
+            return due
+        state = self._static_servers.get(name)
+        session = state.session if state is not None else None
+        if session is None:
+            return now  # raced an eviction — reconnect path handles it next tick
+        try:
+            await asyncio.wait_for(session.send_ping(), timeout=self._STATIC_HEALTH_PING_TIMEOUT_S)
+        except Exception as exc:
+            self._cb_record_failure(name)
+            evict = self._static_servers.get(name)
+            if evict is not None:
+                evict.session = None
+            self._static_reconnect_next[name] = now  # reconnect asap
+            self._static_reconnect_attempt.pop(name, None)
+            log.info(
+                "MCP static health: '%s' failed liveness ping (%s); evicting to reconnect",
+                name,
+                type(exc).__name__,
+            )
+            return now
+        self._static_next_ping[name] = now + self._static_health_check_s
+        return self._static_next_ping[name]
 
     def _cb_auto_reconnect(self, server_name: str) -> Any:
         """Attempt reconnection for a disconnected server during half-open probe.

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -458,6 +458,12 @@ class StaticServerState:
     tools: list[dict[str, Any]] = field(default_factory=list)
     resources: list[dict[str, Any]] = field(default_factory=list)
     prompts: list[dict[str, Any]] = field(default_factory=list)
+    # Dispatch counter for the health-loop eviction interlock (mirrors
+    # ``PoolEntryState.in_flight``): the liveness ping skips and never evicts a
+    # server with ``in_flight > 0`` so a long-running ``call_tool`` pins its
+    # session against teardown. Incremented/decremented on the mcp-loop around
+    # the session op by ``_static_session_op``.
+    in_flight: int = 0
     supports_list_changed: bool = False
     supports_resources: bool = False
     supports_prompts: bool = False
@@ -895,9 +901,20 @@ class MCPClientManager:
     # fail-fast, a different clock) so recovery is prompt.
     _STATIC_RECONNECT_BASE_S = 1.0
     _STATIC_RECONNECT_MAX_S = 60.0
-    # Liveness-ping timeout: a static server that can't answer a ping in this
-    # long is treated as down (evict → reconnect).
-    _STATIC_HEALTH_PING_TIMEOUT_S = 5.0
+    # Liveness-ping timeout. Deliberately generous (a slow-but-working server
+    # must not churn): a ping that times out is treated as "slow, not dead" —
+    # rescheduled, NOT evicted (only a ``_is_dead_transport`` failure evicts).
+    # Well beyond the 120s dispatch call is unnecessary; a ping is a lightweight
+    # round-trip, but heavy servers / congested links can still take seconds.
+    _STATIC_HEALTH_PING_TIMEOUT_S = 30.0
+    # Outer bound on a single autonomous reconnect ATTEMPT. ``_connect_one_locked``
+    # bounds only the handshake (``_CONNECT_TIMEOUT``); its post-handshake
+    # ``list_tools``/``list_resources``/``list_prompts`` are unbounded, so a server
+    # that handshakes then stalls discovery would wedge the loop AND hold the
+    # per-name lock forever. Bound from the caller side (invariant: never edit
+    # ``_connect_one_locked``'s connect internals) with headroom for a worst-case
+    # handshake plus fast discovery.
+    _STATIC_RECONNECT_ATTEMPT_TIMEOUT_S = float(_CONNECT_TIMEOUT + 15)
 
     # Notification debounce
     _NOTIFICATION_DEBOUNCE = 5.0  # seconds between refreshes per server
@@ -3652,29 +3669,36 @@ class MCPClientManager:
 
         async def _reconnect() -> None:
             self._cb_clear(name)
-            state = self._static_servers.get(name)
-            if state is not None:
-                state.session = None
-                await self._pre_close_streams(name)
-                old_stack = state.stack
-                state.stack = None
-                if old_stack is not None:
-                    await self._safe_close_stack(old_stack)
-            try:
-                await self._connect_one(name, cfg)
-            except Exception:
-                # Connect failed mid-reconnect — drop the stale per-server
-                # catalog so the merged tool/resource/prompt maps don't keep
-                # advertising entries with no live session behind them.
-                fail_state = self._static_servers.get(name)
-                if fail_state is not None:
-                    fail_state.tools = []
-                    fail_state.resources = []
-                    fail_state.prompts = []
-                self._rebuild_tools()
-                self._rebuild_resources()
-                self._rebuild_prompts()
-                raise
+            # Hold the per-name connect lock across teardown AND rebuild so an
+            # autonomous health-loop reconnect can never interleave its own
+            # teardown/rebuild on the shared ``StaticServerState`` mid-flight
+            # (delivering the ``_connect_one`` docstring's "operator refresh can
+            # never interleave" claim). Call the LOCKED body directly — we hold
+            # the lock, and ``_connect_one`` would deadlock re-acquiring it.
+            async with self._static_connect_lock_for(name):
+                state = self._static_servers.get(name)
+                if state is not None:
+                    state.session = None
+                    await self._pre_close_streams(name)
+                    old_stack = state.stack
+                    state.stack = None
+                    if old_stack is not None:
+                        await self._safe_close_stack(old_stack)
+                try:
+                    await self._connect_one_locked(name, cfg)
+                except Exception:
+                    # Connect failed mid-reconnect — drop the stale per-server
+                    # catalog so the merged tool/resource/prompt maps don't keep
+                    # advertising entries with no live session behind them.
+                    fail_state = self._static_servers.get(name)
+                    if fail_state is not None:
+                        fail_state.tools = []
+                        fail_state.resources = []
+                        fail_state.prompts = []
+                    self._rebuild_tools()
+                    self._rebuild_resources()
+                    self._rebuild_prompts()
+                    raise
 
         future = asyncio.run_coroutine_threadsafe(_reconnect(), self._loop)
         try:
@@ -3728,24 +3752,37 @@ class MCPClientManager:
         if self._loop is not None:
 
             async def _remove() -> None:
-                # Close session + transport via per-server stack
-                state = self._static_servers.get(name)
-                if state is not None:
-                    state.session = None
-                    await self._pre_close_streams(name)
-                    stack = state.stack
-                    state.stack = None
-                    if stack is not None:
-                        await self._safe_close_stack(stack)
-                # Clean up per-server state (on the event loop thread)
-                self._static_servers.pop(name, None)
-                self._last_error.pop(name, None)
-                self._last_notification_refresh.pop(name, None)
-                self._cb_clear(name)
-                # Rebuild merged state (serialized with notification handlers)
-                self._rebuild_tools()
-                self._rebuild_resources()
-                self._rebuild_prompts()
+                # Hold the per-name connect lock across teardown so an autonomous
+                # health-loop reconnect can't interleave (config was already
+                # popped above, so no NEW reconnect will start; this serializes
+                # against one already in flight).
+                async with self._static_connect_lock_for(name):
+                    # Close session + transport via per-server stack
+                    state = self._static_servers.get(name)
+                    if state is not None:
+                        state.session = None
+                        await self._pre_close_streams(name)
+                        stack = state.stack
+                        state.stack = None
+                        if stack is not None:
+                            await self._safe_close_stack(stack)
+                    # Clean up per-server state (on the event loop thread)
+                    self._static_servers.pop(name, None)
+                    self._last_error.pop(name, None)
+                    self._last_notification_refresh.pop(name, None)
+                    self._cb_clear(name)
+                    # Clear health-loop backoff/ping state so a later re-add of
+                    # the same name doesn't inherit stale ``due`` deadlines.
+                    self._static_reconnect_attempt.pop(name, None)
+                    self._static_reconnect_next.pop(name, None)
+                    self._static_next_ping.pop(name, None)
+                    # Rebuild merged state (serialized with notification handlers)
+                    self._rebuild_tools()
+                    self._rebuild_resources()
+                    self._rebuild_prompts()
+                # Drop the now-orphaned per-name lock AFTER releasing it (the
+                # server is gone; a re-add re-creates it lazily).
+                self._static_connect_locks.pop(name, None)
 
             future = asyncio.run_coroutine_threadsafe(_remove(), self._loop)
             try:
@@ -4245,28 +4282,52 @@ class MCPClientManager:
     async def _static_health_tick(self) -> float:
         """One health pass. Returns seconds to sleep until the next due event.
 
-        MUST run on the mcp-loop. Per-server failures are isolated. The returned
-        sleep is the soonest per-server deadline (next reconnect attempt for a
-        down server, next ping for a connected one), clamped so the loop neither
-        busy-spins nor sleeps through a short backoff.
+        MUST run on the mcp-loop. Servers are processed CONCURRENTLY (one slow
+        connect must not block liveness for every other server) with per-server
+        exception isolation. The returned sleep is against a FRESHLY-read clock —
+        the per-server work can take seconds, so the tick-start ``now`` is stale
+        by return — computed from the soonest per-server monotonic deadline and
+        clamped so the loop neither busy-spins nor sleeps through a short backoff.
         """
         now = time.monotonic()
+        names = [
+            name
+            for name in list(self._server_configs.keys())
+            # Per-user pools are managed separately; ``__`` names can never
+            # connect (``_connect_one``'s reserved-delimiter guard), so retrying
+            # them forever would only spam ``log.error`` every interval.
+            if name not in self._oauth_user_server_names and "__" not in name
+        ]
+        if not names:
+            return self._static_health_check_s
+        results = await asyncio.gather(
+            *(self._static_health_one(name, now) for name in names),
+            return_exceptions=True,
+        )
         soonest = now + self._static_health_check_s
-        for name in list(self._server_configs.keys()):
-            if name in self._oauth_user_server_names:
-                continue  # per-user pools are managed separately
-            state = self._static_servers.get(name)
-            connected = state is not None and state.session is not None
-            try:
-                if connected:
-                    due = await self._static_ping_one(name, now)
-                else:
-                    due = await self._static_reconnect_one(name, now)
-            except Exception:
-                log.debug("MCP static health: server '%s' pass failed", name, exc_info=True)
+        for name, res in zip(names, results, strict=True):
+            if isinstance(res, BaseException):
+                # A genuine external cancel (loop shutdown) must propagate so
+                # ``_static_health_loop``'s shutdown path returns; only per-server
+                # errors are isolated.
+                if isinstance(res, asyncio.CancelledError):
+                    raise res
+                log.debug("MCP static health: server '%s' pass failed", name, exc_info=res)
                 due = now + self._static_health_check_s
+            else:
+                due = res
             soonest = min(soonest, due)
-        return max(0.5, soonest - now)
+        # Fresh clock (fix): deadlines are absolute-monotonic; sleeping
+        # ``soonest - now`` would over-sleep by the tick's own elapsed time.
+        return max(0.5, soonest - time.monotonic())
+
+    async def _static_health_one(self, name: str, now: float) -> float:
+        """Ping a connected server or reconnect a disconnected one; return its
+        next-due monotonic deadline. Runs concurrently per server in the tick."""
+        state = self._static_servers.get(name)
+        if state is not None and state.session is not None:
+            return await self._static_ping_one(name, now)
+        return await self._static_reconnect_one(name, now)
 
     def _static_reconnect_delay(self, attempt: int) -> float:
         """Full-jitter capped-exponential backoff: ``uniform(0, min(CAP, BASE*2^n))``.
@@ -4297,12 +4358,30 @@ class MCPClientManager:
             return now + self._static_health_check_s
         try:
             log.info("MCP static health: reconnecting '%s'", name)
-            await self._connect_one(name, cfg)
+            # Bound the whole attempt from the OUTSIDE (invariant: never edit
+            # ``_connect_one_locked``'s connect internals). ``_connect_one_locked``
+            # bounds only the handshake; its post-handshake discovery is unbounded,
+            # so a server that handshakes then stalls ``list_tools`` would wedge
+            # this single loop coroutine and hold the per-name lock forever. On
+            # timeout the CancelledError unwinds through ``_connect_one``'s
+            # ``async with`` lock (released) and is converted to ``TimeoutError``,
+            # handled below as a failed attempt.
+            async with asyncio.timeout(self._STATIC_RECONNECT_ATTEMPT_TIMEOUT_S):
+                await self._connect_one(name, cfg)
             state = self._static_servers.get(name)
             if state is None or state.session is None:
                 raise RuntimeError("reconnect produced no session")
         except Exception as exc:
             self._cb_record_failure(name)
+            # Drop any partially-initialized session (e.g. handshake OK but a
+            # timed-out ``list_tools`` left ``state.session`` set) so the next
+            # tick reconnects cleanly — respecting the backoff below — instead of
+            # pinging a half-open session. Mirrors ``_record_and_evict_on_dead_
+            # transport``: null the session, leave the stack for ``_connect_one``'s
+            # stale-and-stack guard to reap.
+            st = self._static_servers.get(name)
+            if st is not None:
+                st.session = None
             attempt = self._static_reconnect_attempt.get(name, 0) + 1
             self._static_reconnect_attempt[name] = attempt
             delay = self._static_reconnect_delay(attempt)
@@ -4318,10 +4397,18 @@ class MCPClientManager:
                 exc,
             )
             return self._static_reconnect_next[name]
-        # Success — reset backoff, close the breaker, schedule the first ping,
+        # Success — reset the health-loop's own backoff, schedule the first ping,
         # and reconcile catalog drift off the critical path (mirrors
         # ``_cb_auto_reconnect``: the session is usable immediately).
-        self._cb_record_success(name)
+        #
+        # Breaker: clear only the OPEN-CIRCUIT DEADLINE, not the whole failure
+        # count. A transport reconnect proves the transport recovered, so dispatch
+        # should flow (not be fast-failed) — but for a connect-OK / calls-FAIL
+        # server, resetting ``_consecutive_failures`` here (as ``_cb_record_success``
+        # would) means the count oscillates 0->1->0 and the breaker never trips.
+        # Leaving the count lets a genuine call-failure pattern still escalate to
+        # the threshold; a real dispatch SUCCESS is what resets it.
+        self._circuit_open_until.pop(name, None)
         self._static_reconnect_attempt.pop(name, None)
         self._static_reconnect_next.pop(name, None)
         self._static_next_ping[name] = now + self._static_health_check_s
@@ -4335,13 +4422,28 @@ class MCPClientManager:
     async def _static_ping_one(self, name: str, now: float) -> float:
         """Liveness-ping a connected static server; evict a dead-but-idle one.
 
-        Returns the monotonic deadline of the next ping. A server that fails a
-        ping — a dead transport, or no answer within the timeout — is evicted
-        (``session = None``) so the next tick reconnects it, and its breaker
-        records a failure so dispatch fails fast in the meantime. ``ping`` is a
-        core-protocol request every healthy server answers, so a failure is
-        unambiguous; we don't try to distinguish protocol from transport.
+        Returns the monotonic deadline of the next ping. Classification mirrors
+        the dispatch path's ``_record_and_evict_on_dead_transport``:
+
+          * a genuinely DEAD transport (``_is_dead_transport``) is evicted
+            (``session = None``) so the next tick reconnects it, and its breaker
+            records a failure so dispatch fails fast meanwhile;
+          * a protocol ``McpError``, an ``httpx.PoolTimeout``, or a plain ping
+            TIMEOUT is "slow, not dead" — the ping is rescheduled WITHOUT evicting
+            or tripping the breaker (a strict 5s ping vs a 120s dispatch would
+            otherwise churn a heavy-but-working server every cycle);
+          * a BUSY server (``in_flight > 0``) is skipped entirely — it can't
+            answer a ping mid-call, and tearing it down would abort that call
+            (the ``StaticServerState`` in-flight interlock, mirroring the pool
+            path's ``_close_pool_entry_if_idle``).
         """
+        # Recovered-server hygiene: a live session means any stale health-loop
+        # backoff (left by a dispatch/operator reconnect the loop didn't drive)
+        # is wrong — clear it so a later autonomous reconnect isn't delayed by a
+        # stale ``due``.
+        self._static_reconnect_attempt.pop(name, None)
+        self._static_reconnect_next.pop(name, None)
+
         due = self._static_next_ping.get(name, now)
         if now < due:
             return due
@@ -4349,37 +4451,96 @@ class MCPClientManager:
         session = state.session if state is not None else None
         if session is None:
             return now  # raced an eviction — reconnect path handles it next tick
+        if state is not None and state.in_flight > 0:
+            # Busy serving a dispatch → demonstrably alive; skip ping + evict.
+            self._static_next_ping[name] = now + self._static_health_check_s
+            return self._static_next_ping[name]
         try:
-            await asyncio.wait_for(session.send_ping(), timeout=self._STATIC_HEALTH_PING_TIMEOUT_S)
-        except Exception as exc:
-            self._cb_record_failure(name)
+            # invariant-18: ``asyncio.timeout`` (NOT ``wait_for``) so ``send_ping``
+            # runs in THIS task and anyio cancel-scope exit stays same-task.
+            async with asyncio.timeout(self._STATIC_HEALTH_PING_TIMEOUT_S) as ping_timeout:
+                await session.send_ping()
+        except (Exception, asyncio.CancelledError, BaseExceptionGroup) as exc:
+            # ``asyncio.timeout`` converts its OWN expiry to ``TimeoutError``;
+            # ``ping_timeout.expired()`` is the unambiguous signal. A wedged anyio
+            # transport can surface the timeout-scoped cancel as a stray
+            # CancelledError / BaseExceptionGroup, so we catch the full trio — but
+            # a bare CancelledError when the timeout did NOT fire is an EXTERNAL
+            # cancel (loop shutdown) and MUST propagate so ``_static_health_loop``
+            # stops via its ``except asyncio.CancelledError: return``.
+            if not ping_timeout.expired() and isinstance(exc, asyncio.CancelledError):
+                raise
+            dead = (not ping_timeout.expired()) and _is_dead_transport(exc)
+            # Re-check in-flight under this synchronous handler: a dispatch may
+            # have started during the ping window; never evict a busy server.
+            # Session-identity: only act on the session we actually PINGED — a
+            # concurrent reconnect may have installed a fresh one during the await
+            # window, and our stale ping's death says nothing about it (evicting
+            # or tripping the breaker for it would undo a good reconnect).
             evict = self._static_servers.get(name)
-            if evict is not None:
+            busy = evict is not None and evict.in_flight > 0
+            if dead and evict is not None and not busy and evict.session is session:
+                self._cb_record_failure(name)
                 evict.session = None
-            self._static_reconnect_next[name] = now  # reconnect asap
-            self._static_reconnect_attempt.pop(name, None)
-            log.info(
-                "MCP static health: '%s' failed liveness ping (%s); evicting to reconnect",
+                self._static_reconnect_next[name] = now  # reconnect asap
+                self._static_reconnect_attempt.pop(name, None)
+                log.info(
+                    "MCP static health: '%s' failed liveness ping (%s); evicting to reconnect",
+                    name,
+                    type(exc).__name__,
+                )
+                return now
+            # Slow / protocol / pool-saturation / busy / swapped-session: not an
+            # actionable death — reschedule, don't evict, don't trip the breaker.
+            log.debug(
+                "MCP static health: '%s' ping did not confirm liveness (%s); rescheduling",
                 name,
                 type(exc).__name__,
             )
-            return now
+            self._static_next_ping[name] = now + self._static_health_check_s
+            return self._static_next_ping[name]
         self._static_next_ping[name] = now + self._static_health_check_s
         return self._static_next_ping[name]
 
     def _cb_auto_reconnect(self, server_name: str) -> Any:
         """Attempt reconnection for a disconnected server during half-open probe.
 
-        Returns the new session on success, or raises on failure.
+        Returns the new session on success, or raises on failure. Coordinates
+        with the per-name connect lock so it does not race — or blindly re-do —
+        an autonomous health-loop reconnect for the same server: if a health
+        reconnect already established (or, while we wait for the lock, just
+        establishes) a session, it is REUSED rather than torn down and rebuilt,
+        and no spurious breaker failure is recorded for what was merely lock
+        contention on a reachable server.
         """
         cfg = self._server_configs.get(server_name)
         if not cfg or self._loop is None:
             raise RuntimeError(f"MCP server '{server_name}' is not connected")
-        reconnect_future = asyncio.run_coroutine_threadsafe(
-            self._connect_one(server_name, cfg), self._loop
-        )
+
+        async def _reconnect_for_dispatch() -> Any:
+            # A health-loop reconnect may already have re-established the session
+            # while this dispatch was being scheduled — reuse it, don't pile a
+            # second reconnect on the shared state.
+            state = self._static_servers.get(server_name)
+            if state is not None and state.session is not None:
+                return state.session
+            # Take the per-name lock so teardown/rebuild can't interleave with a
+            # concurrent health-loop / operator reconnect (call the LOCKED body
+            # directly — we already hold the lock, and ``_connect_one`` would
+            # deadlock re-acquiring it).
+            async with self._static_connect_lock_for(server_name):
+                # Re-check under the lock: a health reconnect we queued BEHIND
+                # may have just finished and installed a fresh session. Reuse it.
+                state = self._static_servers.get(server_name)
+                if state is not None and state.session is not None:
+                    return state.session
+                await self._connect_one_locked(server_name, cfg)
+                state = self._static_servers.get(server_name)
+                return state.session if state is not None else None
+
+        reconnect_future = asyncio.run_coroutine_threadsafe(_reconnect_for_dispatch(), self._loop)
         try:
-            reconnect_future.result(timeout=self._CONNECT_TIMEOUT)
+            session = reconnect_future.result(timeout=self._CONNECT_TIMEOUT)
         except concurrent.futures.TimeoutError:
             reconnect_future.cancel()
             self._cb_record_failure(server_name)
@@ -4387,8 +4548,6 @@ class MCPClientManager:
         except Exception as exc:
             self._cb_record_failure(server_name)
             raise RuntimeError(f"MCP server '{server_name}' reconnect failed: {exc}") from None
-        state = self._static_servers.get(server_name)
-        session = state.session if state is not None else None
         if session is None:
             self._cb_record_failure(server_name)
             raise RuntimeError(f"MCP server '{server_name}' reconnect produced no session")
@@ -4435,6 +4594,29 @@ class MCPClientManager:
             evict = self._static_servers.get(server_name)
             if evict is not None:
                 evict.session = None
+
+    async def _static_session_op(self, server_name: str, op: Coroutine[Any, Any, Any]) -> Any:
+        """Await a static session op on the mcp-loop, pinned against eviction.
+
+        Increments the server's ``in_flight`` counter for the duration of the
+        awaited op and decrements it in ``finally`` (mirrors the pool path's
+        ``entry.in_flight`` accounting at ``_dispatch_pool_with_entry``). The
+        health-loop ping skips and never evicts a server with ``in_flight > 0``,
+        so a long-running ``call_tool`` can't be torn down mid-flight by a
+        liveness reconnect. MUST be scheduled onto the mcp-loop; the
+        increment/decrement wraps ONLY the session op, not the sync bridge.
+        ``StaticServerState`` identity is stable across reconnects (PR #296
+        invariant 5: ``_ensure_static_state`` get-or-creates), so the same
+        object is decremented that was incremented.
+        """
+        state = self._static_servers.get(server_name)
+        if state is None:
+            return await op
+        state.in_flight += 1
+        try:
+            return await op
+        finally:
+            state.in_flight -= 1
 
     def call_tool_sync(
         self,
@@ -4504,7 +4686,8 @@ class MCPClientManager:
         assert self._loop is not None
 
         future = asyncio.run_coroutine_threadsafe(
-            session.call_tool(original_name, arguments), self._loop
+            self._static_session_op(server_name, session.call_tool(original_name, arguments)),
+            self._loop,
         )
         try:
             result = future.result(timeout=timeout)
@@ -5899,7 +6082,9 @@ class MCPClientManager:
             session = self._cb_auto_reconnect(server_name)
         assert self._loop is not None
 
-        future = asyncio.run_coroutine_threadsafe(session.read_resource(uri), self._loop)
+        future = asyncio.run_coroutine_threadsafe(
+            self._static_session_op(server_name, session.read_resource(uri)), self._loop
+        )
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
@@ -5992,7 +6177,10 @@ class MCPClientManager:
         assert self._loop is not None
 
         future = asyncio.run_coroutine_threadsafe(
-            session.get_prompt(original_name, arguments=arguments), self._loop
+            self._static_session_op(
+                server_name, session.get_prompt(original_name, arguments=arguments)
+            ),
+            self._loop,
         )
         try:
             result = future.result(timeout=timeout)


### PR DESCRIPTION
## Problem

Static (non-`oauth_user`) MCP servers had **no autonomous reconnect**. Every reconnect path was lazy — a tool dispatch (`_cb_auto_reconnect`), an operator refresh, or a config edit — so a server that went down and came back **while nobody was dispatching to it stayed disconnected until someone acted**. That's the reported failure: a downed MCP server that Turnstone never recovers without a restart or manual reconnect.

A cross-boundary read of the SDK (`mcp` 1.28.1) confirmed there's nothing upstream to lean on:
- the only client reconnect anywhere is the streamable-http GET (notification) stream, capped at **2 attempts**, flat ~1s delay, no backoff, no jitter — and it gives up **silently**;
- the other transports (stdio, sse, websocket) have **zero** reconnect;
- `ClientSessionGroup` is a naive aggregator with no health/reconnect; `send_ping` exists but nothing calls it; the receive loop just exits on stream death.

Worse, a session whose transport dies **while idle** survives as a non-`None` `ClientSession` with closed streams — nothing evicts it, so even a later dispatch may not notice until it fails.

## Change

A static-server health loop on the mcp-loop (started in `_connect_all`; `mcp.static_health_check_seconds`, default 30, `<= 0` disables):

- **Reconnect (layer 1):** a disconnected server (`session is None`) is reconnected on a **capped, jittered, forever** backoff — full jitter, base 1s, cap 60s, **no attempt limit**. A server that returns after a long outage reconnects within ~a minute; a permanently-misconfigured one costs at most one attempt per cap (with decayed logging). The health loop owns this clock; the **circuit breaker stays the *dispatch* fail-fast gate** (a tool call to a down server errors immediately rather than blocking on the forever-retry), and the loop keeps breaker state in sync so an open breaker closes on reconnect.
- **Liveness (layer 2):** a connected server is `send_ping`-ed each cadence; a **dead-but-idle** session — which nothing else would notice — is evicted so the next tick reconnects it. This is the core of the "never reconnects" failure.

### Concurrency fix
`_connect_one` is split into a thin per-name-lock **wrapper** + `_connect_one_locked` (body unchanged, only relocated — the delicate anyio / `wait_for` connect logic is untouched). The health loop, a dispatch's `_cb_auto_reconnect`, and an operator refresh could otherwise interleave teardown/rebuild on the shared `StaticServerState` and corrupt it — a **latent pre-existing race** this also closes.

## Out of scope (follow-up)
Silent **GET-stream / notification death** — the SDK stops the notification stream after 2 attempts while the request path stays alive, so `send_ping` is blind to it (POST works, notifications don't). The fix is bounded **session recycling**, which needs a static in-flight guard first (only `PoolEntryState` tracks `in_flight` today). Tracked for a follow-up.

## Verification
Root cause verified by code + SDK trace (not assumed). The fix is pinned by deterministic unit tests — notably `test_ping_one_dead_session_evicts_for_reconnect` (a connected-but-dead session nothing else notices → evicted → reconnected), the reported failure made deterministic. Also: backoff bounds (capped / jittered / forever, no overflow), reconnect success resets backoff + closes breaker, reconnect retries forever, in-flight skip, per-name serialization (no overlap), ping keeps-healthy / evicts-dead / evicts-on-timeout, tick skips `oauth_user`, start + disable gating, clean cancel. Full MCP (933) + session (361) suites green locally. A live killable-server smoke test is a worthwhile follow-up (suite is mock-based by convention).
