### PR TITLE
fix(ui): ephemeral panes close on split-dismiss instead of orphaning a tab

### DIFF
--- a/tests/test_preview_js.py
+++ b/tests/test_preview_js.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
 _SHARED = _ROOT / "turnstone/shared_static"
+_PANE_JS = _SHARED / "pane.js"
 _PREVIEW_JS = _SHARED / "preview.js"
 _CONVERSATION_JS = _SHARED / "conversation.js"
 _INTERACTIVE_JS = _SHARED / "interactive.js"
@@ -155,3 +156,59 @@ class TestStylesheets:
         assert "var(--hair)" in body
         for legacy in ("var(--green)", "var(--red)", "var(--fg)"):
             assert legacy not in body
+
+
+class TestEphemeralDismiss:
+    """The preview is an ephemeral pane: dismissing its split cell CLOSES it
+    (tab and content gone) instead of parking an orphan tab whose only reopen
+    is the transcript chip.  Regression guard for the pane/tab desync."""
+
+    def test_preview_pane_is_ephemeral(self) -> None:
+        """createPreviewPane must flag the pane ephemeral — the whole fix keys
+        off this bit."""
+        body = _read(_PREVIEW_JS)
+        assert "ephemeral: true" in body, "the preview pane must declare itself ephemeral"
+
+    def test_shellpane_carries_the_ephemeral_flag(self) -> None:
+        body = _read(_PANE_JS)
+        assert "this.ephemeral = opts.ephemeral || false;" in body, (
+            "ShellPane must accept and default the ephemeral flag"
+        )
+
+    def test_cell_chip_closes_ephemeral_pane_outright(self) -> None:
+        """In a split the ✕ chip normally HIDES the cell (closeCell); for an
+        ephemeral pane it must fall through to close() — the `!pane.ephemeral`
+        guard is what routes it there.  Pin BOTH the guard and where the
+        skipped case lands (the else), or gutting the else regresses the fix
+        while the guard string survives verbatim."""
+        body = _read(_PANE_JS)
+        assert "if (this._layout && this._leafFor(pane.id) && !pane.ephemeral)" in body, (
+            "the cell chip must skip closeCell for an ephemeral pane"
+        )
+        assert "else this.close(pane.id);" in body, (
+            "the skipped (ephemeral / single-pane) case must land on close()"
+        )
+
+    def test_cell_chip_signals_destruction_for_ephemeral(self) -> None:
+        """The glyph/label must not lie: an ephemeral pane's split chip reads
+        as a destructive close (✕ + danger hover + 'Close pane'), never the
+        reversible '− / Hide from split'."""
+        body = _read(_PANE_JS)
+        assert "const destroys = !multi || pane.ephemeral;" in body, (
+            "chip mode must treat ephemeral panes as destructive even in a split"
+        )
+
+    def test_unsplit_closes_ephemeral_non_survivors(self) -> None:
+        """Collapsing the split from the OTHER pane must not orphan the preview
+        either — unsplit closes ephemeral panes it isn't keeping."""
+        body = _read(_PANE_JS)
+        assert "const keep = this._activeId;" in body, (
+            "the unsplit survivor must be the FOCUSED pane — the filter's "
+            "`id !== keep` guard is only correct if keep is _activeId"
+        )
+        assert "for (const id of doomed) this.close(id);" in body, (
+            "unsplit must destroy ephemeral panes it does not keep"
+        )
+        assert "return id !== keep && p && p.ephemeral;" in body, (
+            "unsplit must spare the focused survivor and non-ephemeral panes"
+        )

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -866,16 +866,20 @@ def test_pane_manager_split_engine() -> None:
     assert "_restoreLayout(data)" in pane and "seen.has(d.paneId)" in pane
     # the visible-but-unfocused tab marker
     assert 'classList.toggle("shown"' in pane
-    # per-pane ✕: split mode hides ONE cell keeping the tab (closeCell);
-    # single-pane it closes the pane (withheld from non-closable) — the click
-    # decides at click time, the label tracks the mode.  Manager-injected into
-    # the pane SECTION (content untouched), removed via _clearCellStyle.
+    # per-pane ✕: split mode hides ONE cell keeping the tab (closeCell), EXCEPT
+    # an ephemeral pane which closes outright; single-pane it closes the pane
+    # (withheld from non-closable) — the click decides at click time, the label
+    # tracks the mode.  Manager-injected into the pane SECTION (content
+    # untouched), removed via _clearCellStyle.  Ephemeral-dismiss behaviour has
+    # its own deep coverage in test_preview_js.py::TestEphemeralDismiss.
     assert "closeCell(paneId)" in pane and "_refreshCellChips()" in pane
     assert 'b.className = "cell-unsplit"' in pane
     assert '"Close pane"' in pane, "the single-pane chip mode"
     # mode-DISTINCT glyphs (designer P1: identical signifier + locus with a
-    # reversible/destructive divergence is a mode-error trap)
-    assert 'b.textContent = multi ? "−" : "✕"' in pane
+    # reversible/destructive divergence is a mode-error trap) — a click that
+    # cannot be a reversible cell-hide shows ✕, else −.
+    assert "const destroys = !multi || pane.ephemeral;" in pane
+    assert 'b.textContent = destroys ? "✕" : "−"' in pane
     assert '"cell-unsplit--close"' in pane
     assert "this._removeCellChip(pane)" in pane
     # open-beside: the coordinator child-link placement (split right of the

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -45,6 +45,12 @@ export class ShellPane {
     this.glyph = opts.glyph || null; // a single static char shown in the tab (e.g. "◇"); stateful panes use a live .ui-glyph-* instead
     this.stateful = opts.stateful || false; // conversational panes: tab glyph tracks live Tier-1 state (set via setTabGlyph)
     this.closable = opts.closable !== false; // dashboard is not closable
+    // Ephemeral: a pane with no standalone background-tab life.  Dismissing its
+    // split cell (the ✕ chip, or unsplit) CLOSES it — destroy, not the default
+    // hide-and-keep-the-tab — because there is no meaningful re-open-from-tab;
+    // its reopen affordance lives elsewhere (the transcript preview chip).  The
+    // preview singleton sets this; conversational panes do not.
+    this.ephemeral = opts.ephemeral || false;
     // DOM — created and owned by the PaneManager on mount:
     this.el = null; // <section class="pane">
     this.bodyEl = null; // <div class="pane-body"> — pane content host
@@ -617,11 +623,21 @@ export class PaneManager {
     return { ok: true };
   }
 
-  /** Collapse back to a single pane — the focused one.  The other panes stay
-   *  open as tabs (they just stop being visible); nothing is closed. */
+  /** Collapse back to a single pane — the focused one.  Other panes stay open
+   *  as tabs (they just stop being visible) — EXCEPT ephemeral ones (e.g. the
+   *  preview), which have no background-tab life and close outright rather than
+   *  linger as orphan tabs.  The focused survivor is spared even if ephemeral. */
   unsplit() {
     if (!this._layout) return;
-    this._exitLayout(this._activeId);
+    const keep = this._activeId;
+    const doomed = this._leaves()
+      .map((l) => l.paneId)
+      .filter((id) => {
+        const p = this._panes.get(id);
+        return id !== keep && p && p.ephemeral;
+      });
+    for (const id of doomed) this.close(id); // collapses its cell, then destroys
+    if (this._layout) this._exitLayout(keep); // a close() may have already exited
     this._renderTabs();
     this._persist();
     this._notifyActive();
@@ -873,7 +889,11 @@ export class PaneManager {
       b.type = "button";
       b.className = "cell-unsplit";
       b.addEventListener("click", () => {
-        if (this._layout && this._leafFor(pane.id)) this.closeCell(pane.id);
+        // In a multi-cell split the chip HIDES this cell (the tab stays) —
+        // except an ephemeral pane (e.g. the preview), which has no background-
+        // tab life and so closes outright, exactly as it does single-pane.
+        if (this._layout && this._leafFor(pane.id) && !pane.ephemeral)
+          this.closeCell(pane.id);
         else this.close(pane.id);
       });
       pane.el.append(b);
@@ -882,11 +902,15 @@ export class PaneManager {
     // Mode-DISTINCT glyphs — an identical signifier at an identical locus with
     // divergent outcomes is a mode-error trap (split-mode muscle memory would
     // fire the destructive close): − hides the cell (reversible — the tab
-    // stays), ✕ closes the pane.  Close mode also wears a danger hover
-    // (shell.css .cell-unsplit--close).
-    b.textContent = multi ? "−" : "✕";
-    b.classList.toggle("cell-unsplit--close", !multi);
-    const label = multi ? "Hide from split — the tab stays open" : "Close pane";
+    // stays), ✕ closes the pane.  The chip DESTROYS whenever the click cannot be
+    // a reversible cell-hide: single-pane always, and an ephemeral pane even in
+    // a split.  Close mode also wears a danger hover (shell.css .cell-unsplit--close).
+    const destroys = !multi || pane.ephemeral;
+    b.textContent = destroys ? "✕" : "−";
+    b.classList.toggle("cell-unsplit--close", destroys);
+    const label = destroys
+      ? "Close pane"
+      : "Hide from split — the tab stays open";
     b.title = label;
     b.setAttribute("aria-label", label);
   }

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -636,8 +636,12 @@ export class PaneManager {
         const p = this._panes.get(id);
         return id !== keep && p && p.ephemeral;
       });
-    for (const id of doomed) this.close(id); // collapses its cell, then destroys
-    if (this._layout) this._exitLayout(keep); // a close() may have already exited
+    // close() destroys the pane AND renders/persists/notifies; a 2-cell split
+    // fully collapses inside it, so bail before repeating that work.  Only a
+    // 3+-cell split (or an empty doom list) still needs the exit + refresh here.
+    for (const id of doomed) this.close(id);
+    if (!this._layout) return;
+    this._exitLayout(keep);
     this._renderTabs();
     this._persist();
     this._notifyActive();

--- a/turnstone/shared_static/preview.js
+++ b/turnstone/shared_static/preview.js
@@ -204,6 +204,10 @@ export function createPreviewPane(extra, hostApi) {
     type: "preview",
     title: "Preview",
     glyph: "▤",
+    // Dismissing the preview cell CLOSES it (tab and all) instead of parking an
+    // orphan tab — its content is transient tool output and its reopen lives on
+    // the transcript chip, not the tab bar.
+    ephemeral: true,
   });
 
   // Viewed-descriptor history (session-scoped): entries are {descriptor, ctx}.

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -828,8 +828,10 @@
   pointer-events: none;
 }
 /* per-pane ✕ — on every visible pane.  Split mode: "hide this cell" (the TAB
-   stays — closeCell); single-pane: "close pane" (withheld from the unclosable
-   Dashboard).  Shell chrome floating over pane content: elevated panel +
+   stays — closeCell), but an ephemeral pane (the preview) closes outright;
+   single-pane: "close pane" (withheld from the unclosable Dashboard).  The
+   destructive modes flip the glyph to ✕ and wear .cell-unsplit--close.
+   Shell chrome floating over pane content: elevated panel +
    hairline so it reads as the shell's, not the conversation's; sits clear of
    the 2px focus bar and the cell corner. */
 .cell-unsplit {

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -827,11 +827,11 @@
   z-index: 13; /* above the ring overlay — a clean bar, not bar-plus-ring-line */
   pointer-events: none;
 }
-/* per-pane ✕ — on every visible pane.  Split mode: "hide this cell" (the TAB
-   stays — closeCell), but an ephemeral pane (the preview) closes outright;
-   single-pane: "close pane" (withheld from the unclosable Dashboard).  The
-   destructive modes flip the glyph to ✕ and wear .cell-unsplit--close.
-   Shell chrome floating over pane content: elevated panel +
+/* per-pane dismiss chip (.cell-unsplit) — on every visible pane.  Split mode:
+   "−" hides this cell (the TAB stays — closeCell), but an ephemeral pane (the
+   preview) shows "✕" and closes outright; single-pane: "✕" closes the pane
+   (withheld from the unclosable Dashboard).  The destructive "✕" modes wear
+   .cell-unsplit--close.  Shell chrome floating over pane content: elevated panel +
    hairline so it reads as the shell's, not the conversation's; sits clear of
    the 2px focus bar and the cell corner. */
 .cell-unsplit {


### PR DESCRIPTION
## What

The preview pane opens beside the conversation as a split cell. Dismissing that cell — the per-cell chip, or **Unsplit** from the other pane — ran `closeCell()`, which hides the pane but keeps it in `_panes`/`_order`, leaving an **orphan tab** with no meaningful reopen. The preview's reopen affordance is the transcript chip, not the tab bar, so the lingering tab earned nothing and (once the split collapsed) clicking it showed the transient preview full-screen in place of the conversation.

## Change

Add an `ephemeral` flag on `ShellPane`:

- For an ephemeral pane the cell chip and Unsplit route to `close()` — destroying the pane **and** its tab — and the chip's glyph/label read as a destructive close (`✕` / "Close pane") rather than a reversible hide (`−` / "Hide from split"), so the signifier matches the outcome.
- Unsplit still **spares the focused survivor** even when it is ephemeral (the button's contract is "keep the focused pane"); an ephemeral pane is destroyed only when Unsplit would otherwise *background* it.
- The preview pane sets the flag; conversational panes (dashboard/admin/interactive/coordinator) do not, so an all-conversation split is unchanged — with no ephemeral panes, `unsplit()` reduces to the prior `_exitLayout(_activeId)`.

## Testing

`tests/test_preview_js.py` gains a `TestEphemeralDismiss` class pinning the flag default, the chip routing/glyph, and the Unsplit doom-filter; `tests/test_shell_js.py`'s split-engine guard is updated for the new `destroys` chip logic. Full frontend-JS suite green (`test_preview_js`, `test_shell_js`, `test_interactive_pane_js`, `test_conversation_js`, `test_app_js` — 211 passed), ruff clean.
