### PR TITLE
Fix send button stuck disabled by pruning orphaned approval cycles

### DIFF
--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -409,3 +409,23 @@ def test_pane_handles_cross_user_409() -> None:
     assert "r.status === 409" in body
     assert 'status: "cross_user_interjection"' in body
     assert 'data.status === "cross_user_interjection"' in body
+
+
+def test_sync_approval_state_prunes_orphan_cycles() -> None:
+    """``_syncApprovalState`` prunes cycles whose block elements are no longer
+    in the living DOM (``.isConnected === false``).  This covers the rare case
+    where an ``approve_request`` event is processed between a DOM wipe
+    (``clear_ui`` / ``replay_truncated`` / ``replaceChildren``) and the
+    refetch-restore — the cycle card lives in a detached subtree, the matching
+    ``approval_resolved`` never arrives, and the send button stays disabled
+    forever without this guard.  The pin guards against a future refactor that
+    drops the orphan prune but doesn't otherwise break ``_syncApprovalState``."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    fn_start = body.index("_syncApprovalState() {")
+    assert "entry.blockEls && !entry.blockEls.some((el) => el.isConnected)" in body, (
+        "orphan pruning must check .isConnected on block elements"
+    )
+    tail = body[fn_start : body.index("_oldestCycleId()", fn_start)]
+    assert "this.approvalCycles.delete(cid);" in tail, (
+        "orphan pruning must delete the cycle from the Map"
+    )

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -541,6 +541,18 @@ class Pane {
   // live.
 
   _syncApprovalState() {
+    // Prune orphaned cycles whose block elements are no longer in the DOM.
+    // A clear_ui / replay_truncated / re-render that wipes the conversation
+    // subtree (messagesEl.replaceChildren()) also clears approvalCycles via
+    // _resetStreamingRefs.  But if an approve_request event is processed
+    // between the wipe and the refetch, its cycle card is in a detached
+    // subtree and the matching approval_resolved may never arrive — leaving
+    // pendingApproval=true and the send button disabled forever.
+    for (const [cid, entry] of this.approvalCycles) {
+      if (entry.blockEls && !entry.blockEls.some((el) => el.isConnected)) {
+        this.approvalCycles.delete(cid);
+      }
+    }
     const first = this.approvalCycles.values().next();
     const active = first.done ? null : first.value;
     this.pendingApproval = this.approvalCycles.size > 0;
@@ -2952,8 +2964,16 @@ class Pane {
           ),
       });
       block.appendChild(actions);
+    }
+
+    // Append BEFORE registering the approval cycle — the orphan-prune in
+    // _syncApprovalState checks blockEls.every(el => el.isConnected), so
+    // a freshly-built block (not yet in the DOM) would be mistaken for an
+    // orphan and immediately pruned if we registered before appending.
+    if (!announced) this.messagesEl.appendChild(block);
+    if (!autoApproved) {
       this._registerApprovalCycle(cycleId, [block], items);
-      const fb = actions.querySelector(".conv-feedback");
+      const fb = block.querySelector(".conv-feedback");
       // Focus the feedback field only for the FIRST (oldest) live cycle —
       // a sibling card arriving while the user is typing into another
       // cycle's field must not steal focus mid-word.
@@ -2963,8 +2983,6 @@ class Pane {
         });
       }
     }
-
-    if (!announced) this.messagesEl.appendChild(block);
     this._relinkAgentCards(items);
     this.scrollToBottom(stick);
   }

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -2967,9 +2967,10 @@ class Pane {
     }
 
     // Append BEFORE registering the approval cycle — the orphan-prune in
-    // _syncApprovalState checks blockEls.every(el => el.isConnected), so
-    // a freshly-built block (not yet in the DOM) would be mistaken for an
-    // orphan and immediately pruned if we registered before appending.
+    // _syncApprovalState checks that no blockEls are connected
+    // (!blockEls.some(el => el.isConnected)), so a freshly-built block
+    // (not yet in the DOM) would be mistaken for an orphan and immediately
+    // pruned if we registered before appending.
     if (!announced) this.messagesEl.appendChild(block);
     if (!autoApproved) {
       this._registerApprovalCycle(cycleId, [block], items);


### PR DESCRIPTION
## Problem

The send button occasionally stays disabled after an approval cycle completes. The composer label reads "Send" (not "Queue"), so busy state is correctly false — but the button is unclickable. Switching pane tabs away and back temporarily fixes it.

## Root cause

An orphaned entry in `this.approvalCycles` — a cycle whose approval card is no longer in the living DOM — keeps `pendingApproval=true` forever. The matching `approval_resolved` never arrives, and with the card detached there are no visible buttons to resolve it by hand, so `_reconcileSendDisabled()` holds `sendBtn.disabled` true indefinitely.

The orphan is left behind when a `clear_ui` / `replay_truncated` re-render (`messagesEl.replaceChildren()`) races an `approve_request`: the cycle ends up registered while its card sits in a detached subtree, so no later event clears it.

The tab-switch workaround confirmed it: `replayHistory` → `_resetStreamingRefs()` swaps in a fresh Map, clearing all cycles and re-enabling send.

## Fix

1. **Core fix** — `_syncApprovalState()` prunes any cycle whose block elements are all disconnected (`!entry.blockEls.some(el => el.isConnected)`) before recomputing `pendingApproval`. Because this runs inside `_registerApprovalCycle`, an orphan registered against a detached subtree is pruned the moment it is created — so the button never sticks, and any later register/resolve re-sweeps as well.

2. **Ordering fix** — `showInlineToolBlock` now appends the block to the DOM *before* calling `_registerApprovalCycle`, so the new prune doesn't mistake a just-registered live cycle (element not yet connected) for an orphan.

**Scope:** this targets stuck-*invisible* orphans (detached card). A cycle whose card is still connected and visible is deliberately left alone — it stays resolvable via its own approve/deny buttons, so it never strands the composer.

## Testing

- Added `test_sync_approval_state_prunes_orphan_cycles`; all 18 static-analysis tests in `test_interactive_pane_js.py` pass
- `ruff check` clean
