### PR TITLE
fix(ui): make pane hotkeys work off macOS and match across surfaces

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -17,6 +17,9 @@ import pytest
 
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
 _INTERACTIVE_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/interactive.js"
+_SHELL_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/shell.js"
+_CONSOLE_APP_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/app.js"
+_CONSOLE_INDEX = Path(__file__).resolve().parent.parent / "turnstone/console/static/index.html"
 
 
 def _pane_method_offset(body: str, name: str) -> int:
@@ -555,7 +558,6 @@ _CONSOLE_ADMIN_JS = Path(__file__).resolve().parent.parent / "turnstone/console/
 _CONSOLE_GOVERNANCE_JS = (
     Path(__file__).resolve().parent.parent / "turnstone/console/static/governance.js"
 )
-_CONSOLE_INTERACTIVE_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/app.js"
 
 
 _UNSAFE_CODE_SINK_LINT_TARGETS = [
@@ -566,7 +568,7 @@ _UNSAFE_CODE_SINK_LINT_TARGETS = [
     ("turnstone/console/static/coordinator/coordinator.js", _COORD_JS),
     ("turnstone/console/static/admin.js", _CONSOLE_ADMIN_JS),
     ("turnstone/console/static/governance.js", _CONSOLE_GOVERNANCE_JS),
-    ("turnstone/console/static/app.js", _CONSOLE_INTERACTIVE_JS),
+    ("turnstone/console/static/app.js", _CONSOLE_APP_JS),
 ]
 
 
@@ -1756,4 +1758,108 @@ def test_global_stream_recovery_floor_and_render_coalescing() -> None:
     fire = body.index("function fireRender()")
     assert "requestAnimationFrame(" in body[fire : fire + 700], (
         "fireRender must coalesce subscriber repaints to one per frame"
+    )
+
+
+def test_server_global_accels_are_platform_aware_and_scoped() -> None:
+    """The standalone's keydown handler owns only the GLOBAL accels — new
+    workstream, switch, dashboard.  They pick the modifier per platform (Ctrl on
+    macOS where the browser owns Cmd, Alt elsewhere) so Ctrl+T/1-9 aren't eaten
+    by the browser off macOS.  The per-pane verbs (edit/refresh/fork/delete/
+    close) moved to shell.js, so the handler must not invoke them itself."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    assert "const IS_MAC" in body and 'navigator.platform.indexOf("Mac")' in body, (
+        "the accelerators need a platform check to choose Ctrl vs Alt"
+    )
+    handler = body[body.index('document.addEventListener("keydown"') :]
+    assert "const paneMod" in handler, (
+        "global accels must gate on the platform-aware paneMod, not raw ctrlKey"
+    )
+    assert 'e.ctrlKey && e.key === "t"' not in handler, (
+        "Ctrl+T is browser-reserved off macOS — new workstream must bind via paneMod"
+    )
+    assert "newWorkstream()" in handler and "switchTab(" in handler, (
+        "the standalone handler still owns new + switch"
+    )
+    # macOS Ctrl+T / Ctrl+D are the Cocoa transpose / delete-forward text
+    # bindings; the creation/dashboard chords must yield while typing, through
+    # the shared TS_SHELL.inEditable guard (not a per-file copy).
+    assert "TS_SHELL.inEditable(" in handler, (
+        "new + dashboard must yield to text editing (macOS Ctrl+T / Ctrl+D)"
+    )
+    # The per-pane verbs are shell.js's job now — the standalone handler must not
+    # double-bind them (shell.js drives them off the active pane's menu).
+    for verb in ("editWorkstreamTitle()", "forkWorkstream()", "confirmDeleteWorkstream()"):
+        assert verb not in handler, (
+            f"{verb} moved to shell.js — the app.js handler must not also bind it"
+        )
+
+
+def test_shortcut_overlay_labels_match_the_platform_modifier() -> None:
+    """The '?' help overlay must advertise the same modifier the handler
+    listens for — Ctrl on macOS, Alt on Windows/Linux — instead of a hardcoded
+    Ctrl that is wrong (and non-functional) off macOS."""
+    index = _INDEX_HTML.read_text(encoding="utf-8")
+    assert "const PANE_MOD" in index and 'navigator.platform.indexOf("Mac")' in index, (
+        "the overlay must compute its modifier label per platform"
+    )
+    assert "${PANE_MOD}+T" in index, "the New-workstream badge must render through PANE_MOD"
+    assert '<span class="kb-key">Ctrl+T</span>' not in index, (
+        "the New-workstream badge must not hardcode Ctrl (wrong off macOS)"
+    )
+
+
+def test_pane_menu_accels_are_shared_and_platform_aware() -> None:
+    """shell.js is the single source of truth for the per-pane tab-menu
+    shortcuts: the badge string and the keydown handler come from ONE registry,
+    so a badge can't advertise a chord the handler ignores.  Badges must be
+    platform-aware (no hardcoded Ctrl), and the shared handler must drive the
+    ACTIVE pane's own menu so each surface contributes only what it supports."""
+    shell = _SHELL_JS.read_text(encoding="utf-8")
+    assert "PANE_MENU_ACCELS" in shell and "function paneAccelBadge" in shell, (
+        "shell.js must own the accel registry + badge builder"
+    )
+    assert "const PANE_MOD_LABEL" in shell and 'navigator.platform.indexOf("Mac")' in shell, (
+        "the shared badge must be platform-aware (Ctrl on macOS, Alt elsewhere)"
+    )
+    # The tab-menu items carry a stable accel + a computed badge, NOT a hardcoded
+    # Ctrl string that would lie on Windows/Linux.
+    for accel in ("close-pane", "edit-title", "refresh-title", "delete"):
+        assert f'accel: "{accel}"' in shell, f"tab menu must tag the {accel} item"
+    assert 'key: "Ctrl+Shift+E"' not in shell and 'key: "Ctrl+W"' not in shell, (
+        "tab-menu badges must go through paneAccelBadge, not hardcoded Ctrl"
+    )
+    # The shared handler resolves the active pane and runs its menu item by accel.
+    assert "paneAccelFor(e)" in shell and "pane.tabMenu()" in shell, (
+        "the shared keydown handler must drive the active pane's menu by accel"
+    )
+    # The typing guard is shared (TS_SHELL.inEditable), not copied per surface.
+    assert "function inEditable(" in shell and "inEditable," in shell, (
+        "shell.js must define + expose the shared inEditable guard on TS_SHELL"
+    )
+    ui = _APP_JS.read_text(encoding="utf-8")
+    console = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    assert "_inEditable" not in ui and "_consoleInEditable" not in console, (
+        "surfaces must use TS_SHELL.inEditable, not a per-file copy of the guard"
+    )
+
+
+def test_console_has_matching_pane_hotkeys() -> None:
+    """The console regained pane hotkeys to match the standalone: a keydown
+    handler for switch (Mod+1-9) + dashboard (Ctrl+D), and a '?' overlay that
+    advertises them platform-aware.  New workstream and Fork are intentionally
+    omitted (no console fork / blank-new surface)."""
+    app = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    assert (
+        "_CONSOLE_IS_MAC" in app and "statefulTabs()" in app and 'openPane("dashboard")' in app
+    ), "the console must wire switch (statefulTabs) + dashboard hotkeys"
+    index = _CONSOLE_INDEX.read_text(encoding="utf-8")
+    assert "const PANE_MOD" in index and '"Panes"' in index, (
+        "the console '?' overlay needs a platform-aware Panes section"
+    )
+    assert "${PANE_MOD}+W" in index and "${PANE_MOD}+Shift+E" in index, (
+        "console badges must render through PANE_MOD"
+    )
+    assert '"Fork"' not in index and "New workstream" not in index, (
+        "Fork + New are intentionally omitted on the console"
     )

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -444,7 +444,8 @@ def test_shell_bridges_setrowbadge_for_classic_subsystems() -> None:
     badge the same way the gear deletion did)."""
     body = _SHELL_JS.read_text(encoding="utf-8")
     assert 'setRowBadge } from "./rail.js"' in body, "shell must import setRowBadge from rail.js"
-    assert "notifySessionClosed, setRowBadge }" in body, (
+    ts_shell = body[body.index("window.TS_SHELL = {") :][:200]
+    assert "setRowBadge" in ts_shell, (
         "TS_SHELL must expose setRowBadge for classic subsystems (the consent-badge bridge)"
     )
 
@@ -1011,7 +1012,8 @@ def test_shell_closes_pane_on_ws_closed() -> None:
     assert 'pm.getPane("interactive", wsId)' in shell
     assert "if (p) pm.close(p.id)" in shell, "ws_closed closes the pane, not mark-dead"
     assert "showDeadBanner" in shell, "the banner lane must survive for non-closed deaths"
-    assert "window.TS_SHELL = { panes: pm, caps, notifySessionClosed, setRowBadge }" in shell, (
+    ts_shell = shell[shell.index("window.TS_SHELL = {") :][:200]
+    assert "panes: pm" in ts_shell and "notifySessionClosed" in ts_shell, (
         "the seam must be exported on TS_SHELL for the console's Tier-1 handler"
     )
     app = _CONSOLE_APP.read_text(encoding="utf-8")

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1887,6 +1887,49 @@ document.addEventListener("keydown", function (e) {
   if (!_homeCoordComposer.sendBtn.disabled) submitHomeCoord();
 });
 
+// Global pane accelerators for the console — switch panes and jump to the
+// Dashboard.  The per-pane tab-menu actions (close pane, edit/refresh title,
+// delete) are bound once in shell.js off the active pane's OWN menu, so they
+// match the standalone automatically; only these shell-level chords live here.
+// New workstream and Fork are omitted: the console starts work from the
+// Dashboard and has no interactive fork surface yet.
+//
+// Modifier per platform: Ctrl on macOS (the browser owns Cmd), Alt on
+// Windows/Linux (Ctrl is the browser's own switch-tab / bookmark accelerator).
+const _CONSOLE_IS_MAC =
+  (navigator.platform && navigator.platform.indexOf("Mac") > -1) || false;
+
+document.addEventListener("keydown", function (e) {
+  if (document.querySelector("dialog:modal")) return;
+  const pm = window.TS_SHELL && window.TS_SHELL.panes;
+  if (!pm) return;
+
+  // Ctrl+D: jump to the Dashboard pane.  Kept on Ctrl every platform — Alt+D is
+  // the browser's focus-address-bar.  Yields to macOS delete-forward in fields.
+  if (e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && e.key === "d") {
+    if (window.TS_SHELL.inEditable(e.target)) return;
+    e.preventDefault();
+    pm.openPane("dashboard");
+    return;
+  }
+
+  const paneMod = _CONSOLE_IS_MAC
+    ? e.ctrlKey && !e.altKey && !e.metaKey
+    : e.altKey && !e.ctrlKey && !e.metaKey;
+  if (!paneMod || e.shiftKey) return;
+
+  // <mod>+1..9: switch among the open conversational panes (mirrors a browser's
+  // Ctrl+1..9); works while composing.
+  if (e.key >= "1" && e.key <= "9") {
+    const tabs = pm.statefulTabs();
+    const idx = parseInt(e.key, 10) - 1;
+    if (idx < tabs.length) {
+      e.preventDefault();
+      pm.activate(tabs[idx].id);
+    }
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Saved coordinators — closed sessions persisted on disk.  Mirrors the
 // interactive UI's "Saved Workstreams" table (same /shared/cards.js

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -3837,6 +3837,14 @@
         orchestration: true,
         brandSub: "console",
       };
+      // Pane accelerators bind to Ctrl on macOS (the browser owns Cmd and
+      // leaves Ctrl free) and to Alt on Windows/Linux (Ctrl is the browser's
+      // own switch-tab accelerator).  Must match what app.js / shell.js listen
+      // for on this host.
+      const PANE_MOD =
+        navigator.platform && navigator.platform.indexOf("Mac") > -1
+          ? "Ctrl"
+          : "Alt";
       window.TURNSTONE_KB_SHORTCUTS = [
         {
           title: "Navigation",
@@ -3857,6 +3865,31 @@
           ],
         },
         {
+          title: "Panes",
+          keys: [
+            {
+              desc: "Switch pane",
+              badge: `<span class="kb-key">${PANE_MOD}+1</span>\u2026<span class="kb-key">${PANE_MOD}+9</span>`,
+            },
+            {
+              desc: "Close pane",
+              badge: `<span class="kb-key">${PANE_MOD}+W</span>`,
+            },
+            {
+              desc: "Edit title",
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+E</span>`,
+            },
+            {
+              desc: "Refresh title",
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+R</span>`,
+            },
+            {
+              desc: "Delete workstream",
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+X</span>`,
+            },
+          ],
+        },
+        {
           title: "General",
           keys: [
             {
@@ -3867,6 +3900,10 @@
                   ? "\u2318"
                   : "Ctrl") +
                 '</span>+<span class="kb-key">Enter</span>',
+            },
+            {
+              desc: "Toggle dashboard",
+              badge: '<span class="kb-key">Ctrl+D</span>',
             },
             { desc: "Show this help", badge: '<span class="kb-key">?</span>' },
             { desc: "Close overlay", badge: '<span class="kb-key">Esc</span>' },

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -253,6 +253,68 @@ function postWsVerb(base, wsId, verb, body) {
   );
 }
 
+// --- Pane accelerators -----------------------------------------------------
+// ONE source of truth for the pane keyboard shortcuts, shared by BOTH the
+// tab-menu key badges (below) and the keydown handler (in mountShell), so a
+// badge can never advertise a chord the handler doesn't actually listen for.
+//
+// The modifier is chosen per platform: Ctrl on macOS (the browser owns Cmd and
+// leaves Ctrl free) and Alt on Windows/Linux (there Ctrl IS the browser's own
+// new-tab / close-tab / switch-tab accelerator and never reaches the page).
+const IS_MAC =
+  (navigator.platform && navigator.platform.indexOf("Mac") > -1) || false;
+const PANE_MOD_LABEL = IS_MAC ? "Ctrl" : "Alt";
+
+// The per-pane menu actions that also carry a shortcut, keyed by a stable id
+// (the menu item's `accel`).  `letter` is matched case-insensitively; `shift`
+// gates the Shift-family.  Close-pane is the one non-Shift chord.
+const PANE_MENU_ACCELS = {
+  "close-pane": { letter: "w", shift: false },
+  "edit-title": { letter: "e", shift: true },
+  "refresh-title": { letter: "r", shift: true },
+  fork: { letter: "f", shift: true },
+  delete: { letter: "x", shift: true },
+};
+
+// The badge string for a menu accel, e.g. "Alt+Shift+E" — platform-correct.
+function paneAccelBadge(id) {
+  const a = PANE_MENU_ACCELS[id];
+  if (!a) return "";
+  return (
+    PANE_MOD_LABEL + (a.shift ? "+Shift" : "") + "+" + a.letter.toUpperCase()
+  );
+}
+
+// True when `e` carries the pane modifier and no other primary modifier — on
+// Windows/Linux AltGr surfaces as Ctrl+Alt, so this keeps accented-character
+// entry (and the browser's own Ctrl chords) from firing pane shortcuts.
+function paneModDown(e) {
+  return IS_MAC
+    ? e.ctrlKey && !e.altKey && !e.metaKey
+    : e.altKey && !e.ctrlKey && !e.metaKey;
+}
+
+// Which per-pane menu accel (if any) a keydown triggers, else null.
+function paneAccelFor(e) {
+  if (!paneModDown(e)) return null;
+  const k = e.key.toLowerCase();
+  for (const id in PANE_MENU_ACCELS) {
+    const a = PANE_MENU_ACCELS[id];
+    if (!!e.shiftKey === a.shift && k === a.letter) return id;
+  }
+  return null;
+}
+
+// True when focus is in an editable element.  On macOS Ctrl+T / Ctrl+D are the
+// Cocoa "transpose" / "delete-forward" text bindings, so each surface's
+// creation and dashboard chords must yield to text editing while a field is
+// focused.  Exposed on TS_SHELL so both app.js surfaces share ONE definition.
+function inEditable(el) {
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable;
+}
+
 // Tab-action menu items for a conversational pane — the three-verb close plus
 // the per-persona verbs.  Pane-type-derived AND deployment-aware, in two lanes:
 // the classic verb GLOBALS where they exist (the standalone's ui/static app.js,
@@ -275,11 +337,15 @@ function convTabMenu(pane, pm, wsId, opts) {
     if (typeof G.refreshWorkstreamTitle === "function")
       items.push({
         label: "Refresh title",
+        accel: "refresh-title",
+        key: paneAccelBadge("refresh-title"),
         action: () => G.refreshWorkstreamTitle(wsId),
       });
     else if (base != null)
       items.push({
         label: "Refresh title",
+        accel: "refresh-title",
+        key: paneAccelBadge("refresh-title"),
         action: () =>
           postWsVerb(base, wsId, "refresh-title")
             .then((r) =>
@@ -292,12 +358,15 @@ function convTabMenu(pane, pm, wsId, opts) {
     if (typeof G.editWorkstreamTitle === "function")
       items.push({
         label: "Edit title",
-        key: "Ctrl+Shift+E",
+        accel: "edit-title",
+        key: paneAccelBadge("edit-title"),
         action: () => G.editWorkstreamTitle(wsId),
       });
     else if (base != null)
       items.push({
         label: "Edit title",
+        accel: "edit-title",
+        key: paneAccelBadge("edit-title"),
         action: () => {
           const f = findWs(wsId, false);
           const cur = (f && (f.ws.name || f.ws.title)) || "";
@@ -319,7 +388,8 @@ function convTabMenu(pane, pm, wsId, opts) {
     if (typeof G.forkWorkstream === "function")
       items.push({
         label: "Fork",
-        key: "Ctrl+Shift+F",
+        accel: "fork",
+        key: paneAccelBadge("fork"),
         action: () => G.forkWorkstream(wsId),
       });
   }
@@ -334,7 +404,8 @@ function convTabMenu(pane, pm, wsId, opts) {
   // Close pane — drop the tab, leave the session running (PaneManager-level).
   items.push({
     label: "Close pane",
-    key: "Ctrl+W",
+    accel: "close-pane",
+    key: paneAccelBadge("close-pane"),
     action: () => pm.close(pane.id),
   });
   // Close workstream — stop the session itself (distinct from closing the tab).
@@ -346,13 +417,16 @@ function convTabMenu(pane, pm, wsId, opts) {
     if (typeof G.confirmDeleteWorkstream === "function")
       items.push({
         label: "Delete",
-        key: "Ctrl+Shift+X",
+        accel: "delete",
+        key: paneAccelBadge("delete"),
         cls: "destructive",
         action: () => G.confirmDeleteWorkstream(wsId),
       });
     else if (base != null)
       items.push({
         label: "Delete",
+        accel: "delete",
+        key: paneAccelBadge("delete"),
         cls: "destructive",
         action: () => {
           if (!window.confirm("Delete this session? This cannot be undone."))
@@ -510,6 +584,33 @@ async function mountShell() {
   });
   pm.onActiveChange(() => setDrawer(false));
 
+  // Pane keyboard accelerators (shared by every surface): the per-pane tab-menu
+  // actions — close pane, edit/refresh title, fork, delete — driven off the
+  // ACTIVE conversational pane's OWN menu, so the chord runs the exact action
+  // its badge advertises and each surface contributes only the items it
+  // supports (the console omits Fork; a non-conversational pane has no tabMenu
+  // and is skipped).  The global accels — new, switch, dashboard — live in each
+  // surface's app.js.  None of these chords overlap in-field text editing
+  // (close is Mod+W; the rest are Mod+Shift+…), so no typing guard is needed.
+  document.addEventListener("keydown", (e) => {
+    if (document.querySelector("dialog:modal")) return;
+    const accel = paneAccelFor(e);
+    if (!accel) return;
+    const active = pm.getActive();
+    if (!active) return;
+    const pane = pm.getPane(active.type, active.rawId);
+    if (!pane || typeof pane.tabMenu !== "function") return;
+    let item;
+    try {
+      item = (pane.tabMenu() || []).find((it) => it.accel === accel);
+    } catch (err) {
+      return; // a pane whose menu throws simply has no accelerators
+    }
+    if (!item || typeof item.action !== "function") return;
+    e.preventDefault();
+    item.action();
+  });
+
   // Split controls (the revived split-view): they act on the FOCUSED pane.
   // Split right / split down open a second cell beside/below it, filled with
   // the most-recently-used backgrounded tab; Unsplit returns to one pane and
@@ -574,7 +675,12 @@ async function mountShell() {
   pm.registerType("admin", () => {
     const pane = new ShellPane({ type: "admin", title: "Admin", glyph: "⚙" });
     pane.tabMenu = () => [
-      { label: "Close pane", key: "Ctrl+W", action: () => pm.close(pane.id) },
+      {
+        label: "Close pane",
+        accel: "close-pane",
+        key: paneAccelBadge("close-pane"),
+        action: () => pm.close(pane.id),
+      },
     ];
     pane.onMount = function () {
       if (viewAdminEl) {
@@ -911,7 +1017,13 @@ async function mountShell() {
   // in ui/static/app.js) stamp a count chip on a Manage row without importing the
   // ESM rail module — the shell is its module bridge.  Generic: the rail owns the
   // chip mechanism, the caller owns what the count means.
-  window.TS_SHELL = { panes: pm, caps, notifySessionClosed, setRowBadge };
+  window.TS_SHELL = {
+    panes: pm,
+    caps,
+    notifySessionClosed,
+    setRowBadge,
+    inEditable,
+  };
 
   // Login fan-out: app.js owns the single window.onLoginSuccess (the Tier-1
   // reconnect, set at load).  Wrap it in a tiny registry so EVERY conversational

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -2098,6 +2098,20 @@ function _formatRelativeTimestamp(iso) {
   }
 }
 
+// The GLOBAL pane accelerators — new workstream, switch, and dashboard.  The
+// per-pane tab-menu actions (close pane, edit/refresh title, fork, delete) are
+// bound once in shell.js off the active pane's own menu, so they stay identical
+// across the standalone and the console; only these roster/shell-level chords
+// live here.
+//
+// The modifier is chosen per platform: Ctrl on macOS (the browser owns Cmd and
+// leaves Ctrl free) and Alt on Windows/Linux (there Ctrl IS the browser's own
+// new-tab / switch-tab accelerator and never reaches the page).
+const IS_MAC =
+  (navigator.platform && navigator.platform.indexOf("Mac") > -1) || false;
+
+// The typing guard (`inEditable`) lives on TS_SHELL — shell.js is the single
+// source of truth for these keyboard helpers, shared by both surfaces.
 document.addEventListener("keydown", function (e) {
   // Defer while a document-modal hatch dialog is open — native dialogs own
   // their Escape, and global shortcuts must not fire under the top layer.
@@ -2108,60 +2122,40 @@ document.addEventListener("keydown", function (e) {
     return;
   }
 
-  // Ctrl+D: toggle dashboard
-  if (e.ctrlKey && e.key === "d") {
+  // Ctrl+D: toggle dashboard.  Left on Ctrl for every platform — it is
+  // cancelable everywhere (the Cmd+D / Ctrl+D bookmark dialog), whereas Alt+D
+  // is the browser's "focus the address bar" and can't be reclaimed.  Yields to
+  // text editing (macOS delete-forward) while a field is focused.
+  if (e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && e.key === "d") {
+    if (window.TS_SHELL && window.TS_SHELL.inEditable(e.target)) return;
     e.preventDefault();
     toggleDashboard();
     return;
   }
-  // Ctrl+T: new tab
-  if (e.ctrlKey && e.key === "t") {
+
+  // The pane modifier: Ctrl on macOS, Alt elsewhere.  Require it WITHOUT the
+  // other primary modifier — on Windows/Linux AltGr surfaces as Ctrl+Alt, and
+  // this guard keeps accented-character entry from firing Alt shortcuts.
+  const paneMod = IS_MAC
+    ? e.ctrlKey && !e.altKey && !e.metaKey
+    : e.altKey && !e.ctrlKey && !e.metaKey;
+  if (!paneMod || e.shiftKey) return;
+
+  // <mod>+T: new workstream.  Yields to text editing (macOS transpose) while a
+  // field is focused.
+  if (e.key.toLowerCase() === "t") {
+    if (window.TS_SHELL && window.TS_SHELL.inEditable(e.target)) return;
     e.preventDefault();
     newWorkstream();
     return;
   }
-  // Ctrl+1..9: switch tabs
-  if (e.ctrlKey && e.key >= "1" && e.key <= "9") {
+  // <mod>+1..9: switch workstreams.  No text-binding overlap, so it works even
+  // while composing — mirroring a browser's own Ctrl+1..9.
+  if (e.key >= "1" && e.key <= "9") {
     e.preventDefault();
-    const idx = parseInt(e.key) - 1;
+    const idx = parseInt(e.key, 10) - 1;
     const wsIds = Object.keys(workstreams);
     if (idx < wsIds.length) switchTab(wsIds[idx]);
-    return;
-  }
-  // Workstream action shortcuts — only preventDefault when a workstream
-  // is active, so native browser shortcuts (e.g. Ctrl+Shift+R hard reload)
-  // still work when no workstream is focused.
-  if (e.ctrlKey && e.shiftKey) {
-    const wsActionKey = e.key.toLowerCase();
-    const activeWsId = !dashboardVisible && getCurrentWsId();
-    if (wsActionKey === "e" && activeWsId) {
-      e.preventDefault();
-      editWorkstreamTitle();
-      return;
-    }
-    if (wsActionKey === "f" && activeWsId) {
-      e.preventDefault();
-      forkWorkstream();
-      return;
-    }
-    // X not D — D conflicts with Chrome DevTools
-    if (
-      wsActionKey === "x" &&
-      activeWsId &&
-      Object.keys(workstreams).length > 1
-    ) {
-      e.preventDefault();
-      confirmDeleteWorkstream();
-      return;
-    }
-  }
-  // Ctrl+W: close current workstream tab
-  if (e.ctrlKey && !e.shiftKey && e.key === "w") {
-    if (Object.keys(workstreams).length > 1) {
-      e.preventDefault();
-      closeWorkstream(getCurrentWsId());
-    }
-    return;
   }
 });
 

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -557,25 +557,45 @@
         orchestration: false,
         brandSub: "server",
       };
+      // Pane accelerators bind to Ctrl on macOS (where the browser owns Cmd
+      // and leaves Ctrl free) and to Alt on Windows/Linux (where Ctrl is the
+      // browser's own new-tab/close-tab/switch-tab accelerator).  The overlay
+      // labels must match whatever app.js actually listens for on this host.
+      const PANE_MOD =
+        navigator.platform && navigator.platform.indexOf("Mac") > -1
+          ? "Ctrl"
+          : "Alt";
       window.TURNSTONE_KB_SHORTCUTS = [
         {
           title: "Workstreams",
           keys: [
             {
               desc: "New workstream",
-              badge: '<span class="kb-key">Ctrl+T</span>',
+              badge: `<span class="kb-key">${PANE_MOD}+T</span>`,
             },
             {
-              desc: "Refresh title",
-              badge: '<span class="kb-key">Ctrl+Shift+R</span>',
+              desc: "Close pane",
+              badge: `<span class="kb-key">${PANE_MOD}+W</span>`,
+            },
+            {
+              desc: "Switch workstream",
+              badge: `<span class="kb-key">${PANE_MOD}+1</span>…<span class="kb-key">${PANE_MOD}+9</span>`,
             },
             {
               desc: "Edit title",
-              badge: '<span class="kb-key">Ctrl+Shift+E</span>',
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+E</span>`,
+            },
+            {
+              desc: "Refresh title",
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+R</span>`,
             },
             {
               desc: "Fork workstream",
-              badge: '<span class="kb-key">Ctrl+Shift+F</span>',
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+F</span>`,
+            },
+            {
+              desc: "Delete workstream",
+              badge: `<span class="kb-key">${PANE_MOD}+Shift+X</span>`,
             },
           ],
         },
@@ -615,6 +635,10 @@
         {
           title: "General",
           keys: [
+            {
+              desc: "Toggle dashboard",
+              badge: '<span class="kb-key">Ctrl+D</span>',
+            },
             { desc: "Show this help", badge: '<span class="kb-key">?</span>' },
           ],
         },


### PR DESCRIPTION
The pane/workstream accelerators only worked on macOS. They were bound to `Ctrl`, which on Windows/Linux **is** the browser's own accelerator: `Ctrl+T`, `Ctrl+W` and `Ctrl+1-9` were swallowed by the browser (new tab / close tab / switch tab) and never reached the page. macOS browsers own `Cmd` instead, so `Ctrl` was free there and everything appeared to work.

On top of that the shortcuts were declared in three places that had drifted apart — the `?` overlay, each `app.js` keydown handler, and the tab-menu badges in `shell.js`. The console fell to `convTabMenu`'s node-proxy fallback lane, which dropped every shortcut badge (and Fork), so its tab menu showed no accelerators and `Ctrl+W` there just closed the browser tab.

## What changed

- **Platform-aware modifier** — `Ctrl` on macOS (the browser owns `Cmd` and leaves `Ctrl` free), `Alt` on Windows/Linux (where `Ctrl` is the browser's accelerator).
- **`shell.js` is now the single source of truth** for the per-pane accelerators: one `accel` registry drives *both* the platform-aware badge *and* one shared keydown handler that invokes the **active pane's own menu item** — so a badge can't advertise a chord the handler ignores, and each surface contributes only what it supports.
- **Console reached parity** — its tab-menu shortcuts now render and fire (edit / refresh / delete / close via the node proxy), plus switch (`Mod+1-9`) and dashboard (`Ctrl+D`). **Fork is omitted** (no console fork surface yet).
- The previously-dead **Refresh title** (`Mod+Shift+R`) is wired.

## Behavior changes worth flagging

- **`Mod+W` now uniformly means "Close pane"** (drop the tab, session keeps running) — matching its badge and the universal `Ctrl+W` convention. Previously the standalone's `Ctrl+W` *stopped the session*; that's still available as the un-hotkeyed "Close workstream" menu item.
- **`Ctrl+T` / `Ctrl+D` yield to text editing** while a field is focused (macOS transpose / delete-forward); switch/close keep working while composing.

## Collision audit

After the platform swap, no *hard* (uncancelable) browser collisions remain. Residual soft ones are handled: the macOS in-field text bindings are covered by the typing guard, and `Alt+D` (focus-address-bar) is dodged by keeping dashboard on `Ctrl+D`.

## Tests

407 frontend guard tests pass (`test_app_js`, `test_shell_js`, `test_console`, …); ruff + mypy clean; all JS `node --check`-clean. Added guards pinning the platform-aware badges, the shared accel handler, console parity, and the shared `inEditable` guard.

Follow-up (not in this PR): a console **Fork** surface would let the console reach full 1:1 parity.