### PR TITLE
fix: postgres history-search resilience + client-construction error classification

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -167,6 +167,38 @@ class TestModelRegistry:
         with pytest.raises(ValueError, match="Unknown model alias"):
             reg.get_client("nonexistent")
 
+    def test_client_construction_failure_is_value_error(self) -> None:
+        # Environment failures inside SDK construction (e.g. httpx raising
+        # FileNotFoundError for a CA bundle deleted by a venv rebuild) must
+        # surface as ValueError so routes answer 503-with-message instead
+        # of an opaque 500.
+        reg = self._make_registry()
+        with (
+            patch(
+                "turnstone.core.model_registry.create_client",
+                side_effect=FileNotFoundError(2, "No such file or directory"),
+            ),
+            pytest.raises(ValueError, match="'default'.*FileNotFoundError") as excinfo,
+        ):
+            reg.get_client("default")
+        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+        # Nothing half-constructed may be cached — a later call with a
+        # repaired environment must construct for real.
+        assert "default" not in reg._clients
+
+    def test_client_construction_value_error_passes_through(self) -> None:
+        # create_client's own misconfig ValueErrors already carry
+        # remediation text and must not be double-wrapped.
+        reg = self._make_registry()
+        with (
+            patch(
+                "turnstone.core.model_registry.create_client",
+                side_effect=ValueError("anthropic-compatible requires base_url"),
+            ),
+            pytest.raises(ValueError, match="^anthropic-compatible requires base_url$"),
+        ):
+            reg.get_client("default")
+
     def test_shutdown(self) -> None:
         reg = self._make_registry()
         reg.get_client("default")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -176,12 +176,17 @@ class TestModelRegistry:
         with (
             patch(
                 "turnstone.core.model_registry.create_client",
-                side_effect=FileNotFoundError(2, "No such file or directory"),
+                side_effect=FileNotFoundError(2, "No such file", "/gone/cacert.pem"),
             ),
             pytest.raises(ValueError, match="'default'.*FileNotFoundError") as excinfo,
         ):
             reg.get_client("default")
         assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+        # The message is echoed in 503 bodies: exception TYPE only — the
+        # raw exception text can embed filesystem paths and must stay in
+        # the server log.
+        assert "/gone/cacert.pem" not in str(excinfo.value)
+        assert "No such file" not in str(excinfo.value)
         # Nothing half-constructed may be cached — a later call with a
         # repaired environment must construct for real.
         assert "default" not in reg._clients

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 import sqlalchemy as sa
 
 from turnstone.core.storage._schema import workstreams
@@ -575,6 +576,48 @@ class TestSearch:
         backend.save_message("s1", "user", "msg2")
         results = backend.search_history_recent(limit=1)
         assert len(results) == 1
+
+    def test_search_history_survives_oversized_row(self, backend):
+        # A multi-MB row of mostly-unique words: on PostgreSQL its full
+        # tsvector exceeds the 1MB hard limit, which used to abort every
+        # search_history scan ("string is too long for tsvector") — one
+        # giant tool dump silently killed history recall entirely.
+        backend.register_workstream("s1")
+        giant = "gargantuan beacon " + " ".join(f"w{i}" for i in range(300_000))
+        assert len(giant) > 2_000_000
+        backend.save_message("s1", "tool", giant)
+        backend.save_message("s1", "user", "hello world")
+
+        results = backend.search_history("hello")
+        assert any("hello" in str(r[3]) for r in results)
+
+        # The oversized row itself stays findable by its head.
+        results = backend.search_history("gargantuan beacon")
+        assert any("gargantuan" in str(r[3]) for r in results)
+
+    def test_search_history_fts_error_falls_back_to_ilike(self, request, backend, monkeypatch):
+        # PostgreSQL only: a failed FTS statement aborts the connection's
+        # autobegun transaction, and the ILIKE fallback runs on that same
+        # connection — without a rollback first it dies with
+        # InFailedSqlTransaction instead of returning results.
+        if request.config.getoption("--storage-backend") != "postgresql":
+            pytest.skip("exercises PostgreSQL aborted-transaction fallback")
+
+        backend.register_workstream("s1")
+        backend.save_message("s1", "user", "hello fallback world")
+
+        real_execute = sa.engine.Connection.execute
+
+        def failing_fts_execute(self, statement, *args, **kwargs):
+            if "to_tsvector" in str(statement):
+                # A genuine server-side error, so the transaction is aborted
+                # exactly as when to_tsvector rejects a row.
+                return real_execute(self, sa.text("SELECT 1/0"))
+            return real_execute(self, statement, *args, **kwargs)
+
+        monkeypatch.setattr(sa.engine.Connection, "execute", failing_fts_execute)
+        results = backend.search_history("fallback")
+        assert any("fallback" in str(r[3]) for r in results)
 
 
 # -- Workstream operations -----------------------------------------------------

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -145,9 +145,25 @@ class ModelRegistry:
                 raise ValueError(f"Unknown model alias: {alias}")
             if alias not in self._clients:
                 cfg = self._models[alias]
-                self._clients[alias] = create_client(
-                    cfg.provider, base_url=cfg.base_url, api_key=cfg.api_key
-                )
+                try:
+                    self._clients[alias] = create_client(
+                        cfg.provider, base_url=cfg.base_url, api_key=cfg.api_key
+                    )
+                except ValueError:
+                    # create_client's own misconfig errors already carry
+                    # remediation text — pass through untouched.
+                    raise
+                except Exception as exc:
+                    # SDK construction can fail on environment problems the
+                    # config never sees — e.g. httpx resolving a CA-bundle
+                    # path that a venv rebuild deleted (FileNotFoundError).
+                    # Routes map ValueError to a 503 with the message;
+                    # anything else surfaces as an opaque 500, so re-type
+                    # here where the alias is known.
+                    raise ValueError(
+                        f"failed to construct {cfg.provider} client for model "
+                        f"alias {alias!r}: {type(exc).__name__}: {exc}"
+                    ) from exc
             return self._clients[alias]
 
     def get_provider(self, alias: str) -> LLMProvider:

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -159,10 +159,20 @@ class ModelRegistry:
                     # path that a venv rebuild deleted (FileNotFoundError).
                     # Routes map ValueError to a 503 with the message;
                     # anything else surfaces as an opaque 500, so re-type
-                    # here where the alias is known.
+                    # here where the alias is known.  The ValueError text is
+                    # echoed to HTTP callers, so it carries only the
+                    # exception TYPE — arbitrary SDK exception text can
+                    # embed filesystem paths; the full detail goes to the
+                    # server log instead.
+                    log.warning(
+                        "Client construction failed for model alias %r (provider %s)",
+                        alias,
+                        cfg.provider,
+                        exc_info=True,
+                    )
                     raise ValueError(
                         f"failed to construct {cfg.provider} client for model "
-                        f"alias {alias!r}: {type(exc).__name__}: {exc}"
+                        f"alias {alias!r}: {type(exc).__name__} (details in server log)"
                     ) from exc
             return self._clients[alias]
 

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -178,6 +178,13 @@ from turnstone.core.workstream import BULK_CLOSE_STATE_VALUES, WorkstreamKind
 
 log = get_logger(__name__)
 
+# PostgreSQL rejects any tsvector larger than 1MB ("string is too long for
+# tsvector"), and search_history computes tsvectors inline per row — so one
+# oversized row would abort the whole scan and every search with it.  Worst
+# case a tsvector runs ~4x its input (unique short lexemes + position data),
+# so 250K chars keeps even pathological rows safely under the limit.
+_FTS_INPUT_CAP_CHARS = 250_000
+
 
 def _resolve_pg_listen_url(override: str, sqlalchemy_url: str) -> str:
     """Resolve the URL used by the dedicated LISTEN connection.
@@ -1289,26 +1296,31 @@ class PostgreSQLBackend:
             scope_params["excl_ws"] = exclude_ws_id
             scope_params["excl_after"] = -1 if exclude_after is None else exclude_after
         with self._conn() as conn:
-            # Use PostgreSQL full-text search if search_vector column exists
+            # Full-text search over an inline tsvector (there is no indexed
+            # search_vector column).  The input is capped — see
+            # _FTS_INPUT_CAP_CHARS — so a single giant row (multi-MB tool
+            # dumps exist) cannot trip PostgreSQL's 1MB tsvector limit and
+            # abort every search; oversized rows stay findable by their head.
             try:
                 return list(
                     conn.execute(
                         sa.text(
                             "SELECT c.timestamp, c.ws_id, c.role, c.content, c.tool_name "
                             "FROM conversations c "
-                            "WHERE to_tsvector('english', COALESCE(c.content, '')) "
+                            "WHERE to_tsvector('english', left(COALESCE(c.content, ''), :fts_cap)) "
                             "   @@ plainto_tsquery('english', :query) "
                             # Exclude compaction-checkpoint markers (resume-only
                             # summary artifacts); IS DISTINCT FROM is NULL-safe so
                             # normal rows (_source NULL) are not dropped.
                             "AND c._source IS DISTINCT FROM :compaction_source "
                             + scope_sql
-                            + "ORDER BY ts_rank(to_tsvector('english', COALESCE(c.content, '')), "
+                            + "ORDER BY ts_rank(to_tsvector('english', left(COALESCE(c.content, ''), :fts_cap)), "
                             "   plainto_tsquery('english', :query)) DESC "
                             "LIMIT :limit OFFSET :offset"
                         ),
                         {
                             "query": query,
+                            "fts_cap": _FTS_INPUT_CAP_CHARS,
                             "compaction_source": _COMPACTION_SOURCE,
                             "limit": capped,
                             "offset": capped_offset,
@@ -1317,6 +1329,11 @@ class PostgreSQLBackend:
                     ).fetchall()
                 )
             except Exception:
+                # The failed statement aborted the connection's autobegun
+                # transaction; PostgreSQL then refuses every command until a
+                # rollback, so without this the fallback can never run
+                # (InFailedSqlTransaction).
+                conn.rollback()
                 # Fallback to ILIKE
                 return list(
                     conn.execute(


### PR DESCRIPTION
## Summary

Two independent fixes surfaced by the same incident trail.

### 1. Postgres `search_history` died on any oversized row (storage)

`search_history` computed `to_tsvector('english', content)` inline per row. PostgreSQL hard-errors when a single row's tsvector exceeds 1MB, and the error aborts the whole scan — one 2.1MB bash tool-result row silently killed **all** history recall (`memory.py` catches and returns `[]`). A second dormant bug compounded it: the ILIKE fallback ran on the same connection whose autobegun transaction the failed FTS statement had aborted, so it deterministically raised `InFailedSqlTransaction` — the fallback had never been reachable on postgres.

- Cap FTS input at `left(COALESCE(content,''), 250000)` in both the WHERE and `ts_rank` sites (worst-case tsvector expansion ~4x input keeps 250K chars safely under the 1MB limit; giant rows stay findable by their head)
- `conn.rollback()` before the ILIKE fallback
- SQLite needs no change (FTS5 shadow table indexes at write time, no comparable limit)

### 2. Client-construction failures surfaced as opaque 500s (models)

SDK client construction can fail on environment problems the config never sees — observed: httpx resolving a certifi CA path that a venv rebuild had deleted (`FileNotFoundError`), which turned every workstream open/create on the node into `500 internal error, correlation_id=…`. `ModelRegistry.get_client` now re-types non-ValueError construction failures as `ValueError` naming the alias and original error, so the existing route lane answers 503 with actionable text. `create_client`'s own misconfig ValueErrors pass through untouched, and nothing half-constructed is cached.

## Testing

- Regression tests fail on the unfixed code and pass with the fix (storage tests run against both backends; the fallback test is postgres-only and forces a genuine server-side error so the transaction really aborts)
- Original tsvector failure reproduced byte-identical with a read-only query against the affected instance; the capped query returns results on the same data
- `ruff` + `mypy` clean; `test_storage_sqlite.py` green in sqlite and postgres modes (86/86), `test_model_registry.py` 130/130