### PR TITLE
feat: concurrent approval cycles + judge-gated sub-agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tools/skill_audit_analysis/data/
 tools/skill_audit_analysis/output/
 design_ideas/
 .claude/
+docs/design/

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -11201,6 +11201,7 @@
               }
             ],
             "default": null,
+            "description": "Inline BASE override \u2014 required. Every persona must name a prompt source; built-in file-backed personas are seeded by migration, not created here, so an operator-created persona must supply base_prompt.",
             "title": "Base Prompt"
           },
           "tool_allowlist": {
@@ -11259,7 +11260,7 @@
         "type": "object"
       },
       "UpdatePersonaRequest": {
-        "description": "PATCH body \u2014 absent fields are left unchanged.\n\nExplicit ``null`` is meaningful only on the two resettable fields:\n``base_prompt: null`` clears the override back to the kind's stock\nBASE, and ``tool_allowlist: null`` resets to unrestricted.  ``null``\non the boolean flags or ``applies_to_kinds`` is ignored (treated as\nabsent), so a client serializing unset optionals as null cannot\narchive a persona or flip levers by accident.\n\nArchive = ``{\"enabled\": false}``; default flip = ``{\"is_default\": true}``\non the successor (storage demotes the incumbent atomically).  ``name``\nis immutable; existing workstreams are never affected by edits.",
+        "description": "PATCH body \u2014 absent fields are left unchanged.\n\nExplicit ``null`` resets ``tool_allowlist`` to unrestricted, and \u2014 on a\nBUILT-IN persona only \u2014 clears ``base_prompt`` (the operator override),\nreverting to that persona's file-backed prompt.  An OPERATOR persona has no\nfallback source, so ``base_prompt: null`` on one is rejected: every persona\nmust name a prompt source.  ``null`` on the boolean flags or\n``applies_to_kinds`` is ignored (treated as absent), so a client serializing\nunset optionals as null cannot archive a persona or flip levers by accident.\n\nArchive = ``{\"enabled\": false}``; default flip = ``{\"is_default\": true}``\non the successor (storage demotes the incumbent atomically).  ``name``\nis immutable; existing workstreams are never affected by edits.",
         "properties": {
           "display_name": {
             "anyOf": [
@@ -13305,21 +13306,17 @@
           },
           "pending_approval": {
             "default": false,
-            "description": "True when the workstream is parked on ``_approval_event`` awaiting an operator approve/deny.  Mirrors the same field on ``DashboardWorkstream`` / cluster live projections so a freshly-loaded chat tab can render the inline approval gate from the detail snapshot before SSE replay arrives.",
+            "description": "True when at least one approval cycle is live (a gate thread parked awaiting an operator approve/deny).  Mirrors the same field on ``DashboardWorkstream`` / cluster live projections so a freshly-loaded chat tab can render the inline approval gate from the detail snapshot before SSE replay arrives.",
             "title": "Pending Approval",
             "type": "boolean"
           },
-          "pending_approval_detail": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PendingApprovalDetail"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Inline approval payload \u2014 same shape as ``DashboardWorkstream.pending_approval_detail``.  ``None`` when no approval is pending.  Lets a reload paint the action row + judge verdicts immediately instead of relying on the SSE approve_request replay timing window."
+          "pending_approval_details": {
+            "description": "Inline approval payloads, one per live cycle, oldest first \u2014 same shape as ``DashboardWorkstream.pending_approval_details``.  Empty when no approval is pending.  Lets a reload paint every action row + judge verdicts immediately instead of relying on the SSE approve_request replay timing window.  Replaces 1.6's ``pending_approval_detail`` single-object field (breaking, 1.7).",
+            "items": {
+              "$ref": "#/components/schemas/PendingApprovalDetail"
+            },
+            "title": "Pending Approval Details",
+            "type": "array"
           }
         },
         "required": [
@@ -13332,8 +13329,14 @@
         "type": "object"
       },
       "PendingApprovalDetail": {
-        "description": "Inline approval payload merged into ``DashboardWorkstream``.\n\nSet when a workstream's ``approve_tools`` is parked on\n``_approval_event``; ``None`` (omitted) otherwise. Cross-tenant\nexposure here follows the same trusted-team posture as\n``activity`` / ``tokens`` \u2014 see ``server.py``'s ``dashboard``\nhandler comment.",
+        "description": "Inline approval payload merged into ``DashboardWorkstream``.\n\nOne entry per live approval CYCLE \u2014 a gate thread parked in\n``approve_tools`` awaiting the operator.  Parallel task agents run\nconcurrent gates, so a workstream can have several of these at\nonce (``pending_approval_details``, oldest first).  Cross-tenant\nexposure here follows the same trusted-team posture as\n``activity`` / ``tokens`` \u2014 see ``server.py``'s ``dashboard``\nhandler comment.",
         "properties": {
+          "cycle_id": {
+            "default": "",
+            "description": "Identity of this approval cycle.  Echo it back on ``POST /v1/api/workstreams/{ws_id}/approve`` to resolve exactly this round \u2014 required for correctness when several cycles are live (parallel task agents).",
+            "title": "Cycle Id",
+            "type": "string"
+          },
           "call_id": {
             "default": "",
             "description": "Primary call_id \u2014 first non-empty call_id in items list order. Matches the 409 ``current_call_id`` response from ``POST /v1/api/workstreams/{ws_id}/approve`` so the UI can render the same identifier the server reports as current.",

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2692,21 +2692,17 @@
           },
           "pending_approval": {
             "default": false,
-            "description": "True when the workstream is parked on ``_approval_event`` awaiting an operator approve/deny.  Mirrors the same field on ``DashboardWorkstream`` / cluster live projections so a freshly-loaded chat tab can render the inline approval gate from the detail snapshot before SSE replay arrives.",
+            "description": "True when at least one approval cycle is live (a gate thread parked awaiting an operator approve/deny).  Mirrors the same field on ``DashboardWorkstream`` / cluster live projections so a freshly-loaded chat tab can render the inline approval gate from the detail snapshot before SSE replay arrives.",
             "title": "Pending Approval",
             "type": "boolean"
           },
-          "pending_approval_detail": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PendingApprovalDetail"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Inline approval payload \u2014 same shape as ``DashboardWorkstream.pending_approval_detail``.  ``None`` when no approval is pending.  Lets a reload paint the action row + judge verdicts immediately instead of relying on the SSE approve_request replay timing window."
+          "pending_approval_details": {
+            "description": "Inline approval payloads, one per live cycle, oldest first \u2014 same shape as ``DashboardWorkstream.pending_approval_details``.  Empty when no approval is pending.  Lets a reload paint every action row + judge verdicts immediately instead of relying on the SSE approve_request replay timing window.  Replaces 1.6's ``pending_approval_detail`` single-object field (breaking, 1.7).",
+            "items": {
+              "$ref": "#/components/schemas/PendingApprovalDetail"
+            },
+            "title": "Pending Approval Details",
+            "type": "array"
           }
         },
         "required": [
@@ -2719,8 +2715,14 @@
         "type": "object"
       },
       "PendingApprovalDetail": {
-        "description": "Inline approval payload merged into ``DashboardWorkstream``.\n\nSet when a workstream's ``approve_tools`` is parked on\n``_approval_event``; ``None`` (omitted) otherwise. Cross-tenant\nexposure here follows the same trusted-team posture as\n``activity`` / ``tokens`` \u2014 see ``server.py``'s ``dashboard``\nhandler comment.",
+        "description": "Inline approval payload merged into ``DashboardWorkstream``.\n\nOne entry per live approval CYCLE \u2014 a gate thread parked in\n``approve_tools`` awaiting the operator.  Parallel task agents run\nconcurrent gates, so a workstream can have several of these at\nonce (``pending_approval_details``, oldest first).  Cross-tenant\nexposure here follows the same trusted-team posture as\n``activity`` / ``tokens`` \u2014 see ``server.py``'s ``dashboard``\nhandler comment.",
         "properties": {
+          "cycle_id": {
+            "default": "",
+            "description": "Identity of this approval cycle.  Echo it back on ``POST /v1/api/workstreams/{ws_id}/approve`` to resolve exactly this round \u2014 required for correctness when several cycles are live (parallel task agents).",
+            "title": "Cycle Id",
+            "type": "string"
+          },
           "call_id": {
             "default": "",
             "description": "Primary call_id \u2014 first non-empty call_id in items list order. Matches the 409 ``current_call_id`` response from ``POST /v1/api/workstreams/{ws_id}/approve`` so the UI can render the same identifier the server reports as current.",
@@ -3004,17 +3006,13 @@
             "default": null,
             "title": "Project Id"
           },
-          "pending_approval_detail": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PendingApprovalDetail"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Inline approval payload for the coordinator children-tree UI. Carries the merged ``_pending_approval`` items list + per-call_id LLM verdict cache so a coord can render approve/deny buttons + judge pill without a separate per-child round-trip. ``None`` when no approval is pending. Also surfaced (verbatim) on ``GET /v1/api/cluster/ws/live`` via the ``_CLUSTER_WS_LIVE_KEYS`` projection."
+          "pending_approval_details": {
+            "description": "Inline approval payload for the coordinator children-tree UI: EVERY live approval cycle, oldest first \u2014 parallel task agents gate concurrently, so a workstream can hold several prompts at once.  Each entry carries the cycle's items + per-call_id LLM verdict cache so a coord can render approve/deny buttons + judge pill without a separate per-child round-trip; resolve each with its ``cycle_id``.  Empty when no approval is pending.  Also surfaced (verbatim) on ``GET /v1/api/cluster/ws/live`` via the ``_CLUSTER_WS_LIVE_KEYS`` projection.  Replaces 1.6's ``pending_approval_detail`` single-object field (breaking, 1.7).",
+            "items": {
+              "$ref": "#/components/schemas/PendingApprovalDetail"
+            },
+            "title": "Pending Approval Details",
+            "type": "array"
           },
           "recent_auto_approvals": {
             "description": "Per-ws ring buffer (cap 10) of recent tool calls that bypassed the operator approval gate. Surfaces ``WebUI._recent_auto_approvals`` so the coord-tree row can render an 'auto-approved by ...' pill when the child's skill / blanket / admin-policy rules silently let a tool through. Also projected onto ``GET /v1/api/cluster/ws/live`` via ``_CLUSTER_WS_LIVE_KEYS``.",

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -75,15 +75,25 @@ export interface ToolInfoEvent {
   items: Array<Record<string, unknown>>;
 }
 
+/** One approval CYCLE awaiting the operator.  Several can be outstanding
+ *  at once (parallel task agents each gate their own tool calls) — key
+ *  prompt UI by `cycle_id` and echo it back on the approve POST. */
 export interface ApproveRequestEvent {
   type: "approve_request";
+  cycle_id: string;
   items: Array<Record<string, unknown>>;
+  judge_pending?: boolean;
 }
 
+/** A specific approval cycle resolved; `cycle_id`/`call_ids` identify
+ *  which prompt to dismiss. */
 export interface ApprovalResolvedEvent {
   type: "approval_resolved";
   approved: boolean;
   feedback: string;
+  always?: boolean;
+  cycle_id: string;
+  call_ids: string[];
 }
 
 export interface ToolResultEvent {

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -77,23 +77,33 @@ export interface ToolInfoEvent {
 
 /** One approval CYCLE awaiting the operator.  Several can be outstanding
  *  at once (parallel task agents each gate their own tool calls) — key
- *  prompt UI by `cycle_id` and echo it back on the approve POST. */
+ *  prompt UI by `cycle_id` and echo it back on the approve POST.
+ *
+ *  `cycle_id` is optional because it was added in 1.7: a pre-1.7 server
+ *  omits it on the wire, so a current SDK talking to an older node sees
+ *  `undefined`.  Resolve those the legacy way (no selector → oldest
+ *  cycle). A current server always sends it. */
 export interface ApproveRequestEvent {
   type: "approve_request";
-  cycle_id: string;
+  cycle_id?: string;
   items: Array<Record<string, unknown>>;
   judge_pending?: boolean;
 }
 
 /** A specific approval cycle resolved; `cycle_id`/`call_ids` identify
- *  which prompt to dismiss. */
+ *  which prompt to dismiss.
+ *
+ *  Both are optional for the same reason as `ApproveRequestEvent.cycle_id`
+ *  — a pre-1.7 server emits neither, so a bare "something resolved"
+ *  dismisses the sole tracked prompt (the legacy fallback the UI and
+ *  channel adapters keep). A current server always sends both. */
 export interface ApprovalResolvedEvent {
   type: "approval_resolved";
   approved: boolean;
   feedback: string;
   always?: boolean;
-  cycle_id: string;
-  call_ids: string[];
+  cycle_id?: string;
+  call_ids?: string[];
 }
 
 export interface ToolResultEvent {

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -166,6 +166,13 @@ export class TurnstoneServer extends BaseClient {
     approved?: boolean;
     feedback?: string | null;
     always?: boolean;
+    /** Resolve exactly this approval cycle (from ApproveRequestEvent.cycle_id).
+     *  Omitting it resolves the OLDEST live cycle — ambiguous when parallel
+     *  task agents have several prompts outstanding, so pass it whenever the
+     *  triggering event is known. */
+    cycleId?: string;
+    /** Alternative selector: any call_id inside the target cycle. */
+    callId?: string;
   }): Promise<StatusResponse> {
     return this.request(
       "POST",
@@ -175,6 +182,8 @@ export class TurnstoneServer extends BaseClient {
           approved: opts.approved ?? true,
           feedback: opts.feedback,
           always: opts.always,
+          cycle_id: opts.cycleId,
+          call_id: opts.callId,
         },
       },
     );

--- a/sdk/typescript/tests/server-attachments.test.ts
+++ b/sdk/typescript/tests/server-attachments.test.ts
@@ -104,7 +104,6 @@ describe("TurnstoneServer attachments", () => {
     const [, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({
       message: "hi",
-      ws_id: "ws-X",
       attachment_ids: ["a1", "a2"],
     });
   });
@@ -117,7 +116,7 @@ describe("TurnstoneServer attachments", () => {
     });
     await client.send("hi", "ws-X");
     const [, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(JSON.parse(init.body)).toEqual({ message: "hi", ws_id: "ws-X" });
+    expect(JSON.parse(init.body)).toEqual({ message: "hi" });
   });
 
   it("createWorkstream with attachments sends multipart and auto-generates ws_id", async () => {

--- a/sdk/typescript/tests/server.test.ts
+++ b/sdk/typescript/tests/server.test.ts
@@ -74,8 +74,8 @@ describe("TurnstoneServer", () => {
     await client.send("Hello", "ws1");
 
     const [url, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe("http://test/v1/api/send");
-    expect(JSON.parse(init.body)).toEqual({ message: "Hello", ws_id: "ws1" });
+    expect(url).toBe("http://test/v1/api/workstreams/ws1/send");
+    expect(JSON.parse(init.body)).toEqual({ message: "Hello" });
   });
 
   it("injects auth header when token provided", async () => {

--- a/tests/_replay_helpers.py
+++ b/tests/_replay_helpers.py
@@ -51,6 +51,12 @@ def make_replay_mocks(
     ui._ws_messages = 0
     for key, value in ui_overrides.items():
         setattr(ui, key, value)
+    # Both replay paths read cycle cards via ``pending_approval_cards()``
+    # (one card per concurrent approval cycle).  Model it from the
+    # single-slot ``_pending_approval`` override so tests keep seeding
+    # the one field; a bare MagicMock here would iterate empty and
+    # silently drop the approve_request from the replay.
+    ui.pending_approval_cards = lambda: [ui._pending_approval] if ui._pending_approval else []
     ws = MagicMock()
     ws.session = session
     request = MagicMock()

--- a/tests/test_channel_discord.py
+++ b/tests/test_channel_discord.py
@@ -41,6 +41,11 @@ def _bind_ws_event_handlers(bot, cls):
             attr = getattr(cls, name)
             if callable(attr):
                 setattr(bot, name, attr.__get__(bot, cls))
+    # ``_handle_stream_end`` delegates the all-cycles sweep to
+    # ``_pop_ws_approvals``; bind the real method too so dispatcher
+    # tests observe the pop instead of a spec'd AsyncMock no-op.
+    if hasattr(cls, "_pop_ws_approvals"):
+        bot._pop_ws_approvals = cls._pop_ws_approvals.__get__(bot, cls)
 
 
 def _make_message(*, bot=False, guild=True, content="hello", channel=None, reference=None):
@@ -537,7 +542,7 @@ class TestApprovalVerdictDisplay:
                 },
             }
         ]
-        event = ApproveRequestEvent(ws_id="ws-1", items=items)
+        event = ApproveRequestEvent(ws_id="ws-1", cycle_id="cyc-1", items=items)
         _run(bot._on_ws_event("ws-1", thread, event))
 
         # thread.send was called with an embed containing a verdict field
@@ -551,8 +556,8 @@ class TestApprovalVerdictDisplay:
         assert "HIGH" in field.value
         assert "85%" in field.value
 
-        # Pending approval message tracked
-        assert "ws-1" in bot._pending_approval_msgs
+        # Pending approval message tracked under (ws_id, cycle_id).
+        assert ("ws-1", "cyc-1") in bot._pending_approval_msgs
 
     def test_approval_without_verdict(self):
         """ApproveRequestEvent items without verdict still work normally."""
@@ -585,10 +590,11 @@ class TestApprovalVerdictDisplay:
         embed = MagicMock()
         msg.embeds = [embed]
         msg.edit = AsyncMock()
-        bot._pending_approval_msgs["ws-1"] = msg
+        bot._pending_approval_msgs[("ws-1", "cyc-1")] = (msg, frozenset({"c-1"}))
 
         event = IntentVerdictEvent(
             ws_id="ws-1",
+            call_id="c-1",
             func_name="bash",
             risk_level="high",
             recommendation="deny",
@@ -628,7 +634,10 @@ class TestApprovalVerdictDisplay:
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
-        bot._pending_approval_msgs = {"ws-1": MagicMock()}
+        bot._pending_approval_msgs = {
+            ("ws-1", "cyc-1"): (MagicMock(), frozenset()),
+            ("ws-1", "cyc-2"): (MagicMock(), frozenset()),
+        }
         bot._notify_reply_channels = {}
         _bind_ws_event_handlers(bot, TurnstoneBot)
 
@@ -636,7 +645,8 @@ class TestApprovalVerdictDisplay:
         event = StreamEndEvent(ws_id="ws-1")
         _run(bot._on_ws_event("ws-1", thread, event))
 
-        assert "ws-1" not in bot._pending_approval_msgs
+        # ALL of the ws's cycles are swept, not just one entry.
+        assert not bot._pending_approval_msgs
 
 
 class TestStreamEndBehavior:
@@ -1657,19 +1667,21 @@ class TestApprovalResolved:
         bot = self._make_bot()
         thread = AsyncMock()
 
-        # Set up a pending approval message with components.
+        # Set up a pending approval message with components.  The event
+        # below carries no cycle_id (pre-multi-cycle server) — the
+        # legacy fallback clears the ws's single tracked entry.
         approval_msg = MagicMock()
         approval_msg.embeds = [MagicMock()]
         approval_msg.components = []
         approval_msg.edit = AsyncMock()
-        bot._pending_approval_msgs["ws-1"] = approval_msg
+        bot._pending_approval_msgs[("ws-1", "cyc-1")] = (approval_msg, frozenset())
 
         event = ApprovalResolvedEvent(ws_id="ws-1", approved=False, feedback="timeout")
         _run(bot._on_ws_event("ws-1", thread, event))
 
         approval_msg.edit.assert_awaited_once()
         # Pending approval message should be removed.
-        assert "ws-1" not in bot._pending_approval_msgs
+        assert not bot._pending_approval_msgs
 
     def test_disables_buttons_on_approved(self):
         from turnstone.sdk.events import ApprovalResolvedEvent
@@ -1681,9 +1693,11 @@ class TestApprovalResolved:
         approval_msg.embeds = [MagicMock()]
         approval_msg.components = []
         approval_msg.edit = AsyncMock()
-        bot._pending_approval_msgs["ws-1"] = approval_msg
+        bot._pending_approval_msgs[("ws-1", "cyc-1")] = (approval_msg, frozenset())
 
-        event = ApprovalResolvedEvent(ws_id="ws-1", approved=True)
+        # Cycle-routed resolution: the event's cycle_id selects exactly
+        # this tracked message.
+        event = ApprovalResolvedEvent(ws_id="ws-1", approved=True, cycle_id="cyc-1")
         _run(bot._on_ws_event("ws-1", thread, event))
 
         approval_msg.edit.assert_awaited_once()

--- a/tests/test_channel_routing.py
+++ b/tests/test_channel_routing.py
@@ -87,7 +87,7 @@ class TestSendApproval:
         monkeypatch.setattr(router._server, "approve", mock_approve)
         await router.send_approval("ws-1", "corr-abc", approved=True, feedback="ok")
         mock_approve.assert_awaited_once_with(
-            ws_id="ws-1", approved=True, feedback="ok", always=False
+            ws_id="ws-1", approved=True, feedback="ok", always=False, cycle_id="corr-abc"
         )
 
     @pytest.mark.anyio
@@ -99,7 +99,7 @@ class TestSendApproval:
         monkeypatch.setattr(router._server, "approve", mock_approve)
         await router.send_approval("ws-1", "corr-abc", approved=False)
         mock_approve.assert_awaited_once_with(
-            ws_id="ws-1", approved=False, feedback=None, always=False
+            ws_id="ws-1", approved=False, feedback=None, always=False, cycle_id="corr-abc"
         )
 
     @pytest.mark.anyio
@@ -110,7 +110,9 @@ class TestSendApproval:
         mock_approve = AsyncMock()
         monkeypatch.setattr(console_router._console, "route_approve", mock_approve)
         await console_router.send_approval("ws-1", "corr-abc", approved=True, always=True)
-        mock_approve.assert_awaited_once_with(ws_id="ws-1", approved=True, feedback="", always=True)
+        mock_approve.assert_awaited_once_with(
+            ws_id="ws-1", approved=True, feedback="", always=True, cycle_id="corr-abc"
+        )
 
 
 class TestDeleteRoute:

--- a/tests/test_channel_slack.py
+++ b/tests/test_channel_slack.py
@@ -576,10 +576,11 @@ class TestApprovalOwnership:
 
         bot, router, client = _make_bot()
         ws_id = "ws-1"
-        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+        bot._pending_approval[(ws_id, "corr-1")] = PendingApproval(  # type: ignore[attr-defined]
             channel="C01SAPU5414",
             message_ts="111.222",
             owner_user_id="U_OWNER",
+            cycle_id="corr-1",
         )
 
         body = {
@@ -598,10 +599,11 @@ class TestApprovalOwnership:
 
         bot, router, client = _make_bot()
         ws_id = "ws-1"
-        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+        bot._pending_approval[(ws_id, "corr-1")] = PendingApproval(  # type: ignore[attr-defined]
             channel="C01SAPU5414",
             message_ts="111.222",
             owner_user_id="U_OWNER",
+            cycle_id="corr-1",
         )
 
         body = {
@@ -620,10 +622,11 @@ class TestApprovalOwnership:
 
         bot, router, client = _make_bot()
         ws_id = "ws-1"
-        bot._pending_approval[ws_id] = PendingApproval(  # type: ignore[attr-defined]
+        bot._pending_approval[(ws_id, "corr-1")] = PendingApproval(  # type: ignore[attr-defined]
             channel="C01SAPU5414",
             message_ts="111.222",
             owner_user_id="U_OWNER",
+            cycle_id="corr-1",
         )
 
         body = {
@@ -776,7 +779,9 @@ class TestWsEventDispatch:
         bot, client = self._make_ws_bot()
 
         event = ApproveRequestEvent(
-            ws_id="ws-1", items=[{"func_name": "bash", "needs_approval": True}]
+            ws_id="ws-1",
+            cycle_id="cyc-1",
+            items=[{"call_id": "c-1", "func_name": "bash", "needs_approval": True}],
         )
         route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
         _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
@@ -784,8 +789,12 @@ class TestWsEventDispatch:
         client.chat_postMessage.assert_awaited_once()
         call_kwargs = client.chat_postMessage.call_args[1]
         assert "blocks" in call_kwargs
-        assert "ws-1" in bot._pending_approval  # type: ignore[attr-defined]
-        assert bot._pending_approval["ws-1"].owner_user_id == "U12345"  # type: ignore[attr-defined]
+        # Tracked under (ws_id, cycle_id) so concurrent cycles each get
+        # their own Slack message.
+        entry = bot._pending_approval[("ws-1", "cyc-1")]  # type: ignore[attr-defined]
+        assert entry.owner_user_id == "U12345"
+        assert entry.cycle_id == "cyc-1"
+        assert entry.call_ids == frozenset({"c-1"})
 
     def test_intent_verdict_updates_approval_message(self) -> None:
         from turnstone.channels.slack.bot import PendingApproval
@@ -797,14 +806,17 @@ class TestWsEventDispatch:
             return_value={"ok": True, "messages": [{"blocks": []}]}
         )
 
-        bot._pending_approval["ws-1"] = PendingApproval(  # type: ignore[attr-defined]
+        bot._pending_approval[("ws-1", "cyc-1")] = PendingApproval(  # type: ignore[attr-defined]
             channel="C1",
             message_ts="999.000",
             owner_user_id="U12345",
+            cycle_id="cyc-1",
+            call_ids=frozenset({"c-1"}),
         )
 
         event = IntentVerdictEvent(
             ws_id="ws-1",
+            call_id="c-1",
             func_name="bash",
             risk_level="high",
             confidence=0.9,
@@ -821,17 +833,20 @@ class TestWsEventDispatch:
         from turnstone.sdk.events import ApprovalResolvedEvent
 
         bot, client = self._make_ws_bot()
-        bot._pending_approval["ws-1"] = PendingApproval(  # type: ignore[attr-defined]
+        bot._pending_approval[("ws-1", "cyc-9")] = PendingApproval(  # type: ignore[attr-defined]
             channel="C1",
             message_ts="999.000",
             owner_user_id="U12345",
+            cycle_id="cyc-9",
         )
 
+        # Event WITHOUT a cycle_id (pre-multi-cycle server): the legacy
+        # fallback clears the ws's single tracked entry, as before.
         event = ApprovalResolvedEvent(ws_id="ws-1", approved=True)
         route = SlackRoute(channel="C1", user_id="U12345", thread_ts="123.456")
         _run(bot._on_ws_event("ws-1", route, event))  # type: ignore[attr-defined]
 
-        assert "ws-1" not in bot._pending_approval  # type: ignore[attr-defined]
+        assert not bot._pending_approval  # type: ignore[attr-defined]
         client.chat_update.assert_awaited_once()
 
     def test_link_prefix_does_not_hijack_regular_prompt(self) -> None:

--- a/tests/test_coord_ui_approve_tools.py
+++ b/tests/test_coord_ui_approve_tools.py
@@ -525,12 +525,16 @@ class TestBroadcastApprovalResolved:
         collector = MagicMock()
         ConsoleCoordinatorUI._collector = collector
         try:
-            ui._broadcast_approval_resolved(True, "lgtm", always=True)
+            ui._broadcast_approval_resolved(
+                True, "lgtm", always=True, cycle_id="cyc-1", call_ids=("c-1", "c-2")
+            )
             collector.emit_console_ws_approval_resolved.assert_called_once_with(
                 "coord-a",
                 approved=True,
                 feedback="lgtm",
                 always=True,
+                cycle_id="cyc-1",
+                call_ids=["c-1", "c-2"],
             )
         finally:
             ConsoleCoordinatorUI._collector = None
@@ -546,6 +550,8 @@ class TestBroadcastApprovalResolved:
                 approved=False,
                 feedback="",
                 always=False,
+                cycle_id="",
+                call_ids=[],
             )
         finally:
             ConsoleCoordinatorUI._collector = None

--- a/tests/test_coordinator_adapter.py
+++ b/tests/test_coordinator_adapter.py
@@ -195,6 +195,21 @@ def test_emit_tolerates_collector_exception() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_cleanup_ui_sweeps_all_approval_cycles_on_registry_uis() -> None:
+    """The real ConsoleCoordinatorUI carries the approval-cycle
+    registry: cleanup denies + wakes EVERY parked gate via
+    ``resolve_all_approvals`` (parallel task agents can hold several),
+    not the pre-cycle single-slot kick."""
+    adapter, _ = _make_adapter()
+    ws = _make_ws()
+    ws.ui.resolve_all_approvals = MagicMock(return_value=2)  # type: ignore[attr-defined]
+    adapter.cleanup_ui(ws)
+    ws.ui.resolve_all_approvals.assert_called_once_with(  # type: ignore[attr-defined]
+        False, "Workstream closed"
+    )
+    assert ws.ui._fg_event.is_set()  # type: ignore[attr-defined]
+
+
 def test_cleanup_ui_unblocks_events_and_broadcasts_to_listeners() -> None:
     adapter, _ = _make_adapter()
     ws = _make_ws()

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -1103,18 +1103,7 @@ def test_approve_resolves_ui_event(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     assert isinstance(ws.ui, ConsoleCoordinatorUI)
-    ws.ui._pending_approval = {
-        "type": "approve_request",
-        "items": [
-            {
-                "call_id": "c-1",
-                "func_name": "spawn_workstream",
-                "approval_label": "spawn_workstream",
-                "needs_approval": True,
-            }
-        ],
-    }
-    ws.ui._approval_event.clear()
+    cycle = _seed_pending(ws, "c-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1122,34 +1111,46 @@ def test_approve_resolves_ui_event(storage):
         headers=_COORD_HEADERS,
     )
     assert resp.status_code == 200
-    assert ws.ui._approval_event.is_set()
-    assert ws.ui._approval_result == (True, None)
+    assert resp.json()["cycle_id"] == cycle.cycle_id
+    assert cycle.event.is_set()
+    assert cycle.result == (True, None)
     assert "spawn_workstream" in ws.ui.auto_approve_tools
 
 
-def _seed_pending(ws, *call_ids: str) -> None:
-    ws.ui._pending_approval = {
+def _seed_pending(ws, *call_ids: str, func_name: str = "spawn_workstream"):
+    """Register a live ApprovalCycle on the coord UI the way its
+    ``approve_tools`` gate does, returning the cycle for direct
+    event/result assertions (the pre-cycle singleton
+    ``_approval_event`` / ``_approval_result`` slots are gone)."""
+    from turnstone.core.session_ui_base import ApprovalCycle
+
+    items = [
+        {
+            "call_id": cid,
+            "func_name": func_name,
+            "approval_label": func_name,
+            "needs_approval": True,
+        }
+        for cid in call_ids
+    ]
+    card = {
         "type": "approve_request",
-        "items": [
-            {
-                "call_id": cid,
-                "func_name": "spawn_workstream",
-                "approval_label": "spawn_workstream",
-                "needs_approval": True,
-            }
-            for cid in call_ids
-        ],
+        "cycle_id": f"cyc-{'-'.join(call_ids)}",
+        "items": ws.ui._serialize_approval_items(items),
+        "judge_pending": False,
     }
-    ws.ui._approval_event.clear()
+    cycle = ApprovalCycle(items, card, None)
+    ws.ui._register_approval_cycle(cycle)
+    return cycle
 
 
 def test_approve_409_on_stale_call_id(storage):
     """Body call_id doesn't match any pending item → 409 with the
-    current primary call_id so the UI can re-render against the
-    new round."""
+    current primary call_id + cycle_id so the UI can re-render
+    against the new round."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    _seed_pending(ws, "c-current")
+    cycle = _seed_pending(ws, "c-current")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1160,17 +1161,17 @@ def test_approve_409_on_stale_call_id(storage):
     body = resp.json()
     assert body["error"] == "stale call_id"
     assert body["current_call_id"] == "c-current"
-    # Approval event must NOT be set — no resolve_approval ran.
-    assert not ws.ui._approval_event.is_set()
+    assert body["current_cycle_id"] == cycle.cycle_id
+    # The live cycle must NOT have been resolved.
+    assert not cycle.event.is_set()
 
 
 def test_approve_409_when_no_pending_and_call_id_sent(storage):
-    """Body sends a call_id but the UI has no pending approval —
-    409 with current_call_id=None so the UI knows to clear the row."""
+    """Body sends a call_id but the UI has no live cycle — 409 with
+    current_call_id=None so the UI knows to clear the row."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    # No _pending_approval seeded → ui._pending_approval is None.
-    ws.ui._approval_event.clear()
+    # No cycle registered.
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1179,18 +1180,18 @@ def test_approve_409_when_no_pending_and_call_id_sent(storage):
     )
     assert resp.status_code == 409
     body = resp.json()
-    assert body["error"] == "no pending approval"
+    assert body["error"] == "stale call_id"
     assert body["current_call_id"] is None
-    assert not ws.ui._approval_event.is_set()
+    assert body["current_cycle_id"] is None
 
 
 def test_approve_no_call_id_preserves_backward_compat(storage):
     """Existing clients (CLI, channel adapters) that omit call_id
-    must still resolve approvals — the guard only kicks in when
-    call_id is present in the body."""
+    must still resolve approvals — a selector-less body lands on the
+    oldest live cycle."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    _seed_pending(ws, "c-1")
+    cycle = _seed_pending(ws, "c-1")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1198,18 +1199,18 @@ def test_approve_no_call_id_preserves_backward_compat(storage):
         headers=_COORD_HEADERS,
     )
     assert resp.status_code == 200
-    assert ws.ui._approval_event.is_set()
+    assert resp.json()["cycle_id"] == cycle.cycle_id
+    assert cycle.event.is_set()
 
 
-def test_approve_no_call_id_no_pending_falls_through(storage):
-    """Legacy clients (no call_id) calling approve when pending is
-    None hit the existing resolve_approval no-op path — the new
-    guard must not change that behavior. Regression guard for the
-    legacy code path that the call_id check intentionally bypasses."""
+def test_approve_no_call_id_no_pending_resolves_nothing(storage):
+    """Legacy clients (no call_id) calling approve with no live cycle:
+    200 with ``cycle_id: null`` — the handler resolves NOTHING rather
+    than racing a cycle that registers between its lookup and its
+    resolve (the client can't have been looking at one)."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    ws.ui._approval_event.clear()
-    # No _pending_approval seeded.
+    # No cycle registered.
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1217,7 +1218,7 @@ def test_approve_no_call_id_no_pending_falls_through(storage):
         headers=_COORD_HEADERS,
     )
     assert resp.status_code == 200
-    assert ws.ui._approval_event.is_set()
+    assert resp.json()["cycle_id"] is None
 
 
 def test_approve_call_id_matches_any_item_in_multi_envelope(storage):
@@ -1226,7 +1227,7 @@ def test_approve_call_id_matches_any_item_in_multi_envelope(storage):
     one-boolean semantics of resolve_approval."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    _seed_pending(ws, "c-1", "c-2", "c-3")
+    cycle = _seed_pending(ws, "c-1", "c-2", "c-3")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(
         f"/v1/api/workstreams/{ws.id}/approve",
@@ -1234,7 +1235,61 @@ def test_approve_call_id_matches_any_item_in_multi_envelope(storage):
         headers=_COORD_HEADERS,
     )
     assert resp.status_code == 200
-    assert ws.ui._approval_event.is_set()
+    assert cycle.event.is_set()
+
+
+def test_selectorless_always_whitelists_only_the_resolved_oldest_cycle(storage):
+    """sweep-3 regression: with several live cycles, a selector-less
+    "Approve + Always" must whitelist the tools of the cycle it
+    actually resolved (the oldest) — not a sibling's."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    oldest = _seed_pending(ws, "a-1", func_name="spawn_workstream")
+    newer = _seed_pending(ws, "b-1", func_name="send_message")
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/approve",
+        json={"approved": True, "always": True},  # no selector
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["cycle_id"] == oldest.cycle_id
+    assert oldest.event.is_set()
+    assert not newer.event.is_set()
+    assert "spawn_workstream" in ws.ui.auto_approve_tools
+    assert "send_message" not in ws.ui.auto_approve_tools
+
+
+def test_approve_always_skips_whitelist_when_pinned_cycle_lost_the_race(storage):
+    """sweep-3 regression: the handler collects always-names from the
+    cycle its lookup pinned; if that cycle is resolved by someone else
+    (gate timeout, peer tab) between lookup and resolve, the whitelist
+    must NOT grow — approving a card that already resolved must not
+    auto-approve anything."""
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    _seed_pending(ws, "a-1", func_name="spawn_workstream")
+    ui = ws.ui
+    real_find = ui.find_approval_cycle
+
+    def racing_find(**kwargs):
+        card = real_find(**kwargs)
+        if card is not None:
+            # A concurrent resolver wins the gap between the handler's
+            # lookup and its (pinned) resolve.
+            ui.resolve_approval(False, "raced", cycle_id=card["cycle_id"])
+        return card
+
+    ui.find_approval_cycle = racing_find
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+    resp = client.post(
+        f"/v1/api/workstreams/{ws.id}/approve",
+        json={"approved": True, "always": True},
+        headers=_COORD_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["cycle_id"] is None
+    assert "spawn_workstream" not in ws.ui.auto_approve_tools
 
 
 # ---------------------------------------------------------------------------
@@ -1521,15 +1576,19 @@ def test_export_404_when_kind_interactive(storage):
 
 
 def test_cancel_resolves_pending_approval(storage):
+    """Cancel addresses the workstream, not one batch — EVERY live
+    cycle resolves (parallel task agents can hold several gates)."""
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     assert isinstance(ws.ui, ConsoleCoordinatorUI)
-    ws.ui._pending_approval = {"type": "approve_request", "items": []}
-    ws.ui._approval_event.clear()
+    first = _seed_pending(ws, "c-1")
+    second = _seed_pending(ws, "c-2")
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
     resp = client.post(f"/v1/api/workstreams/{ws.id}/cancel", headers=_COORD_HEADERS)
     assert resp.status_code == 200
-    assert ws.ui._approval_event.is_set()
+    assert first.event.is_set()
+    assert second.event.is_set()
+    assert first.result == (False, "Cancelled by user")
 
 
 def test_cancel_response_always_includes_dropped_key(storage):
@@ -2399,6 +2458,7 @@ def test_cluster_inspect_node_backed_pending_approval_detail_passes_through(stor
     ws_id = "f0" * 16
     _seed_node_workstream(storage, ws_id=ws_id, node_id="node-a")
     detail = {
+        "cycle_id": "cyc-bash",
         "call_id": "c-bash",
         "judge_pending": False,
         "items": [
@@ -2427,7 +2487,7 @@ def test_cluster_inspect_node_backed_pending_approval_detail_passes_through(stor
                 "activity_state": "approval",
                 "activity": "awaiting approval",
                 "tokens": 100,
-                "pending_approval_detail": detail,
+                "pending_approval_details": [detail],
             }
         ]
     }
@@ -2438,7 +2498,7 @@ def test_cluster_inspect_node_backed_pending_approval_detail_passes_through(stor
     assert resp.status_code == 200
     live = resp.json()["live"]
     assert live["pending_approval"] is True  # derived bool, existing behavior
-    assert live["pending_approval_detail"] == detail  # full payload, new behavior
+    assert live["pending_approval_details"] == [detail]  # full payload passthrough
 
 
 def test_cluster_inspect_node_backed_pending_approval_synthesized(storage):

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -313,17 +313,17 @@ def test_coordinator_js_handle_child_state_no_longer_reads_sse_pending_approval_
     )
 
     # The merge body must preserve BOTH pending_approval and
-    # pending_approval_detail from prev — preserving only one would
+    # pending_approval_details from prev — preserving only one would
     # render a row with a phantom badge but no buttons (or vice versa).
     merge_body = re.search(
         r"mergedLive\s*=\s*Object\.assign\(\s*\{\}\s*,\s*live\s*,\s*\{"
         r"[^}]*pending_approval:\s*prev\.live\.pending_approval[^}]*"
-        r"pending_approval_detail:\s*prev\.live\.pending_approval_detail",
+        r"pending_approval_details:\s*prev\.live\.pending_approval_details",
         body,
     )
     assert merge_body is not None, (
         "Merge body must preserve both pending_approval AND "
-        "pending_approval_detail from prev.live — preserving only one "
+        "pending_approval_details from prev.live — preserving only one "
         "creates a half-rendered approval row."
     )
 

--- a/tests/test_phase6_endpoints.py
+++ b/tests/test_phase6_endpoints.py
@@ -228,34 +228,42 @@ def test_bulk_live_coordinator_row_uses_manager_snapshot(storage):
     live = body["results"][ws.id]
     assert live is not None
     assert "pending_approval" in live
-    # New field always present on the wire — None when no approval
-    # is pending so the JS can `key in row` without surprise.
-    assert "pending_approval_detail" in live
-    assert live["pending_approval_detail"] is None
+    # The details list is always present on the wire — empty when no
+    # approval is pending so the JS can `key in row` without surprise.
+    # Replaces 1.6's singular ``pending_approval_detail`` null
+    # (breaking, 1.7).
+    assert "pending_approval_details" in live
+    assert live["pending_approval_details"] == []
 
 
-def test_bulk_live_coordinator_row_includes_pending_approval_detail(storage):
-    """When _pending_approval is set on a coord UI, the live block
-    surfaces the merged items + judge_verdict payload through the
-    coord-pseudo-node path. End-to-end equivalent of the dashboard
-    test in test_server_authz, but for the console live-bulk
-    endpoint that the coord tree UI actually consumes."""
+def test_bulk_live_coordinator_row_includes_pending_approval_details(storage):
+    """When an approval cycle is live on a coord UI, the live block
+    surfaces one detail entry per cycle with merged items +
+    judge_verdict through the coord-pseudo-node path. End-to-end
+    equivalent of the dashboard test in test_server_authz, but for
+    the console live-bulk endpoint that the coord tree UI actually
+    consumes."""
+    from turnstone.core.session_ui_base import ApprovalCycle
+
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
-    ws.ui._pending_approval = {
+    items = [
+        {
+            "call_id": "c-99",
+            "header": "spawn_workstream",
+            "preview": "{...}",
+            "func_name": "spawn_workstream",
+            "approval_label": "spawn_workstream",
+            "needs_approval": True,
+        }
+    ]
+    card = {
         "type": "approve_request",
-        "items": [
-            {
-                "call_id": "c-99",
-                "header": "spawn_workstream",
-                "preview": "{...}",
-                "func_name": "spawn_workstream",
-                "approval_label": "spawn_workstream",
-                "needs_approval": True,
-            }
-        ],
+        "cycle_id": "cyc-99",
+        "items": ws.ui._serialize_approval_items(items),
         "judge_pending": False,
     }
+    ws.ui._register_approval_cycle(ApprovalCycle(items, card, None))
     ws.ui._llm_verdicts["c-99"] = {
         "recommendation": "approve",
         "risk_level": "low",
@@ -269,8 +277,10 @@ def test_bulk_live_coordinator_row_includes_pending_approval_detail(storage):
     assert resp.status_code == 200
     live = resp.json()["results"][ws.id]
     assert live["pending_approval"] is True  # boolean derived flag
-    detail = live["pending_approval_detail"]
-    assert detail is not None
+    details = live["pending_approval_details"]
+    assert len(details) == 1
+    detail = details[0]
+    assert detail["cycle_id"] == "cyc-99"
     assert detail["call_id"] == "c-99"
     assert detail["items"][0]["func_name"] == "spawn_workstream"
     assert detail["items"][0]["judge_verdict"]["recommendation"] == "approve"

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -88,18 +88,19 @@ class _FakeUI:
         self._ws_turn_tool_calls = 0
         self._llm_verdicts: dict[str, dict[str, Any]] = {}
 
-    def serialize_pending_approval_detail(self) -> dict[str, Any] | None:
-        # Mirrors SessionUIBase.serialize_pending_approval_detail —
+    def serialize_pending_approval_details(self) -> list[dict[str, Any]]:
+        # Mirrors SessionUIBase.serialize_pending_approval_details —
         # the fake is monkeypatched in for ``WebUI`` and the dashboard
         # handler reads this method during projection. Real subclasses
-        # inherit from ``SessionUIBase``; the fake replicates the
-        # shape directly to stay decoupled.
+        # iterate their approval-cycle registry (one entry per live
+        # cycle); the fake models a single slot, so the list carries
+        # zero or one entries.
         pending = self._pending_approval
         if pending is None:
-            return None
+            return []
         items = pending.get("items") or []
         if not items:
-            return None
+            return []
         call_ids = [item.get("call_id", "") for item in items]
         # Match the real impl's pattern (session_ui_base.py): snapshot
         # references under the lock, copy after release. Writers only
@@ -133,11 +134,14 @@ class _FakeUI:
         # fake here keeps test-vs-prod behavioural drift from
         # masking a real-shape regression.
         primary = next((cid for cid in call_ids if cid), "")
-        return {
-            "call_id": primary,
-            "judge_pending": bool(pending.get("judge_pending", False)),
-            "items": serialized,
-        }
+        return [
+            {
+                "cycle_id": pending.get("cycle_id", ""),
+                "call_id": primary,
+                "judge_pending": bool(pending.get("judge_pending", False)),
+                "items": serialized,
+            }
+        ]
 
     def serialize_recent_auto_approvals(self) -> list[dict[str, Any]]:
         # Empty buffer for tests that don't exercise the auto-approve
@@ -671,28 +675,35 @@ class TestDashboardTrustedTeamVisibility:
         owners = {w["user_id"] for w in data["workstreams"]}
         assert {"user-a", "user-b"}.issubset(owners)
 
-    def test_dashboard_pending_approval_detail_default_none(self, app_client):
-        """No pending approval → field is explicitly null on the wire so
-        consumers can distinguish "not present" from "absent key"."""
+    def test_dashboard_pending_approval_details_default_empty(self, app_client):
+        """No pending approval → the list field is explicitly empty on
+        the wire so consumers can distinguish "nothing pending" from
+        "absent key".  Replaces 1.6's singular ``pending_approval_detail``
+        null (breaking, 1.7)."""
         client, _mgr = app_client
         client.post("/v1/api/workstreams/new", json={"name": "a"}, headers=_auth("user-a"))
         resp = client.get("/v1/api/dashboard", headers=_auth("user-a"))
         assert resp.status_code == 200
         rows = resp.json()["workstreams"]
         assert len(rows) == 1
-        assert "pending_approval_detail" in rows[0]
-        assert rows[0]["pending_approval_detail"] is None
+        assert "pending_approval_details" in rows[0]
+        assert rows[0]["pending_approval_details"] == []
+        # The 1.6 singular field is GONE, not null — a consumer still
+        # reading it should break loudly, not read None forever.
+        assert "pending_approval_detail" not in rows[0]
 
-    def test_dashboard_pending_approval_detail_merges_judge_verdict(self, app_client):
+    def test_dashboard_pending_approval_details_merge_judge_verdict(self, app_client):
         """When _pending_approval is set on a ws's UI, /dashboard
-        embeds the merged items + judge_verdict so coord live-bulk
-        callers can render inline approve/deny buttons."""
+        embeds one detail entry per live cycle with merged items +
+        judge_verdict so coord live-bulk callers can render inline
+        approve/deny buttons."""
         client, mgr = app_client
         client.post("/v1/api/workstreams/new", json={"name": "a"}, headers=_auth("user-a"))
         ws_id = next(iter(mgr.list_all())).id
         ui = mgr.get(ws_id).ui
         ui._pending_approval = {
             "type": "approve_request",
+            "cycle_id": "cyc-1",
             "items": [
                 {
                     "call_id": "c-1",
@@ -714,8 +725,10 @@ class TestDashboardTrustedTeamVisibility:
         resp = client.get("/v1/api/dashboard", headers=_auth("user-a"))
         assert resp.status_code == 200
         row = next(w for w in resp.json()["workstreams"] if w["ws_id"] == ws_id)
-        detail = row["pending_approval_detail"]
-        assert detail is not None
+        details = row["pending_approval_details"]
+        assert len(details) == 1
+        detail = details[0]
+        assert detail["cycle_id"] == "cyc-1"
         assert detail["call_id"] == "c-1"
         assert detail["judge_pending"] is False
         item = detail["items"][0]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -798,6 +798,89 @@ class TestTaskExec:
         captured[0](fake_verdict)  # must not raise
         session.ui.on_intent_verdict.assert_not_called()
 
+    def test_evaluate_intent_agent_gate_owns_generation_off_the_main_slot(
+        self, tmp_db, monkeypatch
+    ) -> None:
+        """Sub-agent gates run the SAME judge pipeline as the main loop
+        but as their OWN generation (release blocker #1: task_agent
+        calls used to reach the gate judge-blind).  The main-loop
+        supersede slot stays untouched — with parallel task agents,
+        publishing into it would make every sibling's verdicts look
+        stale to the previous sibling's callback — while the generation
+        is stamped on the items for the UI's origin checks, registered
+        for ``close()``'s sweep, delivered alongside the verdict, and
+        grounded on the SUB-AGENT's trajectory (its task prompt is the
+        delegation contract), not the parent conversation."""
+        import threading
+
+        from turnstone.core.session_ui_base import SessionUIBase
+        from turnstone.core.trajectory import turns_from_dicts
+
+        class _GateUI(SessionUIBase):
+            pass
+
+        session = _make_session()
+        ui = _GateUI(ws_id="ws-gate", user_id="u1")
+        ui.on_intent_verdict = MagicMock()  # shadow: capture delivery kwargs
+        session.ui = ui
+
+        captured: dict[str, Any] = {}
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "call_id": "c1", "tier": "llm"}
+        fake_judge = MagicMock()
+
+        def _eval(items, convo, **kw):
+            captured["convo"] = convo
+            captured["callback"] = kw.get("callback")
+            captured["cancel_event"] = kw.get("cancel_event")
+            captured["done"] = kw.get("done_callback")
+            return [fake_verdict] * len(items)
+
+        fake_judge.evaluate.side_effect = _eval
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        main_slot = threading.Event()
+        session._judge_cancel_event = main_slot
+        agent_turns = turns_from_dicts([{"role": "user", "content": "Task: reindex the docs tree"}])
+        item = {"call_id": "c1", "func_name": "bash", "needs_approval": True, "command": "ls"}
+
+        ev = session._evaluate_intent([item], conversation=agent_turns, agent_gate=True)
+
+        assert ev is not None and ev is not main_slot
+        # Main-loop slot untouched by the sub-agent spawn.
+        assert session._judge_cancel_event is main_slot
+        # Generation stamped for the UI's origin checks + close() sweep,
+        # and handed to the daemon as its cancel event.
+        assert item["_judge_event"] is ev
+        assert ev in session._judge_cancel_events
+        assert captured["cancel_event"] is ev
+        # Judge grounded on the sub-agent trajectory, not session.messages.
+        assert any("reindex the docs tree" in str(m) for m in captured["convo"])
+        # Delivery rides the generation into the UI.
+        captured["callback"](fake_verdict)
+        assert ui.on_intent_verdict.call_args.kwargs.get("judge_event") is ev
+        # Daemon completion keeps the close()-sweep set exact.
+        captured["done"]()
+        assert ev not in session._judge_cancel_events
+
+    def test_close_fires_agent_gate_judge_generations(self, tmp_db, monkeypatch) -> None:
+        """``close()`` aborts EVERY in-flight judge daemon — including
+        sub-agent generations that never touched the main slot — so a
+        torn-down session can't leave daemons running against a dead
+        UI."""
+        session = _make_session()
+        fake_verdict = MagicMock()
+        fake_verdict.to_dict.return_value = {"verdict_id": "v0", "call_id": "c1", "tier": "llm"}
+        fake_judge = MagicMock()
+        fake_judge.evaluate.side_effect = lambda items, *_a, **_kw: [fake_verdict] * len(items)
+        monkeypatch.setattr(session, "_ensure_judge", lambda: fake_judge)
+
+        item = {"call_id": "c1", "func_name": "bash", "needs_approval": True, "command": "ls"}
+        ev = session._evaluate_intent([item], conversation=[], agent_gate=True)
+        assert ev is not None and not ev.is_set()
+        session.close()
+        assert ev.is_set()
+
     def _drive_gate(self, session, monkeypatch, *, cancel_on_approval: bool):
         """Run one needs_approval bash item through ``_execute_tools`` with a
         stubbed judge + approval gate; return the cancel event the judge

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -13,8 +13,11 @@ in its own test files.
 
 from __future__ import annotations
 
+import contextlib
 import queue
 import threading
+import time
+from collections.abc import Callable, Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -93,22 +96,67 @@ def test_enqueue_tolerates_full_listener_queue() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_approval_sets_result_and_unblocks_event() -> None:
+def _register_cycle(
+    ui: SessionUIBase,
+    call_ids: list[str],
+    *,
+    judge_event: object | None = None,
+) -> Any:
+    """Register a live ApprovalCycle the way ``approve_tools`` does.
+
+    Builds the card from wire-shaped items so serializer tests see the
+    exact production shape, registers under the lock, and returns the
+    cycle for direct assertions.
+    """
+    from turnstone.core.session_ui_base import ApprovalCycle
+
+    items = [
+        {"call_id": cid, "func_name": "bash", "approval_label": "bash", "needs_approval": True}
+        for cid in call_ids
+    ]
+    card: dict[str, Any] = {
+        "type": "approve_request",
+        "cycle_id": f"cycle-{'-'.join(call_ids)}",
+        "items": ui._serialize_approval_items(items),
+        "judge_pending": False,
+    }
+    cycle = ApprovalCycle(items, card, judge_event)
+    ui._register_approval_cycle(cycle)
+    return cycle
+
+
+def test_resolve_approval_sets_result_and_unblocks_cycle_event() -> None:
     ui = _make_ui()
-    ui._approval_event.clear()
-    ui.resolve_approval(True, "looks good")
-    assert ui._approval_result == (True, "looks good")
-    assert ui._approval_event.is_set()
+    cycle = _register_cycle(ui, ["c1"])
+    resolved = ui.resolve_approval(True, "looks good")
+    assert resolved == cycle.cycle_id
+    assert cycle.result == (True, "looks good")
+    assert cycle.resolved is True
+    assert cycle.event.is_set()
+
+
+def test_resolve_approval_without_live_cycle_is_a_noop() -> None:
+    """No live cycle → nothing to resolve: returns None and broadcasts
+    nothing (the old singleton overwrote a shared result slot and
+    leaked a stale ``approval_resolved`` event on idle cancels)."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    assert ui.resolve_approval(True, "nobody asked") is None
+    assert lq.empty()
 
 
 def test_resolve_approval_broadcasts_approval_resolved() -> None:
     ui = _make_ui()
+    cycle = _register_cycle(ui, ["c1"])
     lq = ui._register_listener()
     ui.resolve_approval(False, "nope")
     event = lq.get_nowait()
     assert event["type"] == "approval_resolved"
     assert event["approved"] is False
     assert event["feedback"] == "nope"
+    # Cycle identity rides the event so clients dismiss the RIGHT card.
+    assert event["cycle_id"] == cycle.cycle_id
+    assert event["call_ids"] == ["c1"]
 
 
 # ---------------------------------------------------------------------------
@@ -156,24 +204,52 @@ def test_on_intent_verdict_persists_verdict_row() -> None:
     assert kwargs["call_id"] == "c1"
 
 
-def test_on_intent_verdict_queues_pending_when_decision_unset() -> None:
+def test_on_intent_verdict_parks_on_owning_cycle_when_undecided() -> None:
+    ui = _make_ui()
+    cycle = _register_cycle(ui, ["c1"])
+    with _patch_get_storage(MagicMock()):
+        ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
+    assert cycle.pending_verdicts == [{"verdict_id": "v1", "call_id": "c1"}]
+
+
+def test_on_intent_verdict_without_owner_is_cache_only() -> None:
+    """No live cycle owns the call (pre-cycle Smart-Approvals arrival):
+    the verdict caches for the wait/replay but parks nowhere — the
+    gate's registration sweep adopts it when the cycle is created."""
     ui = _make_ui()
     with _patch_get_storage(MagicMock()):
         ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
-    assert ui._pending_verdicts == [{"verdict_id": "v1", "call_id": "c1"}]
+    assert ui._llm_verdicts["c1"]["verdict_id"] == "v1"
+    assert ui._approval_cycles == {}
 
 
 def test_on_intent_verdict_stamps_immediately_when_decision_already_set() -> None:
-    """Late-arriving verdict (after approval resolved) gets
-    user_decision stamped immediately instead of queued."""
+    """Late-arriving verdict (after its round resolved) gets
+    user_decision stamped from the per-call decision map instead of
+    parked — the run-to-completion daemon can deliver seconds after
+    the gate closed."""
     storage = MagicMock()
     ui = _make_ui()
-    ui._last_verdict_decision = "approved"
+    ui._recent_decisions["c-late"] = ("approved", None)
     with _patch_get_storage(storage):
         ui.on_intent_verdict({"verdict_id": "v-late", "call_id": "c-late"})
-    # Not queued — decision was already set.
-    assert ui._pending_verdicts == []
     storage.update_intent_verdict.assert_called_once_with("v-late", user_decision="approved")
+
+
+def test_on_intent_verdict_late_stamp_is_per_call_not_global() -> None:
+    """Concurrent-cycles regression: sibling B's late verdict must NOT
+    inherit sibling A's decision — the old single ``_last_verdict_decision``
+    string stamped every late verdict with whichever round resolved last."""
+    storage = MagicMock()
+    ui = _make_ui()
+    _register_cycle(ui, ["a1"])
+    _register_cycle(ui, ["b1"])
+    with _patch_get_storage(storage):
+        ui.resolve_approval(True, None, call_id="a1")  # approve A only
+        ui.on_intent_verdict({"verdict_id": "v-b", "call_id": "b1"})
+    # B's verdict is parked on B's still-open cycle, unstamped.
+    for call in storage.update_intent_verdict.call_args_list:
+        assert call.args[0] != "v-b", "sibling A's decision leaked onto B's verdict"
 
 
 def test_on_superseded_intent_verdict_persists_without_live_surfaces() -> None:
@@ -201,7 +277,6 @@ def test_on_superseded_intent_verdict_persists_without_live_surfaces() -> None:
     assert kwargs["user_decision"] == "superseded"
     assert lq.empty()  # no SSE delivery
     assert "c-late" not in ui._llm_verdicts  # no replay-cache write
-    assert ui._pending_verdicts == []  # no decision-stamp park
     assert "user_decision" not in verdict  # caller's dict not mutated
 
 
@@ -221,54 +296,64 @@ def test_llm_verdict_cache_evicts_oldest_at_cap() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Approval cycle reset — the bug-1 regression
+# Per-round verdict purge — the bug-1 regression, scoped for concurrency
 # ---------------------------------------------------------------------------
 
 
-def test_reset_approval_cycle_clears_decision_and_cache() -> None:
+def test_purge_round_verdicts_is_scoped_to_the_entering_batch() -> None:
+    """Successor of the whole-cache reset: entering a gate evicts stale
+    verdict state for ITS call_ids only — a concurrent sibling cycle's
+    cached verdicts must survive (the old full clear wiped them
+    mid-wait and sent qualifying batches to a human)."""
     ui = _make_ui()
-    ui._last_verdict_decision = "approved"
+    ui._recent_decisions["c-stale"] = ("approved", None)
     ui._llm_verdicts["c-stale"] = {"verdict_id": "stale"}
-    ui._reset_approval_cycle()
-    assert ui._last_verdict_decision == ""
-    assert ui._llm_verdicts == {}
+    ui._verdict_origins["c-stale"] = 123
+    ui._llm_verdicts["c-sibling"] = {"verdict_id": "sibling"}
+    ui._purge_round_verdicts({"c-stale"})
+    assert "c-stale" not in ui._llm_verdicts
+    assert "c-stale" not in ui._verdict_origins
+    assert "c-stale" not in ui._recent_decisions
+    # The concurrent sibling's verdict is untouched.
+    assert ui._llm_verdicts["c-sibling"]["verdict_id"] == "sibling"
 
 
 def test_late_verdict_in_new_round_not_stamped_with_prior_decision() -> None:
-    """Regression test for the ultrareview bug-1 finding.
+    """Regression test for the ultrareview bug-1 finding, cycle-scoped.
 
-    Round 1: approve → _last_verdict_decision = "approved".
-    Round 2 begins: caller calls _reset_approval_cycle().
+    Round 1 (call c1): approve → decision recorded for c1 only.
+    Round 2 (call c2, new cycle) begins.
     A verdict fires mid-round 2: must NOT inherit "approved" from
-    round 1. Must land in _pending_verdicts waiting for this round's
-    resolution.
+    round 1. Must park on round 2's cycle awaiting ITS resolution.
     """
     storage = MagicMock()
     ui = _make_ui()
-    # Simulate round 1 completion.
+    # Round 1 completion.
+    _register_cycle(ui, ["c1"])
     with _patch_get_storage(storage):
         ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
         ui.resolve_approval(True, None)
-    assert ui._last_verdict_decision == "approved"
-    # Round 2 begins — subclass approve_tools calls this at entry.
-    ui._reset_approval_cycle()
+    assert ui._recent_decisions.get("c1") == ("approved", None)
+    # Round 2 begins — approve_tools purges the entering ids and
+    # registers a fresh cycle.
+    ui._purge_round_verdicts({"c2"})
+    cycle2 = _register_cycle(ui, ["c2"])
     # Late judge fires during round 2 BEFORE the user decides.
     with _patch_get_storage(storage):
         ui.on_intent_verdict({"verdict_id": "v2", "call_id": "c2"})
-    # The new verdict must be pending (awaiting this round's decision),
+    # The new verdict parks on round 2's cycle (awaiting its decision),
     # NOT already stamped with round 1's "approved".
-    assert ui._pending_verdicts == [{"verdict_id": "v2", "call_id": "c2"}]
-    # update_intent_verdict was only called ONCE: for v1 when round 1
-    # resolved. v2 should NOT have been stamped.
+    assert cycle2.pending_verdicts == [{"verdict_id": "v2", "call_id": "c2"}]
     for call in storage.update_intent_verdict.call_args_list:
         assert call.args[0] != "v2", "late verdict was stamped with prior round's decision"
 
 
-def test_both_subclasses_call_reset_from_approve_tools() -> None:
-    """Regression for bug-1: the real subclass ``approve_tools``
-    methods must invoke ``_reset_approval_cycle`` at entry. Without
-    this, coord sessions that already resolved a prior approval stamp
-    the next round's late verdicts with the stale decision.
+def test_both_subclasses_purge_round_state_from_approve_tools() -> None:
+    """Regression for bug-1, scoped: the real subclass ``approve_tools``
+    bodies must purge the ENTERING batch's stale verdict state at entry
+    — a provider that reuses call_ids across turns must not have round
+    1's cached ``approve`` pre-satisfy round 2's Smart-Approvals wait.
+    A concurrent sibling's cache entry survives.
     """
     import turnstone.server
     from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
@@ -277,39 +362,47 @@ def test_both_subclasses_call_reset_from_approve_tools() -> None:
 
     for cls in (webui, ConsoleCoordinatorUI):
         ui = cls(ws_id="ws-x", user_id="u1")
-        # Stage state as if a prior approval round already finished.
-        ui._last_verdict_decision = "approved"
-        ui._llm_verdicts["stale"] = {"verdict_id": "stale"}
-        # Entering approve_tools for a new round — the reset must fire.
-        # Pass items with needs_approval=False so approve_tools returns
-        # without blocking on user input.
+        # Stage state as if a prior round already finished on the SAME
+        # call_id this round reuses, plus an unrelated sibling entry.
+        ui._recent_decisions["c-reused"] = ("approved", None)
+        ui._llm_verdicts["c-reused"] = {"verdict_id": "stale"}
+        ui._llm_verdicts["c-sibling"] = {"verdict_id": "sibling"}
+        # Entering approve_tools for the new round — the scoped purge
+        # must fire for c-reused.  needs_approval=False so the gate
+        # returns without blocking on user input.
         with _patch_get_storage(MagicMock()):
-            ui.approve_tools([{"func_name": "ls", "needs_approval": False}])
-        assert ui._last_verdict_decision == "", (
-            f"{cls.__name__}.approve_tools did not call _reset_approval_cycle "
-            "— next round's verdicts would inherit the prior decision"
+            ui.approve_tools([{"call_id": "c-reused", "func_name": "ls", "needs_approval": False}])
+        assert "c-reused" not in ui._llm_verdicts, (
+            f"{cls.__name__}.approve_tools did not purge the entering batch's "
+            "stale cached verdict — round 2 could ride round 1's approve"
         )
-        assert ui._llm_verdicts == {}, (
-            f"{cls.__name__}.approve_tools did not clear the LLM verdict cache"
+        assert "c-reused" not in ui._recent_decisions, (
+            f"{cls.__name__}.approve_tools did not purge the entering batch's "
+            "stale decision — this round's verdicts would inherit it"
+        )
+        assert ui._llm_verdicts.get("c-sibling") == {"verdict_id": "sibling"}, (
+            f"{cls.__name__}.approve_tools wiped a concurrent sibling's verdict"
         )
 
 
 def test_on_intent_verdict_decision_check_and_queue_are_atomic() -> None:
     """Regression for the on_intent_verdict ↔ resolve_approval race.
 
-    Prior implementation acquired ``_ws_lock`` twice: once to read
-    ``_last_verdict_decision``, once to append to
-    ``_pending_verdicts``. Between those two acquisitions
-    ``resolve_approval`` could swap-and-clear the pending list and
-    set the decision — our verdict then got appended to the fresh
-    list and stamped with the NEXT round's decision.
+    The owner-check, the park, and the fallback decision-read must
+    happen under a SINGLE lock acquisition: ``resolve_approval`` marks
+    the cycle resolved and records the per-call decision atomically
+    under the same lock, so exactly one side wins — the verdict is
+    either parked pre-decision (resolve stamps it from the cycle's
+    ``pending_verdicts``) or stamped post-decision (from
+    ``_recent_decisions``).  A check-then-release-then-park pattern
+    reopens the window where a verdict lands unparked AND unstamped —
+    an audit row stuck at "pending" forever.
 
-    Fix: decision check + append happen under a single lock
-    acquisition. This test counts lock acquisitions during one
-    ``on_intent_verdict`` and fails if the release-then-reacquire
-    pattern returns.
+    This test counts lock acquisitions during one ``on_intent_verdict``
+    and fails if the release-then-reacquire pattern returns.
     """
     ui = _make_ui()
+    _register_cycle(ui, ["c1"])
     acquire_count = 0
     original_lock = ui._ws_lock
 
@@ -335,32 +428,34 @@ def test_on_intent_verdict_decision_check_and_queue_are_atomic() -> None:
     with _patch_get_storage(MagicMock()):
         ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
     # Two acquisitions: one for the cache write (call_id is truthy),
-    # one for decision-check + pending-append. Before the fix there
-    # were three, with a window resolve_approval could slip into.
+    # one for owner-check + park-or-stamp. A third acquisition means
+    # the release-then-reacquire window is back.
     assert acquire_count == 2, (
         f"on_intent_verdict acquired _ws_lock {acquire_count} times; "
-        "decision-check + pending-append must happen under ONE acquisition "
+        "owner-check + park-or-stamp must happen under ONE acquisition "
         "to avoid a race with resolve_approval"
     )
 
 
 def test_resolve_approval_stamps_all_pending_verdicts() -> None:
-    """Normal path: multiple verdicts queued during the round, all get
+    """Normal path: multiple verdicts parked on the round's cycle, all
     stamped with the user's decision on resolve."""
     storage = MagicMock()
     ui = _make_ui()
+    cycle = _register_cycle(ui, ["c1", "c2"])
     with _patch_get_storage(storage):
         ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
         ui.on_intent_verdict({"verdict_id": "v2", "call_id": "c2"})
-    assert len(ui._pending_verdicts) == 2
+    assert len(cycle.pending_verdicts) == 2
     with _patch_get_storage(storage):
         ui.resolve_approval(False, "too risky")
     # Both verdicts get stamped.
     stamped_ids = {c.args[0] for c in storage.update_intent_verdict.call_args_list}
     assert stamped_ids == {"v1", "v2"}
-    # Pending list cleared after resolve.
-    assert ui._pending_verdicts == []
-    assert ui._last_verdict_decision == "denied"
+    # Cycle's park cleared after resolve; decisions recorded per call.
+    assert cycle.pending_verdicts == []
+    assert ui._recent_decisions.get("c1") == ("denied", None)
+    assert ui._recent_decisions.get("c2") == ("denied", None)
 
 
 # ---------------------------------------------------------------------------
@@ -377,12 +472,13 @@ def test_resolve_approval_timeout_kwarg_writes_timeout_value() -> None:
     string used to carry this distinction but the column alone could not."""
     storage = MagicMock()
     ui = _make_ui()
+    _register_cycle(ui, ["c1"])
     with _patch_get_storage(storage):
         ui.on_intent_verdict({"verdict_id": "v1", "call_id": "c1"})
     with _patch_get_storage(storage):
         ui.resolve_approval(False, "expired", timeout=True)
     storage.update_intent_verdict.assert_any_call("v1", user_decision="timeout")
-    assert ui._last_verdict_decision == "timeout"
+    assert ui._recent_decisions.get("c1") == ("timeout", None)
 
 
 def test_resolve_approval_timeout_with_approved_raises() -> None:
@@ -442,11 +538,6 @@ def test_on_intent_verdict_consumes_auto_approve_reason() -> None:
     assert kwargs["user_decision"] == "auto_approve_tools"
     # Consumed on read so the same call_id can't double-stamp later.
     assert "c-x" not in ui._auto_approve_reasons
-    # Auto-stamped verdicts must NOT join _pending_verdicts — the
-    # row's final decision is already set; appending would let a
-    # later resolve_approval overwrite the auto-reason with the
-    # manual decision (real audit-trail clobber bug).
-    assert ui._pending_verdicts == []
 
 
 def test_on_intent_verdict_auto_reason_survives_resolve_cycle() -> None:
@@ -459,6 +550,7 @@ def test_on_intent_verdict_auto_reason_survives_resolve_cycle() -> None:
     ``"approved"``/``"denied"`` by the resolve path."""
     storage = MagicMock()
     ui = _make_ui()
+    _register_cycle(ui, ["c-pending"])
     ui._auto_approve_reasons["c-auto"] = ("policy", 0.0)
     with _patch_get_storage(storage):
         # LLM verdict fires for the auto-approved sibling.
@@ -627,39 +719,54 @@ def test_record_output_assessment_defaults_to_heuristic_tier() -> None:
 
 
 # ---------------------------------------------------------------------------
-# serialize_pending_approval_detail — dashboard projection
+# serialize_pending_approval_details — dashboard projection (per cycle)
 # ---------------------------------------------------------------------------
 
 
-def test_serialize_pending_approval_detail_returns_none_when_unset() -> None:
+def _register_card_cycle(ui: SessionUIBase, card: dict[str, Any]) -> Any:
+    """Register a cycle from a raw approve_request card (shape-exact tests)."""
+    from turnstone.core.session_ui_base import ApprovalCycle
+
+    cycle = ApprovalCycle(list(card.get("items") or []), card, None)
+    ui._register_approval_cycle(cycle)
+    return cycle
+
+
+def test_serialize_pending_approval_details_empty_when_no_cycles() -> None:
     ui = _make_ui()
-    assert ui.serialize_pending_approval_detail() is None
+    assert ui.serialize_pending_approval_details() == []
 
 
-def test_serialize_pending_approval_detail_returns_none_when_items_empty() -> None:
+def test_serialize_pending_approval_details_skips_empty_items_card() -> None:
     ui = _make_ui()
-    ui._pending_approval = {"type": "approve_request", "items": [], "judge_pending": False}
-    assert ui.serialize_pending_approval_detail() is None
+    _register_card_cycle(
+        ui, {"type": "approve_request", "cycle_id": "cy-0", "items": [], "judge_pending": False}
+    )
+    assert ui.serialize_pending_approval_details() == []
 
 
-def test_serialize_pending_approval_detail_merges_judge_verdict() -> None:
+def test_serialize_pending_approval_details_merges_judge_verdict() -> None:
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [
-            {
-                "call_id": "c-1",
-                "header": "bash",
-                "preview": "$ ls",
-                "func_name": "bash",
-                "approval_label": "bash",
-                "needs_approval": True,
-                "error": None,
-                "verdict": {"recommendation": "review", "tier": "heuristic"},
-            }
-        ],
-        "judge_pending": True,
-    }
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [
+                {
+                    "call_id": "c-1",
+                    "header": "bash",
+                    "preview": "$ ls",
+                    "func_name": "bash",
+                    "approval_label": "bash",
+                    "needs_approval": True,
+                    "error": None,
+                    "heuristic_verdict": {"recommendation": "review", "tier": "heuristic"},
+                }
+            ],
+            "judge_pending": True,
+        },
+    )
     ui._llm_verdicts["c-1"] = {
         "verdict_id": "v-1",
         "call_id": "c-1",
@@ -667,8 +774,10 @@ def test_serialize_pending_approval_detail_merges_judge_verdict() -> None:
         "recommendation": "deny",
         "tier": "llm",
     }
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
+    details = ui.serialize_pending_approval_details()
+    assert len(details) == 1
+    detail = details[0]
+    assert detail["cycle_id"] == "cy-1"
     assert detail["call_id"] == "c-1"
     assert detail["judge_pending"] is True
     assert len(detail["items"]) == 1
@@ -681,63 +790,100 @@ def test_serialize_pending_approval_detail_merges_judge_verdict() -> None:
     assert item["judge_verdict"]["risk_level"] == "high"
 
 
-def test_serialize_pending_approval_detail_judge_verdict_none_when_missing() -> None:
+def test_serialize_pending_approval_details_judge_verdict_none_when_missing() -> None:
     """No cached verdict for the call_id → judge_verdict is None,
     not absent or some sentinel."""
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [{"call_id": "c-1", "func_name": "ls", "needs_approval": True}],
-        "judge_pending": True,
-    }
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
-    assert detail["items"][0]["judge_verdict"] is None
-    assert detail["items"][0]["heuristic_verdict"] is None
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [{"call_id": "c-1", "func_name": "ls", "needs_approval": True}],
+            "judge_pending": True,
+        },
+    )
+    details = ui.serialize_pending_approval_details()
+    assert details[0]["items"][0]["judge_verdict"] is None
+    assert details[0]["items"][0]["heuristic_verdict"] is None
 
 
-def test_serialize_pending_approval_detail_multi_item() -> None:
+def test_serialize_pending_approval_details_multi_item() -> None:
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [
-            {"call_id": "c-1", "func_name": "bash", "needs_approval": True},
-            {"call_id": "c-2", "func_name": "mcp__sf__query", "needs_approval": True},
-        ],
-        "judge_pending": False,
-    }
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [
+                {"call_id": "c-1", "func_name": "bash", "needs_approval": True},
+                {"call_id": "c-2", "func_name": "mcp__sf__query", "needs_approval": True},
+            ],
+            "judge_pending": False,
+        },
+    )
     ui._llm_verdicts["c-2"] = {"recommendation": "deny", "risk_level": "crit"}
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
+    details = ui.serialize_pending_approval_details()
+    detail = details[0]
     assert detail["call_id"] == "c-1"  # primary = first item
     assert len(detail["items"]) == 2
     assert detail["items"][0]["judge_verdict"] is None
     assert detail["items"][1]["judge_verdict"]["recommendation"] == "deny"
 
 
-def test_serialize_pending_approval_detail_tool_policy_denied_passthrough() -> None:
+def test_serialize_pending_approval_details_one_entry_per_live_cycle() -> None:
+    """Parallel task agents: every live cycle serializes, oldest first,
+    each addressable by its cycle_id — the single-slot serializer only
+    ever showed the one card the last writer left behind."""
+    ui = _make_ui()
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-old",
+            "items": [{"call_id": "a-1", "func_name": "bash", "needs_approval": True}],
+            "judge_pending": False,
+        },
+    )
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-new",
+            "items": [{"call_id": "b-1", "func_name": "write_file", "needs_approval": True}],
+            "judge_pending": False,
+        },
+    )
+    details = ui.serialize_pending_approval_details()
+    assert [d["cycle_id"] for d in details] == ["cy-old", "cy-new"]
+    assert [d["call_id"] for d in details] == ["a-1", "b-1"]
+
+
+def test_serialize_pending_approval_details_tool_policy_denied_passthrough() -> None:
     """A tool-policy-denied item carries error + needs_approval=False
     after WebUI.approve_tools mutates the items list. The serializer
     must round-trip both fields so the JS can detect the
     POLICY-BLOCKED matrix row and render the banner instead of
     approve/deny buttons."""
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [
-            {
-                "call_id": "c-1",
-                "func_name": "rm_rf",
-                "approval_label": "rm_rf",
-                "needs_approval": False,
-                "error": "Blocked by tool policy (pattern match for 'rm_rf')",
-            }
-        ],
-        "judge_pending": False,
-    }
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
-    item = detail["items"][0]
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [
+                {
+                    "call_id": "c-1",
+                    "func_name": "rm_rf",
+                    "approval_label": "rm_rf",
+                    "needs_approval": False,
+                    "error": "Blocked by tool policy (pattern match for 'rm_rf')",
+                }
+            ],
+            "judge_pending": False,
+        },
+    )
+    item = ui.serialize_pending_approval_details()[0]["items"][0]
     # Both fields are the JS detection keys for the POLICY-BLOCKED
     # branch in renderApprovalBlock — drift here silently regresses
     # to a buttoned approve UI on a server-blocked call.
@@ -745,26 +891,29 @@ def test_serialize_pending_approval_detail_tool_policy_denied_passthrough() -> N
     assert item["error"] == "Blocked by tool policy (pattern match for 'rm_rf')"
 
 
-def test_serialize_pending_approval_detail_judge_unavailable_path() -> None:
+def test_serialize_pending_approval_details_judge_unavailable_path() -> None:
     """No judge_verdict + no heuristic_verdict + judge_pending=False
     is the (judge unavailable) matrix row — the JS detects it via
     !verdict && !judgePending && !policyBlocked. Verify the
     serialized payload preserves the absence of all three signals."""
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [
-            {
-                "call_id": "c-1",
-                "func_name": "bash",
-                "approval_label": "bash",
-                "needs_approval": True,
-            }
-        ],
-        "judge_pending": False,
-    }
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [
+                {
+                    "call_id": "c-1",
+                    "func_name": "bash",
+                    "approval_label": "bash",
+                    "needs_approval": True,
+                }
+            ],
+            "judge_pending": False,
+        },
+    )
+    detail = ui.serialize_pending_approval_details()[0]
     assert detail["judge_pending"] is False
     item = detail["items"][0]
     assert item["judge_verdict"] is None
@@ -773,18 +922,21 @@ def test_serialize_pending_approval_detail_judge_unavailable_path() -> None:
     assert item["error"] is None
 
 
-def test_serialize_pending_approval_detail_returned_dict_is_decoupled() -> None:
+def test_serialize_pending_approval_details_returned_dict_is_decoupled() -> None:
     """Mutating the returned dict must not corrupt the cached
     verdict, which other consumers may still read."""
     ui = _make_ui()
-    ui._pending_approval = {
-        "type": "approve_request",
-        "items": [{"call_id": "c-1", "func_name": "bash", "needs_approval": True}],
-        "judge_pending": False,
-    }
+    _register_card_cycle(
+        ui,
+        {
+            "type": "approve_request",
+            "cycle_id": "cy-1",
+            "items": [{"call_id": "c-1", "func_name": "bash", "needs_approval": True}],
+            "judge_pending": False,
+        },
+    )
     ui._llm_verdicts["c-1"] = {"recommendation": "approve"}
-    detail = ui.serialize_pending_approval_detail()
-    assert detail is not None
+    detail = ui.serialize_pending_approval_details()[0]
     detail["items"][0]["judge_verdict"]["recommendation"] = "MUTATED"
     assert ui._llm_verdicts["c-1"]["recommendation"] == "approve"
 
@@ -1535,19 +1687,27 @@ def test_concurrent_writer_and_register_with_snapshot_no_loss_no_dup() -> None:
 
 
 class _SeedingUI(_ConcreteUI):
-    """Re-delivers seeded LLM verdicts right after the approval-cycle
-    reset clears the cache — simulates the async judge daemon delivering
-    them via ``on_intent_verdict`` during the Smart Approvals wait, which
-    is the only point at which they can land and survive the reset."""
+    """Re-delivers seeded LLM verdicts right after the per-round purge
+    evicts the entering batch's ids — simulates the async judge daemon
+    delivering them via ``on_intent_verdict`` during the Smart Approvals
+    wait, which is the only point at which they can land and survive
+    the purge.  ``seed_judge_event`` optionally tags the deliveries with
+    a generation, for window tests that need a STALE-generation arrival
+    between the purge and the cycle registration."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.seed_verdicts: list[dict[str, Any]] = []
+        self.seed_judge_event: threading.Event | None = None
 
-    def _reset_approval_cycle(self) -> None:
-        super()._reset_approval_cycle()
+    def _purge_round_verdicts(
+        self,
+        call_ids: set[str],
+        keep_origin: threading.Event | None = None,
+    ) -> None:
+        super()._purge_round_verdicts(call_ids, keep_origin=keep_origin)
         for verdict in self.seed_verdicts:
-            self.on_intent_verdict(dict(verdict))
+            self.on_intent_verdict(dict(verdict), judge_event=self.seed_judge_event)
 
 
 def _patch_policies(verdicts: dict[str, str]):  # type: ignore[no-untyped-def]
@@ -1775,19 +1935,17 @@ def test_smart_approval_skips_budget_override_pseudo_tool() -> None:
 
 
 def test_smart_approval_stamps_verdict_user_decision() -> None:
-    """The LLM verdict arrived during the wait (parked in
-    ``_pending_verdicts`` as pending); the smart stage pulls it out so a
-    sibling's resolve can't re-stamp it, and records ``smart_approval`` on
-    both the cached dict and the persisted row."""
+    """The LLM verdict arrived during the wait (cache-only — no cycle
+    exists yet at that point); the smart stage stamps ``smart_approval``
+    on both the cached dict and the persisted row, and the non-"pending"
+    stamp keeps every later cycle-registration sweep away from it."""
     storage = MagicMock()
     ui = _smart_ui()
     item = _pending_item("c1")
     verdict = _llm_verdict("c1", recommendation="approve", confidence=0.99)
     ui._llm_verdicts["c1"] = verdict
-    ui._pending_verdicts = [verdict]  # as on_intent_verdict would have parked it
     with _patch_get_storage(storage):
         ui._apply_smart_approvals([item])
-    assert ui._pending_verdicts == []
     assert ui._llm_verdicts["c1"]["user_decision"] == "smart_approval"
     storage.update_intent_verdict.assert_called_once_with("v-c1", user_decision="smart_approval")
 
@@ -1812,7 +1970,7 @@ def test_approve_tools_smart_approves_whole_batch_without_prompt() -> None:
     assert item["auto_approve_reason"] == "smart_approval"
     assert item["needs_approval"] is False
     assert ui._pending_approval is None  # operator was never prompted
-    assert ui._pending_verdicts == []  # smart verdict pulled out + stamped
+    assert ui._approval_cycles == {}  # no cycle was ever registered
     # No approval prompt was fanned out to listeners.
     events = []
     while True:
@@ -2035,16 +2193,17 @@ def test_smart_approval_holds_batch_with_duplicate_call_ids() -> None:
     assert a.get("auto_approved") is not True
 
 
-def test_on_intent_verdict_skips_append_for_already_finalized_verdict() -> None:
+def test_on_intent_verdict_skips_park_for_already_finalized_verdict() -> None:
     """Guards the audit-corruption race: a verdict already stamped with a
     final user_decision (e.g. ``_finalize_smart_verdicts`` ran between this
-    verdict's notify and its append) is NOT re-parked in _pending_verdicts,
-    so a later round's resolve_approval can't overwrite its audit row."""
+    verdict's notify and its park) is NOT parked on its owning cycle,
+    so that cycle's resolve_approval can't overwrite the audit row."""
     ui = _make_ui()
+    cycle = _register_cycle(ui, ["c1"])
     verdict = {"verdict_id": "v1", "call_id": "c1", "user_decision": "smart_approval"}
     with _patch_get_storage(MagicMock()):
         ui.on_intent_verdict(verdict)
-    assert ui._pending_verdicts == []
+    assert cycle.pending_verdicts == []
     assert ui._llm_verdicts["c1"]["user_decision"] == "smart_approval"
 
 
@@ -2264,3 +2423,395 @@ class TestAgentTrajectoryStash:
         assert ui.get_agent_trajectory("t0") is None
         assert ui.get_agent_trajectory("t2") is None
         assert ui.get_agent_trajectory(f"t{_AGENT_TRAJECTORY_CAP + 2}") is not None
+
+
+# ---------------------------------------------------------------------------
+# Concurrent approval cycles — parallel task agents each run their own gate.
+# Regression matrix for the two 1.7 release blockers: cross-approval (one
+# click resolving every parked gate) and the lost-wakeup hang (a sibling's
+# gate entry eating a just-fired resolution).
+# ---------------------------------------------------------------------------
+
+
+_Spawn = Callable[[dict[str, Any]], tuple[threading.Thread, dict[str, Any]]]
+
+
+@contextlib.contextmanager
+def _gate_harness(ui: SessionUIBase) -> Iterator[_Spawn]:
+    """ONE storage/policy patch pair + spawn + guaranteed teardown for
+    concurrent ``approve_tools`` gates.
+
+    The patches are applied ONCE, on the calling thread, and cover every
+    spawned gate thread: ``mock.patch`` start/stop of the SAME target
+    from concurrent threads corrupts the patcher's restore stack — the
+    second stop can reinstall the first thread's mock as the "original",
+    leaking it into every later test in the process.
+
+    Teardown keeps sweeping ``resolve_all_approvals`` until every gate
+    thread has exited — a gate that registers its cycle after a single
+    sweep would otherwise park for the full approval timeout and trip
+    the conftest thread-leak guard.
+    """
+    threads: list[threading.Thread] = []
+
+    def spawn(item: dict[str, Any]) -> tuple[threading.Thread, dict[str, Any]]:
+        box: dict[str, Any] = {}
+
+        def _run() -> None:
+            approved, feedback = ui.approve_tools([item])
+            box["approved"] = approved
+            box["feedback"] = feedback
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        threads.append(t)
+        return t, box
+
+    with _patch_get_storage(MagicMock()), _patch_policies({}):
+        try:
+            yield spawn
+        finally:
+            stop = time.monotonic() + 5.0
+            while any(t.is_alive() for t in threads) and time.monotonic() < stop:
+                ui.resolve_all_approvals(False, "test teardown")
+                time.sleep(0.01)
+            for t in threads:
+                t.join(timeout=1.0)
+
+
+def _wait_for_cycles(ui: SessionUIBase, count: int, deadline: float = 5.0) -> None:
+    stop = time.monotonic() + deadline
+    while time.monotonic() < stop:
+        with ui._ws_lock:
+            if len(ui._approval_cycles) >= count:
+                return
+        time.sleep(0.005)
+    raise AssertionError(f"never saw {count} live cycles")
+
+
+def test_concurrent_gates_resolve_independently() -> None:
+    """THE cross-approval regression: two parallel gates, two separate
+    decisions.  Approving A's cycle must not wake B, and B's later
+    denial must reach B's thread — one click can no longer resolve
+    every parked batch with the same verdict."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, box_a = spawn(_pending_item("a-1"))
+        tb, box_b = spawn(_pending_item("b-1"))
+        _wait_for_cycles(ui, 2)
+        assert ui.resolve_approval(True, "run it", call_id="a-1") is not None
+        ta.join(timeout=5.0)
+        assert not ta.is_alive(), "A's gate did not wake on its own resolution"
+        # B is still parked — A's approval must NOT have leaked to it.
+        assert tb.is_alive(), "resolving A also unblocked B (cross-approval)"
+        assert box_a == {"approved": True, "feedback": "run it"}
+        assert ui.resolve_approval(False, "not this one", call_id="b-1") is not None
+        tb.join(timeout=5.0)
+        assert not tb.is_alive()
+        assert box_b["approved"] is False
+        assert box_b["feedback"] == "not this one"
+
+
+def test_sibling_gate_entry_cannot_eat_a_resolution() -> None:
+    """THE lost-wakeup regression: under the singleton event, sibling B
+    entering the gate ran ``event.clear()`` and could erase A's
+    just-fired resolution — A then parked for the full 3600s timeout
+    ("approval dialog stuck").  Per-cycle events make the interleaving
+    structurally impossible: A's resolution lands on A's OWN event, so
+    B's registration can't touch it."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, box_a = spawn(_pending_item("a-1"))
+        _wait_for_cycles(ui, 1)
+        # Resolve A and IMMEDIATELY register sibling B — the old code's
+        # clear() window.  A must still return promptly.
+        ui.resolve_approval(True, None, call_id="a-1")
+        spawn(_pending_item("b-1"))
+        ta.join(timeout=5.0)
+        assert not ta.is_alive(), (
+            "A's gate lost its wakeup when sibling B entered — the singleton-event race is back"
+        )
+        assert box_a["approved"] is True
+
+
+def test_selectorless_resolve_hits_oldest_cycle() -> None:
+    """Legacy clients (CLI wrappers, channel adapters, old tabs) send no
+    selector — the decision lands on the OLDEST live cycle, matching
+    the order the prompts were issued."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, box_a = spawn(_pending_item("a-1"))
+        _wait_for_cycles(ui, 1)
+        tb, _box_b = spawn(_pending_item("b-1"))
+        _wait_for_cycles(ui, 2)
+        ui.resolve_approval(True, "first in, first out")
+        ta.join(timeout=5.0)
+        assert not ta.is_alive(), "selector-less resolve missed the oldest cycle"
+        assert box_a["approved"] is True
+        assert tb.is_alive(), "selector-less resolve hit more than one cycle"
+
+
+def test_resolve_all_approvals_wakes_every_gate() -> None:
+    """The cancel/close sweep: every parked gate wakes with its own
+    denied result."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, box_a = spawn(_pending_item("a-1"))
+        tb, box_b = spawn(_pending_item("b-1"))
+        _wait_for_cycles(ui, 2)
+        assert ui.resolve_all_approvals(False, "Cancelled by user") == 2
+        ta.join(timeout=5.0)
+        tb.join(timeout=5.0)
+        assert box_a["approved"] is False
+        assert box_b["approved"] is False
+        assert "Cancelled by user" in (box_a["feedback"] or "")
+
+
+def test_resolve_all_approvals_noop_when_idle() -> None:
+    """Idle cancels stay silent — no stale approval_resolved broadcast."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    assert ui.resolve_all_approvals(False, "Cancelled by user") == 0
+    assert lq.empty()
+
+
+def test_double_resolution_is_a_guarded_noop() -> None:
+    """A second decision racing the first (two tabs, or timeout racing a
+    click) must not re-resolve, re-broadcast, or clobber the recorded
+    result."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, box_a = spawn(_pending_item("a-1"))
+        _wait_for_cycles(ui, 1)
+        first = ui.resolve_approval(True, "yes", call_id="a-1")
+        second = ui.resolve_approval(False, "no", call_id="a-1")
+        assert first is not None
+        assert second is None
+        ta.join(timeout=5.0)
+        assert box_a == {"approved": True, "feedback": "yes"}
+
+
+def test_pending_cards_and_legacy_view_track_cycles() -> None:
+    """``pending_approval_cards`` lists every live cycle's card (SSE
+    replay repaints them all); the legacy ``_pending_approval`` view
+    tracks the OLDEST for boolean-ish consumers and rolls forward as
+    cycles resolve."""
+    ui = _make_ui()
+    with _gate_harness(ui) as spawn:
+        ta, _box_a = spawn(_pending_item("a-1"))
+        _wait_for_cycles(ui, 1)
+        spawn(_pending_item("b-1"))
+        _wait_for_cycles(ui, 2)
+        cards = ui.pending_approval_cards()
+        assert [c["items"][0]["call_id"] for c in cards] == ["a-1", "b-1"]
+        assert ui._pending_approval is not None
+        assert ui._pending_approval["items"][0]["call_id"] == "a-1"
+        ui.resolve_approval(True, None, call_id="a-1")
+        ta.join(timeout=5.0)
+        # View rolls forward to the surviving cycle.
+        assert ui._pending_approval is not None
+        assert ui._pending_approval["items"][0]["call_id"] == "b-1"
+
+
+def test_stale_generation_verdict_cannot_touch_live_cycle() -> None:
+    """A prior turn's run-to-completion daemon delivering a reused
+    call_id must not satisfy the NEW cycle's wait: the delivery's
+    generation (its cancel event) is identity-checked against the
+    owning cycle's — mismatch persists for audit only, with no cache
+    write, no SSE, no park."""
+    storage = MagicMock()
+    ui = _make_ui()
+    fresh_gen = threading.Event()
+    stale_gen = threading.Event()
+    cycle = _register_cycle(ui, ["c-reused"], judge_event=fresh_gen)
+    lq = ui._register_listener()
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict(
+            {"verdict_id": "v-stale", "call_id": "c-reused", "tier": "llm"},
+            judge_event=stale_gen,
+        )
+    assert "c-reused" not in ui._llm_verdicts
+    assert cycle.pending_verdicts == []
+    assert lq.empty()
+    kwargs = storage.upsert_intent_verdict.call_args.kwargs
+    assert kwargs["user_decision"] == "superseded"
+    # The cycle's OWN generation delivers normally.
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict(
+            {"verdict_id": "v-fresh", "call_id": "c-reused", "tier": "llm"},
+            judge_event=fresh_gen,
+        )
+    assert ui._llm_verdicts["c-reused"]["verdict_id"] == "v-fresh"
+    assert cycle.pending_verdicts and cycle.pending_verdicts[0]["verdict_id"] == "v-fresh"
+
+
+def test_smart_approval_rejects_stale_origin_verdict() -> None:
+    """Smart-Approvals qualification requires the cached verdict to have
+    been delivered by THIS batch's judge generation — a cached approve
+    of unknown/stale origin sends the batch to a human."""
+    ui = _smart_ui()
+    ui.smart_approval_wait_seconds = 0.05
+    fresh_gen = threading.Event()
+    item = _pending_item("c1")
+    item["_judge_event"] = fresh_gen
+    ui._llm_verdicts["c1"] = _llm_verdict("c1", recommendation="approve", confidence=0.99)
+    ui._verdict_origins["c1"] = id(object())  # a different generation delivered it
+    with _patch_get_storage(MagicMock()):
+        remaining = ui._apply_smart_approvals([item])
+    assert remaining == [item]
+    assert item.get("auto_approved") is not True
+    # Same verdict with the RIGHT origin qualifies.
+    ui._verdict_origins["c1"] = id(fresh_gen)
+    with _patch_get_storage(MagicMock()):
+        remaining = ui._apply_smart_approvals([item])
+    assert remaining == []
+    assert item["auto_approved"] is True
+
+
+def test_concurrent_smart_gate_and_human_gate() -> None:
+    """A smart-qualifying batch auto-approves while a sibling batch is
+    parked on a human — the sibling's cycle survives untouched (the old
+    whole-cache reset at gate entry wiped its verdicts mid-wait)."""
+    ui = _make_ui()
+    ui.smart_approvals_enabled = True
+    ui.smart_approval_threshold = 0.95
+    ui.smart_approval_wait_seconds = 1.0
+    # Regression guard: if the smart batch ever falls through to the
+    # human gate (it runs on THIS thread), fail in seconds instead of
+    # hanging the suite for the full approval timeout.
+    ui._APPROVAL_WAIT_TIMEOUT = 10.0
+    with _gate_harness(ui) as spawn:
+        # Human-gated sibling parks first.
+        ta, box_a = spawn(_pending_item("a-1"))
+        _wait_for_cycles(ui, 1)
+        # Smart-qualifying batch flows straight through on this thread —
+        # its verdict was delivered by its OWN generation before the
+        # gate was entered, so the entry purge must spare it.
+        gen = threading.Event()
+        item = _pending_item("s-1")
+        item["_judge_event"] = gen
+        ui._llm_verdicts["s-1"] = _llm_verdict("s-1", recommendation="approve", confidence=0.99)
+        ui._verdict_origins["s-1"] = id(gen)
+        approved, _ = ui.approve_tools([item])
+        assert approved is True
+        assert item["auto_approved"] is True
+        # Sibling still parked, its cycle + verdict path intact.
+        assert ta.is_alive()
+        ui.resolve_approval(True, "ok", call_id="a-1")
+        ta.join(timeout=5.0)
+        assert box_a["approved"] is True
+
+
+def test_purge_round_verdicts_keeps_entry_from_the_entering_generation() -> None:
+    """``keep_origin``: a verdict the entering batch's OWN judge spawn
+    already delivered survives the entry purge.  The judge daemon is
+    spawned before the gate is entered, so a fast judge can beat the
+    gate to the cache — evicting its verdict as if it were a prior
+    round's leftover stalled the Smart-Approvals wait to its full
+    budget and sent an already-cleared batch to a human.  Foreign
+    generations and prior-round decisions still purge."""
+    ui = _make_ui()
+    gen = threading.Event()
+    other_gen = threading.Event()
+    ui._llm_verdicts["c-own"] = {"verdict_id": "own"}
+    ui._verdict_origins["c-own"] = id(gen)
+    ui._llm_verdicts["c-foreign"] = {"verdict_id": "foreign"}
+    ui._verdict_origins["c-foreign"] = id(other_gen)
+    ui._recent_decisions["c-own"] = ("approved", None)
+    ui._purge_round_verdicts({"c-own", "c-foreign"}, keep_origin=gen)
+    assert ui._llm_verdicts.get("c-own") == {"verdict_id": "own"}
+    assert ui._verdict_origins.get("c-own") == id(gen)
+    assert "c-foreign" not in ui._llm_verdicts
+    assert "c-foreign" not in ui._verdict_origins
+    # Decisions never survive: this round has not been decided yet.
+    assert "c-own" not in ui._recent_decisions
+
+
+def test_smart_gate_uses_verdict_delivered_before_gate_entry() -> None:
+    """Production shape of the generation-aware purge: judge spawned
+    before the gate, verdict delivered before ``approve_tools`` runs.
+    The entry purge spares the same-generation verdict, so the smart
+    wait sees it immediately and the batch auto-approves without a
+    human prompt or a full-budget stall."""
+    ui = _smart_ui()
+    ui.smart_approval_wait_seconds = 3.0
+    # Regression guard: a purged verdict sends this batch to the human
+    # gate on THIS thread — bound the park so the test fails instead of
+    # hanging the suite.
+    ui._APPROVAL_WAIT_TIMEOUT = 1.0
+    gen = threading.Event()
+    item = _pending_item("s-1")
+    item["_judge_event"] = gen
+    with _patch_get_storage(MagicMock()), _patch_policies({}):
+        # The "fast judge": delivery lands before the gate is entered.
+        ui.on_intent_verdict(_llm_verdict("s-1"), judge_event=gen)
+        approved, _feedback = ui.approve_tools([item])
+    assert approved is True, "entry purge evicted this batch's own pre-delivered verdict"
+    assert item["auto_approved"] is True
+
+
+def test_registration_evicts_stale_generation_window_arrival() -> None:
+    """A STALE generation delivering into the purge→register window
+    (the entry purge can't see arrivals that land during the policy
+    round-trip or the smart wait) must not blank the card's "judge
+    analysing" cue, be adopted into ``pending_verdicts`` for
+    decision-stamping, or linger in the replay cache once the cycle
+    registers."""
+    ui = _SeedingUI(ws_id="ws-1", user_id="u1")
+    stale_gen = threading.Event()
+    fresh_gen = threading.Event()
+    # _SeedingUI re-delivers right after the entry purge — inside the
+    # purge→register window — tagged with the STALE generation.
+    ui.seed_verdicts = [_llm_verdict("w-1")]
+    ui.seed_judge_event = stale_gen
+    item = _pending_item("w-1")
+    item["_judge_event"] = fresh_gen
+    with _gate_harness(ui) as spawn:
+        _t, box = spawn(item)
+        _wait_for_cycles(ui, 1)
+        with ui._ws_lock:
+            cycle = next(iter(ui._approval_cycles.values()))
+        assert "w-1" not in ui._llm_verdicts, "stale window arrival survived registration"
+        assert "w-1" not in ui._verdict_origins
+        assert cycle.card["judge_pending"] is True, "stale verdict blanked the judge cue"
+        assert [v["verdict_id"] for v in cycle.pending_verdicts] == ["h-w-1"], (
+            "stale window arrival was adopted for decision-stamping"
+        )
+        ui.resolve_approval(True, None, call_id="w-1")
+    assert box["approved"] is True
+
+
+def test_late_stale_generation_verdict_stamps_superseded() -> None:
+    """A late verdict from generation A delivering AFTER its round
+    resolved — and after a reused call_id's round from generation B
+    also resolved — must not steal B's recorded decision.  Recorded
+    decisions are generation-tagged: a mismatched late delivery stamps
+    ``superseded`` (same vocabulary as the superseded persist path); a
+    same-generation late delivery still stamps the real decision."""
+    storage = MagicMock()
+    ui = _make_ui()
+    gen_a = threading.Event()
+    gen_b = threading.Event()
+    # Round B (reusing the call_id generation A once judged) resolves
+    # and its gate unregisters the cycle — the decision survives only
+    # in ``_recent_decisions``, tagged with B's generation.
+    cycle_b = _register_cycle(ui, ["c-reuse"], judge_event=gen_b)
+    with _patch_get_storage(storage):
+        ui.resolve_approval(True, None, call_id="c-reuse")
+    ui._unregister_approval_cycle(cycle_b)
+    assert ui._recent_decisions["c-reuse"] == ("approved", gen_b)
+    # Generation A's run-to-completion daemon delivers late — no live
+    # owner, and the decision on file belongs to B.
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict(
+            {"verdict_id": "v-stale-late", "call_id": "c-reuse", "tier": "llm"},
+            judge_event=gen_a,
+        )
+    storage.update_intent_verdict.assert_any_call("v-stale-late", user_decision="superseded")
+    # B's own late delivery still stamps B's real decision.
+    with _patch_get_storage(storage):
+        ui.on_intent_verdict(
+            {"verdict_id": "v-b-late", "call_id": "c-reuse", "tier": "llm"},
+            judge_event=gen_b,
+        )
+    storage.update_intent_verdict.assert_any_call("v-b-late", user_decision="approved")

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1598,7 +1598,7 @@ class TestDetailInteractive:
             "user_id": "test-user",
             "kind": "interactive",
             "pending_approval": False,
-            "pending_approval_detail": None,
+            "pending_approval_details": [],
         }
 
     def test_pending_approval_fields_propagate_from_ui(self):
@@ -1631,23 +1631,26 @@ class TestDetailInteractive:
             ],
             "judge_pending": True,
         }
-        loaded_ws.ui.serialize_pending_approval_detail = MagicMock(
-            return_value={
-                "call_id": "c-1",
-                "judge_pending": True,
-                "items": [
-                    {
-                        "call_id": "c-1",
-                        "func_name": "spawn_workstream",
-                        "needs_approval": True,
-                        "heuristic_verdict": {
-                            "recommendation": "approve",
-                            "risk_level": "low",
-                            "confidence": 0.9,
-                        },
-                    }
-                ],
-            }
+        loaded_ws.ui.serialize_pending_approval_details = MagicMock(
+            return_value=[
+                {
+                    "cycle_id": "cyc-1",
+                    "call_id": "c-1",
+                    "judge_pending": True,
+                    "items": [
+                        {
+                            "call_id": "c-1",
+                            "func_name": "spawn_workstream",
+                            "needs_approval": True,
+                            "heuristic_verdict": {
+                                "recommendation": "approve",
+                                "risk_level": "low",
+                                "confidence": 0.9,
+                            },
+                        }
+                    ],
+                }
+            ]
         )
         mock_mgr = MagicMock()
         mock_mgr.get.return_value = loaded_ws
@@ -1657,9 +1660,12 @@ class TestDetailInteractive:
         assert r.status_code == 200
         body = r.json()
         assert body["pending_approval"] is True
-        assert body["pending_approval_detail"]["call_id"] == "c-1"
-        assert body["pending_approval_detail"]["judge_pending"] is True
-        items = body["pending_approval_detail"]["items"]
+        details = body["pending_approval_details"]
+        assert len(details) == 1
+        assert details[0]["cycle_id"] == "cyc-1"
+        assert details[0]["call_id"] == "c-1"
+        assert details[0]["judge_pending"] is True
+        items = details[0]["items"]
         assert len(items) == 1
         assert items[0]["func_name"] == "spawn_workstream"
         assert items[0]["needs_approval"] is True
@@ -1680,7 +1686,7 @@ class TestDetailInteractive:
         loaded_ws.user_id = "test-user"
         loaded_ws.kind = "coordinator"
         loaded_ws.ui._pending_approval = {"items": []}
-        loaded_ws.ui.serialize_pending_approval_detail = MagicMock(
+        loaded_ws.ui.serialize_pending_approval_details = MagicMock(
             side_effect=RuntimeError("verdict object is malformed"),
         )
         mock_mgr = MagicMock()
@@ -1691,7 +1697,7 @@ class TestDetailInteractive:
         assert r.status_code == 200
         body = r.json()
         assert body["pending_approval"] is True
-        assert body["pending_approval_detail"] is None
+        assert body["pending_approval_details"] == []
 
     def test_lazy_rehydrates_on_miss(self):
         """``mgr.get`` miss → ``mgr.open`` rehydrate. Same flow as coord;
@@ -1801,7 +1807,7 @@ class TestTenantCheckOnReadEndpoints:
         # Sensitive fields the PR added must not surface for a
         # non-owning caller.
         assert "name" not in body
-        assert "pending_approval_detail" not in body
+        assert "pending_approval_details" not in body
         assert "user_id" not in body
         # And mgr.get was NEVER consulted — the gate fires first.
         mock_mgr.get.assert_not_called()
@@ -1832,7 +1838,7 @@ class TestTenantCheckOnReadEndpoints:
         body = r.json()
         assert body["ws_id"] == ws_id
         assert body["pending_approval"] is False
-        assert body["pending_approval_detail"] is None
+        assert body["pending_approval_details"] == []
 
     def test_history_404s_when_tenant_check_rejects(self, _inject_storage):
         """A non-owning interactive caller reading another user's ws_id

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -339,13 +339,24 @@ class RecentAutoApproval(BaseModel):
 class PendingApprovalDetail(BaseModel):
     """Inline approval payload merged into ``DashboardWorkstream``.
 
-    Set when a workstream's ``approve_tools`` is parked on
-    ``_approval_event``; ``None`` (omitted) otherwise. Cross-tenant
+    One entry per live approval CYCLE — a gate thread parked in
+    ``approve_tools`` awaiting the operator.  Parallel task agents run
+    concurrent gates, so a workstream can have several of these at
+    once (``pending_approval_details``, oldest first).  Cross-tenant
     exposure here follows the same trusted-team posture as
     ``activity`` / ``tokens`` — see ``server.py``'s ``dashboard``
     handler comment.
     """
 
+    cycle_id: str = Field(
+        default="",
+        description=(
+            "Identity of this approval cycle.  Echo it back on "
+            "``POST /v1/api/workstreams/{ws_id}/approve`` to resolve "
+            "exactly this round — required for correctness when "
+            "several cycles are live (parallel task agents)."
+        ),
+    )
     call_id: str = Field(
         default="",
         description=(
@@ -388,16 +399,21 @@ class DashboardWorkstream(BaseModel):
     parent_ws_id: str | None = None
     user_id: str = ""
     project_id: str | None = None
-    pending_approval_detail: PendingApprovalDetail | None = Field(
-        default=None,
+    pending_approval_details: list[PendingApprovalDetail] = Field(
+        default_factory=list,
         description=(
             "Inline approval payload for the coordinator children-tree "
-            "UI. Carries the merged ``_pending_approval`` items list + "
-            "per-call_id LLM verdict cache so a coord can render "
-            "approve/deny buttons + judge pill without a separate "
-            "per-child round-trip. ``None`` when no approval is pending. "
-            "Also surfaced (verbatim) on ``GET /v1/api/cluster/ws/live`` "
-            "via the ``_CLUSTER_WS_LIVE_KEYS`` projection."
+            "UI: EVERY live approval cycle, oldest first — parallel "
+            "task agents gate concurrently, so a workstream can hold "
+            "several prompts at once.  Each entry carries the cycle's "
+            "items + per-call_id LLM verdict cache so a coord can "
+            "render approve/deny buttons + judge pill without a "
+            "separate per-child round-trip; resolve each with its "
+            "``cycle_id``.  Empty when no approval is pending.  Also "
+            "surfaced (verbatim) on ``GET /v1/api/cluster/ws/live`` "
+            "via the ``_CLUSTER_WS_LIVE_KEYS`` projection.  Replaces "
+            "1.6's ``pending_approval_detail`` single-object field "
+            "(breaking, 1.7)."
         ),
     )
     recent_auto_approvals: list[RecentAutoApproval] = Field(
@@ -482,21 +498,25 @@ class WorkstreamDetailResponse(BaseModel):
     pending_approval: bool = Field(
         default=False,
         description=(
-            "True when the workstream is parked on ``_approval_event`` "
-            "awaiting an operator approve/deny.  Mirrors the same field "
-            "on ``DashboardWorkstream`` / cluster live projections so a "
-            "freshly-loaded chat tab can render the inline approval gate "
-            "from the detail snapshot before SSE replay arrives."
+            "True when at least one approval cycle is live (a gate "
+            "thread parked awaiting an operator approve/deny).  Mirrors "
+            "the same field on ``DashboardWorkstream`` / cluster live "
+            "projections so a freshly-loaded chat tab can render the "
+            "inline approval gate from the detail snapshot before SSE "
+            "replay arrives."
         ),
     )
-    pending_approval_detail: PendingApprovalDetail | None = Field(
-        default=None,
+    pending_approval_details: list[PendingApprovalDetail] = Field(
+        default_factory=list,
         description=(
-            "Inline approval payload — same shape as ``DashboardWorkstream"
-            ".pending_approval_detail``.  ``None`` when no approval is "
-            "pending.  Lets a reload paint the action row + judge "
+            "Inline approval payloads, one per live cycle, oldest "
+            "first — same shape as ``DashboardWorkstream"
+            ".pending_approval_details``.  Empty when no approval is "
+            "pending.  Lets a reload paint every action row + judge "
             "verdicts immediately instead of relying on the SSE "
-            "approve_request replay timing window."
+            "approve_request replay timing window.  Replaces 1.6's "
+            "``pending_approval_detail`` single-object field "
+            "(breaking, 1.7)."
         ),
     )
 

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -287,8 +287,8 @@ class ListWorkstreamsResponse(BaseModel):
 class PendingApprovalItem(BaseModel):
     """One pending tool-call inside a ``PendingApprovalDetail`` envelope.
 
-    Mirrors the dict ``SessionUIBase.serialize_pending_approval_detail``
-    emits per item. ``heuristic_verdict`` / ``judge_verdict`` are kept
+    Mirrors the dict ``SessionUIBase.serialize_pending_approval_details``
+    emits per item inside each cycle entry. ``heuristic_verdict`` / ``judge_verdict`` are kept
     loosely-typed because the underlying verdict shape varies by tier;
     consumers that want the full structure can decode against
     :class:`turnstone.sdk.events.IntentVerdictEvent`.

--- a/turnstone/channels/_routing.py
+++ b/turnstone/channels/_routing.py
@@ -11,13 +11,15 @@ import asyncio
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from turnstone.channels._config import CREATE_LOCK_CAP
 from turnstone.core.log import get_logger
 from turnstone.sdk._types import TurnstoneAPIError
 from turnstone.sdk.console import AsyncTurnstoneConsole
 from turnstone.sdk.server import AsyncTurnstoneServer
+
+_V = TypeVar("_V")
 
 
 @dataclass
@@ -43,7 +45,7 @@ class PolicyVerdict:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, MutableMapping
 
     from turnstone.core.storage import StorageBackend
 
@@ -54,6 +56,57 @@ _CHANNEL_DEFAULT_TTL = 300.0  # cache channel default alias for 5 minutes
 _MODELS_CACHE_TTL = 30.0  # cache model list for autocomplete
 _ROUTE_CACHE_TTL = 30.0  # cache (channel_type, channel_id) → ws_id lookups
 _ROUTE_CACHE_CAP = 4096  # LRU bound on the lookup cache
+
+
+# ---------------------------------------------------------------------------
+# Pending-approval bookkeeping shared by the channel adapters.
+#
+# Every adapter tracks its posted approval prompts in a dict keyed by
+# ``(ws_id, cycle_id)`` — one entry per concurrent approval cycle — and
+# needs the same two lookups: "this exact cycle, falling back to the
+# workstream's single entry when the cycle_id is empty" (events from a
+# pre-multi-cycle server, or buttons posted before an in-flight
+# upgrade), and "everything for this workstream" (stream end / close /
+# unsubscribe sweeps).  Centralised here so the legacy-fallback
+# semantics can't drift between adapters.
+# ---------------------------------------------------------------------------
+
+
+def get_cycle_entry(
+    entries: Mapping[tuple[str, str], _V],
+    ws_id: str,
+    cycle_id: str,
+) -> _V | None:
+    """Exact ``(ws_id, cycle_id)`` lookup with the pre-multi-cycle fallback.
+
+    An empty *cycle_id* falls back to the workstream's single tracked
+    entry; a NON-empty one never falls back (a stale cycle must not
+    resolve an unrelated prompt).
+    """
+    entry = entries.get((ws_id, cycle_id))
+    if entry is None and not cycle_id:
+        entry = next((v for (wid, _), v in entries.items() if wid == ws_id), None)
+    return entry
+
+
+def pop_cycle_entry(
+    entries: MutableMapping[tuple[str, str], _V],
+    ws_id: str,
+    cycle_id: str,
+) -> _V | None:
+    """Like :func:`get_cycle_entry`, but removes the matched entry."""
+    entry = entries.pop((ws_id, cycle_id), None)
+    if entry is None and not cycle_id:
+        key = next((k for k in entries if k[0] == ws_id), None)
+        if key is not None:
+            entry = entries.pop(key, None)
+    return entry
+
+
+def pop_ws_entries(entries: MutableMapping[tuple[str, str], _V], ws_id: str) -> None:
+    """Drop every entry tracked under *ws_id* (all cycles)."""
+    for key in [k for k in entries if k[0] == ws_id]:
+        entries.pop(key, None)
 
 
 class ChannelRouter:
@@ -428,15 +481,33 @@ class ChannelRouter:
         feedback: str = "",
         always: bool = False,
     ) -> None:
-        """Approve or deny a pending tool call via the server API."""
+        """Approve or deny a pending tool call via the server API.
+
+        ``correlation_id`` is the cycle_id captured from the
+        ``approve_request`` event the adapter displayed; forwarding it
+        makes the decision land on exactly that cycle.  With parallel
+        task agents a workstream can hold several prompts — a
+        selector-less approve would resolve the OLDEST, which may not
+        be the message the user answered.  Empty string (policy /
+        auto-approve sweeps that act on "whatever is pending") keeps
+        the legacy oldest-first behavior.
+        """
         if self._console:
             await self._console.route_approve(
-                ws_id=ws_id, approved=approved, feedback=feedback, always=always
+                ws_id=ws_id,
+                approved=approved,
+                feedback=feedback,
+                always=always,
+                cycle_id=correlation_id,
             )
         else:
             assert self._server is not None
             await self._server.approve(
-                ws_id=ws_id, approved=approved, feedback=feedback or None, always=always
+                ws_id=ws_id,
+                approved=approved,
+                feedback=feedback or None,
+                always=always,
+                cycle_id=correlation_id or None,
             )
         log.debug(
             "channel_router.send_approval",

--- a/turnstone/channels/discord/bot.py
+++ b/turnstone/channels/discord/bot.py
@@ -23,7 +23,7 @@ import httpx
 
 from turnstone.channels._config import MAX_NOTIFY_TRACKING
 from turnstone.channels._formatter import chunk_message
-from turnstone.channels._routing import ChannelRouter
+from turnstone.channels._routing import ChannelRouter, pop_cycle_entry, pop_ws_entries
 from turnstone.channels._sse import run_sse_stream
 from turnstone.core.log import get_logger
 from turnstone.sdk.events import (
@@ -235,10 +235,15 @@ class TurnstoneBot:
         # List preserves call order for FIFO matching when the same tool name
         # appears more than once in a single turn.
         self._tool_info_msgs: dict[str, list[tuple[str, str, str, discord.Message]]] = {}
-        # Track the Discord message containing the pending approval embed per
-        # workstream so that IntentVerdictEvent can update it with LLM judge
-        # results.
-        self._pending_approval_msgs: dict[str, discord.Message] = {}
+        # Track the Discord message containing each pending approval embed,
+        # keyed by (ws_id, cycle_id) — parallel task agents make several
+        # approval cycles live per workstream at once, each its own embed.
+        # The value carries the cycle's member call_ids so
+        # IntentVerdictEvent (keyed by call_id) updates the RIGHT embed
+        # with LLM judge results.
+        self._pending_approval_msgs: dict[
+            tuple[str, str], tuple[discord.Message, frozenset[str]]
+        ] = {}
         # Notification reply tracking: maps Discord message ID ->
         # (ws_id, target_discord_user_id) so that DM replies can be routed
         # back to the originating workstream.  The target user ID is checked
@@ -413,12 +418,16 @@ class TurnstoneBot:
             with contextlib.suppress(Exception):
                 await thinking_msg.delete()
         self._tool_info_msgs.pop(ws_id, None)
-        self._pending_approval_msgs.pop(ws_id, None)
+        self._pop_ws_approvals(ws_id)
         self._notify_reply_channels.pop(ws_id, None)
         # Purge stale notification tracking entries for this workstream.
         stale = [mid for mid, entry in self._notify_ws_map.items() if entry[0] == ws_id]
         for mid in stale:
             del self._notify_ws_map[mid]
+
+    def _pop_ws_approvals(self, ws_id: str) -> None:
+        """Drop every tracked approval embed for *ws_id* (all cycles)."""
+        pop_ws_entries(self._pending_approval_msgs, ws_id)
 
     async def unsubscribe_ws(self, ws_id: str) -> None:
         """Cancel the SSE listener for *ws_id* and clean up streaming state."""
@@ -680,6 +689,10 @@ class TurnstoneBot:
         from turnstone.channels._formatter import format_approval_request, format_verdict
         from turnstone.channels.discord.views import ApprovalView
 
+        # Every decision below is about THIS event's cycle — forward its
+        # cycle_id so the resolution can't land on a sibling round
+        # (parallel task agents can have several prompts outstanding).
+        cycle_id = event.cycle_id
         # Evaluate admin tool policies before auto-approve.
         policy_verdict = await self.router.evaluate_tool_policies(event.items)
         policy_handled = False
@@ -687,22 +700,19 @@ class TurnstoneBot:
             denied = ", ".join(policy_verdict.denied_tools)
             await self.router.send_approval(
                 ws_id,
-                "",
+                cycle_id,
                 approved=False,
                 feedback=f"Blocked by tool policy: {denied}",
             )
             await thread.send(f"*Tool blocked by admin policy: {denied}*")
             policy_handled = True
         elif policy_verdict.kind == "allow":
-            await self.router.send_approval(ws_id, "", approved=True)
+            await self.router.send_approval(ws_id, cycle_id, approved=True)
             await thread.send("*Tool approved by policy.*")
             policy_handled = True
 
         if not policy_handled and (self.config.auto_approve or self._should_auto_approve(event)):
-            # correlation_id is empty because the server's /api/approve
-            # endpoint resolves approvals by ws_id alone (one pending
-            # approval per workstream at a time).
-            await self.router.send_approval(ws_id, "", approved=True)
+            await self.router.send_approval(ws_id, cycle_id, approved=True)
             await thread.send("*Tool auto-approved.*")
         elif not policy_handled:
             text = format_approval_request(event.items)
@@ -721,9 +731,15 @@ class TurnstoneBot:
                         value=format_verdict(verdict),
                         inline=False,
                     )
-            embed.set_footer(text=f"{ws_id}||{_thread_owner_id(thread)}")
+            # Footer format ws_id|cycle_id|owner — the persistent view
+            # parses it back on click and routes the decision to exactly
+            # this cycle.
+            embed.set_footer(text=f"{ws_id}|{cycle_id}|{_thread_owner_id(thread)}")
             msg = await thread.send(embed=embed, view=ApprovalView(self)._view)
-            self._pending_approval_msgs[ws_id] = msg
+            call_ids = frozenset(
+                str(it.get("call_id", "")) for it in event.items if it.get("call_id")
+            )
+            self._pending_approval_msgs[(ws_id, cycle_id)] = (msg, call_ids)
 
     async def _handle_intent_verdict(
         self,
@@ -734,8 +750,18 @@ class TurnstoneBot:
 
         from turnstone.channels._formatter import format_verdict
 
-        # LLM judge verdict arrived — update the pending approval embed.
-        approval_msg = self._pending_approval_msgs.get(ws_id)
+        # LLM judge verdict arrived — update the pending approval embed
+        # whose cycle contains this call_id (several can be live at once
+        # under parallel task agents).  Legacy entries (empty call_ids)
+        # accept any verdict for the ws, as before.
+        approval_msg = next(
+            (
+                msg
+                for (wid, _), (msg, call_ids) in self._pending_approval_msgs.items()
+                if wid == ws_id and (not call_ids or event.call_id in call_ids)
+            ),
+            None,
+        )
         if approval_msg and approval_msg.embeds:
             embed = approval_msg.embeds[0]
             verdict_data = {
@@ -771,9 +797,12 @@ class TurnstoneBot:
         event: ApprovalResolvedEvent,
     ) -> None:
         # Server resolved the approval (timeout, external approve/reject).
-        # Disable the buttons so they can't be clicked stale.
-        approval_msg = self._pending_approval_msgs.pop(ws_id, None)
-        if approval_msg is not None:
+        # Disable the buttons so they can't be clicked stale.  Route by
+        # the event's cycle_id; a pre-multi-cycle server (no cycle_id)
+        # clears the ws's single tracked entry, as before.
+        entry = pop_cycle_entry(self._pending_approval_msgs, ws_id, event.cycle_id)
+        if entry is not None:
+            approval_msg = entry[0]
             from turnstone.channels.discord.views import disable_message_buttons
 
             label = "Approved" if event.approved else "Denied"
@@ -809,8 +838,8 @@ class TurnstoneBot:
                 # for multi-turn DM conversations.
                 if last_msg is not None:
                     self._track_notification(last_msg.id, ws_id, target_user_id)
-        # Clean up pending approval message tracking.
-        self._pending_approval_msgs.pop(ws_id, None)
+        # Clean up pending approval message tracking (all cycles).
+        self._pop_ws_approvals(ws_id)
 
     # -- helpers -------------------------------------------------------------
 

--- a/turnstone/channels/discord/views.py
+++ b/turnstone/channels/discord/views.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from turnstone.channels._routing import pop_cycle_entry
 from turnstone.core.log import get_logger
 
 if TYPE_CHECKING:
@@ -187,7 +188,9 @@ class ApprovalView:
 
         label = "Always Approved" if always else ("Approved" if approved else "Rejected")
         # Pop pending approval so ApprovalResolvedEvent doesn't double-update.
-        self.bot._pending_approval_msgs.pop(ws_id, None)
+        # Keyed by (ws_id, cycle_id); a legacy footer without a cycle_id
+        # clears the ws's single tracked entry.
+        pop_cycle_entry(self.bot._pending_approval_msgs, ws_id, correlation_id)
         await _disable_buttons(interaction, label)
         await interaction.followup.send(
             f"Tool execution **{label.lower()}**.",

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -36,7 +36,12 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from turnstone.channels._config import MAX_NOTIFY_TRACKING
 from turnstone.channels._formatter import chunk_message
-from turnstone.channels._routing import ChannelRouter
+from turnstone.channels._routing import (
+    ChannelRouter,
+    get_cycle_entry,
+    pop_cycle_entry,
+    pop_ws_entries,
+)
 from turnstone.channels._sse import run_sse_stream
 from turnstone.channels.slack.routes import SlackRoute
 from turnstone.core.log import get_logger
@@ -128,6 +133,13 @@ class PendingApproval:
     # approval message (matches the pre-refactor "fetch live blocks
     # and append" behavior).
     blocks: list[dict[str, Any]] = field(default_factory=list)
+    # Approval-cycle identity + member call_ids.  A workstream can hold
+    # several concurrent cycles (parallel task agents), each its own
+    # Slack message; the cycle_id routes the button click to exactly
+    # this round and call_ids route IntentVerdictEvents (keyed by
+    # call_id) onto the right message.
+    cycle_id: str = ""
+    call_ids: frozenset[str] = frozenset()
 
 
 @dataclass
@@ -275,7 +287,11 @@ class TurnstoneSlackBot:
         self._sse_tasks: dict[str, asyncio.Task[None]] = {}
         self._streaming: dict[str, StreamingMessage] = {}
 
-        self._pending_approval: dict[str, PendingApproval] = {}
+        # Keyed by (ws_id, cycle_id) — one entry per approval MESSAGE.
+        # Parallel task agents make several cycles live per ws at once;
+        # the old ws_id-only key silently replaced the tracked message
+        # so verdict edits and resolution updates hit the wrong prompt.
+        self._pending_approval: dict[tuple[str, str], PendingApproval] = {}
         self._notify_ws_map: dict[str, tuple[str, SlackRoute]] = {}
         # Per-workstream override used to route the next streamed assistant
         # response back into a Slack notification reply thread instead of the
@@ -865,7 +881,11 @@ class TurnstoneSlackBot:
             return
 
         ws_id, correlation_id = parts
-        entry = self._pending_approval.get(ws_id)
+        # correlation_id = the cycle_id stamped into the button value at
+        # post time; pre-multi-cycle messages carry "" — fall back to
+        # the ws's single tracked entry so an in-flight upgrade doesn't
+        # orphan an already-posted prompt.
+        entry = get_cycle_entry(self._pending_approval, ws_id, correlation_id)
         actor_user_id = body.get("user", {}).get("id", "")
         channel = body["container"]["channel_id"]
         verb = "approve" if approved else "deny"
@@ -899,12 +919,12 @@ class TurnstoneSlackBot:
             )
             return
 
-        await self.router.send_approval(ws_id, correlation_id, approved=approved)
+        await self.router.send_approval(ws_id, entry.cycle_id, approved=approved)
         # Drop the pending entry now that we've handled it locally. Otherwise
         # the subsequent ApprovalResolvedEvent will rewrite the message a
         # second time ("Tool approved" → "Approved") — wasted chat_update and
         # a visible edit flicker.
-        self._pending_approval.pop(ws_id, None)
+        self._pending_approval.pop((ws_id, entry.cycle_id), None)
         ts = body["container"]["message_ts"]
         update_text = "Tool approved" if approved else "Tool denied"
         event_key = "approve" if approved else "deny"
@@ -941,6 +961,10 @@ class TurnstoneSlackBot:
         self._subscribed_ws.add(ws_id)
         log.info("slack.subscribed", ws_id=ws_id, channel_id=channel_id)
 
+    def _pop_ws_approvals(self, ws_id: str) -> None:
+        """Drop every tracked approval message for *ws_id* (all cycles)."""
+        pop_ws_entries(self._pending_approval, ws_id)
+
     def _clear_ws_state(self, ws_id: str) -> None:
         """Drop all in-memory state keyed by *ws_id*.
 
@@ -950,7 +974,7 @@ class TurnstoneSlackBot:
         """
         self._subscribed_ws.discard(ws_id)
         self._streaming.pop(ws_id, None)
-        self._pending_approval.pop(ws_id, None)
+        self._pop_ws_approvals(ws_id)
         self._clear_notification_tracking_for_ws(ws_id)
 
     async def unsubscribe_ws(self, ws_id: str) -> None:
@@ -1062,13 +1086,17 @@ class TurnstoneSlackBot:
         thread_ts = route.thread_ts or ""
         owner_user_id = route.user_id
 
+        # Every decision this handler takes is about THIS event's cycle —
+        # forward its cycle_id so the resolution can't land on a sibling
+        # round (parallel task agents can have several outstanding).
+        cycle_id = event.cycle_id
         verdict = await self.router.evaluate_tool_policies(event.items)
         policy_handled = False
         if verdict.kind == "deny":
             denied = ", ".join(verdict.denied_tools)
             await self.router.send_approval(
                 ws_id,
-                "",
+                cycle_id,
                 approved=False,
                 feedback=f"Blocked by tool policy: {denied}",
             )
@@ -1079,7 +1107,7 @@ class TurnstoneSlackBot:
             )
             policy_handled = True
         elif verdict.kind == "allow":
-            await self.router.send_approval(ws_id, "", approved=True)
+            await self.router.send_approval(ws_id, cycle_id, approved=True)
             await self._client.chat_postMessage(
                 channel=slack_channel,
                 thread_ts=thread_ts or None,
@@ -1088,7 +1116,7 @@ class TurnstoneSlackBot:
             policy_handled = True
 
         if not policy_handled and (self.config.auto_approve or self._should_auto_approve(event)):
-            await self.router.send_approval(ws_id, "", approved=True)
+            await self.router.send_approval(ws_id, cycle_id, approved=True)
             await self._client.chat_postMessage(
                 channel=slack_channel,
                 thread_ts=thread_ts or None,
@@ -1097,7 +1125,7 @@ class TurnstoneSlackBot:
         elif not policy_handled:
             await self._send_approval_request(
                 ws_id,
-                "",
+                cycle_id,
                 event.items,
                 slack_channel,
                 thread_ts,
@@ -1105,7 +1133,18 @@ class TurnstoneSlackBot:
             )
 
     async def _handle_intent_verdict(self, ws_id: str, event: IntentVerdictEvent) -> None:
-        entry = self._pending_approval.get(ws_id)
+        # Route the verdict onto the message whose cycle contains this
+        # call_id — with several prompts live, editing "the" entry would
+        # stack the judge section on the wrong message.  Legacy entries
+        # (empty call_ids) accept any verdict for the ws, as before.
+        entry = next(
+            (
+                v
+                for (wid, _), v in self._pending_approval.items()
+                if wid == ws_id and (not v.call_ids or event.call_id in v.call_ids)
+            ),
+            None,
+        )
         if entry is None:
             return
 
@@ -1138,7 +1177,9 @@ class TurnstoneSlackBot:
             log.debug("slack.verdict_message_update_failed", ws_id=ws_id, exc_info=True)
 
     async def _handle_approval_resolved(self, ws_id: str, event: ApprovalResolvedEvent) -> None:
-        entry = self._pending_approval.pop(ws_id, None)
+        # Route by the event's cycle_id; a pre-multi-cycle server (no
+        # cycle_id) clears the ws's single tracked entry, as before.
+        entry = pop_cycle_entry(self._pending_approval, ws_id, event.cycle_id)
         if entry is None:
             return
 
@@ -1174,7 +1215,7 @@ class TurnstoneSlackBot:
         ):
             self._track_notification(sm.message_ts, ws_id, reply_route)
 
-        self._pending_approval.pop(ws_id, None)
+        self._pop_ws_approvals(ws_id)
 
     async def _handle_error(self, route: SlackRoute, event: ErrorEvent) -> None:
         safe_msg = event.message[:500] if event.message else "An error occurred"
@@ -1254,15 +1295,18 @@ class TurnstoneSlackBot:
             blocks=cast("list[dict[str, Any]]", blocks),
         )
         if resp.get("ok"):
-            self._pending_approval[ws_id] = PendingApproval(
+            self._pending_approval[(ws_id, correlation_id)] = PendingApproval(
                 channel=channel,
                 message_ts=resp["ts"],
                 owner_user_id=owner_user_id,
                 blocks=list(cast("list[dict[str, Any]]", blocks)),
+                cycle_id=correlation_id,
+                call_ids=frozenset(str(it.get("call_id", "")) for it in items if it.get("call_id")),
             )
             log.info(
                 "slack.pending_approval_stored",
                 ws_id=ws_id,
+                cycle_id=correlation_id,
                 channel=channel,
                 thread_ts=thread_ts,
                 owner_user_id=owner_user_id,

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -324,8 +324,13 @@ class TerminalUI(SessionUI):
     def on_state_change(self, state: str) -> None:
         pass  # base TerminalUI ignores state changes
 
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
-        """Display LLM judge verdict — called from daemon thread while approval is pending."""
+    def on_intent_verdict(self, verdict: dict[str, Any], judge_event: object | None = None) -> None:
+        """Display LLM judge verdict — called from daemon thread while approval is pending.
+
+        ``judge_event`` (the delivering judge generation) is a
+        cycle-registry concern — the terminal renders every verdict it
+        receives and ignores it.
+        """
         risk = verdict.get("risk_level", "medium")
         rec = verdict.get("recommendation", "review")
         summary = verdict.get("intent_summary", "")

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -733,6 +733,9 @@ class ClusterCollector:
                 # coordinator's tree UI can clear the pending-approval
                 # pill the moment the user decides, rather than waiting
                 # for the subsequent state-change piggyback.
+                # ``cycle_id`` / ``call_ids`` name WHICH cycle resolved —
+                # a child running parallel task agents can have several
+                # approval blocks live at once.
                 ws_id = data.get("ws_id", "")
                 if ws_id:
                     pending_events.append(
@@ -743,6 +746,8 @@ class ClusterCollector:
                             "approved": bool(data.get("approved", False)),
                             "feedback": data.get("feedback", "") or "",
                             "always": bool(data.get("always", False)),
+                            "cycle_id": data.get("cycle_id", "") or "",
+                            "call_ids": data.get("call_ids") or [],
                         }
                     )
 
@@ -1391,6 +1396,8 @@ class ClusterCollector:
         approved: bool,
         feedback: str = "",
         always: bool = False,
+        cycle_id: str = "",
+        call_ids: list[str] | None = None,
     ) -> None:
         """Fan an ``approval_resolved`` decision for a console-pseudo-node ws.
 
@@ -1407,6 +1414,8 @@ class ClusterCollector:
                 "approved": approved,
                 "feedback": feedback,
                 "always": always,
+                "cycle_id": cycle_id,
+                "call_ids": call_ids or [],
             }
         )
 

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -670,6 +670,11 @@ class CoordinatorAdapter:
                     "approved": bool(event.get("approved", False)),
                     "feedback": event.get("feedback", "") or "",
                     "always": bool(event.get("always", False)),
+                    # Which cycle resolved — the tree row can hold several
+                    # approval blocks when the child runs parallel task
+                    # agents; empty (legacy node) clears them all.
+                    "cycle_id": event.get("cycle_id", "") or "",
+                    "call_ids": event.get("call_ids") or [],
                 }
             else:  # approve_request
                 # Push path for the initial approval items —

--- a/turnstone/console/coordinator_ui.py
+++ b/turnstone/console/coordinator_ui.py
@@ -5,8 +5,8 @@ Mirrors ``turnstone.server.WebUI`` but scoped to the console's needs:
 - Per-session SSE listener fan-out (inherited from
   :class:`SessionUIBase` — same ``threading.Lock`` + queue list
   pattern WebUI uses).
-- ``threading.Event`` + ``_approval_result`` for blocking the worker
-  thread until a console endpoint delivers the decision (inherited).
+- Per-cycle ``ApprovalCycle`` registry for blocking each gate thread
+  until a console endpoint delivers its decision (inherited).
 - Per-ws metric tracking + turn-content accumulator + activity
   bookkeeping (inherited from :class:`SessionUIBase` post the rich
   ``ws_state`` payload lift). Coord populates the same
@@ -196,6 +196,8 @@ class ConsoleCoordinatorUI(SessionUIBase):
         feedback: str | None = None,
         *,
         always: bool = False,
+        cycle_id: str = "",
+        call_ids: tuple[str, ...] = (),
     ) -> None:
         """Fan an ``approval_resolved`` decision to the cluster collector.
 
@@ -213,6 +215,8 @@ class ConsoleCoordinatorUI(SessionUIBase):
                 approved=approved,
                 feedback=feedback or "",
                 always=always,
+                cycle_id=cycle_id,
+                call_ids=list(call_ids),
             )
         except Exception:
             log.debug(
@@ -317,8 +321,12 @@ class ConsoleCoordinatorUI(SessionUIBase):
             return
         fire_judge_verdict_metric(cm, verdict, "heuristic")
 
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
-        super().on_intent_verdict(verdict)
+    def on_intent_verdict(
+        self,
+        verdict: dict[str, Any],
+        judge_event: object | None = None,
+    ) -> None:
+        super().on_intent_verdict(verdict, judge_event)
         cm = ConsoleCoordinatorUI._console_metrics
         if cm is None:
             return

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1047,12 +1047,14 @@ _CLUSTER_WS_LIVE_KEYS = (
     "model_alias",
     "title",
     "name",
-    # Carries the inline approve/deny payload (items + judge_verdict)
-    # so coord live-bulk callers can render row-level UI without a
-    # per-child round-trip. ``None`` when no approval is pending.
-    # Cross-tenant exposure follows the trusted-team posture documented
-    # on ``SessionUIBase.serialize_pending_approval_detail``.
-    "pending_approval_detail",
+    # Carries the inline approve/deny payloads (one per live cycle,
+    # items + judge_verdict each) so coord live-bulk callers can render
+    # row-level UI without a per-child round-trip. ``[]`` when no
+    # approval is pending; several entries when parallel task agents
+    # gate concurrently.  Cross-tenant exposure follows the trusted-team
+    # posture documented on
+    # ``SessionUIBase.serialize_pending_approval_details``.
+    "pending_approval_details",
     # Ring buffer of the child's recent auto-approves (last 10) for
     # the coord-tree's "auto-approved by skill X" pill.  Without this
     # the operator has no surface to see WHICH tool calls bypassed
@@ -1170,16 +1172,16 @@ def _coordinator_live_snapshot(ws: Any) -> dict[str, Any]:
         val = getattr(obj, name, "") if obj else ""
         return val if isinstance(val, str) else ""
 
-    # Coord rows synthesize the same ``pending_approval_detail`` shape
+    # Coord rows synthesize the same ``pending_approval_details`` shape
     # the node-side dashboard produces — single source of truth via
-    # ``SessionUIBase.serialize_pending_approval_detail``. The console
+    # ``SessionUIBase.serialize_pending_approval_details``. The console
     # coord LLM judge isn't wired today (``coordinator_ui.py:138``
     # hardcodes ``judge_pending=False``), so ``judge_verdict`` will
     # always be ``None`` for these rows; the coord-self stretch in
     # the plan covers that follow-up. ``ui`` may be ``None`` in
     # transient states (newly-created ws before activation); every
     # active coord UI is a ``SessionUIBase`` and supports the method.
-    pending_approval_detail = ui.serialize_pending_approval_detail() if ui is not None else None
+    pending_approval_details = ui.serialize_pending_approval_details() if ui is not None else []
     recent_auto_approvals = ui.serialize_recent_auto_approvals() if ui is not None else []
 
     return {
@@ -1194,7 +1196,7 @@ def _coordinator_live_snapshot(ws: Any) -> dict[str, Any]:
         "title": "",
         "name": getattr(ws, "name", "") or "",
         "pending_approval": pending_approval,
-        "pending_approval_detail": pending_approval_detail,
+        "pending_approval_details": pending_approval_details,
         "recent_auto_approvals": recent_auto_approvals,
     }
 
@@ -1286,15 +1288,15 @@ async def _fetch_live_block(
             # ``activity_state="approval"`` is set inside approve_tools
             # AFTER the state transition fires, so a bulk fetch that
             # races with that window can see state=attention and
-            # activity_state="" simultaneously. A non-null
-            # ``pending_approval_detail`` is also a definitive signal
-            # (the serializer only emits non-None when ``_pending_approval``
-            # is set on the UI). Any of the three flips this true; the
-            # frontend reducer mirrors the same disjunction.
+            # activity_state="" simultaneously. A non-empty
+            # ``pending_approval_details`` is also a definitive signal
+            # (the serializer emits entries only for live cycles). Any
+            # of the three flips this true; the frontend reducer
+            # mirrors the same disjunction.
             live["pending_approval"] = (
                 live.get("activity_state") == "approval"
                 or entry.get("state") == "attention"
-                or live.get("pending_approval_detail") is not None
+                or bool(live.get("pending_approval_details"))
             )
             return live
     return None
@@ -3561,16 +3563,18 @@ def _coord_events_replay(
     """
     yield from session_replay_preamble(ws.session, ui)
 
-    pending_approval = getattr(ui, "_pending_approval", None)
-    if pending_approval is not None:
-        yield pending_approval
-        # Cached LLM verdicts that fired since the approval prompt
-        # — without this replay, a reconnecting / refreshing tab
-        # sees the approve_request prompt but no judge chip, and
-        # since intent_verdict only fires once per call_id (no
-        # push to a late subscriber), the chip would never appear
-        # until the operator re-invokes the action. Mirrors the
-        # interactive path at ``turnstone/server.py:875-878``.
+    # EVERY live approval cycle replays (parallel task agents can have
+    # several outstanding), each card followed once by the cached LLM
+    # verdicts — without this replay, a reconnecting / refreshing tab
+    # sees the approve_request prompts but no judge chips, and since
+    # intent_verdict only fires once per call_id (no push to a late
+    # subscriber), the chips would never appear until the operator
+    # re-invokes the action. Mirrors the interactive path in
+    # ``turnstone/server.py`` (fresh-connect replay).
+    cards_fn = getattr(ui, "pending_approval_cards", None)
+    pending_cards = cards_fn() if callable(cards_fn) else []
+    if pending_cards:
+        yield from pending_cards
         llm_verdicts = getattr(ui, "_llm_verdicts", None)
         ws_lock = getattr(ui, "_ws_lock", None)
         if llm_verdicts and ws_lock is not None:

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -4130,8 +4130,8 @@ function createCoordinatorPane(root, wsId, opts) {
     const existing = childrenState.get(childId);
     if (!existing) return;
     existing.state = ev.reason === "deleted" ? "deleted" : "closed";
-    // Clearing the live cache eagerly on close prevents a stale
-    // pending_approval_detail from continuing to render approve/deny
+    // Clearing the live cache eagerly on close prevents stale
+    // pending_approval_details from continuing to render approve/deny
     // buttons on a closed row (its TTL would otherwise survive into
     // the closed/deleted lifecycle until natural expiry).
     invalidateLiveBadge(childId);

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1310,6 +1310,7 @@ function createCoordinatorPane(root, wsId, opts) {
         approved: !!approved,
         always: !!always,
         call_id: callId,
+        cycle_id: batch.dataset.cycleId || null,
       });
       if (!resp.ok) throw new Error("approve failed: HTTP " + resp.status);
     } catch (e) {
@@ -1465,6 +1466,9 @@ function createCoordinatorPane(root, wsId, opts) {
     }
     if (allMapped) {
       const existing = toolRows.get(items[0].call_id).batch;
+      // Late cycle identity (SSE approve_request upgrading a replay /
+      // early-paint shell) — stamp it so the approve POST can route.
+      if (opts.cycleId) existing.dataset.cycleId = opts.cycleId;
       // Upgrade-in-place: when SSE arrives with a more specific state
       // than the placeholder history replay rendered, morph the
       // existing shell instead of leaving stale chrome.  The two real
@@ -1578,6 +1582,10 @@ function createCoordinatorPane(root, wsId, opts) {
       summaryText,
       tierText: _pickBatchTier(items),
     });
+    // Approval-cycle identity — _resolveBatchAction posts it back so
+    // the decision lands on exactly this round when several batches
+    // are pending (parallel task agents).
+    if (opts.cycleId) batch.dataset.cycleId = opts.cycleId;
     if (opts.pending) batch.classList.add("conv-batch--pending");
     else if (opts.auto) batch.classList.add("conv-batch--auto");
     else if (opts.resolved) {
@@ -1732,12 +1740,13 @@ function createCoordinatorPane(root, wsId, opts) {
   // directly, and inline action buttons drive _resolveBatchAction.
   // ------------------------------------------------------------------
 
-  function showApproval(items, judgePending) {
+  function showApproval(items, judgePending, cycleId) {
     const list = (items || []).filter(Boolean);
     if (list.length === 0) return;
     const batch = appendToolBatch(list, {
       pending: true,
       judgePending: !!judgePending,
+      cycleId: cycleId || "",
     });
     const firstPending = list.find((it) => it.needs_approval);
     if (batch && firstPending && firstPending.call_id) {
@@ -2233,7 +2242,7 @@ function createCoordinatorPane(root, wsId, opts) {
         loadChildren({ replace: true });
         loadTasks();
         // Drop the live-badge cache too — entries within the 5s TTL
-        // can carry stale pending_approval_detail (the child may
+        // can carry stale pending_approval_details (the child may
         // have resolved its approval during the SSE gap).  Without
         // this clear, inline approve/deny buttons could render on
         // a row whose approval was resolved elsewhere; the next
@@ -2448,26 +2457,36 @@ function createCoordinatorPane(root, wsId, opts) {
         break;
       case "approve_request":
         // appendToolBatch is idempotent on call_ids — the console replays
-        // _pending_approval into every new SSE subscriber, so reconnect
-        // won't double-render the construct.
-        showApproval(ev.items, !!ev.judge_pending);
+        // every live cycle's card into every new SSE subscriber, so
+        // reconnect won't double-render the construct.
+        showApproval(ev.items, !!ev.judge_pending, ev.cycle_id || "");
         break;
       case "approval_resolved": {
-        // Server-driven resolution.  Morph the active pending batch
-        // (the construct that posted the approve POST).  The server
-        // event carries `approved` + `feedback` only — the "always"
-        // intent.  Server now echoes ``always`` on the SSE payload
-        // (post-PR-447) so cross-tab resolution renders the right
-        // status pill on every subscribed tab — not just the one
-        // that clicked.  Fall back to this tab's stashed dataset
-        // flag for backward compat with a server hot-deploy where
-        // the SSE event might briefly omit the field.
-        // Fall back to a DOM lookup if activeBatch was never set
-        // (e.g. cross-tab resolution where this tab never rendered
-        // the approval gate before the resolved event landed).
-        const target =
-          activeBatch ||
-          messagesEl.querySelector(".conv-batch.conv-batch--pending");
+        // Server-driven resolution.  Route to the batch whose rows
+        // carry one of the resolved call_ids — several batches can be
+        // pending at once (parallel task agents), and morphing "the
+        // active" one would resolve the wrong construct.  Server now
+        // echoes ``always`` on the SSE payload (post-PR-447) so
+        // cross-tab resolution renders the right status pill on every
+        // subscribed tab — not just the one that clicked.  Fall back
+        // to this tab's stashed dataset flag for backward compat with
+        // a server hot-deploy where the SSE event might briefly omit
+        // the field.  Legacy events without call_ids fall back to
+        // activeBatch / the last pending batch (single-cycle server).
+        let target = null;
+        const resolvedIds = Array.isArray(ev.call_ids) ? ev.call_ids : [];
+        for (const cid of resolvedIds) {
+          const mapped = toolRows.get(cid);
+          if (mapped && mapped.batch) {
+            target = mapped.batch;
+            break;
+          }
+        }
+        if (!target) {
+          target =
+            activeBatch ||
+            messagesEl.querySelector(".conv-batch.conv-batch--pending");
+        }
         if (target) {
           const wasAlways =
             ev.always === true ||
@@ -2971,11 +2990,18 @@ function createCoordinatorPane(root, wsId, opts) {
     // \u2014 without it the operator sees a "demand for action" badge
     // with no actionable content.
     if (cached && cached.live && cached.live.pending_approval) {
-      const detail = cached.live.pending_approval_detail;
-      const block = detail
-        ? renderApprovalBlock(child, detail)
-        : renderApprovalPlaceholder(child);
-      if (block) row.appendChild(block);
+      // One block per live cycle — a child running parallel task agents
+      // can gate several batches at once, each independently resolvable.
+      const details = _liveApprovalDetails(cached.live);
+      if (details.length) {
+        details.forEach((detail) => {
+          const block = renderApprovalBlock(child, detail);
+          if (block) row.appendChild(block);
+        });
+      } else {
+        const block = renderApprovalPlaceholder(child);
+        if (block) row.appendChild(block);
+      }
     }
     // Recent auto-approves — tools that bypassed the operator gate
     // (skill ``allowed_tools`` allowlist / blanket / admin policy /
@@ -3130,6 +3156,16 @@ function createCoordinatorPane(root, wsId, opts) {
     header.appendChild(pill);
     block.appendChild(header);
     return block;
+  }
+
+  // Normalize the live block's approval payload to a list of cycle
+  // details (``pending_approval_details``).  Defensive against a
+  // malformed entry: non-arrays fold to [].
+  function _liveApprovalDetails(live) {
+    if (!live) return [];
+    return Array.isArray(live.pending_approval_details)
+      ? live.pending_approval_details.filter(Boolean)
+      : [];
   }
 
   function renderApprovalBlock(child, detail) {
@@ -3397,7 +3433,7 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   // Submit the approve POST + handle the result.  On success, locally
-  // clear pending_approval_detail so the row re-renders without
+  // clear the resolved cycle from pending_approval_details so the row re-renders without
   // buttons immediately (optimistic update \u2014 the next live-bulk poll
   // confirms).  On 409 (stale call_id), refresh the live block so the
   // row re-renders against the new round.
@@ -3423,6 +3459,7 @@ function createCoordinatorPane(root, wsId, opts) {
         approved: !!approved,
         always: false,
         call_id: callId,
+        cycle_id: (detail && detail.cycle_id) || null,
       });
       if (resp.status === 409) {
         // Stale call_id \u2014 server has rolled to a new round, or
@@ -3477,9 +3514,15 @@ function createCoordinatorPane(root, wsId, opts) {
       // pill flickers back. (Caught by /review bug-4.)
       const cached = liveBadgeCache.get(targetWsId);
       if (cached && cached.live) {
+        // Optimistically remove ONLY the resolved cycle — sibling
+        // cycles (parallel task agents) keep their buttons.  The
+        // pending flag clears only when no cycles remain.
+        const remaining = _liveApprovalDetails(cached.live).filter(
+          (d) => d !== detail && d.cycle_id !== (detail && detail.cycle_id),
+        );
         cached.live = Object.assign({}, cached.live, {
-          pending_approval: false,
-          pending_approval_detail: null,
+          pending_approval: remaining.length > 0,
+          pending_approval_details: remaining,
         });
         cached.sseUpdatedAt = Date.now();
         _liveBadgeCacheSet(targetWsId, cached);
@@ -3488,8 +3531,14 @@ function createCoordinatorPane(root, wsId, opts) {
       // badge in .meta disappears immediately too — without this, the
       // row shows the badge with no buttons for ~50-150ms until the
       // child_ws_approval_resolved push or next state event lands.
+      // Only when NO cycles remain: a sibling prompt keeps the badge.
+      const cachedAfter = liveBadgeCache.get(targetWsId);
+      const anyLeft =
+        cachedAfter &&
+        cachedAfter.live &&
+        _liveApprovalDetails(cachedAfter.live).length > 0;
       const childState = childrenState.get(targetWsId);
-      if (childState && childState.activity_state === "approval") {
+      if (childState && childState.activity_state === "approval" && !anyLeft) {
         childState.activity_state = "";
       }
       renderChildren();
@@ -3895,7 +3944,7 @@ function createCoordinatorPane(root, wsId, opts) {
         ) {
           mergedLive = Object.assign({}, live, {
             pending_approval: prev.live.pending_approval,
-            pending_approval_detail: prev.live.pending_approval_detail,
+            pending_approval_details: prev.live.pending_approval_details,
           });
         }
         _liveBadgeCacheSet(id, {
@@ -3996,10 +4045,20 @@ function createCoordinatorPane(root, wsId, opts) {
     // misses 30+ children all sitting in attention. (Caught manual
     // testing: 30 children all state=attention rendered with no
     // approval blocks because pendingApproval was always false.)
-    const pendingApproval =
+    // The ws-level activity signal is COARSE under parallel task
+    // agents: one gate resolving (activity flips to "tool") while a
+    // sibling is still parked would read as "no approval pending".
+    // The per-cycle details list is the authoritative surface — a
+    // non-empty list keeps the row pending regardless of the
+    // activity flicker; per-cycle removal happens in
+    // handleChildApprovalResolved, and the bulk fetch reconciles a
+    // dropped resolution event within its ~2s TTL.
+    const coarsePending =
       existing.state === "attention" || existing.activity_state === "approval";
     const cached = liveBadgeCache.get(childId);
     const cachedLive = (cached && cached.live) || {};
+    const pendingApproval =
+      coarsePending || _liveApprovalDetails(cachedLive).length > 0;
     // Rising-edge detection BEFORE we mutate the cache. The chat-pane
     // tool batches already announce assertively
     // (renderApprovalDock / appendToolBatch); the children-tree was
@@ -4018,18 +4077,18 @@ function createCoordinatorPane(root, wsId, opts) {
     // authoritatively writes a value the bulk fetch must not
     // resurrect (a stale bulk-fetch landing within
     // SSE_AUTHORITATIVE_MS would otherwise re-render the cleared
-    // approval block). Setting ``pending_approval=true`` does NOT
+    // approval blocks). Setting ``pending_approval=true`` does NOT
     // claim cache authority — the bulk fetch is the source of
-    // truth for ``pending_approval_detail``, and bumping
+    // truth for ``pending_approval_details``, and bumping
     // sseUpdatedAt here makes the merge guard in flushLiveFetches
-    // preserve our stale (often null) detail over the bulk
+    // preserve our stale (often empty) details over the bulk
     // fetch's actual data, leaving the row stuck on the loading
     // placeholder. (Caught when the screenshot showed buttons
     // briefly then loading replaced them.)
     const detailClearedAuthoritatively =
       !pendingApproval && cachedLive.pending_approval === true;
     if (!pendingApproval) {
-      nextLive.pending_approval_detail = null;
+      nextLive.pending_approval_details = [];
     }
     _liveBadgeCacheSet(childId, {
       live: nextLive,
@@ -4114,17 +4173,23 @@ function createCoordinatorPane(root, wsId, opts) {
     if (!callId) return;
     const cached = liveBadgeCache.get(childId);
     const cachedLive = (cached && cached.live) || {};
-    const detail = cachedLive.pending_approval_detail;
+    // Stamp onto the CYCLE containing this call_id — several details
+    // can be live at once (parallel task agents).
+    const detail = _liveApprovalDetails(cachedLive).find(
+      (d) =>
+        Array.isArray(d.items) &&
+        d.items.some((it) => it && it.call_id === callId),
+    );
     if (!detail) {
-      // No pending_approval_detail to stamp the verdict onto. The
-      // verdict is still durable in storage; the next bulk fetch
-      // will hydrate the detail and include the verdict via the
-      // existing serialize path.
+      // No pending detail to stamp the verdict onto. The verdict is
+      // still durable in storage; the next bulk fetch will hydrate
+      // the details and include the verdict via the existing
+      // serialize path.
       return;
     }
     // Stamp on the matching item (UI render reads judge_verdict per
     // item) AND on the by-call_id map (matches the
-    // serialize_pending_approval_detail shape).
+    // serialize_pending_approval_details shape).
     const items = Array.isArray(detail.items) ? detail.items : [];
     for (const item of items) {
       if (item && item.call_id === callId) {
@@ -4153,8 +4218,15 @@ function createCoordinatorPane(root, wsId, opts) {
     if (!childId) return;
     const cached = liveBadgeCache.get(childId);
     const cachedLive = (cached && cached.live) || {};
-    cachedLive.pending_approval = false;
-    cachedLive.pending_approval_detail = null;
+    // Remove ONLY the resolved cycle; siblings keep their buttons.
+    // Legacy events without a cycle_id (pre-multi-cycle node) clear
+    // everything, matching the old single-slot behavior.
+    const details = _liveApprovalDetails(cachedLive);
+    const remaining = ev.cycle_id
+      ? details.filter((d) => d.cycle_id !== ev.cycle_id)
+      : [];
+    cachedLive.pending_approval = remaining.length > 0;
+    cachedLive.pending_approval_details = remaining;
     _liveBadgeCacheSet(childId, {
       live: cachedLive,
       fetched: cached ? cached.fetched : 0,
@@ -4179,8 +4251,17 @@ function createCoordinatorPane(root, wsId, opts) {
     if (!detail) return;
     const cached = liveBadgeCache.get(childId);
     const cachedLive = (cached && cached.live) || {};
+    // Append (or replace, keyed by cycle_id) — several cycles can be
+    // outstanding under parallel task agents; a sibling's push must
+    // not clobber ours.  Legacy nodes without cycle_id fold to a
+    // single-slot replace via the shared "" key.
+    const key = detail.cycle_id || "";
+    const details = _liveApprovalDetails(cachedLive).filter(
+      (d) => (d.cycle_id || "") !== key,
+    );
+    details.push(detail);
     cachedLive.pending_approval = true;
-    cachedLive.pending_approval_detail = detail;
+    cachedLive.pending_approval_details = details;
     _liveBadgeCacheSet(childId, {
       live: cachedLive,
       fetched: cached ? cached.fetched : 0,
@@ -4530,19 +4611,20 @@ function createCoordinatorPane(root, wsId, opts) {
     // NOT re-run this (SSE re-delivers approve_request live, and replaying a
     // stale pre-rewind pending batch would be wrong).
     try {
-      const pendingDetail =
+      const pendingDetails =
         wsSnapshot &&
         wsSnapshot.pending_approval &&
-        wsSnapshot.pending_approval_detail &&
-        Array.isArray(wsSnapshot.pending_approval_detail.items)
-          ? wsSnapshot.pending_approval_detail
-          : null;
-      if (pendingDetail) {
+        Array.isArray(wsSnapshot.pending_approval_details)
+          ? wsSnapshot.pending_approval_details
+          : [];
+      pendingDetails.forEach((pendingDetail) => {
+        if (!pendingDetail || !Array.isArray(pendingDetail.items)) return;
         appendToolBatch(pendingDetail.items, {
           pending: true,
           judgePending: !!pendingDetail.judge_pending,
+          cycleId: pendingDetail.cycle_id || "",
         });
-      }
+      });
     } catch (e) {
       console.warn("pending-approval replay failed", e);
     }

--- a/turnstone/core/adapters/_ui_cleanup.py
+++ b/turnstone/core/adapters/_ui_cleanup.py
@@ -33,8 +33,18 @@ def cleanup_session_ui(ws: Workstream) -> None:
         ws.session.cancel()
     ui = ws.ui
     if ui is not None:
-        if hasattr(ui, "_approval_event"):
-            ui._approval_result = False, None  # type: ignore[attr-defined]
+        if hasattr(ui, "resolve_all_approvals"):
+            # Deny + unblock EVERY live approval cycle — with parallel
+            # task agents several gate threads can be parked at once,
+            # and each must wake with its own (denied) result.
+            with contextlib.suppress(Exception):
+                ui.resolve_all_approvals(False, "Workstream closed")
+        elif hasattr(ui, "_approval_event"):
+            # Pre-cycle external SessionUI impls: the old single-slot
+            # contract.  Without this kick their gate thread stays
+            # parked on a workstream that no longer exists.
+            if hasattr(ui, "_approval_result"):
+                ui._approval_result = (False, None)
             ui._approval_event.set()
         if hasattr(ui, "_fg_event"):
             ui._fg_event.set()

--- a/turnstone/core/adapters/interactive_adapter.py
+++ b/turnstone/core/adapters/interactive_adapter.py
@@ -6,7 +6,7 @@ surface is asymmetric on the interactive side and the asymmetry is
 load-bearing — see ``InteractiveAdapter`` docstring.
 
 Uses ``WebUI``'s per-UI listener set for ``cleanup_ui`` — the same
-hooks (``_approval_event`` / ``_fg_event`` + the ``ws_closed``
+hooks (``resolve_all_approvals`` / ``_fg_event`` + the ``ws_closed``
 broadcast) the old ``WorkstreamManager._cleanup_ui`` touched.
 """
 

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -1058,6 +1058,7 @@ class IntentJudge:
         messages: list[dict[str, Any]],
         callback: Callable[[IntentVerdict], None],
         cancel_event: threading.Event | None = None,
+        done_callback: Callable[[], None] | None = None,
     ) -> list[IntentVerdict]:
         """Evaluate tool calls. Returns heuristic verdicts immediately.
 
@@ -1078,6 +1079,12 @@ class IntentJudge:
                 newer batch supersedes this generation, on session
                 close, and — only when ``cancel_on_approval`` is
                 enabled — as soon as the approval gate resolves.
+            done_callback: Invoked exactly once from the daemon's
+                ``finally`` when this generation finishes — normally,
+                cancelled, or by escape of a delivery error.  ChatSession
+                uses it to retire the generation's cancel event from its
+                live set (parallel task agents each spawn a generation;
+                ``close()`` aborts whatever is still live).
 
         Returns:
             List of heuristic verdicts (one per item), available immediately.
@@ -1103,7 +1110,7 @@ class IntentJudge:
         # Spawn daemon thread for LLM judge
         thread = threading.Thread(
             target=self._run_judge,
-            args=(items, messages, heuristic_verdicts, callback, cancel_event),
+            args=(items, messages, heuristic_verdicts, callback, cancel_event, done_callback),
             daemon=True,
             name="intent-judge",
         )
@@ -1118,6 +1125,7 @@ class IntentJudge:
         heuristic_verdicts: list[IntentVerdict],
         callback: Callable[[IntentVerdict], None],
         cancel_event: threading.Event | None = None,
+        done_callback: Callable[[], None] | None = None,
     ) -> None:
         """Daemon thread: run LLM judge for each item and invoke callback.
 
@@ -1207,6 +1215,11 @@ class IntentJudge:
                     client.close()
             except Exception:
                 log.debug("judge.client_close_failed", exc_info=True)
+            if done_callback is not None:
+                try:
+                    done_callback()
+                except Exception:
+                    log.debug("judge.done_callback_failed", exc_info=True)
 
     def _deliver_fallbacks(
         self,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1062,8 +1062,13 @@ class SessionUI(Protocol):
     ) -> int | None: ...
     def on_state_change(self, state: str) -> None: ...
     def on_rename(self, name: str) -> None: ...
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
-        """Called when the LLM judge produces a verdict for a pending approval."""
+    def on_intent_verdict(self, verdict: dict[str, Any], judge_event: object | None = None) -> None:
+        """Called when the LLM judge produces a verdict for a pending approval.
+
+        ``judge_event`` identifies the delivering daemon's generation
+        (its cancel event); multi-cycle UIs use its identity to reject a
+        stale generation's verdict aimed at a live approval cycle.
+        """
         ...
 
     def on_output_warning(self, call_id: str, assessment: dict[str, Any]) -> None:
@@ -1497,6 +1502,15 @@ class ChatSession:
         self._judge_config: JudgeConfig | None = judge_config
         self._judge: IntentJudge | None = None
         self._judge_cancel_event: threading.Event | None = None
+        # EVERY live judge generation's cancel event — the main loop's
+        # (also mirrored in the slot above, which carries the supersede
+        # semantics) plus one per sub-agent gate; parallel task agents
+        # spawn judges concurrently, and ``close()`` must be able to
+        # abort them all.  Membership is exact: added at spawn, removed
+        # by the daemon's ``done_callback``.  Own lock — spawns happen
+        # on the main worker AND agent pool threads.
+        self._judge_cancel_events: set[threading.Event] = set()
+        self._judge_events_lock = threading.Lock()
         # Output-guard LLM judge (lazy-initialized, issue #560 mitigation #1).
         # Lives alongside ``_judge`` and is reset by the same client/model
         # swap paths so both judges pick up new credentials.
@@ -2709,6 +2723,12 @@ class ChatSession:
         """Release resources (listener registrations, etc.)."""
         if self._judge_cancel_event is not None:
             self._judge_cancel_event.set()
+        # Abort every in-flight judge daemon — with parallel task agents
+        # several sub-agent generations can be live beyond the main slot.
+        with self._judge_events_lock:
+            live_judges = list(self._judge_cancel_events)
+        for ev in live_judges:
+            ev.set()
         if self._mcp_client and self._mcp_refresh_cb:
             # ``user_id`` MUST match the value used at registration —
             # the listener identity is ``(user_id, callback)``, not
@@ -7557,6 +7577,9 @@ class ChatSession:
     def _evaluate_intent(
         self,
         items: list[dict[str, Any]],
+        *,
+        conversation: list[Turn] | None = None,
+        agent_gate: bool = False,
     ) -> threading.Event | None:
         """Run intent validation on pending approval items.
 
@@ -7573,6 +7596,26 @@ class ChatSession:
         ``judge.cancel_on_approval`` is enabled — the default leaves
         the daemon running to completion so every call gets a real
         LLM verdict for the audit trail.
+
+        ``conversation`` is the trajectory the judge grounds intent
+        against — defaults to the session's main messages.  A task
+        agent's gate passes its own sub-trajectory: the task prompt in
+        it is the delegation contract the operator approved when they
+        let ``task_agent`` run, so "does this call serve the task" is
+        the right local alignment question (alignment-to-user was
+        anchored one level up, at the task_agent approval itself).
+
+        ``agent_gate`` marks a sub-agent generation: it must NOT touch
+        ``_judge_cancel_event`` — that slot carries the MAIN loop's
+        supersede semantics, and with parallel task agents each
+        spawning a judge, publish-into-the-slot would make every
+        agent's verdicts look stale to the previous agent's callback
+        (only the last spawn would survive).  Sub-agent staleness is
+        instead enforced per-cycle: the batch's items carry this
+        generation's event (``_judge_event``) and the UI identity-
+        checks it at delivery and at Smart-Approvals qualification.
+        Every generation, both kinds, lands in ``_judge_cancel_events``
+        so ``close()`` can abort all in-flight daemons.
         """
         judge = self._ensure_judge()
         if not judge:
@@ -7820,9 +7863,28 @@ class ChatSession:
         # turn has superseded it (this turn always runs before its own
         # approve_tools, so the assignment is in place before any verdict can
         # land).  ``_execute_tools`` re-asserts the same value and handles the
-        # judge-disabled (None) case.
+        # judge-disabled (None) case.  Sub-agent generations skip the slot —
+        # see the ``agent_gate`` docstring note — but every generation joins
+        # ``_judge_cancel_events`` for ``close()``; the set is kept exact by
+        # the daemon's ``done_callback`` (fires in its ``finally``).
         cancel_event = threading.Event()
-        self._judge_cancel_event = cancel_event
+        if not agent_gate:
+            self._judge_cancel_event = cancel_event
+        with self._judge_events_lock:
+            self._judge_cancel_events.add(cancel_event)
+        # Stamp the generation on each judged item: the UI's approval
+        # cycle captures it to bind cached verdicts to THIS spawn
+        # (Smart-Approvals origin check + stale-delivery rejection).
+        # Private key — ``_serialize_approval_items`` uses an explicit
+        # field allowlist, so it never reaches the wire.
+        for it in pending:
+            it["_judge_event"] = cancel_event
+
+        # SessionUIBase accepts the generation alongside the verdict;
+        # other UIs (CLI, eval) keep the bare one-arg call.
+        from turnstone.core.session_ui_base import SessionUIBase
+
+        ui_takes_event = isinstance(self.ui, SessionUIBase)
 
         def _on_verdict(verdict: object) -> None:
             """Callback from the daemon judge thread.
@@ -7831,13 +7893,20 @@ class ChatSession:
             replaced this judge generation.  With ``cancel_on_approval=False``
             (the default) the prior turn's daemon runs to completion and would
             otherwise write a stale verdict — keyed only by ``call_id`` — into
-            the freshly-reset ``_llm_verdicts`` cache; a model that reuses a
+            the freshly-purged ``_llm_verdicts`` cache; a model that reuses a
             ``call_id`` across turns could then ride that stale ``approve`` to
             a wrongful Smart Approval of a *different* call.  Identity-
             comparing the live generation closes that without affecting
             same-turn late delivery (``cancel_on_approval=False`` still
             streams this turn's verdicts, since the session event still
             points at this ``cancel_event``).
+
+            A sub-agent generation (``agent_gate``) has no session-level
+            slot to compare against — concurrent agents each own a live
+            generation.  Its staleness is enforced downstream by
+            ``SessionUIBase.on_intent_verdict``, which identity-checks
+            the delivering generation against the owning cycle's
+            ``judge_event`` before touching any live surface.
 
             Superseded verdicts still reach the audit table via the UI's
             ``on_superseded_intent_verdict`` (persist-only, duck-typed —
@@ -7846,7 +7915,7 @@ class ChatSession:
             the next turn began left ``intent_verdicts`` claiming the judge
             never answered.
             """
-            if self._judge_cancel_event is not cancel_event:
+            if not agent_gate and self._judge_cancel_event is not cancel_event:
                 persist_only = getattr(self.ui, "on_superseded_intent_verdict", None)
                 if persist_only is not None:
                     try:
@@ -7855,15 +7924,27 @@ class ChatSession:
                         log.debug("judge.superseded_verdict_persist_failed", exc_info=True)
                 return
             try:
-                self.ui.on_intent_verdict(verdict.to_dict())  # type: ignore[attr-defined]
+                if ui_takes_event:
+                    self.ui.on_intent_verdict(
+                        verdict.to_dict(),  # type: ignore[attr-defined]
+                        judge_event=cancel_event,
+                    )
+                else:
+                    self.ui.on_intent_verdict(verdict.to_dict())  # type: ignore[attr-defined]
             except Exception:
                 log.debug("judge.verdict_delivery_failed", exc_info=True)
 
+        def _on_done() -> None:
+            with self._judge_events_lock:
+                self._judge_cancel_events.discard(cancel_event)
+
+        convo = conversation if conversation is not None else self.messages
         heuristic_verdicts = judge.evaluate(
             pending,
-            dicts_from_turns(self.messages),  # snapshot — daemon thread must not see mutations
+            dicts_from_turns(convo),  # snapshot — daemon thread must not see mutations
             callback=_on_verdict,
             cancel_event=cancel_event,
+            done_callback=_on_done,
         )
 
         # Attach heuristic verdicts to items for the approval UI
@@ -8402,6 +8483,28 @@ class ChatSession:
     # Phase 2 — approve: display all previews, single prompt (serial)
     # Phase 3 — execute: run approved tools (parallel if multiple)
 
+    def _push_smart_approval_config(self) -> None:
+        """Push the live Smart Approvals config onto the UI before a gate.
+
+        Called just before EVERY ``approve_tools`` — the main loop's and
+        each sub-agent gate's — so a hot-reloaded ``judge.*`` change
+        takes effect on the next batch whichever path gates it.  Only
+        SessionUIBase carries the smart-approval gate (the CLI / eval
+        UIs have their own ``approve_tools``); the isinstance check both
+        skips those and narrows the type for the attribute writes.
+        ``approve_tools`` acts on these only when the judge is enabled
+        AND ``judge.smart_approvals`` is on, so the feature stays inert
+        (human-gated, as today) unless explicitly turned on.
+        """
+        from turnstone.core.session_ui_base import SessionUIBase
+
+        if isinstance(self.ui, SessionUIBase):
+            jc = self._judge_cfg
+            self.ui.smart_approvals_enabled = bool(jc and jc.enabled and jc.smart_approvals)
+            if jc is not None:
+                self.ui.smart_approval_threshold = jc.confidence_threshold
+                self.ui.smart_approval_wait_seconds = jc.timeout
+
     def _execute_tools(
         self, tool_calls: list[dict[str, Any]]
     ) -> tuple[list[tuple[str, str | list[dict[str, Any]]]], str | None]:
@@ -8481,22 +8584,7 @@ class ChatSession:
         judge_cancel = self._evaluate_intent(items)
         self._judge_cancel_event = judge_cancel  # track for close()
 
-        # Push the live Smart Approvals config onto the UI just before the
-        # gate so a hot-reloaded ``judge.*`` change takes effect on this
-        # batch.  Only SessionUIBase carries the smart-approval gate (the
-        # CLI / eval UIs have their own ``approve_tools``); the isinstance
-        # check both skips those and narrows the type for the attribute
-        # writes.  ``approve_tools`` acts on these only when the judge is
-        # enabled AND ``judge.smart_approvals`` is on, so the feature stays
-        # inert (human-gated, as today) unless explicitly turned on.
-        from turnstone.core.session_ui_base import SessionUIBase
-
-        if isinstance(self.ui, SessionUIBase):
-            jc = self._judge_cfg
-            self.ui.smart_approvals_enabled = bool(jc and jc.enabled and jc.smart_approvals)
-            if jc is not None:
-                self.ui.smart_approval_threshold = jc.confidence_threshold
-                self.ui.smart_approval_wait_seconds = jc.timeout
+        self._push_smart_approval_config()
 
         # Phase 2: approve via UI
         self._emit_state("attention")
@@ -14340,7 +14428,37 @@ class ChatSession:
                         is_tool_error = self._tool_error_flags.pop(tc_dict["id"], False)
                     # Tools not in auto_tools require user approval.
                     elif "execute" in prepared:
-                        approved, denial_feedback = self.ui.approve_tools([prepared])
+                        # Run the SAME intent-validation pipeline the main
+                        # loop runs (issue: sub-agent calls previously hit
+                        # the gate judge-blind — no heuristic verdict on
+                        # the card, no LLM verdict, no audit row, and
+                        # Smart Approvals could never clear them).  The
+                        # judge grounds intent in the sub-agent's OWN
+                        # trajectory: its task prompt is the delegation
+                        # contract the operator approved, so "does this
+                        # call serve the task" is the local alignment
+                        # question.  ``agent_gate=True`` keeps this
+                        # generation off the main-loop supersede slot —
+                        # parallel siblings each own theirs — and the
+                        # config push honours a hot judge.* reload per
+                        # gate, exactly like the main loop.
+                        agent_judge_cancel = self._evaluate_intent(
+                            [prepared],
+                            conversation=agent_turns,
+                            agent_gate=True,
+                        )
+                        self._push_smart_approval_config()
+                        try:
+                            approved, denial_feedback = self.ui.approve_tools([prepared])
+                        finally:
+                            # Mirror the main gate's post-decision policy:
+                            # fire the abort only when the operator opted
+                            # into ``judge.cancel_on_approval``; default
+                            # leaves the daemon to finish for the audit
+                            # trail (bounded to this one call).
+                            jc_live = self._judge_cfg
+                            if agent_judge_cancel and jc_live and jc_live.cancel_on_approval:
+                                agent_judge_cancel.set()
                         if not approved and not prepared.get("denied"):
                             # ``approve_tools`` already stamps a SPECIFIC
                             # denial_msg on a denied item (the matched policy

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -708,12 +708,15 @@ def make_approve_handler(
 ) -> Handler:
     """Lifted body for ``POST {prefix}/{ws_id}/approve``.
 
-    Resolves a pending tool approval on the workstream's UI. Both
-    kinds expose the same approve / feedback / always body shape and
-    the same ``ui.resolve_approval(approved, feedback)`` mechanic;
-    differences are auth scope, manager lookup, and the
-    ``__budget_override__`` filter (interactive-only — coord workstreams
-    don't have the budget-override pseudo-tool).
+    Resolves ONE pending approval cycle on the workstream's UI. Both
+    kinds expose the same approve / feedback / always / call_id /
+    cycle_id body shape and the same cycle-routed
+    ``ui.resolve_approval(...)`` mechanic; differences are auth scope,
+    manager lookup, and the ``__budget_override__`` filter
+    (interactive-only — coord workstreams don't have the
+    budget-override pseudo-tool).  With parallel task agents a
+    workstream can hold several cycles; a body without a selector
+    resolves the oldest.
 
     ``accepted_permissions`` is OR-checked via :func:`require_any_permission`
     only when ``cfg.permission_gate`` is ``None`` — i.e. for the
@@ -766,49 +769,140 @@ def make_approve_handler(
                 {"error": "session UI does not support approval"},
                 status_code=409,
             )
-        # ``_pending_approval`` and ``auto_approve_tools`` aren't on the
-        # ``SessionUI`` Protocol — both interactive ``WebUI`` and
-        # ``ConsoleCoordinatorUI`` add them, but a kind-agnostic body
-        # has to look them up dynamically. The CLI ``CliUI`` wouldn't
-        # have either, so accessing through ``getattr`` is also safer.
-        pending = getattr(ui, "_pending_approval", None)
         auto_approve_tools = getattr(ui, "auto_approve_tools", None)
-        # call_id guard — when the body sends a call_id, it must
-        # match one of the currently-pending items. Stops a stale
-        # row in the coordinator's children tree (where the operator
-        # clicked approve on call A) from silently resolving an
-        # unrelated call B that took A's place after the row was
-        # rendered. Empty/missing call_id preserves backward-compat
-        # for clients (CLI, channel adapters) that don't track it.
+        # Cycle routing — with parallel task agents a workstream can
+        # have SEVERAL approval cycles live at once, each its own
+        # prompt.  A decision addresses exactly one:
+        #   - ``cycle_id`` (new clients) selects it directly;
+        #   - ``call_id`` (coord tree rows, channel adapters) selects
+        #     the cycle containing that call — and doubles as the
+        #     legacy stale-guard: a click on a row whose round was
+        #     already replaced 409s instead of silently resolving an
+        #     unrelated batch;
+        #   - neither (CLI wrappers, old tabs) → the OLDEST live cycle,
+        #     matching the order the prompts were issued.
         body_call_id_raw = body.get("call_id", "")
         body_call_id = body_call_id_raw.strip() if isinstance(body_call_id_raw, str) else ""
-        if body_call_id:
-            if pending is None:
-                return JSONResponse(
-                    {"error": "no pending approval", "current_call_id": None},
-                    status_code=409,
-                )
-            pending_items = pending.get("items") or []
-            pending_call_ids = {
-                item.get("call_id", "") for item in pending_items if item.get("call_id")
-            }
-            if body_call_id not in pending_call_ids:
-                # Primary = first non-empty call_id in list order, matching
-                # ``serialize_pending_approval_detail``. The two definitions
-                # must agree so the UI can re-render against the same
-                # identifier the server reports as current.
+        body_cycle_id_raw = body.get("cycle_id", "")
+        body_cycle_id = body_cycle_id_raw.strip() if isinstance(body_cycle_id_raw, str) else ""
+        find_cycle = getattr(ui, "find_approval_cycle", None)
+        target_card: dict[str, Any] | None = None
+        pinned_cycle_id: str | None = None
+        if find_cycle is not None:
+            target_card = find_cycle(cycle_id=body_cycle_id or None, call_id=body_call_id or None)
+            if target_card is None and (body_cycle_id or body_call_id):
+                # Selector given but nothing matched: the round was
+                # resolved/replaced after this client rendered it.
+                # Report the CURRENT oldest cycle (first entry of
+                # ``serialize_pending_approval_details``) so the client
+                # can re-render against what the server thinks is live.
+                current = find_cycle()
+                current_items = (current or {}).get("items") or []
                 primary = next(
-                    (item.get("call_id", "") for item in pending_items if item.get("call_id")),
+                    (item.get("call_id", "") for item in current_items if item.get("call_id")),
                     None,
                 )
                 return JSONResponse(
-                    {"error": "stale call_id", "current_call_id": primary},
+                    {
+                        "error": ("stale call_id" if body_call_id else "stale cycle_id"),
+                        "current_call_id": primary,
+                        "current_cycle_id": (current or {}).get("cycle_id"),
+                    },
                     status_code=409,
                 )
-        if always and approved and pending and auto_approve_tools is not None:
+            # Pin the resolution to the exact cycle the lookup returned.
+            # For selector-less bodies the lookup and the resolve would
+            # otherwise EACH independently pick "the oldest" — a cycle
+            # resolving in the gap (gate timeout, peer tab, smart
+            # approval) silently retargets the resolve at the next
+            # cycle while the always-names below were collected from
+            # the previous one, whitelisting a batch the operator never
+            # looked at.
+            pinned_cycle_id = (target_card or {}).get("cycle_id") or None
+        else:
+            # Legacy/stub UI (tests, external SessionUI impls): fall back
+            # to the single-slot view for the always-names read below.
+            target_card = getattr(ui, "_pending_approval", None)
+            if body_call_id:
+                if target_card is None:
+                    return JSONResponse(
+                        {"error": "no pending approval", "current_call_id": None},
+                        status_code=409,
+                    )
+                legacy_ids = {
+                    item.get("call_id", "")
+                    for item in target_card.get("items") or []
+                    if item.get("call_id")
+                }
+                if body_call_id not in legacy_ids:
+                    primary = next(iter(sorted(legacy_ids)), None)
+                    return JSONResponse(
+                        {"error": "stale call_id", "current_call_id": primary},
+                        status_code=409,
+                    )
+        # Resolve FIRST, then whitelist: the "Approve + Always" names
+        # must describe the cycle that actually resolved.  On the cycle
+        # path the resolve is pinned to the lookup's cycle_id, so the
+        # only race left is that cycle resolving in the gap — then
+        # ``resolved_cycle`` comes back ``None`` and the whitelist below
+        # is skipped (approving a card someone else already resolved
+        # must not grow the auto-approve set).  ``always`` still rides
+        # the ``approval_resolved`` SSE event so peer tabs that didn't
+        # click can render the right status pill ("✓ approved · always"
+        # vs plain "✓ approved") without a side-channel broadcast.
+        try:
+            if find_cycle is not None:
+                if pinned_cycle_id is not None:
+                    resolved_cycle = ui.resolve_approval(
+                        approved,
+                        feedback,
+                        always=always,
+                        cycle_id=pinned_cycle_id,
+                    )
+                elif body_call_id or body_cycle_id:
+                    # Lookup matched a card that carries no cycle_id
+                    # (custom registrations outside ``approve_tools``):
+                    # honor the client's own selector.
+                    resolved_cycle = ui.resolve_approval(
+                        approved,
+                        feedback,
+                        always=always,
+                        call_id=body_call_id or None,
+                        cycle_id=body_cycle_id or None,
+                    )
+                else:
+                    # No selector AND nothing pending at lookup time:
+                    # resolve nothing rather than racing a cycle that
+                    # registered in the gap — the client can't have
+                    # been looking at it.
+                    resolved_cycle = None
+            else:
+                resolved_cycle = ui.resolve_approval(
+                    approved,
+                    feedback,
+                    always=always,
+                    call_id=body_call_id or None,
+                    cycle_id=body_cycle_id or None,
+                )
+        except TypeError:
+            # Pre-cycle SessionUI impls (external/custom) without the
+            # selector kwargs.
+            resolved_cycle = ui.resolve_approval(approved, feedback, always=always)
+        if (
+            always
+            and approved
+            and target_card
+            and auto_approve_tools is not None
+            # Cycle-registry UIs: whitelist only when OUR resolve landed
+            # on the pinned cycle (non-None return).  Stub/legacy UIs
+            # (no registry) keep the unconditional legacy behavior —
+            # their resolve's return value carries no cycle contract to
+            # gate on.
+            and (find_cycle is None or resolved_cycle is not None)
+        ):
             tool_names: set[str] = {
                 it.get("approval_label", "") or it.get("func_name", "")
-                for it in pending.get("items", [])
+                for it in target_card.get("items", [])
                 if it.get("needs_approval") and it.get("func_name") and not it.get("error")
             }
             tool_names.discard("")
@@ -828,13 +922,7 @@ def make_approve_handler(
                 if source_map is not None:
                     for t in tool_names:
                         source_map[t] = AutoApproveReason.ALWAYS
-        # Forward ``always`` so the resulting ``approval_resolved`` SSE
-        # event carries the intent — peer tabs that didn't click but
-        # are subscribed to the same workstream can render the right
-        # status pill ("✓ approved · always" vs plain "✓ approved")
-        # without needing a side-channel broadcast.
-        ui.resolve_approval(approved, feedback, always=always)
-        return JSONResponse({"status": "ok"})
+        return JSONResponse({"status": "ok", "cycle_id": resolved_cycle})
 
     return approve
 
@@ -1154,13 +1242,13 @@ def make_cancel_handler(
       ``coord_mgr.cancel`` which silently no-op'd on a placeholder;
       the lifted body 400s for parity with interactive's existing
       "No session" branch.
-    - ``resolve_approval`` is **gated on ``ui._pending_approval is not None``**
-      because :meth:`SessionUIBase.resolve_approval` is *not*
-      idempotent — it always broadcasts ``approval_resolved`` and
-      overwrites ``_approval_result``. Without the gate, every idle
-      cancel would leak a stale resolution event to SSE listeners.
-      The gate preserves the recovery semantics for the genuine
-      stuck case while skipping the broadcast on idle cancels.
+    - Pending approvals are denied via ``resolve_all_approvals`` —
+      cancel addresses the workstream, so EVERY live cycle (parallel
+      task agents can park several gates at once) wakes with its own
+      denied result.  The sweep is a no-op when nothing is pending
+      (no stale ``approval_resolved`` broadcast on idle cancels);
+      legacy/stub UIs without it fall back to the old single-slot
+      ``resolve_approval`` gated on ``_pending_approval``.
     """
 
     async def cancel(request: Request) -> Response:
@@ -1218,29 +1306,34 @@ def make_cancel_handler(
                 dropped = {}
 
         # Always set the cooperative cancel flag — cheap, no harm if
-        # nothing's running. resolve_approval is gated on its
-        # ``_pending_approval`` slot: pre-lift coord called it
-        # unconditionally via ``mgr.cancel`` (which is
-        # recovery-friendly: a stuck approval-pending state from a
-        # crashed worker can still be cleared), but ``resolve_approval``
-        # is NOT idempotent — calling it with no pending approval
-        # broadcasts a stale ``approval_resolved`` SSE event and
-        # overwrites ``_approval_result``. Gating on the pending slot
-        # preserves the recovery semantics for the actual stuck case
-        # while skipping the broadcast on idle cancels.
+        # nothing's running.  Cancel addresses the WORKSTREAM, so it
+        # denies EVERY live approval cycle: with parallel task agents
+        # several gate threads can be parked at once and each must wake
+        # with its own (denied) result.  ``resolve_all_approvals`` is a
+        # no-op with no live cycles (returns 0, no SSE broadcast), so
+        # idle cancels stay silent — the same property the old
+        # pending-slot gate provided; the recovery semantics for a
+        # stuck approval-pending state are preserved because a stuck
+        # cycle IS a live cycle.  Legacy/stub UIs without the sweep
+        # keep the old single-slot fallback.
         try:
             session.cancel()
         except Exception:
             log.debug("ws.cancel.session_failed ws=%s", ws_id[:8], exc_info=True)
-        if hasattr(ui, "resolve_approval") and getattr(ui, "_pending_approval", None) is not None:
-            try:
+        try:
+            if hasattr(ui, "resolve_all_approvals"):
+                ui.resolve_all_approvals(False, "Cancelled by user")
+            elif (
+                hasattr(ui, "resolve_approval")
+                and getattr(ui, "_pending_approval", None) is not None
+            ):
                 ui.resolve_approval(False, "Cancelled by user")
-            except Exception:
-                log.debug(
-                    "ws.cancel.resolve_approval_failed ws=%s",
-                    ws_id[:8],
-                    exc_info=True,
-                )
+        except Exception:
+            log.debug(
+                "ws.cancel.resolve_approval_failed ws=%s",
+                ws_id[:8],
+                exc_info=True,
+            )
 
         # The remaining steps only matter when a worker is actually
         # running: force-recovery has nothing to recover otherwise,
@@ -3630,9 +3723,10 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
         if not ws_id:
             return JSONResponse({"error": "ws_id is required"}, status_code=400)
 
-        # Cross-tenant gate.  PR 447 added ``pending_approval_detail``
-        # to the response (tool previews, function arguments, LLM
-        # judge reasoning) — a richer payload than the pre-PR
+        # Cross-tenant gate.  PR 447 added the inline approval payload
+        # (now ``pending_approval_details``) to the response (tool
+        # previews, function arguments, LLM judge reasoning) — a
+        # richer payload than the pre-PR
         # ``{ws_id, name, state, user_id, kind}`` tuple.  Coord wires
         # ``tenant_check=None`` (the cluster-wide ``admin.coordinator``
         # permission_gate covers it); interactive wires
@@ -3690,26 +3784,28 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
         # paint the inline approval gate from this single response
         # instead of waiting for the SSE approve_request replay (which
         # introduces a brief --running flash on reload).  Both keys
-        # (``pending_approval`` + ``pending_approval_detail``) are
+        # (``pending_approval`` + ``pending_approval_details``) are
         # always present in the response: a UI that doesn't expose
-        # ``serialize_pending_approval_detail`` (CLI / channel
-        # adapters) reports ``False`` / ``null`` for them.  The
+        # ``serialize_pending_approval_details`` (CLI / channel
+        # adapters) reports ``False`` / ``[]`` for them.  The
         # ``_pending_approval`` lookup is asserted as ``dict`` (its
-        # only real production shape — see
-        # ``SessionUIBase._pending_approval``) so a MagicMock-based
-        # unit test or other non-dict sentinel doesn't trip the path.
+        # only real production shape — the oldest-cycle view kept by
+        # ``SessionUIBase``) so a MagicMock-based unit test or other
+        # non-dict sentinel doesn't trip the path.
         pending_approval = False
-        pending_approval_detail: dict[str, Any] | None = None
+        pending_approval_details: list[dict[str, Any]] = []
         ui = ws.ui
         pending_raw = getattr(ui, "_pending_approval", None) if ui is not None else None
         if isinstance(pending_raw, dict):
             pending_approval = True
-            serializer = getattr(ui, "serialize_pending_approval_detail", None)
+            # Full per-cycle list — parallel task agents can have
+            # several prompts live; the reload path paints them all.
+            serializer = getattr(ui, "serialize_pending_approval_details", None)
             if callable(serializer):
                 try:
-                    serialized = serializer()
-                    if isinstance(serialized, dict) or serialized is None:
-                        pending_approval_detail = serialized
+                    maybe_list = serializer()
+                    if isinstance(maybe_list, list):
+                        pending_approval_details = maybe_list
                 except Exception:
                     # Defensive: a malformed verdict object inside the
                     # serializer shouldn't fail the entire detail
@@ -3730,7 +3826,7 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
                 "user_id": ws.user_id,
                 "kind": ws.kind,
                 "pending_approval": pending_approval,
-                "pending_approval_detail": pending_approval_detail,
+                "pending_approval_details": pending_approval_details,
             }
         )
 

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -2223,7 +2223,7 @@ class SessionUIBase:
         see which path silently approved each call.
 
         Heuristic verdict surfaces under ``heuristic_verdict`` for
-        consistency with :meth:`serialize_pending_approval_detail`
+        consistency with :meth:`serialize_pending_approval_details`
         and :class:`api.server_schemas.PendingApprovalItem` — pre-
         fix this method emitted ``verdict`` while the dashboard
         payload used ``heuristic_verdict``, leaving JS consumers

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -51,6 +51,80 @@ _DEFAULT_LISTENER_QUEUE_MAX = 500
 # recalls honestly as "not retained" rather than a fabricated 0-step card.
 _AGENT_TRAJECTORY_CAP = 256
 
+# How many resolved-cycle decisions to remember (call_id → decision) so a
+# late LLM verdict — the run-to-completion judge can deliver seconds after
+# its gate resolved — still lands with the decision the operator actually
+# took.  Bounded because call_ids of resolved cycles accrue forever on a
+# long-running workstream.  Invariant for the cap: it must exceed the
+# number of call_ids the session can resolve inside one judge-deadline
+# window (the daemon's delivery bound), or an eviction could orphan a
+# still-in-flight verdict as forever-"pending" in the audit table.  A
+# smart-approvals storm across parallel task agents resolves tens of
+# calls per second at the extreme; 1024 covers minutes of that, and the
+# entries are (str, (str, Event)) — negligible memory.
+_RECENT_DECISION_CAP = 1024
+
+
+class ApprovalCycle:
+    """One in-flight human-approval round on a workstream.
+
+    The approval gate used to be a per-UI singleton — one pending card,
+    one ``threading.Event``, one result slot.  Parallel task agents
+    broke that: each sub-agent thread runs its own gate, so several
+    rounds are now live at once and each needs its own wait/result/
+    verdict bookkeeping.  ``approve_tools`` registers one of these per
+    human-gated batch in ``_approval_cycles`` (insertion-ordered =
+    oldest-first); HTTP resolvers route a decision to exactly one cycle
+    by ``cycle_id`` / member ``call_id`` (or the oldest, for legacy
+    selector-less clients).
+
+    Lifecycle: created + registered by the gate thread, resolved
+    exactly once by :meth:`SessionUIBase.resolve_approval` (double
+    resolution is a guarded no-op), unregistered by the gate thread
+    after its wait returns.  ``event``/``result`` are per-cycle so one
+    decision can never leak onto a concurrent sibling round — the
+    cross-approval hazard the singleton design had.
+    """
+
+    __slots__ = (
+        "call_ids",
+        "card",
+        "cycle_id",
+        "decision",
+        "event",
+        "items",
+        "judge_event",
+        "pending_verdicts",
+        "resolved",
+        "result",
+    )
+
+    def __init__(
+        self,
+        items: list[dict[str, Any]],
+        card: dict[str, Any],
+        judge_event: threading.Event | None,
+    ) -> None:
+        self.cycle_id: str = card.get("cycle_id", "") or uuid.uuid4().hex
+        self.items = items
+        self.card = card
+        self.call_ids: set[str] = {it.get("call_id", "") for it in items if it.get("call_id")}
+        # The judge generation that evaluated this batch — identity-
+        # compared against the delivering daemon's cancel event so a
+        # stale generation (a prior turn's run-to-completion daemon
+        # whose provider reused call_ids) can never satisfy THIS
+        # cycle's Smart-Approvals wait or park verdicts on it.
+        self.judge_event: threading.Event | None = judge_event
+        self.event = threading.Event()
+        self.result: tuple[bool, str | None] = (False, None)
+        self.resolved = False
+        self.decision = ""
+        # LLM verdicts that fired during this round, awaiting the
+        # operator's decision stamp (was the UI-global
+        # ``_pending_verdicts`` list).
+        self.pending_verdicts: list[dict[str, Any]] = []
+
+
 # Sub-agent scope, PER-THREAD.  A task agent's progress chatter reaches the UI as
 # ``on_info`` lines ("[task done] N chars", a tool's "fetched N chars") that
 # carry no call_id — they can't nest under the task card and would escape to the
@@ -304,13 +378,20 @@ class SessionUIBase:
         )
         # (Sub-agent ``on_info`` suppression is per-thread via the module-level
         # ``_agent_scope_var`` contextvar — no instance field.)
-        # Approval blocking — the worker thread calls approve_tools
-        # which waits on _approval_event; the /approve endpoint sets
-        # it via resolve_approval.
-        self._approval_event = threading.Event()
-        self._approval_result: tuple[bool, str | None] = (False, None)
-        # Pending approval shape — re-sent on SSE reconnect so a user
-        # switching tabs still sees the prompt.
+        # Approval blocking — each gate thread (main loop, or a parallel
+        # task-agent thread) registers an :class:`ApprovalCycle` here and
+        # waits on the CYCLE's own event; the /approve endpoint routes a
+        # decision to exactly one cycle via resolve_approval.  Insertion-
+        # ordered (dict) = oldest-first, which is the resolution order for
+        # legacy selector-less approvals.  Guarded by ``_ws_lock``.
+        self._approval_cycles: dict[str, ApprovalCycle] = {}
+        # Legacy single-slot view of the OLDEST live cycle's card — many
+        # read-only consumers (cancel gating, dashboard booleans, history
+        # ``awaiting_approval``) only need "is something pending"; they
+        # keep working unchanged against this view.  Maintained under
+        # ``_ws_lock`` by ``_refresh_pending_approval_view`` on every
+        # register/unregister.  Multi-cycle-aware surfaces (SSE replay,
+        # dashboard detail, approve routing) use ``_approval_cycles``.
         self._pending_approval: dict[str, Any] | None = None
         self.auto_approve = False
         self.auto_approve_tools: set[str] = set()
@@ -433,14 +514,26 @@ class SessionUIBase:
         # ``None`` until the first broadcast so the first emit always
         # fires.
         self._last_broadcast_activity: tuple[str, str] | None = None
-        # Verdicts from the LLM intent judge — tracked so
-        # ``resolve_approval`` can stamp a ``user_decision`` onto every
-        # verdict that fired during this approval round.
-        self._pending_verdicts: list[dict[str, Any]] = []
-        self._last_verdict_decision: str = ""
+        # Decisions of recently-resolved cycles (call_id → decision
+        # string) so a late LLM verdict — the run-to-completion daemon
+        # can deliver after its gate resolved — is stamped with what the
+        # operator actually chose.  Replaces the single
+        # ``_last_verdict_decision`` string, which under concurrent
+        # cycles stamped sibling B's late verdicts with sibling A's
+        # decision.  FIFO-bounded; guarded by ``_ws_lock``.
+        self._recent_decisions: collections.OrderedDict[str, tuple[str, threading.Event | None]] = (
+            collections.OrderedDict()
+        )
         # Verdict cache for SSE reconnect replay (tab switching
         # shouldn't lose the judge's final call on a just-run tool).
         self._llm_verdicts: dict[str, dict[str, Any]] = {}
+        # Judge-generation origin per cached verdict: ``call_id`` →
+        # ``id(cancel_event)`` of the daemon that delivered it.  The
+        # Smart-Approvals qualification loop compares this against the
+        # batch's own generation so a stale daemon's verdict (reused
+        # call_id across turns) can satisfy neither the wait nor the
+        # auto-approve bar.  Evicted in lockstep with ``_llm_verdicts``.
+        self._verdict_origins: dict[str, int] = {}
         # Signalled by ``on_intent_verdict`` whenever an LLM verdict
         # lands in ``_llm_verdicts``; Smart Approvals (``approve_tools``)
         # waits on it for the verdicts of the calls it's about to gate.
@@ -834,18 +927,114 @@ class SessionUIBase:
     # Approval blocking gates
     # ------------------------------------------------------------------
 
-    def _reset_approval_cycle(self) -> None:
-        """Clear per-round verdict state at the start of a new approval.
+    def _purge_round_verdicts(
+        self,
+        call_ids: set[str],
+        keep_origin: threading.Event | None = None,
+    ) -> None:
+        """Evict stale verdict state for the call_ids entering a new gate.
 
-        Subclasses call this at the top of ``approve_tools`` so late
-        verdicts from the previous round can't leak their
-        ``user_decision`` onto the next round's verdicts, and the SSE
-        reconnect replay cache doesn't serve stale tool verdicts to a
-        client that just switched tabs mid-approval.
+        Successor of the old whole-cache ``_reset_approval_cycle``: with
+        concurrent cycles a full clear wiped a live sibling's verdicts
+        mid-wait, so eviction is now scoped to the entering batch.  It
+        protects the same two things the reset did — a provider that
+        reuses call_ids across turns can't have a PRIOR round's cached
+        verdict pre-satisfy this round's Smart-Approvals wait, and the
+        reconnect-replay cache can't serve that stale verdict onto the
+        new round's card — without touching any other cycle's state.
+
+        ``keep_origin`` is the entering batch's own judge generation
+        (its cancel event): a cached verdict THAT generation delivered
+        survives the purge.  The judge daemon is spawned before the
+        gate is entered, so a fast judge can deliver ahead of this
+        purge (the policy DB round-trip sits in between) — evicting its
+        verdict would stall the Smart-Approvals wait to its full budget
+        and send an already-cleared batch to a human.  Prior-round
+        decisions for a reused call_id are evicted unconditionally:
+        this round has not been decided yet, whatever generation ruled
+        before.
         """
         with self._ws_lock:
-            self._last_verdict_decision = ""
-            self._llm_verdicts.clear()
+            for cid in call_ids:
+                if keep_origin is None or self._verdict_origins.get(cid) != id(keep_origin):
+                    self._llm_verdicts.pop(cid, None)
+                    self._verdict_origins.pop(cid, None)
+                self._recent_decisions.pop(cid, None)
+
+    # ------------------------------------------------------------------
+    # Approval-cycle registry
+    # ------------------------------------------------------------------
+
+    def _refresh_pending_approval_view(self) -> None:
+        """Point the legacy ``_pending_approval`` slot at the oldest cycle.
+
+        Caller must hold ``_ws_lock``.  Boolean-ish consumers (cancel
+        gating, dashboard ``pending_approval`` flags, history
+        ``awaiting_approval``) read the slot directly; they see "some
+        cycle is live", which is exactly the question they ask.
+        """
+        first = next(iter(self._approval_cycles.values()), None)
+        self._pending_approval = first.card if first is not None else None
+
+    def _register_approval_cycle(self, cycle: ApprovalCycle) -> None:
+        with self._ws_lock:
+            self._approval_cycles[cycle.cycle_id] = cycle
+            self._refresh_pending_approval_view()
+
+    def _unregister_approval_cycle(self, cycle: ApprovalCycle) -> None:
+        with self._ws_lock:
+            self._approval_cycles.pop(cycle.cycle_id, None)
+            self._refresh_pending_approval_view()
+
+    def _select_cycle_locked(
+        self,
+        *,
+        cycle_id: str | None = None,
+        call_id: str | None = None,
+    ) -> ApprovalCycle | None:
+        """Pick the cycle a decision addresses.  Caller holds ``_ws_lock``.
+
+        Precedence: explicit ``cycle_id`` → member ``call_id`` → the
+        oldest unresolved cycle (legacy clients that never learned to
+        send a selector: CLI wrappers, channel adapters, old tabs).
+        Only unresolved cycles are eligible — a second click racing the
+        gate thread's unregister must not re-resolve.
+        """
+        if cycle_id:
+            cycle = self._approval_cycles.get(cycle_id)
+            return cycle if cycle is not None and not cycle.resolved else None
+        if call_id:
+            for cycle in self._approval_cycles.values():
+                if call_id in cycle.call_ids and not cycle.resolved:
+                    return cycle
+            return None
+        return next((c for c in self._approval_cycles.values() if not c.resolved), None)
+
+    def find_approval_cycle(
+        self,
+        *,
+        cycle_id: str | None = None,
+        call_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Public card lookup for HTTP handlers (pre-resolve inspection).
+
+        Returns the matched cycle's ``approve_request`` card (the dict
+        also used for SSE replay), or ``None``.  Same selector
+        precedence as resolution, so "which cycle will this decision
+        hit" and "which cycle did it hit" can never disagree.
+        """
+        with self._ws_lock:
+            cycle = self._select_cycle_locked(cycle_id=cycle_id, call_id=call_id)
+            return cycle.card if cycle is not None else None
+
+    def pending_approval_cards(self) -> list[dict[str, Any]]:
+        """All live cycles' ``approve_request`` cards, oldest first.
+
+        SSE fresh-connect/reconnect replay yields each so a returning
+        tab repaints EVERY outstanding prompt, not just the newest.
+        """
+        with self._ws_lock:
+            return [c.card for c in self._approval_cycles.values()]
 
     def resolve_approval(
         self,
@@ -854,61 +1043,128 @@ class SessionUIBase:
         *,
         always: bool = False,
         timeout: bool = False,
-    ) -> None:
-        """Unblock a pending approval with the caller's decision.
+        call_id: str | None = None,
+        cycle_id: str | None = None,
+    ) -> str | None:
+        """Unblock ONE pending approval cycle with the caller's decision.
 
-        Broadcasts ``approval_resolved`` so every connected tab can
-        dismiss its prompt modal in sync (e.g. desktop dismisses when
-        phone approves). Updates ``user_decision`` on every LLM
-        intent-verdict that fired during this approval round — the
-        audit trail reflects what the user actually chose.
+        Routes to a single :class:`ApprovalCycle` — by ``cycle_id``, by
+        member ``call_id``, or (selector-less legacy callers: CLI
+        wrappers, channel adapters, cancel/timeout paths) the oldest
+        unresolved cycle.  Returns the resolved ``cycle_id`` or ``None``
+        when nothing matched — a second click racing the gate thread, or
+        a stale selector.  One decision can no longer fan out to every
+        parked gate: each cycle owns its event/result, which is the
+        whole fix for the cross-approval hazard the singleton slot had.
+
+        Broadcasts ``approval_resolved`` (now carrying ``cycle_id`` +
+        ``call_ids``) so every connected tab dismisses the RIGHT prompt
+        in sync. Updates ``user_decision`` on every LLM intent-verdict
+        that fired during this cycle's round — the audit trail reflects
+        what the user actually chose for THESE calls.
 
         ``always`` reports whether the resolving caller asked for
         "Approve + Always" (the tool name has been added to
         ``auto_approve_tools`` upstream by the HTTP handler — this
         method only echoes the intent on the SSE event so peer tabs
-        can label their resolved-status pill correctly).  Keyword-only
-        + default ``False`` so the four pre-existing callers (cancel,
-        timeout, channel adapters) compile unchanged.
+        can label their resolved-status pill correctly).
 
         ``timeout`` flips the persisted ``user_decision`` from
         ``"denied"`` to ``"timeout"`` so the audit trail can
         distinguish an active user denial from a passive
-        approval-timeout expiry — the feedback string carries the
-        same information today but operators querying on the
-        ``user_decision`` column alone could not tell them apart.
-        Mutually exclusive with ``approved=True`` (a timeout is a
-        passive denial); the combination raises ``ValueError`` so a
-        future caller can't accidentally ship a row whose audit
-        column says ``"timeout"`` while the SSE event reports
-        ``approved=True``.
+        approval-timeout expiry.  Mutually exclusive with
+        ``approved=True`` (a timeout is a passive denial); the
+        combination raises ``ValueError``.
         """
         if timeout and approved:
             raise ValueError("resolve_approval: timeout=True is incompatible with approved=True")
         decision_str = "timeout" if timeout else ("approved" if approved else "denied")
-        # Swap-and-clear + set decision under lock to avoid racing
-        # with the daemon judge thread's ``on_intent_verdict`` appends.
+        # Select + mark resolved + swap verdicts out under ONE lock
+        # acquisition so a concurrent resolver can't double-resolve and
+        # the judge daemon's ``on_intent_verdict`` can't append to a
+        # list we're about to stamp.
         with self._ws_lock:
-            pending = self._pending_verdicts
-            self._pending_verdicts = []
-            self._last_verdict_decision = decision_str
+            cycle = self._select_cycle_locked(cycle_id=cycle_id, call_id=call_id)
+            if cycle is None:
+                return None
+            cycle.resolved = True
+            cycle.decision = decision_str
+            cycle.result = (approved, feedback)
+            pending = cycle.pending_verdicts
+            cycle.pending_verdicts = []
+            # Remember the decision per call_id — tagged with the
+            # cycle's judge generation — so this round's late verdicts
+            # (run-to-completion daemon) stamp correctly even after the
+            # cycle is unregistered, while a STALE generation's late
+            # verdict under a reused call_id can be told apart and
+            # stamped ``superseded`` instead of stealing this decision.
+            for cid in cycle.call_ids:
+                self._recent_decisions[cid] = (decision_str, cycle.judge_event)
+                self._recent_decisions.move_to_end(cid)
+            while len(self._recent_decisions) > _RECENT_DECISION_CAP:
+                self._recent_decisions.popitem(last=False)
         if pending:
             self._persist_verdict_decisions(pending, decision_str)
-        self._approval_result = (approved, feedback)
+        sorted_call_ids = sorted(cycle.call_ids)
         self._enqueue(
             {
                 "type": "approval_resolved",
                 "approved": approved,
                 "feedback": feedback or "",
                 "always": bool(always),
+                "cycle_id": cycle.cycle_id,
+                "call_ids": sorted_call_ids,
             }
         )
         # Kind-specific cross-stream broadcast — ConsoleCoordinatorUI
         # overrides to push onto the cluster bus so a coord parent's
         # tree UI clears the pending-approval pill in lockstep with
         # the actual decision. Stage 3 Step 4.
-        self._broadcast_approval_resolved(approved, feedback, always=always)
-        self._approval_event.set()
+        self._broadcast_approval_resolved(
+            approved,
+            feedback,
+            always=always,
+            cycle_id=cycle.cycle_id,
+            call_ids=tuple(sorted_call_ids),
+        )
+        cycle.event.set()
+        return cycle.cycle_id
+
+    def resolve_all_approvals(
+        self,
+        approved: bool,
+        feedback: str | None = None,
+        *,
+        timeout: bool = False,
+    ) -> int:
+        """Resolve EVERY live cycle with one decision; returns the count.
+
+        For the sweep paths where the operator's intent addresses the
+        workstream, not a specific batch: cancel ("stop everything"),
+        session close, worker-recovery.  Loops :meth:`resolve_approval`
+        oldest-first so per-cycle bookkeeping (verdict stamps, SSE
+        dismissals, per-cycle events) runs identically to a targeted
+        resolution.
+
+        Deliberately optimistic about concurrency: the scan re-runs
+        after every attempt, so a cycle that a gate timeout (or another
+        resolver) claims between our scan and our
+        :meth:`resolve_approval` call is simply not counted — it was
+        resolved either way — and the rescan picks up cycles that
+        REGISTER mid-sweep, which a snapshot-then-resolve loop would
+        miss.  Termination: every iteration either resolves its target
+        or observes it already resolved; resolved cycles never re-enter
+        the scan.
+        """
+        count = 0
+        while True:
+            with self._ws_lock:
+                target = next((c for c in self._approval_cycles.values() if not c.resolved), None)
+                target_id = target.cycle_id if target is not None else None
+            if target_id is None:
+                return count
+            if self.resolve_approval(approved, feedback, timeout=timeout, cycle_id=target_id):
+                count += 1
 
     @staticmethod
     def _persist_verdict_decisions(
@@ -949,16 +1205,33 @@ class SessionUIBase:
         6. Heuristic verdict persistence (one row per ``_heuristic_verdict``
            item) + ``_record_judge_metric`` hook (subclass-overridden to
            feed the node's or console's Prometheus collector).
-        7. Emit the ``approve_request`` and block on ``_approval_event``
-           up to ``_APPROVAL_WAIT_TIMEOUT``.
+        7. Register an :class:`ApprovalCycle`, emit its ``approve_request``
+           card, and block on the CYCLE's event up to
+           ``_APPROVAL_WAIT_TIMEOUT``.
 
         ``__budget_override__`` is interactive-only today (coord
         workstreams don't have token budgets), but the carve-out check
         is cheap (``any(...)`` over pending) and is a no-op on coord;
         kept unconditional so a future coord-skill path picks it up
         for free.
+
+        Reentrant by design: several gate threads (main loop + parallel
+        task agents) run this body concurrently, each against its own
+        :class:`ApprovalCycle`.  Shared state is touched only under
+        ``_ws_lock`` and scoped to this batch's call_ids.
         """
-        self._reset_approval_cycle()
+        # The batch's judge generation, stamped by ``_evaluate_intent`` —
+        # one event per spawn, shared by every item in the batch.  Read
+        # before the purge so the purge can spare verdicts this very
+        # generation already delivered.
+        judge_event = next(
+            (it.get("_judge_event") for it in items if it.get("_judge_event") is not None),
+            None,
+        )
+        self._purge_round_verdicts(
+            {it.get("call_id", "") for it in items if it.get("call_id")},
+            keep_origin=judge_event,
+        )
 
         # Early-paint the pending tool batch — BEFORE the tool-policy lookup,
         # the Smart Approvals verdict wait (``judge.smart_approvals`` parks here
@@ -1163,8 +1436,9 @@ class SessionUIBase:
         # (mixed-path case: policy allowed some, others still prompt)
         # carry their auto_approve_reason directly; items still pending
         # operator decision carry ``"pending"`` and get updated by
-        # ``resolve_approval`` on close.  ``_pending_verdicts`` only
-        # tracks the latter — auto-approved verdicts are already final.
+        # ``resolve_approval`` on close.  The cycle's ``pending_verdicts``
+        # only tracks the latter — auto-approved verdicts are already
+        # final.
         heuristic_verdicts: list[dict[str, Any]] = []
         pending_verdicts: list[dict[str, Any]] = []
         for item in items:
@@ -1183,21 +1457,6 @@ class SessionUIBase:
             self._record_judge_metric(hv)
         self._persist_intent_verdicts_bulk(heuristic_verdicts, default_tier="heuristic")
 
-        with self._ws_lock:
-            # Normally a plain assignment: in the async flow the LLM judge
-            # is slower than this setup so ``_pending_verdicts`` is still
-            # the empty list ``_reset_approval_cycle`` left it.  But Smart
-            # Approvals deliberately waits for verdicts upstream, so by here
-            # ``on_intent_verdict`` has already parked the LLM verdicts of
-            # the human-pending siblings; carry them across the reassignment
-            # so ``resolve_approval`` can stamp their ``user_decision``
-            # (without this they'd be dropped and stuck at ``"pending"``).
-            # Smart-approved calls were pulled out + stamped already by
-            # ``_finalize_smart_verdicts``, so they don't reappear here.
-            pending_cids = {hv.get("call_id") for hv in pending_verdicts}
-            early_llm = [v for v in self._pending_verdicts if v.get("call_id") in pending_cids]
-            self._pending_verdicts = pending_verdicts + early_llm
-
         # Record any items the policy block already auto-approved
         # before falling through to the prompt — without this the
         # mixed-policy-then-prompt path leaves the policy bypass
@@ -1212,18 +1471,62 @@ class SessionUIBase:
         # Approvals the gate already waited for every verdict, so they are
         # present and this is false (no spurious "judge working" spinner /
         # poll); in the normal async flow they haven't arrived yet → true.
+        #
+        # The card carries a ``cycle_id`` so clients and HTTP resolvers
+        # address THIS round among concurrent siblings (parallel task
+        # agents run their own gates through this same body).
+        cycle_id = uuid.uuid4().hex
+        card: dict[str, Any] = {
+            "type": "approve_request",
+            "cycle_id": cycle_id,
+            "items": self._serialize_approval_items(items),
+        }
+        cycle = ApprovalCycle(items, card, judge_event)
         with self._ws_lock:
+            # Evict any cached verdict for this batch's call_ids that a
+            # STALE judge generation delivered into the purge→register
+            # window (delivery is concurrent with this gate; the
+            # entry-time purge can't see arrivals that land during the
+            # policy round-trip or the Smart-Approvals wait).  By
+            # registration time these call_ids belong to THIS
+            # generation — a wrong-generation entry would blank the
+            # "judge analysing" cue below, be adopted into
+            # ``pending_verdicts`` for decision-stamping, and replay
+            # onto the new card on reconnect.  Once the cycle is
+            # registered, ``on_intent_verdict``'s owner check keeps
+            # such deliveries out on its own.
+            if judge_event is not None:
+                for cid in {it.get("call_id", "") for it in items if it.get("call_id")}:
+                    if cid in self._llm_verdicts and self._verdict_origins.get(cid) != id(
+                        judge_event
+                    ):
+                        del self._llm_verdicts[cid]
+                        self._verdict_origins.pop(cid, None)
             judge_pending = any(
                 it.get("_heuristic_verdict") and it.get("call_id", "") not in self._llm_verdicts
                 for it in items
             )
-        self._approval_event.clear()
-        self._pending_approval = {
-            "type": "approve_request",
-            "items": self._serialize_approval_items(items),
-            "judge_pending": judge_pending,
-        }
-        self._enqueue(self._pending_approval)
+            card["judge_pending"] = judge_pending
+            # Park this round's verdicts on the cycle: the heuristic rows
+            # just persisted as ``"pending"``, plus any LLM verdicts that
+            # arrived EARLY (the Smart-Approvals wait runs before the
+            # cycle exists, so ``on_intent_verdict`` cached them with no
+            # cycle to park on).  ``resolve_approval`` stamps the final
+            # ``user_decision`` on exactly this set.  Smart-approved
+            # calls were pulled out + stamped by
+            # ``_finalize_smart_verdicts`` already and their cached dicts
+            # carry a non-"pending" decision, so the early sweep skips
+            # them.
+            pending_cids = {hv.get("call_id") for hv in pending_verdicts}
+            early_llm = [
+                v
+                for cid, v in self._llm_verdicts.items()
+                if cid in pending_cids and v.get("user_decision", "pending") == "pending"
+            ]
+            cycle.pending_verdicts = pending_verdicts + early_llm
+            self._approval_cycles[cycle.cycle_id] = cycle
+            self._refresh_pending_approval_view()
+        self._enqueue(card)
         # Cross-stream broadcast — push the items via the cluster bus
         # so a coord parent's tree UI can render the inline approve/deny
         # block without waiting for a bulk fetch. Without this, the
@@ -1231,13 +1534,12 @@ class SessionUIBase:
         # to ATTENTION fires upstream BEFORE approve_tools runs (see
         # session.py:_emit_state("attention") preceding ui.approve_tools),
         # so a bulk fetch landing in the ~50-200ms window between
-        # _emit_state and this point sees ``_pending_approval=None``
-        # and returns ``pending_approval_detail: null``. The 5s TTL
-        # then locks the coord row on a "loading" placeholder until
-        # the next state event triggers a refresh — which never comes
-        # while parked on _approval_event.wait. The push path
-        # eliminates the race.
-        self._broadcast_approve_request(self._pending_approval)
+        # _emit_state and this point sees no live cycle and returns
+        # ``pending_approval_detail: null``. The 5s TTL then locks the
+        # coord row on a "loading" placeholder until the next state
+        # event triggers a refresh — which never comes while parked on
+        # the cycle's event.wait. The push path eliminates the race.
+        self._broadcast_approve_request(card)
         # Smart Approvals waited for the LLM verdicts BEFORE this card was
         # built, so on_intent_verdict already fanned out their
         # ``intent_verdict`` events while no card existed — a live client
@@ -1248,19 +1550,27 @@ class SessionUIBase:
         # empty here) and when the feature is off.
         if self.smart_approvals_enabled:
             self._replay_pending_verdicts(items)
-        if not self._approval_event.wait(timeout=self._APPROVAL_WAIT_TIMEOUT):
-            # Approval timed out (e.g., user disconnected). Deny via
-            # resolve_approval so verdicts and state are updated consistently.
-            # Feedback string derives from ``_APPROVAL_WAIT_TIMEOUT`` so the
-            # text follows the constant if the timeout knob moves.
-            log.warning("Approval timed out for ws_id=%s", self.ws_id)
-            self.resolve_approval(
-                False,
-                f"Approval timed out after {self._APPROVAL_WAIT_TIMEOUT}s",
-                timeout=True,
-            )
-        self._pending_approval = None
-        approved, feedback = self._approval_result
+        try:
+            if not cycle.event.wait(timeout=self._APPROVAL_WAIT_TIMEOUT):
+                # Approval timed out (e.g., user disconnected). Deny via
+                # resolve_approval so verdicts and state are updated
+                # consistently — targeted at THIS cycle so a sibling gate
+                # timing out can't deny someone else's round.  Feedback
+                # string derives from ``_APPROVAL_WAIT_TIMEOUT`` so the
+                # text follows the constant if the timeout knob moves.
+                log.warning("Approval timed out for ws_id=%s", self.ws_id)
+                self.resolve_approval(
+                    False,
+                    f"Approval timed out after {self._APPROVAL_WAIT_TIMEOUT}s",
+                    timeout=True,
+                    cycle_id=cycle.cycle_id,
+                )
+        finally:
+            # Gate thread owns the cycle's lifecycle end-to-end; the
+            # resolver only flips its state.  Unregister even if the
+            # wait raises so a dead gate can't strand a zombie card.
+            self._unregister_approval_cycle(cycle)
+        approved, feedback = cycle.result
 
         if not approved:
             denial_msg = "Denied by user"
@@ -1336,6 +1646,16 @@ class SessionUIBase:
         self._await_llm_verdicts(needed, self.smart_approval_wait_seconds)
 
         threshold = self.smart_approval_threshold
+        # This batch's judge generation — every cached verdict must have
+        # been delivered by THIS spawn's daemon.  A verdict of a stale
+        # generation (prior turn's run-to-completion daemon + a provider
+        # that reuses call_ids) fails qualification and the batch goes to
+        # a human.  ``None`` when the caller never ran the judge (legacy
+        # tests) — origin check skipped, matching the old behavior.
+        expected_gen = next(
+            (it.get("_judge_event") for it in candidates if it.get("_judge_event") is not None),
+            None,
+        )
         qualified: dict[str, dict[str, Any]] = {}
         with self._ws_lock:
             for it in candidates:
@@ -1343,12 +1663,17 @@ class SessionUIBase:
                 v = self._llm_verdicts.get(cid)
                 # Require a COMPLETED LLM verdict — tier "llm", not the
                 # "llm_fallback" error carry-over ("heuristic" never lands in
-                # this cache) — recommending "approve" at/above threshold.
+                # this cache) — recommending "approve" at/above threshold,
+                # delivered by this batch's own judge generation.
                 if (
                     v is None
                     or v.get("tier") != "llm"
                     or v.get("recommendation") != "approve"
                     or self._verdict_confidence(v) < threshold
+                    or (
+                        expected_gen is not None
+                        and self._verdict_origins.get(cid) != id(expected_gen)
+                    )
                 ):
                     return pending  # one fails → none of the batch auto-approves
                 hv = it.get("_heuristic_verdict") or {}
@@ -1412,15 +1737,17 @@ class SessionUIBase:
     def _finalize_smart_verdicts(self, smart_ids: set[str]) -> None:
         """Stamp ``smart_approval`` on the LLM verdicts of auto-approved calls.
 
-        The verdicts arrived during ``_await_llm_verdicts`` — before the
-        call was tagged auto-approved — so ``on_intent_verdict`` parked
-        them in ``_pending_verdicts`` with ``user_decision="pending"``.
-        Pull them out (so a human-pending sibling's ``resolve_approval``
-        can't overwrite the reason), stamp the cached dict in place (the
-        reconnect-replay payload reflects the final decision), and UPDATE
-        the persisted rows.  The matching heuristic verdict is stamped by
-        ``approve_tools``'s own persistence path via the ``auto_approved``
-        tag set just before this call.
+        The verdicts arrived during ``_await_llm_verdicts`` — before any
+        cycle existed for this round (the gate registers its
+        :class:`ApprovalCycle` only after the wait, and a fully
+        smart-approved batch never registers one at all) — so they live
+        only in the ``_llm_verdicts`` cache.  Stamp the cached dict in
+        place (the reconnect-replay payload reflects the final decision,
+        and the non-"pending" ``user_decision`` keeps every later parking
+        sweep away from it) and UPDATE the persisted rows.  The matching
+        heuristic verdict is stamped by ``approve_tools``'s own
+        persistence path via the ``auto_approved`` tag set just before
+        this call.
         """
         stamped: list[dict[str, Any]] = []
         with self._ws_lock:
@@ -1429,10 +1756,6 @@ class SessionUIBase:
                 if v is not None:
                     v["user_decision"] = AutoApproveReason.SMART_APPROVAL
                     stamped.append(v)
-            if self._pending_verdicts:
-                self._pending_verdicts = [
-                    v for v in self._pending_verdicts if v.get("call_id") not in smart_ids
-                ]
         if stamped:
             self._persist_verdict_decisions(stamped, AutoApproveReason.SMART_APPROVAL)
 
@@ -1467,14 +1790,28 @@ class SessionUIBase:
     # place.
     _APPROVAL_WAIT_TIMEOUT = 3600
 
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
+    def on_intent_verdict(
+        self,
+        verdict: dict[str, Any],
+        judge_event: object | None = None,
+    ) -> None:
         """Deliver an LLM intent-judge verdict to the frontend + persist.
 
         Caches under ``_ws_lock`` for SSE reconnect replay, persists
         the row to storage, and either records the caller's
         ``user_decision`` immediately (if the approval already
-        resolved) or parks the verdict in ``_pending_verdicts`` for
-        ``resolve_approval`` to stamp on close.
+        resolved) or parks the verdict on its owning
+        :class:`ApprovalCycle` for ``resolve_approval`` to stamp.
+
+        ``judge_event`` is the delivering daemon's cancel event —
+        its identity names the judge GENERATION.  When the verdict's
+        call_id belongs to a live cycle evaluated by a DIFFERENT
+        generation (a provider that reuses call_ids across turns +
+        a prior turn's run-to-completion daemon still delivering),
+        the verdict is persisted for audit only: no cache write, no
+        cond notify, no park — a stale ``approve`` must never satisfy
+        the new round's Smart-Approvals wait.  ``None`` (legacy/test
+        callers) skips the generation check.
 
         When the verdict arrives for a call_id that ``approve_tools``
         already auto-approved (the LLM judge is async and can fire
@@ -1486,15 +1823,34 @@ class SessionUIBase:
         """
         call_id = verdict.get("call_id", "")
         auto_reason = ""
+        decision = ""
         if call_id:
             with self._ws_lock:
+                owner = next(
+                    (c for c in self._approval_cycles.values() if call_id in c.call_ids),
+                    None,
+                )
+                if (
+                    owner is not None
+                    and judge_event is not None
+                    and owner.judge_event is not None
+                    and owner.judge_event is not judge_event
+                ):
+                    # Stale generation aimed at a LIVE cycle — the one
+                    # collision that could smart-approve the wrong call.
+                    stale = dict(verdict)
+                    stale.setdefault("user_decision", "superseded")
+                    self._persist_intent_verdict(stale)
+                    return
                 if (
                     len(self._llm_verdicts) >= self._LLM_VERDICT_CACHE_MAX
                     and call_id not in self._llm_verdicts
                 ):
                     oldest_key = next(iter(self._llm_verdicts))
                     del self._llm_verdicts[oldest_key]
+                    self._verdict_origins.pop(oldest_key, None)
                 self._llm_verdicts[call_id] = verdict
+                self._verdict_origins[call_id] = id(judge_event)
                 # Wake any Smart Approvals wait parked on this call's
                 # verdict (``_verdict_cond`` shares ``_ws_lock``, so the
                 # notify is valid here and the waiter re-checks its
@@ -1516,43 +1872,72 @@ class SessionUIBase:
         # SSE listeners). Stage 3 Step 4.
         self._broadcast_intent_verdict(verdict)
         self._persist_intent_verdict(verdict)
-        # Decision check + either queue or flag-for-persist happen
-        # under ONE lock acquisition so resolve_approval can't swap-
-        # and-clear _pending_verdicts between our read and our
-        # append. Without this: decide "no decision yet" → release
-        # lock → resolve_approval swaps the list + sets decision →
-        # we re-acquire and append to the fresh (empty) list; verdict
-        # sits queued until the next round, gets stamped with the
-        # WRONG decision.  Storage UPDATE happens outside the lock
-        # on the already-resolved path — no contention with other
-        # ws-scoped work.
         # If ``auto_reason`` was stamped above, the verdict already
         # carries the final ``user_decision`` for this row.  Neither
-        # path below applies: appending to ``_pending_verdicts`` would
-        # cause ``resolve_approval`` (on the manual-approval sibling
-        # in a mixed batch) to overwrite the auto-reason with
+        # path below applies: parking on a cycle would cause
+        # ``resolve_approval`` (on the manual-approval sibling in a
+        # mixed batch) to overwrite the auto-reason with
         # ``"approved"``/``"denied"``/``"timeout"``; the
         # ``_persist_verdict_decisions`` immediate-stamp path would
-        # overwrite it the same way from a prior cycle's decision.
+        # overwrite it the same way from the round's decision.
         # Skip both so the audit trail keeps the auto-approve reason.
         if auto_reason:
             return
         with self._ws_lock:
-            decision = self._last_verdict_decision
-            # Skip the append when the verdict already carries a final
-            # ``user_decision``.  Smart Approvals' ``_finalize_smart_verdicts``
-            # runs on the worker thread the moment ``_await_llm_verdicts``
-            # wakes — which is this method's ``notify_all`` (above), fired
-            # BEFORE this append and with an unlocked ``_persist_intent_verdict``
-            # in between.  So finalize can stamp ``smart_approval`` on this
-            # same cached dict and clear ``_pending_verdicts`` before we get
-            # here; without this guard we'd re-park the already-final verdict,
-            # and the NEXT round's ``resolve_approval`` would overwrite its
-            # audit row with approved/denied/timeout.  (The reverse ordering —
-            # append before finalize — is handled by finalize's own
-            # ``_pending_verdicts`` filter.)
-            if not decision and verdict.get("user_decision", "pending") == "pending":
-                self._pending_verdicts.append(verdict)
+            # Park-or-stamp under ONE lock acquisition so
+            # ``resolve_approval`` can't interleave: it marks the cycle
+            # resolved AND records the per-call decision atomically
+            # under this same lock, so exactly one of the two branches
+            # below sees the verdict — parked pre-decision (the resolve
+            # stamps it from ``pending_verdicts``) or stamped
+            # post-decision (from ``_recent_decisions``).  A two-step
+            # check-then-park reintroduces the audit-corruption race
+            # the old single-slot code fixed.
+            #
+            # Skip both when the verdict already carries a final
+            # ``user_decision`` — Smart Approvals'
+            # ``_finalize_smart_verdicts`` runs on the worker thread
+            # the moment ``_await_llm_verdicts`` wakes (this method's
+            # ``notify_all`` above) and can stamp ``smart_approval``
+            # on this same cached dict before we get here; re-parking
+            # it would let a later resolution overwrite the audit row.
+            # No live owner and no decision (pre-cycle Smart-Approvals
+            # arrival) → cache-only: the gate's registration sweep
+            # picks pending verdicts up from ``_llm_verdicts`` when
+            # the cycle is created.
+            if verdict.get("user_decision", "pending") == "pending":
+                owner = next(
+                    (
+                        c
+                        for c in self._approval_cycles.values()
+                        if call_id in c.call_ids and not c.resolved
+                    ),
+                    None,
+                )
+                if owner is not None:
+                    owner.pending_verdicts.append(verdict)
+                else:
+                    recent = self._recent_decisions.get(call_id)
+                    if recent is not None:
+                        prior_decision, origin = recent
+                        if (
+                            judge_event is not None
+                            and origin is not None
+                            and origin is not judge_event
+                        ):
+                            # The recorded decision belongs to a
+                            # DIFFERENT generation's round under a
+                            # reused call_id — the round this verdict
+                            # was judging resolved and fell out of
+                            # ``_recent_decisions`` before delivery.
+                            # Stamping it with the other round's
+                            # decision would claim the operator ruled
+                            # on THIS verdict; ``superseded`` is the
+                            # honest terminal state (same vocabulary
+                            # as :meth:`on_superseded_intent_verdict`).
+                            decision = "superseded"
+                        else:
+                            decision = prior_decision
         if decision:
             self._persist_verdict_decisions([verdict], decision)
 
@@ -1717,18 +2102,18 @@ class SessionUIBase:
         except Exception:
             log.debug("Failed to persist intent verdict", exc_info=True)
 
-    def serialize_pending_approval_detail(self) -> dict[str, Any] | None:
-        """Build the inline approval payload for dashboard projection.
+    def serialize_pending_approval_details(self) -> list[dict[str, Any]]:
+        """Per-cycle inline-approval payloads, EVERY live cycle, oldest first.
 
-        Merges :attr:`_pending_approval` items with the per-call_id
-        LLM verdict cache so a coordinator's children-tree row can
-        render inline approve/deny buttons + judge-verdict pill
-        without making a separate per-child round-trip. Returns
-        ``None`` when no approval is pending.
+        Merges each cycle's card items with the per-call_id LLM verdict
+        cache so a coordinator's children-tree row can render inline
+        approve/deny buttons + judge-verdict pill without a separate
+        per-child round-trip; one entry per live cycle (parallel task
+        agents each gate their own batch), each addressable by its
+        ``cycle_id``.  Empty when nothing is pending.
 
-        The shape mirrors the inline tool-call info already broadcast
-        via the ``approve_request`` SSE event but adds a
-        ``judge_verdict`` sibling per item (looked up from
+        The per-entry shape mirrors the ``approve_request`` SSE event
+        but adds a ``judge_verdict`` sibling per item (looked up from
         :attr:`_llm_verdicts`, the cache seeded by
         :meth:`on_intent_verdict`). Heuristic verdicts already carried
         on items are forwarded as ``heuristic_verdict``.
@@ -1743,56 +2128,60 @@ class SessionUIBase:
         assumption, project the verdict to a safe subset before
         embedding (or move the field behind ``admin.cluster.inspect``).
         """
-        pending = self._pending_approval
-        if pending is None:
-            return None
-        items = pending.get("items") or []
-        if not items:
-            return None
-        call_ids = [item.get("call_id", "") for item in items]
-        # Snapshot verdict references under lock, deepcopy after
-        # release. Writers (``on_intent_verdict`` daemon judge
-        # thread + ``_reset_approval_cycle`` worker thread) only
-        # ASSIGN entries, never mutate them in place — so a snapped
-        # reference is stable after the lock drops, and the
-        # subsequent deepcopy can run lock-free even though
-        # verdict dicts carry list-typed ``evidence`` that
-        # downstream callers might mutate. This keeps the lock
-        # window O(N items) without paying the deepcopy cost
-        # (O(verdict size)) under contention with the per-token
-        # write path that also holds ``_ws_lock``.
         with self._ws_lock:
-            verdict_refs = {
-                cid: self._llm_verdicts[cid]
-                for cid in call_ids
-                if cid and cid in self._llm_verdicts
-            }
-        verdicts = {cid: copy.deepcopy(v) for cid, v in verdict_refs.items()}
-        serialized: list[dict[str, Any]] = []
-        for item in items:
-            cid = item.get("call_id", "")
-            serialized.append(
+            cards = [(c.cycle_id, c.card) for c in self._approval_cycles.values()]
+            # Snapshot verdict references under lock, deepcopy after
+            # release. Writers (``on_intent_verdict`` daemon judge
+            # thread) only ASSIGN entries, never mutate them in place —
+            # so a snapped reference is stable after the lock drops, and
+            # the subsequent deepcopy can run lock-free even though
+            # verdict dicts carry list-typed ``evidence`` that
+            # downstream callers might mutate. This keeps the lock
+            # window O(N items) without paying the deepcopy cost
+            # (O(verdict size)) under contention with the per-token
+            # write path that also holds ``_ws_lock``.
+            verdict_refs = dict(self._llm_verdicts)
+        verdicts: dict[str, dict[str, Any]] = {}
+        details: list[dict[str, Any]] = []
+        for cycle_id, card in cards:
+            items = card.get("items") or []
+            if not items:
+                continue
+            call_ids = [item.get("call_id", "") for item in items]
+            serialized: list[dict[str, Any]] = []
+            for item in items:
+                cid = item.get("call_id", "")
+                if cid in verdict_refs and cid not in verdicts:
+                    verdicts[cid] = copy.deepcopy(verdict_refs[cid])
+                serialized.append(
+                    {
+                        "call_id": cid,
+                        "header": item.get("header", ""),
+                        "preview": item.get("preview", ""),
+                        "func_name": item.get("func_name", ""),
+                        "approval_label": item.get("approval_label", ""),
+                        "needs_approval": item.get("needs_approval", False),
+                        "error": item.get("error"),
+                        # Card items are already wire-shaped by
+                        # ``_serialize_approval_items`` — the heuristic
+                        # verdict rides under ``heuristic_verdict``.
+                        "heuristic_verdict": item.get("heuristic_verdict"),
+                        "judge_verdict": verdicts.get(cid),
+                    }
+                )
+            # Primary call_id = first non-empty in list order (matches the
+            # 409 response shape from ``make_approve_handler`` so the UI
+            # can render the same identifier the server thinks is current).
+            primary = next((cid for cid in call_ids if cid), "")
+            details.append(
                 {
-                    "call_id": cid,
-                    "header": item.get("header", ""),
-                    "preview": item.get("preview", ""),
-                    "func_name": item.get("func_name", ""),
-                    "approval_label": item.get("approval_label", ""),
-                    "needs_approval": item.get("needs_approval", False),
-                    "error": item.get("error"),
-                    "heuristic_verdict": item.get("verdict"),
-                    "judge_verdict": verdicts.get(cid),
+                    "cycle_id": cycle_id,
+                    "call_id": primary,
+                    "judge_pending": bool(card.get("judge_pending", False)),
+                    "items": serialized,
                 }
             )
-        # Primary call_id = first non-empty in list order (matches the
-        # 409 response shape from ``make_approve_handler`` so the UI
-        # can render the same identifier the server thinks is current).
-        primary = next((cid for cid in call_ids if cid), "")
-        return {
-            "call_id": primary,
-            "judge_pending": bool(pending.get("judge_pending", False)),
-            "items": serialized,
-        }
+        return details
 
     # ---------------------------------------------------------------
     # Auto-approve visibility — shared by interactive + coord UIs
@@ -2640,12 +3029,17 @@ class SessionUIBase:
         feedback: str | None = None,  # noqa: ARG002 — hook stub
         *,
         always: bool = False,  # noqa: ARG002 — hook stub
+        cycle_id: str = "",  # noqa: ARG002 — hook stub
+        call_ids: tuple[str, ...] = (),  # noqa: ARG002 — hook stub
     ) -> None:
         """Fan an ``approval_resolved`` decision out to the kind's transport.
 
         Default: no-op. ``ConsoleCoordinatorUI`` overrides to push to
         the cluster bus so the parent coordinator's tree UI can clear
         the pending-approval pill in sync with the actual decision.
+        ``cycle_id`` / ``call_ids`` name WHICH cycle resolved — with
+        parallel task agents several are live, and a bare decision
+        would clear the wrong block.
         """
 
     def _broadcast_approve_request(self, detail: dict[str, Any]) -> None:  # noqa: ARG002 — hook stub

--- a/turnstone/eval/core.py
+++ b/turnstone/eval/core.py
@@ -136,7 +136,7 @@ class NullUI:
     def on_rename(self, name: str) -> None:
         pass
 
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
+    def on_intent_verdict(self, verdict: dict[str, Any], judge_event: object | None = None) -> None:
         pass
 
     def on_output_warning(self, call_id: str, assessment: dict[str, Any]) -> None:

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -421,13 +421,24 @@ class AsyncTurnstoneConsole(_BaseClient):
         approved: bool = True,
         feedback: str = "",
         always: bool = False,
+        cycle_id: str = "",
+        call_id: str = "",
     ) -> dict[str, Any]:
-        """Approve or reject a pending tool call via the routing proxy."""
+        """Approve or reject a pending tool call via the routing proxy.
+
+        ``cycle_id`` / ``call_id`` select the approval cycle when the
+        workstream has several live (parallel task agents); omitting
+        both resolves the oldest.
+        """
         body: dict[str, Any] = {"approved": approved}
         if feedback:
             body["feedback"] = feedback
         if always:
             body["always"] = True
+        if cycle_id:
+            body["cycle_id"] = cycle_id
+        if call_id:
+            body["call_id"] = call_id
         return await self._request(
             "POST", f"/v1/api/route/workstreams/{ws_id}/approve", json_body=body
         )
@@ -1357,10 +1368,17 @@ class TurnstoneConsole:
         approved: bool = True,
         feedback: str = "",
         always: bool = False,
+        cycle_id: str = "",
+        call_id: str = "",
     ) -> dict[str, Any]:
         return self._runner.run(
             self._async.route_approve(
-                ws_id=ws_id, approved=approved, feedback=feedback, always=always
+                ws_id=ws_id,
+                approved=approved,
+                feedback=feedback,
+                always=always,
+                cycle_id=cycle_id,
+                call_id=call_id,
             )
         )
 

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -157,16 +157,35 @@ class ToolInfoEvent(ServerEvent):
 
 @dataclass
 class ApproveRequestEvent(ServerEvent):
+    """One approval CYCLE awaiting the operator.
+
+    ``cycle_id`` names the round: echo it back on the approve POST to
+    resolve exactly this batch.  Several of these can be outstanding at
+    once — parallel task agents each gate their own tool calls — so
+    clients must key prompt UI by ``cycle_id``, not assume a singleton.
+    """
+
     type: str = "approve_request"
+    cycle_id: str = ""
     items: list[dict[str, Any]] = field(default_factory=list)
     judge_pending: bool = False
 
 
 @dataclass
 class ApprovalResolvedEvent(ServerEvent):
+    """A specific approval cycle resolved (by any connected client).
+
+    ``cycle_id`` / ``call_ids`` identify WHICH prompt to dismiss —
+    with concurrent cycles a bare "something resolved" would dismiss
+    the wrong card.
+    """
+
     type: str = "approval_resolved"
     approved: bool = False
     feedback: str = ""
+    always: bool = False
+    cycle_id: str = ""
+    call_ids: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/turnstone/sdk/server.py
+++ b/turnstone/sdk/server.py
@@ -276,12 +276,26 @@ class AsyncTurnstoneServer(_BaseClient):
         approved: bool = True,
         feedback: str | None = None,
         always: bool = False,
+        cycle_id: str | None = None,
+        call_id: str | None = None,
     ) -> StatusResponse:
+        """Resolve one approval cycle.
+
+        ``cycle_id`` (from the ``approve_request`` event) or ``call_id``
+        (any member call) selects the cycle; omitting both resolves the
+        OLDEST live one — ambiguous when parallel task agents have
+        several prompts outstanding, so pass a selector whenever the
+        triggering event is known.
+        """
         body: dict[str, Any] = {"approved": approved}
         if feedback is not None:
             body["feedback"] = feedback
         if always:
             body["always"] = True
+        if cycle_id:
+            body["cycle_id"] = cycle_id
+        if call_id:
+            body["call_id"] = call_id
         return await self._request(
             "POST",
             f"/v1/api/workstreams/{ws_id}/approve",
@@ -684,9 +698,18 @@ class TurnstoneServer:
         approved: bool = True,
         feedback: str | None = None,
         always: bool = False,
+        cycle_id: str | None = None,
+        call_id: str | None = None,
     ) -> StatusResponse:
         return self._runner.run(
-            self._async.approve(ws_id=ws_id, approved=approved, feedback=feedback, always=always)
+            self._async.approve(
+                ws_id=ws_id,
+                approved=approved,
+                feedback=feedback,
+                always=always,
+                cycle_id=cycle_id,
+                call_id=call_id,
+            )
         )
 
     def command(self, *, ws_id: str, command: str) -> StatusResponse:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -256,12 +256,16 @@ class WebUI(SessionUIBase):
         feedback: str | None = None,
         *,
         always: bool = False,
+        cycle_id: str = "",
+        call_ids: tuple[str, ...] = (),
     ) -> None:
         """Send an ``approval_resolved`` decision to the global SSE channel.
 
         Clears the parent's pending-approval pill in lockstep with
         the actual decision rather than waiting for the next
-        state-change piggyback.
+        state-change piggyback.  ``cycle_id`` / ``call_ids`` identify
+        WHICH cycle resolved so the coord tree clears the right block
+        when several are live (parallel task agents).
         """
         if WebUI._global_queue is not None:
             with contextlib.suppress(queue.Full):
@@ -272,6 +276,8 @@ class WebUI(SessionUIBase):
                         "approved": approved,
                         "feedback": feedback or "",
                         "always": bool(always),
+                        "cycle_id": cycle_id,
+                        "call_ids": list(call_ids),
                     }
                 )
 
@@ -402,11 +408,15 @@ class WebUI(SessionUIBase):
                     {"type": "ws_rename", "ws_id": self.ws_id, "name": name}
                 )
 
-    def on_intent_verdict(self, verdict: dict[str, Any]) -> None:
+    def on_intent_verdict(
+        self,
+        verdict: dict[str, Any],
+        judge_event: object | None = None,
+    ) -> None:
         """Extend :meth:`SessionUIBase.on_intent_verdict` with a
         node-level prometheus metric update.
         """
-        super().on_intent_verdict(verdict)
+        super().on_intent_verdict(verdict, judge_event)
         fire_judge_verdict_metric(_metrics, verdict, "llm")
 
     # ``on_output_warning`` inherited from :class:`SessionUIBase`.
@@ -746,9 +756,15 @@ def _interactive_events_replay(
 
     # Pending approval re-injection (so a reconnecting tab sees the
     # prompt) + cached LLM verdicts received since the prompt fired.
-    pending_approval = getattr(ui, "_pending_approval", None)
-    if pending_approval is not None:
-        yield pending_approval
+    # EVERY live cycle replays — parallel task agents can have several
+    # prompts outstanding, and a tab that repaints only the newest
+    # leaves the others unanswerable.  Cards first (oldest-first), then
+    # the verdict cache once: clients route ``intent_verdict`` by
+    # call_id, so ordering across cards is irrelevant as long as every
+    # card exists before its verdicts.
+    pending_cards = ui.pending_approval_cards() if hasattr(ui, "pending_approval_cards") else []
+    if pending_cards:
+        yield from pending_cards
         with ui._ws_lock:
             cached_verdicts = list(ui._llm_verdicts.values())
         for v in cached_verdicts:
@@ -881,16 +897,16 @@ def _build_node_snapshot(app_state: Any) -> dict[str, Any]:
         title = ""
         if ws.session:
             title = get_workstream_display_name(ws.session.ws_id) or ""
-        # ``pending_approval_detail`` mirrors the dashboard handler's
+        # ``pending_approval_details`` mirrors the dashboard handler's
         # projection so the console collector's reconnect-via-snapshot
         # path (``_reconcile_node``) can carry the rich approval payload
         # across reconnects — without it, a child sitting in approval-
         # pending across a console restart or network blip would render
         # with no buttons until the next state change. Same data, same
         # ``read`` scope as ``/v1/api/dashboard``.
-        approval_detail: dict[str, Any] | None = None
-        if ui is not None and hasattr(ui, "serialize_pending_approval_detail"):
-            approval_detail = ui.serialize_pending_approval_detail()
+        approval_details: list[dict[str, Any]] = []
+        if ui is not None and hasattr(ui, "serialize_pending_approval_details"):
+            approval_details = ui.serialize_pending_approval_details()
         ws_list.append(
             {
                 "id": ws.id,
@@ -909,7 +925,7 @@ def _build_node_snapshot(app_state: Any) -> dict[str, Any]:
                 "user_id": ws.user_id,
                 "project_id": ws.project_id,
                 "persona": ws.persona,
-                "pending_approval_detail": approval_detail,
+                "pending_approval_details": approval_details,
             }
         )
     return {
@@ -1132,7 +1148,7 @@ async def dashboard(request: Request) -> JSONResponse:
                 "user_id": ws.user_id,
                 "project_id": ws.project_id,
                 "persona": ws.persona,
-                "pending_approval_detail": ui.serialize_pending_approval_detail(),
+                "pending_approval_details": ui.serialize_pending_approval_details(),
                 # Per-ws ring buffer of recent auto-approves (last 10).
                 # Lets the coord-tree render a "recently auto-approved
                 # by skill X" pill without a per-child round-trip — the

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -200,11 +200,23 @@ class Pane {
     // null when idle/error or when the backend sends no acting id
     // (unauthenticated / older backend).
     this._actingUserId = null;
+    // Live approval cycles, cycleId → {blockEls, callIds}.  Parallel task
+    // agents gate concurrently, so several approve_request cards can be
+    // outstanding at once; each resolves independently by its cycle_id.
+    // Insertion order = arrival order — keyboard shortcuts act on the
+    // OLDEST (first) entry.  pendingApproval / approvalBlockEl are
+    // DERIVED views maintained by _syncApprovalState(): the boolean for
+    // the many "is anything pending" readers, the element pointing at
+    // the active (oldest) cycle's card for keyboard/feedback routing.
+    this.approvalCycles = new Map();
     this.pendingApproval = false;
     this.approvalBlockEl = null;
-    // Early-paint shell from a ``tool_pending`` event, awaiting its
-    // authoritative ``tool_info`` / ``approve_request`` upgrade.
-    this.announcedBlockEl = null;
+    // Early-paint shells from ``tool_pending`` events, keyed by their
+    // sorted call_id set, awaiting the authoritative ``tool_info`` /
+    // ``approve_request`` upgrade.  A Map (not a single slot): with
+    // parallel task agents several announces can be in flight, and a
+    // sibling's announce must not discard ours.
+    this.announcedBlocks = new Map();
     this.retryDelay = 1000;
     this.model = "";
     this.modelAlias = "";
@@ -255,9 +267,10 @@ class Pane {
     this.currentReasoningEl = null;
     this.contentBuffer = "";
     this.setBusy(false);
+    this.approvalCycles = new Map();
     this.pendingApproval = false;
     this.approvalBlockEl = null;
-    this.announcedBlockEl = null;
+    this.announcedBlocks = new Map();
     this._pendingEditSend = null;
     this.inputEl.disabled = false;
     this.attachments.clearChips();
@@ -491,9 +504,44 @@ class Pane {
     this.scrollToBottom(true);
   }
 
-  getFeedback() {
-    if (!this.approvalBlockEl) return null;
-    const inp = this.approvalBlockEl.querySelector(".conv-feedback");
+  // --- Approval-cycle bookkeeping -----------------------------------------
+  // The backend registers one ApprovalCycle per human-gated batch; parallel
+  // task agents make several live at once.  Cards register here on paint and
+  // deregister on resolution; the composer stays disabled while ANY cycle is
+  // live.
+
+  _syncApprovalState() {
+    const first = this.approvalCycles.values().next();
+    const active = first.done ? null : first.value;
+    this.pendingApproval = this.approvalCycles.size > 0;
+    this.approvalBlockEl = active ? active.blockEls[0] : null;
+    this.inputEl.disabled = this.pendingApproval;
+    this.sendBtn.disabled = this.pendingApproval || this.busy;
+  }
+
+  _oldestCycleId() {
+    const first = this.approvalCycles.keys().next();
+    return first.done ? null : first.value;
+  }
+
+  _registerApprovalCycle(cycleId, blockEls, items) {
+    const callIds = (items || []).map((it) => it && it.call_id).filter(Boolean);
+    this.approvalCycles.set(cycleId, { blockEls, callIds });
+    this._syncApprovalState();
+  }
+
+  // Cycle id for pre-multi-cycle servers that omit it: synthesize a stable
+  // key from the batch's first call_id so the Map still routes uniquely.
+  _cycleKey(evt) {
+    if (evt.cycle_id) return evt.cycle_id;
+    const first = ((evt.items || [])[0] || {}).call_id || "";
+    return "legacy:" + first;
+  }
+
+  getFeedback(blockEl) {
+    const el = blockEl || this.approvalBlockEl;
+    if (!el) return null;
+    const inp = el.querySelector(".conv-feedback");
     return inp && inp.value.trim() ? inp.value.trim() : null;
   }
 
@@ -614,15 +662,26 @@ class Pane {
     }
     badge.replaceWith(buildConvVerdict(verdict, { judgePending: false }));
 
-    this.updateVerdictGlow(verdict.recommendation);
+    this.updateVerdictGlow(
+      verdict.recommendation,
+      vRow ? vRow.closest(".conv-batch") : null,
+    );
   }
 
-  updateVerdictGlow(recommendation) {
-    if (!this.approvalBlockEl) return;
-    const actions = this.approvalBlockEl.querySelector(".conv-actions");
+  updateVerdictGlow(recommendation, batchEl) {
+    // Glow is a PER-BATCH aggregate: score the batch that owns the
+    // verdict, not whichever cycle happens to be oldest.  With
+    // concurrent approval cycles a sibling's verdict must neither
+    // recolor the oldest card (the old single-El read seeded `worst`
+    // with the sibling's recommendation) nor leave its own card
+    // stale.  Batch-less rows (legacy replay shapes) fall back to the
+    // oldest live cycle — the pre-multi-cycle behavior.
+    const scope = batchEl || this.approvalBlockEl;
+    if (!scope) return;
+    const actions = scope.querySelector(".conv-actions");
     if (!actions) return;
     // Collect all verdict badges currently visible in this approval block.
-    const badges = this.approvalBlockEl.querySelectorAll(".conv-verdict");
+    const badges = scope.querySelectorAll(".conv-verdict");
     let worst = recommendation;
     for (let i = 0; i < badges.length; i++) {
       const recEl = badges[i].querySelector(".conv-verdict-rec");
@@ -751,27 +810,77 @@ class Pane {
     // keys type; elsewhere y|Enter approve, n|Esc deny, a = approve-all.
     this.el.addEventListener("keydown", (e) => {
       if (!this.pendingApproval || !this.approvalBlockEl) return;
-      const fb = this.approvalBlockEl.querySelector(".conv-feedback");
-      if (fb && document.activeElement === fb) {
+      // Keyboard acts on the OLDEST live cycle (the one approvalBlockEl
+      // tracks); sibling cards from parallel task agents resolve by
+      // their own buttons or become oldest in turn.  When the feedback
+      // field getting the keystroke belongs to a DIFFERENT cycle's
+      // card, route to THAT cycle instead — the user is clearly acting
+      // on the card they're typing into.
+      let targetId = this._oldestCycleId();
+      let targetBlock = this.approvalBlockEl;
+      const ae = document.activeElement;
+      if (ae && ae.classList && ae.classList.contains("conv-feedback")) {
+        for (const [cid, entry] of this.approvalCycles) {
+          if (entry.blockEls.some((el) => el.contains(ae))) {
+            targetId = cid;
+            targetBlock = entry.blockEls[0];
+            break;
+          }
+        }
+      }
+      const fb = targetBlock
+        ? targetBlock.querySelector(".conv-feedback")
+        : null;
+      if (ae && fb && ae === fb) {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
-          this.resolveApproval(true, false, this.getFeedback());
+          this.resolveApproval(
+            true,
+            false,
+            this.getFeedback(targetBlock),
+            false,
+            targetId,
+          );
         } else if (e.key === "Escape") {
           e.preventDefault();
-          this.resolveApproval(false, false, this.getFeedback());
+          this.resolveApproval(
+            false,
+            false,
+            this.getFeedback(targetBlock),
+            false,
+            targetId,
+          );
         }
         return;
       }
       const k = e.key.toLowerCase();
       if (k === "y" || e.key === "Enter") {
         e.preventDefault();
-        this.resolveApproval(true, false, this.getFeedback());
+        this.resolveApproval(
+          true,
+          false,
+          this.getFeedback(targetBlock),
+          false,
+          targetId,
+        );
       } else if (k === "n" || e.key === "Escape") {
         e.preventDefault();
-        this.resolveApproval(false, false, this.getFeedback());
+        this.resolveApproval(
+          false,
+          false,
+          this.getFeedback(targetBlock),
+          false,
+          targetId,
+        );
       } else if (k === "a") {
         e.preventDefault();
-        this.resolveApproval(true, true, this.getFeedback());
+        this.resolveApproval(
+          true,
+          true,
+          this.getFeedback(targetBlock),
+          false,
+          targetId,
+        );
       }
     });
 
@@ -1435,8 +1544,20 @@ class Pane {
         break;
 
       case "approve_request":
-        if (!this._routeAgentItems(evt.items, "approve", evt.judge_pending)) {
-          this.showInlineToolBlock(evt.items, false, evt.judge_pending);
+        if (
+          !this._routeAgentItems(
+            evt.items,
+            "approve",
+            evt.judge_pending,
+            this._cycleKey(evt),
+          )
+        ) {
+          this.showInlineToolBlock(
+            evt.items,
+            false,
+            evt.judge_pending,
+            this._cycleKey(evt),
+          );
         }
         break;
 
@@ -1449,7 +1570,15 @@ class Pane {
         break;
 
       case "approval_resolved":
-        this.resolveApproval(evt.approved, false, evt.feedback, true);
+        // Route to the resolved cycle; an event without a cycle_id
+        // (pre-multi-cycle server) falls back to the oldest.
+        this.resolveApproval(
+          evt.approved,
+          false,
+          evt.feedback,
+          true,
+          evt.cycle_id || this._oldestCycleId(),
+        );
         break;
 
       case "tool_output_chunk":
@@ -2282,7 +2411,11 @@ class Pane {
     this.currentAssistantBodyEl = null;
     this.currentReasoningEl = null;
     this.contentBuffer = "";
-    this.announcedBlockEl = null;
+    // Approval cycles + announce shells point into the wiped subtree too;
+    // the replayed history / detail snapshot re-registers live ones.
+    this.approvalCycles = new Map();
+    this.announcedBlocks = new Map();
+    this._syncApprovalState();
     this._thinkingEl = null;
     this._retryHolderEl = null;
   }
@@ -2625,10 +2758,22 @@ class Pane {
     // so auto-follow would silently disengage at exactly tool-call time.  Token
     // streaming stays pinned without this because each append is sub-threshold.
     const stick = this.isNearBottom();
-    // Drop a previous un-consumed announce so shells don't pile up.
-    if (this.announcedBlockEl) {
-      this.announcedBlockEl.remove();
-      this.announcedBlockEl = null;
+    // Key the shell by its call_id set.  A re-announce of the SAME batch
+    // replaces its own shell; shells of OTHER batches stay — parallel
+    // task agents announce concurrently and must not discard each other.
+    // Bounded: shells whose upgrade never arrives (dropped SSE) are
+    // evicted oldest-first past the cap so they can't pile up forever.
+    const key = this._announceKey(items);
+    const prior = this.announcedBlocks.get(key);
+    if (prior) {
+      prior.remove();
+      this.announcedBlocks.delete(key);
+    }
+    while (this.announcedBlocks.size >= 8) {
+      const oldestKey = this.announcedBlocks.keys().next().value;
+      const oldest = this.announcedBlocks.get(oldestKey);
+      if (oldest) oldest.remove();
+      this.announcedBlocks.delete(oldestKey);
     }
     const block = document.createElement("div");
     block.className =
@@ -2651,44 +2796,36 @@ class Pane {
         block.appendChild(buildConvVerdict(verdict, { judgePending: true }));
       }
     });
-    this.announcedBlockEl = block;
+    this.announcedBlocks.set(key, block);
     this.messagesEl.appendChild(block);
     this._relinkAgentCards(list);
     this.scrollToBottom(stick);
     toolAnnounce(_toolAnnounceText(list));
   }
 
-  // Hand back the early-paint shell to upgrade in place if it matches this
-  // batch's call_ids, else null (caller builds fresh).  Clears the tracking
-  // ref so the shell is consumed exactly once.  Matching by id set is
-  // defensive — the interactive pane is strictly serial, so an announce is
-  // always followed by ITS approve_request / tool_info — but it guarantees a
-  // stale shell can never capture a different batch.
+  _announceKey(items) {
+    return JSON.stringify(
+      (items || [])
+        .map((it) => it && it.call_id)
+        .filter(Boolean)
+        .sort(),
+    );
+  }
+
+  // Hand back the early-paint shell to upgrade in place if one exists for
+  // this batch's call_id set, else null (caller builds fresh).  Deletes the
+  // entry so the shell is consumed exactly once.  Keyed lookup (not a single
+  // slot): parallel task agents keep several shells in flight, and taking
+  // one must not disturb the others.
   _takeAnnouncedBlock(items) {
-    const block = this.announcedBlockEl;
+    const key = this._announceKey(items);
+    const block = this.announcedBlocks.get(key);
     if (!block) return null;
-    this.announcedBlockEl = null;
-    const want = (items || [])
-      .map((it) => it.call_id)
-      .filter(Boolean)
-      .sort();
-    let have = [];
-    try {
-      have = JSON.parse(block.dataset.callIds || "[]");
-    } catch (_e) {
-      have = [];
-    }
-    have = have.slice().sort();
-    const matches =
-      want.length === have.length && want.every((id, i) => id === have[i]);
-    if (!matches) {
-      block.remove(); // stale orphan — discard, caller builds fresh
-      return null;
-    }
+    this.announcedBlocks.delete(key);
     return block;
   }
 
-  showInlineToolBlock(items, autoApproved, judgePending) {
+  showInlineToolBlock(items, autoApproved, judgePending, cycleId) {
     // Capture pin before _takeAnnouncedBlock/append change scrollHeight — see
     // announceToolBlock for why post-append measurement breaks here.
     const stick = this.isNearBottom();
@@ -2753,19 +2890,42 @@ class Pane {
           : "",
         glowRec,
         withFeedback: true,
-        onApprove: () => this.resolveApproval(true, false, this.getFeedback()),
-        onDeny: () => this.resolveApproval(false, false, this.getFeedback()),
-        onAlways: () => this.resolveApproval(true, true, this.getFeedback()),
+        onApprove: () =>
+          this.resolveApproval(
+            true,
+            false,
+            this.getFeedback(block),
+            false,
+            cycleId,
+          ),
+        onDeny: () =>
+          this.resolveApproval(
+            false,
+            false,
+            this.getFeedback(block),
+            false,
+            cycleId,
+          ),
+        onAlways: () =>
+          this.resolveApproval(
+            true,
+            true,
+            this.getFeedback(block),
+            false,
+            cycleId,
+          ),
       });
       block.appendChild(actions);
-      this.pendingApproval = true;
-      this.approvalBlockEl = block;
-      this.inputEl.disabled = true;
-      this.sendBtn.disabled = true;
+      this._registerApprovalCycle(cycleId, [block], items);
       const fb = actions.querySelector(".conv-feedback");
-      requestAnimationFrame(() => {
-        if (fb) fb.focus();
-      });
+      // Focus the feedback field only for the FIRST (oldest) live cycle —
+      // a sibling card arriving while the user is typing into another
+      // cycle's field must not steal focus mid-word.
+      if (this._oldestCycleId() === cycleId) {
+        requestAnimationFrame(() => {
+          if (fb) fb.focus();
+        });
+      }
     }
 
     if (!announced) this.messagesEl.appendChild(block);
@@ -2773,29 +2933,40 @@ class Pane {
     this.scrollToBottom(stick);
   }
 
-  resolveApproval(approved, always, feedback, skipPost) {
-    if (!this.approvalBlockEl) return;
+  resolveApproval(approved, always, feedback, skipPost, cycleId) {
+    // Resolve exactly ONE cycle — parallel task agents can have several
+    // cards live; a decision must never bleed onto a sibling's.  No
+    // cycleId (legacy caller) → the oldest.
+    const id = cycleId || this._oldestCycleId();
+    if (!id) return;
+    const entry = this.approvalCycles.get(id);
+    if (!entry) return; // already resolved (peer tab / server race) — idempotent
+    this.approvalCycles.delete(id);
+
     // Capture pin before the status badge reflows the block — see
     // announceToolBlock.
     const stick = this.isNearBottom();
-    this.pendingApproval = false;
 
-    const actions = this.approvalBlockEl.querySelector(".conv-actions");
-    if (actions) actions.remove();
+    entry.blockEls.forEach((el) => {
+      const actions = el.querySelector(".conv-actions");
+      if (actions) actions.remove();
+    });
+    const statusHost = entry.blockEls[0];
+    if (statusHost) {
+      statusHost.appendChild(
+        buildConvStatus({ approved, always, feedback: feedback || "" }),
+      );
+      statusHost.classList.add(
+        approved ? "conv-batch--approved" : "conv-batch--denied",
+      );
+    }
 
-    this.approvalBlockEl.appendChild(
-      buildConvStatus({ approved, always, feedback: feedback || "" }),
-    );
-    this.approvalBlockEl.classList.add(
-      approved ? "conv-batch--approved" : "conv-batch--denied",
-    );
-    this.approvalBlockEl = null;
-
-    this.inputEl.disabled = false;
-    this.sendBtn.disabled = this.busy;
-    this.inputEl.focus();
+    this._syncApprovalState();
+    if (!this.pendingApproval) this.inputEl.focus();
 
     // POST to server (skip when server already resolved, e.g. timeout).
+    // cycle_id pins the decision to THIS round server-side; call_id
+    // rides along as defense-in-depth (the server 409s a stale pair).
     if (!skipPost) {
       authFetch(
         this._base +
@@ -2809,6 +2980,8 @@ class Pane {
             approved: approved,
             feedback: feedback || null,
             always: !!always,
+            cycle_id: id.startsWith("legacy:") ? null : id,
+            call_id: entry.callIds[0] || null,
           }),
         },
       ).catch((err) => {
@@ -2826,7 +2999,7 @@ class Pane {
   // — their handlers find the row by call_id anywhere under messagesEl,
   // including inside the card body.  Returns true when handled (the caller then
   // skips the top-level rendering path).
-  _routeAgentItems(items, mode, judgePending) {
+  _routeAgentItems(items, mode, judgePending, cycleId) {
     if (!items || !items.length) return false;
     const parentId = items[0] && items[0].parent_call_id;
     if (!parentId) return false;
@@ -2854,6 +3027,7 @@ class Pane {
       if (toggle) toggle.setAttribute("aria-expanded", "true");
     }
     const stick = this.isNearBottom();
+    const approveRows = [];
     items.forEach((item) => {
       if (!item || !item.parent_call_id) return;
       const escId = item.call_id ? CSS.escape(item.call_id) : "";
@@ -2875,20 +3049,33 @@ class Pane {
           glowRec: verdict && verdict.recommendation,
           withFeedback: true,
           onApprove: () =>
-            this.resolveApproval(true, false, this.getFeedback()),
-          onDeny: () => this.resolveApproval(false, false, this.getFeedback()),
+            this.resolveApproval(
+              true,
+              false,
+              this.getFeedback(row),
+              false,
+              cycleId,
+            ),
+          onDeny: () =>
+            this.resolveApproval(
+              false,
+              false,
+              this.getFeedback(row),
+              false,
+              cycleId,
+            ),
         });
         row.appendChild(actions);
-        // Reuse the session-level approval resolution: the backend's
-        // approve_tools blocks on ONE pending decision, so pointing
-        // approvalBlockEl at this nested row is enough for resolveApproval to
-        // POST /approve and unblock it.
-        this.pendingApproval = true;
-        this.approvalBlockEl = row;
-        this.inputEl.disabled = true;
-        this.sendBtn.disabled = true;
+        approveRows.push(row);
       }
     });
+    if (mode === "approve" && approveRows.length) {
+      // Register this nested batch as its own approval cycle — the
+      // backend gates each sub-agent batch independently, so buttons
+      // must resolve THIS cycle, not "the" pending one (parallel task
+      // agents can have several nested prompts live at once).
+      this._registerApprovalCycle(cycleId, approveRows, items);
+    }
     this._updateAgentLabel(card);
     this.scrollToBottom(stick);
     return true;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -210,6 +210,11 @@ class Pane {
     // the active (oldest) cycle's card for keyboard/feedback routing.
     this.approvalCycles = new Map();
     this.pendingApproval = false;
+    // Cross-user send gate (another participant's turn is in flight),
+    // recomputed in _reconcileSendBlock. Stored on the App because the
+    // App — not the Composer — owns sendBtn.disabled (see
+    // _reconcileSendDisabled + the composer's externalDisable option).
+    this._crossUserBlocked = false;
     this.approvalBlockEl = null;
     // Early-paint shells from ``tool_pending`` events, keyed by their
     // sorted call_id set, awaiting the authoritative ``tool_info`` /
@@ -273,6 +278,10 @@ class Pane {
     this.announcedBlocks = new Map();
     this._pendingEditSend = null;
     this.inputEl.disabled = false;
+    // setBusy(false) above reconciled sendBtn.disabled while
+    // pendingApproval was still stale-true; re-reconcile now that the
+    // cycle state is cleared so a reset-from-pending re-enables send.
+    this._reconcileSendDisabled();
     this.attachments.clearChips();
     this._stopRecording(true);
     this._stopTTS();
@@ -348,12 +357,33 @@ class Pane {
     }
     const blocked =
       !!this.busy && !!this._actingUserId && !!me && this._actingUserId !== me;
+    this._crossUserBlocked = blocked;
+    // Still drive the Composer's placeholder / title hint — externalDisable
+    // suppresses only its disabled write, not the hint.
     this.composer.setSendBlocked(
       blocked,
       blocked
         ? "Another participant's turn is in progress - wait for it to finish."
         : "",
     );
+    this._reconcileSendDisabled();
+  }
+
+  // Single owner of ``sendBtn.disabled``.  The Composer runs with
+  // ``externalDisable``, so it never writes the flag itself (it still
+  // rotates the Send/Queue label + placeholder + stop button on
+  // ``setBusy``); this combines every disable axis instead, so two
+  // writers can't clobber each other on event ordering.
+  //
+  // ``busy`` is deliberately NOT an axis: this composer is
+  // ``queueWhileBusy``, so a running turn keeps Send clickable as
+  // "Queue".  The old ``pendingApproval || this.busy`` both defeated
+  // that affordance (Send disabled while merely busy) and let
+  // ``composer.setBusy`` — which re-enables in queue mode — race the
+  // approval disable back off when a ``state_change`` fired after the
+  // approve_request card rendered.
+  _reconcileSendDisabled() {
+    this.sendBtn.disabled = this.pendingApproval || this._crossUserBlocked;
   }
 
   showEmptyState() {
@@ -516,7 +546,7 @@ class Pane {
     this.pendingApproval = this.approvalCycles.size > 0;
     this.approvalBlockEl = active ? active.blockEls[0] : null;
     this.inputEl.disabled = this.pendingApproval;
-    this.sendBtn.disabled = this.pendingApproval || this.busy;
+    this._reconcileSendDisabled();
   }
 
   _oldestCycleId() {
@@ -992,6 +1022,12 @@ class Pane {
       },
       stopBtn: true,
       queueWhileBusy: true,
+      // The App owns sendBtn.disabled: it has to combine three axes the
+      // Composer can't see together \u2014 a live approval cycle, the
+      // cross-user send gate, and busy \u2014 so the Composer's own
+      // disabled write (which re-enables in queueWhileBusy mode) would
+      // otherwise race the approval disable back off on event ordering.
+      externalDisable: true,
       busyPlaceholder: "Queue a message\u2026 (!!! for urgent)",
       onSend: () => {
         this.sendMessage();


### PR DESCRIPTION
## Summary

Fixes the two last release blockers for 1.7 stable:

1. **Smart approvals never fired for `task_agent` tool calls** — the sub-agent gate bypassed the intent pipeline entirely: no heuristic verdict on the card, no LLM verdict, no audit row, nothing for Smart Approvals to qualify.
2. **Manual webui approvals broke under parallel task agents** — the approval pipeline was a per-UI singleton (one card, one Event, one result slot) multiplexed by N concurrent gates: one click could resolve every parked batch with the same verdict, a sibling's gate entry could eat a just-fired resolution (the 3600s "stuck dialog" hang), and Approve+Always could whitelist a different batch than the one on screen.

## Architecture

- `SessionUIBase` keeps a registry of `ApprovalCycle` objects keyed by `cycle_id`: per-cycle event/result/decision/verdict parking, oldest-first selector-less resolution, guarded double-resolution, and a `resolve_all_approvals` sweep for cancel/close/worker-recovery. The legacy `_pending_approval` slot survives as a maintained oldest-cycle view for boolean-ish consumers.
- Sub-agent gates run `_evaluate_intent` with the sub-agent's own trajectory as judge context (its task prompt is the delegation contract) as their **own generation** — never touching the main loop's supersede slot; every generation registers so `close()` aborts all in-flight daemons; `judge.cancel_on_approval` fires per gate.
- Verdict bookkeeping is **generation-exact** end to end: the entry purge spares verdicts the batch's own judge already delivered (a fast judge no longer stalls the Smart-Approvals wait to its full budget), registration evicts stale-generation arrivals from the purge-to-register window, recent decisions are generation-tagged (a stale generation's late verdict stamps `superseded` instead of stealing a reused call_id's decision), and Smart-Approvals qualification identity-checks the delivering generation.
- `POST /approve` accepts `cycle_id` / `call_id`, 409s stale selectors with the current cycle's ids, pins selector-less resolutions to the cycle the lookup returned, and applies Approve+Always names only after the pinned cycle actually resolved.
- Channels track prompts by `(ws_id, cycle_id)` with the pre-multi-cycle fallback centralised in `_routing.py`; both frontends render one card per cycle with per-cycle resolution and per-batch verdict glow.

## Breaking (1.7)

`pending_approval_detail` (singular) is removed from dashboard rows, workstream detail, node snapshots, and cluster live blocks — replaced by `pending_approval_details`: a list, one entry per live cycle, each carrying its `cycle_id`. stable/1.6 keeps the old shape.

## Testing

- New concurrency regression matrix: cross-approval independence, lost-wakeup at gate entry, FIFO selector-less resolution, resolve-all sweep, double-resolution no-op, the generation-exactness set (stale delivery, origin check, purge keep, window eviction, late `superseded` stamp), concurrent smart+human gates, sub-agent judge wiring, and endpoint tests for cycle pinning + the Approve+Always race guard.
- Full suite: 8509 passed / 0 failed. mypy clean (229 files), ruff clean, `tsc --noEmit` clean.
- Full TS SDK vitest suite green (30/30) — including 3 formerly-stale `send()` cases that expected the pre-verb-lift `/v1/api/send` shape; corrected to the path-keyed contract (pre-existing on main, folded in).
