### PR TITLE
Client-side credential redaction for tool call cards

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -9,6 +9,8 @@ manual testing.
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -18,6 +20,9 @@ import pytest
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
 _INTERACTIVE_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/interactive.js"
 _SHELL_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/shell.js"
+_REDACT_CREDENTIALS_JS = (
+    Path(__file__).resolve().parent.parent / "turnstone/shared_static/redact_credentials.js"
+)
 _CONSOLE_APP_JS = Path(__file__).resolve().parent.parent / "turnstone/console/static/app.js"
 _CONSOLE_INDEX = Path(__file__).resolve().parent.parent / "turnstone/console/static/index.html"
 
@@ -957,6 +962,7 @@ _CONST_GUARD_BUNDLES = _SWEPT_BUNDLES + [
     _REPO_ROOT / "turnstone/shared_static/rail.js",
     _REPO_ROOT / "turnstone/shared_static/interactive.js",
     _REPO_ROOT / "turnstone/shared_static/conversation.js",
+    _REPO_ROOT / "turnstone/shared_static/redact_credentials.js",
 ]
 
 
@@ -1269,41 +1275,49 @@ def test_swept_bundle_has_no_const_reassign(bundle: Path) -> None:
         )
 
 
-def test_redact_api_keys_runtime_smoke() -> None:
-    """Runtime smoke for ``_redactApiKeys``.  The function is pure — no
-    DOM dependency — so it transplants cleanly into a standalone
-    ``node -e`` invocation.  This is the bit that would have caught
-    the original ``const redacted`` bug (which ``node --check`` and a
-    pure-static keyword scan both miss; the ``TypeError`` only fires
-    at call-time)."""
-    body = _INTERACTIVE_JS.read_text(encoding="utf-8")
-    m = re.search(
-        r"function _redactApiKeys\(text\) \{.*?\n\}\n",
-        body,
-        re.DOTALL,
-    )
-    assert m is not None, "_redactApiKeys not found in app.js"
-    fn = m.group(0)
-    script = (
-        fn
-        + "\nconst q = _redactApiKeys('https://x?api_key=abc&u=foo');\n"
+def test_redact_credentials_runtime_smoke() -> None:
+    """Runtime smoke for ``redactCredentials`` via a temp harness file.
+    The function is pure (no DOM dependency).  Tests the shared module
+    directly via ESM import (replaces the legacy ``_redactApiKeys`` test
+    which now delegates to this)."""
+    import tempfile
+
+    mod_path = _REDACT_CREDENTIALS_JS.resolve()
+    harness = (
+        "import { redactCredentials } from "
+        + json.dumps(str(mod_path))
+        + ";\n"
+        + "const q = redactCredentials('https://x?api_key=abc&u=foo');\n"
         + 'if (q !== "https://x?api_key=***&u=foo") '
         + "throw new Error('query-string redact failed: ' + q);\n"
-        + 'const j = _redactApiKeys(\'{"api_key":"abc"}\');\n'
+        + 'const j = redactCredentials(\'{"api_key":"abc"}\');\n'
         + 'if (j !== \'{"api_key":"***"}\') '
         + "throw new Error('json-style redact failed: ' + j);\n"
+        + "// Bearer token redaction\n"
+        + "const b = redactCredentials('Authorization: Bearer abcdefghijklmnopqrstuvwxyz');\n"
+        + "if (!b.includes('[REDACTED:api_key]')) "
+        + "throw new Error('bearer redact failed: ' + b);\n"
+        + "// Connection string redaction\n"
+        + "const c = redactCredentials('postgresql://user:pass@localhost/db');\n"
+        + "if (!c.includes('[REDACTED:password]')) "
+        + "throw new Error('conn-string redact failed: ' + c);\n"
     )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(harness)
+        tmp = f.name
     try:
         proc = subprocess.run(
-            ["node", "-e", script],
+            ["node", tmp],
             capture_output=True,
             text=True,
             timeout=15,
         )
     except FileNotFoundError:
         pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
     assert proc.returncode == 0, (
-        f"_redactApiKeys runtime smoke failed.  stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        f"redactCredentials runtime smoke failed.  stdout={proc.stdout!r} stderr={proc.stderr!r}"
     )
 
 

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -49,6 +49,7 @@ _ESM_BUNDLES = [
     _SHARED / "composer_queue.js",
     _SHARED / "interactive.js",
     _SHARED / "conversation.js",
+    _SHARED / "redact_credentials.js",
 ]
 
 # Sink scan: everything except renderer.js — the one sanctioned HTML-string
@@ -68,6 +69,7 @@ _ESM_NO_VAR_BUNDLES = [
     _SHARED / "auth.js",
     _SHARED / "interactive.js",
     _SHARED / "conversation.js",
+    _SHARED / "redact_credentials.js",
 ]
 
 # The same unsafe DOM-write / dynamic-code sink set that ``test_app_js.py``

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -40,6 +40,7 @@ import {
   batchKicker,
   indexLabel,
 } from "/shared/conversation.js";
+import { redactCredentials } from "/shared/redact_credentials.js";
 
 function buildCoordChrome(root, opts) {
   opts = opts || {};
@@ -533,7 +534,7 @@ function createCoordinatorPane(root, wsId, opts) {
       /* fall through */
     }
     if (!parsed || typeof parsed !== "object") {
-      return esc(rawText);
+      return esc(redactCredentials(rawText));
     }
     // Normalize to an array of rows we can linkify.
     let rows = [];
@@ -543,7 +544,7 @@ function createCoordinatorPane(root, wsId, opts) {
       rows = [parsed];
     }
     if (rows.length === 0) {
-      return "<pre>" + esc(JSON.stringify(parsed, null, 2)) + "</pre>";
+      return "<pre>" + esc(redactCredentials(JSON.stringify(parsed, null, 2))) + "</pre>";
     }
     const lines = rows.map((row) => {
       const safeWs = row.ws_id && WS_ID_RE.test(row.ws_id) ? row.ws_id : null;

--- a/turnstone/core/output_guard.py
+++ b/turnstone/core/output_guard.py
@@ -109,7 +109,8 @@ _RE_ENV_SECRET_KEY = re.compile(
 _RE_JSON_SECRET = re.compile(
     r'"(?:api_key|apikey|api_secret|secret_key|secret|password|passwd|'
     r"token|access_token|refresh_token|auth_token|private_key|"
-    r'client_secret|webhook_secret|signing_key|encryption_key)"\s*:\s*"([^"]{8,})"',
+    r"client_secret|webhook_secret|signing_key|encryption_key|"
+    r'authorization)"\s*:\s*"([^"]{8,})"',
     re.IGNORECASE,
 )
 

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -13,6 +13,8 @@
 // never innerHTML.  Builders return a detached element and let the caller append
 // + scroll, so they stay pane- and transport-agnostic.
 
+import { redactCredentials } from "./redact_credentials.js";
+
 // ANSI / CSI escape stripper — a tool that emits control sequences (bash through
 // MCP, or a child node) must land as readable text in the result block.
 // Null-safe: a non-string argument coerces to "" rather than throwing.
@@ -632,7 +634,7 @@ export function buildConvResult(output, opts) {
       " chars total — truncated for display)";
   }
   const body = document.createElement("span");
-  body.textContent = pretty;
+  body.textContent = redactCredentials(pretty);
   block.appendChild(body);
   return block;
 }

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -35,6 +35,7 @@ import {
   batchKicker,
   indexLabel,
 } from "./conversation.js";
+import { redactCredentials } from "./redact_credentials.js";
 import { authFetch } from "./auth.js";
 import { showToast } from "./toast.js";
 import { Composer } from "./composer.js";
@@ -3656,22 +3657,6 @@ function _formatRuntime(item) {
   return h > 0 ? h + "h " + m + "m" : m + "m";
 }
 
-function _redactApiKeys(text) {
-  // Query-string style: api_key=VALUE
-  let redacted = text.replace(
-    /(?:api_key|apiKey|api-key|token)=[^&\s"]+/g,
-    function (m) {
-      return m.split("=")[0] + "=***";
-    },
-  );
-  // JSON style: "api_key": "VALUE"
-  redacted = redacted.replace(
-    /(["'](?:api_key|apiKey|api-key|token)["']\s*:\s*["'])([^"']*)(['"])/gi,
-    "$1***$3",
-  );
-  return redacted;
-}
-
 function _tryPrettyJson(text) {
   let obj;
   try {
@@ -3679,7 +3664,7 @@ function _tryPrettyJson(text) {
   } catch (e) {
     return null;
   }
-  return _redactApiKeys(JSON.stringify(obj, null, 2));
+  return redactCredentials(JSON.stringify(obj, null, 2));
 }
 
 // ---------------------------------------------------------------------------
@@ -4146,7 +4131,7 @@ function renderToolOutput(stripped, isError) {
       return out;
     }
   }
-  out.textContent = _redactApiKeys(stripped);
+  out.textContent = redactCredentials(stripped);
   return out;
 }
 
@@ -4181,7 +4166,7 @@ function buildMediaEmbed(media, rawJson) {
   // Collapsed raw JSON for inspection (with redacted API keys)
   const raw = document.createElement("div");
   raw.className = "tool-output";
-  raw.textContent = _tryPrettyJson(rawJson) || _redactApiKeys(rawJson);
+  raw.textContent = _tryPrettyJson(rawJson) || redactCredentials(rawJson);
   makeCollapsible(raw);
   wrapper.appendChild(raw);
 
@@ -4306,7 +4291,7 @@ function buildMcpErrorEmbed(err, rawJson, onConsent) {
   details.appendChild(summary);
   const pre = document.createElement("pre");
   pre.className = "tool-output";
-  pre.textContent = _tryPrettyJson(rawJson) || _redactApiKeys(rawJson);
+  pre.textContent = _tryPrettyJson(rawJson) || redactCredentials(rawJson);
   details.appendChild(pre);
   wrapper.appendChild(details);
 

--- a/turnstone/shared_static/redact_credentials.js
+++ b/turnstone/shared_static/redact_credentials.js
@@ -1,0 +1,160 @@
+// redact_credentials.js — client-side credential redaction for tool call cards.
+//
+// Visual-only censorship of credentials in tool output BEFORE it hits the DOM.
+// Mirrors the backend patterns in turnstone/core/output_guard.py so the
+// frontend and backend redaction stay consistent.
+//
+// ES module — imported by conversation.js (shared substrate) and by
+// interactive.js directly (which also replaces its legacy _redactApiKeys).
+// Pure function, no DOM dependency, safe to test via `node -e`.
+//
+// Patterns (in order of application):
+//   1. PEM private key blocks        → [REDACTED:private_key]
+//   2. Connection strings            → user:[REDACTED:password]@host
+//   3. Well-known API key formats    → [REDACTED:api_key]
+//      (sk-proj-, sk-, ghp_, gho_, AKIA, AIza, Bearer token, token=, key=)
+//   4. Query-string api_key/token    → key=***  (backward compat)
+//   5. JSON-style key/value          → "key": "***"  (backward compat)
+//   6. JSON secret keys              → "secret": "[REDACTED:secret]"
+//   7. ENV secret lines              → SECRET_KEY=[REDACTED:secret]
+//
+// House style: no innerHTML, no DOM access, no side-effects.
+
+// ---------------------------------------------------------------------------
+// PEM private key blocks (multiline, whole-block replacement)
+// ---------------------------------------------------------------------------
+const _RE_PRIVATE_KEY_BLOCK =
+  /-----BEGIN\s+(?:RSA\s+|EC\s+|OPENSSH\s+|PGP\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|EC\s+|OPENSSH\s+|PGP\s+)?PRIVATE\s+KEY-----/g;
+
+// ---------------------------------------------------------------------------
+// Connection strings — preserves protocol + user, redacts only the password
+//   postgresql://user:pass@host   →   postgresql://user:[REDACTED:password]@host
+//   https://user:token@api.example.com → https://user:[REDACTED:password]@api.example.com
+// ---------------------------------------------------------------------------
+const _RE_CONNECTION_STRING =
+  /(?:postgresql\+?(?:psycopg)?|mysql|mongodb|redis|amqp|sqlite|https?):\/\/[^:@\s]+:[^@\s]+@/g;
+
+function _redactConnPassword(match) {
+  return match.replace(/:\/\/([^:@\s]+):([^@\s]+)@/, "://$1:[REDACTED:password]@");
+}
+
+// ---------------------------------------------------------------------------
+// Well-known API key / token formats (ordered most-specific first)
+// ---------------------------------------------------------------------------
+const _CREDENTIAL_REPLACEMENTS = [
+  // OpenAI project-scoped keys   sk-proj-xxxxxxxxxx...
+  [/sk-proj-[a-zA-Z0-9\-]{20,}/g, "[REDACTED:api_key]"],
+  // OpenAI standard keys          sk-xxxxxxxxxx...
+  [/sk-[a-zA-Z0-9]{20,}/g, "[REDACTED:api_key]"],
+  // GitHub personal access tokens ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  [/ghp_[a-zA-Z0-9]{36}/g, "[REDACTED:api_key]"],
+  // GitHub OAuth tokens           gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  [/gho_[a-zA-Z0-9]{36}/g, "[REDACTED:api_key]"],
+  // AWS access key IDs            AKIAxxxxxxxxxxxxxxxx
+  [/AKIA[0-9A-Z]{16}/g, "[REDACTED:api_key]"],
+  // Google API keys               AIzaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  [/AIza[a-zA-Z0-9_\-]{35}/g, "[REDACTED:api_key]"],
+  // Bearer tokens — min 20 chars of JWT/opaque token
+  [/Bearer\s+[a-zA-Z0-9._~+/=\-]{20,}/g, "[REDACTED:api_key]"],
+  // token= in query strings (20+ hex/alnum chars)
+  [/token=[a-zA-Z0-9]{20,}/g, "[REDACTED:api_key]"],
+  // key= in query strings (20+ chars)
+  [/key=[a-zA-Z0-9]{20,}/g, "[REDACTED:api_key]"],
+];
+
+// ---------------------------------------------------------------------------
+// Query-string api_key / token redaction (legacy _redactApiKeys compat)
+//   ?api_key=abc123   →   ?api_key=***
+//   &apiKey=abc       →   &apiKey=***
+// ---------------------------------------------------------------------------
+const _RE_QUERY_CRED = /(?:api_key|apiKey|api-key|token)=[^&\s"]+/g;
+
+// ---------------------------------------------------------------------------
+// JSON-style simple redaction (legacy _redactApiKeys compat)
+//   {"api_key": "abc"}   →   {"api_key": "***"}
+// ---------------------------------------------------------------------------
+const _RE_JSON_STYLE_CRED = /(["'](?:api_key|apiKey|api-key|token|authorization|Authorization)["']\s*:\s*["'])([^"']*)(['"])/gi;
+
+// ---------------------------------------------------------------------------
+// JSON secret keys — comprehensive set matching backend
+//   "api_key": "sk-abcdefghijklmnopqrst"  →  "api_key": "[REDACTED:secret]"
+// ---------------------------------------------------------------------------
+const _RE_JSON_SECRET_KEY_VALUE =
+  /"(?:api_key|apikey|api_secret|secret_key|secret|password|passwd|token|access_token|refresh_token|auth_token|private_key|client_secret|webhook_secret|signing_key|encryption_key|authorization|Authorization)"\s*:\s*"([^"]{8,})"/gi;
+
+function _redactJsonSecretValue(fullMatch) {
+  // Locate the value capture within the match
+  const valStart = fullMatch.indexOf('"', fullMatch.indexOf(":") + 1) + 1;
+  // valEnd is the index of the closing quote of the value
+  const valEnd = fullMatch.lastIndexOf('"');
+  if (valStart <= 0 || valEnd <= valStart) return fullMatch;
+  return fullMatch.slice(0, valStart) + "[REDACTED:secret]" + fullMatch.slice(valEnd);
+}
+
+// ---------------------------------------------------------------------------
+// ENV secret line redaction — matches the backend's two-regex pipeline
+//   SECRET_KEY=abc123           →   SECRET_KEY=[REDACTED:secret]
+//   DATABASE_URL=postgres://…   →   DATABASE_URL=[REDACTED:secret]
+//   FOO=bar                     →   not redacted (no secret-bearing key name)
+// ---------------------------------------------------------------------------
+const _RE_ENV_SECRET_LINE = /[A-Z][A-Z_0-9]+=\S+/g;
+const _RE_ENV_SECRET_KEY =
+  /(?:^|_)(?:SECRET|TOKEN|PASSWORD|CREDENTIAL|DSN)(?:_|$)|(?:^|_)KEY(?:_|$)|^(?:DATABASE_URL|TURNSTONE_DB_URL|DB_URL)$/i;
+
+function _redactEnvLine(match) {
+  const eqIdx = match.indexOf("=");
+  if (eqIdx < 0) return match;
+  const key = match.slice(0, eqIdx);
+  if (_RE_ENV_SECRET_KEY.test(key)) {
+    return key + "=[REDACTED:secret]";
+  }
+  return match;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact known credential patterns in a string for display.
+ *
+ * Matches the backend's output_guard._redact_credentials patterns, applied
+ * in priority order so more-specific patterns take precedence.  Pure function,
+ * no side-effects.
+ *
+ * @param {string} text - The raw text to redact
+ * @returns {string} Text with credential values replaced by redaction markers
+ */
+export function redactCredentials(text) {
+  if (!text) return text;
+
+  let result = String(text);
+
+  // 1. PEM private key blocks (whole-block removal)
+  result = result.replace(_RE_PRIVATE_KEY_BLOCK, "[REDACTED:private_key]");
+
+  // 2. Connection string passwords (preserve user)
+  result = result.replace(_RE_CONNECTION_STRING, _redactConnPassword);
+
+  // 3. Well-known API key / token formats
+  for (const [re, replacement] of _CREDENTIAL_REPLACEMENTS) {
+    result = result.replace(re, replacement);
+  }
+
+  // 4. Query-string credential params (backward compat with _redactApiKeys)
+  result = result.replace(_RE_QUERY_CRED, (m) => {
+    const eq = m.indexOf("=");
+    return eq >= 0 ? m.slice(0, eq) + "=***" : m;
+  });
+
+  // 5. JSON-style simple redaction (backward compat with _redactApiKeys)
+  result = result.replace(_RE_JSON_STYLE_CRED, "$1***$3");
+
+  // 6. JSON secret key values (comprehensive set, backend-parity)
+  result = result.replace(_RE_JSON_SECRET_KEY_VALUE, _redactJsonSecretValue);
+
+  // 7. ENV secret lines
+  result = result.replace(_RE_ENV_SECRET_LINE, _redactEnvLine);
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Models output credentials (Bearer tokens, API keys, connection strings, etc.) in tool call output (code snippets, curl commands, JSON payloads). The backend already has a comprehensive `redact_credentials()` in the output guard, but the frontend was only doing minimal `api_key=` / `"api_key":""` redaction (in interactive.js) and **no redaction at all** in the coordinator view.

This PR introduces a shared ES6+ module with full pattern coverage and wires it into both frontend surfaces.

### New: `shared_static/redact_credentials.js`

Pure ES6+ module exporting `redactCredentials(text)` that mirrors the backend's `output_guard._redact_credentials()`:

| Priority | Pattern | Example → Replacement |
|---|---|---|
| 1 | PEM private key blocks | `-----BEGIN RSA PRIVATE KEY-----…-----END KEY-----` → `[REDACTED:private_key]` |
| 2 | Connection strings | `postgresql://user:pass@host` → `postgresql://user:[REDACTED:password]@host` |
| 3 | Well-known API keys | `sk-proj-`, `sk-`, `ghp_`, `gho_`, `AKIA`, `AIza`, `Bearer …` → `[REDACTED:api_key]` |
| 4 | Query-string creds | `?api_key=abc` → `?api_key=***` |
| 5 | JSON-style keys | `{"api_key": "abc"}` → `{"api_key": "***"}` |
| 6 | JSON secret values | `"password": "secret123"`, `"authorization": "Bearer …"` → `[REDACTED:secret]` |
| 7 | ENV secret lines | `SECRET_KEY=value` → `SECRET_KEY=[REDACTED:secret]` |

### Integration points

- **`shared_static/conversation.js`** - imported and applied in `buildConvResult()`, which covers all coordinator view tool call cards
- **`shared_static/interactive.js`** - replaced the legacy minimal `_redactApiKeys` with the shared module in all four call sites (`renderToolOutput`, `_tryPrettyJson`, `buildMediaEmbed`, `buildMcpErrorEmbed`)
- **`console/static/coordinator/coordinator.js`** - imported and applied in `renderToolOutput()` fallback paths

### Backend parity

- Added `authorization` to `_RE_JSON_SECRET` in `output_guard.py` so the output guard flags and redacts Authorization-headers-in-JSON the same way

### Tests

- Ported runtime smoke test from the removed `_redactApiKeys` to directly import the new module
- Added `redact_credentials.js` to the const-reassign, var-free, and sink guard bundles