### PR TITLE
fix(mcp): flaky-server 100% CPU spin — per-server transport owner tasks

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2209,6 +2209,7 @@ class TestSafeCloseStack:
 
     def test_suppresses_runtime_error(self):
         """RuntimeError from broken cancel scope is suppressed."""
+        mgr = MCPClientManager({})
 
         async def _run():
             stack = AsyncExitStack()
@@ -2220,12 +2221,13 @@ class TestSafeCloseStack:
 
             stack.aclose = _broken_close
             # Should not raise
-            await MCPClientManager._safe_close_stack(stack)
+            await mgr._safe_close_stack(stack)
 
         asyncio.run(_run())
 
     def test_suppresses_cancelled_error(self):
         """CancelledError during close is suppressed."""
+        mgr = MCPClientManager({})
 
         async def _run():
             stack = AsyncExitStack()
@@ -2235,7 +2237,25 @@ class TestSafeCloseStack:
                 raise asyncio.CancelledError()
 
             stack.aclose = _cancel_close
-            await MCPClientManager._safe_close_stack(stack)
+            await mgr._safe_close_stack(stack)
+
+        asyncio.run(_run())
+
+    def test_suppressed_close_triggers_scope_disarm(self):
+        """A suppressed close runs the orphaned-scope disarm backstop."""
+        mgr = MCPClientManager({})
+
+        async def _run():
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+
+            async def _broken_close():
+                raise RuntimeError("Attempted to exit cancel scope in a different task")
+
+            stack.aclose = _broken_close
+            with patch.object(mgr, "_maybe_disarm_orphaned_scopes") as disarm:
+                await mgr._safe_close_stack(stack)
+            disarm.assert_called_once()
 
         asyncio.run(_run())
 
@@ -2455,10 +2475,12 @@ class TestCircuitBreaker:
         mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
         mock_session = MagicMock()
         mock_session.call_tool = MagicMock(return_value="sentinel")
-        # Seed both session and stack so the test can verify stack survives.
-        old_stack = MagicMock()
+        # Seed session + owner so the test can verify the owner survives.
+        old_owner = MagicMock()
         old_streams = (MagicMock(), MagicMock())
-        _seed_static_state(mgr, "test", session=mock_session, stack=old_stack, streams=old_streams)
+        _seed_static_state(
+            mgr, "test", session=mock_session, owner_task=old_owner, streams=old_streams
+        )
         mgr._loop = MagicMock()
         mgr._tool_map["mcp__test__ping"] = ("test", "ping")
         mock_future = MagicMock()
@@ -2468,11 +2490,11 @@ class TestCircuitBreaker:
             pytest.raises(BrokenPipeError),
         ):
             mgr.call_tool_sync("mcp__test__ping", {}, timeout=5)
-        # Session evicted, but stack/streams remain for the stale-and-stack
-        # guard in _connect_one to clean up on next reconnect attempt.
+        # Session evicted, but the owner/streams remain for the stale guard in
+        # _connect_one_locked to close on the next reconnect attempt.
         state = mgr._static_servers["test"]
         assert state.session is None
-        assert state.stack is old_stack
+        assert state.owner_task is old_owner
         assert state.streams is old_streams
 
     def test_independent_circuits_per_server(self):
@@ -2958,42 +2980,47 @@ class TestReconnectSync:
         ``reconnect_sync`` no longer carries its own copy. Drive the REAL locked
         body via a no-command stdio cfg: the stale-guard runs, then the connect
         early-returns, so the ordering is observable without a live server."""
-        mgr, _loop, _thread = running_loop_mgr
+        mgr, loop, _thread = running_loop_mgr
         mgr._server_configs["srv"] = {"type": "stdio"}  # no command → early return
 
         order: list[str] = []
-        old_stack = MagicMock(spec=AsyncExitStack)
+
+        async def _make_owner() -> tuple[asyncio.Event, asyncio.Task[None]]:
+            ev = asyncio.Event()
+
+            async def _parked_owner() -> None:
+                await ev.wait()
+                order.append("owner_exit")
+
+            task = asyncio.create_task(_parked_owner())
+            await asyncio.sleep(0)
+            return ev, task
+
+        ev, old_owner = _run_hl(loop, _make_owner())
 
         async def _pre_close(name: str) -> None:
             order.append("pre_close")
             # Session must already be nulled when streams close (canonical order).
             assert mgr._static_servers["srv"].session is None
 
-        async def _safe_close(stack: Any) -> None:
-            # Only the OLD stack is closed on this path (the fresh connect
-            # stack is aclose()d directly by the no-command early return).
-            assert stack is old_stack
-            order.append("safe_close")
-
-        # Seed the old session/stack/streams that the stale-guard should clear.
+        # Seed the old session/owner/streams that the stale-guard should close.
         _seed_static_state(
             mgr,
             "srv",
             session=MagicMock(),
-            stack=old_stack,
+            owner_task=old_owner,
+            close_requested=ev,
             streams=(MagicMock(), MagicMock()),
         )
 
-        with (
-            patch.object(mgr, "_pre_close_streams", side_effect=_pre_close),
-            patch.object(mgr, "_safe_close_stack", side_effect=_safe_close),
-        ):
+        with patch.object(mgr, "_pre_close_streams", side_effect=_pre_close):
             result = mgr.reconnect_sync("srv")
-        assert order == ["pre_close", "safe_close"]  # teardown ran, in order
+        assert order == ["pre_close", "owner_exit"]  # teardown ran, in order
         assert result["connected"] is False  # no command — nothing to rebuild
         state = mgr._static_servers["srv"]
         assert state.session is None
-        assert state.stack is not old_stack  # old stack cleared from state
+        assert state.owner_task is None  # old owner cleared from state
+        assert old_owner.done() and not old_owner.cancelled()
 
     def test_reconnect_failure_returns_error_dict(self, running_loop_mgr):
         mgr, _loop, _thread = running_loop_mgr
@@ -4013,7 +4040,7 @@ class TestEnsureStaticConnected:
         """session None + in_flight > 0 → defer (None) without teardown; once
         the sibling call drains, the next call reconnects."""
         mgr, loop, _ = running_loop_mgr
-        state = _seed_static_state(mgr, "srv", session=None, stack=MagicMock(spec=AsyncExitStack))
+        state = _seed_static_state(mgr, "srv", session=None)
         state.in_flight = 1
         sess = MagicMock()
 
@@ -4179,30 +4206,75 @@ class TestTeardownStaticSession:
     stale-guard and remove_server_sync)."""
 
     def test_teardown_order_and_state_cleared(self, running_loop_mgr) -> None:
+        """Close protocol: session nulled, close event set BEFORE the first
+        await (a teardown cancelled mid-flight must still have delivered the
+        owner's marching orders), streams pre-closed, then the parked owner
+        exits GRACEFULLY — no cancel."""
         mgr, loop, _ = running_loop_mgr
         order: list[str] = []
-        old_stack = MagicMock(spec=AsyncExitStack)
+
+        async def _make_owner() -> tuple[asyncio.Event, asyncio.Task[None]]:
+            ev = asyncio.Event()
+
+            async def _parked_owner() -> None:
+                await ev.wait()
+                order.append("owner_exit")
+
+            task = asyncio.create_task(_parked_owner())
+            await asyncio.sleep(0)  # let the owner park
+            return ev, task
+
+        ev, owner = _run_hl(loop, _make_owner())
 
         async def _pre_close(name: str) -> None:
             order.append("pre_close")
             # Session nulled FIRST so concurrent dispatch reads see
             # "disconnected", not a corpse.
             assert mgr._static_servers["srv"].session is None
+            # The close signal precedes the first await of the teardown.
+            assert ev.is_set()
 
-        async def _safe_close(stack: Any) -> None:
-            order.append("safe_close")
-            assert stack is old_stack
-
-        _seed_static_state(mgr, "srv", session=MagicMock(), stack=old_stack)
-        with (
-            patch.object(mgr, "_pre_close_streams", side_effect=_pre_close),
-            patch.object(mgr, "_safe_close_stack", side_effect=_safe_close),
-        ):
+        _seed_static_state(mgr, "srv", session=MagicMock(), owner_task=owner, close_requested=ev)
+        with patch.object(mgr, "_pre_close_streams", side_effect=_pre_close):
             _run_hl(loop, mgr._teardown_static_session("srv"))
-        assert order == ["pre_close", "safe_close"]
+        assert order == ["pre_close", "owner_exit"]
         state = mgr._static_servers["srv"]
         assert state.session is None
-        assert state.stack is None
+        assert state.owner_task is None
+        assert state.close_requested is None
+        assert owner.done() and not owner.cancelled()  # graceful, no escalation
+
+    def test_teardown_escalates_to_single_cancel(self, running_loop_mgr) -> None:
+        """An owner that ignores the close event gets EXACTLY one cancel — a
+        second cancel is the zombie-minting mistake the protocol forbids, so
+        the count is pinned, not just the final cancelled state."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._OWNER_CLOSE_GRACE_S = 0.05  # keep the graceful window short
+        cancel_calls: list[Any] = []
+
+        async def _make_owner() -> asyncio.Task[None]:
+            async def _stubborn_owner() -> None:
+                await asyncio.sleep(3600)  # never watches the event
+
+            task = asyncio.create_task(_stubborn_owner())
+            await asyncio.sleep(0)
+            real_cancel = task.cancel
+
+            def _counting_cancel(*args: Any, **kwargs: Any) -> bool:
+                cancel_calls.append(args)
+                return real_cancel(*args, **kwargs)
+
+            task.cancel = _counting_cancel  # type: ignore[method-assign]
+            return task
+
+        owner = _run_hl(loop, _make_owner())
+        _seed_static_state(
+            mgr, "srv", session=MagicMock(), owner_task=owner, close_requested=asyncio.Event()
+        )
+        _run_hl(loop, mgr._teardown_static_session("srv"))
+        assert owner.cancelled()
+        assert len(cancel_calls) == 1  # one cancel, never a second
+        assert mgr._static_servers["srv"].owner_task is None
 
     def test_teardown_missing_server_is_noop(self, running_loop_mgr) -> None:
         mgr, loop, _ = running_loop_mgr

--- a/tests/test_mcp_live_flaky_server.py
+++ b/tests/test_mcp_live_flaky_server.py
@@ -1,0 +1,207 @@
+"""Live flaky-server smoke test: SIGKILL-flap a real MCP server, no CPU spin.
+
+End-to-end regression for the flaky-server 100%-CPU incident: a real
+streamable-http MCP server (FastMCP, subprocess) is SIGKILLed and restarted
+several times underneath a real ``MCPClientManager`` with the health loop
+running on compressed timings. The production failure signature was armed
+anyio ``CancelScope``s — each one re-delivers cancellation via ``call_soon``
+every event-loop iteration, forever (~10^5+ callbacks/s), one more per flap
+cycle — so the pass criterion is structural: after the flaps settle, ZERO
+armed scopes exist on the mcp-loop, exactly one transport owner is alive, the
+health loop still runs, and a real tool call round-trips.
+
+Self-contained (spawns its own server; no LLM backend, no network beyond
+127.0.0.1) — deliberately NOT marked ``live``. Wall clock ~10-15s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import signal
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from turnstone.core.mcp_client import MCPClientManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SERVER_SRC = textwrap.dedent(
+    '''
+    """Healthy streamable-http MCP server; the test SIGKILLs it to flap."""
+    import sys
+
+    from mcp.server.fastmcp import FastMCP
+
+    port = int(sys.argv[1])
+    mcp = FastMCP("flaky-victim", host="127.0.0.1", port=port)
+
+
+    @mcp.tool()
+    def ping_me(x: int) -> int:
+        """Return x + 1."""
+        return x + 1
+
+
+    if __name__ == "__main__":
+        mcp.run(transport="streamable-http")
+    '''
+).lstrip()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_tcp_ready(port: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.3):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def _wait_session_live(mgr: MCPClientManager, name: str, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        state = mgr._static_servers.get(name)
+        if state is not None and state.session is not None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+async def _armed_scope_count() -> int:
+    """Armed scopes hosted on THIS (the mcp) loop — mirrors the production
+    disarm sweep's scoping, and keeps an unrelated scope on another loop that
+    is momentarily mid-cancellation from flaking the assertion."""
+    import asyncio as _asyncio
+
+    from anyio._backends._asyncio import CancelScope
+
+    this_loop = _asyncio.get_running_loop()
+    armed = 0
+    for obj in gc.get_objects():
+        if not isinstance(obj, CancelScope):
+            continue
+        if getattr(obj, "_cancel_handle", None) is None:
+            continue
+        host = getattr(obj, "_host_task", None)
+        if host is not None and host.get_loop() is not this_loop:
+            continue
+        armed += 1
+    return armed
+
+
+async def _live_owner_count() -> int:
+    return sum(
+        1
+        for t in asyncio.all_tasks()
+        if t.get_name().startswith("mcp-transport-owner:") and not t.done()
+    )
+
+
+class TestFlakyServerNoSpin:
+    def test_sigkill_flap_cycle_no_armed_scopes_and_recovers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The subprocess runs sys.executable, so importability HERE is a
+        # faithful proxy for the server side. Environment gaps skip, not fail.
+        pytest.importorskip("mcp.server.fastmcp")
+        script = tmp_path / "flaky_srv.py"
+        script.write_text(SERVER_SRC)
+        port = _free_port()
+
+        # Compress recovery timings so 3 flap cycles fit a unit-test budget.
+        monkeypatch.setattr(MCPClientManager, "_CONNECT_TIMEOUT", 3)
+        monkeypatch.setattr(MCPClientManager, "_TCP_PROBE_TIMEOUT", 1)
+        monkeypatch.setattr(MCPClientManager, "_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S", 5.0)
+        monkeypatch.setattr(MCPClientManager, "_STATIC_RECONNECT_CALLER_TIMEOUT_S", 6.0)
+        monkeypatch.setattr(MCPClientManager, "_STATIC_RECONNECT_BASE_S", 0.2)
+        monkeypatch.setattr(MCPClientManager, "_STATIC_RECONNECT_MAX_S", 0.8)
+        monkeypatch.setattr(MCPClientManager, "_STATIC_HEALTH_PING_TIMEOUT_S", 1.5)
+
+        def _spawn_server(*, initial: bool = False) -> subprocess.Popen[bytes]:
+            proc = subprocess.Popen(
+                [sys.executable, str(script), str(port)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if not _wait_tcp_ready(port, 10.0):
+                proc.kill()
+                proc.wait(timeout=5)
+                if initial:
+                    # Environment gap (loaded CI runner, sandboxed sockets) —
+                    # not a regression signal. Mid-test respawns DO fail: the
+                    # server already bound once, so a vanishing rebind is real.
+                    pytest.skip("flaky-server subprocess did not come up")
+                raise AssertionError("flaky server did not come back up mid-test")
+            return proc
+
+        proc: subprocess.Popen[bytes] | None = None
+        mgr: MCPClientManager | None = None
+        try:
+            proc = _spawn_server(initial=True)
+            with patch(
+                "turnstone.core.mcp_client.load_config",
+                return_value={"static_health_check_seconds": 0.4},
+            ):
+                mgr = MCPClientManager(
+                    {"flaky": {"type": "http", "url": f"http://127.0.0.1:{port}/mcp"}}
+                )
+            mgr.start()
+            assert _wait_session_live(mgr, "flaky", 8.0), "initial connect failed"
+
+            for _cycle in range(3):
+                proc.send_signal(signal.SIGKILL)
+                proc.wait()
+                time.sleep(0.6)  # dead window: health loop sees the corpse
+                proc = _spawn_server()
+                assert _wait_session_live(mgr, "flaky", 10.0), (
+                    f"no reconnect after flap cycle {_cycle}"
+                )
+
+            # Let in-flight teardown/backoff machinery fully settle.
+            time.sleep(1.5)
+
+            assert mgr._loop is not None
+            armed = asyncio.run_coroutine_threadsafe(_armed_scope_count(), mgr._loop).result(
+                timeout=10
+            )
+            owners = asyncio.run_coroutine_threadsafe(_live_owner_count(), mgr._loop).result(
+                timeout=10
+            )
+            health = mgr._static_health_task
+
+            # The production failure signature: one armed scope per flap cycle.
+            assert armed == 0, f"{armed} armed cancel scope(s) — the CPU-spin signature"
+            # Exactly the current session's owner is alive; the flapped ones
+            # all unwound instead of leaking.
+            assert owners == 1
+            # The recovery machinery itself survived every flap.
+            assert health is not None and not health.done()
+            # The structural fix did the work — the disarm backstop never ran.
+            assert mgr._last_scope_disarm == 0.0
+
+            # And the recovered session actually dispatches.
+            out = mgr.call_tool_sync("mcp__flaky__ping_me", {"x": 41}, timeout=10)
+            assert "42" in out
+        finally:
+            if mgr is not None:
+                mgr.shutdown()
+            if proc is not None:
+                proc.send_signal(signal.SIGKILL)
+                proc.wait(timeout=5)

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1033,22 +1033,22 @@ class TestStaticPathUnchanged:
 
         from turnstone.core import mcp_client
 
-        # The connect body (incl. the streamablehttp_client call site) lives in
-        # ``_connect_one_locked``; ``_connect_one`` is now a per-name-lock wrapper.
-        source = inspect.getsource(mcp_client.MCPClientManager._connect_one_locked)
+        # The static path's streamablehttp_client call site lives in the
+        # transport owner task (``_static_transport_owner``); ``_connect_one``
+        # is a per-name-lock wrapper and ``_connect_one_locked`` only waits on
+        # the owner's readiness.
+        source = inspect.getsource(mcp_client.MCPClientManager._static_transport_owner)
 
         # The static path's streamablehttp_client invocation should NOT
         # mention ``httpx_client_factory``. Pool path keeps it.
-        # Find the streamablehttp_client(...) call inside _connect_one.
         assert "streamablehttp_client" in source
-        # The call site in _connect_one is bare — no factory keyword.
-        # We grep by line: the factory keyword must not appear in the
-        # static-path source.
+        # The call site in the owner is bare — no factory keyword. We grep by
+        # line: the factory keyword must not appear in the static-path source.
         for line in source.splitlines():
             if "httpx_client_factory" in line:
                 pytest.fail(
-                    "_connect_one (static path) passes httpx_client_factory to "
-                    "streamablehttp_client; hard invariant 1 violated."
+                    "_static_transport_owner (static path) passes httpx_client_factory "
+                    "to streamablehttp_client; hard invariant 1 violated."
                 )
 
 

--- a/tests/test_mcp_transport_owner.py
+++ b/tests/test_mcp_transport_owner.py
@@ -187,6 +187,48 @@ class TestTransportOwnerLifecycle:
         # The cms were still unwound in-task despite the stray cancel.
         assert fake["events"][-2:] == ["session_exit", "transport_exit"]
 
+    def test_base_exception_escape_resolves_waiter_and_propagates(self, running_loop_mgr) -> None:
+        """A BaseException-derived escape that is neither CancelledError nor
+        Exception/group (a library control-flow escape; SystemExit and
+        KeyboardInterrupt take the same path but additionally stop the loop —
+        asyncio semantics, unobservable in-process) is NOT swallowed — it
+        propagates from the owner task — but the waiter must still be resolved
+        with a transport-failure error, or the connecting caller would block
+        until its outer bound (and ``_connect_all``'s initial connect has
+        none)."""
+        mgr, loop, _ = running_loop_mgr
+
+        class _TransportLibraryEscape(BaseException):
+            pass
+
+        @asynccontextmanager
+        async def escaping_stdio_client(_params: Any):
+            raise _TransportLibraryEscape("control-flow escape")
+            yield  # pragma: no cover
+
+        async def _drive() -> tuple[BaseException | None, BaseException | None]:
+            ready: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+            close_requested = asyncio.Event()
+            owner = asyncio.create_task(
+                mgr._static_transport_owner(
+                    "srv", mgr._server_configs["srv"], ready, close_requested
+                )
+            )
+            waiter_exc: BaseException | None = None
+            try:
+                await ready
+            except BaseException as e:  # noqa: BLE001 - asserting the exact type below
+                waiter_exc = e
+            await asyncio.wait({owner}, timeout=5)
+            owner_exc = owner.exception() if owner.done() and not owner.cancelled() else None
+            return waiter_exc, owner_exc
+
+        with patch("turnstone.core.mcp_client.stdio_client", escaping_stdio_client):
+            waiter_exc, owner_exc = _run(loop, _drive(), timeout=10)
+
+        assert isinstance(waiter_exc, ConnectionError)  # waiter resolved, never hung
+        assert isinstance(owner_exc, _TransportLibraryEscape)  # propagated, unswallowed
+
     def test_connect_failure_unwinds_owner_and_raises(self, running_loop_mgr) -> None:
         mgr, loop, _ = running_loop_mgr
 

--- a/tests/test_mcp_transport_owner.py
+++ b/tests/test_mcp_transport_owner.py
@@ -1,0 +1,394 @@
+"""Transport owner-task lifecycle + anyio cancel-scope zombie regressions.
+
+Covers the two bugs behind the flaky-MCP-server 100%-CPU incident:
+
+* Bug 1 — an anyio cancel scope whose host task has finished can never be
+  exited; once cancelled (SDK task-group child death, or a teardown racing a
+  connect) anyio re-delivers cancellation to it via ``call_soon`` every loop
+  iteration, forever. The fix routes every transport cm through a long-lived
+  per-server OWNER task (enter, park, exit — all in one task) with a
+  one-cancel close protocol; these tests pin the protocol's behavior.
+* Bug 2 — ``BaseExceptionGroup`` (BaseException-derived) escaping
+  ``except Exception`` killed ``_connect_all`` before the health/sweep loops
+  were created, silently disabling all autonomous recovery.
+
+The live end-to-end flap test (real server, SIGKILL cycle) lives in
+``test_mcp_live_flaky_server.py``; these are fast mock-transport unit tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from turnstone.core.mcp_client import MCPClientManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def running_loop_mgr():
+    """Background-loop fixture matching the static-path test convention."""
+    cfg: dict[str, Any] = {"srv": {"type": "stdio", "command": "fake-cmd"}}
+    mgr = MCPClientManager(cfg)
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True, name="mcp-owner-test-loop")
+    thread.start()
+    mgr._loop = loop
+    try:
+        yield mgr, loop, thread
+    finally:
+
+        async def _drain(m: MCPClientManager) -> None:
+            for attr in (
+                "_user_pool_eviction_task",
+                "_user_token_sweep_task",
+                "_static_health_task",
+            ):
+                task = getattr(m, attr)
+                if task is not None:
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
+                    setattr(m, attr, None)
+            for state in m._static_servers.values():
+                owner = state.owner_task
+                if owner is not None and not owner.done():
+                    if state.close_requested is not None:
+                        state.close_requested.set()
+                    owner.cancel()
+                    with contextlib.suppress(BaseException):
+                        await owner
+
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(_drain(mgr), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        if not thread.is_alive():
+            loop.close()
+
+
+def _run(loop: asyncio.AbstractEventLoop, coro: Any, timeout: float = 5.0) -> Any:
+    return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=timeout)
+
+
+def _make_session_mock() -> AsyncMock:
+    """A ClientSession-shaped mock good enough for connect + discovery."""
+    session = AsyncMock()
+    session.initialize = AsyncMock()
+    session.get_server_capabilities = MagicMock(return_value=None)
+    session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+    return session
+
+
+def _fake_transport_and_session(mgr_module_patches: dict[str, Any]) -> dict[str, Any]:
+    """Build fake stdio transport + ClientSession cms, recording enter/exit."""
+    events: list[str] = []
+    session = _make_session_mock()
+
+    @asynccontextmanager
+    async def fake_stdio_client(_params: Any):
+        events.append("transport_enter")
+        try:
+            yield (AsyncMock(), AsyncMock())
+        finally:
+            events.append("transport_exit")
+
+    @asynccontextmanager
+    async def fake_client_session_cm():
+        events.append("session_enter")
+        try:
+            yield session
+        finally:
+            events.append("session_exit")
+
+    def fake_client_session(_read: Any, _write: Any, message_handler: Any = None):
+        return fake_client_session_cm()
+
+    mgr_module_patches["stdio_client"] = fake_stdio_client
+    mgr_module_patches["ClientSession"] = fake_client_session
+    return {"events": events, "session": session}
+
+
+# ---------------------------------------------------------------------------
+# Owner lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestTransportOwnerLifecycle:
+    def test_connect_installs_owner_and_teardown_closes_gracefully(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+            state = mgr._static_servers["srv"]
+            assert state.session is fake["session"]
+            owner = state.owner_task
+            assert owner is not None and not owner.done()
+            assert state.close_requested is not None
+            assert fake["events"] == ["transport_enter", "session_enter"]
+
+            _run(loop, mgr._teardown_static_session("srv"))
+
+        # Graceful close: the parked owner exits via the event — no cancel —
+        # and unwinds BOTH cms in-task, inner-out.
+        assert owner.done() and not owner.cancelled()
+        assert fake["events"] == [
+            "transport_enter",
+            "session_enter",
+            "session_exit",
+            "transport_exit",
+        ]
+        assert state.session is None
+        assert state.owner_task is None
+        assert state.close_requested is None
+
+    def test_owner_death_evicts_session(self, running_loop_mgr) -> None:
+        """Trigger-A observer: the transport collapsing under a live session
+        (owner task dies without a requested close) evicts the session so the
+        health loop / next dispatch reconnects instead of probing a corpse."""
+        mgr, loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+            state = mgr._static_servers["srv"]
+            owner = state.owner_task
+            assert owner is not None and state.session is fake["session"]
+
+            # Simulate the transport task group collapsing: the owner gets a
+            # stray cancellation (exactly what anyio's scope delivery does).
+            loop.call_soon_threadsafe(owner.cancel)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and state.owner_task is not None:
+                time.sleep(0.02)
+
+        assert owner.done()
+        assert state.session is None  # evicted by the done-callback
+        assert state.owner_task is None
+        # The cms were still unwound in-task despite the stray cancel.
+        assert fake["events"][-2:] == ["session_exit", "transport_exit"]
+
+    def test_connect_failure_unwinds_owner_and_raises(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+
+        @asynccontextmanager
+        async def failing_stdio_client(_params: Any):
+            raise ConnectionError("refused")
+            yield  # pragma: no cover
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", failing_stdio_client),
+            pytest.raises(ConnectionError, match="refused"),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+
+        state = mgr._static_servers["srv"]
+        assert state.session is None
+        assert state.owner_task is None
+
+        async def _no_owner_tasks() -> int:
+            return sum(
+                1
+                for t in asyncio.all_tasks()
+                if t.get_name().startswith("mcp-transport-owner:") and not t.done()
+            )
+
+        assert _run(loop, _no_owner_tasks()) == 0
+
+    def test_caller_cancel_mid_connect_does_not_abandon_cms(self, running_loop_mgr) -> None:
+        """Bug-1 core regression: cancelling the CONNECTING caller (attempt
+        timeout, shutdown, sync boundary giving up) must close the owner via
+        the one-cancel protocol — the transport cm still exits, in-task."""
+        mgr, loop, _ = running_loop_mgr
+        events: list[str] = []
+        entered = asyncio.Event()
+
+        @asynccontextmanager
+        async def hanging_stdio_client(_params: Any):
+            events.append("transport_enter")
+            try:
+                entered.set()
+                await asyncio.sleep(3600)  # server accepted, then stalled
+                yield (AsyncMock(), AsyncMock())
+            finally:
+                events.append("transport_exit")
+
+        async def _drive() -> None:
+            connect = asyncio.create_task(
+                mgr._connect_one_locked("srv", mgr._server_configs["srv"])
+            )
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            connect.cancel()  # the attempt-timeout / shutdown shape
+            with contextlib.suppress(asyncio.CancelledError):
+                await connect
+            # The owner must be closed (one cancel) and fully unwound.
+            deadline = asyncio.get_running_loop().time() + 5
+            while asyncio.get_running_loop().time() < deadline:
+                owners = [
+                    t
+                    for t in asyncio.all_tasks()
+                    if t.get_name().startswith("mcp-transport-owner:") and not t.done()
+                ]
+                if not owners:
+                    return
+                await asyncio.sleep(0.02)
+            raise AssertionError("owner task still alive after caller cancel")
+
+        with patch("turnstone.core.mcp_client.stdio_client", hanging_stdio_client):
+            _run(loop, _drive(), timeout=15)
+
+        assert events == ["transport_enter", "transport_exit"]
+        assert mgr._static_servers["srv"].session is None
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: BaseExceptionGroup vs except Exception
+# ---------------------------------------------------------------------------
+
+
+class TestBaseExceptionGroupHardening:
+    def test_connect_all_survives_group_and_starts_loops(self, running_loop_mgr) -> None:
+        """A transport failure wrapped in BaseExceptionGroup (e.g. an
+        accept-then-RST server collapsing the SDK task group with a stray
+        CancelledError inside) must not kill ``_connect_all`` before the
+        health/sweep loops are started — that silently disabled ALL
+        autonomous recovery."""
+        mgr, loop, _ = running_loop_mgr
+        # Pin the loop cadences: the assertions below require both loops to be
+        # ENABLED, independent of whatever mcp config the environment carries.
+        mgr._user_token_sweep_s = 240.0
+        mgr._static_health_check_s = 30.0
+
+        async def _exploding_connect(name: str, _cfg: dict[str, Any]) -> None:
+            raise BaseExceptionGroup("transport collapsed", [asyncio.CancelledError()])
+
+        with patch.object(mgr, "_connect_one", side_effect=_exploding_connect):
+            _run(loop, mgr._connect_all())
+
+        assert mgr._connected.is_set()
+        assert "srv" in mgr._last_error
+        health = mgr._static_health_task
+        sweep = mgr._user_token_sweep_task
+        assert health is not None and not health.done()
+        assert sweep is not None and not sweep.done()
+
+    def test_health_loop_survives_group(self, running_loop_mgr) -> None:
+        mgr, loop, _ = running_loop_mgr
+        ticks: list[int] = []
+
+        async def _tick_then_group() -> float:
+            ticks.append(1)
+            if len(ticks) == 1:
+                raise BaseExceptionGroup("boom", [asyncio.CancelledError()])
+            return 3600.0
+
+        mgr._static_health_check_s = 0.05  # quick recovery sleep after the group
+        with patch.object(mgr, "_static_health_tick", side_effect=_tick_then_group):
+
+            async def _drive() -> asyncio.Task[None]:
+                task = asyncio.create_task(mgr._static_health_loop())
+                deadline = asyncio.get_running_loop().time() + 5
+                while asyncio.get_running_loop().time() < deadline and len(ticks) < 2:
+                    await asyncio.sleep(0.02)
+                assert len(ticks) >= 2, "loop died on BaseExceptionGroup"
+                assert not task.done()
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                return task
+
+            _run(loop, _drive(), timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Orphaned-scope disarm backstop
+# ---------------------------------------------------------------------------
+
+
+class TestScopeDisarmBackstop:
+    def test_disarms_exactly_the_all_done_scope_on_this_loop(self, running_loop_mgr) -> None:
+        """One sweep over three armed scopes must touch EXACTLY the true
+        orphan: the all-done-tasks scope hosted on the mcp-loop. The
+        live-task scope (its task may still drain the scope) and the
+        hostless scope (loop unknown — not ours to reach into) stay armed.
+        Asserting ``disarmed == 1`` discriminates both failure directions:
+        a no-op sweep and an over-eager one."""
+        mgr, loop, _ = running_loop_mgr
+
+        async def _arm_and_sweep() -> dict[str, Any]:
+            from anyio._backends._asyncio import CancelScope
+
+            this_loop = asyncio.get_running_loop()
+
+            async def _noop() -> None:
+                return None
+
+            blocker = asyncio.Event()
+
+            async def _parked() -> None:
+                await blocker.wait()
+
+            done_task = asyncio.create_task(_noop())
+            await done_task
+            live_task = asyncio.create_task(_parked())
+            await asyncio.sleep(0)
+
+            orphan = CancelScope()
+            orphan._host_task = done_task
+            orphan._tasks.add(done_task)
+            orphan._cancel_handle = this_loop.call_soon(lambda: None)
+
+            live_scope = CancelScope()
+            live_scope._host_task = live_task
+            live_scope._tasks.add(live_task)
+            live_scope._cancel_handle = this_loop.call_soon(lambda: None)
+
+            hostless = CancelScope()
+            hostless._tasks.add(done_task)
+            hostless._cancel_handle = this_loop.call_soon(lambda: None)
+
+            mgr._last_scope_disarm = 0.0
+            disarmed = mgr._maybe_disarm_orphaned_scopes("unit test")
+            results = {
+                "disarmed": disarmed,
+                "orphan_handle_cleared": orphan._cancel_handle is None,
+                "orphan_tasks_cleared": len(orphan._tasks) == 0,
+                "live_still_armed": live_scope._cancel_handle is not None,
+                "live_task_kept": live_task in live_scope._tasks,
+                "hostless_still_armed": hostless._cancel_handle is not None,
+                "rate_limited_second": mgr._maybe_disarm_orphaned_scopes("again"),
+            }
+            for scope in (live_scope, hostless):
+                if scope._cancel_handle is not None:
+                    scope._cancel_handle.cancel()
+                    scope._cancel_handle = None
+                scope._tasks.clear()
+            blocker.set()
+            await live_task
+            return results
+
+        r = _run(loop, _arm_and_sweep())
+        assert r["disarmed"] == 1
+        assert r["orphan_handle_cleared"] and r["orphan_tasks_cleared"]
+        assert r["live_still_armed"] and r["live_task_kept"]
+        assert r["hostless_still_armed"]
+        assert r["rate_limited_second"] == 0

--- a/tests/test_mcp_transport_owner.py
+++ b/tests/test_mcp_transport_owner.py
@@ -217,7 +217,10 @@ class TestTransportOwnerLifecycle:
             waiter_exc: BaseException | None = None
             try:
                 await ready
-            except BaseException as e:  # noqa: BLE001 - asserting the exact type below
+            except (Exception, _TransportLibraryEscape) as e:
+                # Exception covers the expected ConnectionError; the escape
+                # type covers the exact regression this test guards (the raw
+                # escape leaking to the waiter instead of being converted).
                 waiter_exc = e
             await asyncio.wait({owner}, timeout=5)
             owner_exc = owner.exception() if owner.done() and not owner.cancelled() else None

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -115,7 +115,16 @@ def running_loop_mgr():
         # handlers don't fire after pytest has torn its handlers down. Mirrors
         # the production ``shutdown()`` shape.
         async def _drain(m: MCPClientManager) -> None:
-            for attr in ("_user_pool_eviction_task", "_user_token_sweep_task"):
+            # ``_static_health_task`` included: since the BaseExceptionGroup
+            # hardening, ``_connect_all`` reliably starts (and keeps alive) the
+            # health loop even when every configured connect fails — a test
+            # that drives ``_connect_all`` must drain it like production
+            # ``shutdown()`` does, or the task is destroyed pending at GC.
+            for attr in (
+                "_user_pool_eviction_task",
+                "_user_token_sweep_task",
+                "_static_health_task",
+            ):
                 task = getattr(m, attr)
                 if task is not None:
                     task.cancel()

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1595,9 +1595,8 @@ class MCPClientManager:
                 with contextlib.suppress(BaseException):
                     ready.exception()  # mark retrieved: the waiter may be gone
             raise
-        except BaseException as exc:
-            pre_ready = not ready.done()
-            if pre_ready:
+        except (BaseExceptionGroup, Exception) as exc:
+            if not ready.done():
                 # Connect-phase failure: deliver to the waiting caller. Phase
                 # timeouts arrive as TimeoutError (``asyncio.timeout`` converts
                 # its own cancel in THIS task); transport task-group failures
@@ -1606,17 +1605,26 @@ class MCPClientManager:
                 ready.set_exception(exc)
                 with contextlib.suppress(BaseException):
                     ready.exception()  # mark retrieved: the waiter may be gone
-            if not isinstance(exc, (Exception, BaseExceptionGroup)):
-                # An interpreter-level exit (KeyboardInterrupt, SystemExit)
-                # must keep unwinding the task — delivery to the waiter was
-                # this arm's only job for it.
-                raise
-            if pre_ready:
                 return
             # Post-ready death: the server dropped the transport under a live
             # session. The done-callback evicts; the health loop owns the
             # reconnect story. Quiet — a flapping server would otherwise spam.
             log.debug("MCP transport owner for '%s' terminated: %r", name, exc)
+        finally:
+            # BaseExceptions outside the arms above (interpreter exits, or a
+            # library's BaseException-derived control-flow escape) keep
+            # unwinding this task — but must still resolve the waiter, or the
+            # connecting caller blocks until its outer bound (and
+            # _connect_all's initial connect has none). For SystemExit /
+            # KeyboardInterrupt asyncio additionally stops the loop right
+            # after, making the delivery moot there — it is load-bearing for
+            # every other BaseException shape, and free for the exits.
+            if not ready.done():
+                ready.set_exception(
+                    ConnectionError(f"MCP transport owner for '{name}' exited during connect")
+                )
+                with contextlib.suppress(BaseException):
+                    ready.exception()  # mark retrieved: the waiter may be gone
 
     def _on_static_owner_death(self, name: str, task: asyncio.Task[None]) -> None:
         """Done-callback for a transport owner: observe UNREQUESTED death.

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+import gc
 import json
 import random
 import threading
@@ -453,7 +454,17 @@ class StaticServerState:
 
     name: str
     session: Any | None = None
-    stack: AsyncExitStack | None = None
+    # Transport ownership. The owner task is the ONE task that enters and
+    # exits the transport + ClientSession context managers (anyio cancel
+    # scopes are host-task-bound: a scope whose host task has finished can
+    # never be exited, and anyio then re-delivers cancellation to it in a
+    # ``call_soon`` loop forever — the SDK #2147 100%-CPU spin). The exit
+    # stack is deliberately a LOCAL of the owner coroutine, unreachable from
+    # other tasks, so nothing can ``aclose()`` it cross-task. Teardown asks
+    # the owner to close via ``close_requested`` (see
+    # ``_teardown_static_session`` for the close protocol).
+    owner_task: asyncio.Task[None] | None = None
+    close_requested: asyncio.Event | None = None
     streams: tuple[Any, Any] | None = None
     tools: list[dict[str, Any]] = field(default_factory=list)
     resources: list[dict[str, Any]] = field(default_factory=list)
@@ -554,8 +565,8 @@ class MCPClientManager:
         self._exit_stack: AsyncExitStack | None = None
 
         # Per-server state for auth_type ∈ {none, static}.  Each entry holds
-        # session/stack/streams/catalog/capability flags for one name-keyed
-        # connection.  The upcoming per-user pool integration introduces a
+        # session/owner-task/streams/catalog/capability flags for one
+        # name-keyed connection.  The upcoming per-user pool integration introduces a
         # sibling pool-entry map for auth_type=oauth_user; static entries
         # always live here.
         self._static_servers: dict[str, StaticServerState] = {}
@@ -727,6 +738,9 @@ class MCPClientManager:
         # is Turnstone's own reconnect — nothing upstream to lean on. <= 0
         # disables the loop entirely.
         self._static_health_check_s = float(mcp_cfg.get("static_health_check_seconds", 30))
+        # Rate-limit clock for the orphaned-scope disarm backstop
+        # (:meth:`_maybe_disarm_orphaned_scopes`). Monotonic; 0.0 = never ran.
+        self._last_scope_disarm: float = 0.0
 
         # OAuth integration. ``set_app_state`` wires app_state in after the
         # lifespan has built the token store / OAuth helpers; pool dispatch
@@ -860,7 +874,14 @@ class MCPClientManager:
                 await self._connect_one(name, cfg)
             except asyncio.CancelledError:
                 raise  # propagate so the background task can be cleanly stopped
-            except Exception as exc:
+            except (Exception, BaseExceptionGroup) as exc:
+                # ``BaseExceptionGroup`` explicitly: anyio task groups wrap a
+                # transport failure that includes a stray CancelledError (an
+                # accept-then-RST server, a cancel-scope collapse) into a
+                # BaseException-derived group that ``except Exception`` MISSES.
+                # Before this arm, one such server at startup killed
+                # ``_connect_all`` before the health/sweep loops below were
+                # ever created — silently disabling all autonomous recovery.
                 log.warning("Failed to connect MCP server '%s'", name, exc_info=True)
                 self._set_error(name, f"{type(exc).__name__}: {exc}")
                 self._cb_record_failure(name)
@@ -907,13 +928,14 @@ class MCPClientManager:
     # Well beyond the 120s dispatch call is unnecessary; a ping is a lightweight
     # round-trip, but heavy servers / congested links can still take seconds.
     _STATIC_HEALTH_PING_TIMEOUT_S = 30.0
-    # Outer bound on a single autonomous reconnect ATTEMPT. ``_connect_one_locked``
-    # bounds only the handshake (``_CONNECT_TIMEOUT``); its post-handshake
-    # ``list_tools``/``list_resources``/``list_prompts`` are unbounded, so a server
-    # that handshakes then stalls discovery would wedge the loop AND hold the
-    # per-name lock forever. Bound from the caller side (invariant: never edit
-    # ``_connect_one_locked``'s connect internals) with headroom for a worst-case
-    # handshake plus fast discovery.
+    # Outer bound on a single autonomous reconnect ATTEMPT. The transport
+    # owner bounds only the connect phases (``_CONNECT_TIMEOUT`` each); the
+    # post-handshake ``list_tools``/``list_resources``/``list_prompts`` run in
+    # the calling task and are unbounded, so a server that handshakes then
+    # stalls discovery would wedge the loop AND hold the per-name lock
+    # forever. Bound from the caller side with headroom for a worst-case
+    # handshake plus fast discovery — safe to cancel now: the transport cms
+    # live in the owner task, which is closed via the one-cancel protocol.
     _STATIC_RECONNECT_ATTEMPT_TIMEOUT_S = float(_CONNECT_TIMEOUT + 15)
 
     # Caller-side wait for a reconnect routed through ``_ensure_static_connected``
@@ -925,6 +947,23 @@ class MCPClientManager:
     # half-discovered session installed with no breaker record, or an operator
     # teardown silently timing out behind a slow reconnect that holds the lock.
     _STATIC_RECONNECT_CALLER_TIMEOUT_S = _STATIC_RECONNECT_ATTEMPT_TIMEOUT_S + 10.0
+
+    # Transport-owner close protocol (see ``_teardown_static_session``).
+    # Grace for the GRACEFUL phase: the parked owner is asked to close via its
+    # event and unwinds the transport cms in-task; the SDK's streamable-http
+    # ``__aexit__`` may issue a session-termination DELETE, so allow it a few
+    # seconds before escalating.
+    _OWNER_CLOSE_GRACE_S = 5.0
+    # Grace for the ESCALATED phase: after the single ``cancel()``. If the
+    # unwind is STILL running when this expires, the owner is left to finish
+    # on its own — it is self-contained and completing solo is harmless; a
+    # SECOND cancel is what must never happen (it abandons anyio scope exits
+    # mid-flight, minting the exact zombie this design removes).
+    _OWNER_CANCEL_GRACE_S = 5.0
+    # Rate limit for the orphaned-scope disarm sweep (``gc.get_objects`` walk;
+    # cheap enough on failure paths, too heavy to run on every suppressed
+    # close in a storm).
+    _SCOPE_DISARM_MIN_INTERVAL_S = 30.0
 
     # Notification debounce
     _NOTIFICATION_DEBOUNCE = 5.0  # seconds between refreshes per server
@@ -1089,8 +1128,7 @@ class MCPClientManager:
                 f"MCP server '{label}' unreachable at {host}:{port}: {exc}"
             ) from None
 
-    @staticmethod
-    async def _safe_close_stack(stack: AsyncExitStack) -> None:
+    async def _safe_close_stack(self, stack: AsyncExitStack) -> None:
         """Close an AsyncExitStack, suppressing errors from broken anyio scopes.
 
         Called from exception handlers — must not raise, otherwise cleanup
@@ -1119,49 +1157,163 @@ class MCPClientManager:
         scope-exit identity. The 5s bound stays as protection against
         ``aclose()`` hanging on a broken stack (a never-completing
         anyio task during teardown).
+
+        A suppressed close is also the tell that a task group may have been
+        cancelled without its host being able to drain it (the anyio
+        no-progress ``_deliver_cancellation`` spin), so it triggers the
+        rate-limited orphaned-scope disarm sweep as a backstop.
         """
         try:
             async with asyncio.timeout(5):
                 await stack.aclose()
         except (Exception, asyncio.CancelledError, BaseExceptionGroup):
             log.debug("Error closing AsyncExitStack; ignoring", exc_info=True)
+            self._maybe_disarm_orphaned_scopes("suppressed stack close")
+
+    def _maybe_disarm_orphaned_scopes(self, context: str) -> int:
+        """Disarm anyio cancel scopes that can never drain (rate-limited backstop).
+
+        anyio's ``CancelScope._deliver_cancellation`` reschedules itself via
+        ``call_soon`` for as long as ANY task remains registered in the scope —
+        including tasks that are already ``done()``, on which ``task.cancel()``
+        is a silent no-op. A cancelled scope whose registered tasks have all
+        finished (host task abandoned mid-exit, or a transport task group whose
+        child died after the connecting task returned) therefore spins the
+        event loop at 100% CPU forever (verified against anyio 4.14.1; no
+        upstream fix as of that release). The owner-task architecture prevents
+        Turnstone's static path from ever creating that state; this sweep is
+        the belt-and-suspenders for anything else (the pool path's cross-task
+        closes, SDK internals, future regressions).
+
+        Only scopes where EVERY registered task is done are touched — by then
+        no task can ever exit the scope, so cancelling the armed handle and
+        clearing the task set cannot suppress a real cancellation delivery.
+        (Coverage note: the unit tests pin the all-done gate and the field
+        manipulation with a synthetic handle; a REAL self-rescheduling
+        ``_deliver_cancellation`` storm is prevented structurally by the owner
+        architecture, so no test drives one through this sweep.)
+
+        MUST run on the mcp-loop, and only touches scopes HOSTED on it: the
+        ``gc.get_objects()`` walk is process-global, and in ``turnstone-server``
+        this process also runs FastAPI/httpx anyio scopes on the MAIN loop —
+        cancelling another loop's ``call_soon`` handle or clearing a set that
+        loop may be iterating is a cross-thread reach with no thread-safety
+        contract. Foreign-loop orphans are that loop's problem to fix.
+        Returns the number of scopes disarmed. Rate-limited because the walk
+        is O(heap).
+        """
+        now = time.monotonic()
+        if now - self._last_scope_disarm < self._SCOPE_DISARM_MIN_INTERVAL_S:
+            return 0
+        self._last_scope_disarm = now
+        try:
+            from anyio._backends._asyncio import CancelScope as _AnyioCancelScope
+        except ImportError:  # pragma: no cover - anyio is a hard dependency
+            return 0
+        disarmed = 0
+        for obj in gc.get_objects():
+            if not isinstance(obj, _AnyioCancelScope):
+                continue
+            handle = getattr(obj, "_cancel_handle", None)
+            tasks = getattr(obj, "_tasks", None)
+            if handle is None or tasks is None:
+                continue
+            try:
+                host = getattr(obj, "_host_task", None)
+                if host is None or host.get_loop() is not self._loop:
+                    continue
+                if any(not t.done() for t in tasks):
+                    continue
+                handle.cancel()
+                obj._cancel_handle = None
+                tasks.clear()
+                disarmed += 1
+            except Exception:  # never let the backstop become its own failure
+                log.debug("Failed to disarm a cancel scope", exc_info=True)
+        if disarmed:
+            log.warning(
+                "MCP: disarmed %d orphaned anyio cancel scope(s) after %s "
+                "(each was re-delivering cancellation every loop iteration)",
+                disarmed,
+                context,
+            )
+        return disarmed
 
     async def _safe_teardown_on_connect_failure(
         self, key: str | tuple[str, str], stack: AsyncExitStack
     ) -> None:
         """Pre-close streams + close the stack on a connect-time failure.
 
-        Shared by ``_connect_one`` (static) and ``_connect_one_pool``
-        (per-(user, server)) — both raise from inside the stream-enter /
-        session-init try blocks, and both must drain the anyio
-        zero-buffer ``send()`` calls before closing the stack to avoid
-        the SDK #2147 CPU busy-loop.
+        POOL PATH ONLY (``_connect_one_pool``) — it raises from inside the
+        stream-enter / session-init try blocks and must drain the anyio
+        zero-buffer ``send()`` calls before closing the stack to avoid the
+        SDK #2147 CPU busy-loop. The static path no longer builds stacks in
+        the connecting task at all: its transport cms live inside the
+        per-server owner task (:meth:`_static_transport_owner`), which unwinds
+        them in-task on failure.
         """
         await self._pre_close_streams(key)
         await self._safe_close_stack(stack)
 
     async def _teardown_static_session(self, name: str) -> None:
-        """Tear down a static server's session/stack (the ONE canonical order).
+        """Tear down a static server's session/transport (the ONE canonical order).
 
-        Shared by :meth:`_connect_one_locked`'s stale-guard and
-        :meth:`remove_server_sync` so a future ordering fix lands in one place:
-        null the session FIRST (concurrent dispatch reads see "disconnected",
-        not a corpse), pre-close the transport streams (unblocks anyio tasks
-        stuck on zero-buffer ``send()`` — SDK #2147), then close the captured
-        stack. MUST run under the per-name connect lock. Callers decide WHEN
-        teardown is safe — live-session reuse and the ``in_flight`` interlock
-        are enforced by :meth:`_ensure_static_connected`, not here. No-op when
-        the server has no state.
+        Shared by :meth:`_connect_one_locked`'s stale-guard,
+        :meth:`remove_server_sync`, and shutdown so a future ordering fix lands
+        in one place. MUST run under the per-name connect lock (shutdown is
+        exempt: the health loop and dispatch drivers are already stopped).
+        Callers decide WHEN teardown is safe — live-session reuse and the
+        ``in_flight`` interlock are enforced by :meth:`_ensure_static_connected`,
+        not here. No-op when the server has no state.
+
+        Close protocol (the anyio host-task invariant): the transport +
+        ``ClientSession`` cms were entered by the server's OWNER task and can
+        only be exited by it — an exit stack ``aclose()`` from any other task
+        raises anyio's cross-task scope-exit error, and a scope whose host
+        task has finished can never drain, which arms anyio's
+        ``_deliver_cancellation`` retry into a permanent ``call_soon`` storm
+        (the SDK #2147 100%-CPU spin this design removes). So:
+
+        1. null the session (concurrent dispatch reads see "disconnected");
+        2. pre-close the transport streams (unblocks anyio transport tasks
+           stuck on zero-buffer ``send()`` and lets the SDK's readers/writers
+           exit promptly);
+        3. ask the owner to close (``close_requested.set()``) and give its
+           in-task unwind ``_OWNER_CLOSE_GRACE_S``;
+        4. escalate to ONE ``cancel()`` and wait ``_OWNER_CANCEL_GRACE_S``;
+        5. if it is STILL unwinding, leave it to finish solo (it is
+           self-contained; a SECOND cancel would abandon a scope exit
+           mid-flight and mint the exact zombie this protocol exists to
+           prevent) and run the orphaned-scope disarm sweep as a backstop.
         """
         state = self._static_servers.get(name)
         if state is None:
             return
         state.session = None
+        owner = state.owner_task
+        close_requested = state.close_requested
+        state.owner_task = None
+        state.close_requested = None
+        # Signal BEFORE the first await: if this coroutine is itself cancelled
+        # mid-teardown, the owner must already have its marching orders — a
+        # parked owner that never learns of the close would hold the transport
+        # open forever.
+        if close_requested is not None:
+            close_requested.set()
         await self._pre_close_streams(name)
-        old_stack = state.stack
-        state.stack = None
-        if old_stack is not None:
-            await self._safe_close_stack(old_stack)
+        if owner is None or owner.done():
+            return
+        _done, pending = await asyncio.wait({owner}, timeout=self._OWNER_CLOSE_GRACE_S)
+        if pending:
+            owner.cancel()
+            _done, pending = await asyncio.wait({owner}, timeout=self._OWNER_CANCEL_GRACE_S)
+        if pending:
+            log.warning(
+                "MCP transport owner for '%s' still unwinding after close+cancel; "
+                "leaving it to finish on its own",
+                name,
+            )
+            self._maybe_disarm_orphaned_scopes(f"slow owner unwind for '{name}'")
 
     def _static_connect_lock_for(self, name: str) -> asyncio.Lock:
         """Return the per-server connect lock for ``name`` (lazily created).
@@ -1219,9 +1371,12 @@ class MCPClientManager:
            abort it mid-flight. Defer — the next driver pass reconnects once
            it drains (mirrors the pool path's ``_close_pool_entry_if_idle``).
         4. **Bounded connect** — :meth:`_connect_one_locked` under
-           ``_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S`` from the caller side
-           (invariant: never edit its connect internals; its own bounds cover
-           only the handshake, not discovery).
+           ``_STATIC_RECONNECT_ATTEMPT_TIMEOUT_S`` from the caller side (the
+           owner task's internal bounds cover only the connect phases, not
+           discovery). Cancelling the caller here is SAFE: the transport cms
+           live in the owner task, which is closed via the one-cancel
+           protocol and unwinds in-task — a caller-side cancel can no longer
+           abandon an anyio scope mid-exit (the old 100%-CPU zombie).
 
         The circuit breaker is OWNED here for connect outcomes — callers must
         not record the connect again. Success clears only the OPEN-CIRCUIT
@@ -1300,93 +1455,15 @@ class MCPClientManager:
             self._circuit_open_until.pop(name, None)
             return state.session
 
-    async def _connect_one_locked(self, name: str, cfg: dict[str, Any]) -> None:
-        """Connect to a single MCP server and discover its tools.
+    def _make_static_notification_handler(self, name: str) -> Any:
+        """Build the per-server notification handler for a static session.
 
-        MUST run under the per-server connect lock (see :meth:`_connect_one`).
+        Dispatches tool, resource, and prompt list-change notifications to the
+        appropriate refresh method (body unchanged from the pre-owner-task
+        closure in ``_connect_one_locked``; extracted because the session cm
+        is now entered by the transport owner).
         """
-        # Operate on a single state object throughout: get-or-create up front
-        # so the stale-entry guard and the post-handshake field assignments
-        # touch the same instance (PR #296 invariant 5: identity stability).
-        state = self._ensure_static_state(name)
 
-        # Guard: tear down stale session/stack so we don't leak.  Transport
-        # errors in the sync dispatch methods evict the session but leave the
-        # stack behind; ``_teardown_static_session`` clears both (and is a
-        # no-op on a brand new entry).
-        await self._teardown_static_session(name)
-
-        # Per-server exit stack for clean per-server lifecycle management
-        stack = AsyncExitStack()
-        await stack.__aenter__()
-
-        transport = cfg.get("type", "stdio")
-        try:
-            if transport in ("http", "streamable-http") or "url" in cfg:
-                # Pre-flight TCP check: fail fast before entering the anyio
-                # task group in streamablehttp_client.  An immediate connect
-                # failure (ECONNREFUSED) inside the anyio context causes a
-                # CancelledError that escapes asyncio.wait_for and leaves
-                # orphaned cancel-scope tasks spinning at 100% CPU.
-                await self._tcp_probe(name, cfg["url"])
-
-                # ``wait_for`` retained — the static path is byte-identical
-                # (invariant 1) and its narrow connect-once / no-eviction-then-
-                # reuse pattern doesn't trigger the cross-task scope-exit that
-                # f6a3b66 fixed for ``_safe_close_stack`` and that the pool
-                # path's ``_connect_one_pool`` migrated at line 1206 below.
-                # Migrating here would change the static path's bytes; reverting
-                # 1206 to match would re-introduce the pool-path flake. Pin both
-                # directions.
-                read, write, _ = await asyncio.wait_for(
-                    stack.enter_async_context(
-                        streamablehttp_client(url=cfg["url"], headers=cfg.get("headers"))
-                    ),
-                    timeout=self._CONNECT_TIMEOUT,
-                )
-                # Stash stream refs so _pre_close_streams can unblock anyio
-                # transport tasks before the cancel scope fires (SDK #2147).
-                state.streams = (read, write)
-            else:
-                # Default: stdio transport
-                command = cfg.get("command", "")
-                if not command:
-                    log.warning("MCP server '%s' has no command configured", name)
-                    await stack.aclose()
-                    return
-                from turnstone.core.env import scrubbed_env
-
-                env = scrubbed_env(extra=cfg.get("env", {}))
-                params = StdioServerParameters(
-                    command=command,
-                    args=cfg.get("args", []),
-                    env=env,
-                )
-                read, write = await stack.enter_async_context(stdio_client(params))
-                state.streams = (read, write)
-        except asyncio.CancelledError:
-            # Stray CancelledError from broken anyio cancel scope -- treat as
-            # connection failure.  But if the task is genuinely being cancelled
-            # (shutdown), re-raise so we don't block teardown.
-            task = asyncio.current_task()
-            if task is not None and task.cancelling():
-                await self._safe_teardown_on_connect_failure(name, stack)
-                raise
-            log.warning("MCP server '%s' connection failed (anyio cancel)", name)
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise TimeoutError(f"Connection failed for '{name}'") from None
-        except TimeoutError:
-            log.warning(
-                "MCP server '%s' connection timed out after %ds", name, self._CONNECT_TIMEOUT
-            )
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise TimeoutError(f"Connection timed out after {self._CONNECT_TIMEOUT}s") from None
-        except Exception:
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise
-
-        # Register notification handler — dispatches tool, resource, and
-        # prompt list-change notifications to the appropriate refresh method.
         async def _on_notification(
             msg: Any,  # RequestResponder | ServerNotification | Exception
         ) -> None:
@@ -1423,35 +1500,203 @@ class MCPClientManager:
                 log.warning("Refresh after notification failed for '%s'", name, exc_info=True)
                 self._set_error(name, f"Refresh failed: {exc}")
 
+        return _on_notification
+
+    async def _static_transport_owner(
+        self,
+        name: str,
+        cfg: dict[str, Any],
+        ready: asyncio.Future[Any],
+        close_requested: asyncio.Event,
+    ) -> None:
+        """Own the transport + session cm lifecycle for one static server.
+
+        THE anyio host-task invariant, and the fix for the flaky-server
+        100%-CPU regression: anyio cancel scopes (inside the SDK's
+        ``streamablehttp_client`` / ``stdio_client`` / ``ClientSession`` task
+        groups) are bound to the task that enters them. A scope whose host
+        task has finished can never be exited, and once such a scope is
+        cancelled — by anyio's own ``task_done`` when a transport child dies
+        with the server, or by ``ClientSession.__aexit__`` during a later
+        teardown — anyio re-delivers cancellation to it in a ``call_soon``
+        loop every event-loop iteration, forever (~10^5+ callbacks/s per
+        scope, verified against anyio 4.14.1; no upstream fix). Entering the
+        cms from short-lived connect tasks (every health tick is a new task)
+        made that state routine.
+
+        So this long-lived task IS the cm host: it enters the transport and
+        ``ClientSession`` contexts, initializes (each phase bounded by a
+        SAME-TASK ``asyncio.timeout``, whose cancel unwinds the async-with
+        chain in-task and completes), reports readiness, then parks. It
+        unwinds — again in-task — on any of:
+
+          * a requested close (``close_requested`` set by the teardown
+            protocol in :meth:`_teardown_static_session`);
+          * ONE ``cancel()`` (teardown escalation, or shutdown);
+          * the transport task group collapsing underneath it because the
+            server died — anyio cancels the scope, finds THIS task alive and
+            parked, and the delivery drains normally instead of spinning.
+
+        The exit stack is deliberately a local: nothing outside this task can
+        reach it to ``aclose()`` cross-task. Connect-phase failures are
+        delivered through *ready*; post-ready death is observed by the
+        done-callback (:meth:`_on_static_owner_death`), which evicts the
+        session for the health loop / next dispatch to reconnect.
+        """
+        state = self._ensure_static_state(name)
         try:
-            session = await stack.enter_async_context(
-                ClientSession(read, write, message_handler=_on_notification)  # type: ignore[arg-type]
-            )
-        except Exception:
-            await self._safe_teardown_on_connect_failure(name, stack)
+            async with AsyncExitStack() as stack:
+                transport = cfg.get("type", "stdio")
+                if transport in ("http", "streamable-http") or "url" in cfg:
+                    async with asyncio.timeout(self._CONNECT_TIMEOUT):
+                        read, write, _ = await stack.enter_async_context(
+                            streamablehttp_client(url=cfg["url"], headers=cfg.get("headers"))
+                        )
+                else:
+                    from turnstone.core.env import scrubbed_env
+
+                    env = scrubbed_env(extra=cfg.get("env", {}))
+                    params = StdioServerParameters(
+                        command=cfg.get("command", ""),
+                        args=cfg.get("args", []),
+                        env=env,
+                    )
+                    async with asyncio.timeout(self._CONNECT_TIMEOUT):
+                        read, write = await stack.enter_async_context(stdio_client(params))
+                # Stash stream refs so _pre_close_streams can unblock the
+                # SDK's transport tasks promptly during teardown (SDK #2147).
+                state.streams = (read, write)
+                session = await stack.enter_async_context(
+                    ClientSession(
+                        read,
+                        write,
+                        message_handler=self._make_static_notification_handler(name),
+                    )
+                )
+                async with asyncio.timeout(self._CONNECT_TIMEOUT):
+                    await session.initialize()
+                if not ready.done():
+                    ready.set_result(session)
+                await close_requested.wait()
+        except asyncio.CancelledError:
+            if not ready.done():
+                ready.set_exception(ConnectionError(f"MCP connect for '{name}' was cancelled"))
+                with contextlib.suppress(BaseException):
+                    ready.exception()  # mark retrieved: the waiter may be gone
+            raise
+        except BaseException as exc:
+            if not ready.done():
+                # Connect-phase failure: deliver to the waiting caller. Phase
+                # timeouts arrive as TimeoutError (``asyncio.timeout`` converts
+                # its own cancel in THIS task); transport task-group failures
+                # may be BaseExceptionGroup — passed through, the consumers
+                # handle groups explicitly.
+                ready.set_exception(exc)
+                with contextlib.suppress(BaseException):
+                    ready.exception()  # mark retrieved: the waiter may be gone
+                return
+            # Post-ready death: the server dropped the transport under a live
+            # session. The done-callback evicts; the health loop owns the
+            # reconnect story. Quiet — a flapping server would otherwise spam.
+            log.debug("MCP transport owner for '%s' terminated: %r", name, exc)
+
+    def _on_static_owner_death(self, name: str, task: asyncio.Task[None]) -> None:
+        """Done-callback for a transport owner: observe UNREQUESTED death.
+
+        A requested teardown de-registers the owner from state before closing
+        it, so reaching here with ``state.owner_task is task`` means the
+        transport collapsed underneath a live session (server died, stream
+        dropped) — the owner unwound its scopes in-task (its job) and the
+        session is now a corpse. Evict it so dispatch fails fast into
+        reconnect and the health loop picks it up on its next tick, instead
+        of every caller rediscovering the corpse via a dead-transport error.
+        The breaker is left alone: no dispatch failure was observed, and
+        connect outcomes are recorded by ``_ensure_static_connected``.
+        """
+        with contextlib.suppress(BaseException):
+            if not task.cancelled():
+                task.exception()  # mark retrieved; the owner already logged
+        state = self._static_servers.get(name)
+        if state is None or state.owner_task is not task:
+            return
+        state.owner_task = None
+        state.close_requested = None
+        if state.session is not None:
+            state.session = None
+            log.info("MCP server '%s' transport terminated; session evicted for reconnect", name)
+
+    async def _connect_one_locked(self, name: str, cfg: dict[str, Any]) -> None:
+        """Connect to a single MCP server and discover its tools.
+
+        MUST run under the per-server connect lock (see :meth:`_connect_one`).
+
+        The transport + session cms are entered by a dedicated OWNER task
+        (:meth:`_static_transport_owner`); this method only WAITS for it to
+        report readiness — so a caller-side cancellation (the attempt timeout
+        in ``_ensure_static_connected``, shutdown, a sync boundary giving up)
+        can never abandon an anyio cancel scope mid-exit. On failure the owner
+        unwinds fully in its own task. This method's job is bookkeeping:
+        the close protocol on the way in (stale-guard), state fields and
+        catalog discovery on the way out.
+        """
+        # Operate on a single state object throughout: get-or-create up front
+        # so the stale-entry guard and the post-handshake field assignments
+        # touch the same instance (PR #296 invariant 5: identity stability).
+        state = self._ensure_static_state(name)
+
+        # Guard: close any stale owner/session so we don't leak. Transport
+        # errors in the sync dispatch methods evict the session but leave the
+        # owner (and its open transport) behind; the close protocol clears
+        # both (and is a no-op on a brand new entry).
+        await self._teardown_static_session(name)
+
+        transport = cfg.get("type", "stdio")
+        if transport in ("http", "streamable-http") or "url" in cfg:
+            # Pre-flight TCP check: fail fast before spawning an owner and
+            # entering the SDK's anyio task group at all (an ECONNREFUSED
+            # surfaces here as a clean ConnectionError instead of a
+            # cancel-scope unwind).
+            await self._tcp_probe(name, cfg["url"])
+        elif not cfg.get("command", ""):
+            # Default transport is stdio; without a command there is nothing
+            # to spawn. Preserves the historical no-session no-raise shape
+            # (``_ensure_static_connected`` converts it to a clean failure).
+            log.warning("MCP server '%s' has no command configured", name)
+            return
+
+        loop = asyncio.get_running_loop()
+        ready: asyncio.Future[Any] = loop.create_future()
+        close_requested = asyncio.Event()
+        owner = asyncio.create_task(
+            self._static_transport_owner(name, cfg, ready, close_requested),
+            name=f"mcp-transport-owner:{name}",
+        )
+        owner.add_done_callback(lambda t: self._on_static_owner_death(name, t))
+        try:
+            session = await ready
+        except asyncio.CancelledError:
+            # Caller cancelled while the owner was still connecting. Close the
+            # owner with the one-cancel protocol and let its unwind finish
+            # in-task; never abandon it mid-exit, never cancel twice.
+            close_requested.set()
+            if not owner.done():
+                owner.cancel()
+                await asyncio.wait({owner}, timeout=self._OWNER_CANCEL_GRACE_S)
+            raise
+        except BaseException:
+            # Connect failed: the owner delivered the failure and is unwinding
+            # itself in-task. Reap quietly, then surface the error.
+            await asyncio.wait({owner}, timeout=self._OWNER_CLOSE_GRACE_S)
             raise
 
-        state.stack = stack
-        try:
-            # ``wait_for`` retained — see line 905 for the static-path
-            # exemption from the pool-path migration (invariant 1 byte-identical).
-            await asyncio.wait_for(session.initialize(), timeout=self._CONNECT_TIMEOUT)
-        except asyncio.CancelledError:
-            state.stack = None
-            task = asyncio.current_task()
-            if task is not None and task.cancelling():
-                await self._safe_teardown_on_connect_failure(name, stack)
-                raise
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise TimeoutError(f"MCP handshake failed for '{name}'") from None
-        except TimeoutError:
-            state.stack = None
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise TimeoutError(f"MCP handshake timed out after {self._CONNECT_TIMEOUT}s") from None
-        except Exception:
-            state.stack = None
-            await self._safe_teardown_on_connect_failure(name, stack)
-            raise
+        if owner.done():
+            # The transport collapsed in the instant between readiness and the
+            # caller resuming (flapping server). Treat it as a failed connect
+            # rather than installing a corpse the first dispatch trips over.
+            raise ConnectionError(f"MCP server '{name}' transport died during connect")
+
+        state.owner_task = owner
+        state.close_requested = close_requested
         state.session = session
 
         # Check push notification support for each capability
@@ -2226,7 +2471,9 @@ class MCPClientManager:
                 await self._sweep_user_token_freshness()
             except asyncio.CancelledError:
                 return
-            except Exception:
+            except (Exception, BaseExceptionGroup):
+                # BaseExceptionGroup: same rationale as ``_static_health_loop``
+                # — a transport-layer group must not kill the loop.
                 log.warning("MCP token-freshness sweep iteration failed", exc_info=True)
             delay = self._user_token_sweep_s  # subsequent sweeps wait the full cadence
 
@@ -2453,7 +2700,9 @@ class MCPClientManager:
                 await self._evict_idle_pool_entries()
             except asyncio.CancelledError:
                 return
-            except Exception:
+            except (Exception, BaseExceptionGroup):
+                # BaseExceptionGroup: same rationale as ``_static_health_loop``
+                # — a transport-layer group must not kill the loop.
                 log.warning("MCP pool eviction iteration failed", exc_info=True)
 
     async def _evict_idle_pool_entries(self) -> None:
@@ -3099,7 +3348,10 @@ class MCPClientManager:
                 added, removed = await self._refresh_server(name)
                 self._cb_record_success(name)
                 results[name] = (added, removed)
-            except Exception as exc:
+            except (Exception, BaseExceptionGroup) as exc:
+                # BaseExceptionGroup: a transport task-group failure from the
+                # reconnect/refresh must stay isolated to this server, not
+                # abort the whole refresh pass.
                 log.warning("Refresh failed for MCP server '%s'", name, exc_info=True)
                 self._set_error(name, f"Refresh failed: {exc}")
                 results[name] = ([], [])
@@ -3664,20 +3916,48 @@ class MCPClientManager:
             except Exception:
                 log.debug("Error closing MCP pool sessions", exc_info=True)
 
-        # Close all per-server stacks (transports + sessions)
+        # Close all per-server transports (owner tasks own the cm stacks).
+        # Parallel version of ``_teardown_static_session``'s close protocol:
+        # signal every owner first, give them one shared graceful window, then
+        # ONE cancel each for stragglers and a short drain — never a second
+        # cancel (it would abandon an anyio scope exit mid-flight; the owner
+        # completing solo is harmless, and the loop is stopping anyway).
         if self._loop and self._static_servers:
 
-            async def _close_all_stacks() -> None:
-                # Pre-close streams to prevent anyio CPU busy-loop during teardown
-                for srv_name in list(self._static_servers):
+            async def _close_all_owners() -> None:
+                owners: list[asyncio.Task[None]] = []
+                for srv_name, srv_state in list(self._static_servers.items()):
+                    srv_state.session = None
+                    owner = srv_state.owner_task
+                    close_requested = srv_state.close_requested
+                    srv_state.owner_task = None
+                    srv_state.close_requested = None
+                    if close_requested is not None:
+                        close_requested.set()
+                    if owner is not None and not owner.done():
+                        owners.append(owner)
+                    # Pre-close streams to unblock the SDK's transport tasks
+                    # (anyio zero-buffer send — SDK #2147) so owners unwind fast.
                     await self._pre_close_streams(srv_name)
-                for srv_state in self._static_servers.values():
-                    if srv_state.stack is not None:
-                        await self._safe_close_stack(srv_state.stack)
+                if not owners:
+                    return
+                _done, pending = await asyncio.wait(owners, timeout=self._OWNER_CLOSE_GRACE_S)
+                for owner in pending:
+                    owner.cancel()
+                if pending:
+                    _done, pending = await asyncio.wait(
+                        pending, timeout=self._OWNER_CANCEL_GRACE_S / 2
+                    )
+                    if pending:
+                        log.warning(
+                            "MCP shutdown: %d transport owner(s) still unwinding; "
+                            "left to the dying loop",
+                            len(pending),
+                        )
 
-            future = asyncio.run_coroutine_threadsafe(_close_all_stacks(), self._loop)
+            future = asyncio.run_coroutine_threadsafe(_close_all_owners(), self._loop)
             try:
-                future.result(timeout=10)
+                future.result(timeout=12)
             except Exception:
                 log.debug("Error closing MCP sessions", exc_info=True)
 
@@ -3934,7 +4214,7 @@ class MCPClientManager:
                 # popped above, so no NEW reconnect will start; this serializes
                 # against one already in flight).
                 async with self._static_connect_lock_for(name):
-                    # Close session + transport via per-server stack
+                    # Close session + transport via the owner close protocol
                     await self._teardown_static_session(name)
                     # Clean up per-server state (on the event loop thread)
                     self._static_servers.pop(name, None)
@@ -4467,7 +4747,13 @@ class MCPClientManager:
                     return  # genuine shutdown
                 log.warning("MCP static health: stray cancellation absorbed; continuing")
                 await asyncio.sleep(self._static_health_check_s)
-            except Exception:
+            except (Exception, BaseExceptionGroup):
+                # BaseExceptionGroup explicitly: an anyio task-group collapse
+                # that wraps a stray CancelledError is BaseException-derived
+                # and would otherwise kill the only autonomous reconnect
+                # driver, silently. A genuine shutdown racing the group is
+                # still honored: the pending cancel fires at the sleep below
+                # and the CancelledError arm above returns.
                 log.warning("MCP static health iteration failed", exc_info=True)
                 await asyncio.sleep(self._static_health_check_s)
 
@@ -4567,10 +4853,13 @@ class MCPClientManager:
         try:
             log.info("MCP static health: reconnecting '%s'", name)
             session = await self._ensure_static_connected(name, cfg)
-        except Exception as exc:
+        except (Exception, BaseExceptionGroup) as exc:
             # The primitive already recorded the breaker failure and dropped
             # any partially-initialized session; only the health loop's own
-            # backoff state advances here.
+            # backoff state advances here. BaseExceptionGroup explicitly: a
+            # transport task-group failure must advance the backoff like any
+            # other connect error, not skip it (a hot every-tick retry) by
+            # escaping to the tick's exception isolation.
             attempt = self._static_reconnect_attempt.get(name, 0) + 1
             self._static_reconnect_attempt[name] = attempt
             delay = self._static_reconnect_delay(attempt)
@@ -4748,9 +5037,11 @@ class MCPClientManager:
             # No breaker record: see docstring — lock contention is not a
             # server failure, and this boundary cannot tell the two apart.
             raise RuntimeError(f"MCP server '{server_name}' reconnect timed out") from None
-        except Exception as exc:
+        except (Exception, BaseExceptionGroup) as exc:
             # Real connect failures were already recorded by the primitive;
             # recording here again would double-count one outcome.
+            # BaseExceptionGroup: normalize a transport task-group failure to
+            # the same RuntimeError shape every dispatch caller expects.
             raise RuntimeError(f"MCP server '{server_name}' reconnect failed: {exc}") from None
         if session is None:
             # Deliberate skip: the server was removed while we queued, or a
@@ -4789,9 +5080,10 @@ class MCPClientManager:
         Closed/BrokenResourceError, the SDK-swallowed ``McpError(CONNECTION_CLOSED)``,
         a server-restarted session, or a gone httpx connection — IS a transport
         failure even when it is an ``McpError``, so it trips the breaker AND evicts
-        the session (leaving stack/streams for ``_connect_one``'s stale-and-stack
-        guard to reap). Eviction is what lets the next dispatch's ``session is
-        None`` check fire ``_cb_auto_reconnect`` instead of re-using the corpse.
+        the session (leaving the owner/streams for ``_connect_one_locked``'s
+        stale-guard close protocol to reap). Eviction is what lets the next
+        dispatch's ``session is None`` check fire ``_cb_auto_reconnect`` instead
+        of re-using the corpse.
         """
         dead = _is_dead_transport(exc)
         if dead or not isinstance(exc, McpError):

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1198,10 +1198,21 @@ class MCPClientManager:
         this process also runs FastAPI/httpx anyio scopes on the MAIN loop —
         cancelling another loop's ``call_soon`` handle or clearing a set that
         loop may be iterating is a cross-thread reach with no thread-safety
-        contract. Foreign-loop orphans are that loop's problem to fix.
+        contract. Foreign-loop orphans are that loop's problem to fix. The
+        guard below ENFORCES the mcp-loop requirement rather than trusting
+        callers (a suppressed close can fire before ``start()`` or after
+        ``shutdown()``, when there is no mcp-loop to be on), and a skipped
+        call does not advance the rate-limit clock — a legitimate on-loop
+        sweep may be needed immediately after.
         Returns the number of scopes disarmed. Rate-limited because the walk
         is O(heap).
         """
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            return 0
+        if self._loop is None or running is not self._loop:
+            return 0
         now = time.monotonic()
         if now - self._last_scope_disarm < self._SCOPE_DISARM_MIN_INTERVAL_S:
             return 0
@@ -1585,7 +1596,8 @@ class MCPClientManager:
                     ready.exception()  # mark retrieved: the waiter may be gone
             raise
         except BaseException as exc:
-            if not ready.done():
+            pre_ready = not ready.done()
+            if pre_ready:
                 # Connect-phase failure: deliver to the waiting caller. Phase
                 # timeouts arrive as TimeoutError (``asyncio.timeout`` converts
                 # its own cancel in THIS task); transport task-group failures
@@ -1594,6 +1606,12 @@ class MCPClientManager:
                 ready.set_exception(exc)
                 with contextlib.suppress(BaseException):
                     ready.exception()  # mark retrieved: the waiter may be gone
+            if not isinstance(exc, (Exception, BaseExceptionGroup)):
+                # An interpreter-level exit (KeyboardInterrupt, SystemExit)
+                # must keep unwinding the task — delivery to the waiter was
+                # this arm's only job for it.
+                raise
+            if pre_ready:
                 return
             # Post-ready death: the server dropped the transport under a live
             # session. The done-callback evicts; the health loop owns the


### PR DESCRIPTION
## Problem

A crash-looping ("flaky") MCP server drives the mcp-loop thread to a sustained, **climbing** 100%+ CPU spin that never recovers — one more increment per crash/restart cycle. Regression of the original SDK #2147 CPU-pegging incident family, resurfaced by #768's autonomous recovery (which made the trigger a routine, forever-repeating event instead of a rare one).

## Root cause

anyio cancel scopes are **host-task-bound**: only the task that entered a scope can exit it. The static connect path entered the SDK's `streamablehttp_client` / `stdio_client` / `ClientSession` task-group scopes from short-lived tasks (every health tick is a new task), so scopes routinely outlived their host. Once such a scope is cancelled with its host already finished —

- **Trigger A**: a transport child task dies with the server → anyio `task_done` → `cancel_scope.cancel()`, or
- **Trigger B**: a later cross-task teardown → `ClientSession.__aexit__` → `cancel_scope.cancel()`

— anyio 4.14.1's `CancelScope._deliver_cancellation` can never make progress (`task.cancel()` on a done task is a no-op, but `should_retry = True` for any task still registered) and reschedules itself via `call_soon` **every event-loop iteration, forever**: measured ~900k callbacks/s per zombie scope, one new zombie per flap cycle. No upstream anyio fix exists as of 4.14.1.

A second bug rode along: `BaseExceptionGroup` (BaseException-derived, e.g. an accept-then-RST server collapsing the SDK task group around a stray `CancelledError`) escaped `except Exception` in `_connect_all` and killed it **before the health/token-sweep loops were created** — silently disabling all autonomous recovery.

## Fix

- **`_static_transport_owner`** — one long-lived task per static server enters the transport + `ClientSession` cms, initializes (same-task `asyncio.timeout` phase bounds), reports readiness via a future, parks on a close event, and unwinds everything in-task. Scopes always have a live host; the zombie state is unconstructible. The exit stack is an owner-coroutine local — nothing can `aclose()` it cross-task.
- **One-cancel close protocol** (`_teardown_static_session`): null session → set the close event *before the first await* → pre-close streams → graceful wait → at most ONE `cancel()` → never a second (that abandons a scope exit mid-flight — the zombie-minting move). Shutdown closes all owners in parallel with the same protocol.
- **Instant dead-server detection**: unrequested owner death (transport collapsed under a live session) evicts the session via a done-callback immediately, instead of waiting up to 30s for the liveness ping.
- **`_maybe_disarm_orphaned_scopes`** — rate-limited gc-walk backstop that disarms armed scopes whose registered tasks are all done, scoped strictly to scopes hosted on the mcp-loop (the walk is process-global and the server also runs FastAPI/httpx anyio scopes on the main loop — not ours to reach into). Covers paths not yet migrated.
- **`BaseExceptionGroup` arms** in `_connect_all`, `_static_health_loop`, `_user_token_sweep_loop`, `_user_pool_eviction_loop`, `_static_reconnect_one`, `_refresh_all`, and the `_cb_auto_reconnect` boundary. Genuine shutdown cancellation still stops every loop (verified: it arrives as a bare `CancelledError` at the loop task, and each swallow arm re-raises the pending cancel at its next await).

## Verification

- Live SIGKILL-flap repro (real FastMCP subprocess, kill/restart cycle): **130%+ CPU climbing → 0.3% flat**, zero armed scopes, task/FD counts flat.
- Accept-then-RST repro: both background loops now start and survive (previously both silently dead).
- Full suite **8470 passed / 0 failed**; ruff + mypy clean.
- New regression tests: owner-lifecycle + close-protocol units (including an exactly-one-cancel pin and a caller-cancel-mid-connect test proving the cm still exits), `_connect_all` BaseExceptionGroup regression, a discriminating disarm-sweep test, and a ~10s live SIGKILL-flap smoke test (spawns its own server; skips on environment gaps) asserting zero armed scopes, exactly one live owner, a running health loop, an unused backstop, and a post-recovery tool call — the killable-server coverage the suite previously lacked.

## Scope note / follow-up

The `oauth_user` **pool path** (`_connect_one_pool` + its teardowns) intentionally keeps the old cross-task-close shape in this PR — it has the same latent exposure, currently covered by the disarm backstop. A stacked PR migrating it to the owner pattern follows.