### PR TITLE
feat(personas): agent discoverability + forgiving name resolution

### DIFF
--- a/docs/personas.md
+++ b/docs/personas.md
@@ -118,9 +118,37 @@ seeded):
   `persona` argument, validated when the coordinator prepares the spawn
   and re-checked by the node that creates the child (children are always
   interactive-kind). Omitted means the interactive **default** — a child
-  never inherits its parent coordinator's persona. Sub-agents spawned via
-  `task_agent` have no persona parameter at all; they keep their own
-  identity and envelope.
+  never inherits its parent coordinator's persona.
+- **Sub-agents**: `task_agent` takes a `persona` argument setting the
+  sub-agent's identity and capability envelope (resolved against
+  interactive-kind personas, frozen into the task at prep). Omitted keeps
+  the default autonomous task-agent identity — never the parent's persona.
+
+## How agents discover personas
+
+Agents are told, not expected to guess: the live persona list (enabled,
+interactive-kind — children and sub-agents are always interactive) is
+injected into the `persona` parameter description of `task_agent`,
+`spawn_workstream`, and `spawn_batch` whenever the session's tool surface
+is rendered — session start, MCP catalog change, model-registry reload.
+Each entry carries the name, the default marker, and the persona's
+one-line description so the model can pick by purpose (descriptions drop
+out past 25 personas; the name list always enumerates completely).
+
+A persona created after that render is still reachable — pass its name.
+Every resolve failure enumerates the names currently valid for the kind,
+so a stale list (or a typo) self-corrects on the next attempt.
+
+Resolution is forgiving on all surfaces (they share one rule):
+
+- names match case-insensitively (`Writer` resolves `writer`);
+- an input that uniquely matches a persona's **display name**
+  (case-insensitive, among the kind's enabled personas — display names are
+  not unique, and a same-label persona of another kind neither blocks nor
+  wins) resolves to that persona; an ambiguous match errors, listing the
+  candidate slugs;
+- whatever variant matched, the stamped identity, approval chrome, and
+  wire always carry the canonical `name` slug.
 
 ## Authoring (console)
 
@@ -128,7 +156,12 @@ Personas are managed in the console's **Manage → Governance → Personas**
 tab. The admin shelf exposes exactly the four levers plus the kind
 list, the default marker, and archive. Rules:
 
-- `name` is an immutable lowercase slug; edit `display_name` instead.
+- `name` is an immutable lowercase slug — and the identifier agents and
+  the CLI launch the persona by (`persona=` on the spawn tools,
+  `--persona` on the CLI); the create shelf says so under **Name**.
+  `display_name` is a list label, editable any time, and deliberately
+  not an identifier (a unique display name happens to resolve, as a
+  forgiveness fallback — don't design workflows around it).
 - Exactly one default per kind, storage-enforced: flipping the flag on a
   successor demotes the incumbent atomically, defaults are single-kind,
   and a default cannot be archived.

--- a/tests/test_persona_guards.py
+++ b/tests/test_persona_guards.py
@@ -1329,3 +1329,180 @@ class TestCreateStampsPersona:
         assert ws is not None and ws.session is not None
         assert ws.session._persona_name == ""
         assert not ws.persona
+
+
+# ---------------------------------------------------------------------------
+# Guard 10 — discovery: the calling LLM is TOLD which personas exist.  The
+# live enabled interactive-kind list rides the `persona` parameter
+# description of task_agent / spawn_workstream / spawn_batch, rebuilt from
+# the pristine TOOLS base on every render; storage-less sessions keep the
+# base text untouched.  Resolution is forgiving (case, unique display name)
+# but everything downstream carries the canonical slug.
+# ---------------------------------------------------------------------------
+
+
+def _persona_desc(session: ChatSession, tool_name: str) -> str:
+    tool = next(t for t in session._tools if t.get("function", {}).get("name") == tool_name)
+    prop = ChatSession._persona_property(tool["function"]["parameters"]["properties"])
+    assert prop is not None, f"{tool_name} has no persona parameter"
+    return prop["description"]
+
+
+def _pristine_persona_desc(tool_name: str) -> str:
+    from turnstone.core.tools import TOOLS
+
+    tool = next(t for t in TOOLS if t["function"]["name"] == tool_name)
+    prop = ChatSession._persona_property(tool["function"]["parameters"]["properties"])
+    assert prop is not None, f"{tool_name} has no persona parameter"
+    return prop["description"]
+
+
+class TestPersonaDiscovery:
+    def _seed(self) -> None:
+        get_storage().create_persona(
+            {
+                "persona_id": "p-eng",
+                "name": "engineer",
+                "display_name": "Engineer",
+                "description": "Default engineering identity",
+                "base_prompt": "E",
+                "applies_to_kinds": ["interactive"],
+                "is_default": True,
+            }
+        )
+        get_storage().create_persona(
+            {
+                "persona_id": "p-wri",
+                "name": "writer",
+                "display_name": "Creative Writer",
+                "description": "Prose-first writing partner",
+                "base_prompt": "W",
+                "applies_to_kinds": ["interactive"],
+            }
+        )
+
+    def _coord_session(self, mock_openai_client: Any) -> ChatSession:
+        return _session(
+            mock_openai_client,
+            kind=WorkstreamKind.COORDINATOR,
+            user_id="u1",
+            coord_client=MagicMock(),
+        )
+
+    def test_task_agent_description_lists_personas(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        session = _session(mock_openai_client)
+        desc = _persona_desc(session, "task_agent")
+        assert desc.startswith(_pristine_persona_desc("task_agent"))
+        assert "Available personas:" in desc
+        # Default first, then A→Z, each with its one-line description.
+        assert desc.index("`engineer` (default)") < desc.index("`writer`")
+        assert "Prose-first writing partner" in desc
+
+    def test_spawn_tools_list_personas_for_coordinators(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        session = self._coord_session(mock_openai_client)
+        for tool_name in ("spawn_workstream", "spawn_batch"):
+            desc = _persona_desc(session, tool_name)
+            assert desc.startswith(_pristine_persona_desc(tool_name))
+            assert "Available personas:" in desc
+            assert "`engineer` (default)" in desc
+
+    def test_coordinator_kind_personas_are_not_offered(self, tmp_db, mock_openai_client) -> None:
+        # Children and sub-agents are always interactive-kind; a
+        # coordinator-only persona in the list would be a guaranteed error.
+        self._seed()
+        get_storage().create_persona(
+            {
+                "persona_id": "p-exe",
+                "name": "executive",
+                "base_prompt": "X",
+                "applies_to_kinds": ["coordinator"],
+            }
+        )
+        session = self._coord_session(mock_openai_client)
+        assert "`executive`" not in _persona_desc(session, "spawn_workstream")
+
+    def test_storage_down_keeps_pristine_base(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        with patch("turnstone.core.storage.is_storage_initialized", return_value=False):
+            session = _session(mock_openai_client)
+        assert _persona_desc(session, "task_agent") == _pristine_persona_desc("task_agent")
+
+    def test_rerender_is_idempotent_and_tracks_archive(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        session = _session(mock_openai_client)
+        session._render_agent_tool_descriptions()
+        session._render_agent_tool_descriptions()
+        desc = _persona_desc(session, "task_agent")
+        assert desc.count("Available personas:") == 1
+        # Archive one persona; the next render must drop it, not append.
+        storage = get_storage()
+        writer = storage.get_persona_by_name("writer")
+        assert writer is not None
+        storage.update_persona(writer["persona_id"], enabled=False)
+        session._render_agent_tool_descriptions()
+        desc = _persona_desc(session, "task_agent")
+        assert "`writer`" not in desc
+        assert desc.count("Available personas:") == 1
+
+    def test_large_shelf_drops_prose_keeps_every_name(self, tmp_db, mock_openai_client) -> None:
+        storage = get_storage()
+        for i in range(26):
+            storage.create_persona(
+                {
+                    "persona_id": f"p-{i:02d}",
+                    "name": f"persona-{i:02d}",
+                    "description": "UNIQUE-PROSE-MARKER",
+                    "base_prompt": "x",
+                    "applies_to_kinds": ["interactive"],
+                }
+            )
+        session = _session(mock_openai_client)
+        desc = _persona_desc(session, "task_agent")
+        for i in range(26):
+            assert f"`persona-{i:02d}`" in desc
+        assert "UNIQUE-PROSE-MARKER" not in desc
+
+    def test_spawn_forgives_case_and_display_name_but_stamps_slug(
+        self, tmp_db, mock_openai_client
+    ) -> None:
+        self._seed()
+        session = self._coord_session(mock_openai_client)
+        for variant in ("WRITER", "Writer", "Creative Writer"):
+            item = session._prepare_spawn_workstream("c1", {"persona": variant})
+            assert not item.get("error"), item.get("error")
+            assert item["persona"] == "writer"
+
+    def test_spawn_batch_rows_land_on_canonical_slug(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        session = self._coord_session(mock_openai_client)
+        item = session._prepare_spawn_batch(
+            "c1",
+            {
+                "children": [
+                    {"initial_message": "a", "persona": "WRITER"},
+                    {"initial_message": "b", "persona": "Creative Writer"},
+                ]
+            },
+        )
+        assert not item.get("error"), item.get("error")
+        personas = [c["persona"] for c in item["children"] if "_error" not in c]
+        assert personas == ["writer", "writer"]
+
+    def test_task_agent_prep_canonicalizes_header_and_stamp(
+        self, tmp_db, mock_openai_client
+    ) -> None:
+        self._seed()
+        session = _session(mock_openai_client)
+        item = session._prepare_task("t1", {"prompt": "go", "persona": "Writer"})
+        assert not item.get("error"), item.get("error")
+        assert item["persona"] == "writer"
+        assert "persona: writer" in item["header"]
+
+    def test_unknown_persona_error_enumerates_live_names(self, tmp_db, mock_openai_client) -> None:
+        self._seed()
+        session = self._coord_session(mock_openai_client)
+        item = session._prepare_spawn_workstream("c1", {"persona": "nope"})
+        assert item.get("error")
+        assert "Available for interactive: engineer (default), writer" in item["error"]

--- a/tests/test_persona_snapshot.py
+++ b/tests/test_persona_snapshot.py
@@ -125,3 +125,191 @@ class TestConfigParsing:
         cfg["persona_memory"] = "True"
         with pytest.raises(ValueError, match="persona_memory"):
             snapshot_from_config(cfg)
+
+
+class _FakeStorage:
+    """Minimal storage double for resolve tests — exact-name index + list."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def get_persona_by_name(self, name: str) -> dict | None:
+        return next((dict(r) for r in self._rows if r["name"] == name), None)
+
+    def list_personas(self, include_disabled: bool = False) -> list[dict]:
+        return [dict(r) for r in self._rows if include_disabled or r.get("enabled")]
+
+
+def _rows() -> list[dict]:
+    return [
+        {
+            "name": "engineer",
+            "display_name": "Engineer",
+            "enabled": True,
+            "is_default": True,
+            "applies_to_kinds": ["interactive"],
+        },
+        {
+            "name": "writer",
+            "display_name": "Creative Writer",
+            "enabled": True,
+            "applies_to_kinds": ["interactive"],
+        },
+        {
+            "name": "executive",
+            "display_name": "Executive",
+            "enabled": True,
+            "applies_to_kinds": ["coordinator"],
+        },
+        {
+            "name": "retired",
+            "display_name": "Retired Persona",
+            "enabled": False,
+            "applies_to_kinds": ["interactive"],
+        },
+    ]
+
+
+class TestForgivingResolution:
+    """resolve_persona_for_kind — one shared rule, forgiving on all surfaces.
+
+    Exact slug first, then the lowercased input, then a UNIQUE
+    case-insensitive display-name match; every failure enumerates the
+    kind's live names (the self-correction path for stale tool
+    descriptions), and callers stamp the returned row's canonical slug.
+    """
+
+    def _resolve(self, name: str, kind: str = "interactive", rows: list[dict] | None = None):
+        from turnstone.core.personas import resolve_persona_for_kind
+
+        return resolve_persona_for_kind(_FakeStorage(rows or _rows()), name, kind)
+
+    def test_exact_slug_resolves(self) -> None:
+        row, err = self._resolve("writer")
+        assert err == "" and row is not None and row["name"] == "writer"
+
+    def test_case_variants_resolve_to_canonical_row(self) -> None:
+        for variant in ("Writer", "WRITER", " writer "):
+            row, err = self._resolve(variant)
+            assert err == "" and row is not None and row["name"] == "writer"
+
+    def test_unique_display_name_resolves_to_slug(self) -> None:
+        for variant in ("Creative Writer", "creative writer"):
+            row, err = self._resolve(variant)
+            assert err == "" and row is not None and row["name"] == "writer"
+
+    def test_ambiguous_display_name_names_the_candidates(self) -> None:
+        rows = _rows() + [
+            {
+                "name": "novelist",
+                "display_name": "creative writer",
+                "enabled": True,
+                "applies_to_kinds": ["interactive"],
+            }
+        ]
+        row, err = self._resolve("Creative Writer", rows=rows)
+        assert row is None
+        assert "more than one display name" in err
+        assert "novelist" in err and "writer" in err
+        assert "use the exact name" in err
+
+    def test_same_display_name_across_kinds_resolves_per_kind(self) -> None:
+        # The label the caller saw came from a kind-filtered surface, so a
+        # same-label persona of the OTHER kind must neither block (spurious
+        # ambiguity) nor win (cross-kind resolution).
+        rows = _rows() + [
+            {
+                "name": "helper-coord",
+                "display_name": "Helper",
+                "enabled": True,
+                "applies_to_kinds": ["coordinator"],
+            },
+            {
+                "name": "helper-int",
+                "display_name": "Helper",
+                "enabled": True,
+                "applies_to_kinds": ["interactive"],
+            },
+        ]
+        row, err = self._resolve("Helper", rows=rows)
+        assert err == "" and row is not None and row["name"] == "helper-int"
+        row, err = self._resolve("Helper", kind="coordinator", rows=rows)
+        assert err == "" and row is not None and row["name"] == "helper-coord"
+
+    def test_wrong_kind_display_match_is_not_found_with_choices(self) -> None:
+        # Display names are labels, not identifiers: a label that only exists
+        # on another kind's persona reads as unknown for THIS kind (with the
+        # kind's live choices attached) — never as a cross-kind resolution.
+        rows = _rows() + [
+            {
+                "name": "chief",
+                "display_name": "The Chief",
+                "enabled": True,
+                "applies_to_kinds": ["coordinator"],
+            }
+        ]
+        row, err = self._resolve("The Chief", rows=rows)
+        assert row is None
+        assert "not found or disabled" in err
+        assert "Available for interactive: engineer (default), writer" in err
+
+    def test_whitespace_input_never_matches_blank_display_names(self) -> None:
+        # display_name defaults to "" — a whitespace-only input (reachable via
+        # CLI `--persona "  "`) must read as unknown, never resolve to a
+        # blank-labelled persona or report a bogus ambiguity.
+        rows = _rows() + [
+            {
+                "name": "unlabelled",
+                "display_name": "",
+                "enabled": True,
+                "applies_to_kinds": ["interactive"],
+            },
+            {
+                "name": "unlabelled-too",
+                "display_name": "   ",
+                "enabled": True,
+                "applies_to_kinds": ["interactive"],
+            },
+        ]
+        for raw in ("", " ", "   "):
+            row, err = self._resolve(raw, rows=rows)
+            assert row is None
+            assert "not found or disabled" in err
+            assert "more than one display name" not in err
+
+    def test_unknown_error_lists_kind_names_default_first(self) -> None:
+        row, err = self._resolve("nope")
+        assert row is None
+        assert "Persona not found or disabled: nope" in err
+        assert "Available for interactive: engineer (default), writer" in err
+        assert "executive" not in err  # wrong kind
+        assert "retired" not in err  # disabled
+
+    def test_kind_mismatch_reports_canonical_slug_and_choices(self) -> None:
+        row, err = self._resolve("Executive")  # case-forgiven, then kind-refused
+        assert row is None
+        assert "'executive' does not apply to kind 'interactive'" in err
+        assert "Available for interactive: engineer (default), writer" in err
+
+    def test_disabled_persona_is_not_resolvable_by_any_route(self) -> None:
+        for variant in ("retired", "RETIRED", "Retired Persona"):
+            row, err = self._resolve(variant)
+            assert row is None
+            assert "not found or disabled" in err
+
+    def test_storage_none_is_a_distinct_error(self) -> None:
+        from turnstone.core.personas import resolve_persona_for_kind
+
+        row, err = resolve_persona_for_kind(None, "writer", "interactive")
+        assert row is None and err == "persona storage unavailable"
+
+    def test_listing_failure_degrades_to_plain_error(self) -> None:
+        class _Broken(_FakeStorage):
+            def list_personas(self, include_disabled: bool = False) -> list[dict]:
+                raise RuntimeError("db gone")
+
+        from turnstone.core.personas import resolve_persona_for_kind
+
+        row, err = resolve_persona_for_kind(_Broken(_rows()), "nope", "interactive")
+        assert row is None
+        assert "Persona not found or disabled: nope" in err

--- a/tests/test_persona_snapshot.py
+++ b/tests/test_persona_snapshot.py
@@ -280,7 +280,7 @@ class TestForgivingResolution:
     def test_unknown_error_lists_kind_names_default_first(self) -> None:
         row, err = self._resolve("nope")
         assert row is None
-        assert "Persona not found or disabled: nope" in err
+        assert "Persona not found or disabled: 'nope'" in err
         assert "Available for interactive: engineer (default), writer" in err
         assert "executive" not in err  # wrong kind
         assert "retired" not in err  # disabled
@@ -312,4 +312,4 @@ class TestForgivingResolution:
 
         row, err = resolve_persona_for_kind(_Broken(_rows()), "nope", "interactive")
         assert row is None
-        assert "Persona not found or disabled: nope" in err
+        assert "Persona not found or disabled: 'nope'" in err

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -2709,7 +2709,15 @@
                 aria-atomic="true"
               ></div>
               <input id="pr-persona-id" type="hidden" />
-              <label for="pr-name">Name</label>
+              <label for="pr-name"
+                >Name
+                <span class="label-hint"
+                  >how agents and the CLI launch it — persona=&lt;name&gt; on
+                  task_agent / spawn_workstream / spawn_batch, --persona
+                  &lt;name&gt; on the CLI. Case doesn't matter; the display
+                  name below is only a label in lists</span
+                ></label
+              >
               <input
                 id="pr-name"
                 type="text"

--- a/turnstone/core/personas.py
+++ b/turnstone/core/personas.py
@@ -67,6 +67,39 @@ class PersonaSnapshot:
         }
 
 
+def _enabled_personas(storage: Any) -> list[dict[str, Any]]:
+    """Enabled persona rows, or ``[]`` when listing fails.
+
+    Swallowing here keeps the forgiving-lookup and error-enrichment paths
+    from introducing raise paths the exact-match lookup never had (the CLI
+    calls ``resolve_persona_for_kind`` uncaught).
+    """
+    try:
+        return list(storage.list_personas())
+    except Exception:
+        return []
+
+
+def persona_names_for_kind(storage: Any, kind: str) -> list[str]:
+    """Enabled persona names applying to ``kind`` — default first, then A→Z.
+
+    The default carries a ``" (default)"`` suffix so error text and tool
+    descriptions read the same way everywhere.
+    """
+    rows = [r for r in _enabled_personas(storage) if kind in (r.get("applies_to_kinds") or [])]
+    rows.sort(key=lambda r: (not r.get("is_default"), str(r.get("name") or "")))
+    return [
+        str(r["name"]) + (" (default)" if r.get("is_default") else "")
+        for r in rows
+        if r.get("name")
+    ]
+
+
+def _available_for_kind(storage: Any, kind: str) -> str:
+    names = persona_names_for_kind(storage, kind)
+    return f" Available for {kind}: {', '.join(names)}." if names else ""
+
+
 def resolve_persona_for_kind(
     storage: Any, name: str, kind: str
 ) -> tuple[dict[str, Any] | None, str]:
@@ -79,14 +112,54 @@ def resolve_persona_for_kind(
     (per-org personas, a new kind) cannot leave the surfaces disagreeing.
     ``storage is None`` reports a distinct storage-unavailable error — a
     storage outage must never masquerade as "unknown persona".
+
+    Lookup is forgiving: exact name first (stored names are lowercase slugs,
+    create-path validated), then the lowercased input, then a case-insensitive
+    match on display names.  ``display_name`` carries no uniqueness
+    constraint, so the fallback is deliberately narrow: candidates are the
+    ENABLED personas ELIGIBLE FOR ``kind`` (the label the caller saw came
+    from a kind-filtered surface — picker or injected tool description — so
+    a same-label persona of another kind must neither block nor win), and
+    the match is accepted only when exactly one candidate remains; duplicates
+    refuse loudly, naming the candidate slugs.  Callers must stamp/emit the
+    returned row's ``name``, never the input, so a forgiven variant can't
+    leak into ``workstream_config`` or approval chrome.  Failure messages
+    enumerate the kind's valid names: tool descriptions render the persona
+    list at session start, so this is how a caller with a stale list (or a
+    typo) self-corrects.
     """
     if storage is None:
         return None, "persona storage unavailable"
-    row = storage.get_persona_by_name(name)
+    wanted = name.strip()
+    row = storage.get_persona_by_name(wanted)
+    if row is None and wanted != wanted.lower():
+        row = storage.get_persona_by_name(wanted.lower())
+    if row is None and wanted:
+        # The non-empty gate is load-bearing: display_name defaults to "", so
+        # a whitespace-only input would otherwise match every blank-labelled
+        # persona and silently stamp an envelope the caller never named.
+        target = wanted.lower()
+        matches = [
+            r
+            for r in _enabled_personas(storage)
+            if kind in (r.get("applies_to_kinds") or [])
+            and str(r.get("display_name") or "").strip().lower() == target
+        ]
+        if len(matches) == 1:
+            row = matches[0]
+        elif len(matches) > 1:
+            slugs = ", ".join(sorted(str(m["name"]) for m in matches))
+            return None, (
+                f"Persona name {name!r} matches more than one display name "
+                f"(personas: {slugs}); use the exact name"
+            )
     if not row or not row.get("enabled", False):
-        return None, f"Persona not found or disabled: {name}"
+        return None, f"Persona not found or disabled: {name}.{_available_for_kind(storage, kind)}"
     if kind not in (row.get("applies_to_kinds") or []):
-        return None, f"Persona {name!r} does not apply to kind {kind!r}"
+        return None, (
+            f"Persona {row['name']!r} does not apply to kind {kind!r}."
+            f"{_available_for_kind(storage, kind)}"
+        )
     return row, ""
 
 

--- a/turnstone/core/personas.py
+++ b/turnstone/core/personas.py
@@ -154,7 +154,10 @@ def resolve_persona_for_kind(
                 f"(personas: {slugs}); use the exact name"
             )
     if not row or not row.get("enabled", False):
-        return None, f"Persona not found or disabled: {name}.{_available_for_kind(storage, kind)}"
+        # ``!r`` matters: forgiven inputs include whitespace-only and
+        # trailing-space typos, which an unquoted interpolation renders
+        # invisible in CLI output and logs.
+        return None, f"Persona not found or disabled: {name!r}.{_available_for_kind(storage, kind)}"
     if kind not in (row.get("applies_to_kinds") or []):
         return None, (
             f"Persona {row['name']!r} does not apply to kind {kind!r}."

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -151,6 +151,7 @@ from turnstone.core.tools import (
     PRIMARY_KEY_MAP,
     TASK_AGENT_TOOLS,
     TASK_AUTO_TOOLS,
+    TOOLS,
     merge_mcp_tools,
 )
 from turnstone.core.trajectory import (
@@ -2491,43 +2492,114 @@ class ChatSession:
         self._render_agent_tool_descriptions()
         self._rebuild_tool_search()
 
-    def _render_agent_tool_descriptions(self) -> None:
-        """Inject the live alias list into the ``model`` parameter description
-        on the task_agent tool.
+    # Tools whose ``persona`` parameter names an interactive-kind persona —
+    # task_agent sub-agents and spawned children are always interactive.
+    _PERSONA_ARG_TOOLS = ("task_agent", "spawn_workstream", "spawn_batch")
 
-        Lets the calling LLM see which aliases are valid right now.
-        Called on session init and on registry reload (via
-        ``refresh_agent_tool_schemas``).  No-op when no registry is
-        configured (CLI single-model case).
+    def _persona_catalog_line(self) -> str:
+        """One sentence enumerating the enabled interactive-kind personas.
+
+        This is the persona DISCOVERY path for calling LLMs: without it a
+        coordinator or interactive agent has no way to learn which names the
+        ``persona=`` argument accepts.  Returns ``""`` when storage is not up
+        (never auto-initializes it — this runs at session construction),
+        listing fails, or nothing applies; the resolve-time error, which
+        enumerates the live names, remains the self-correction path for lists
+        rendered before a persona edit.
+        """
+        from turnstone.core.storage import get_storage, is_storage_initialized
+
+        if not is_storage_initialized():
+            return ""
+        try:
+            rows = [
+                r
+                for r in get_storage().list_personas()
+                if "interactive" in (r.get("applies_to_kinds") or [])
+            ]
+        except Exception:
+            log.debug("persona_catalog.list_failed", exc_info=True)
+            return ""
+        if not rows:
+            return ""
+        rows.sort(key=lambda r: (not r.get("is_default"), str(r.get("name") or "")))
+        # Descriptions help the model pick by purpose, but an operator shelf
+        # with dozens of personas would bloat every request — past 25, names
+        # still enumerate completely and only the prose is dropped.
+        include_desc = len(rows) <= 25
+        parts = []
+        for r in rows:
+            entry = f"`{r['name']}`"
+            if r.get("is_default"):
+                entry += " (default)"
+            if include_desc:
+                desc = " ".join(str(r.get("description") or "").split())
+                if len(desc) > 96:
+                    desc = desc[:95].rstrip() + "…"
+                if desc:
+                    entry += f" — {desc}"
+            parts.append(entry)
+        return "Available personas: " + "; ".join(parts) + "."
+
+    def _render_agent_tool_descriptions(self) -> None:
+        """Inject live option lists into agent-tool parameter descriptions.
+
+        Two lists, one mechanism:
+
+        - model aliases → ``task_agent.model`` (skipped when no registry is
+          configured — the CLI single-model case);
+        - enabled interactive-kind personas → the ``persona`` parameter on
+          task_agent / spawn_workstream / spawn_batch, so the calling LLM can
+          discover valid names instead of guessing (children and sub-agents
+          are always interactive-kind).
+
+        Lets the calling LLM see which values are valid right now.  Called on
+        session init and on registry reload (via
+        ``refresh_agent_tool_schemas``); personas listed reflect that render
+        moment — resolve errors enumerate the live set, so a stale list
+        self-corrects on the next attempt.
 
         Replaces affected tool dicts with deep copies so the module-level
-        tool-list constants stay untouched across sessions.
+        tool-list constants stay untouched across sessions.  Both rewrites
+        rebuild their full description text every render (persona text from
+        the pristine ``TOOLS`` base) — never append to the previous render's
+        output, so a list that shrinks to nothing clears rather than
+        lingering stale.
 
         task_agent lives in ``self._tools`` (the main session's tool set) —
         not in ``self._task_tools``, which is what *sub-agents* see
         (sub-agents don't get delegation tools to avoid infinite recursion).
         """
-        if self._registry is None:
-            return
         # Hide ``default`` from the alias list — the LLM reads the English
         # word and picks it explicitly, which routes to whichever model
         # carries that alias rather than the operator-configured per-role
         # default (task_alias).  Omitting ``model=`` already selects the
         # per-role default; offering the literal name as an alternative
         # invites the bypass.
-        aliases = sorted(a for a in self._registry.list_aliases() if a != "default")
+        aliases: list[str] = []
+        if self._registry is not None:
+            aliases = sorted(a for a in self._registry.list_aliases() if a != "default")
         aliases_str = ", ".join(f"`{a}`" for a in aliases)
+        persona_line = self._persona_catalog_line()
+        persona_base: dict[str, str] = {}
+        for tool in TOOLS:
+            fn = tool.get("function") or {}
+            if fn.get("name") in self._PERSONA_ARG_TOOLS:
+                prop = self._persona_property(fn.get("parameters", {}).get("properties", {}))
+                persona_base[fn["name"]] = (prop or {}).get("description", "")
 
         new_tools: list[dict[str, Any]] = []
         for tool in self._tools:
             fn = tool.get("function") or {}
             name = fn.get("name", "")
-            if name != "task_agent":
+            rewrite_model = name == "task_agent" and self._registry is not None
+            rewrite_persona = name in self._PERSONA_ARG_TOOLS
+            if not rewrite_model and not rewrite_persona:
                 new_tools.append(tool)
                 continue
             new_tool = copy.deepcopy(tool)
             props = new_tool.get("function", {}).get("parameters", {}).get("properties", {})
-            if "model" in props:
+            if rewrite_model and "model" in props:
                 # Always rewrite — a reload that filters down to no
                 # alternatives (only ``default`` remains in the registry)
                 # must clear any stale alias names left over from a prior
@@ -2544,8 +2616,33 @@ class ChatSession:
                         "Omit to use the current session model. "
                         "(No alternative aliases configured in this session.)"
                     )
+            if rewrite_persona:
+                prop = self._persona_property(props)
+                if prop is not None:
+                    base = persona_base.get(name, "")
+                    prop["description"] = f"{base} {persona_line}".strip() if persona_line else base
             new_tools.append(new_tool)
         self._tools = new_tools
+
+    @staticmethod
+    def _persona_property(props: dict[str, Any]) -> dict[str, Any] | None:
+        """Locate the ``persona`` schema dict inside a tool's properties.
+
+        task_agent and spawn_workstream carry it top-level; spawn_batch
+        nests it per-child under ``children.items.properties``.  Returns the
+        live (mutable) dict so the render loop can rewrite its description,
+        or ``None`` when the tool has no persona parameter.
+        """
+        top = props.get("persona")
+        if isinstance(top, dict):
+            return top
+        # Every isinstance gate matters: name-colliding MCP tools ride the
+        # same merged list, and list-form ``items`` is legal JSON Schema.
+        children = props.get("children")
+        items = children.get("items") if isinstance(children, dict) else None
+        sub = items.get("properties") if isinstance(items, dict) else None
+        nested = sub.get("persona") if isinstance(sub, dict) else None
+        return nested if isinstance(nested, dict) else None
 
     def refresh_agent_tool_schemas(self) -> None:
         """Public entry point: re-render the task_agent tool
@@ -9841,6 +9938,10 @@ class ChatSession:
                         "unavailable). Retry, or omit `persona` for the default identity."
                     ),
                 }
+            # Canonical slug from the resolved row — forgiving resolution may
+            # have matched a case variant or a display name, and the approval
+            # header + item stamp must carry the persona's real name.
+            persona_arg = snap.name
             persona_prompt = snap.prompt
             persona_tools = snap.tools
             persona_mcp = snap.mcp
@@ -10594,7 +10695,7 @@ class ChatSession:
         target_node = self._flatten_spawn_arg(args.get("target_node"), 64)
         persona = self._flatten_spawn_arg(args.get("persona"), 64)
         if persona:
-            persona_err = self._validate_child_persona(persona)
+            persona, persona_err = self._validate_child_persona(persona)
             if persona_err:
                 return self._coord_tool_error(call_id, "spawn_workstream", persona_err)
         if skill:
@@ -10635,26 +10736,32 @@ class ChatSession:
             "persona": persona,
         }
 
-    def _validate_child_persona(self, persona: str) -> str:
+    def _validate_child_persona(self, persona: str) -> tuple[str, str]:
         """Prep-time gate for a spawn's ``persona`` arg.
 
-        Returns an error string (empty = valid).  Children are always
-        ``kind=interactive`` — see ``CoordinatorClient.spawn``.  The
-        receiving node's create handler re-resolves through the SAME
-        shared rule (``resolve_persona_for_kind``) and stamps; this gate
-        just turns an inevitable HTTP 400 into a clean tool error the
-        model can react to.  Best-effort: a storage blip defers the
-        verdict to the create handler rather than blocking the spawn.
+        Returns ``(canonical_name, error)`` — an empty error means valid, and
+        ``canonical_name`` is the resolved row's slug (forgiving resolution
+        accepts case variants and unique display names, but the wire, the
+        preview chrome, and the child's stamp must carry the real name).
+        Children are always ``kind=interactive`` — see
+        ``CoordinatorClient.spawn``.  The receiving node's create handler
+        re-resolves through the SAME shared rule
+        (``resolve_persona_for_kind``) and stamps; this gate just turns an
+        inevitable HTTP 400 into a clean tool error the model can react to.
+        Best-effort: a storage blip defers the verdict to the create handler
+        rather than blocking the spawn (the raw name rides through).
         """
         try:
             storage = get_storage()
             if storage is None:
-                return ""
-            _row, err = resolve_persona_for_kind(storage, persona, "interactive")
+                return persona, ""
+            row, err = resolve_persona_for_kind(storage, persona, "interactive")
         except Exception:
-            log.debug("spawn.persona_precheck_failed persona=%s", persona, exc_info=True)
-            return ""
-        return err
+            log.debug("spawn.persona_precheck_failed", persona=persona, exc_info=True)
+            return persona, ""
+        if err or row is None:
+            return persona, err or f"unknown persona {persona!r}"
+        return str(row["name"]), ""
 
     def _exec_spawn_workstream(self, item: dict[str, Any]) -> tuple[str, str]:
         call_id = item["call_id"]
@@ -10747,8 +10854,10 @@ class ChatSession:
         normalised: list[dict[str, Any]] = []
         preview_rows: list[str] = []
         # Persona prechecks hit storage; a fan-out batch usually repeats one
-        # persona across all children, so memoize per prepare call.
-        persona_verdicts: dict[str, str] = {}
+        # persona across all children, so memoize per prepare call.  Keyed by
+        # the raw arg, valued ``(canonical_slug, error)`` — rows spelling the
+        # same forgiven variant land on the same stamped name.
+        persona_verdicts: dict[str, tuple[str, str]] = {}
         skill_verdicts: dict[str, str] = {}
         for idx, raw in enumerate(raw_children):
             if not isinstance(raw, dict):
@@ -10779,8 +10888,14 @@ class ChatSession:
                 # failing the whole batch.
                 if persona not in persona_verdicts:
                     persona_verdicts[persona] = self._validate_child_persona(persona)
-                if persona_verdicts[persona]:
-                    spec["_error"] = persona_verdicts[persona]
+                canonical, persona_err = persona_verdicts[persona]
+                if persona_err:
+                    spec["_error"] = persona_err
+                else:
+                    # Preview chrome below reads the local too — keep both
+                    # on the canonical slug.
+                    persona = canonical
+                    spec["persona"] = canonical
             if skill and not spec.get("_error"):
                 # Same principal-load-only risk gate as spawn_workstream,
                 # surfaced per-row (partial-success) rather than failing the


### PR DESCRIPTION
## Problem

Personas had no discovery path for the agents that launch them: `task_agent`, `spawn_workstream`, and `spawn_batch` all take `persona=`, but nothing enumerated valid names — a coordinator or interactive agent could only guess. On top of that, resolution was an exact case-sensitive match on the slug, while the UI leads with display names, so `persona=Writer` or `persona=Creative Writer` failed with no path to the right answer.

## Changes

**Discovery — the live catalog rides the tool schema.** `_render_agent_tool_descriptions` (the existing model-alias injection path) now also appends the enabled interactive-kind persona list to the `persona` parameter description of `task_agent` / `spawn_workstream` / `spawn_batch`: name, default marker, and the persona's one-line description (≤96 chars; names-only past 25 personas so an oversized shelf can't bloat every request). Rebuilt from the pristine `TOOLS` base each render — idempotent, and archived personas drop out. `spawn_batch`'s persona property is nested per-child under `children.items.properties`, located via a null-safe helper so name-colliding MCP tools can't break the render. The catalog read gates on `is_storage_initialized()` (not `get_storage()`, which would auto-init SQLite during session construction).

**Forgiving resolution — one rule, all surfaces.** `resolve_persona_for_kind` (shared by the HTTP create handler, CLI `--persona`, the coordinator spawn precheck, and task_agent prep) now resolves exact slug → lowercased input → case-insensitive display-name match. The display fallback is deliberately narrow: candidates are the kind's enabled personas only (a same-label persona of another kind neither blocks nor wins), the match must be unique (duplicates refuse loudly, naming the candidate slugs), and whitespace-only input never matches blank display names (`display_name` defaults to `""`). Every failure enumerates the kind's currently-valid names — the self-correction path for a stale injected list, and de-facto discovery for CLI users.

**Canonical slug everywhere.** Whatever variant matched, the stamped identity is the row's real `name`: task_agent prep rewrites its arg from the resolved snapshot, and `_validate_child_persona` now returns `(canonical, error)` with both spawn call sites adopting it — approval headers, the wire, and `workstream_config` never carry a forgiven variant.

**UX + docs.** The create-persona shelf gains a hint under **Name** (agents and the CLI launch the persona by this name, case-insensitive; the display name is only a list label). `docs/personas.md` gains a "How agents discover personas" section and drops the stale claim that `task_agent` has no persona parameter.

## Notes

- A persona created mid-session appears in new sessions' tool descriptions immediately but not in already-rendered ones (renders happen at session init, MCP catalog change, and registry reload; there is no console→node push for persona edits). Accepted: the resolve-error enumeration covers the window.
- Display-name matching is a forgiveness fallback, not a contract — docs say so explicitly. Slugs always shadow display names, and a disabled slug is reported as disabled rather than falling through to someone else's identical display name.

## Testing

- New resolver unit suite: case variants, unique/ambiguous/cross-kind display names, whitespace input vs blank display names, disabled exclusion, kind-mismatch, storage-none, listing-failure degradation.
- New guards: injection content + default-first ordering, idempotent re-render, archive drop-out, 25-persona prose cutoff, coordinator-kind exclusion, pristine base when storage is down, canonical stamping through `spawn_workstream` / `spawn_batch` / `task_agent`, enumerated error text.
- Full affected sweep green (persona endpoints/storage/guards/snapshot, session, coordinator tools, tools schema, server authz); ruff + ruff format + mypy clean; adversarially reviewed — the one confirmed finding (whitespace input matching blank display names via CLI) is fixed and regression-tested here.
