### PR TITLE
fix: Reproduced the confirmed sub-case of #591: run_migrations()

### DIFF
--- a/tests/test_migration_schema_ahead.py
+++ b/tests/test_migration_schema_ahead.py
@@ -1,0 +1,100 @@
+"""Regression test for issue #591 (rolling git-installs vs. shared schema).
+
+Reproduces the rolling-upgrade race: one node applies a migration the *other*
+node's checkout has never heard of. Before this fix, ``run_migrations()``:
+
+* on SQLite, swallowed Alembic's "Can't locate revision" failure as a
+  non-fatal warning and returned normally — the node booted up silently
+  attached to a schema its code didn't understand;
+* on PostgreSQL, propagated Alembic's raw, cryptic ``CommandError`` instead
+  of a clear, actionable one.
+
+``run_migrations()`` now runs a pre-flight check (``_check_schema_not_ahead``)
+that raises ``SchemaAheadOfCodeError`` before either backend path gets a
+chance to run — and, on SQLite, before the broad non-fatal ``except`` can
+swallow it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+from turnstone.core.storage._migrate import SchemaAheadOfCodeError, run_migrations
+
+_MIGRATIONS_DIR = str(
+    Path(__file__).resolve().parent.parent / "turnstone" / "core" / "storage" / "migrations"
+)
+
+
+def _alembic_cfg(db_path: Path) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", _MIGRATIONS_DIR)
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+class _EngineStub:
+    """Minimal stand-in for a StorageBackend — run_migrations only reads _engine."""
+
+    def __init__(self, engine: Any) -> None:
+        self._engine = engine
+
+
+def test_run_migrations_rejects_unknown_future_revision(tmp_path: Path) -> None:
+    """A node whose code is behind the schema must fail fast, not silently boot."""
+    db_path = tmp_path / "ahead.db"
+    command.upgrade(_alembic_cfg(db_path), "head")
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        # Simulate node1 having already applied a migration this (older)
+        # checkout's script directory doesn't contain.
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text("UPDATE alembic_version SET version_num = 'FUTURE_MIGRATION_UNKNOWN'")
+            )
+
+        try:
+            run_migrations(_EngineStub(engine), "sqlite")
+        except SchemaAheadOfCodeError as exc:
+            assert "FUTURE_MIGRATION_UNKNOWN" in str(exc)
+        else:
+            raise AssertionError(
+                "run_migrations() silently succeeded against a schema ahead of "
+                "this checkout's migrations — issue #591 regression"
+            )
+    finally:
+        engine.dispose()
+
+
+def test_run_migrations_succeeds_on_compatible_schema(tmp_path: Path) -> None:
+    """Sanity check: a DB at a known (mid-upgrade) revision migrates normally."""
+    db_path = tmp_path / "compatible.db"
+    command.upgrade(_alembic_cfg(db_path), "064")
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        run_migrations(_EngineStub(engine), "sqlite")
+        with engine.connect() as conn:
+            rev = conn.execute(sa.text("SELECT version_num FROM alembic_version")).scalar()
+        assert rev is not None
+    finally:
+        engine.dispose()
+
+
+def test_run_migrations_succeeds_on_fresh_database(tmp_path: Path) -> None:
+    """Sanity check: a brand-new DB (no alembic_version yet) migrates normally."""
+    db_path = tmp_path / "fresh.db"
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        run_migrations(_EngineStub(engine), "sqlite")
+        with engine.connect() as conn:
+            rev = conn.execute(sa.text("SELECT version_num FROM alembic_version")).scalar()
+        assert rev is not None
+    finally:
+        engine.dispose()

--- a/turnstone/core/storage/_migrate.py
+++ b/turnstone/core/storage/_migrate.py
@@ -12,6 +12,42 @@ log = get_logger(__name__)
 _MIGRATIONS_DIR = str(Path(__file__).parent / "migrations")
 
 
+class SchemaAheadOfCodeError(RuntimeError):
+    """Raised when the database's Alembic revision is unknown to this checkout.
+
+    On a rolling git-pull upgrade, a node that has already applied a newer
+    migration leaves ``alembic_version`` pointing at a revision this (older,
+    not-yet-upgraded) node's migration scripts have never heard of. Left
+    unchecked, Alembic fails deep inside dependency resolution with an opaque
+    "Can't locate revision" error — or, on SQLite, that error gets logged as a
+    non-fatal warning and the node boots up silently attached to a schema its
+    code doesn't understand. See issue #591.
+    """
+
+
+def _check_schema_not_ahead(engine: Any, cfg: Any) -> None:
+    """Refuse to proceed if the DB's current revision is unknown to this checkout."""
+    from alembic.runtime.migration import MigrationContext
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(cfg)
+    known_revisions = {rev.revision for rev in script.walk_revisions()}
+
+    with engine.connect() as conn:
+        current_rev = MigrationContext.configure(conn).get_current_revision()
+
+    if current_rev is not None and current_rev not in known_revisions:
+        msg = (
+            f"Database schema is at revision {current_rev!r}, which this "
+            "installation's migrations do not recognize. Another node in the "
+            "cluster has likely already applied a newer migration than this "
+            "node's code knows about (a rolling git-pull upgrade applied out "
+            "of order). Upgrade this node's code to match before starting it "
+            "against this database."
+        )
+        raise SchemaAheadOfCodeError(msg)
+
+
 def run_migrations(storage: Any, backend: str) -> None:
     """Run pending Alembic migrations.
 
@@ -34,6 +70,11 @@ def run_migrations(storage: Any, backend: str) -> None:
     # Check if this is an existing database without alembic_version
     if backend == "sqlite":
         _bootstrap_existing_sqlite(engine, cfg)
+
+    # Fatal regardless of backend, and deliberately outside the try/excepts
+    # below — those exist to swallow transient/connection-class failures, and
+    # must not also swallow "this node's code is behind the schema."
+    _check_schema_not_ahead(engine, cfg)
 
     if backend == "postgresql":
         try:


### PR DESCRIPTION
Fixes #591

## Summary
Reproduced the confirmed sub-case of #591: run_migrations() silently swallowed a 'DB schema ahead of this checkout's migrations' error on SQLite (logged as a non-fatal warning, node booted up anyway) and raised Alembic's cryptic CommandError on PostgreSQL. Added a pre-flight _check_schema_not_ahead() check in turnstone/core/storage/_migrate.py that compares the DB's current alembic revision against the ScriptDirectory's known revisions and raises a clear SchemaAheadOfCodeError before either backend's try/except can mask it — turning a rolling git-pull node's silent/opaque failure into an explicit, actionable startup error.

## Changes
- `turnstone/core/storage/_migrate.py`
- `tests/test_migration_schema_ahead.py`

## How this was tested
Ran `pytest` locally.
