### PR TITLE
fix(providers): session effort always reaches the local-lane wire; operator-owned local capabilities

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -824,12 +824,17 @@ the levers live in the chat template, reached through
   `true` — the same contract as the real lane's manual mode. ("Always
   on" / `thinking_mode = "adaptive"` instead always sends `true`: the
   model self-regulates, so the knob never force-disables — mirroring
-  the native adaptive branch.) Templates
-  with a graded effort key (gpt-oss-style) additionally set
-  `effort_param` (e.g. `"reasoning_effort"`), plus optional
-  `reasoning_effort_values` / `default_reasoning_effort` to validate
-  the knob before it reaches the template; without declared values the
-  knob is forwarded as-is. The knob is ordinal, and validation
+  the native adaptive branch.) The graded effort value always rides
+  alongside the toggle: under `effort_param` when the operator names
+  the template's key, else under the conventional fallback key
+  (`reasoning_effort`) on the anthropic-compatible lane — the user's
+  effort setting always reaches the wire, and a template that doesn't
+  reference the kwarg ignores it. On the openai-compatible lane the
+  undeclared-key case rides the flat top-level `reasoning_effort`
+  param instead (the documented compat field), forwarded verbatim.
+  Optional `reasoning_effort_values` / `default_reasoning_effort`
+  validate the knob before it reaches the server; without declared
+  values the knob is forwarded as-is. The knob is ordinal, and validation
   respects that: an off-list knob value rounds UP onto the declared
   list and a value above the ceiling rides the ceiling
   (`snap_reasoning_effort`) — asking for more effort than the model
@@ -858,7 +863,11 @@ the levers live in the chat template, reached through
   toggle unconditionally `true` whenever thinking mode was enabled. A
   stored per-model `reasoning_effort = "none"` now disables thinking
   on such models — pick any real level (or clear the override) to keep
-  it on.
+  it on. Also since 1.7.0a7 the effort level itself always reaches the
+  wire on the local lanes (previously dropped unless
+  `reasoning_effort_values` was declared): flat `reasoning_effort` on
+  openai-compatible, the `effort_param`-or-fallback template key on
+  anthropic-compatible when reasoning control is engaged.
 * **Operator pin (static).** Entries under `{"chat_template_kwargs":
   ...}` in the admin Models extra-body field ride the SDK's
   `extra_body` unconditionally and win over the knob mapping on key

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -634,8 +634,17 @@ function tool (the model always searches). Citations from `url_citation`
 annotations are formatted as footnotes. Extended prompt cache retention
 (`prompt_cache_retention: "24h"`) is enabled for GPT-5.x models at no
 additional cost. Cached token counts are extracted from
-`usage.prompt_tokens_details.cached_tokens`. Unknown models (local servers) get
-permissive defaults with `supports_vision=False` and use SearxNG for web search.
+`usage.prompt_tokens_details.cached_tokens`. Unknown models get permissive
+defaults with `supports_vision=False` and use SearxNG for web search. The
+`openai-compatible` lane never consults this table at all — on either API
+surface (the responses pin is served by a compat-mode
+`OpenAIResponsesProvider`, mirroring `AnthropicProvider(compat=True)`): a
+local server serves whatever the operator named it (vLLM
+`--served-model-name` is a free string), so a prefix collision with a cloud
+model id must not inherit that model's sampling/effort contract — every
+local model gets the plain defaults, and anything beyond them is declared on
+the model definition (capabilities JSON + `server_compat`), matching the
+`anthropic-compatible` lane.
 
 **AnthropicProvider** (`_anthropic.py`): converts OpenAI-format messages to
 Anthropic content blocks, maps `system`/`developer` roles to the `system`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -883,10 +883,17 @@ Only the Responses API surface (native reasoning) ignores it.
 
 The console surfaces this projection as an *effective effort ladder*:
 the admin model form's per-model effort select and the skill
-launch-config effort select annotate knob positions that alias to the
-same wire behavior (e.g. "Max (= high)"), computed server-side by
-`providers/effort_ladder.py` from the same mapping functions the
-providers use at request time and shipped on `/v1/api/models` rows and
+launch-config effort select annotate each position with what the
+request will carry, in plain words — a position whose delivered level
+matches its name stays plain ("Max"), a snapped position says so
+("Low — sends high"), the adaptive lanes' none position warns
+"thinking stays on", and budget detail lives in the tooltip. A
+position is never labeled after a sibling that shares its wire (that
+rendered "Max (= minimal)", implying a downgrade the wire doesn't
+contain). Computed server-side by `providers/effort_ladder.py` from
+the same mapping functions the providers use at request time and
+shipped on `/v1/api/models` rows (every row carries `effort_ladder`,
+empty when the capabilities column fails to parse) and
 `POST /v1/api/admin/models/effort-ladder`. The ladder describes what
 Turnstone sends — a server-side template may alias further (DeepSeek-V4
 folds `low`/`medium` into its default `high` tier).

--- a/tests/data/wire_payloads/anthropic_compat__mid_orphan.json
+++ b/tests/data/wire_payloads/anthropic_compat__mid_orphan.json
@@ -1,0 +1,78 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Weather in Paris and London?",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "id": "call_1",
+          "input": {
+            "city": "Paris"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        },
+        {
+          "id": "call_2",
+          "input": {
+            "city": "London"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "18C, clear.",
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        },
+        {
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+          "is_error": true,
+          "tool_use_id": "call_2",
+          "type": "tool_result"
+        },
+        {
+          "text": "Actually, never mind London.",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/anthropic_compat__multipart.json
+++ b/tests/data/wire_payloads/anthropic_compat__multipart.json
@@ -1,0 +1,33 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "What's in this image?",
+          "type": "text"
+        },
+        {
+          "source": {
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+            "media_type": "image/png",
+            "type": "base64"
+          },
+          "type": "image"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5
+}

--- a/tests/data/wire_payloads/anthropic_compat__native_orphan.json
+++ b/tests/data/wire_payloads/anthropic_compat__native_orphan.json
@@ -1,0 +1,70 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Think about the weather.",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "signature": "sig-abc",
+          "thinking": "The user wants weather.",
+          "type": "thinking"
+        },
+        {
+          "text": "Let me check.",
+          "type": "text"
+        },
+        {
+          "id": "call_1",
+          "input": {
+            "city": "Paris"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+          "is_error": true,
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/anthropic_compat__native_reasoning.json
+++ b/tests/data/wire_payloads/anthropic_compat__native_reasoning.json
@@ -1,0 +1,69 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Think about the weather.",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "signature": "sig-abc",
+          "thinking": "The user wants weather.",
+          "type": "thinking"
+        },
+        {
+          "text": "Let me check.",
+          "type": "text"
+        },
+        {
+          "id": "call_1",
+          "input": {
+            "city": "Paris"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "18C, clear.",
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/anthropic_compat__operator_system.json
+++ b/tests/data/wire_payloads/anthropic_compat__operator_system.json
@@ -1,0 +1,63 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Run the deploy.",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "id": "call_1",
+          "input": {},
+          "name": "deploy",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "deployed",
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        },
+        {
+          "text": "Great, what's next?",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "system": "Output-guard: deploy output looked clean.",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/anthropic_compat__text.json
+++ b/tests/data/wire_payloads/anthropic_compat__text.json
@@ -1,0 +1,33 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Hi there.",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "text": "Hello! How can I help?",
+          "type": "text"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": "What's the weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5
+}

--- a/tests/data/wire_payloads/anthropic_compat__toolcall_complete.json
+++ b/tests/data/wire_payloads/anthropic_compat__toolcall_complete.json
@@ -1,0 +1,69 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "id": "call_1",
+          "input": {
+            "city": "Paris"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "18C, clear.",
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        }
+      ],
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "text": "It's 18C and clear in Paris.",
+          "type": "text"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/anthropic_compat__trailing_orphan.json
+++ b/tests/data/wire_payloads/anthropic_compat__trailing_orphan.json
@@ -1,0 +1,61 @@
+{
+  "cache_control": {
+    "type": "ephemeral"
+  },
+  "extra_body": {
+    "chat_template_kwargs": {
+      "enable_thinking": true,
+      "reasoning_effort": "high"
+    }
+  },
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    },
+    {
+      "content": [
+        {
+          "id": "call_1",
+          "input": {
+            "city": "Paris"
+          },
+          "name": "get_weather",
+          "type": "tool_use"
+        }
+      ],
+      "role": "assistant"
+    },
+    {
+      "content": [
+        {
+          "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+          "is_error": true,
+          "tool_use_id": "call_1",
+          "type": "tool_result"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "qwen3.6-27b",
+  "temperature": 0.5,
+  "tools": [
+    {
+      "description": "Look up the weather for a city.",
+      "input_schema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      },
+      "name": "get_weather"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/google__mid_orphan.json
+++ b/tests/data/wire_payloads/google__mid_orphan.json
@@ -33,7 +33,7 @@
       "tool_call_id": "call_1"
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_2"
     },

--- a/tests/data/wire_payloads/google__native_orphan.json
+++ b/tests/data/wire_payloads/google__native_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/google__trailing_orphan.json
+++ b/tests/data/wire_payloads/google__trailing_orphan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "content": "Tool execution was cancelled. Outcome UNKNOWN \u2014 this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
+      "content": "Tool execution was cancelled. Outcome UNKNOWN — this call may have begun executing before the generation was stopped; do not assume it did not run, and reconcile before re-issuing it.",
       "role": "tool",
       "tool_call_id": "call_1"
     }

--- a/tests/data/wire_payloads/openai_chat__mid_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__mid_orphan.json
@@ -43,6 +43,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__multipart.json
+++ b/tests/data/wire_payloads/openai_chat__multipart.json
@@ -18,6 +18,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__native_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__native_orphan.json
@@ -26,6 +26,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__native_reasoning.json
+++ b/tests/data/wire_payloads/openai_chat__native_reasoning.json
@@ -26,6 +26,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__operator_system.json
+++ b/tests/data/wire_payloads/openai_chat__operator_system.json
@@ -34,6 +34,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__text.json
+++ b/tests/data/wire_payloads/openai_chat__text.json
@@ -15,6 +15,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__toolcall_complete.json
+++ b/tests/data/wire_payloads/openai_chat__toolcall_complete.json
@@ -30,6 +30,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/data/wire_payloads/openai_chat__trailing_orphan.json
+++ b/tests/data/wire_payloads/openai_chat__trailing_orphan.json
@@ -26,6 +26,7 @@
     }
   ],
   "model": "gpt-4o-mini",
+  "reasoning_effort": "medium",
   "stream": true,
   "stream_options": {
     "include_usage": true

--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -372,6 +372,30 @@ def test_effort_ladder_parses_string_capabilities(storage: SQLiteBackend) -> Non
     assert ladder["max"] == "on"
 
 
+def test_effort_ladder_key_survives_malformed_capabilities(
+    storage: SQLiteBackend,
+) -> None:
+    """A capabilities column that fails to parse must not drop the key —
+    every row carries ``effort_ladder`` (empty on failure) so clients can
+    index it unconditionally instead of null-checking per row."""
+    storage.create_model_definition(
+        definition_id="m1",
+        alias="broken",
+        model="model-x",
+        provider="openai-compatible",
+        base_url="http://localhost:8000/v1",
+        api_key="dummy",
+        context_window=131072,
+        capabilities="{not valid json",
+        enabled=True,
+        created_by="admin",
+    )
+    body = _get_models(_make_client(storage))
+    entry = body["models"][0]
+    assert set(entry) == {"alias", "model", "provider", "effort_ladder"}
+    assert entry["effort_ladder"] == []
+
+
 def test_effort_ladder_honors_responses_api_surface(storage: SQLiteBackend) -> None:
     """server_compat.api_surface (namespaced inside the capabilities JSON)
     switches the projection to the flat-param path — no template toggle."""

--- a/tests/test_console_available_models.py
+++ b/tests/test_console_available_models.py
@@ -368,8 +368,8 @@ def test_effort_ladder_parses_string_capabilities(storage: SQLiteBackend) -> Non
     body = _get_models(_make_client(storage))
     ladder = {r["value"]: r["effective"] for r in body["models"][0]["effort_ladder"]}
     assert ladder["none"] == "off"
-    assert ladder["medium"] == "on"
-    assert ladder["max"] == "on"
+    assert ladder["medium"] == "on+medium"
+    assert ladder["max"] == "on+max"
 
 
 def test_effort_ladder_key_survives_malformed_capabilities(

--- a/tests/test_console_effort_ladder.py
+++ b/tests/test_console_effort_ladder.py
@@ -44,7 +44,7 @@ def test_valid_request_returns_ladder() -> None:
     assert resp.status_code == 200, resp.text
     ladder = {r["value"]: r["effective"] for r in resp.json()["ladder"]}
     assert ladder["none"] == "off"
-    assert ladder["high"] == "on"
+    assert ladder["high"] == "on+high"
 
 
 def test_api_surface_switches_projection() -> None:

--- a/tests/test_effort_ladder.py
+++ b/tests/test_effort_ladder.py
@@ -21,12 +21,17 @@ def _as_map(ladder: list[dict[str, str]]) -> dict[str, str]:
 
 
 class TestLocalLanes:
-    def test_qwen_style_toggle_only_two_groups(self) -> None:
-        """Toggle-only model: none=off, everything else one 'on' group."""
+    def test_toggle_engaged_carries_graded_value_per_position(self) -> None:
+        """No declared effort key: the toggle rides the knob AND the graded
+        value is forwarded under the fallback template key — the user's
+        effort setting always reaches the wire (a template that doesn't
+        reference the kwarg ignores it), so every position is distinct."""
         caps = ModelCapabilities(thinking_mode="manual", thinking_param="enable_thinking")
         eff = _as_map(effort_ladder("anthropic-compatible", caps))
         assert eff["none"] == "off"
-        assert {eff[k] for k in KNOB_VALUES if k != "none"} == {"on"}
+        assert eff["minimal"] == "on+minimal"
+        assert eff["max"] == "on+max"
+        assert len({eff[k] for k in KNOB_VALUES}) == len(KNOB_VALUES)
 
     def test_freeform_effort_param_forwards_each_value(self) -> None:
         """deepseek-style config: toggle + verbatim effort per position."""

--- a/tests/test_effort_ladder_wire_parity.py
+++ b/tests/test_effort_ladder_wire_parity.py
@@ -37,7 +37,10 @@ import pytest
 
 from tests._wire_capture import RecordingClient
 from turnstone.core.providers import create_provider
-from turnstone.core.providers._protocol import ModelCapabilities
+from turnstone.core.providers._protocol import (
+    EFFORT_TEMPLATE_FALLBACK_PARAM,
+    ModelCapabilities,
+)
 from turnstone.core.providers.effort_ladder import KNOB_VALUES, effort_ladder
 
 # Above the largest manual-mode thinking budget (max: 65536) so the
@@ -271,14 +274,21 @@ def _wire_payload(shape: Shape, knob: str) -> dict[str, Any]:
     return dict(client.captured["payload"])
 
 
-def _effort_wire_subset(payload: dict[str, Any], caps: ModelCapabilities) -> dict[str, Any]:
+def _effort_wire_subset(payload: dict[str, Any], shape: Shape) -> dict[str, Any]:
     """Every effort-related lever in *payload*, normalized across lanes.
 
     Keys: ``thinking`` (native Anthropic param), ``output_effort``
     (Anthropic ``output_config.effort``), ``flat`` (Chat Completions
     ``reasoning_effort`` / Responses ``reasoning.effort``), ``toggle``
-    and ``template_effort`` (``extra_body.chat_template_kwargs``).
+    and ``template_effort`` (``extra_body.chat_template_kwargs`` — the
+    graded key is ``caps.effort_param``, else the fallback template key
+    on the anthropic-compatible lane, whose only effort channel is the
+    template).
     """
+    caps = shape.caps
+    effort_key = caps.effort_param or (
+        EFFORT_TEMPLATE_FALLBACK_PARAM if shape.provider == "anthropic-compatible" else ""
+    )
     subset: dict[str, Any] = {}
     if "thinking" in payload:
         subset["thinking"] = payload["thinking"]
@@ -293,13 +303,13 @@ def _effort_wire_subset(payload: dict[str, Any], caps: ModelCapabilities) -> dic
     extra_body = payload.get("extra_body")
     ctk = extra_body.get("chat_template_kwargs") if isinstance(extra_body, dict) else None
     if isinstance(ctk, dict):
-        known = {caps.thinking_param, caps.effort_param} - {""}
+        known = {caps.thinking_param, effort_key} - {""}
         unexpected = set(ctk) - known
         assert not unexpected, f"unexpected chat_template_kwargs keys: {unexpected}"
         if caps.thinking_param in ctk:
             subset["toggle"] = ctk[caps.thinking_param]
-        if caps.effort_param and caps.effort_param in ctk:
-            subset["template_effort"] = ctk[caps.effort_param]
+        if effort_key and effort_key in ctk:
+            subset["template_effort"] = ctk[effort_key]
     return subset
 
 
@@ -350,12 +360,12 @@ def _decode_template(provider: str, caps: ModelCapabilities, token: str) -> dict
         parts = parts[1:]
     if parts:
         assert len(parts) == 1, f"unparseable ladder token: {token!r}"
-        if caps.effort_param:
+        if caps.effort_param or provider == "anthropic-compatible":
+            # Declared graded key, or the anthropic-compatible fallback
+            # template key — that lane has no flat channel, so a graded
+            # part there is always template-borne.
             expected["template_effort"] = parts[0]
         else:
-            # The anthropic-compatible lane has no flat channel, so a
-            # bare effort part there could only be the template key.
-            assert provider != "anthropic-compatible", token
             expected["flat"] = parts[0]
     return expected
 
@@ -372,7 +382,7 @@ def test_ladder_tokens_match_wire(shape: Shape) -> None:
     assert [row["value"] for row in ladder] == list(KNOB_VALUES)
     for row in ladder:
         knob, token = row["value"], row["effective"]
-        observed = _effort_wire_subset(_wire_payload(shape, knob), shape.caps)
+        observed = _effort_wire_subset(_wire_payload(shape, knob), shape)
         expected = _decode_token(shape, token)
         assert observed == expected, (
             f"{shape.id}/knob={knob}: ladder says {token!r} which decodes to "
@@ -387,9 +397,7 @@ def test_equal_tokens_iff_equal_wire(shape: Shape) -> None:
         row["value"]: row["effective"]
         for row in effort_ladder(shape.provider, shape.caps, shape.api_surface)
     }
-    subsets = {
-        knob: _effort_wire_subset(_wire_payload(shape, knob), shape.caps) for knob in KNOB_VALUES
-    }
+    subsets = {knob: _effort_wire_subset(_wire_payload(shape, knob), shape) for knob in KNOB_VALUES}
     for a, b in itertools.combinations(KNOB_VALUES, 2):
         same_token = tokens[a] == tokens[b]
         same_wire = subsets[a] == subsets[b]

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -217,27 +217,39 @@ class TestCompatReasoningControl:
         return client.messages.stream.call_args[1]
 
     def test_manual_toggle_on(self) -> None:
-        """Any non-none effort turns the template toggle on; wire stays clean."""
+        """Any non-none effort turns the toggle on AND carries the graded
+        value under the fallback key — the user's effort setting always
+        reaches the wire; a template that doesn't reference the kwarg
+        ignores it."""
         kwargs = self._stream_kwargs(self._MANUAL_CAPS, "medium")
-        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "medium"}
+        }
         assert "thinking" not in kwargs
         assert kwargs["temperature"] == 0.6  # never forced to 1.0 on compat
 
     @pytest.mark.parametrize("knob", ["none", ""])
     def test_manual_toggle_off(self, knob: str) -> None:
-        """Effort "none"/empty disables thinking — native manual-mode parity."""
+        """Effort "none"/empty disables thinking — native manual-mode parity;
+        no effort key rides when thinking is off."""
         kwargs = self._stream_kwargs(self._MANUAL_CAPS, knob)
         assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
         assert "thinking" not in kwargs
 
     def test_adaptive_always_on(self) -> None:
-        """Adaptive never knob-disables — native-adaptive contract, no native dict."""
+        """Adaptive never knob-disables — native-adaptive contract, no native
+        dict; the graded value rides for on-positions only."""
         caps = dataclasses.replace(self._MANUAL_CAPS, thinking_mode="adaptive")
-        for knob in ("high", "none"):
-            kwargs = self._stream_kwargs(caps, knob)
-            assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
-            assert "thinking" not in kwargs
-            assert kwargs["temperature"] == 0.6
+        kwargs = self._stream_kwargs(caps, "high")
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "high"}
+        }
+        assert "thinking" not in kwargs
+        assert kwargs["temperature"] == 0.6
+        kwargs = self._stream_kwargs(caps, "none")
+        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert "thinking" not in kwargs
+        assert kwargs["temperature"] == 0.6
 
     def test_default_caps_inject_nothing(self) -> None:
         """Untouched compat defaults (thinking_mode=none) keep today's wire."""
@@ -305,7 +317,9 @@ class TestCompatReasoningControl:
         )
         kwargs = self._stream_kwargs(caps, "high")
         assert "output_config" not in kwargs
-        assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": "high"}
+        }
 
     def test_create_completion_same_injection(self) -> None:
         """The non-streaming path shares _build_thinking_and_kwargs."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2095,13 +2095,19 @@ class TestOpenAIParameterGating:
     def setup_method(self) -> None:
         self.provider = OpenAIProvider()
 
-    def test_unknown_model_no_reasoning_effort(self) -> None:
-        """Unknown/local models should NOT receive top-level reasoning_effort."""
+    def test_local_model_effort_forwarded_verbatim(self) -> None:
+        """Local-lane models receive the session knob verbatim on the flat
+        param (effort_passthrough) — the user's effort setting always
+        reaches the wire; "none" stays omitted (nothing to disable
+        beyond the template toggle)."""
         caps = self.provider.get_capabilities("my-local-model")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
-        assert "reasoning_effort" not in kwargs
+        assert kwargs["reasoning_effort"] == "medium"
         assert kwargs["temperature"] == 0.7
+        kwargs = {}
+        apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
+        assert "reasoning_effort" not in kwargs
 
     def test_gpt5_no_temperature_has_reasoning_effort(self) -> None:
         """GPT-5 base: no temperature, reasoning_effort sent."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -12,10 +12,12 @@ from turnstone.core.lowering import repair_wire_messages
 from turnstone.core.providers._openai import OpenAIProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_common import (
+    OPENAI_COMPAT_DEFAULT,
     apply_cache_retention,
     apply_temperature_and_effort,
     apply_tool_search,
     format_citations,
+    lookup_openai_capabilities,
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
@@ -1671,6 +1673,25 @@ class TestProviderFactory:
         assert openai_prov.provider_name == "openai"
         assert compat.provider_name == "openai-compatible"
 
+    def test_openai_compatible_never_consults_commercial_registry(self) -> None:
+        """Local-lane model ids are operator-chosen strings — a prefix
+        collision with a cloud model id must not inherit that model's
+        sampling/effort contract, on either API surface.  Cloud lookups
+        are unaffected."""
+        from turnstone.core.providers import create_provider
+
+        compat = create_provider("openai-compatible")
+        compat_responses = create_provider("openai-compatible", api_surface="responses")
+        for name in ("gpt-5.5-my-finetune", "o3-distill", "deepseek-v4-flash", ""):
+            assert compat.get_capabilities(name) is OPENAI_COMPAT_DEFAULT
+            assert compat_responses.get_capabilities(name) is OPENAI_COMPAT_DEFAULT
+        # The commercial lane keeps resolving its registry rows — through
+        # the factory AND through the non-compat class default.
+        cloud = create_provider("openai").get_capabilities("gpt-5.5")
+        assert cloud.default_reasoning_effort == "medium"
+        assert "xhigh" in cloud.reasoning_effort_values
+        assert create_provider("openai") is not compat_responses
+
     def test_create_provider_returns_singleton(self) -> None:
         from turnstone.core.providers import create_provider
 
@@ -2084,7 +2105,7 @@ class TestOpenAIParameterGating:
 
     def test_gpt5_no_temperature_has_reasoning_effort(self) -> None:
         """GPT-5 base: no temperature, reasoning_effort sent."""
-        caps = self.provider.get_capabilities("gpt-5")
+        caps = lookup_openai_capabilities("gpt-5")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="high")
         assert "temperature" not in kwargs
@@ -2093,7 +2114,7 @@ class TestOpenAIParameterGating:
     def test_gpt51_temperature_when_effort_none(self) -> None:
         """GPT-5.1: temperature only when reasoning_effort='none'; the
         declared "none" level is forwarded explicitly (knob = off)."""
-        caps = self.provider.get_capabilities("gpt-5.1")
+        caps = lookup_openai_capabilities("gpt-5.1")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
         assert kwargs["temperature"] == 0.7
@@ -2101,7 +2122,7 @@ class TestOpenAIParameterGating:
 
     def test_gpt51_no_temperature_when_reasoning_active(self) -> None:
         """GPT-5.1: no temperature when reasoning is active."""
-        caps = self.provider.get_capabilities("gpt-5.1")
+        caps = lookup_openai_capabilities("gpt-5.1")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="high")
         assert "temperature" not in kwargs
@@ -2110,7 +2131,7 @@ class TestOpenAIParameterGating:
     def test_o_series_no_temperature_but_effort_forwarded(self) -> None:
         """O-series: no temperature; low/medium/high ARE valid effort
         values (all o-series except o1-mini) and the knob reaches them."""
-        caps = self.provider.get_capabilities("o3")
+        caps = lookup_openai_capabilities("o3")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
         assert "temperature" not in kwargs
@@ -2118,14 +2139,14 @@ class TestOpenAIParameterGating:
 
     def test_o1_mini_has_no_effort_control(self) -> None:
         """o1-mini is the one o-series model without reasoning_effort."""
-        caps = self.provider.get_capabilities("o1-mini")
+        caps = lookup_openai_capabilities("o1-mini")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
         assert "reasoning_effort" not in kwargs
 
     def test_gpt5_pro_unsupported_effort_falls_back(self) -> None:
         """GPT-5 pro only supports 'high'; unsupported values fall back to default."""
-        caps = self.provider.get_capabilities("gpt-5-pro")
+        caps = lookup_openai_capabilities("gpt-5-pro")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="medium")
         assert "temperature" not in kwargs
@@ -2133,14 +2154,14 @@ class TestOpenAIParameterGating:
 
     def test_gpt5_pro_supported_effort_passes_through(self) -> None:
         """GPT-5 pro accepts 'high' directly."""
-        caps = self.provider.get_capabilities("gpt-5-pro")
+        caps = lookup_openai_capabilities("gpt-5-pro")
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="high")
         assert kwargs["reasoning_effort"] == "high"
 
     def test_gpt54_1m_context_and_effort(self) -> None:
         """GPT-5.4: 1M context, temperature when effort=none, xhigh supported."""
-        caps = self.provider.get_capabilities("gpt-5.4")
+        caps = lookup_openai_capabilities("gpt-5.4")
         assert caps.context_window == 1050000
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="none")
@@ -2153,7 +2174,7 @@ class TestOpenAIParameterGating:
 
     def test_gpt54_pro_no_temperature_always_reasoning(self) -> None:
         """GPT-5.4 pro: no temperature, medium/high/xhigh only."""
-        caps = self.provider.get_capabilities("gpt-5.4-pro")
+        caps = lookup_openai_capabilities("gpt-5.4-pro")
         assert caps.context_window == 1050000
         kwargs: dict[str, Any] = {}
         apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="low")
@@ -2162,7 +2183,7 @@ class TestOpenAIParameterGating:
 
     def test_gpt55_1m_context_and_effort(self) -> None:
         """GPT-5.5: 1M context, temperature when effort=none, xhigh supported."""
-        caps = self.provider.get_capabilities("gpt-5.5")
+        caps = lookup_openai_capabilities("gpt-5.5")
         assert caps.context_window == 1050000
         assert caps.supports_tool_search is True
         assert caps.supports_vision is True
@@ -2177,7 +2198,7 @@ class TestOpenAIParameterGating:
 
     def test_gpt55_pro_no_temperature_always_reasoning(self) -> None:
         """GPT-5.5 pro: no temperature, medium/high/xhigh only."""
-        caps = self.provider.get_capabilities("gpt-5.5-pro")
+        caps = lookup_openai_capabilities("gpt-5.5-pro")
         assert caps.context_window == 1050000
         assert caps.supports_tool_search is True
         kwargs: dict[str, Any] = {}
@@ -2793,19 +2814,19 @@ class TestOpenAIWebSearch:
 
     def test_search_model_capability(self) -> None:
         """Search models should have supports_web_search=True."""
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         assert caps.supports_web_search is True
 
     def test_non_search_model_no_web_search(self) -> None:
         """Regular models should not have supports_web_search."""
-        caps = self.provider.get_capabilities("gpt-5")
+        caps = lookup_openai_capabilities("gpt-5")
         assert caps.supports_web_search is False
-        caps = self.provider.get_capabilities("gpt-5.2")
+        caps = lookup_openai_capabilities("gpt-5.2")
         assert caps.supports_web_search is False
 
     def test_apply_web_search_injects_options(self) -> None:
         """For search models, web_search_options should be added to kwargs."""
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         kwargs: dict[str, Any] = {"model": "gpt-5-search-api"}
         tools: list[dict[str, Any]] = [
             {"type": "function", "function": {"name": "bash", "description": "Run bash"}},
@@ -2822,7 +2843,7 @@ class TestOpenAIWebSearch:
 
     def test_apply_web_search_no_op_for_regular_models(self) -> None:
         """For non-search models, no web_search_options, tools unchanged."""
-        caps = self.provider.get_capabilities("gpt-5")
+        caps = lookup_openai_capabilities("gpt-5")
         kwargs: dict[str, Any] = {"model": "gpt-5"}
         tools: list[dict[str, Any]] = [
             {"type": "function", "function": {"name": "web_search", "description": "Search"}},
@@ -2833,7 +2854,7 @@ class TestOpenAIWebSearch:
 
     def test_apply_web_search_returns_none_when_only_web_search(self) -> None:
         """If web_search was the only tool, return None after removing it."""
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         kwargs: dict[str, Any] = {}
         tools: list[dict[str, Any]] = [
             {"type": "function", "function": {"name": "web_search", "description": "Search"}},
@@ -2847,7 +2868,7 @@ class TestOpenAIWebSearch:
         toolset) must NOT gain native search — the option stays off and the
         tools pass through untouched.  Contrast test_apply_web_search_with_
         no_tools, which covers the tool-less utility-call case."""
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         assert caps.supports_web_search is True
         kwargs: dict[str, Any] = {"model": "gpt-5-search-api"}
         tools: list[dict[str, Any]] = [
@@ -2922,7 +2943,7 @@ class TestOpenAIWebSearch:
         visibility set, coordinator toolset, or a tool-less utility call —
         must not gain native search at the provider layer.
         """
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         kwargs: dict[str, Any] = {}
         result = self.provider._apply_web_search(kwargs, caps, None)
         assert "web_search_options" not in kwargs
@@ -2930,7 +2951,7 @@ class TestOpenAIWebSearch:
 
     def test_apply_web_search_replaces_client_def(self) -> None:
         """With the client def present, it is filtered and the option set."""
-        caps = self.provider.get_capabilities("gpt-5-search-api")
+        caps = lookup_openai_capabilities("gpt-5-search-api")
         kwargs: dict[str, Any] = {}
         tools = [{"type": "function", "function": {"name": "web_search"}}]
         result = self.provider._apply_web_search(kwargs, caps, tools)
@@ -2956,6 +2977,10 @@ class TestOpenAIWebSearch:
                         "function": {"name": "web_search", "description": "Search"},
                     },
                 ],
+                # The local lane resolves no commercial rows — the search
+                # model's capabilities ride in explicitly, as the session
+                # layer would pass them.
+                capabilities=lookup_openai_capabilities("gpt-5-search-api"),
             )
         )
         call_kwargs = client.chat.completions.create.call_args[1]
@@ -3376,22 +3401,18 @@ class TestAnthropicToolSearch:
 
 
 class TestOpenAIToolSearch:
-    """Test OpenAI provider tool search injection."""
+    """Test OpenAI tool search injection (registry rows + shared helper)."""
 
-    @pytest.fixture()
-    def provider(self):
-        return OpenAIProvider()
-
-    def test_tool_search_capability_on_gpt54(self, provider):
-        caps = provider.get_capabilities("gpt-5.4")
+    def test_tool_search_capability_on_gpt54(self):
+        caps = lookup_openai_capabilities("gpt-5.4")
         assert caps.supports_tool_search is True
 
-    def test_tool_search_not_supported_on_gpt5(self, provider):
-        caps = provider.get_capabilities("gpt-5")
+    def test_tool_search_not_supported_on_gpt5(self):
+        caps = lookup_openai_capabilities("gpt-5")
         assert caps.supports_tool_search is False
 
-    def test_apply_tool_search_marks_deferred(self, provider):
-        caps = provider.get_capabilities("gpt-5.4")
+    def test_apply_tool_search_marks_deferred(self):
+        caps = lookup_openai_capabilities("gpt-5.4")
         tools = [
             {"type": "function", "function": {"name": "bash", "description": "Run commands"}},
             {
@@ -3407,16 +3428,16 @@ class TestOpenAIToolSearch:
         # slack tool deferred
         assert result[1]["defer_loading"] is True
 
-    def test_apply_tool_search_no_op_without_deferred(self, provider):
-        caps = provider.get_capabilities("gpt-5.4")
+    def test_apply_tool_search_no_op_without_deferred(self):
+        caps = lookup_openai_capabilities("gpt-5.4")
         tools = [
             {"type": "function", "function": {"name": "bash", "description": "Run commands"}},
         ]
         result = apply_tool_search(caps, tools, None)
         assert result == tools
 
-    def test_apply_tool_search_no_op_on_unsupported_model(self, provider):
-        caps = provider.get_capabilities("gpt-5")
+    def test_apply_tool_search_no_op_on_unsupported_model(self):
+        caps = lookup_openai_capabilities("gpt-5")
         tools = [
             {"type": "function", "function": {"name": "bash", "description": "Run commands"}},
         ]
@@ -3484,13 +3505,12 @@ class TestVisionCapabilities:
         assert caps.supports_vision is False
 
     def test_openai_commercial_supports_vision(self) -> None:
-        provider = OpenAIProvider()
         for model in ("gpt-5", "gpt-5-mini", "gpt-5.4", "o3", "o4-mini"):
-            caps = provider.get_capabilities(model)
+            caps = lookup_openai_capabilities(model)
             assert caps.supports_vision is True, f"{model} should support vision"
 
     def test_openai_default_no_vision(self) -> None:
-        """Unknown models (local servers) default to no vision."""
+        """Local-lane models (any name) default to no vision."""
         provider = OpenAIProvider()
         caps = provider.get_capabilities("some-local-model")
         assert caps.supports_vision is False

--- a/tests/test_wire_payload_golden.py
+++ b/tests/test_wire_payload_golden.py
@@ -36,6 +36,7 @@ from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._google import GoogleProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.providers._protocol import ModelCapabilities
 
 if TYPE_CHECKING:
     from turnstone.core.providers._protocol import LLMProvider
@@ -45,11 +46,21 @@ _UPDATE = os.environ.get("UPDATE_WIRE_GOLDENS") == "1"
 
 
 def _capture(
-    provider: LLMProvider, *, model: str, messages: list[dict[str, Any]], **opts: Any
+    provider: LLMProvider,
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    caps: ModelCapabilities | None = None,
+    **opts: Any,
 ) -> dict[str, Any]:
-    """Drive ``create_streaming`` against a recording client; return the SDK kwargs."""
+    """Drive ``create_streaming`` against a recording client; return the SDK kwargs.
+
+    *caps* overrides the provider's own capability lookup — required for the
+    anthropic-compatible lane, which has no static table (an operator-run model
+    definition supplies its capabilities).
+    """
     client = RecordingClient()
-    caps = provider.get_capabilities(model)
+    caps = caps or provider.get_capabilities(model)
     # Mirror the session's wire prep: orphan repair runs once on the canonical
     # Turns (``ChatSession._prepare_wire_messages``), then the result is lowered
     # to the dict projection the translator consumes.  Fixtures arrive
@@ -264,3 +275,36 @@ def test_wire_payload(
     provider = factory()
     payload = _capture(provider, model=model, messages=[dict(m) for m in messages], **opts)
     _assert_golden(f"{provider_id}__{fixture_id}", payload)
+
+
+# The anthropic-compatible lane (vLLM /v1/messages) has no static capability
+# table and carries reasoning control in ``extra_body.chat_template_kwargs``
+# rather than the native ``thinking`` param — a wire shape the matrix above
+# never exercises (both AnthropicProvider rows are the native lane). Freeze it
+# with the capabilities a manual-mode model definition supplies and a real
+# effort level, so the graded ``reasoning_effort`` key is pinned in the golden
+# (never the native ``thinking`` param, and no forced ``temperature=1.0``).
+_COMPAT_CAPS = ModelCapabilities(
+    context_window=262144,
+    max_output_tokens=64000,
+    token_param="max_tokens",
+    thinking_mode="manual",
+    thinking_param="enable_thinking",
+    supports_reasoning_replay=True,
+)
+
+
+@pytest.mark.parametrize("fixture_id", sorted(_FIXTURES))
+def test_wire_payload_anthropic_compat(fixture_id: str) -> None:
+    messages, opts = _FIXTURES[fixture_id]
+    provider = AnthropicProvider(compat=True)
+    payload = _capture(
+        provider,
+        model="qwen3.6-27b",
+        messages=[dict(m) for m in messages],
+        caps=_COMPAT_CAPS,
+        reasoning_effort="high",
+        **opts,
+    )
+    assert "thinking" not in payload, "compat lane must never send the native thinking param"
+    _assert_golden(f"anthropic_compat__{fixture_id}", payload)

--- a/tests/test_wire_payload_golden.py
+++ b/tests/test_wire_payload_golden.py
@@ -85,7 +85,10 @@ def _assert_golden(name: str, payload: dict[str, Any]) -> None:
     norm = _normalize(payload)
     if _UPDATE:
         GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(norm, indent=2, sort_keys=True) + "\n")
+        # ensure_ascii=False keeps non-ASCII (em dashes in repair
+        # messages) literal, matching the existing baselines — a regen
+        # must not churn unrelated lines into \uXXXX escapes.
+        path.write_text(json.dumps(norm, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
         return
     assert path.exists(), f"missing golden {name!r}; run UPDATE_WIRE_GOLDENS=1 to baseline"
     assert norm == json.loads(path.read_text()), f"wire-payload drift for {name!r}"

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1914,10 +1914,14 @@ async def list_available_models(request: Request) -> JSONResponse:
 
     models = []
     for r in rows:
+        # ``effort_ladder`` starts as the empty list so the row schema is
+        # stable even when the try block below bails on a malformed
+        # capabilities column — clients can index the key unconditionally.
         entry: dict[str, Any] = {
             "alias": r["alias"],
             "model": r["model"],
             "provider": r["provider"],
+            "effort_ladder": [],
         }
         try:
             # ``capabilities`` is a JSON string (sa.Text column) with

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -7671,10 +7671,17 @@ function _annotateEffortSelect(sel, ladder) {
       if (eff === "default") {
         label += " — model default";
       } else if (eff === "on") {
-        // Bare toggle-on without a graded value: only the adaptive
-        // lanes' none position produces this — the knob cannot
-        // disable an adaptive model's thinking.
+        // Local adaptive lane, none position: we send only the thinking
+        // toggle (no effort grade exists), so the knob can't turn
+        // thinking off — that is the whole story here.
         label += " — thinking stays on";
+      } else if (eff === "adaptive") {
+        // Native Anthropic adaptive: thinking is ALWAYS on and an effort
+        // level rides output_config on every graded position, so
+        // "thinking stays on" is true everywhere and not what sets the
+        // none position apart.  What "none" uniquely means is that no
+        // effort is pinned — the model self-regulates it.
+        label += " — model sets effort";
       } else if (eff !== "off") {
         // "off" needs no echo on the none position.  Otherwise strip
         // the toggle prefix and budget qualifier ("on+high" → "high",

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6905,7 +6905,10 @@ function showCreateModelModal() {
   document.getElementById("model-thinking-param").value = "";
   document.getElementById("model-thinking-param-row").hidden = true;
   document.getElementById("model-effort-param").value = "";
-  _annotateEffortSelect(document.getElementById("model-reasoning-effort"), null);
+  _annotateEffortSelect(
+    document.getElementById("model-reasoning-effort"),
+    null,
+  );
   document.getElementById("model-extra-body").value = "";
   document.getElementById("model-capabilities").value = "";
   // Clear validation error styling from prior submit attempts
@@ -6988,7 +6991,8 @@ function showEditModelModal(definitionId) {
       // effort-knob → chat_template_kwargs mapping
       // (merge_reasoning_template_kwargs).
       const tmVal = capsObj.thinking_mode || "";
-      const tmCaptured = tmVal === "" || tmVal === "manual" || tmVal === "adaptive";
+      const tmCaptured =
+        tmVal === "" || tmVal === "manual" || tmVal === "adaptive";
       if (tmCaptured) {
         document.getElementById("model-thinking-mode").value = tmVal;
         document.getElementById("model-thinking-param").value =
@@ -7639,24 +7643,22 @@ function _onModelFieldChange() {
   _scheduleEffortLadder();
 }
 
-/* Effort-ladder annotation: label knob positions that alias to the same
-   wire behavior for a given model, from the server-computed projection
+/* Effort-ladder annotation: each knob position states, in plain words,
+   what the request will carry — from the server-computed projection
    (providers/effort_ladder.py — equal "effective" tokens ⇒ identical
-   requests).  Defined here and shared as a page global with
-   governance.js (skill launch config), which loads after this file. */
+   requests).  A position whose delivered level matches its name stays
+   plain ("Max"); a snapped position says so ("Low — sends high"); the
+   adaptive none position warns "thinking stays on"; budget detail
+   lives in the tooltip.  Never label a position after a sibling that
+   shares its token — that rendered "Max (= minimal)", implying a
+   downgrade the wire doesn't contain.  Defined here and shared as a
+   page global with governance.js (skill launch config), which loads
+   after this file. */
 function _annotateEffortSelect(sel, ladder) {
   if (!sel) return;
   const byVal = {};
   (ladder || []).forEach(function (row) {
     byVal[row.value] = row.effective;
-  });
-  // First selectable position per effective token — restricted to the
-  // options THIS select offers, so an alias label never points at a
-  // position the user cannot pick (the skill shelf omits none/minimal).
-  const firstOf = {};
-  Array.from(sel.options).forEach(function (opt) {
-    const eff = byVal[opt.value];
-    if (eff !== undefined && !(eff in firstOf)) firstOf[eff] = opt.value;
   });
   Array.from(sel.options).forEach(function (opt) {
     if (!opt.value) return; // "" = inherit-the-default option
@@ -7665,13 +7667,22 @@ function _annotateEffortSelect(sel, ladder) {
     let title = "";
     const eff = byVal[opt.value];
     if (eff !== undefined) {
-      const first = firstOf[eff];
-      if (first !== opt.value) {
-        label += " (= " + first + ")";
-      } else if (eff === "default") {
-        label += " (model default)";
-      }
       title = "sends: " + eff;
+      if (eff === "default") {
+        label += " — model default";
+      } else if (eff === "on") {
+        // Bare toggle-on without a graded value: only the adaptive
+        // lanes' none position produces this — the knob cannot
+        // disable an adaptive model's thinking.
+        label += " — thinking stays on";
+      } else if (eff !== "off") {
+        // "off" needs no echo on the none position.  Otherwise strip
+        // the toggle prefix and budget qualifier ("on+high" → "high",
+        // "high·budget:16384" → "high", bare "budget:4096" → "" = no
+        // suffix); the tooltip keeps the full token.
+        const wire = eff.replace(/^on\+/, "").replace(/(^|·)budget:\d+$/, "");
+        if (wire && wire !== opt.value) label += " — sends " + wire;
+      }
     }
     opt.textContent = label;
     opt.title = title;

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1802,7 +1802,7 @@
                     type="text"
                     id="model-effort-param"
                     class="sh-mono"
-                    placeholder="e.g. reasoning_effort (gpt-oss)"
+                    placeholder="reasoning_effort / reasoning"
                   />
                 </div>
                 <label for="model-extra-body"

--- a/turnstone/core/providers/__init__.py
+++ b/turnstone/core/providers/__init__.py
@@ -35,15 +35,18 @@ __all__ = [
     "lookup_model_capabilities",
 ]
 
-# Singleton instances (stateless, safe to share).  ``_openai_provider``
-# is reused for both cloud OpenAI and ``openai-compatible`` with
-# ``api_surface="responses"`` — see the ``create_provider`` docstring.
+# Singleton instances (stateless, safe to share).
+# ``_openai_compat_responses_provider`` serves ``openai-compatible``
+# pinned to ``api_surface="responses"``: same request shape as cloud
+# OpenAI, but compat mode skips the commercial capability table — the
+# whole openai-compatible lane is operator-owned regardless of surface.
 # ``_xai_provider`` is its own singleton because it overrides
 # ``_build_kwargs`` to add ``*_call_output`` includes for xAI's hidden
 # server-tool outputs.
 _provider_lock = threading.Lock()
 _openai_provider = OpenAIResponsesProvider()
 _openai_compat_provider = OpenAIChatCompletionsProvider()
+_openai_compat_responses_provider = OpenAIResponsesProvider(compat=True)
 _xai_provider = XAIProvider()
 _anthropic_provider: LLMProvider | None = None
 _anthropic_compat_provider: LLMProvider | None = None
@@ -76,11 +79,11 @@ def create_provider(
     e.g. vLLM).  ``provider_name="openai"`` always uses the Responses
     API regardless of *api_surface*.
 
-    Note: the ``OpenAIResponsesProvider`` singleton is reused for both
-    cloud OpenAI and ``openai-compatible`` + responses, so its
-    ``provider_name`` reports ``"openai"`` even when serving an
-    openai-compatible config.  Code that needs to distinguish the two
-    must read ``ModelConfig.provider`` and ``server_compat["api_surface"]``
+    Note: ``openai-compatible`` + responses is served by a compat-mode
+    ``OpenAIResponsesProvider`` (operator-owned capabilities, no
+    commercial table), whose ``provider_name`` still reports
+    ``"openai"``.  Code that needs to distinguish the two must read
+    ``ModelConfig.provider`` and ``server_compat["api_surface"]``
     rather than ``provider.provider_name``.
     """
     global _anthropic_provider, _anthropic_compat_provider, _google_provider  # noqa: PLW0603
@@ -93,7 +96,7 @@ def create_provider(
                 f"Unknown api_surface: {api_surface!r}. Supported: {', '.join(_VALID_API_SURFACES)}"
             )
         if normalised == "responses":
-            return _openai_provider
+            return _openai_compat_responses_provider
         return _openai_compat_provider
     if provider_name == "xai":
         return _xai_provider

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from turnstone.core.attachments import safe_attachment_label
 from turnstone.core.providers._protocol import (
+    EFFORT_TEMPLATE_FALLBACK_PARAM,
     CompletionResult,
     ModelCapabilities,
     StreamChunk,
@@ -420,8 +421,17 @@ class AnthropicProvider:
             # schema (silently dropped) and must not have temperature forced
             # to 1.0 — reasoning control rides chat_template_kwargs instead,
             # folded into extra_params here so the extra_body forwarding
-            # below carries it to the wire.
-            extra_params = merge_reasoning_template_kwargs(caps, reasoning_effort, extra_params)
+            # below carries it to the wire.  This lane has no flat effort
+            # param, so the graded value falls back to the conventional
+            # template key when the operator engaged reasoning control
+            # without naming one — the session effort setting always
+            # reaches the wire.
+            extra_params = merge_reasoning_template_kwargs(
+                caps,
+                reasoning_effort,
+                extra_params,
+                fallback_effort_param=EFFORT_TEMPLATE_FALLBACK_PARAM,
+            )
         elif caps.thinking_mode == "adaptive":
             thinking_dict: dict[str, Any] = {"type": "adaptive"}
             if caps.thinking_display:

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 import structlog
 
 from turnstone.core.providers._openai_common import (
+    OPENAI_COMPAT_DEFAULT,
     RETRYABLE_ERROR_NAMES,
     apply_cache_retention,
     apply_temperature_and_effort,
     apply_tool_search,
     extract_usage,
     format_citations,
-    lookup_openai_capabilities,
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
@@ -47,7 +47,10 @@ class OpenAIChatCompletionsProvider:
         return "openai-compatible"
 
     def get_capabilities(self, model: str) -> ModelCapabilities:
-        return lookup_openai_capabilities(model)
+        # Operator-owned lane — never the commercial table (see
+        # ``OPENAI_COMPAT_DEFAULT``).  GoogleProvider subclasses this
+        # class and overrides with its own registry.
+        return OPENAI_COMPAT_DEFAULT
 
     # -- message preparation --------------------------------------------------
 

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -291,12 +291,17 @@ OPENAI_DEFAULT = ModelCapabilities()
 # collision with a cloud model id ("gpt-5.5-my-finetune", "o3-distill")
 # would inherit that model's sampling and effort contract, none of which
 # holds for the box actually serving the name.  Every local model gets
-# the plain dataclass defaults — the same fallthrough unmatched names
-# always got — and anything beyond them is declared by the operator on
+# the plain dataclass defaults plus ``effort_passthrough`` — the session
+# effort knob is forwarded verbatim on the flat ``reasoning_effort``
+# param (the documented compat field; tolerant servers ignore it, vLLM
+# maps it into the template where supported) unless the operator
+# declares ``reasoning_effort_values`` (then the ordinal snap applies)
+# or an ``effort_param`` (then the template channel claims the value
+# and the flat param is suppressed).  Everything else is declared on
 # the model definition (capabilities JSON + server_compat), mirroring
 # ``_ANTHROPIC_COMPAT_DEFAULT`` and ``lookup_model_capabilities``'s
 # "no static table for local models" contract.
-OPENAI_COMPAT_DEFAULT = ModelCapabilities()
+OPENAI_COMPAT_DEFAULT = ModelCapabilities(effort_passthrough=True)
 
 
 def lookup_openai_capabilities(model: str) -> ModelCapabilities:

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -282,8 +282,21 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
     ),
 }
 
-# Default for unknown models (local servers: vLLM, llama.cpp, etc.)
+# Default for unknown models on the commercial lane.
 OPENAI_DEFAULT = ModelCapabilities()
+
+# The ``openai-compatible`` lane (either API surface) never consults the
+# commercial table above: a local server serves whatever the operator
+# named it (vLLM ``--served-model-name`` is a free string), so a prefix
+# collision with a cloud model id ("gpt-5.5-my-finetune", "o3-distill")
+# would inherit that model's sampling and effort contract, none of which
+# holds for the box actually serving the name.  Every local model gets
+# the plain dataclass defaults — the same fallthrough unmatched names
+# always got — and anything beyond them is declared by the operator on
+# the model definition (capabilities JSON + server_compat), mirroring
+# ``_ANTHROPIC_COMPAT_DEFAULT`` and ``lookup_model_capabilities``'s
+# "no static table for local models" contract.
+OPENAI_COMPAT_DEFAULT = ModelCapabilities()
 
 
 def lookup_openai_capabilities(model: str) -> ModelCapabilities:

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 import structlog
 
 from turnstone.core.providers._openai_common import (
+    OPENAI_COMPAT_DEFAULT,
     RETRYABLE_ERROR_NAMES,
     apply_cache_retention,
     apply_temperature,
@@ -97,17 +98,31 @@ def convert_content_parts(parts: list[Any]) -> list[dict[str, Any]]:
 
 
 class OpenAIResponsesProvider:
-    """Provider for commercial OpenAI models via the Responses API.
+    """Provider for the Responses API — commercial OpenAI, plus the
+    ``openai-compatible`` lane pinned to ``api_surface="responses"``.
 
     Translates between turnstone's internal OpenAI Chat Completions-like
     message format and the Responses API input/output format.
+
+    *compat* mirrors ``AnthropicProvider(compat=True)``: the compat-mode
+    instance serves operator-run Responses endpoints, so capability
+    lookup skips the commercial table (``OPENAI_COMPAT_DEFAULT`` — the
+    model id is an operator-chosen string there, and a prefix collision
+    with a cloud model id must not inherit its contract).  The request
+    shape is identical in both modes; ``XAIProvider`` subclasses the
+    default (non-compat) mode.
     """
+
+    def __init__(self, *, compat: bool = False) -> None:
+        self._compat = compat
 
     @property
     def provider_name(self) -> str:
         return "openai"
 
     def get_capabilities(self, model: str) -> ModelCapabilities:
+        if self._compat:
+            return OPENAI_COMPAT_DEFAULT
         return lookup_openai_capabilities(model)
 
     # -- message conversion --------------------------------------------------

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -95,6 +95,13 @@ class ModelCapabilities:
     effort_levels: tuple[str, ...] = ()
     reasoning_effort_values: tuple[str, ...] = ()
     default_reasoning_effort: str = "medium"
+    # Local-lane contract: with NO declared ``reasoning_effort_values``
+    # the session knob is forwarded VERBATIM instead of omitted — the
+    # user's effort setting always reaches the wire, and the serving
+    # box is the authority on what it means.  Commercial rows leave
+    # this False: there, an empty values list means the model has no
+    # effort control at all (o1-mini) and the param must be omitted.
+    effort_passthrough: bool = False
     supports_web_search: bool = False
     supports_tool_search: bool = False
     supports_vision: bool = False
@@ -191,8 +198,18 @@ def resolve_reasoning_effort(caps: ModelCapabilities, reasoning_effort: str) -> 
     charge of a knob that promises off.  Models without a declared
     ``"none"`` get the param omitted, and ``"none"`` is never a snap
     target for other knob positions.
+
+    With no declared values, ``caps.effort_passthrough`` (local lanes)
+    forwards the knob verbatim — the user's effort setting always
+    reaches the wire and the serving box decides what it means; without
+    the flag an empty list means "no effort control" and the param is
+    omitted (commercial rows).
     """
-    if not caps.reasoning_effort_values or not reasoning_effort:
+    if not reasoning_effort:
+        return None
+    if not caps.reasoning_effort_values:
+        if caps.effort_passthrough and reasoning_effort != "none":
+            return reasoning_effort
         return None
     if reasoning_effort == "none":
         return "none" if "none" in caps.reasoning_effort_values else None
@@ -222,21 +239,35 @@ def flat_effort_suppressed(caps: ModelCapabilities) -> bool:
     return bool(caps.effort_param)
 
 
+# Default chat-template key for the graded effort value on lanes whose
+# ONLY effort channel is ``chat_template_kwargs`` (anthropic-compatible —
+# vLLM's /v1/messages schema has no flat ``reasoning_effort`` param).
+# Injected when the operator engaged template reasoning control
+# (thinking_mode manual/adaptive) without naming an effort key: the
+# user's effort setting must reach the wire regardless, a template that
+# doesn't reference the kwarg ignores it, and ``caps.effort_param``
+# overrides the name for templates that grade under something else
+# (e.g. "reasoning").
+EFFORT_TEMPLATE_FALLBACK_PARAM = "reasoning_effort"
+
+
 def reasoning_template_kwargs(
     caps: ModelCapabilities,
     reasoning_effort: str,
+    *,
+    fallback_effort_param: str = "",
 ) -> dict[str, Any]:
     """``chat_template_kwargs`` entries carrying reasoning control.
 
     On local model servers the reasoning levers live in the chat template:
-    a boolean toggle (``caps.thinking_param``) and an optional graded
-    effort key (``caps.effort_param``, gpt-oss-style templates).  The
-    session effort knob drives both, mirroring the native Anthropic
-    contracts: ``"manual"`` maps ``"none"``/empty to an explicit
-    ``false`` (``_reasoning_params`` parity — the knob is the switch),
-    while ``"adaptive"`` always sends ``true`` (the model self-regulates;
-    the native adaptive branch never lets the knob force-disable
-    thinking).  The effort value is validated via
+    a boolean toggle (``caps.thinking_param``) and a graded effort key
+    (``caps.effort_param``, else *fallback_effort_param* on lanes with no
+    flat effort channel).  The session effort knob drives both, mirroring
+    the native Anthropic contracts: ``"manual"`` maps ``"none"``/empty to
+    an explicit ``false`` (``_reasoning_params`` parity — the knob is the
+    switch), while ``"adaptive"`` always sends ``true`` (the model
+    self-regulates; the native adaptive branch never lets the knob
+    force-disable thinking).  The effort value is validated via
     ``resolve_reasoning_effort`` when the model declares
     ``reasoning_effort_values`` (off-list knob values round up onto the
     declared list, capped at its ceiling); with no declared values the
@@ -249,14 +280,21 @@ def reasoning_template_kwargs(
         updates[caps.thinking_param] = effort_on
     elif caps.thinking_mode == "adaptive":
         updates[caps.thinking_param] = True
-    if caps.effort_param and effort_on:
+    # A declared effort_param is an operator opt-in at any thinking_mode
+    # (gpt-oss-style boxes grade without a toggle).  The FALLBACK key
+    # rides only when template reasoning control is engaged — a
+    # thinking_mode="none" box keeps its inject-nothing contract.
+    effort_param = caps.effort_param or (
+        fallback_effort_param if caps.thinking_mode in ("manual", "adaptive") else ""
+    )
+    if effort_param and effort_on:
         effort = (
             resolve_reasoning_effort(caps, reasoning_effort)
             if caps.reasoning_effort_values
             else reasoning_effort
         )
         if effort:
-            updates[caps.effort_param] = effort
+            updates[effort_param] = effort
     return updates
 
 
@@ -264,6 +302,8 @@ def merge_reasoning_template_kwargs(
     caps: ModelCapabilities,
     reasoning_effort: str,
     extra_params: dict[str, Any] | None,
+    *,
+    fallback_effort_param: str = "",
 ) -> dict[str, Any] | None:
     """Merge ``reasoning_template_kwargs`` into a copy of the extra params.
 
@@ -274,7 +314,9 @@ def merge_reasoning_template_kwargs(
     ``server_compat`` pin beats the knob mapping.  The caller's dict
     (and its ``chat_template_kwargs`` sub-dict) is never mutated.
     """
-    updates = reasoning_template_kwargs(caps, reasoning_effort)
+    updates = reasoning_template_kwargs(
+        caps, reasoning_effort, fallback_effort_param=fallback_effort_param
+    )
     if not updates:
         return dict(extra_params) if extra_params else extra_params
     merged = dict(extra_params) if extra_params else {}

--- a/turnstone/core/providers/effort_ladder.py
+++ b/turnstone/core/providers/effort_ladder.py
@@ -40,6 +40,7 @@ from turnstone.core.providers._anthropic import (
     _map_reasoning_to_effort,
 )
 from turnstone.core.providers._protocol import (
+    EFFORT_TEMPLATE_FALLBACK_PARAM,
     ModelCapabilities,
     flat_effort_suppressed,
     reasoning_template_kwargs,
@@ -151,12 +152,17 @@ def _effective_anthropic(caps: ModelCapabilities, knob: str) -> str:
 
 def _effective_local(provider_name: str, caps: ModelCapabilities, knob: str) -> str:
     """Chat lanes — mirrors ``merge_reasoning_template_kwargs`` (+ flat param)."""
-    updates = reasoning_template_kwargs(caps, knob)
+    # The anthropic-compatible request path passes the fallback effort
+    # key (its only effort channel is chat_template_kwargs); the chat
+    # lanes carry effort on the flat param instead.
+    fallback = EFFORT_TEMPLATE_FALLBACK_PARAM if provider_name == "anthropic-compatible" else ""
+    updates = reasoning_template_kwargs(caps, knob, fallback_effort_param=fallback)
+    effort_param = caps.effort_param or fallback
     parts: list[str] = []
     if caps.thinking_param in updates:
         parts.append("on" if updates[caps.thinking_param] else "off")
-    if caps.effort_param and caps.effort_param in updates:
-        parts.append(str(updates[caps.effort_param]))
+    if effort_param and effort_param in updates:
+        parts.append(str(updates[effort_param]))
     # Chat-completions providers also send the flat param unless a
     # declared effort_param claims the template channel — the same
     # ``flat_effort_suppressed`` predicate ``apply_temperature_and_effort``


### PR DESCRIPTION
## Summary

Follow-up to the reasoning-effort conformance refactor, from field testing on operator-run servers: on the local lanes the session effort level was silently dropped unless the operator had declared a full effort vocabulary, the effort select then degenerated into positions labeled after each other ("Max (= minimal)"), and a local model whose operator-chosen name prefix-collided with a cloud model id inherited that model's sampling/effort contract. Four fixes:

1. **The session effort level always reaches the local-lane wire.** openai-compatible carries the knob verbatim on the flat `reasoning_effort` param; anthropic-compatible carries it in `chat_template_kwargs` beside the toggle — under the operator's `effort_param`, else the conventional fallback key (`reasoning_effort`; a template that doesn't reference the kwarg ignores it). Declared `reasoning_effort_values` still snap ordinally (up to the nearest declared level, ceiling-capped); `thinking_mode="none"` still injects nothing. Commercial lanes unchanged — an empty declared list still means "no effort control" (o1-mini).
2. **Local-lane capabilities are operator-owned.** `openai-compatible` never consults the commercial capability table on either API surface (the responses pin is served by a compat-mode `OpenAIResponsesProvider`, mirroring `AnthropicProvider(compat=True)`). Previously a box named "o3-distill" silently lost temperature support and "gpt-5.5-my-finetune" was sent gpt-5.5's snapped effort vocabulary.
3. **Effort-select annotations state, in plain words, what the request carries.** Exact deliveries stay plain ("Max"); snapped positions read "Low — sends high"; the adaptive none position warns "thinking stays on"; budget detail lives in the tooltip. A position is never labeled after a sibling that shares its wire.
4. **`/v1/api/models` rows always carry `effort_ladder`** (empty when the capabilities column fails to parse) — stable row schema, no per-row null-checks.

## Verification

- Before/after proof matrices: capability resolution + the full knob→wire ladder per lane (openai-compatible on both surfaces, anthropic-compatible, openai, anthropic, google, xai), generated by importing the package from origin/main vs this branch and driving the same `create_provider().get_capabilities()` / `effort_ladder_for_model()` paths the session layer and console use. Commercial sections are byte-identical; every diff line is one of the fixes above.
- Ladder↔wire parity harness extended (fallback-key awareness, passthrough shapes); both invariants — each token decodes to the exact effort wire subset, equal tokens ⇔ identical wire — hold across all shapes.
- Full suite green (8488 passed); mypy strict and ruff clean.
- Wire goldens re-baselined for the passthrough (`+reasoning_effort` on the openai_chat payloads); the golden writer is pinned to `ensure_ascii=False` after discovering the previous baselines had been hand-edited past the writer and could not be reproduced by an honest regen.

## ⚠ Behavior changes on upgrade

- Local servers now receive the session effort level (previously dropped unless a vocabulary was declared): flat `reasoning_effort` on openai-compatible, the `effort_param`-or-fallback template kwarg on anthropic-compatible when reasoning control is engaged. Tolerant servers ignore unknown fields and unreferenced template kwargs.
- openai-compatible definitions whose model id prefix-collides with a cloud model id no longer inherit the cloud row — declare capabilities on the model definition. The supported path for commercial models remains their native provider lanes.
