### PR TITLE
docs: add funding button (GitHub Sponsors + PayPal)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Funding platforms for the GitHub "Sponsor" button.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [eous]
+custom: ["https://paypal.me/eousphoros"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/turnstone)](https://pypi.org/project/turnstone/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/Nh3bWMacaq)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/eous)
 
 Self-hosted, local-first orchestration for tool-using AI agents. Give LLMs real tools — shell, files, search, web — and run them across your own cluster with direct HTTP routing and interactive interfaces. Your code, your models, your data stay on hardware you control: no telemetry, no phone-home.
 
@@ -170,6 +171,14 @@ UML diagrams in [`docs/diagrams/`](docs/diagrams/):
 - An OpenAI-compatible API endpoint, Anthropic API key, or Google Gemini API key
 - Optional: Discord / Slack channel integrations (`pip install turnstone[discord,slack]`)
 - [Git LFS](https://git-lfs.com/) for cloning (diagram PNGs)
+
+## Support
+
+Turnstone is free, Apache-2.0, and self-hosted — no paid tier, no telemetry, no upsell. If it saves you time or you'd like to help keep development moving, you can sponsor the project:
+
+**[❤ Sponsor Turnstone →](https://github.com/sponsors/eous)**  ·  one-off via **[PayPal](https://paypal.me/eousphoros)**
+
+Sponsorship is entirely optional and funds maintenance, new features, and infrastructure. Prefer to contribute in other ways? Filing issues, improving docs, and [pull requests](CONTRIBUTING.md) help just as much.
 
 ## Community
 


### PR DESCRIPTION
Adds a "Support / fund this" surface to the repo.

## Changes
- `.github/FUNDING.yml` — enables the native GitHub **Sponsor** button (repo header + issue sidebar). GitHub Sponsors handle `eous`, with PayPal (`paypal.me/eousphoros`) as a `custom:` fallback link.
- `README.md` — a `Sponsor ❤` badge in the badge row and a `## Support` section (GitHub Sponsors as the primary CTA, PayPal as a one-off fallback).

## Notes
- The native Sponsor button only renders once `FUNDING.yml` is on the default branch (`main`), so it goes live on merge.
- GitHub Sponsors takes a 0% platform fee; PayPal charges its standard receiving fee.
