### PR TITLE
refactor(providers): conform reasoning-effort control to API and model specs across all lanes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -852,6 +852,16 @@ both local-server lanes, so `thinking_mode`/`thinking_param`/
 `effort_param` mean the same thing whichever endpoint serves the model.
 Only the Responses API surface (native reasoning) ignores it.
 
+The console surfaces this projection as an *effective effort ladder*:
+the admin model form's per-model effort select and the skill
+launch-config effort select annotate knob positions that alias to the
+same wire behavior (e.g. "Max (= high)"), computed server-side by
+`providers/effort_ladder.py` from the same mapping functions the
+providers use at request time and shipped on `/v1/api/models` rows and
+`POST /v1/api/admin/models/effort-ladder`. The ladder describes what
+Turnstone sends — a server-side template may alias further (DeepSeek-V4
+folds `low`/`medium` into its default `high` tier).
+
 The `anthropic-compatible` lane never sends Anthropic's native
 `thinking`/`output_config` params — they are not in vLLM's request
 schema. The real `anthropic` provider is unaffected: official Claude

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -812,13 +812,24 @@ the levers live in the chat template, reached through
   maps the session's reasoning-effort knob onto the template toggle
   per-request: effort `none` sends `{<thinking_param>: false}`, any
   other level sends `true` — the same contract as the real lane's
-  manual mode. Templates with a graded effort key (gpt-oss-style)
-  additionally set `effort_param` (e.g. `"reasoning_effort"`), plus
-  optional `reasoning_effort_values` / `default_reasoning_effort` to
-  validate the knob before it reaches the template; without declared
-  values the knob is forwarded as-is. With the default
-  `thinking_mode = "none"` nothing is injected and the server's
-  template default decides.
+  manual mode. (`thinking_mode = "adaptive"` instead always sends
+  `true`: adaptive means the model self-regulates, so the knob never
+  force-disables — mirroring the native adaptive branch.) Templates
+  with a graded effort key (gpt-oss-style) additionally set
+  `effort_param` (e.g. `"reasoning_effort"`), plus optional
+  `reasoning_effort_values` / `default_reasoning_effort` to validate
+  the knob before it reaches the template; without declared values the
+  knob is forwarded as-is. Setting `effort_param` also suppresses the
+  flat top-level `reasoning_effort` request param on the
+  openai-compatible lane — the template channel replaces it, never
+  doubles it. With the default `thinking_mode = "none"` nothing is
+  injected and the server's template default decides.
+
+  Upgrade note: before 1.7.0a7 the openai-compatible lane sent the
+  toggle unconditionally `true` whenever thinking mode was enabled. A
+  stored per-model `reasoning_effort = "none"` now disables thinking
+  on such models — pick any real level (or clear the override) to keep
+  it on.
 * **Operator pin (static).** Entries under `{"chat_template_kwargs":
   ...}` in the admin Models extra-body field ride the SDK's
   `extra_body` unconditionally and win over the knob mapping on key
@@ -831,6 +842,15 @@ Completions requests — `merge_reasoning_template_kwargs` is shared by
 both local-server lanes, so `thinking_mode`/`thinking_param`/
 `effort_param` mean the same thing whichever endpoint serves the model.
 Only the Responses API surface (native reasoning) ignores it.
+
+The `anthropic-compatible` lane never sends Anthropic's native
+`thinking`/`output_config` params — they are not in vLLM's request
+schema. The real `anthropic` provider is unaffected: official Claude
+models keep native thinking, budget mapping, and `output_config`
+effort. A gateway fronting *real* Claude on a Messages-shaped URL
+(e.g. a LiteLLM `anthropic/` route to the Claude API) should use
+`provider = "anthropic"` with a custom `base_url`, which keeps the
+native thinking params.
 
 Verified quirks of vLLM's Anthropic endpoint:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -824,7 +824,12 @@ the levers live in the chat template, reached through
   respects that: an off-list knob value rounds UP onto the declared
   list and a value above the ceiling rides the ceiling
   (`snap_reasoning_effort`) — asking for more effort than the model
-  declares never falls back to a lower default tier.
+  declares never falls back to a lower default tier.  The knob's
+  `none` position is forwarded verbatim when the model declares an
+  explicit `none` level (gpt-5.1+, grok-4.3) — omitting it there would
+  leave a reasoning-on server default (e.g. gpt-5.5's `medium`) in
+  charge of a knob that promises off — and omitted otherwise; `none`
+  is never a snap target for other positions.
   `default_reasoning_effort` only catches values the ordinal snap
   cannot rank (custom strings). Declare values that match the
   template's documented vocabulary: for DeepSeek-V4, which officially

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -819,7 +819,15 @@ the levers live in the chat template, reached through
   `effort_param` (e.g. `"reasoning_effort"`), plus optional
   `reasoning_effort_values` / `default_reasoning_effort` to validate
   the knob before it reaches the template; without declared values the
-  knob is forwarded as-is. Setting `effort_param` also suppresses the
+  knob is forwarded as-is. Only declare values that match the
+  template's documented vocabulary — snapping an off-list knob to the
+  default can defeat a real tier. DeepSeek-V4, for example, officially
+  accepts `high`/`max` (Think High is the default thinking tier;
+  `low`/`medium` alias to `high`, `xhigh` to `max`), so freeform
+  passthrough matches the contract while a `("low", "medium", "high")`
+  values list would make Think Max unreachable. To map an undocumented
+  template, probe with per-request `chat_template_kwargs` and compare
+  `input_tokens`. Setting `effort_param` also suppresses the
   flat top-level `reasoning_effort` request param on the
   openai-compatible lane — the template channel replaces it, never
   doubles it. With the default `thinking_mode = "none"` nothing is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -826,6 +826,12 @@ the levers live in the chat template, reached through
   regardless of the session knob. (Server type and API surface remain
   openai-compatible-only knobs and stay hidden for this provider.)
 
+The same knob mapping drives the `openai-compatible` lane's Chat
+Completions requests — `merge_reasoning_template_kwargs` is shared by
+both local-server lanes, so `thinking_mode`/`thinking_param`/
+`effort_param` mean the same thing whichever endpoint serves the model.
+Only the Responses API surface (native reasoning) ignores it.
+
 Verified quirks of vLLM's Anthropic endpoint:
 
 * The `thinking` request param is silently dropped — use

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -820,13 +820,19 @@ the levers live in the chat template, reached through
   `effort_param` (e.g. `"reasoning_effort"`), plus optional
   `reasoning_effort_values` / `default_reasoning_effort` to validate
   the knob before it reaches the template; without declared values the
-  knob is forwarded as-is. Only declare values that match the
-  template's documented vocabulary — snapping an off-list knob to the
-  default can defeat a real tier. DeepSeek-V4, for example, officially
+  knob is forwarded as-is. The knob is ordinal, and validation
+  respects that: an off-list knob value rounds UP onto the declared
+  list and a value above the ceiling rides the ceiling
+  (`snap_reasoning_effort`) — asking for more effort than the model
+  declares never falls back to a lower default tier.
+  `default_reasoning_effort` only catches values the ordinal snap
+  cannot rank (custom strings). Declare values that match the
+  template's documented vocabulary: for DeepSeek-V4, which officially
   accepts `high`/`max` (Think High is the default thinking tier;
-  `low`/`medium` alias to `high`, `xhigh` to `max`), so freeform
-  passthrough matches the contract while a `("low", "medium", "high")`
-  values list would make Think Max unreachable. To map an undocumented
+  `low`/`medium` alias to `high`, `xhigh` to `max`), a
+  `("high", "max")` values list reproduces the official aliasing
+  exactly — `low`/`medium` round up to `high`, `xhigh` to `max` —
+  and freeform passthrough matches it too. To map an undocumented
   template, probe with per-request `chat_template_kwargs` and compare
   `input_tokens`. Setting `effort_param` also suppresses the
   flat top-level `reasoning_effort` request param on the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -798,15 +798,33 @@ model = "deepseek-ai/DeepSeek-V4-Flash"
 supports_vision = true                    # multimodal checkpoints only
 supports_mid_conversation_system = true   # template-dependent
 context_window = 131072
+thinking_mode = "manual"                  # session effort knob drives the template toggle
+thinking_param = "enable_thinking"        # Qwen/Gemma key; "thinking" for Granite/DeepSeek
 ```
 
-The reasoning toggle does NOT use Anthropic's `thinking` request param.
-Toggle it through the chat template instead: set `{"chat_template_kwargs":
-{"thinking": false}}` as extra body params in the admin Models
-server-compat section (for this provider the section shows only the
-extra-body field — server type, API surface, and thinking mode are
-openai-compatible-only knobs); the provider forwards it via the SDK's
-`extra_body`.
+Reasoning control does NOT use Anthropic's `thinking` request param —
+the levers live in the chat template, reached through
+`chat_template_kwargs` in the request body. Two channels, dynamic first:
+
+* **Session effort knob (dynamic).** Set the model's thinking mode to
+  Enabled in the admin Models form (or `thinking_mode = "manual"` +
+  `thinking_param` under `[models.*.capabilities]`) and the provider
+  maps the session's reasoning-effort knob onto the template toggle
+  per-request: effort `none` sends `{<thinking_param>: false}`, any
+  other level sends `true` — the same contract as the real lane's
+  manual mode. Templates with a graded effort key (gpt-oss-style)
+  additionally set `effort_param` (e.g. `"reasoning_effort"`), plus
+  optional `reasoning_effort_values` / `default_reasoning_effort` to
+  validate the knob before it reaches the template; without declared
+  values the knob is forwarded as-is. With the default
+  `thinking_mode = "none"` nothing is injected and the server's
+  template default decides.
+* **Operator pin (static).** Entries under `{"chat_template_kwargs":
+  ...}` in the admin Models extra-body field ride the SDK's
+  `extra_body` unconditionally and win over the knob mapping on key
+  collision — e.g. pin `{"enable_thinking": true}` to keep thinking on
+  regardless of the session knob. (Server type and API surface remain
+  openai-compatible-only knobs and stay hidden for this provider.)
 
 Verified quirks of vLLM's Anthropic endpoint:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -807,14 +807,15 @@ the levers live in the chat template, reached through
 `chat_template_kwargs` in the request body. Two channels, dynamic first:
 
 * **Session effort knob (dynamic).** Set the model's thinking mode to
-  Enabled in the admin Models form (or `thinking_mode = "manual"` +
-  `thinking_param` under `[models.*.capabilities]`) and the provider
-  maps the session's reasoning-effort knob onto the template toggle
-  per-request: effort `none` sends `{<thinking_param>: false}`, any
-  other level sends `true` — the same contract as the real lane's
-  manual mode. (`thinking_mode = "adaptive"` instead always sends
-  `true`: adaptive means the model self-regulates, so the knob never
-  force-disables — mirroring the native adaptive branch.) Templates
+  "Effort-knob controlled" in the admin Models form (or
+  `thinking_mode = "manual"` + `thinking_param` under
+  `[models.*.capabilities]`) and the provider maps the session's
+  reasoning-effort knob onto the template toggle per-request: effort
+  `none` sends `{<thinking_param>: false}`, any other level sends
+  `true` — the same contract as the real lane's manual mode. ("Always
+  on" / `thinking_mode = "adaptive"` instead always sends `true`: the
+  model self-regulates, so the knob never force-disables — mirroring
+  the native adaptive branch.) Templates
   with a graded effort key (gpt-oss-style) additionally set
   `effort_param` (e.g. `"reasoning_effort"`), plus optional
   `reasoning_effort_values` / `default_reasoning_effort` to validate

--- a/tests/_wire_capture.py
+++ b/tests/_wire_capture.py
@@ -1,0 +1,76 @@
+"""Recording fake SDK client — captures the kwargs at each provider's seam.
+
+Every provider's ``create_streaming`` assembles its kwargs and calls the
+SDK *eagerly* before returning the stream iterator (Anthropic
+``client.messages.stream``, OpenAI ``client.chat.completions.create``,
+Responses ``client.responses.create/stream``), so driving a provider
+against a :class:`RecordingClient` captures the full composed request
+payload without a network round-trip.
+
+Shared by the wire-payload golden harness (``test_wire_payload_golden``)
+and the effort-ladder parity harness (``test_effort_ladder_wire_parity``)
+so both assert against the same capture seam.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _EmptyStream:
+    """Stand-in for an SDK stream / stream-manager: empty iterable AND no-op CM."""
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(())
+
+    def __enter__(self) -> _EmptyStream:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _Seam:
+    """Records the kwargs of a single SDK call, returns an empty stream stub."""
+
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self._sink = sink
+
+    def __call__(self, **kwargs: Any) -> _EmptyStream:
+        # Last write wins; only one seam is exercised per provider call.
+        self._sink["payload"] = kwargs
+        return _EmptyStream()
+
+
+class _Completions:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.create = _Seam(sink)
+
+
+class _Chat:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.completions = _Completions(sink)
+
+
+class _Messages:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.stream = _Seam(sink)
+
+
+class _Responses:
+    def __init__(self, sink: dict[str, Any]) -> None:
+        self.create = _Seam(sink)
+        self.stream = _Seam(sink)
+
+
+class RecordingClient:
+    """Fake SDK client exposing every provider's call seam, recording kwargs."""
+
+    def __init__(self) -> None:
+        self.captured: dict[str, Any] = {}
+        self.messages = _Messages(self.captured)
+        self.chat = _Chat(self.captured)
+        self.responses = _Responses(self.captured)

--- a/tests/data/wire_payloads/google__mid_orphan.json
+++ b/tests/data/wire_payloads/google__mid_orphan.json
@@ -33,7 +33,7 @@
       "tool_call_id": "call_1"
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_2"
     },
@@ -43,6 +43,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__multipart.json
+++ b/tests/data/wire_payloads/google__multipart.json
@@ -18,6 +18,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__native_orphan.json
+++ b/tests/data/wire_payloads/google__native_orphan.json
@@ -20,12 +20,13 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__native_reasoning.json
+++ b/tests/data/wire_payloads/google__native_reasoning.json
@@ -26,6 +26,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__operator_system.json
+++ b/tests/data/wire_payloads/google__operator_system.json
@@ -34,6 +34,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__text.json
+++ b/tests/data/wire_payloads/google__text.json
@@ -15,6 +15,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__toolcall_complete.json
+++ b/tests/data/wire_payloads/google__toolcall_complete.json
@@ -30,6 +30,7 @@
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/google__trailing_orphan.json
+++ b/tests/data/wire_payloads/google__trailing_orphan.json
@@ -20,12 +20,13 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }
   ],
   "model": "gemini-2.5-pro",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -336,10 +336,64 @@ def test_channel_default_alias_blanked_when_disabled(
 
 
 def test_models_payload_strips_secret_fields(storage: SQLiteBackend) -> None:
-    """Regression guard: only alias/model/provider land in the response,
-    never api_key / base_url / context_window / capabilities."""
+    """Regression guard: only alias/model/provider (+ the derived
+    effort_ladder) land in the response, never api_key / base_url /
+    context_window / raw capabilities."""
     _seed_model(storage, definition_id="m1", alias="primary")
     body = _get_models(_make_client(storage))
-    assert body["models"] == [
-        {"alias": "primary", "model": "model-x", "provider": "openai-compatible"}
-    ]
+    assert len(body["models"]) == 1
+    entry = body["models"][0]
+    assert set(entry) == {"alias", "model", "provider", "effort_ladder"}
+    assert entry["alias"] == "primary"
+    assert entry["model"] == "model-x"
+    assert entry["provider"] == "openai-compatible"
+
+
+def test_effort_ladder_parses_string_capabilities(storage: SQLiteBackend) -> None:
+    """The capabilities column is a JSON STRING — the ladder must survive
+    the parse (regression: .items() on the raw string threw and the
+    guard silently dropped the field from every row)."""
+    storage.create_model_definition(
+        definition_id="m1",
+        alias="qwen",
+        model="qwen3.6-27b",
+        provider="anthropic-compatible",
+        base_url="http://localhost:8000",
+        api_key="dummy",
+        context_window=262144,
+        capabilities='{"thinking_mode": "manual", "thinking_param": "enable_thinking"}',
+        enabled=True,
+        created_by="admin",
+    )
+    body = _get_models(_make_client(storage))
+    ladder = {r["value"]: r["effective"] for r in body["models"][0]["effort_ladder"]}
+    assert ladder["none"] == "off"
+    assert ladder["medium"] == "on"
+    assert ladder["max"] == "on"
+
+
+def test_effort_ladder_honors_responses_api_surface(storage: SQLiteBackend) -> None:
+    """server_compat.api_surface (namespaced inside the capabilities JSON)
+    switches the projection to the flat-param path — no template toggle."""
+    caps = (
+        '{"thinking_mode": "manual", "thinking_param": "enable_thinking",'
+        ' "reasoning_effort_values": ["low", "medium", "high"],'
+        ' "server_compat": {"api_surface": "responses"}}'
+    )
+    storage.create_model_definition(
+        definition_id="m1",
+        alias="mistral",
+        model="mistral-medium",
+        provider="openai-compatible",
+        base_url="http://localhost:8000/v1",
+        api_key="dummy",
+        context_window=131072,
+        capabilities=caps,
+        enabled=True,
+        created_by="admin",
+    )
+    body = _get_models(_make_client(storage))
+    ladder = {r["value"]: r["effective"] for r in body["models"][0]["effort_ladder"]}
+    # Responses surface: flat param only — no "on+"/"off" toggle tokens.
+    assert ladder["medium"] == "medium"
+    assert ladder["none"] == "default"

--- a/tests/test_console_effort_ladder.py
+++ b/tests/test_console_effort_ladder.py
@@ -1,0 +1,106 @@
+"""``POST /v1/api/admin/models/effort-ladder`` — live modal projection.
+
+Pure computation over (provider, model, unsaved capability overrides,
+api_surface); every malformed input must land as a 400, never a 500 —
+the body is operator-typed form state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from tests._coord_test_helpers import _AuthMiddleware
+from turnstone.console.server import admin_effort_ladder
+
+
+def _make_client() -> TestClient:
+    app = Starlette(
+        routes=[Route("/v1/api/admin/models/effort-ladder", admin_effort_ladder, methods=["POST"])],
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+    client = TestClient(app)
+    client.headers.update({"X-Test-User": "admin", "X-Test-Perms": "admin.models"})
+    return client
+
+
+def _post(client: TestClient, body: Any) -> Any:
+    return client.post("/v1/api/admin/models/effort-ladder", json=body)
+
+
+def test_valid_request_returns_ladder() -> None:
+    resp = _post(
+        _make_client(),
+        {
+            "provider": "anthropic-compatible",
+            "model": "qwen3.6-27b",
+            "capabilities": {"thinking_mode": "manual", "thinking_param": "enable_thinking"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    ladder = {r["value"]: r["effective"] for r in resp.json()["ladder"]}
+    assert ladder["none"] == "off"
+    assert ladder["high"] == "on"
+
+
+def test_api_surface_switches_projection() -> None:
+    body = {
+        "provider": "openai-compatible",
+        "model": "m",
+        "capabilities": {
+            "thinking_mode": "manual",
+            "reasoning_effort_values": ["low", "medium", "high"],
+        },
+    }
+    client = _make_client()
+    chat = {r["value"]: r["effective"] for r in _post(client, body).json()["ladder"]}
+    body["api_surface"] = "responses"
+    responses = {r["value"]: r["effective"] for r in _post(client, body).json()["ladder"]}
+    assert chat["medium"] == "on+medium"  # toggle + flat on the chat surface
+    assert responses["medium"] == "medium"  # flat only on the responses surface
+
+
+def test_non_dict_json_body_is_400_not_500() -> None:
+    client = _make_client()
+    for body in (None, [], "x", 7):
+        resp = _post(client, body)
+        assert resp.status_code == 400, (body, resp.status_code, resp.text)
+
+
+def test_unknown_provider_is_400() -> None:
+    resp = _post(_make_client(), {"provider": "nope", "model": "m"})
+    assert resp.status_code == 400
+
+
+def test_missing_model_is_400() -> None:
+    resp = _post(_make_client(), {"provider": "openai", "model": ""})
+    assert resp.status_code == 400
+
+
+def test_non_dict_capabilities_is_400() -> None:
+    resp = _post(_make_client(), {"provider": "openai", "model": "m", "capabilities": [1]})
+    assert resp.status_code == 400
+
+
+def test_garbage_capability_value_types_are_400() -> None:
+    """Wrong-typed override values raise inside the resolver → clean 400."""
+    resp = _post(
+        _make_client(),
+        {
+            "provider": "anthropic",
+            "model": "claude-fable-5",
+            "capabilities": {"supports_effort": True, "effort_levels": 5},
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_requires_admin_models_permission() -> None:
+    client = _make_client()
+    client.headers.update({"X-Test-Perms": "read"})
+    resp = _post(client, {"provider": "openai", "model": "m"})
+    assert resp.status_code in (401, 403)

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -1,0 +1,115 @@
+"""Tests for the effective effort-ladder projection.
+
+The ladder must mirror the request-time mapping functions exactly —
+equal ``effective`` tokens promise byte-identical effort behavior on
+the wire, which is what the UI annotations lean on.
+"""
+
+from __future__ import annotations
+
+from turnstone.core.providers._protocol import ModelCapabilities
+from turnstone.core.providers.effort_ladder import (
+    KNOB_VALUES,
+    effort_ladder,
+    effort_ladder_for_model,
+)
+
+
+def _as_map(ladder: list[dict[str, str]]) -> dict[str, str]:
+    assert [r["value"] for r in ladder] == list(KNOB_VALUES)
+    return {r["value"]: r["effective"] for r in ladder}
+
+
+class TestLocalLanes:
+    def test_qwen_style_toggle_only_two_groups(self) -> None:
+        """Toggle-only model: none=off, everything else one 'on' group."""
+        caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
+        eff = _as_map(effort_ladder("anthropic-compatible", caps))
+        assert eff["none"] == "off"
+        assert {eff[k] for k in KNOB_VALUES if k != "none"} == {"on"}
+
+    def test_freeform_effort_param_forwards_each_value(self) -> None:
+        """deepseek-style config: toggle + verbatim effort per position."""
+        caps = ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="thinking",
+            effort_param="reasoning_effort",
+        )
+        eff = _as_map(effort_ladder("anthropic-compatible", caps))
+        assert eff["none"] == "off"
+        assert eff["low"] == "on+low"
+        assert eff["max"] == "on+max"
+
+    def test_validated_effort_param_shows_snapping(self) -> None:
+        """Declared values collapse off-list positions onto the default."""
+        caps = ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="enable_thinking",
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        )
+        eff = _as_map(effort_ladder("openai-compatible", caps))
+        assert eff["xhigh"] == "on+medium"
+        assert eff["max"] == "on+medium"
+        assert eff["high"] == "on+high"
+
+    def test_openai_compatible_flat_param_without_effort_param(self) -> None:
+        caps = ModelCapabilities(
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        )
+        eff = _as_map(effort_ladder("openai-compatible", caps))
+        assert eff["none"] == "default"
+        assert eff["high"] == "high"
+        assert eff["xhigh"] == "medium"
+
+    def test_adaptive_local_never_off(self) -> None:
+        caps = ModelCapabilities(thinking_mode="adaptive", thinking_param="enable_thinking")
+        eff = _as_map(effort_ladder("openai-compatible", caps))
+        assert eff["none"] == "on"
+        assert eff["max"] == "on"
+
+
+class TestNativeAnthropicLane:
+    def test_adaptive_with_effort_levels(self) -> None:
+        caps = ModelCapabilities(
+            thinking_mode="adaptive",
+            supports_effort=True,
+            effort_levels=("low", "medium", "high", "xhigh", "max"),
+        )
+        eff = _as_map(effort_ladder("anthropic", caps))
+        assert eff["none"] == "adaptive"  # thinking on, model decides
+        assert eff["minimal"] == "adaptive"  # unmapped knob level
+        assert eff["low"] == "low"
+        assert eff["max"] == "max"
+
+    def test_manual_budget_ladder(self) -> None:
+        caps = ModelCapabilities(thinking_mode="manual")
+        eff = _as_map(effort_ladder("anthropic", caps))
+        assert eff["none"] == "off"
+        assert eff["low"] == "budget:1024"
+        assert eff["medium"] == "budget:4096"
+        assert eff["high"] == "budget:16384"
+        # Off-map knob levels share the default budget — aliased group.
+        assert eff["minimal"] == eff["xhigh"] == eff["max"] == "budget:4096"
+
+
+class TestFlatParamLanes:
+    def test_google_default_caps(self) -> None:
+        eff = _as_map(effort_ladder_for_model("google", "gemini-3-flash", None))
+        assert eff["none"] == "default"
+        assert eff["minimal"] == "minimal"
+        assert eff["high"] == "high"
+        assert eff["xhigh"] == eff["max"] == "high"
+
+    def test_overrides_merge_and_unknown_keys_ignored(self) -> None:
+        eff = _as_map(
+            effort_ladder_for_model(
+                "google",
+                "gemini-3-flash",
+                {"reasoning_effort_values": [], "not_a_field": True},
+            )
+        )
+        # Operator cleared the values → nothing effort-related is sent.
+        assert set(eff.values()) == {"default"}

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -131,6 +131,34 @@ class TestFlatParamLanes:
         assert responses["medium"] == "medium"
         assert responses["none"] == "default"
 
+    def test_xai_projects_flat_only(self) -> None:
+        """grok-4.3 declares values (none/low/medium/high, default low);
+        off-list knob positions snap to the default."""
+        eff = _as_map(effort_ladder_for_model("xai", "grok-4.3", None))
+        assert eff["none"] == "default"  # resolve_ never forwards "none"
+        assert eff["low"] == "low"
+        assert eff["high"] == "high"
+        assert eff["xhigh"] == eff["max"] == "low"
+
+    def test_xai_ignores_template_overrides(self) -> None:
+        """XAIProvider subclasses OpenAIResponsesProvider, which drops
+        extra_body — a thinking_mode/effort_param override cannot change
+        an xai request, so it must not change the ladder either."""
+        eff = _as_map(
+            effort_ladder_for_model(
+                "xai",
+                "grok-4.3",
+                {
+                    "thinking_mode": "manual",
+                    "thinking_param": "enable_thinking",
+                    "effort_param": "reasoning_effort",
+                },
+            )
+        )
+        assert eff["none"] == "default"  # not "off" — there is no toggle
+        assert eff["medium"] == "medium"
+        assert all("+" not in v and v not in ("on", "off") for v in eff.values())
+
     def test_anthropic_effort_applies_even_with_thinking_mode_none(self) -> None:
         """output_config gates on supports_effort alone at request time."""
         caps = ModelCapabilities(

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -86,6 +86,24 @@ class TestNativeAnthropicLane:
         assert eff["low"] == "low"
         assert eff["max"] == "max"
 
+    def test_sonnet_5_registry_row(self) -> None:
+        """claude-sonnet-5: adaptive + full effort ladder incl. xhigh/max —
+        every knob level above none is a distinct wire behavior."""
+        eff = _as_map(effort_ladder_for_model("anthropic", "claude-sonnet-5", None))
+        assert eff["none"] == "adaptive"
+        assert eff["minimal"] == "low"  # rounds up onto declared levels
+        assert eff["low"] == "low"
+        assert eff["xhigh"] == "xhigh"
+        assert eff["max"] == "max"
+
+    def test_sonnet_4_6_xhigh_rides_max(self) -> None:
+        """Sonnet 4.6 declares (low, medium, high, max) — no xhigh, so the
+        knob's xhigh snaps up onto max rather than down onto high."""
+        eff = _as_map(effort_ladder_for_model("anthropic", "claude-sonnet-4-6", None))
+        assert eff["high"] == "high"
+        assert eff["xhigh"] == "max"
+        assert eff["max"] == "max"
+
     def test_manual_budget_ladder(self) -> None:
         """Budgets are monotone over the whole knob domain."""
         caps = ModelCapabilities(thinking_mode="manual")
@@ -136,10 +154,12 @@ class TestFlatParamLanes:
 
     def test_xai_projects_flat_only(self) -> None:
         """grok-4.3 declares values (none/low/medium/high, default low);
-        knob positions above the ceiling ride the ceiling (high), and the
-        declared "none" is never a snap target."""
+        knob positions above the ceiling ride the ceiling (high).  The
+        declared "none" IS forwarded for the knob's off position (xAI
+        documents it as disabling reasoning) but is never a snap target
+        for other positions."""
         eff = _as_map(effort_ladder_for_model("xai", "grok-4.3", None))
-        assert eff["none"] == "default"  # resolve_ never forwards "none"
+        assert eff["none"] == "none"  # explicit disable, declared by grok
         assert eff["minimal"] == "low"
         assert eff["low"] == "low"
         assert eff["high"] == "high"
@@ -160,9 +180,36 @@ class TestFlatParamLanes:
                 },
             )
         )
-        assert eff["none"] == "default"  # not "off" — there is no toggle
+        assert eff["none"] == "none"  # flat channel, not an "off" toggle
         assert eff["medium"] == "medium"
         assert all("+" not in v and v not in ("on", "off") for v in eff.values())
+
+    def test_openai_gpt55_registry_row(self) -> None:
+        """gpt-5.5 declares none/low/medium/high/xhigh with default medium:
+        knob none sends the explicit "none" level (server default is
+        MEDIUM, so omission would not disable), max rides the xhigh
+        ceiling, minimal rounds up to low."""
+        eff = _as_map(effort_ladder_for_model("openai", "gpt-5.5", None))
+        assert eff["none"] == "none"
+        assert eff["minimal"] == "low"
+        assert eff["xhigh"] == "xhigh"
+        assert eff["max"] == "xhigh"
+
+    def test_openai_o3_registry_row(self) -> None:
+        """o-series (except o1-mini) accept low/medium/high; no declared
+        "none" level, so the knob's off position omits the param."""
+        eff = _as_map(effort_ladder_for_model("openai", "o3", None))
+        assert eff["none"] == "default"
+        assert eff["minimal"] == "low"
+        assert eff["medium"] == "medium"
+        assert eff["xhigh"] == eff["max"] == "high"
+
+    def test_openai_codex_max_has_xhigh(self) -> None:
+        """gpt-5.1-codex-max must not prefix-fall onto the gpt-5.1 row
+        (which lacks xhigh) — xhigh reaches the wire verbatim."""
+        eff = _as_map(effort_ladder_for_model("openai", "gpt-5.1-codex-max", None))
+        assert eff["xhigh"] == "xhigh"
+        assert eff["max"] == "xhigh"
 
     def test_anthropic_effort_applies_even_with_thinking_mode_none(self) -> None:
         """output_config gates on supports_effort alone at request time."""

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -41,7 +41,8 @@ class TestLocalLanes:
         assert eff["max"] == "on+max"
 
     def test_validated_effort_param_shows_snapping(self) -> None:
-        """Declared values collapse off-list positions onto the default."""
+        """Off-list positions round up onto the declared values; above the
+        ceiling they ride the ceiling — never the (possibly lower) default."""
         caps = ModelCapabilities(
             thinking_mode="manual",
             thinking_param="enable_thinking",
@@ -50,9 +51,10 @@ class TestLocalLanes:
             default_reasoning_effort="medium",
         )
         eff = _as_map(effort_ladder("openai-compatible", caps))
-        assert eff["xhigh"] == "on+medium"
-        assert eff["max"] == "on+medium"
+        assert eff["minimal"] == "on+low"
         assert eff["high"] == "on+high"
+        assert eff["xhigh"] == "on+high"
+        assert eff["max"] == "on+high"
 
     def test_openai_compatible_flat_param_without_effort_param(self) -> None:
         caps = ModelCapabilities(
@@ -62,7 +64,7 @@ class TestLocalLanes:
         eff = _as_map(effort_ladder("openai-compatible", caps))
         assert eff["none"] == "default"
         assert eff["high"] == "high"
-        assert eff["xhigh"] == "medium"
+        assert eff["xhigh"] == "high"  # ceiling, not default
 
     def test_adaptive_local_never_off(self) -> None:
         caps = ModelCapabilities(thinking_mode="adaptive", thinking_param="enable_thinking")
@@ -80,19 +82,20 @@ class TestNativeAnthropicLane:
         )
         eff = _as_map(effort_ladder("anthropic", caps))
         assert eff["none"] == "adaptive"  # thinking on, model decides
-        assert eff["minimal"] == "adaptive"  # unmapped knob level
+        assert eff["minimal"] == "low"  # rounds up onto the declared levels
         assert eff["low"] == "low"
         assert eff["max"] == "max"
 
     def test_manual_budget_ladder(self) -> None:
+        """Budgets are monotone over the whole knob domain."""
         caps = ModelCapabilities(thinking_mode="manual")
         eff = _as_map(effort_ladder("anthropic", caps))
         assert eff["none"] == "off"
-        assert eff["low"] == "budget:1024"
+        assert eff["minimal"] == eff["low"] == "budget:1024"  # 1024 = API floor
         assert eff["medium"] == "budget:4096"
         assert eff["high"] == "budget:16384"
-        # Off-map knob levels share the default budget — aliased group.
-        assert eff["minimal"] == eff["xhigh"] == eff["max"] == "budget:4096"
+        assert eff["xhigh"] == "budget:32768"
+        assert eff["max"] == "budget:65536"
 
 
 class TestFlatParamLanes:
@@ -133,12 +136,14 @@ class TestFlatParamLanes:
 
     def test_xai_projects_flat_only(self) -> None:
         """grok-4.3 declares values (none/low/medium/high, default low);
-        off-list knob positions snap to the default."""
+        knob positions above the ceiling ride the ceiling (high), and the
+        declared "none" is never a snap target."""
         eff = _as_map(effort_ladder_for_model("xai", "grok-4.3", None))
         assert eff["none"] == "default"  # resolve_ never forwards "none"
+        assert eff["minimal"] == "low"
         assert eff["low"] == "low"
         assert eff["high"] == "high"
-        assert eff["xhigh"] == eff["max"] == "low"
+        assert eff["xhigh"] == eff["max"] == "high"
 
     def test_xai_ignores_template_overrides(self) -> None:
         """XAIProvider subclasses OpenAIResponsesProvider, which drops

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -103,6 +103,45 @@ class TestFlatParamLanes:
         assert eff["high"] == "high"
         assert eff["xhigh"] == eff["max"] == "high"
 
+    def test_google_override_routes_through_chat_lane(self) -> None:
+        """GoogleProvider inherits _finalize_extra_body — a thinking_mode
+        override changes real requests, and the ladder must mirror it."""
+        eff = _as_map(
+            effort_ladder_for_model(
+                "google",
+                "gemini-3-flash",
+                {"thinking_mode": "manual", "thinking_param": "enable_thinking"},
+            )
+        )
+        assert eff["none"] == "off"
+        assert eff["medium"] == "on+medium"  # toggle + inherited flat param
+
+    def test_responses_surface_projects_flat_only(self) -> None:
+        caps_overrides = {
+            "thinking_mode": "manual",
+            "reasoning_effort_values": ["low", "medium", "high"],
+        }
+        chat = _as_map(effort_ladder_for_model("openai-compatible", "m", caps_overrides))
+        responses = _as_map(
+            effort_ladder_for_model(
+                "openai-compatible", "m", caps_overrides, api_surface="responses"
+            )
+        )
+        assert chat["medium"] == "on+medium"
+        assert responses["medium"] == "medium"
+        assert responses["none"] == "default"
+
+    def test_anthropic_effort_applies_even_with_thinking_mode_none(self) -> None:
+        """output_config gates on supports_effort alone at request time."""
+        caps = ModelCapabilities(
+            thinking_mode="none",
+            supports_effort=True,
+            effort_levels=("low", "medium", "high"),
+        )
+        eff = _as_map(effort_ladder("anthropic", caps))
+        assert eff["high"] == "high"
+        assert eff["none"] == "default"
+
     def test_overrides_merge_and_unknown_keys_ignored(self) -> None:
         eff = _as_map(
             effort_ladder_for_model(

--- a/tests/test_effort_ladder_wire_parity.py
+++ b/tests/test_effort_ladder_wire_parity.py
@@ -40,9 +40,13 @@ from turnstone.core.providers import create_provider
 from turnstone.core.providers._protocol import ModelCapabilities
 from turnstone.core.providers.effort_ladder import KNOB_VALUES, effort_ladder
 
-# Big enough that Anthropic manual-mode budgets are never clamped by
-# max_tokens (the ladder documents budgets unclamped).
-_MAX_TOKENS = 32_000
+# Above the largest manual-mode thinking budget (max: 65536) so the
+# request path's budget<max_tokens clamp never fires — the ladder
+# documents budgets unclamped, so the capture must be too.  (At small
+# per-request max_tokens the clamp can genuinely alias adjacent budget
+# tiers on the wire; that is the ladder's documented approximation, not
+# a parity break.)
+_MAX_TOKENS = 128_000
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/test_effort_ladder_wire_parity.py
+++ b/tests/test_effort_ladder_wire_parity.py
@@ -1,0 +1,395 @@
+"""Ladder↔wire parity harness — the effort ladder must tell the truth.
+
+``effort_ladder`` *projects* the session effort knob through the same
+mapping functions the providers use at request time.  This suite proves
+that projection against the REAL request path: for every provider lane
+and capability shape, each knob position is driven through the actual
+provider ``create_streaming`` against a recording fake client (the same
+SDK-seam capture the wire-payload goldens use), the effort-relevant
+subset of the captured kwargs is extracted, and it must equal what the
+ladder token decodes to.  Two invariants per shape:
+
+1. **Semantics** — each ladder token decodes to an expected wire subset
+   (``on``/``off`` ⇒ the chat-template toggle, ``budget:N`` ⇒ Anthropic
+   thinking budget, a bare level ⇒ the lane's flat/effort channel) and
+   the observed wire subset must match it exactly.
+2. **Grouping** — the ladder's core promise: two knob positions carry
+   equal ``effective`` tokens if and only if they produce identical
+   effort-relevant wire payloads.
+
+A failure here means the UI annotates behavior the wire does not have —
+the bug class that shipped xai in the ladder's chat-lane set even though
+``XAIProvider`` rides the Responses surface, which drops ``extra_body``.
+
+The harness goes through ``create_provider`` (not direct classes) so the
+provider ROUTING the ladder assumes — e.g. ``api_surface="responses"``
+selecting the Responses adapter — is itself under test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import itertools
+from typing import Any
+
+import pytest
+
+from tests._wire_capture import RecordingClient
+from turnstone.core.providers import create_provider
+from turnstone.core.providers._protocol import ModelCapabilities
+from turnstone.core.providers.effort_ladder import KNOB_VALUES, effort_ladder
+
+# Big enough that Anthropic manual-mode budgets are never clamped by
+# max_tokens (the ladder documents budgets unclamped).
+_MAX_TOKENS = 32_000
+
+
+@dataclasses.dataclass(frozen=True)
+class Shape:
+    """One (provider lane, capability shape) point of the parity matrix."""
+
+    id: str
+    provider: str
+    caps: ModelCapabilities
+    api_surface: str = ""
+    model: str = "m"
+
+
+# Real registry rows for the two lanes whose defaults carry effort values —
+# parity should cover what ships, not only synthetic shapes.
+_GEMINI_CAPS = create_provider("google").get_capabilities("gemini-3-flash")
+_GROK_CAPS = create_provider("xai").get_capabilities("grok-4.3")
+
+SHAPES: tuple[Shape, ...] = (
+    # -- anthropic-compatible (vLLM /v1/messages): template channel only --
+    Shape(
+        "compat-toggle-manual",
+        "anthropic-compatible",
+        ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking"),
+    ),
+    Shape(
+        "compat-toggle-adaptive",
+        "anthropic-compatible",
+        ModelCapabilities(thinking_mode="adaptive", thinking_param="enable_thinking"),
+    ),
+    Shape(
+        "compat-freeform-effort",
+        "anthropic-compatible",
+        ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="thinking",
+            effort_param="reasoning_effort",
+        ),
+    ),
+    Shape(
+        # DeepSeek-V4 official contract: toggle + effort in {high, max}.
+        "compat-validated-effort",
+        "anthropic-compatible",
+        ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="thinking",
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("high", "max"),
+            default_reasoning_effort="high",
+        ),
+    ),
+    Shape(
+        "compat-inert",
+        "anthropic-compatible",
+        ModelCapabilities(thinking_mode="none"),
+    ),
+    # -- openai-compatible on the Chat Completions surface: both channels --
+    Shape(
+        "oc-toggle-only",
+        "openai-compatible",
+        ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking"),
+    ),
+    Shape(
+        "oc-toggle-plus-flat",
+        "openai-compatible",
+        ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="enable_thinking",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        ),
+    ),
+    Shape(
+        "oc-effort-param-suppresses-flat",
+        "openai-compatible",
+        ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="enable_thinking",
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        ),
+    ),
+    Shape(
+        "oc-flat-only",
+        "openai-compatible",
+        ModelCapabilities(
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        ),
+    ),
+    Shape(
+        "oc-adaptive",
+        "openai-compatible",
+        ModelCapabilities(thinking_mode="adaptive", thinking_param="enable_thinking"),
+    ),
+    # -- openai-compatible pinned to the Responses surface: template caps
+    #    become inert and only the native flat channel remains --
+    Shape(
+        "oc-responses-surface",
+        "openai-compatible",
+        ModelCapabilities(
+            thinking_mode="manual",
+            thinking_param="enable_thinking",
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        ),
+        api_surface="responses",
+    ),
+    # -- commercial flat lanes --
+    Shape(
+        "openai-flat",
+        "openai",
+        ModelCapabilities(
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        ),
+    ),
+    Shape("google-default", "google", _GEMINI_CAPS, model="gemini-3-flash"),
+    Shape(
+        # GoogleProvider subclasses the chat provider, so a template
+        # override DOES change real requests — hybrid toggle + flat.
+        "google-manual-override",
+        "google",
+        dataclasses.replace(_GEMINI_CAPS, thinking_mode="manual", thinking_param="enable_thinking"),
+        model="gemini-3-flash",
+    ),
+    Shape("xai-default", "xai", _GROK_CAPS, model="grok-4.3"),
+    Shape(
+        # XAIProvider rides the Responses surface: template overrides are
+        # inert on the wire, and the ladder must not pretend otherwise.
+        "xai-template-override-inert",
+        "xai",
+        dataclasses.replace(
+            _GROK_CAPS,
+            thinking_mode="manual",
+            thinking_param="enable_thinking",
+            effort_param="reasoning_effort",
+        ),
+        model="grok-4.3",
+    ),
+    # -- native Anthropic --
+    Shape(
+        "anthropic-adaptive-effort",
+        "anthropic",
+        ModelCapabilities(
+            thinking_mode="adaptive",
+            supports_effort=True,
+            effort_levels=("low", "medium", "high", "xhigh", "max"),
+        ),
+        model="claude-fable-5",
+    ),
+    Shape(
+        "anthropic-adaptive-plain",
+        "anthropic",
+        ModelCapabilities(thinking_mode="adaptive"),
+        model="claude-fable-5",
+    ),
+    Shape(
+        "anthropic-manual-budgets",
+        "anthropic",
+        ModelCapabilities(thinking_mode="manual"),
+        model="claude-3-7-sonnet-latest",
+    ),
+    Shape(
+        "anthropic-manual-plus-effort",
+        "anthropic",
+        ModelCapabilities(
+            thinking_mode="manual",
+            supports_effort=True,
+            effort_levels=("low", "medium", "high"),
+        ),
+        model="claude-3-7-sonnet-latest",
+    ),
+    Shape(
+        "anthropic-none-effort",
+        "anthropic",
+        ModelCapabilities(
+            thinking_mode="none",
+            supports_effort=True,
+            effort_levels=("low", "medium", "high"),
+        ),
+        model="claude-3-5-haiku-latest",
+    ),
+    Shape(
+        "anthropic-inert",
+        "anthropic",
+        ModelCapabilities(thinking_mode="none"),
+        model="claude-3-5-haiku-latest",
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Wire capture + effort-subset extraction
+# --------------------------------------------------------------------------- #
+
+
+def _wire_payload(shape: Shape, knob: str) -> dict[str, Any]:
+    """Drive the real provider request path; return the captured SDK kwargs."""
+    provider = create_provider(shape.provider, api_surface=shape.api_surface or None)
+    client = RecordingClient()
+    gen = provider.create_streaming(
+        client=client,
+        model=shape.model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=_MAX_TOKENS,
+        reasoning_effort=knob,
+        capabilities=shape.caps,
+    )
+    # kwargs are recorded eagerly during the call above; close the
+    # unconsumed iterator so stream-manager cleanup runs on the stub.
+    close = getattr(gen, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            close()
+    assert "payload" in client.captured, f"{shape.id}: provider made no SDK call"
+    return dict(client.captured["payload"])
+
+
+def _effort_wire_subset(payload: dict[str, Any], caps: ModelCapabilities) -> dict[str, Any]:
+    """Every effort-related lever in *payload*, normalized across lanes.
+
+    Keys: ``thinking`` (native Anthropic param), ``output_effort``
+    (Anthropic ``output_config.effort``), ``flat`` (Chat Completions
+    ``reasoning_effort`` / Responses ``reasoning.effort``), ``toggle``
+    and ``template_effort`` (``extra_body.chat_template_kwargs``).
+    """
+    subset: dict[str, Any] = {}
+    if "thinking" in payload:
+        subset["thinking"] = payload["thinking"]
+    output_config = payload.get("output_config")
+    if isinstance(output_config, dict) and "effort" in output_config:
+        subset["output_effort"] = output_config["effort"]
+    if "reasoning_effort" in payload:
+        subset["flat"] = payload["reasoning_effort"]
+    reasoning = payload.get("reasoning")
+    if isinstance(reasoning, dict) and "effort" in reasoning:
+        subset["flat"] = reasoning["effort"]
+    extra_body = payload.get("extra_body")
+    ctk = extra_body.get("chat_template_kwargs") if isinstance(extra_body, dict) else None
+    if isinstance(ctk, dict):
+        known = {caps.thinking_param, caps.effort_param} - {""}
+        unexpected = set(ctk) - known
+        assert not unexpected, f"unexpected chat_template_kwargs keys: {unexpected}"
+        if caps.thinking_param in ctk:
+            subset["toggle"] = ctk[caps.thinking_param]
+        if caps.effort_param and caps.effort_param in ctk:
+            subset["template_effort"] = ctk[caps.effort_param]
+    return subset
+
+
+# --------------------------------------------------------------------------- #
+# Ladder-token decoding — the token grammar, made executable
+# --------------------------------------------------------------------------- #
+
+
+def _decode_token(shape: Shape, token: str) -> dict[str, Any]:
+    """Expected effort wire subset for a ladder ``effective`` token."""
+    caps = shape.caps
+    if shape.provider == "anthropic":
+        return _decode_native(caps, token)
+    if shape.provider in ("openai", "xai") or shape.api_surface == "responses":
+        return {} if token == "default" else {"flat": token}
+    return _decode_template(shape.provider, caps, token)
+
+
+def _decode_native(caps: ModelCapabilities, token: str) -> dict[str, Any]:
+    if caps.thinking_mode == "adaptive":
+        # Thinking is unconditionally adaptive; a non-"adaptive" token is
+        # the output_config effort level riding on top.
+        expected: dict[str, Any] = {"thinking": {"type": "adaptive"}}
+        if token != "adaptive":
+            expected["output_effort"] = token
+        return expected
+    if token in ("default", "off"):
+        return {}
+    effort, sep, budget = token.partition("·budget:")
+    if sep:
+        return {
+            "output_effort": effort,
+            "thinking": {"type": "enabled", "budget_tokens": int(budget)},
+        }
+    if token.startswith("budget:"):
+        budget_tokens = int(token.removeprefix("budget:"))
+        return {"thinking": {"type": "enabled", "budget_tokens": budget_tokens}}
+    return {"output_effort": token}
+
+
+def _decode_template(provider: str, caps: ModelCapabilities, token: str) -> dict[str, Any]:
+    if token == "default":
+        return {}
+    parts = token.split("+")
+    expected: dict[str, Any] = {}
+    if parts[0] in ("on", "off"):
+        expected["toggle"] = parts[0] == "on"
+        parts = parts[1:]
+    if parts:
+        assert len(parts) == 1, f"unparseable ladder token: {token!r}"
+        if caps.effort_param:
+            expected["template_effort"] = parts[0]
+        else:
+            # The anthropic-compatible lane has no flat channel, so a
+            # bare effort part there could only be the template key.
+            assert provider != "anthropic-compatible", token
+            expected["flat"] = parts[0]
+    return expected
+
+
+# --------------------------------------------------------------------------- #
+# The parity tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: s.id)
+def test_ladder_tokens_match_wire(shape: Shape) -> None:
+    """Invariant 1: each token's decoded meaning equals the captured wire."""
+    ladder = effort_ladder(shape.provider, shape.caps, shape.api_surface)
+    assert [row["value"] for row in ladder] == list(KNOB_VALUES)
+    for row in ladder:
+        knob, token = row["value"], row["effective"]
+        observed = _effort_wire_subset(_wire_payload(shape, knob), shape.caps)
+        expected = _decode_token(shape, token)
+        assert observed == expected, (
+            f"{shape.id}/knob={knob}: ladder says {token!r} which decodes to "
+            f"{expected}, but the wire carries {observed}"
+        )
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: s.id)
+def test_equal_tokens_iff_equal_wire(shape: Shape) -> None:
+    """Invariant 2: token equality ⇔ effort-wire equality, per shape."""
+    tokens = {
+        row["value"]: row["effective"]
+        for row in effort_ladder(shape.provider, shape.caps, shape.api_surface)
+    }
+    subsets = {
+        knob: _effort_wire_subset(_wire_payload(shape, knob), shape.caps) for knob in KNOB_VALUES
+    }
+    for a, b in itertools.combinations(KNOB_VALUES, 2):
+        same_token = tokens[a] == tokens[b]
+        same_wire = subsets[a] == subsets[b]
+        assert same_token == same_wire, (
+            f"{shape.id}: knobs {a!r}/{b!r} have "
+            f"{'equal' if same_token else 'distinct'} tokens "
+            f"({tokens[a]!r} vs {tokens[b]!r}) but "
+            f"{'identical' if same_wire else 'different'} wire subsets "
+            f"({subsets[a]} vs {subsets[b]})"
+        )

--- a/tests/test_effort_ladder_wire_parity.py
+++ b/tests/test_effort_ladder_wire_parity.py
@@ -60,10 +60,11 @@ class Shape:
     model: str = "m"
 
 
-# Real registry rows for the two lanes whose defaults carry effort values —
+# Real registry rows for the lanes whose defaults carry effort values —
 # parity should cover what ships, not only synthetic shapes.
 _GEMINI_CAPS = create_provider("google").get_capabilities("gemini-3-flash")
 _GROK_CAPS = create_provider("xai").get_capabilities("grok-4.3")
+_GPT55_CAPS = create_provider("openai").get_capabilities("gpt-5.5")
 
 SHAPES: tuple[Shape, ...] = (
     # -- anthropic-compatible (vLLM /v1/messages): template channel only --
@@ -159,12 +160,14 @@ SHAPES: tuple[Shape, ...] = (
     ),
     # -- commercial flat lanes --
     Shape(
-        "openai-flat",
+        # Real registry row: none/low/medium/high/xhigh, default medium.
+        # Knob none must send the EXPLICIT "none" level (omission would
+        # leave the server default medium reasoning on); knob max rides
+        # the xhigh ceiling.
+        "openai-gpt-5.5",
         "openai",
-        ModelCapabilities(
-            reasoning_effort_values=("low", "medium", "high"),
-            default_reasoning_effort="medium",
-        ),
+        _GPT55_CAPS,
+        model="gpt-5.5",
     ),
     Shape("google-default", "google", _GEMINI_CAPS, model="gemini-3-flash"),
     Shape(

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -12,6 +12,7 @@ toggle.
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import sys
 from typing import Any
@@ -21,6 +22,7 @@ import pytest
 
 from tests._session_helpers import make_session as _make_session
 from turnstone.core.providers._anthropic import AnthropicProvider
+from turnstone.core.providers._protocol import ModelCapabilities
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -164,6 +166,161 @@ class TestCompatWireShape:
         kwargs = client.messages.stream.call_args[1]
         assert "extra_body" not in kwargs
         assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+
+
+# ===========================================================================
+# TestCompatReasoningControl
+# ===========================================================================
+
+
+class TestCompatReasoningControl:
+    """Session effort knob → ``chat_template_kwargs`` on the compat lane.
+
+    vLLM's ``/v1/messages`` ignores the native ``thinking`` param — the
+    reasoning levers live in the chat template.  ``_compat_extra_params``
+    maps the knob onto ``caps.thinking_param`` (toggle, knob "none" = off,
+    mirroring ``_reasoning_params``) and ``caps.effort_param`` (graded
+    value for gpt-oss-style templates).  Verified live against qwen3.6 on
+    vLLM 2026-07-03: ``{"enable_thinking": false}`` disables thinking,
+    unknown chat_template_kwargs keys are silently ignored.
+    """
+
+    _MANUAL_CAPS = ModelCapabilities(
+        token_param="max_tokens",
+        thinking_mode="manual",
+        thinking_param="enable_thinking",
+    )
+
+    def setup_method(self) -> None:
+        self.provider = AnthropicProvider(compat=True)
+
+    def _stream_kwargs(
+        self,
+        caps: ModelCapabilities | None,
+        reasoning_effort: str,
+        extra_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        client = _capture_client()
+        with patch("turnstone.core.providers._anthropic._ensure_anthropic"):
+            list(
+                self.provider.create_streaming(
+                    client=client,
+                    model="qwen3.6-27b",
+                    messages=[{"role": "user", "content": "hi"}],
+                    temperature=0.6,
+                    reasoning_effort=reasoning_effort,
+                    extra_params=extra_params,
+                    capabilities=caps,
+                )
+            )
+        return client.messages.stream.call_args[1]
+
+    def test_manual_toggle_on(self) -> None:
+        """Any non-none effort turns the template toggle on; wire stays clean."""
+        kwargs = self._stream_kwargs(self._MANUAL_CAPS, "medium")
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert "thinking" not in kwargs
+        assert kwargs["temperature"] == 0.6  # never forced to 1.0 on compat
+
+    @pytest.mark.parametrize("knob", ["none", ""])
+    def test_manual_toggle_off(self, knob: str) -> None:
+        """Effort "none"/empty disables thinking — native manual-mode parity."""
+        kwargs = self._stream_kwargs(self._MANUAL_CAPS, knob)
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert "thinking" not in kwargs
+
+    def test_adaptive_maps_like_manual(self) -> None:
+        """Adaptive on compat drives the toggle too — no native thinking dict."""
+        caps = dataclasses.replace(self._MANUAL_CAPS, thinking_mode="adaptive")
+        kwargs = self._stream_kwargs(caps, "high")
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert "thinking" not in kwargs
+        assert kwargs["temperature"] == 0.6
+
+    def test_default_caps_inject_nothing(self) -> None:
+        """Untouched compat defaults (thinking_mode=none) keep today's wire."""
+        kwargs = self._stream_kwargs(None, "medium")
+        assert "extra_body" not in kwargs
+        assert "thinking" not in kwargs
+
+    def test_effort_param_validated_against_values(self) -> None:
+        """Off-list knob snaps to default_reasoning_effort, not sent raw."""
+        caps = dataclasses.replace(
+            self._MANUAL_CAPS,
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        )
+        kwargs = self._stream_kwargs(caps, "xhigh")
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "medium"}
+        }
+
+    def test_effort_param_freeform_without_values(self) -> None:
+        """No declared values → knob forwarded as-is, template is authority."""
+        caps = ModelCapabilities(
+            token_param="max_tokens",
+            effort_param="reasoning_effort",
+        )
+        kwargs = self._stream_kwargs(caps, "xhigh")
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"reasoning_effort": "xhigh"}}
+
+    def test_effort_param_omitted_on_none(self) -> None:
+        """Knob "none" sends no effort key (and toggles thinking off)."""
+        caps = dataclasses.replace(
+            self._MANUAL_CAPS,
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+        )
+        kwargs = self._stream_kwargs(caps, "none")
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+    def test_operator_override_wins(self) -> None:
+        """server_compat chat_template_kwargs entries beat the knob mapping."""
+        kwargs = self._stream_kwargs(
+            self._MANUAL_CAPS,
+            "none",
+            extra_params={"chat_template_kwargs": {"enable_thinking": True}, "foo": 1},
+        )
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "foo": 1,
+        }
+
+    def test_caller_extra_params_not_mutated(self) -> None:
+        """The session's extra_params dict must never be written through."""
+        extra = {"chat_template_kwargs": {"foo": 1}}
+        self._stream_kwargs(self._MANUAL_CAPS, "medium", extra_params=extra)
+        assert extra == {"chat_template_kwargs": {"foo": 1}}
+
+    def test_no_output_config_on_compat(self) -> None:
+        """supports_effort must not leak Anthropic output_config to vLLM."""
+        caps = dataclasses.replace(
+            self._MANUAL_CAPS,
+            supports_effort=True,
+            effort_levels=("low", "medium", "high"),
+        )
+        kwargs = self._stream_kwargs(caps, "high")
+        assert "output_config" not in kwargs
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_create_completion_same_injection(self) -> None:
+        """The non-streaming path shares _build_thinking_and_kwargs."""
+        client = MagicMock()
+        final = MagicMock(content=[], stop_reason="end_turn")
+        stream = MagicMock()
+        stream.get_final_message.return_value = final
+        client.messages.stream.return_value.__enter__.return_value = stream
+        with patch("turnstone.core.providers._anthropic._ensure_anthropic"):
+            self.provider.create_completion(
+                client=client,
+                model="qwen3.6-27b",
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort="none",
+                capabilities=self._MANUAL_CAPS,
+            )
+        kwargs = client.messages.stream.call_args[1]
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
 # ===========================================================================

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -177,12 +177,13 @@ class TestCompatReasoningControl:
     """Session effort knob → ``chat_template_kwargs`` on the compat lane.
 
     vLLM's ``/v1/messages`` ignores the native ``thinking`` param — the
-    reasoning levers live in the chat template.  ``_compat_extra_params``
-    maps the knob onto ``caps.thinking_param`` (toggle, knob "none" = off,
-    mirroring ``_reasoning_params``) and ``caps.effort_param`` (graded
-    value for gpt-oss-style templates).  Verified live against qwen3.6 on
-    vLLM 2026-07-03: ``{"enable_thinking": false}`` disables thinking,
-    unknown chat_template_kwargs keys are silently ignored.
+    reasoning levers live in the chat template.
+    ``merge_reasoning_template_kwargs`` maps the knob onto
+    ``caps.thinking_param`` (manual: knob "none" = off, mirroring
+    ``_reasoning_params``; adaptive: always on) and ``caps.effort_param``
+    (graded value for gpt-oss-style templates).  Verified live against
+    qwen3.6 on vLLM 2026-07-03: ``{"enable_thinking": false}`` disables
+    thinking, unknown chat_template_kwargs keys are silently ignored.
     """
 
     _MANUAL_CAPS = ModelCapabilities(
@@ -229,13 +230,14 @@ class TestCompatReasoningControl:
         assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
         assert "thinking" not in kwargs
 
-    def test_adaptive_maps_like_manual(self) -> None:
-        """Adaptive on compat drives the toggle too — no native thinking dict."""
+    def test_adaptive_always_on(self) -> None:
+        """Adaptive never knob-disables — native-adaptive contract, no native dict."""
         caps = dataclasses.replace(self._MANUAL_CAPS, thinking_mode="adaptive")
-        kwargs = self._stream_kwargs(caps, "high")
-        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
-        assert "thinking" not in kwargs
-        assert kwargs["temperature"] == 0.6
+        for knob in ("high", "none"):
+            kwargs = self._stream_kwargs(caps, knob)
+            assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+            assert "thinking" not in kwargs
+            assert kwargs["temperature"] == 0.6
 
     def test_default_caps_inject_nothing(self) -> None:
         """Untouched compat defaults (thinking_mode=none) keep today's wire."""

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -246,7 +246,8 @@ class TestCompatReasoningControl:
         assert "thinking" not in kwargs
 
     def test_effort_param_validated_against_values(self) -> None:
-        """Off-list knob snaps to default_reasoning_effort, not sent raw."""
+        """Off-list knob rounds up onto the declared values (ceiling-capped),
+        never sent raw — and never snaps DOWN to the default."""
         caps = dataclasses.replace(
             self._MANUAL_CAPS,
             effort_param="reasoning_effort",
@@ -255,7 +256,7 @@ class TestCompatReasoningControl:
         )
         kwargs = self._stream_kwargs(caps, "xhigh")
         assert kwargs["extra_body"] == {
-            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "medium"}
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "high"}
         }
 
     def test_effort_param_freeform_without_values(self) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1802,6 +1802,39 @@ class TestProviderFactory:
 # ===========================================================================
 
 
+class TestGoogleEffortKnob:
+    """The session effort knob reaches Gemini as a flat reasoning_effort."""
+
+    def _create_kwargs(self, reasoning_effort: str) -> dict[str, Any]:
+        from turnstone.core.providers._google import GoogleProvider
+
+        prov = GoogleProvider()
+        client = MagicMock()
+        client.chat.completions.create.return_value = iter([])
+        list(
+            prov.create_streaming(
+                client=client,
+                model="gemini-3-flash",
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort=reasoning_effort,
+            )
+        )
+        return client.chat.completions.create.call_args[1]
+
+    def test_knob_values_forward_verbatim(self) -> None:
+        for knob in ("minimal", "low", "medium", "high"):
+            assert self._create_kwargs(knob)["reasoning_effort"] == knob
+
+    def test_off_list_knob_snaps_to_high(self) -> None:
+        """xhigh/max are not in Gemini's vocabulary — snap down to high."""
+        for knob in ("xhigh", "max"):
+            assert self._create_kwargs(knob)["reasoning_effort"] == "high"
+
+    def test_none_omits_the_param(self) -> None:
+        """Knob none never sends "none" — 2.5 Pro / 3.x reject disabling."""
+        assert "reasoning_effort" not in self._create_kwargs("none")
+
+
 class TestGoogleProviderFidelity:
     """Tests for thought_signature round-trip via provider_blocks."""
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -153,51 +153,70 @@ class TestOpenAIProvider:
     def test_provider_name(self) -> None:
         assert self.provider.provider_name == "openai-compatible"
 
-    # -- _apply_thinking_mode -------------------------------------------------
+    # -- reasoning template kwargs (_finalize_extra_body) ---------------------
 
     def test_thinking_mode_none_does_nothing(self) -> None:
-        """No thinking params injected when thinking_mode is 'none'."""
+        """No toggle injected when thinking_mode is 'none'; operator keys pass."""
         caps = ModelCapabilities(thinking_mode="none")
-        extra_body: dict[str, Any] = {"chat_template_kwargs": {"reasoning_effort": "medium"}}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert "enable_thinking" not in extra_body["chat_template_kwargs"]
+        extra_params = {"chat_template_kwargs": {"reasoning_effort": "medium"}}
+        eb = self.provider._finalize_extra_body(extra_params, caps, "medium")
+        assert eb is not None
+        assert "enable_thinking" not in eb["chat_template_kwargs"]
+        assert eb["chat_template_kwargs"]["reasoning_effort"] == "medium"
 
     def test_thinking_mode_manual_injects_param(self) -> None:
         """Manual thinking mode injects enable_thinking into chat_template_kwargs."""
         caps = ModelCapabilities(thinking_mode="manual")
-        extra_body: dict[str, Any] = {"chat_template_kwargs": {"reasoning_effort": "medium"}}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert extra_body["chat_template_kwargs"]["enable_thinking"] is True
-        assert extra_body["chat_template_kwargs"]["reasoning_effort"] == "medium"
+        extra_params = {"chat_template_kwargs": {"reasoning_effort": "medium"}}
+        eb = self.provider._finalize_extra_body(extra_params, caps, "medium")
+        assert eb is not None
+        assert eb["chat_template_kwargs"]["enable_thinking"] is True
+        assert eb["chat_template_kwargs"]["reasoning_effort"] == "medium"
+
+    def test_thinking_mode_manual_knob_none_disables(self) -> None:
+        """Effort knob "none" turns the template toggle off, not just quiet."""
+        caps = ModelCapabilities(thinking_mode="manual")
+        eb = self.provider._finalize_extra_body(None, caps, "none")
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
 
     def test_thinking_mode_custom_param(self) -> None:
         """Custom thinking_param (e.g. Granite's 'thinking') is used."""
         caps = ModelCapabilities(thinking_mode="manual", thinking_param="thinking")
-        extra_body: dict[str, Any] = {"chat_template_kwargs": {}}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert extra_body["chat_template_kwargs"]["thinking"] is True
-        assert "enable_thinking" not in extra_body["chat_template_kwargs"]
+        eb = self.provider._finalize_extra_body(None, caps, "medium")
+        assert eb == {"chat_template_kwargs": {"thinking": True}}
 
     def test_thinking_mode_does_not_override_explicit(self) -> None:
         """If operator explicitly set the param to False, provider respects it."""
         caps = ModelCapabilities(thinking_mode="manual")
-        extra_body: dict[str, Any] = {"chat_template_kwargs": {"enable_thinking": False}}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert extra_body["chat_template_kwargs"]["enable_thinking"] is False
-
-    def test_thinking_mode_creates_ctk_if_missing(self) -> None:
-        """Creates chat_template_kwargs dict if not present in extra_body."""
-        caps = ModelCapabilities(thinking_mode="manual")
-        extra_body: dict[str, Any] = {}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert extra_body["chat_template_kwargs"]["enable_thinking"] is True
+        extra_params = {"chat_template_kwargs": {"enable_thinking": False}}
+        eb = self.provider._finalize_extra_body(extra_params, caps, "medium")
+        assert eb is not None
+        assert eb["chat_template_kwargs"]["enable_thinking"] is False
 
     def test_thinking_mode_adaptive(self) -> None:
-        """Adaptive thinking mode also injects the param."""
+        """Adaptive thinking mode drives the toggle the same way."""
         caps = ModelCapabilities(thinking_mode="adaptive")
-        extra_body: dict[str, Any] = {"chat_template_kwargs": {}}
-        OpenAIProvider._apply_thinking_mode(extra_body, caps)
-        assert extra_body["chat_template_kwargs"]["enable_thinking"] is True
+        eb = self.provider._finalize_extra_body(None, caps, "high")
+        assert eb == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_effort_param_injects_knob_value(self) -> None:
+        """effort_param carries the knob into chat_template_kwargs (gpt-oss)."""
+        caps = ModelCapabilities(
+            thinking_mode="none",
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+            default_reasoning_effort="medium",
+        )
+        eb = self.provider._finalize_extra_body(None, caps, "xhigh")
+        assert eb == {"chat_template_kwargs": {"reasoning_effort": "medium"}}
+        assert self.provider._finalize_extra_body(None, caps, "none") is None
+
+    def test_caller_extra_params_not_mutated(self) -> None:
+        """The session dict and its ctk sub-dict survive injection untouched."""
+        caps = ModelCapabilities(thinking_mode="manual")
+        extra_params = {"chat_template_kwargs": {"foo": 1}}
+        self.provider._finalize_extra_body(extra_params, caps, "medium")
+        assert extra_params == {"chat_template_kwargs": {"foo": 1}}
 
     # -- _sanitize_messages ---------------------------------------------------
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -218,7 +218,8 @@ class TestOpenAIProvider:
         assert kwargs["reasoning_effort"] == "medium"
 
     def test_effort_param_injects_knob_value(self) -> None:
-        """effort_param carries the knob into chat_template_kwargs (gpt-oss)."""
+        """effort_param carries the knob into chat_template_kwargs (gpt-oss);
+        a knob above the declared ceiling rides the ceiling, not the default."""
         caps = ModelCapabilities(
             thinking_mode="none",
             effort_param="reasoning_effort",
@@ -226,7 +227,7 @@ class TestOpenAIProvider:
             default_reasoning_effort="medium",
         )
         eb = self.provider._finalize_extra_body(None, caps, "xhigh")
-        assert eb == {"chat_template_kwargs": {"reasoning_effort": "medium"}}
+        assert eb == {"chat_template_kwargs": {"reasoning_effort": "high"}}
         assert self.provider._finalize_extra_body(None, caps, "none") is None
 
     def test_caller_extra_params_not_mutated(self) -> None:
@@ -2386,11 +2387,20 @@ class TestAnthropicReasoningNone:
         result = _map_reasoning_to_effort("xhigh", ("low", "medium", "high", "xhigh", "max"))
         assert result == "xhigh"
 
-    def test_map_xhigh_rejected_by_model_without_it(self) -> None:
+    def test_map_xhigh_snaps_up_through_gap_to_max(self) -> None:
+        """Levels with a hole (no xhigh) round the knob UP to the next
+        declared level rather than dropping output_config entirely."""
         from turnstone.core.providers._anthropic import _map_reasoning_to_effort
 
         result = _map_reasoning_to_effort("xhigh", ("low", "medium", "high", "max"))
-        assert result is None
+        assert result == "max"
+
+    def test_map_above_ceiling_rides_ceiling(self) -> None:
+        from turnstone.core.providers._anthropic import _map_reasoning_to_effort
+
+        assert _map_reasoning_to_effort("max", ("low", "medium", "high")) == "high"
+        assert _map_reasoning_to_effort("minimal", ("low", "medium", "high")) == "low"
+        assert _map_reasoning_to_effort("none", ("low", "medium", "high")) is None
 
 
 # ===========================================================================
@@ -3696,8 +3706,9 @@ class TestAnthropicPromptCaching:
         )
         assert kwargs["output_config"] == {"effort": "xhigh"}
 
-    def test_xhigh_effort_not_applied_to_opus_4_6(self) -> None:
-        """xhigh is not a valid effort level for Opus 4.6 — should be ignored."""
+    def test_xhigh_effort_snaps_to_max_on_opus_4_6(self) -> None:
+        """Opus 4.6 declares (low, medium, high, max) — a knob of xhigh
+        rounds up to max instead of silently dropping output_config."""
         caps = self.provider.get_capabilities("claude-opus-4-6")
         kwargs = self.provider._build_thinking_and_kwargs(
             caps=caps,
@@ -3710,7 +3721,7 @@ class TestAnthropicPromptCaching:
             model="claude-opus-4-6",
             tools=None,
         )
-        assert "output_config" not in kwargs
+        assert kwargs["output_config"] == {"effort": "max"}
 
     @patch("turnstone.core.providers._anthropic._ensure_anthropic")
     def test_streaming_message_start_cache_metrics(self, mock_ensure: MagicMock) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2091,12 +2091,13 @@ class TestOpenAIParameterGating:
         assert kwargs["reasoning_effort"] == "high"
 
     def test_gpt51_temperature_when_effort_none(self) -> None:
-        """GPT-5.1: temperature only when reasoning_effort='none'."""
+        """GPT-5.1: temperature only when reasoning_effort='none'; the
+        declared "none" level is forwarded explicitly (knob = off)."""
         caps = self.provider.get_capabilities("gpt-5.1")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
         assert kwargs["temperature"] == 0.7
-        assert "reasoning_effort" not in kwargs  # "none" is skipped
+        assert kwargs["reasoning_effort"] == "none"
 
     def test_gpt51_no_temperature_when_reasoning_active(self) -> None:
         """GPT-5.1: no temperature when reasoning is active."""
@@ -2106,12 +2107,20 @@ class TestOpenAIParameterGating:
         assert "temperature" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
 
-    def test_o_series_no_temperature_no_reasoning_effort(self) -> None:
-        """O-series: no temperature, no reasoning_effort."""
+    def test_o_series_no_temperature_but_effort_forwarded(self) -> None:
+        """O-series: no temperature; low/medium/high ARE valid effort
+        values (all o-series except o1-mini) and the knob reaches them."""
         caps = self.provider.get_capabilities("o3")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
         assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] == "medium"
+
+    def test_o1_mini_has_no_effort_control(self) -> None:
+        """o1-mini is the one o-series model without reasoning_effort."""
+        caps = self.provider.get_capabilities("o1-mini")
+        kwargs: dict[str, Any] = {}
+        apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
         assert "reasoning_effort" not in kwargs
 
     def test_gpt5_pro_unsupported_effort_falls_back(self) -> None:
@@ -2136,7 +2145,7 @@ class TestOpenAIParameterGating:
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
         assert kwargs["temperature"] == 0.7
-        assert "reasoning_effort" not in kwargs
+        assert kwargs["reasoning_effort"] == "none"  # declared level, forwarded
         kwargs2: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs2, caps, temperature=0.7, reasoning_effort="xhigh")
         assert "temperature" not in kwargs2
@@ -2160,7 +2169,7 @@ class TestOpenAIParameterGating:
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
         assert kwargs["temperature"] == 0.7
-        assert "reasoning_effort" not in kwargs
+        assert kwargs["reasoning_effort"] == "none"  # declared level, forwarded
         kwargs2: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs2, caps, temperature=0.7, reasoning_effort="xhigh")
         assert "temperature" not in kwargs2
@@ -4254,7 +4263,10 @@ class TestResponsesParamBuilding:
         assert kwargs["reasoning"] == {"effort": "high"}
         assert "reasoning_effort" not in kwargs
 
-    def test_no_reasoning_when_none_effort(self) -> None:
+    def test_none_effort_sends_declared_none_level(self) -> None:
+        """gpt-5.4 declares an explicit "none" level — the knob's off
+        position forwards it rather than omitting (omission would leave
+        the server default in charge on models like gpt-5.5)."""
         kwargs = self.provider._build_kwargs(
             model="gpt-5.4",
             messages=[{"role": "user", "content": "Hi"}],
@@ -4264,7 +4276,7 @@ class TestResponsesParamBuilding:
             reasoning_effort="none",
             deferred_names=None,
         )
-        assert "reasoning" not in kwargs
+        assert kwargs["reasoning"] == {"effort": "none"}
 
     def test_store_is_false(self) -> None:
         kwargs = self.provider._build_kwargs(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -193,11 +193,29 @@ class TestOpenAIProvider:
         assert eb is not None
         assert eb["chat_template_kwargs"]["enable_thinking"] is False
 
-    def test_thinking_mode_adaptive(self) -> None:
-        """Adaptive thinking mode drives the toggle the same way."""
+    def test_thinking_mode_adaptive_never_knob_disables(self) -> None:
+        """Adaptive = model self-regulates; knob "none" must not force false."""
         caps = ModelCapabilities(thinking_mode="adaptive")
-        eb = self.provider._finalize_extra_body(None, caps, "high")
-        assert eb == {"chat_template_kwargs": {"enable_thinking": True}}
+        for knob in ("high", "none", ""):
+            eb = self.provider._finalize_extra_body(None, caps, knob)
+            assert eb == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_effort_param_suppresses_flat_reasoning_effort(self) -> None:
+        """Declaring the ctk effort channel must not double-send the flat param."""
+        from turnstone.core.providers._openai_common import apply_temperature_and_effort
+
+        caps = ModelCapabilities(
+            effort_param="reasoning_effort",
+            reasoning_effort_values=("low", "medium", "high"),
+        )
+        kwargs: dict[str, Any] = {}
+        apply_temperature_and_effort(kwargs, caps, 0.5, "medium")
+        assert "reasoning_effort" not in kwargs
+        # Without effort_param the flat param still flows (commercial path).
+        flat_caps = ModelCapabilities(reasoning_effort_values=("low", "medium", "high"))
+        kwargs = {}
+        apply_temperature_and_effort(kwargs, flat_caps, 0.5, "medium")
+        assert kwargs["reasoning_effort"] == "medium"
 
     def test_effort_param_injects_knob_value(self) -> None:
         """effort_param carries the knob into chat_template_kwargs (gpt-oss)."""

--- a/tests/test_server_compat.py
+++ b/tests/test_server_compat.py
@@ -208,7 +208,9 @@ class TestMergeServerCompat:
 
 
 class TestEndToEndRequestShaping:
-    """Compose both layers — session builds extra_params, provider applies thinking."""
+    """Compose both layers — session builds extra_params, provider applies reasoning."""
+
+    provider = OpenAIChatCompletionsProvider()
 
     def test_vllm_gemma_full_flow(self) -> None:
         """Gemma now needs only the thinking param — no server workaround."""
@@ -216,18 +218,27 @@ class TestEndToEndRequestShaping:
         server_compat = {"server_type": "vllm"}
         # Step 1: session forwards (no auto-injection of reasoning_effort).
         extra_params = merge_server_compat(None, server_compat)
-        # Step 2: provider injects thinking param into chat_template_kwargs.
-        extra_body = dict(extra_params)
-        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+        # Step 2: provider folds the effort knob into chat_template_kwargs.
+        extra_body = self.provider._finalize_extra_body(extra_params, caps, "medium")
 
         assert extra_body == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_knob_none_disables_toggle(self) -> None:
+        """Session effort "none" turns the template toggle off dynamically."""
+        caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, {"server_type": "vllm"}), caps, "none"
+        )
+
+        assert extra_body == {"chat_template_kwargs": {"enable_thinking": False}}
 
     def test_server_workaround_composes_with_thinking(self) -> None:
         """A top-level server workaround forwards alongside the injected thinking param."""
         caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
         compat = {"server_type": "llama.cpp", "extra_body": {"reasoning_format": "auto"}}
-        extra_body = dict(merge_server_compat(None, compat))
-        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, compat), caps, "medium"
+        )
 
         assert extra_body == {
             "chat_template_kwargs": {"enable_thinking": True},
@@ -237,20 +248,20 @@ class TestEndToEndRequestShaping:
     def test_granite_thinking_key(self) -> None:
         """Granite uses 'thinking' instead of 'enable_thinking'."""
         caps = ModelCapabilities(thinking_mode="manual", thinking_param="thinking")
-        extra_params = merge_server_compat(None, {})
-        extra_body = dict(extra_params)
-        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, {}), caps, "medium"
+        )
 
         assert extra_body == {"chat_template_kwargs": {"thinking": True}}
 
     def test_non_thinking_model_no_injection(self) -> None:
-        """Non-thinking model gets no chat_template_kwargs at all."""
+        """Non-thinking model gets no extra_body at all."""
         caps = ModelCapabilities()  # thinking_mode="none"
-        extra_params = merge_server_compat(None, {})
-        extra_body = dict(extra_params)
-        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, {}), caps, "medium"
+        )
 
-        assert extra_body == {}
+        assert extra_body is None
 
     def test_operator_reasoning_effort_passthrough(self) -> None:
         """Operator-supplied reasoning_effort under chat_template_kwargs is preserved."""
@@ -259,9 +270,9 @@ class TestEndToEndRequestShaping:
             "server_type": "vllm",
             "extra_body": {"chat_template_kwargs": {"reasoning_effort": "high"}},
         }
-        extra_params = merge_server_compat(None, compat)
-        extra_body = dict(extra_params)
-        OpenAIChatCompletionsProvider._apply_thinking_mode(extra_body, caps)
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, compat), caps, "medium"
+        )
 
         assert extra_body == {
             "chat_template_kwargs": {
@@ -269,6 +280,19 @@ class TestEndToEndRequestShaping:
                 "enable_thinking": True,
             },
         }
+
+    def test_operator_pin_beats_effort_param(self) -> None:
+        """A pinned effort key wins over the knob mapping (setdefault)."""
+        caps = ModelCapabilities(
+            thinking_mode="none",
+            effort_param="reasoning_effort",
+        )
+        compat = {"extra_body": {"chat_template_kwargs": {"reasoning_effort": "low"}}}
+        extra_body = self.provider._finalize_extra_body(
+            merge_server_compat(None, compat), caps, "high"
+        )
+
+        assert extra_body == {"chat_template_kwargs": {"reasoning_effort": "low"}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wire_payload_golden.py
+++ b/tests/test_wire_payload_golden.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
+from tests._wire_capture import RecordingClient
 from turnstone.core.lowering import repair_wire_messages
 from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._google import GoogleProvider
@@ -37,71 +38,10 @@ from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from turnstone.core.providers._protocol import LLMProvider
 
 GOLDEN_DIR = Path(__file__).parent / "data" / "wire_payloads"
 _UPDATE = os.environ.get("UPDATE_WIRE_GOLDENS") == "1"
-
-
-# --------------------------------------------------------------------------- #
-# Recording fake client — captures the kwargs at each provider's SDK seam.
-# --------------------------------------------------------------------------- #
-class _EmptyStream:
-    """Stand-in for an SDK stream / stream-manager: empty iterable AND no-op CM."""
-
-    def __iter__(self) -> Iterator[Any]:
-        return iter(())
-
-    def __enter__(self) -> _EmptyStream:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        return None
-
-
-class _Seam:
-    """Records the kwargs of a single SDK call, returns an empty stream stub."""
-
-    def __init__(self, sink: dict[str, Any]) -> None:
-        self._sink = sink
-
-    def __call__(self, **kwargs: Any) -> _EmptyStream:
-        # Last write wins; only one seam is exercised per provider call.
-        self._sink["payload"] = kwargs
-        return _EmptyStream()
-
-
-class _Completions:
-    def __init__(self, sink: dict[str, Any]) -> None:
-        self.create = _Seam(sink)
-
-
-class _Chat:
-    def __init__(self, sink: dict[str, Any]) -> None:
-        self.completions = _Completions(sink)
-
-
-class _Messages:
-    def __init__(self, sink: dict[str, Any]) -> None:
-        self.stream = _Seam(sink)
-
-
-class _Responses:
-    def __init__(self, sink: dict[str, Any]) -> None:
-        self.create = _Seam(sink)
-        self.stream = _Seam(sink)
-
-
-class RecordingClient:
-    """Fake SDK client exposing every provider's call seam, recording kwargs."""
-
-    def __init__(self) -> None:
-        self.captured: dict[str, Any] = {}
-        self.messages = _Messages(self.captured)
-        self.chat = _Chat(self.captured)
-        self.responses = _Responses(self.captured)
 
 
 def _capture(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1908,8 +1908,26 @@ async def list_available_models(request: Request) -> JSONResponse:
         return err
 
     rows = storage.list_model_definitions(enabled_only=True)
-    # Only expose alias/model/provider — rows also contain api_key, base_url, etc.
-    models = [{"alias": r["alias"], "model": r["model"], "provider": r["provider"]} for r in rows]
+    # Only expose alias/model/provider (+ the derived effort ladder) —
+    # rows also contain api_key, base_url, etc.
+    from turnstone.core.providers.effort_ladder import effort_ladder_for_model
+
+    models = []
+    for r in rows:
+        entry: dict[str, Any] = {
+            "alias": r["alias"],
+            "model": r["model"],
+            "provider": r["provider"],
+        }
+        try:
+            entry["effort_ladder"] = effort_ladder_for_model(
+                r["provider"], r["model"], r.get("capabilities") or {}
+            )
+        except Exception:
+            # Unknown provider string / malformed capabilities row must
+            # not take down the picker — the ladder is an annotation.
+            log.debug("models.effort_ladder_failed alias=%s", r.get("alias"), exc_info=True)
+        models.append(entry)
 
     # Include effective defaults for clients (web UI, channel gateway).
     default_alias = ""
@@ -11592,6 +11610,47 @@ async def admin_model_capabilities(request: Request) -> JSONResponse:
     )
 
 
+async def admin_effort_ladder(request: Request) -> JSONResponse:
+    """POST /v1/api/admin/models/effort-ladder — knob→wire projection.
+
+    Body: ``{"provider": ..., "model": ..., "capabilities": {...}}`` —
+    capabilities are the (possibly unsaved) overrides from the model
+    form, so the modal can annotate its effort select live while the
+    operator edits thinking mode / effort param.  Pure computation; no
+    stored state is read or written.
+    """
+    from turnstone.core.auth import require_permission
+    from turnstone.core.providers.effort_ladder import effort_ladder_for_model
+
+    err = require_permission(request, "admin.models")
+    if err:
+        return err
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    provider = str(body.get("provider") or "").strip()
+    model = str(body.get("model") or "").strip()
+    capabilities = body.get("capabilities")
+
+    if provider not in _MODEL_PROVIDERS:
+        return JSONResponse({"error": f"Unknown provider: {provider!r}"}, status_code=400)
+    if not model:
+        return JSONResponse({"error": "model is required"}, status_code=400)
+    if capabilities is not None and not isinstance(capabilities, dict):
+        return JSONResponse({"error": "capabilities must be an object"}, status_code=400)
+
+    try:
+        ladder = effort_ladder_for_model(provider, model, capabilities or {})
+    except Exception:
+        # Garbage override values (wrong types for capability fields)
+        # surface as a clean 400 rather than a 500 — the form's raw
+        # JSON is operator-typed.
+        return JSONResponse({"error": "could not resolve capabilities"}, status_code=400)
+    return JSONResponse({"provider": provider, "model": model, "ladder": ladder})
+
+
 async def admin_known_models(request: Request) -> JSONResponse:
     """GET /v1/api/admin/model-capabilities/known — list known model name prefixes."""
     from turnstone.core.auth import require_permission
@@ -13987,6 +14046,11 @@ def create_app(
                     Route(
                         "/api/admin/model-capabilities/known",
                         admin_known_models,
+                    ),
+                    Route(
+                        "/api/admin/models/effort-ladder",
+                        admin_effort_ladder,
+                        methods=["POST"],
                     ),
                     # Governance: Prompt Policies
                     Route("/api/admin/prompt-policies", admin_list_prompt_policies),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1921,15 +1921,17 @@ async def list_available_models(request: Request) -> JSONResponse:
         }
         try:
             # ``capabilities`` is a JSON string (sa.Text column) with
-            # ``server_compat`` namespaced inside — parse and split the
-            # same way the model_registry loader does.
+            # ``server_compat`` namespaced inside — parse it the same way
+            # the model_registry loader does.  Read (don't pop) the
+            # namespace: the ladder's field filter drops non-capability
+            # keys, so the parsed dict can stay unmutated.
             caps: dict[str, Any] = {}
             raw_caps = r.get("capabilities")
             if raw_caps:
                 parsed = json.loads(raw_caps)
                 if isinstance(parsed, dict):
                     caps = parsed
-            server_compat = caps.pop("server_compat", {})
+            server_compat = caps.get("server_compat", {})
             api_surface = (
                 server_compat.get("api_surface", "") if isinstance(server_compat, dict) else ""
             )
@@ -11666,7 +11668,14 @@ async def admin_effort_ladder(request: Request) -> JSONResponse:
     except Exception:
         # Garbage override values (wrong types for capability fields)
         # surface as a clean 400 rather than a 500 — the form's raw
-        # JSON is operator-typed.
+        # JSON is operator-typed.  Log it: the same catch would
+        # otherwise mask a genuine resolver bug as a silent 400.
+        log.warning(
+            "models.effort_ladder_resolve_failed provider=%s model=%s",
+            provider,
+            model,
+            exc_info=True,
+        )
         return JSONResponse({"error": "could not resolve capabilities"}, status_code=400)
     return JSONResponse({"provider": provider, "model": model, "ladder": ladder})
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1920,8 +1920,21 @@ async def list_available_models(request: Request) -> JSONResponse:
             "provider": r["provider"],
         }
         try:
+            # ``capabilities`` is a JSON string (sa.Text column) with
+            # ``server_compat`` namespaced inside — parse and split the
+            # same way the model_registry loader does.
+            caps: dict[str, Any] = {}
+            raw_caps = r.get("capabilities")
+            if raw_caps:
+                parsed = json.loads(raw_caps)
+                if isinstance(parsed, dict):
+                    caps = parsed
+            server_compat = caps.pop("server_compat", {})
+            api_surface = (
+                server_compat.get("api_surface", "") if isinstance(server_compat, dict) else ""
+            )
             entry["effort_ladder"] = effort_ladder_for_model(
-                r["provider"], r["model"], r.get("capabilities") or {}
+                r["provider"], r["model"], caps, api_surface=str(api_surface or "")
             )
         except Exception:
             # Unknown provider string / malformed capabilities row must
@@ -11630,9 +11643,14 @@ async def admin_effort_ladder(request: Request) -> JSONResponse:
         body = await request.json()
     except Exception:
         return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    if not isinstance(body, dict):
+        # json() happily parses null/arrays/strings — .get() on those
+        # would 500 where the contract says 400.
+        return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
     provider = str(body.get("provider") or "").strip()
     model = str(body.get("model") or "").strip()
     capabilities = body.get("capabilities")
+    api_surface = str(body.get("api_surface") or "").strip()
 
     if provider not in _MODEL_PROVIDERS:
         return JSONResponse({"error": f"Unknown provider: {provider!r}"}, status_code=400)
@@ -11642,7 +11660,9 @@ async def admin_effort_ladder(request: Request) -> JSONResponse:
         return JSONResponse({"error": "capabilities must be an object"}, status_code=400)
 
     try:
-        ladder = effort_ladder_for_model(provider, model, capabilities or {})
+        ladder = effort_ladder_for_model(
+            provider, model, capabilities or {}, api_surface=api_surface
+        )
     except Exception:
         # Garbage override values (wrong types for capability fields)
         # surface as a clean 400 rather than a 500 — the form's raw

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6905,6 +6905,7 @@ function showCreateModelModal() {
   document.getElementById("model-thinking-param").value = "";
   document.getElementById("model-thinking-param-row").hidden = true;
   document.getElementById("model-effort-param").value = "";
+  _annotateEffortSelect(document.getElementById("model-reasoning-effort"), null);
   document.getElementById("model-extra-body").value = "";
   document.getElementById("model-capabilities").value = "";
   // Clear validation error styling from prior submit attempts
@@ -7033,6 +7034,7 @@ function showEditModelModal(definitionId) {
       });
       _modelRenderTiles();
       _modelCapsRefreshBaseline();
+      _scheduleEffortLadder();
       // Remove structured fields from capabilities display — only delete
       // thinking_mode/thinking_param when the UI successfully captured them.
       delete capsObj.server_compat;
@@ -7625,6 +7627,99 @@ let _modelCapsSeq = 0;
 function _onModelFieldChange() {
   clearTimeout(_capsTimer);
   _capsTimer = setTimeout(_modelCapsRefreshBaseline, 500);
+  _scheduleEffortLadder();
+}
+
+/* Effort-ladder annotation: label knob positions that alias to the same
+   wire behavior for a given model, from the server-computed projection
+   (providers/effort_ladder.py — equal "effective" tokens ⇒ identical
+   requests).  Defined here and shared as a page global with
+   governance.js (skill launch config), which loads after this file. */
+function _annotateEffortSelect(sel, ladder) {
+  if (!sel) return;
+  const byVal = {};
+  const firstOf = {};
+  (ladder || []).forEach(function (row) {
+    byVal[row.value] = row.effective;
+    if (!(row.effective in firstOf)) firstOf[row.effective] = row.value;
+  });
+  Array.from(sel.options).forEach(function (opt) {
+    if (!opt.value) return; // "" = inherit-the-default option
+    if (!opt.dataset.baseLabel) opt.dataset.baseLabel = opt.textContent;
+    let label = opt.dataset.baseLabel;
+    let title = "";
+    const eff = byVal[opt.value];
+    if (eff !== undefined) {
+      const first = firstOf[eff];
+      if (first !== opt.value) {
+        label += " (= " + first + ")";
+      } else if (eff === "default") {
+        label += " (model default)";
+      }
+      title = "sends: " + eff;
+    }
+    opt.textContent = label;
+    opt.title = title;
+  });
+}
+
+let _effortLadderTimer = null;
+let _effortLadderSeq = 0;
+function _scheduleEffortLadder() {
+  clearTimeout(_effortLadderTimer);
+  _effortLadderTimer = setTimeout(_refreshModelEffortLadder, 500);
+}
+function _refreshModelEffortLadder() {
+  const shelf = document.getElementById("model-shelf");
+  const sel = document.getElementById("model-reasoning-effort");
+  if (!shelf || !shelf.open || !sel) return;
+  const provider = document.getElementById("model-provider").value;
+  const modelName = document.getElementById("model-name").value.trim();
+  if (!modelName) {
+    _annotateEffortSelect(sel, null);
+    return;
+  }
+  // Assemble the same capabilities the save path would persist: raw
+  // JSON base, structured thinking/effort fields overlaid.  Mid-edit
+  // invalid JSON annotates from the structured fields alone.
+  let caps = {};
+  const rawText = document.getElementById("model-capabilities").value.trim();
+  if (rawText) {
+    try {
+      const parsed = JSON.parse(rawText);
+      if (_isPlainObject(parsed)) caps = parsed;
+    } catch (e) {
+      /* fall through */
+    }
+  }
+  const tm = document.getElementById("model-thinking-mode").value;
+  if (tm) {
+    caps.thinking_mode = tm;
+    const tp = document.getElementById("model-thinking-param").value;
+    if (tp) caps.thinking_param = tp;
+  }
+  const ep = document.getElementById("model-effort-param").value.trim();
+  if (ep) caps.effort_param = ep;
+  const seq = ++_effortLadderSeq;
+  authFetch("/v1/api/admin/models/effort-ladder", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      provider: provider,
+      model: modelName,
+      capabilities: caps,
+    }),
+  })
+    .then(function (r) {
+      return r.ok ? r.json() : null;
+    })
+    .then(function (d) {
+      if (seq !== _effortLadderSeq) return; // superseded by a newer edit
+      _annotateEffortSelect(sel, d && d.ladder);
+    })
+    .catch(function () {
+      /* silent — annotation only */
+    });
 }
 
 /* Known-model lookup feeding the tile matrix: the table becomes the display
@@ -7771,6 +7866,13 @@ function _refreshModelSuggestions() {
   const provEl = document.getElementById("model-provider");
   const tmEl = document.getElementById("model-thinking-mode");
   if (tmEl) tmEl.addEventListener("change", _toggleThinkingParam);
+  if (tmEl) tmEl.addEventListener("change", _scheduleEffortLadder);
+  ["model-thinking-param", "model-effort-param", "model-capabilities"].forEach(
+    function (id) {
+      const el = document.getElementById(id);
+      if (el) el.addEventListener("input", _scheduleEffortLadder);
+    },
+  );
   const grid = document.getElementById("model-capgrid");
   if (grid) {
     grid.addEventListener("change", function (e) {

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -7046,7 +7046,16 @@ function showEditModelModal(definitionId) {
         // it here would silently drop it on the next unrelated edit-save.
         if (tmVal) delete capsObj.thinking_param;
       }
-      delete capsObj.effort_param;
+      // Strip effort_param only for the lanes whose save path re-adds it
+      // (the same provider gate) — on other providers the field is
+      // hidden and the save path never writes it, so deleting it here
+      // would silently drop a stored key on an unrelated edit-save.
+      if (
+        m.provider === "openai-compatible" ||
+        m.provider === "anthropic-compatible"
+      ) {
+        delete capsObj.effort_param;
+      }
       const capsText = JSON.stringify(capsObj, null, 2);
       document.getElementById("model-capabilities").value =
         capsText === "{}" ? "" : capsText;
@@ -7638,10 +7647,16 @@ function _onModelFieldChange() {
 function _annotateEffortSelect(sel, ladder) {
   if (!sel) return;
   const byVal = {};
-  const firstOf = {};
   (ladder || []).forEach(function (row) {
     byVal[row.value] = row.effective;
-    if (!(row.effective in firstOf)) firstOf[row.effective] = row.value;
+  });
+  // First selectable position per effective token — restricted to the
+  // options THIS select offers, so an alias label never points at a
+  // position the user cannot pick (the skill shelf omits none/minimal).
+  const firstOf = {};
+  Array.from(sel.options).forEach(function (opt) {
+    const eff = byVal[opt.value];
+    if (eff !== undefined && !(eff in firstOf)) firstOf[eff] = opt.value;
   });
   Array.from(sel.options).forEach(function (opt) {
     if (!opt.value) return; // "" = inherit-the-default option
@@ -7676,6 +7691,7 @@ function _refreshModelEffortLadder() {
   const provider = document.getElementById("model-provider").value;
   const modelName = document.getElementById("model-name").value.trim();
   if (!modelName) {
+    _effortLadderSeq++; // invalidate any in-flight response
     _annotateEffortSelect(sel, null);
     return;
   }
@@ -7708,6 +7724,7 @@ function _refreshModelEffortLadder() {
       provider: provider,
       model: modelName,
       capabilities: caps,
+      api_surface: document.getElementById("model-api-surface").value || "",
     }),
   })
     .then(function (r) {
@@ -7873,6 +7890,8 @@ function _refreshModelSuggestions() {
       if (el) el.addEventListener("input", _scheduleEffortLadder);
     },
   );
+  const apiSurfEl = document.getElementById("model-api-surface");
+  if (apiSurfEl) apiSurfEl.addEventListener("change", _scheduleEffortLadder);
   const grid = document.getElementById("model-capgrid");
   if (grid) {
     grid.addEventListener("change", function (e) {

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6979,15 +6979,13 @@ function showEditModelModal(definitionId) {
         ? capsObj.server_compat
         : {};
       // Only extract thinking_mode into the dropdown when the UI can
-      // represent it ("manual" or "") AND the provider round-trips the
-      // dropdown on save (every provider except anthropic-compatible —
-      // see submitCreateModel).  Unrepresentable values like "adaptive"
-      // and anthropic-compatible rows keep thinking_mode in the raw
-      // capabilities JSON so it isn't silently lost on save.
+      // represent it ("manual" or "").  Unrepresentable values like
+      // "adaptive" keep thinking_mode in the raw capabilities JSON so it
+      // isn't silently lost on save.  Both compat lanes round-trip the
+      // dropdown: on anthropic-compatible it drives the effort-knob →
+      // chat_template_kwargs mapping (_compat_extra_params).
       const tmVal = capsObj.thinking_mode || "";
-      const tmRepresentable = tmVal === "" || tmVal === "manual";
-      const tmCaptured =
-        tmRepresentable && (m.provider || "openai") !== "anthropic-compatible";
+      const tmCaptured = tmVal === "" || tmVal === "manual";
       if (tmCaptured) {
         document.getElementById("model-thinking-mode").value = tmVal;
         document.getElementById("model-thinking-param").value =
@@ -7107,13 +7105,11 @@ function submitCreateModel() {
   const providerVal = document.getElementById("model-provider").value;
 
   // Thinking mode → capabilities.  thinking_mode round-trips through the
-  // dropdown for every provider EXCEPT anthropic-compatible, where it
-  // stays in the raw capabilities JSON (mirroring the edit-load lift):
-  // that lane hides the dropdown row and drives reasoning via extra-body
-  // chat_template_kwargs, so a lingering dropdown value must never be
-  // persisted.
+  // dropdown for every provider, including anthropic-compatible (where
+  // manual mode maps the session effort knob onto the template's
+  // thinking toggle via chat_template_kwargs — _compat_extra_params).
   const thinkingMode = document.getElementById("model-thinking-mode").value;
-  if (providerVal !== "anthropic-compatible" && thinkingMode) {
+  if (thinkingMode) {
     caps.thinking_mode = thinkingMode;
     // Preserve thinking_param so Granite/DeepSeek "thinking" key
     // isn't silently reverted to the default "enable_thinking".
@@ -7701,15 +7697,15 @@ function _applyProviderDefaults() {
     scSection.hidden =
       provider !== "openai-compatible" && provider !== "anthropic-compatible";
   }
-  // Within the section, server type / API surface / thinking mode are
-  // openai-compatible knobs — the anthropic-compatible lane is configured
-  // through the extra-body JSON alone, so collapse the section to just
-  // that field.
-  const hideOpenaiOnlyRows = provider === "anthropic-compatible";
-  ["model-server-fields-row", "model-thinking-mode-row"].forEach(function (id) {
-    const row = document.getElementById(id);
-    if (row) row.hidden = hideOpenaiOnlyRows;
-  });
+  // Within the section, server type / API surface are openai-compatible
+  // knobs (Detect heuristics + chat-vs-responses surface pick) and stay
+  // hidden on the anthropic-compatible lane.  Thinking mode applies to
+  // BOTH compat lanes: on anthropic-compatible it opts the model into
+  // the effort-knob → chat_template_kwargs mapping.
+  const serverFieldsRow = document.getElementById("model-server-fields-row");
+  if (serverFieldsRow) {
+    serverFieldsRow.hidden = provider === "anthropic-compatible";
+  }
 }
 
 /* Populate the model name datalist with known model prefixes for the

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6984,7 +6984,7 @@ function showEditModelModal(definitionId) {
       // "adaptive" keep thinking_mode in the raw capabilities JSON so it
       // isn't silently lost on save.  Both compat lanes round-trip the
       // dropdown: on anthropic-compatible it drives the effort-knob →
-      // chat_template_kwargs mapping (_compat_extra_params).
+      // chat_template_kwargs mapping (merge_reasoning_template_kwargs).
       const tmVal = capsObj.thinking_mode || "";
       const tmCaptured = tmVal === "" || tmVal === "manual";
       if (tmCaptured) {
@@ -7037,7 +7037,11 @@ function showEditModelModal(definitionId) {
       delete capsObj.server_compat;
       if (tmCaptured) {
         delete capsObj.thinking_mode;
-        delete capsObj.thinking_param;
+        // Strip thinking_param only when a mode value round-trips through
+        // the dropdown. With mode unset the save path writes neither key,
+        // so a stored thinking_param must stay in the raw JSON — deleting
+        // it here would silently drop it on the next unrelated edit-save.
+        if (tmVal) delete capsObj.thinking_param;
       }
       delete capsObj.effort_param;
       const capsText = JSON.stringify(capsObj, null, 2);
@@ -7113,7 +7117,8 @@ function submitCreateModel() {
   // Thinking mode → capabilities.  thinking_mode round-trips through the
   // dropdown for every provider, including anthropic-compatible (where
   // manual mode maps the session effort knob onto the template's
-  // thinking toggle via chat_template_kwargs — _compat_extra_params).
+  // thinking toggle via chat_template_kwargs —
+  // merge_reasoning_template_kwargs).
   const thinkingMode = document.getElementById("model-thinking-mode").value;
   if (thinkingMode) {
     caps.thinking_mode = thinkingMode;
@@ -7125,10 +7130,18 @@ function submitCreateModel() {
   // Effort param (graded chat-template effort key, e.g. gpt-oss
   // "reasoning_effort") round-trips like thinking_param: lifted out of
   // the raw JSON on edit-load, re-added here when the field is set.
-  const effortParam = document
-    .getElementById("model-effort-param")
-    .value.trim();
-  if (effortParam) caps.effort_param = effortParam;
+  // Gated on the local-server lanes (like the server_compat block
+  // below): the field is hidden for other providers, so a lingering
+  // value from a provider switch must never persist.
+  if (
+    providerVal === "openai-compatible" ||
+    providerVal === "anthropic-compatible"
+  ) {
+    const effortParam = document
+      .getElementById("model-effort-param")
+      .value.trim();
+    if (effortParam) caps.effort_param = effortParam;
+  }
 
   // Build server_compat from structured fields.  Only meaningful for the
   // compat lanes (openai-compatible: all fields; anthropic-compatible: the

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6980,13 +6980,14 @@ function showEditModelModal(definitionId) {
         ? capsObj.server_compat
         : {};
       // Only extract thinking_mode into the dropdown when the UI can
-      // represent it ("manual" or "").  Unrepresentable values like
-      // "adaptive" keep thinking_mode in the raw capabilities JSON so it
-      // isn't silently lost on save.  Both compat lanes round-trip the
-      // dropdown: on anthropic-compatible it drives the effort-knob →
-      // chat_template_kwargs mapping (merge_reasoning_template_kwargs).
+      // represent it ("", "manual" = effort-knob controlled, "adaptive" =
+      // always on).  Unrepresentable/garbage values keep thinking_mode in
+      // the raw capabilities JSON so they aren't silently lost on save.
+      // Both compat lanes round-trip the dropdown: it drives the
+      // effort-knob → chat_template_kwargs mapping
+      // (merge_reasoning_template_kwargs).
       const tmVal = capsObj.thinking_mode || "";
-      const tmCaptured = tmVal === "" || tmVal === "manual";
+      const tmCaptured = tmVal === "" || tmVal === "manual" || tmVal === "adaptive";
       if (tmCaptured) {
         document.getElementById("model-thinking-mode").value = tmVal;
         document.getElementById("model-thinking-param").value =

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6904,6 +6904,7 @@ function showCreateModelModal() {
   document.getElementById("model-thinking-mode").value = "";
   document.getElementById("model-thinking-param").value = "";
   document.getElementById("model-thinking-param-row").hidden = true;
+  document.getElementById("model-effort-param").value = "";
   document.getElementById("model-extra-body").value = "";
   document.getElementById("model-capabilities").value = "";
   // Clear validation error styling from prior submit attempts
@@ -6995,6 +6996,10 @@ function showEditModelModal(definitionId) {
         document.getElementById("model-thinking-param").value = "";
       }
       _toggleThinkingParam();
+      // effort_param is a plain string — always representable, so it lifts
+      // into its field unconditionally (stripped from the raw JSON below).
+      document.getElementById("model-effort-param").value =
+        capsObj.effort_param || "";
       // Server compat: server_type, api_surface, and extra_body workarounds
       document.getElementById("model-server-type").value = sc.server_type || "";
       document.getElementById("model-api-surface").value = sc.api_surface || "";
@@ -7034,6 +7039,7 @@ function showEditModelModal(definitionId) {
         delete capsObj.thinking_mode;
         delete capsObj.thinking_param;
       }
+      delete capsObj.effort_param;
       const capsText = JSON.stringify(capsObj, null, 2);
       document.getElementById("model-capabilities").value =
         capsText === "{}" ? "" : capsText;
@@ -7116,6 +7122,13 @@ function submitCreateModel() {
     const savedParam = document.getElementById("model-thinking-param").value;
     if (savedParam) caps.thinking_param = savedParam;
   }
+  // Effort param (graded chat-template effort key, e.g. gpt-oss
+  // "reasoning_effort") round-trips like thinking_param: lifted out of
+  // the raw JSON on edit-load, re-added here when the field is set.
+  const effortParam = document
+    .getElementById("model-effort-param")
+    .value.trim();
+  if (effortParam) caps.effort_param = effortParam;
 
   // Build server_compat from structured fields.  Only meaningful for the
   // compat lanes (openai-compatible: all fields; anthropic-compatible: the

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -432,6 +432,12 @@ function handleClusterEvent(data) {
     if (typeof _sklcInvalidateModelsCache === "function") {
       _sklcInvalidateModelsCache();
     }
+    if (typeof _sklcScheduleEffortLadder === "function") {
+      // Re-annotate from the fresh cache — an edited model's ladder
+      // would otherwise stay stale until the next keystroke in the
+      // launch-config form.
+      _sklcScheduleEffortLadder();
+    }
     if (
       typeof _adminTab !== "undefined" &&
       _adminTab === "models" &&

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -429,6 +429,9 @@ function handleClusterEvent(data) {
     if (typeof _populateHomeModelDropdowns === "function") {
       _populateHomeModelDropdowns();
     }
+    if (typeof _sklcInvalidateModelsCache === "function") {
+      _sklcInvalidateModelsCache();
+    }
     if (
       typeof _adminTab !== "undefined" &&
       _adminTab === "models" &&

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -1965,6 +1965,7 @@ function showEditTemplateModal(tmplId) {
   document.getElementById("skl-default").checked = tmpl.is_default;
   // Session config fields
   document.getElementById("sklc-model").value = tmpl.model || "";
+  _sklcScheduleEffortLadder();
   document.getElementById("sklc-temperature").value =
     tmpl.temperature != null ? tmpl.temperature : "";
   document.getElementById("sklc-reasoning-effort").value =
@@ -5044,3 +5045,43 @@ function _submitOGPShelf() {
       errEl.classList.add("is-visible");
     });
 }
+
+/* Effort-ladder annotation for the skill launch-config effort select.
+   Resolves the typed alias against /v1/api/models (each row carries a
+   server-computed effort_ladder) and reuses the page-global
+   _annotateEffortSelect from admin.js, which loads before this file. */
+let _sklcModelsPromise = null;
+let _sklcLadderTimer = null;
+function _sklcRefreshEffortLadder() {
+  const sel = document.getElementById("sklc-reasoning-effort");
+  const aliasEl = document.getElementById("sklc-model");
+  if (!sel || !aliasEl || typeof _annotateEffortSelect !== "function") return;
+  const alias = aliasEl.value.trim();
+  if (!alias) {
+    _annotateEffortSelect(sel, null);
+    return;
+  }
+  if (!_sklcModelsPromise) {
+    _sklcModelsPromise = authFetch("/v1/api/models").then(function (r) {
+      return r.json();
+    });
+  }
+  _sklcModelsPromise
+    .then(function (d) {
+      const row = (d.models || []).find(function (m) {
+        return m.alias === alias;
+      });
+      _annotateEffortSelect(sel, row ? row.effort_ladder : null);
+    })
+    .catch(function () {
+      /* silent — annotation only */
+    });
+}
+function _sklcScheduleEffortLadder() {
+  clearTimeout(_sklcLadderTimer);
+  _sklcLadderTimer = setTimeout(_sklcRefreshEffortLadder, 400);
+}
+(function () {
+  const el = document.getElementById("sklc-model");
+  if (el) el.addEventListener("input", _sklcScheduleEffortLadder);
+})();

--- a/turnstone/console/static/governance.js
+++ b/turnstone/console/static/governance.js
@@ -5052,6 +5052,11 @@ function _submitOGPShelf() {
    _annotateEffortSelect from admin.js, which loads before this file. */
 let _sklcModelsPromise = null;
 let _sklcLadderTimer = null;
+/* Called from app.js on the models_changed SSE event so edited/added
+   models don't serve a stale ladder until page reload. */
+function _sklcInvalidateModelsCache() {
+  _sklcModelsPromise = null;
+}
 function _sklcRefreshEffortLadder() {
   const sel = document.getElementById("sklc-reasoning-effort");
   const aliasEl = document.getElementById("sklc-model");
@@ -5062,9 +5067,16 @@ function _sklcRefreshEffortLadder() {
     return;
   }
   if (!_sklcModelsPromise) {
-    _sklcModelsPromise = authFetch("/v1/api/models").then(function (r) {
-      return r.json();
-    });
+    _sklcModelsPromise = authFetch("/v1/api/models")
+      .then(function (r) {
+        return r.json();
+      })
+      .catch(function (e) {
+        // A cached rejection would block every retry (the truthy guard
+        // above) — reset so the next keystroke can refetch.
+        _sklcModelsPromise = null;
+        throw e;
+      });
   }
   _sklcModelsPromise
     .then(function (d) {
@@ -5079,7 +5091,7 @@ function _sklcRefreshEffortLadder() {
 }
 function _sklcScheduleEffortLadder() {
   clearTimeout(_sklcLadderTimer);
-  _sklcLadderTimer = setTimeout(_sklcRefreshEffortLadder, 400);
+  _sklcLadderTimer = setTimeout(_sklcRefreshEffortLadder, 500);
 }
 (function () {
   const el = document.getElementById("sklc-model");

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1903,7 +1903,7 @@
                   <textarea
                     id="model-capabilities"
                     rows="3"
-                    placeholder='{"max_output_tokens": 32000}'
+                    placeholder='{"max_output_tokens": 32000, "reasoning_effort_values": ["low", "high"], "default_reasoning_effort": "low"}'
                   ></textarea>
                 </div>
               </details>

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1771,7 +1771,8 @@
                   >
                   <select id="model-thinking-mode">
                     <option value="">None</option>
-                    <option value="manual">Enabled</option>
+                    <option value="manual">Effort-knob controlled</option>
+                    <option value="adaptive">Always on</option>
                   </select>
                   <div id="model-thinking-param-row" hidden>
                     <label for="model-thinking-param"

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1789,6 +1789,21 @@
                     />
                   </div>
                 </div>
+                <div id="model-effort-param-row">
+                  <label for="model-effort-param"
+                    >Effort param
+                    <span class="label-hint"
+                      >chat-template key for graded effort — empty = template
+                      has none</span
+                    ></label
+                  >
+                  <input
+                    type="text"
+                    id="model-effort-param"
+                    class="sh-mono"
+                    placeholder="e.g. reasoning_effort (gpt-oss)"
+                  />
+                </div>
                 <label for="model-extra-body"
                   >Extra body params
                   <span class="label-hint"

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -78,6 +78,12 @@ _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_bm25"
 # bodies byte-identical when a caller threads thinking overrides.
 _INTERNAL_EXTRA_PARAMS = frozenset({"thinking_budget_tokens"})
 
+# Manual-mode thinking budgets per effort knob level; knob values outside
+# the map (minimal, xhigh, max) fall back to the default budget.  Shared
+# with ``effort_ladder`` so UI projections can't drift from the wire.
+_EFFORT_BUDGET_MAP = {"low": 1024, "medium": 4096, "high": 16384}
+_DEFAULT_THINKING_BUDGET = 4096
+
 # -- model capabilities -------------------------------------------------------
 
 _ANTHROPIC_DEFAULT = ModelCapabilities(
@@ -778,8 +784,7 @@ class AnthropicProvider:
         """
         if not reasoning_effort or reasoning_effort in ("none", ""):
             return {}
-        budget_map = {"low": 1024, "medium": 4096, "high": 16384}
-        budget = budget_map.get(reasoning_effort, 4096)
+        budget = _EFFORT_BUDGET_MAP.get(reasoning_effort, _DEFAULT_THINKING_BUDGET)
         if extra_params and "thinking_budget_tokens" in extra_params:
             budget = extra_params["thinking_budget_tokens"]
         if budget > 0:

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -201,13 +201,37 @@ _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_pdf=True,
         supports_reasoning_replay=True,
     ),
-    "claude-sonnet-4-6": ModelCapabilities(
+    # Sonnet 5: adaptive thinking is on by default (explicit adaptive config
+    # accepted; manual budget_tokens is a 400); unlike Fable 5, an explicit
+    # thinking={"type": "disabled"} IS accepted.  Non-default sampling params
+    # (temperature/top_p/top_k) are a 400, same as Opus 4.8 / Fable 5.
+    # Effort: full ladder incl. xhigh + max; API default is high
+    # (platform.claude.com/docs/en/build-with-claude/effort, 2026-07 check).
+    "claude-sonnet-5": ModelCapabilities(
         context_window=1000000,
-        max_output_tokens=64000,
+        max_output_tokens=128000,
         token_param="max_tokens",
         thinking_mode="adaptive",
         supports_effort=True,
-        effort_levels=("low", "medium", "high"),
+        effort_levels=("low", "medium", "high", "xhigh", "max"),
+        supports_web_search=True,
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_pdf=True,
+        supports_temperature=False,
+        thinking_display="summarized",
+        supports_reasoning_replay=True,
+    ),
+    # Sonnet 4.6: effort ladder tops at max (no xhigh — that level exists
+    # only on Fable 5 / Sonnet 5 / Opus 4.7+); knob xhigh rides max via the
+    # ordinal snap.
+    "claude-sonnet-4-6": ModelCapabilities(
+        context_window=1000000,
+        max_output_tokens=128000,
+        token_param="max_tokens",
+        thinking_mode="adaptive",
+        supports_effort=True,
+        effort_levels=("low", "medium", "high", "max"),
         supports_web_search=True,
         supports_tool_search=True,
         supports_vision=True,

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -79,10 +79,11 @@ _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_bm25"
 _INTERNAL_EXTRA_PARAMS = frozenset({"thinking_budget_tokens"})
 
 # Manual-mode thinking budgets per effort knob level; knob values outside
-# the map (minimal, xhigh, max) fall back to the default budget.  Shared
-# with ``effort_ladder`` so UI projections can't drift from the wire.
-_EFFORT_BUDGET_MAP = {"low": 1024, "medium": 4096, "high": 16384}
-_DEFAULT_THINKING_BUDGET = 4096
+# the map (minimal, xhigh, max) fall back to the default budget.  Public:
+# shared with ``effort_ladder`` so UI projections can't drift from the
+# wire.
+EFFORT_BUDGET_MAP = {"low": 1024, "medium": 4096, "high": 16384}
+DEFAULT_THINKING_BUDGET = 4096
 
 # -- model capabilities -------------------------------------------------------
 
@@ -784,7 +785,7 @@ class AnthropicProvider:
         """
         if not reasoning_effort or reasoning_effort in ("none", ""):
             return {}
-        budget = _EFFORT_BUDGET_MAP.get(reasoning_effort, _DEFAULT_THINKING_BUDGET)
+        budget = EFFORT_BUDGET_MAP.get(reasoning_effort, DEFAULT_THINKING_BUDGET)
         if extra_params and "thinking_budget_tokens" in extra_params:
             budget = extra_params["thinking_budget_tokens"]
         if budget > 0:

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -20,7 +20,7 @@ from turnstone.core.providers._protocol import (
     UsageInfo,
     _join_reasoning_with_cap,
     _lookup_capabilities,
-    resolve_reasoning_effort,
+    merge_reasoning_template_kwargs,
 )
 from turnstone.core.trajectory import materialize_attachments
 
@@ -95,7 +95,7 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 # token_param must be "max_tokens" (the only token param the endpoint
 # accepts); the "thinking" request param is not consumed by vLLM — the
 # reasoning levers ride chat_template_kwargs via extra_body instead
-# (``_compat_extra_params``).  thinking_mode defaults to "none" = inject
+# (``merge_reasoning_template_kwargs``).  thinking_mode defaults to "none" = inject
 # nothing, the server's template default reigns; per-model capabilities
 # opt into the effort-knob-driven toggle with thinking_mode="manual" +
 # thinking_param (plus a graded effort key via effort_param where the
@@ -351,53 +351,6 @@ class AnthropicProvider:
 
     # -- shared param logic --------------------------------------------------
 
-    def _compat_extra_params(
-        self,
-        caps: ModelCapabilities,
-        reasoning_effort: str,
-        extra_params: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        """Fold reasoning control into ``chat_template_kwargs`` (compat lane).
-
-        The reasoning levers on Anthropic-compatible local servers live in
-        the chat template, reached via ``extra_body["chat_template_kwargs"]``
-        — vLLM's ``/v1/messages`` accepts it as a first-class request field.
-
-        Mirrors the native manual-mode contract of ``_reasoning_params``:
-        effort ``"none"``/empty disables thinking, any other level enables
-        it — so the session effort knob drives the template toggle
-        (``caps.thinking_param``) whenever ``caps.thinking_mode`` is
-        ``"manual"`` or ``"adaptive"``.  Templates with a graded effort key
-        (``caps.effort_param``, gpt-oss-style) additionally receive the
-        resolved effort value.  With ``thinking_mode="none"`` and no
-        ``effort_param`` (the untouched-capabilities default) nothing is
-        injected and the server's template default reigns, as before.
-
-        Operator ``server_compat`` entries win on key collision; the
-        caller's dict is never mutated.
-        """
-        updates: dict[str, Any] = {}
-        effort_on = bool(reasoning_effort) and reasoning_effort != "none"
-        if caps.thinking_mode in ("manual", "adaptive"):
-            updates[caps.thinking_param] = effort_on
-        if caps.effort_param and effort_on:
-            effort = (
-                resolve_reasoning_effort(caps, reasoning_effort)
-                if caps.reasoning_effort_values
-                else reasoning_effort
-            )
-            if effort:
-                updates[caps.effort_param] = effort
-        if not updates:
-            return extra_params
-        merged = dict(extra_params) if extra_params else {}
-        raw_ctk = merged.get("chat_template_kwargs")
-        ctk = dict(raw_ctk) if isinstance(raw_ctk, dict) else {}
-        for key, value in updates.items():
-            ctk.setdefault(key, value)
-        merged["chat_template_kwargs"] = ctk
-        return merged
-
     def _build_thinking_and_kwargs(
         self,
         caps: ModelCapabilities,
@@ -419,7 +372,7 @@ class AnthropicProvider:
             # to 1.0 — reasoning control rides chat_template_kwargs instead,
             # folded into extra_params here so the extra_body forwarding
             # below carries it to the wire.
-            extra_params = self._compat_extra_params(caps, reasoning_effort, extra_params)
+            extra_params = merge_reasoning_template_kwargs(caps, reasoning_effort, extra_params)
         elif caps.thinking_mode == "adaptive":
             thinking_dict: dict[str, Any] = {"type": "adaptive"}
             if caps.thinking_display:

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -21,6 +21,7 @@ from turnstone.core.providers._protocol import (
     _join_reasoning_with_cap,
     _lookup_capabilities,
     merge_reasoning_template_kwargs,
+    snap_reasoning_effort,
 )
 from turnstone.core.trajectory import materialize_attachments
 
@@ -78,11 +79,21 @@ _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_bm25"
 # bodies byte-identical when a caller threads thinking overrides.
 _INTERNAL_EXTRA_PARAMS = frozenset({"thinking_budget_tokens"})
 
-# Manual-mode thinking budgets per effort knob level; knob values outside
-# the map (minimal, xhigh, max) fall back to the default budget.  Public:
-# shared with ``effort_ladder`` so UI projections can't drift from the
-# wire.
-EFFORT_BUDGET_MAP = {"low": 1024, "medium": 4096, "high": 16384}
+# Manual-mode thinking budgets per effort knob level — monotone over the
+# whole knob domain (a higher knob position must never buy a smaller
+# budget; the request path still clamps below per-request max_tokens).
+# minimal shares the 1024 floor with low: the API rejects budgets under
+# 1024, so there is no smaller tier to express.  Unknown strings (custom
+# configs) fall back to the default budget.  Public: shared with
+# ``effort_ladder`` so UI projections can't drift from the wire.
+EFFORT_BUDGET_MAP = {
+    "minimal": 1024,
+    "low": 1024,
+    "medium": 4096,
+    "high": 16384,
+    "xhigh": 32768,
+    "max": 65536,
+}
 DEFAULT_THINKING_BUDGET = 4096
 
 # -- model capabilities -------------------------------------------------------
@@ -242,12 +253,19 @@ def _map_reasoning_to_effort(
     reasoning_effort: str,
     valid_levels: tuple[str, ...],
 ) -> str | None:
-    """Map turnstone reasoning_effort to Anthropic effort parameter."""
-    mapping = {"low": "low", "medium": "medium", "high": "high", "xhigh": "xhigh", "max": "max"}
-    effort = mapping.get(reasoning_effort)
-    if effort and effort in valid_levels:
-        return effort
-    return None
+    """Map turnstone reasoning_effort to Anthropic effort parameter.
+
+    Declared levels match verbatim; off-list knob values round up onto
+    the declared levels, capped at their ceiling (a knob above the
+    model's top level must ride the top level, not silently drop
+    output_config).  "none"/empty and unrankable strings return None —
+    no effort param.
+    """
+    if not reasoning_effort or reasoning_effort == "none":
+        return None
+    if reasoning_effort in valid_levels:
+        return reasoning_effort
+    return snap_reasoning_effort(reasoning_effort, valid_levels)
 
 
 # Anthropic accepts only a closed set of content-block types on the

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -20,6 +20,7 @@ from turnstone.core.providers._protocol import (
     UsageInfo,
     _join_reasoning_with_cap,
     _lookup_capabilities,
+    resolve_reasoning_effort,
 )
 from turnstone.core.trajectory import materialize_attachments
 
@@ -93,13 +94,17 @@ _ANTHROPIC_DEFAULT = ModelCapabilities(
 # Anthropic-compatible local servers (vLLM's /v1/messages endpoint):
 # token_param must be "max_tokens" (the only token param the endpoint
 # accepts); the "thinking" request param is not consumed by vLLM — the
-# reasoning toggle rides chat_template_kwargs via extra_body, so
-# thinking_mode stays "none"; supports_reasoning_replay stays True even
-# so, because the endpoint emits and round-trips thinking blocks whenever
-# the chat template enables reasoning (the request param is simply not
-# the switch); native web_search / tool_search server-tool types 400 on
-# vLLM (tools require input_schema); vision is opt-in per model.
-# supports_temperature stays True via the dataclass default.
+# reasoning levers ride chat_template_kwargs via extra_body instead
+# (``_compat_extra_params``).  thinking_mode defaults to "none" = inject
+# nothing, the server's template default reigns; per-model capabilities
+# opt into the effort-knob-driven toggle with thinking_mode="manual" +
+# thinking_param (plus a graded effort key via effort_param where the
+# template has one).  supports_reasoning_replay stays True even at
+# "none", because the endpoint emits and round-trips thinking blocks
+# whenever the chat template enables reasoning (the request param is
+# simply not the switch); native web_search / tool_search server-tool
+# types 400 on vLLM (tools require input_schema); vision is opt-in per
+# model.  supports_temperature stays True via the dataclass default.
 _ANTHROPIC_COMPAT_DEFAULT = ModelCapabilities(
     context_window=200000,
     max_output_tokens=64000,
@@ -346,6 +351,53 @@ class AnthropicProvider:
 
     # -- shared param logic --------------------------------------------------
 
+    def _compat_extra_params(
+        self,
+        caps: ModelCapabilities,
+        reasoning_effort: str,
+        extra_params: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Fold reasoning control into ``chat_template_kwargs`` (compat lane).
+
+        The reasoning levers on Anthropic-compatible local servers live in
+        the chat template, reached via ``extra_body["chat_template_kwargs"]``
+        — vLLM's ``/v1/messages`` accepts it as a first-class request field.
+
+        Mirrors the native manual-mode contract of ``_reasoning_params``:
+        effort ``"none"``/empty disables thinking, any other level enables
+        it — so the session effort knob drives the template toggle
+        (``caps.thinking_param``) whenever ``caps.thinking_mode`` is
+        ``"manual"`` or ``"adaptive"``.  Templates with a graded effort key
+        (``caps.effort_param``, gpt-oss-style) additionally receive the
+        resolved effort value.  With ``thinking_mode="none"`` and no
+        ``effort_param`` (the untouched-capabilities default) nothing is
+        injected and the server's template default reigns, as before.
+
+        Operator ``server_compat`` entries win on key collision; the
+        caller's dict is never mutated.
+        """
+        updates: dict[str, Any] = {}
+        effort_on = bool(reasoning_effort) and reasoning_effort != "none"
+        if caps.thinking_mode in ("manual", "adaptive"):
+            updates[caps.thinking_param] = effort_on
+        if caps.effort_param and effort_on:
+            effort = (
+                resolve_reasoning_effort(caps, reasoning_effort)
+                if caps.reasoning_effort_values
+                else reasoning_effort
+            )
+            if effort:
+                updates[caps.effort_param] = effort
+        if not updates:
+            return extra_params
+        merged = dict(extra_params) if extra_params else {}
+        raw_ctk = merged.get("chat_template_kwargs")
+        ctk = dict(raw_ctk) if isinstance(raw_ctk, dict) else {}
+        for key, value in updates.items():
+            ctk.setdefault(key, value)
+        merged["chat_template_kwargs"] = ctk
+        return merged
+
     def _build_thinking_and_kwargs(
         self,
         caps: ModelCapabilities,
@@ -361,7 +413,14 @@ class AnthropicProvider:
     ) -> dict[str, Any]:
         """Build the full kwargs dict with thinking mode and effort params."""
         thinking_params: dict[str, Any] = {}
-        if caps.thinking_mode == "adaptive":
+        if self._compat:
+            # vLLM's /v1/messages has no ``thinking`` field in its request
+            # schema (silently dropped) and must not have temperature forced
+            # to 1.0 — reasoning control rides chat_template_kwargs instead,
+            # folded into extra_params here so the extra_body forwarding
+            # below carries it to the wire.
+            extra_params = self._compat_extra_params(caps, reasoning_effort, extra_params)
+        elif caps.thinking_mode == "adaptive":
             thinking_dict: dict[str, Any] = {"type": "adaptive"}
             if caps.thinking_display:
                 thinking_dict["display"] = caps.thinking_display
@@ -393,8 +452,11 @@ class AnthropicProvider:
             kwargs["tools"] = anthropic_tools
         kwargs.update(thinking_params)
 
-        # Effort param for models that support it (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5)
-        if caps.supports_effort and reasoning_effort:
+        # Effort param for models that support it (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5).
+        # Never on the compat lane: ``output_config`` is not in vLLM's request
+        # schema — graded effort there is ``caps.effort_param`` via
+        # chat_template_kwargs.
+        if not self._compat and caps.supports_effort and reasoning_effort:
             effort = _map_reasoning_to_effort(reasoning_effort, caps.effort_levels)
             if effort:
                 kwargs["output_config"] = {"effort": effort}

--- a/turnstone/core/providers/_google.py
+++ b/turnstone/core/providers/_google.py
@@ -43,6 +43,19 @@ _GOOGLE_DEFAULT = ModelCapabilities(
     # Gemini's OpenAI-compat endpoint accepts max_tokens (not
     # max_completion_tokens which is OpenAI Responses-specific).
     token_param="max_tokens",
+    # Gemini's OpenAI-compat endpoint accepts a flat ``reasoning_effort``
+    # (2.5 family: thinking_budget 1024/1024/8192/24576 for minimal/low/
+    # medium/high; 3.x family: thinking_level of the same name).  The
+    # declared values are the safe set across ALL current Gemini models:
+    # "none" is excluded because 2.5 Pro and the 3.x family reject
+    # disabling thinking — and ``resolve_reasoning_effort`` never
+    # forwards the knob's "none" anyway (the param is omitted and the
+    # server default applies).  Off-list knob values (xhigh, max) snap
+    # to the default "high".  Encoded from
+    # ai.google.dev/gemini-api/docs/openai (2026-07); not live-verified —
+    # the static-caps pattern for commercial providers.
+    reasoning_effort_values=("minimal", "low", "medium", "high"),
+    default_reasoning_effort="high",
 )
 
 

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -29,6 +29,7 @@ from turnstone.core.providers._protocol import (
     StreamChunk,
     ToolCallDelta,
     _join_reasoning_with_cap,
+    merge_reasoning_template_kwargs,
 )
 from turnstone.core.trajectory import materialize_attachments
 
@@ -117,49 +118,25 @@ class OpenAIChatCompletionsProvider:
 
     # -- thinking mode -------------------------------------------------------
 
-    @staticmethod
-    def _apply_thinking_mode(
-        extra_body: dict[str, Any],
-        caps: ModelCapabilities,
-    ) -> None:
-        """Inject thinking-mode params into *extra_body* based on capabilities.
-
-        When ``caps.thinking_mode`` is ``"manual"`` or ``"adaptive"``, sets
-        the model-family-specific key (``caps.thinking_param``, e.g.
-        ``"enable_thinking"`` or ``"thinking"``) to ``True`` inside
-        ``extra_body["chat_template_kwargs"]``.
-
-        Does nothing when thinking mode is ``"none"`` or the key is already
-        present (operator override via ``extra_body`` takes precedence).
-        """
-        if caps.thinking_mode == "none":
-            return
-        ctk = extra_body.get("chat_template_kwargs")
-        if not isinstance(ctk, dict):
-            ctk = {}
-            extra_body["chat_template_kwargs"] = ctk
-        if caps.thinking_param not in ctk:
-            ctk[caps.thinking_param] = True
-
     def _finalize_extra_body(
         self,
         extra_params: dict[str, Any] | None,
         caps: ModelCapabilities,
+        reasoning_effort: str,
     ) -> dict[str, Any] | None:
-        """Build the final ``extra_body``, injecting thinking params if needed.
+        """Build the final ``extra_body``, injecting reasoning params if needed.
 
-        Returns ``None`` when the result would be empty (no extra_body needed).
-        Shallow-copies *extra_params* and its ``chat_template_kwargs`` so the
-        caller's dict is never mutated.
+        ``merge_reasoning_template_kwargs`` maps the session effort knob onto
+        the template's thinking toggle (``caps.thinking_param``, active when
+        ``thinking_mode`` is manual/adaptive — effort ``"none"`` sends
+        ``false``) and the graded effort key (``caps.effort_param``) inside
+        ``chat_template_kwargs``.  Keys the operator already pinned via
+        ``server_compat`` win; the caller's dict is never mutated.
+
+        Returns ``None`` when the result would be empty (no extra_body
+        needed).
         """
-        eb: dict[str, Any] = {}
-        if extra_params:
-            eb = dict(extra_params)
-            ctk = eb.get("chat_template_kwargs")
-            if isinstance(ctk, dict):
-                eb["chat_template_kwargs"] = dict(ctk)
-        self._apply_thinking_mode(eb, caps)
-        return eb or None
+        return merge_reasoning_template_kwargs(caps, reasoning_effort, extra_params) or None
 
     # -- streaming -----------------------------------------------------------
 
@@ -203,7 +180,7 @@ class OpenAIChatCompletionsProvider:
         tools = apply_tool_search(caps, tools, deferred_names)
         if tools:
             kwargs["tools"] = tools
-        extra_body = self._finalize_extra_body(extra_params, caps)
+        extra_body = self._finalize_extra_body(extra_params, caps, reasoning_effort)
         if extra_body:
             kwargs["extra_body"] = extra_body
         if extra_headers:
@@ -338,7 +315,7 @@ class OpenAIChatCompletionsProvider:
         tools = apply_tool_search(caps, tools, deferred_names)
         if tools:
             kwargs["tools"] = tools
-        extra_body = self._finalize_extra_body(extra_params, caps)
+        extra_body = self._finalize_extra_body(extra_params, caps, reasoning_effort)
         if extra_body:
             kwargs["extra_body"] = extra_body
         if extra_headers:

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -18,6 +18,7 @@ from turnstone.core.providers._protocol import (
     ModelCapabilities,
     UsageInfo,
     _lookup_capabilities,
+    flat_effort_suppressed,
     resolve_reasoning_effort,
 )
 
@@ -296,15 +297,13 @@ def apply_temperature_and_effort(
 ) -> None:
     """Conditionally add temperature and reasoning_effort to *kwargs*.
 
-    Chat Completions API version — reasoning effort is a flat parameter.
-    A set ``caps.effort_param`` declares the chat-template channel
-    (``chat_template_kwargs`` via ``merge_reasoning_template_kwargs``) as
-    the one this server consumes, so the flat param is suppressed: sending
-    both would 400 on servers that reject unknown top-level fields and
-    can disagree with an operator ``server_compat`` pin on tolerant ones.
+    Chat Completions API version — reasoning effort is a flat parameter,
+    suppressed when a declared ``caps.effort_param`` claims the
+    chat-template channel instead (see ``flat_effort_suppressed`` for the
+    rationale; the effort-ladder projection shares the same predicate).
     """
     apply_temperature(kwargs, caps, temperature, reasoning_effort)
-    if caps.effort_param:
+    if flat_effort_suppressed(caps):
         return
     effort = resolve_reasoning_effort(caps, reasoning_effort)
     if effort:

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -81,6 +81,18 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_pdf=True,
         supports_reasoning_replay=True,
     ),
+    # GPT-5.1 codex-max — the model xhigh was introduced on; without this
+    # row it would prefix-match "gpt-5.1" (no xhigh) and the knob's xhigh
+    # would wrongly cap at high.  Responses-only, supports explicit none.
+    "gpt-5.1-codex-max": ModelCapabilities(
+        context_window=400000,
+        max_output_tokens=128000,
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        default_reasoning_effort="medium",
+        supports_vision=True,
+        supports_pdf=True,
+        supports_reasoning_replay=True,
+    ),
     # GPT-5.2 — adds xhigh
     "gpt-5.2": ModelCapabilities(
         context_window=400000,
@@ -135,12 +147,14 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_pdf=True,
         supports_reasoning_replay=True,
     ),
-    # GPT-5.5 — 1M context, native tool search, stronger agentic/tool use
+    # GPT-5.5 — 1M context, native tool search, stronger agentic/tool use.
+    # Unlike 5.1-5.4 (default none), 5.5 defaults to MEDIUM reasoning per
+    # developers.openai.com/api/docs/guides/latest-model (2026-07 check).
     "gpt-5.5": ModelCapabilities(
         context_window=1050000,
         max_output_tokens=128000,
         reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
-        default_reasoning_effort="none",
+        default_reasoning_effort="medium",
         supports_tool_search=True,
         supports_vision=True,
         supports_pdf=True,
@@ -164,6 +178,8 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         max_output_tokens=100000,
         supports_temperature=False,
         supports_streaming=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
@@ -177,10 +193,15 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_pdf=True,
         supports_reasoning_replay=True,
     ),
+    # low/medium/high on every o-series model EXCEPT o1-mini (Azure
+    # reasoning guide, 2026-06 revision) — without declared values the
+    # session knob was silently dropped for these models.
     "o3": ModelCapabilities(
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
@@ -189,6 +210,8 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
@@ -198,6 +221,8 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         max_output_tokens=100000,
         supports_temperature=False,
         supports_streaming=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
@@ -206,6 +231,8 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         context_window=200000,
         max_output_tokens=100000,
         supports_temperature=False,
+        reasoning_effort_values=("low", "medium", "high"),
+        default_reasoning_effort="medium",
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -18,6 +18,7 @@ from turnstone.core.providers._protocol import (
     ModelCapabilities,
     UsageInfo,
     _lookup_capabilities,
+    resolve_reasoning_effort,
 )
 
 log = structlog.get_logger(__name__)
@@ -285,20 +286,6 @@ def apply_temperature(
     if "none" in caps.reasoning_effort_values and reasoning_effort not in ("none", ""):
         return  # Skip temperature when reasoning is active
     kwargs["temperature"] = temperature
-
-
-def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> str | None:
-    """Return the validated reasoning effort value, or ``None`` to omit.
-
-    Validates against supported values and falls back to model default.
-    """
-    if not caps.reasoning_effort_values or not reasoning_effort or reasoning_effort == "none":
-        return None
-    if reasoning_effort in caps.reasoning_effort_values:
-        return reasoning_effort
-    if caps.default_reasoning_effort and caps.default_reasoning_effort != "none":
-        return caps.default_reasoning_effort
-    return None
 
 
 def apply_temperature_and_effort(

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -297,8 +297,15 @@ def apply_temperature_and_effort(
     """Conditionally add temperature and reasoning_effort to *kwargs*.
 
     Chat Completions API version — reasoning effort is a flat parameter.
+    A set ``caps.effort_param`` declares the chat-template channel
+    (``chat_template_kwargs`` via ``merge_reasoning_template_kwargs``) as
+    the one this server consumes, so the flat param is suppressed: sending
+    both would 400 on servers that reject unknown top-level fields and
+    can disagree with an operator ``server_compat`` pin on tolerant ones.
     """
     apply_temperature(kwargs, caps, temperature, reasoning_effort)
+    if caps.effort_param:
+        return
     effort = resolve_reasoning_effort(caps, reasoning_effort)
     if effort:
         kwargs["reasoning_effort"] = effort

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -24,7 +24,6 @@ from turnstone.core.providers._openai_common import (
     format_citations,
     format_document_wrapper,
     lookup_openai_capabilities,
-    resolve_reasoning_effort,
     resolve_server_side_tools,
     sanitize_messages,
 )
@@ -34,6 +33,7 @@ from turnstone.core.providers._protocol import (
     StreamChunk,
     ToolCallDelta,
     _join_reasoning_with_cap,
+    resolve_reasoning_effort,
 )
 from turnstone.core.trajectory import materialize_attachments
 

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -161,6 +161,22 @@ def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> 
     return None
 
 
+def flat_effort_suppressed(caps: ModelCapabilities) -> bool:
+    """True when the flat ``reasoning_effort`` param must NOT be sent.
+
+    A set ``caps.effort_param`` declares the chat-template channel
+    (``chat_template_kwargs`` via ``merge_reasoning_template_kwargs``) as
+    the one this server consumes for graded effort, so the flat param is
+    suppressed: sending both would 400 on servers that reject unknown
+    top-level fields and can disagree with an operator ``server_compat``
+    pin on tolerant ones.  Single source of the rule — the request path
+    (``apply_temperature_and_effort``) and the effort-ladder projection
+    must apply the same predicate or the UI annotates behavior the wire
+    doesn't have.
+    """
+    return bool(caps.effort_param)
+
+
 def reasoning_template_kwargs(
     caps: ModelCapabilities,
     reasoning_effort: str,

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -183,9 +183,19 @@ def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> 
     the declared list, capped at its ceiling (``snap_reasoning_effort``).
     ``default_reasoning_effort`` is the last resort for values the
     ordinal snap cannot rank (custom strings on either side).
+
+    The knob's ``"none"`` position means "no reasoning": it is forwarded
+    verbatim ONLY when the model declares an explicit ``"none"`` level
+    (gpt-5.1+, grok-4.3) — omitting the param there would leave the
+    server default (possibly reasoning ON, e.g. gpt-5.5's ``medium``) in
+    charge of a knob that promises off.  Models without a declared
+    ``"none"`` get the param omitted, and ``"none"`` is never a snap
+    target for other knob positions.
     """
-    if not caps.reasoning_effort_values or not reasoning_effort or reasoning_effort == "none":
+    if not caps.reasoning_effort_values or not reasoning_effort:
         return None
+    if reasoning_effort == "none":
+        return "none" if "none" in caps.reasoning_effort_values else None
     if reasoning_effort in caps.reasoning_effort_values:
         return reasoning_effort
     snapped = snap_reasoning_effort(reasoning_effort, caps.reasoning_effort_values)

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -74,11 +74,21 @@ class ModelCapabilities:
     supports_tools: bool = True
     token_param: str = "max_completion_tokens"
     thinking_mode: str = "none"  # "none" | "manual" | "adaptive"
-    # For openai-compatible servers: the chat_template_kwargs key that
-    # toggles thinking (e.g. "enable_thinking" for Gemma/Qwen,
-    # "thinking" for Granite/DeepSeek).  Ignored when thinking_mode is
-    # "none" or by providers that handle thinking natively (Anthropic).
+    # For local-server lanes (openai-compatible, anthropic-compatible):
+    # the chat_template_kwargs key that toggles thinking (e.g.
+    # "enable_thinking" for Gemma/Qwen, "thinking" for Granite/DeepSeek).
+    # Ignored when thinking_mode is "none" or by providers that handle
+    # thinking natively (real Anthropic).
     thinking_param: str = "enable_thinking"
+    # For the anthropic-compatible lane: the chat_template_kwargs key that
+    # carries a graded reasoning-effort value, for templates that have one
+    # (e.g. "reasoning_effort" for gpt-oss-style templates).  Empty = the
+    # template has no effort lever, send nothing.  The session knob value
+    # is validated against ``reasoning_effort_values`` when that is
+    # non-empty (off-list values snap to ``default_reasoning_effort``);
+    # with no declared values the knob is forwarded as-is and the template
+    # is the authority on validity.
+    effort_param: str = ""
     supports_effort: bool = False
     effort_levels: tuple[str, ...] = ()
     reasoning_effort_values: tuple[str, ...] = ()
@@ -134,6 +144,20 @@ class ModelCapabilities:
     rerank_threshold: float = 0.0
     rerank_scale: str = ""
     rerank_separated: bool = False
+
+
+def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> str | None:
+    """Return the validated reasoning effort value, or ``None`` to omit.
+
+    Validates against supported values and falls back to model default.
+    """
+    if not caps.reasoning_effort_values or not reasoning_effort or reasoning_effort == "none":
+        return None
+    if reasoning_effort in caps.reasoning_effort_values:
+        return reasoning_effort
+    if caps.default_reasoning_effort and caps.default_reasoning_effort != "none":
+        return caps.default_reasoning_effort
+    return None
 
 
 # Operator-friendly UI cap on reasoning text returned from

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -203,18 +203,18 @@ def merge_reasoning_template_kwargs(
     reasoning_effort: str,
     extra_params: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Copy-on-write merge of ``reasoning_template_kwargs`` into extra params.
+    """Merge ``reasoning_template_kwargs`` into a copy of the extra params.
 
-    Returns *extra_params* unchanged (possibly ``None``) when the
-    capabilities call for no injection; otherwise returns a new dict with
-    the reasoning entries folded into ``chat_template_kwargs``.  Existing
-    keys win — an operator ``server_compat`` pin beats the knob mapping.
-    The caller's dict (and its ``chat_template_kwargs`` sub-dict) is never
-    mutated.
+    Returns a new top-level dict whenever *extra_params* is non-empty or
+    an injection applies (``None`` stays ``None`` when there is nothing
+    to inject) — callers may attach the result to a request without
+    aliasing the session's dict.  Existing keys win — an operator
+    ``server_compat`` pin beats the knob mapping.  The caller's dict
+    (and its ``chat_template_kwargs`` sub-dict) is never mutated.
     """
     updates = reasoning_template_kwargs(caps, reasoning_effort)
     if not updates:
-        return extra_params
+        return dict(extra_params) if extra_params else extra_params
     merged = dict(extra_params) if extra_params else {}
     raw_ctk = merged.get("chat_template_kwargs")
     ctk = dict(raw_ctk) if isinstance(raw_ctk, dict) else {}

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -80,14 +80,15 @@ class ModelCapabilities:
     # Ignored when thinking_mode is "none" or by providers that handle
     # thinking natively (real Anthropic).
     thinking_param: str = "enable_thinking"
-    # For the anthropic-compatible lane: the chat_template_kwargs key that
-    # carries a graded reasoning-effort value, for templates that have one
-    # (e.g. "reasoning_effort" for gpt-oss-style templates).  Empty = the
-    # template has no effort lever, send nothing.  The session knob value
-    # is validated against ``reasoning_effort_values`` when that is
-    # non-empty (off-list values snap to ``default_reasoning_effort``);
-    # with no declared values the knob is forwarded as-is and the template
-    # is the authority on validity.
+    # For local-server lanes (openai-compatible, anthropic-compatible):
+    # the chat_template_kwargs key that carries a graded reasoning-effort
+    # value, for templates that have one (e.g. "reasoning_effort" for
+    # gpt-oss-style templates).  Empty = the template has no effort lever,
+    # send nothing.  The session knob value is validated against
+    # ``reasoning_effort_values`` when that is non-empty (off-list values
+    # snap to ``default_reasoning_effort``); with no declared values the
+    # knob is forwarded as-is and the template is the authority on
+    # validity.  See ``reasoning_template_kwargs``.
     effort_param: str = ""
     supports_effort: bool = False
     effort_levels: tuple[str, ...] = ()
@@ -158,6 +159,64 @@ def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> 
     if caps.default_reasoning_effort and caps.default_reasoning_effort != "none":
         return caps.default_reasoning_effort
     return None
+
+
+def reasoning_template_kwargs(
+    caps: ModelCapabilities,
+    reasoning_effort: str,
+) -> dict[str, Any]:
+    """``chat_template_kwargs`` entries carrying reasoning control.
+
+    On local model servers the reasoning levers live in the chat template:
+    a boolean toggle (``caps.thinking_param``, active when ``thinking_mode``
+    is ``"manual"``/``"adaptive"``) and an optional graded effort key
+    (``caps.effort_param``, gpt-oss-style templates).  The session effort
+    knob drives both — ``"none"``/empty turns the toggle off, mirroring the
+    Anthropic provider's native manual-mode contract (``_reasoning_params``).
+    The effort value is validated via ``resolve_reasoning_effort`` when the
+    model declares ``reasoning_effort_values`` (off-list knob values snap to
+    ``default_reasoning_effort``); with no declared values the knob is
+    forwarded as-is and the template is the authority on validity.
+    """
+    updates: dict[str, Any] = {}
+    effort_on = bool(reasoning_effort) and reasoning_effort != "none"
+    if caps.thinking_mode in ("manual", "adaptive"):
+        updates[caps.thinking_param] = effort_on
+    if caps.effort_param and effort_on:
+        effort = (
+            resolve_reasoning_effort(caps, reasoning_effort)
+            if caps.reasoning_effort_values
+            else reasoning_effort
+        )
+        if effort:
+            updates[caps.effort_param] = effort
+    return updates
+
+
+def merge_reasoning_template_kwargs(
+    caps: ModelCapabilities,
+    reasoning_effort: str,
+    extra_params: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Copy-on-write merge of ``reasoning_template_kwargs`` into extra params.
+
+    Returns *extra_params* unchanged (possibly ``None``) when the
+    capabilities call for no injection; otherwise returns a new dict with
+    the reasoning entries folded into ``chat_template_kwargs``.  Existing
+    keys win — an operator ``server_compat`` pin beats the knob mapping.
+    The caller's dict (and its ``chat_template_kwargs`` sub-dict) is never
+    mutated.
+    """
+    updates = reasoning_template_kwargs(caps, reasoning_effort)
+    if not updates:
+        return extra_params
+    merged = dict(extra_params) if extra_params else {}
+    raw_ctk = merged.get("chat_template_kwargs")
+    ctk = dict(raw_ctk) if isinstance(raw_ctk, dict) else {}
+    for key, value in updates.items():
+        ctk.setdefault(key, value)
+    merged["chat_template_kwargs"] = ctk
+    return merged
 
 
 # Operator-friendly UI cap on reasoning text returned from

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -86,9 +86,10 @@ class ModelCapabilities:
     # gpt-oss-style templates).  Empty = the template has no effort lever,
     # send nothing.  The session knob value is validated against
     # ``reasoning_effort_values`` when that is non-empty (off-list values
-    # snap to ``default_reasoning_effort``); with no declared values the
-    # knob is forwarded as-is and the template is the authority on
-    # validity.  See ``reasoning_template_kwargs``.
+    # round UP onto the declared list, capped at its ceiling — see
+    # ``snap_reasoning_effort``); with no declared values the knob is
+    # forwarded as-is and the template is the authority on validity.
+    # See ``reasoning_template_kwargs``.
     effort_param: str = ""
     supports_effort: bool = False
     effort_levels: tuple[str, ...] = ()
@@ -147,15 +148,49 @@ class ModelCapabilities:
     rerank_separated: bool = False
 
 
+# The session effort knob is ORDINAL — snapping must respect this order.
+# "none" is the disable position and is never a snap target (snapping a
+# high knob onto "none" would invert the request into "don't think").
+KNOB_EFFORT_ORDER: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+_KNOB_RANK: dict[str, int] = {value: rank for rank, value in enumerate(KNOB_EFFORT_ORDER)}
+
+
+def snap_reasoning_effort(reasoning_effort: str, declared: tuple[str, ...]) -> str | None:
+    """Round an off-list knob value up onto the declared effort levels.
+
+    Returns the smallest declared level ranking >= the knob; when the
+    knob is above every declared level, the highest declared level (the
+    ceiling — asking for more effort than exists must not fall to a
+    lower tier).  Declared values outside the knob vocabulary cannot be
+    ranked and are reachable only by exact match in the caller; "none"
+    is never a snap target.  Returns ``None`` when the knob itself is
+    unrankable or nothing declared is rankable.
+    """
+    rank = _KNOB_RANK.get(reasoning_effort)
+    if rank is None or reasoning_effort == "none":
+        return None
+    rankable = [(r, v) for v in declared if (r := _KNOB_RANK.get(v)) is not None and v != "none"]
+    if not rankable:
+        return None
+    at_or_above = [(r, v) for r, v in rankable if r >= rank]
+    return min(at_or_above)[1] if at_or_above else max(rankable)[1]
+
+
 def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> str | None:
     """Return the validated reasoning effort value, or ``None`` to omit.
 
-    Validates against supported values and falls back to model default.
+    Declared values match verbatim; off-list knob values round UP onto
+    the declared list, capped at its ceiling (``snap_reasoning_effort``).
+    ``default_reasoning_effort`` is the last resort for values the
+    ordinal snap cannot rank (custom strings on either side).
     """
     if not caps.reasoning_effort_values or not reasoning_effort or reasoning_effort == "none":
         return None
     if reasoning_effort in caps.reasoning_effort_values:
         return reasoning_effort
+    snapped = snap_reasoning_effort(reasoning_effort, caps.reasoning_effort_values)
+    if snapped:
+        return snapped
     if caps.default_reasoning_effort and caps.default_reasoning_effort != "none":
         return caps.default_reasoning_effort
     return None
@@ -193,9 +228,10 @@ def reasoning_template_kwargs(
     the native adaptive branch never lets the knob force-disable
     thinking).  The effort value is validated via
     ``resolve_reasoning_effort`` when the model declares
-    ``reasoning_effort_values`` (off-list knob values snap to
-    ``default_reasoning_effort``); with no declared values the knob is
-    forwarded as-is and the template is the authority on validity.
+    ``reasoning_effort_values`` (off-list knob values round up onto the
+    declared list, capped at its ceiling); with no declared values the
+    knob is forwarded as-is and the template is the authority on
+    validity.
     """
     updates: dict[str, Any] = {}
     effort_on = bool(reasoning_effort) and reasoning_effort != "none"

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -168,20 +168,25 @@ def reasoning_template_kwargs(
     """``chat_template_kwargs`` entries carrying reasoning control.
 
     On local model servers the reasoning levers live in the chat template:
-    a boolean toggle (``caps.thinking_param``, active when ``thinking_mode``
-    is ``"manual"``/``"adaptive"``) and an optional graded effort key
-    (``caps.effort_param``, gpt-oss-style templates).  The session effort
-    knob drives both — ``"none"``/empty turns the toggle off, mirroring the
-    Anthropic provider's native manual-mode contract (``_reasoning_params``).
-    The effort value is validated via ``resolve_reasoning_effort`` when the
-    model declares ``reasoning_effort_values`` (off-list knob values snap to
+    a boolean toggle (``caps.thinking_param``) and an optional graded
+    effort key (``caps.effort_param``, gpt-oss-style templates).  The
+    session effort knob drives both, mirroring the native Anthropic
+    contracts: ``"manual"`` maps ``"none"``/empty to an explicit
+    ``false`` (``_reasoning_params`` parity — the knob is the switch),
+    while ``"adaptive"`` always sends ``true`` (the model self-regulates;
+    the native adaptive branch never lets the knob force-disable
+    thinking).  The effort value is validated via
+    ``resolve_reasoning_effort`` when the model declares
+    ``reasoning_effort_values`` (off-list knob values snap to
     ``default_reasoning_effort``); with no declared values the knob is
     forwarded as-is and the template is the authority on validity.
     """
     updates: dict[str, Any] = {}
     effort_on = bool(reasoning_effort) and reasoning_effort != "none"
-    if caps.thinking_mode in ("manual", "adaptive"):
+    if caps.thinking_mode == "manual":
         updates[caps.thinking_param] = effort_on
+    elif caps.thinking_mode == "adaptive":
+        updates[caps.thinking_param] = True
     if caps.effort_param and effort_on:
         effort = (
             resolve_reasoning_effort(caps, reasoning_effort)

--- a/turnstone/core/providers/effort_ladder.py
+++ b/turnstone/core/providers/effort_ladder.py
@@ -1,0 +1,118 @@
+"""Effective effort-ladder projection — what each knob position actually does.
+
+The session reasoning-effort knob has seven positions; how many are
+DISTINCT depends on the provider lane and the model's capabilities
+(qwen3.6: two — off/on; a freeform ``effort_param`` model: one per
+forwarded value; Claude with effort levels: one per level plus the
+adaptive fallback).  This module projects the knob domain through the
+same mapping functions the providers use at request time, so UIs can
+annotate knob positions that alias to identical wire behavior instead
+of presenting seven positions as seven behaviors.
+
+Pure computation — no network, no provider clients.  Labels are short
+comparable tokens: two knob positions with the same ``effective`` string
+produce the same request.  ``"default"`` means nothing effort-related is
+sent (the server/model default applies); ``"off"``/``"on"`` describe the
+local-lane template toggle.  The ladder describes what Turnstone SENDS —
+a server-side template may alias further (e.g. DeepSeek-V4 maps
+``low``/``medium`` to its default ``high`` tier).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from turnstone.core.providers._anthropic import (
+    _DEFAULT_THINKING_BUDGET,
+    _EFFORT_BUDGET_MAP,
+    _map_reasoning_to_effort,
+)
+from turnstone.core.providers._protocol import (
+    ModelCapabilities,
+    reasoning_template_kwargs,
+    resolve_reasoning_effort,
+)
+
+# The full session-knob domain, in ladder order (mirrors the console
+# selects; "" rides as the caller's alias for its default and is not a
+# ladder row).
+KNOB_VALUES: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+# Lanes whose reasoning control rides chat_template_kwargs
+# (merge_reasoning_template_kwargs) rather than native params.
+_LOCAL_LANES = frozenset({"openai-compatible", "anthropic-compatible"})
+
+
+def effort_ladder(provider_name: str, caps: ModelCapabilities) -> list[dict[str, str]]:
+    """Project every knob position to its effective wire behavior.
+
+    Returns ``[{"value": <knob>, "effective": <token>}, ...]`` in knob
+    order.  Equal ``effective`` tokens ⇒ identical requests.
+    """
+    return [
+        {"value": knob, "effective": _effective(provider_name, caps, knob)} for knob in KNOB_VALUES
+    ]
+
+
+def effort_ladder_for_model(
+    provider_name: str,
+    model: str,
+    capability_overrides: dict[str, Any] | None,
+) -> list[dict[str, str]]:
+    """Ladder for a stored model row: provider defaults + operator overrides.
+
+    Mirrors ``ChatSession._resolve_capabilities`` — overrides are
+    field-filtered and applied over the provider's per-model defaults.
+    """
+    from turnstone.core.providers import create_provider
+
+    caps = create_provider(provider_name).get_capabilities(model)
+    if capability_overrides:
+        fields = {f.name for f in dataclasses.fields(type(caps))}
+        overrides = {k: v for k, v in capability_overrides.items() if k in fields}
+        if overrides:
+            caps = dataclasses.replace(caps, **overrides)
+    return effort_ladder(provider_name, caps)
+
+
+def _effective(provider_name: str, caps: ModelCapabilities, knob: str) -> str:
+    if provider_name == "anthropic":
+        return _effective_anthropic(caps, knob)
+    if provider_name in _LOCAL_LANES:
+        return _effective_local(provider_name, caps, knob)
+    # Flat-param lanes: openai (chat + responses), google, xai.
+    return resolve_reasoning_effort(caps, knob) or "default"
+
+
+def _effective_anthropic(caps: ModelCapabilities, knob: str) -> str:
+    """Native lane — mirrors ``_build_thinking_and_kwargs``."""
+    effort = _map_reasoning_to_effort(knob, caps.effort_levels) if caps.supports_effort else None
+    if caps.thinking_mode == "adaptive":
+        # Thinking always on, model self-regulates; effort rides
+        # output_config when the knob maps onto a supported level.
+        return effort or "adaptive"
+    if caps.thinking_mode == "manual":
+        if not knob or knob == "none":
+            return "off"
+        budget = _EFFORT_BUDGET_MAP.get(knob, _DEFAULT_THINKING_BUDGET)
+        return f"{effort}·budget:{budget}" if effort else f"budget:{budget}"
+    return "default"
+
+
+def _effective_local(provider_name: str, caps: ModelCapabilities, knob: str) -> str:
+    """Local lanes — mirrors ``merge_reasoning_template_kwargs`` (+ flat param)."""
+    updates = reasoning_template_kwargs(caps, knob)
+    parts: list[str] = []
+    if caps.thinking_param in updates:
+        parts.append("on" if updates[caps.thinking_param] else "off")
+    if caps.effort_param and caps.effort_param in updates:
+        parts.append(str(updates[caps.effort_param]))
+    # openai-compatible additionally sends the flat param when no
+    # effort_param declares the template channel (suppression rule in
+    # apply_temperature_and_effort).
+    if provider_name == "openai-compatible" and not caps.effort_param:
+        flat = resolve_reasoning_effort(caps, knob)
+        if flat:
+            parts.append(flat)
+    return "+".join(parts) if parts else "default"

--- a/turnstone/core/providers/effort_ladder.py
+++ b/turnstone/core/providers/effort_ladder.py
@@ -41,6 +41,7 @@ from turnstone.core.providers._anthropic import (
 )
 from turnstone.core.providers._protocol import (
     ModelCapabilities,
+    flat_effort_suppressed,
     reasoning_template_kwargs,
     resolve_reasoning_effort,
 )
@@ -53,11 +54,14 @@ KNOB_VALUES: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhi
 # Providers that serve requests through OpenAIChatCompletionsProvider (or
 # a subclass) and therefore inherit BOTH channels: chat_template_kwargs
 # injection via _finalize_extra_body AND the flat reasoning_effort param
-# via apply_temperature_and_effort.  google/xai belong here because their
-# providers subclass the chat provider — an operator override that sets
-# thinking_mode/effort_param on such a model changes real requests, and
-# the ladder must mirror that.
-_CHAT_LANES = frozenset({"openai-compatible", "google", "xai"})
+# via apply_temperature_and_effort.  google belongs here because
+# GoogleProvider subclasses the chat provider — an operator override that
+# sets thinking_mode/effort_param on such a model changes real requests,
+# and the ladder must mirror that.  xai does NOT: XAIProvider subclasses
+# OpenAIResponsesProvider, whose surface ignores extra_body entirely, so
+# template overrides can never change an xai request and the ladder
+# projects xai through the flat channel only (fallthrough in _effective).
+_CHAT_LANES = frozenset({"openai-compatible", "google"})
 
 
 def effort_ladder(
@@ -122,7 +126,9 @@ def _effective(
             # Responses surface: native reasoning, extra_body ignored.
             return resolve_reasoning_effort(caps, knob) or "default"
         return _effective_local(provider_name, caps, knob)
-    # openai commercial (Responses provider by default).
+    # openai / xai — Responses-surface providers: reasoning rides the
+    # native ``reasoning={"effort": ...}`` param and extra_body is
+    # ignored, so the flat channel is the whole story.
     return resolve_reasoning_effort(caps, knob) or "default"
 
 
@@ -151,11 +157,12 @@ def _effective_local(provider_name: str, caps: ModelCapabilities, knob: str) -> 
         parts.append("on" if updates[caps.thinking_param] else "off")
     if caps.effort_param and caps.effort_param in updates:
         parts.append(str(updates[caps.effort_param]))
-    # Chat-completions providers also send the flat param when no
-    # effort_param declares the template channel (suppression rule in
-    # apply_temperature_and_effort).  The anthropic-compatible lane has
-    # no flat param.
-    if provider_name != "anthropic-compatible" and not caps.effort_param:
+    # Chat-completions providers also send the flat param unless a
+    # declared effort_param claims the template channel — the same
+    # ``flat_effort_suppressed`` predicate ``apply_temperature_and_effort``
+    # applies at request time.  The anthropic-compatible lane has no
+    # flat param.
+    if provider_name != "anthropic-compatible" and not flat_effort_suppressed(caps):
         flat = resolve_reasoning_effort(caps, knob)
         if flat:
             parts.append(flat)

--- a/turnstone/core/providers/effort_ladder.py
+++ b/turnstone/core/providers/effort_ladder.py
@@ -13,9 +13,17 @@ Pure computation — no network, no provider clients.  Labels are short
 comparable tokens: two knob positions with the same ``effective`` string
 produce the same request.  ``"default"`` means nothing effort-related is
 sent (the server/model default applies); ``"off"``/``"on"`` describe the
-local-lane template toggle.  The ladder describes what Turnstone SENDS —
-a server-side template may alias further (e.g. DeepSeek-V4 maps
-``low``/``medium`` to its default ``high`` tier).
+local-lane template toggle.
+
+Two documented approximations:
+
+* The ladder describes what Turnstone SENDS — a server-side template
+  may alias further (e.g. DeepSeek-V4 maps ``low``/``medium`` to its
+  default ``high`` tier).
+* Anthropic manual-mode budgets are shown unclamped.  The request path
+  additionally clamps ``budget_tokens`` below the per-request
+  ``max_tokens``, so a very small ``max_tokens`` can collapse tiers (or
+  disable thinking) at request time — not knowable from capabilities.
 """
 
 from __future__ import annotations
@@ -23,9 +31,12 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+# _map_reasoning_to_effort is Anthropic-lane semantics shared with the
+# request path deliberately — projecting through the same function is
+# what keeps the ladder honest.
 from turnstone.core.providers._anthropic import (
-    _DEFAULT_THINKING_BUDGET,
-    _EFFORT_BUDGET_MAP,
+    DEFAULT_THINKING_BUDGET,
+    EFFORT_BUDGET_MAP,
     _map_reasoning_to_effort,
 )
 from turnstone.core.providers._protocol import (
@@ -39,19 +50,35 @@ from turnstone.core.providers._protocol import (
 # ladder row).
 KNOB_VALUES: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
-# Lanes whose reasoning control rides chat_template_kwargs
-# (merge_reasoning_template_kwargs) rather than native params.
-_LOCAL_LANES = frozenset({"openai-compatible", "anthropic-compatible"})
+# Providers that serve requests through OpenAIChatCompletionsProvider (or
+# a subclass) and therefore inherit BOTH channels: chat_template_kwargs
+# injection via _finalize_extra_body AND the flat reasoning_effort param
+# via apply_temperature_and_effort.  google/xai belong here because their
+# providers subclass the chat provider — an operator override that sets
+# thinking_mode/effort_param on such a model changes real requests, and
+# the ladder must mirror that.
+_CHAT_LANES = frozenset({"openai-compatible", "google", "xai"})
 
 
-def effort_ladder(provider_name: str, caps: ModelCapabilities) -> list[dict[str, str]]:
+def effort_ladder(
+    provider_name: str,
+    caps: ModelCapabilities,
+    api_surface: str = "",
+) -> list[dict[str, str]]:
     """Project every knob position to its effective wire behavior.
 
     Returns ``[{"value": <knob>, "effective": <token>}, ...]`` in knob
     order.  Equal ``effective`` tokens ⇒ identical requests.
+
+    *api_surface* mirrors ``server_compat["api_surface"]``: the
+    ``"responses"`` surface handles reasoning natively and ignores
+    ``extra_body``, so chat-lane providers pinned to it project through
+    the flat param only — the same divergence ``create_provider``
+    applies at request time.
     """
     return [
-        {"value": knob, "effective": _effective(provider_name, caps, knob)} for knob in KNOB_VALUES
+        {"value": knob, "effective": _effective(provider_name, caps, knob, api_surface)}
+        for knob in KNOB_VALUES
     ]
 
 
@@ -59,29 +86,43 @@ def effort_ladder_for_model(
     provider_name: str,
     model: str,
     capability_overrides: dict[str, Any] | None,
+    api_surface: str = "",
 ) -> list[dict[str, str]]:
     """Ladder for a stored model row: provider defaults + operator overrides.
 
     Mirrors ``ChatSession._resolve_capabilities`` — overrides are
     field-filtered and applied over the provider's per-model defaults.
+    Callers holding a raw DB row must parse the ``capabilities`` JSON
+    string first (``model_registry`` does the same) — this function
+    takes a dict.
     """
     from turnstone.core.providers import create_provider
 
-    caps = create_provider(provider_name).get_capabilities(model)
+    caps = create_provider(provider_name, api_surface=api_surface or None).get_capabilities(model)
     if capability_overrides:
         fields = {f.name for f in dataclasses.fields(type(caps))}
         overrides = {k: v for k, v in capability_overrides.items() if k in fields}
         if overrides:
             caps = dataclasses.replace(caps, **overrides)
-    return effort_ladder(provider_name, caps)
+    return effort_ladder(provider_name, caps, api_surface)
 
 
-def _effective(provider_name: str, caps: ModelCapabilities, knob: str) -> str:
+def _effective(
+    provider_name: str,
+    caps: ModelCapabilities,
+    knob: str,
+    api_surface: str = "",
+) -> str:
     if provider_name == "anthropic":
         return _effective_anthropic(caps, knob)
-    if provider_name in _LOCAL_LANES:
+    if provider_name == "anthropic-compatible":
         return _effective_local(provider_name, caps, knob)
-    # Flat-param lanes: openai (chat + responses), google, xai.
+    if provider_name in _CHAT_LANES:
+        if api_surface == "responses":
+            # Responses surface: native reasoning, extra_body ignored.
+            return resolve_reasoning_effort(caps, knob) or "default"
+        return _effective_local(provider_name, caps, knob)
+    # openai commercial (Responses provider by default).
     return resolve_reasoning_effort(caps, knob) or "default"
 
 
@@ -95,23 +136,26 @@ def _effective_anthropic(caps: ModelCapabilities, knob: str) -> str:
     if caps.thinking_mode == "manual":
         if not knob or knob == "none":
             return "off"
-        budget = _EFFORT_BUDGET_MAP.get(knob, _DEFAULT_THINKING_BUDGET)
+        budget = EFFORT_BUDGET_MAP.get(knob, DEFAULT_THINKING_BUDGET)
         return f"{effort}·budget:{budget}" if effort else f"budget:{budget}"
-    return "default"
+    # thinking_mode "none": output_config effort still applies — the
+    # request path gates it on supports_effort alone, not thinking_mode.
+    return effort or "default"
 
 
 def _effective_local(provider_name: str, caps: ModelCapabilities, knob: str) -> str:
-    """Local lanes — mirrors ``merge_reasoning_template_kwargs`` (+ flat param)."""
+    """Chat lanes — mirrors ``merge_reasoning_template_kwargs`` (+ flat param)."""
     updates = reasoning_template_kwargs(caps, knob)
     parts: list[str] = []
     if caps.thinking_param in updates:
         parts.append("on" if updates[caps.thinking_param] else "off")
     if caps.effort_param and caps.effort_param in updates:
         parts.append(str(updates[caps.effort_param]))
-    # openai-compatible additionally sends the flat param when no
+    # Chat-completions providers also send the flat param when no
     # effort_param declares the template channel (suppression rule in
-    # apply_temperature_and_effort).
-    if provider_name == "openai-compatible" and not caps.effort_param:
+    # apply_temperature_and_effort).  The anthropic-compatible lane has
+    # no flat param.
+    if provider_name != "anthropic-compatible" and not caps.effort_param:
         flat = resolve_reasoning_effort(caps, knob)
         if flat:
             parts.append(flat)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4480,16 +4480,14 @@ class ChatSession:
         (``skip_special_tokens``, ``reasoning_format``, or explicit
         ``chat_template_kwargs``) to the OpenAI SDK ``extra_body`` on the
         OpenAI-shaped lanes, and to the Anthropic SDK ``extra_body`` on the
-        anthropic-compatible lane (the channel for vLLM's
-        ``chat_template_kwargs`` reasoning toggle).  Operators
-        running gpt-oss-style local templates that consume ``reasoning_effort``
-        from ``chat_template_kwargs`` should set it explicitly under
-        ``server_compat["extra_body"]["chat_template_kwargs"]``.
+        anthropic-compatible lane.  Entries set here are static operator
+        pins — they win over the dynamic knob mapping below.
 
-        Thinking-mode params (``enable_thinking``, ``thinking``) are added
-        separately by ``OpenAIChatCompletionsProvider._apply_thinking_mode``
-        based on ``ModelCapabilities.thinking_mode`` — the Responses API
-        surface handles reasoning natively and ignores ``extra_body``.
+        Reasoning params (the ``enable_thinking``/``thinking`` toggle and
+        the ``effort_param`` graded key) are added separately by the
+        providers via ``merge_reasoning_template_kwargs``, driven by
+        ``ModelCapabilities`` and the session effort knob — the Responses
+        API surface handles reasoning natively and ignores ``extra_body``.
 
         *model_alias* selects which stored config supplies server compat
         settings.  When ``None``, defaults to the session's primary alias.

--- a/turnstone/deploy/vllm-litellm/README.md
+++ b/turnstone/deploy/vllm-litellm/README.md
@@ -132,6 +132,9 @@ provider = "anthropic-compatible"
 base_url = "http://INFERENCE_HOST:4000"            # /v1/messages (no /v1 suffix)
 api_key = "dummy"
 context_window = 262144
+[models.qwen.capabilities]
+thinking_mode = "manual"          # session effort knob drives the template's
+thinking_param = "enable_thinking"  # thinking toggle (effort "none" = off)
 
 [models.gemma]
 model = "gemma-4-12b"


### PR DESCRIPTION
## Summary

The session reasoning-effort knob was silently dropped or mis-mapped on most provider lanes, and several capability-registry rows had drifted from what the APIs actually document. This branch makes every lane translate the knob into exactly what each API/model spec defines, corrects the registry against official docs, surfaces the resulting per-model behavior in the console, and locks the whole mapping down with a ladder↔wire parity harness so UI annotations can never drift from the wire again.

The real `anthropic` lane's native thinking/budget/`output_config` behavior for official Claude models is preserved throughout — the changes make the *other* lanes as conformant as it was.

## The two channels

Reasoning control reaches models through exactly one of two channels per lane:

| Lane | Channel |
| --- | --- |
| `anthropic` (native) | `thinking` param (adaptive / budget) + `output_config.effort` |
| `anthropic-compatible` (vLLM `/v1/messages`) | `extra_body.chat_template_kwargs` (toggle + optional graded key) — vLLM's schema has no `thinking` param |
| `openai-compatible` (Chat Completions) | `chat_template_kwargs` toggle/effort key **and** flat `reasoning_effort`; a declared `effort_param` claims the template channel and suppresses the flat param (`flat_effort_suppressed`, one predicate shared by request path and ladder) |
| `openai-compatible` pinned to `api_surface="responses"`, `openai`, `xai` | native `reasoning.effort` only — the Responses surface drops `extra_body`, so template capabilities are inert there |
| `google` | flat `reasoning_effort` (documented channel); template overrides genuinely apply because `GoogleProvider` subclasses the chat provider |

## Knob semantics (uniform across lanes)

- `thinking_mode="manual"` — the knob is the switch: `none` sends an explicit off, other positions send on.
- `thinking_mode="adaptive"` — always on; the model self-regulates and the knob never force-disables (native-adaptive parity).
- **Ordinal snapping** (`snap_reasoning_effort`, one implementation): exact match wins; off-list knob values round *up* onto the declared levels; above the ceiling rides the ceiling. Asking for more effort than a model declares never falls back to a lower default tier.
- **`none` means off**: forwarded verbatim where the model declares an explicit `none` level (gpt-5.1+, grok-4.3 — omission would leave a reasoning-on server default like gpt-5.5's `medium` in charge), omitted otherwise, and never a snap target.
- Anthropic manual budgets are monotone over the whole knob domain: 1024/1024/4096/16384/32768/65536 (minimal→max).
- Operator `server_compat` `chat_template_kwargs` pins beat the knob mapping on key collision.

## Registry corrections (verified against official docs, 2026-07)

- **OpenAI** (vocabulary `none/minimal/low/medium/high/xhigh` — no `max` level exists): o1/o3/o3-mini/o3-pro/o4-mini declare `low/medium/high` (previously nothing — the knob was silently dropped for every o-series model); gpt-5.5 default corrected `none`→`medium`; explicit `gpt-5.1-codex-max` row (prefix-matched the gpt-5.1 row and lost `xhigh` on the model that introduced it).
- **Anthropic**: `claude-sonnet-5` row added (previously fell through to the manual-budget default — wrong on every axis): adaptive-by-default thinking, manual budgets 400, sampling params rejected, 1M ctx / 128k out, effort `low..max` incl. `xhigh`. `claude-sonnet-4-6` gains its documented `max` level and 128k max output. Fable 5 / Opus 4.8 / 4.7 / 4.6 / 4.5 rows verified correct.
- **Google**: `_GOOGLE_DEFAULT` declares `minimal/low/medium/high` (previously nothing — knob silently dropped for all Gemini); `none` excluded (2.5-Pro/3.x reject disabling). Encoded from docs, not live-verified (no key on the dev box).
- **xAI**: per-model grok rows were already correct; the *ladder* wrongly treated xai as a chat-lane provider (see audits below).

## Console

- Thinking-mode dropdown: None / Effort-knob controlled (manual) / Always on (adaptive), round-tripping for the local lanes; new Effort param field beside it.
- **Effective effort ladder**: `providers/effort_ladder.py` projects all seven knob positions through the same request-time mapping functions. Exposed on `/v1/api/models` rows and `POST /v1/api/admin/models/effort-ladder`; the admin model form and the skill launch-config effort selects annotate aliased positions ("Max (= xhigh)") with sends-tooltips, refreshing live as capability fields change.

## Verification

- **Ladder↔wire parity harness** (`tests/test_effort_ladder_wire_parity.py`): 22 (lane × capability shape) points — both Anthropic lanes, openai-compatible on both surfaces, openai/google/xai real registry rows, DeepSeek/qwen template contracts, override-inertness scenarios — each knob position driven through the real `create_provider(...).create_streaming` against a recording SDK-seam client. Asserts (1) each ladder token decodes to the exact effort wire subset, and (2) two knobs share a token *iff* they produce identical effort wire. Negative-tested against the xai bug it was built to catch.
- **Live template-contract probes** on two vLLM boxes (qwen3.6-27b, deepseek-v4-flash): server CLI defaults controlled per-request; temp-0 byte-identity and `input_tokens` deltas cross-checked against the official template contracts (qwen: toggle-only, no effort lever; DeepSeek: `high`/`max` with Think-High default and low/medium→high, xhigh→max aliasing — which the ordinal snap now reproduces exactly from a declared values list). Reasoning replay verified against vLLM main and live on both lanes.
- **Two external audits** verified finding-by-finding: round 1 (30 findings → 13 real, headline: the capabilities column is a JSON string and the ladder was silently absent from `/v1/api/models`), round 2 (10 findings → headline: `XAIProvider` subclasses the Responses provider, so template overrides are inert on xai and the ladder must project flat-only). Refuted findings documented with rationale.
- Suites: 900+ affected tests green incl. re-baselined Google wire goldens; mypy strict + ruff clean; CI green per commit.

## ⚠ Behavior changes on upgrade

- The openai-compatible toggle is now knob-driven: a stored `reasoning_effort="none"` disables thinking on template-toggle models (previously always-on). Use the new "Always on" mode to keep the old behavior.
- Off-list knob positions now round up instead of falling to the model default: `xhigh`/`max` ride each model's top tier (previously e.g. `max`→`low` on grok-4.3, `max`→nothing on gpt-5.2).
- Models declaring an explicit `none` level now receive it when the knob is off (previously omitted → server default).
- o-series and Gemini models now receive the knob at all.
- Anthropic manual budgets for `xhigh`/`max` are 32768/65536 (previously the 4096 default); the per-request `budget_tokens < max_tokens` clamp still applies.
