### PR TITLE
fix(sse): batch fast-stream tokens and recover overflowed listeners

### DIFF
--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -122,9 +122,8 @@ def test_coord_on_content_token_accumulates(monkeypatch: pytest.MonkeyPatch) -> 
 
     Batch window forced to 0 (per-token flush) — pins the accumulator
     wiring, not the batching cadence (test_sse_token_batching.py)."""
-    import turnstone.core.session_ui_base as suib
 
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
     ui.on_content_token("Hello ")
     ui.on_content_token("world")

--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -114,11 +114,17 @@ def test_coord_on_aux_usage_leaves_live_counters_untouched() -> None:
     assert ui._ws_context_ratio == 0.0
 
 
-def test_coord_on_content_token_accumulates() -> None:
+def test_coord_on_content_token_accumulates(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pre-lift coord ``on_content_token`` only enqueued; lift turns it
     into the same per-ws accumulator WebUI uses so the collector
     broadcast can piggyback the joined turn content on the IDLE
-    state-change event."""
+    state-change event.
+
+    Batch window forced to 0 (per-token flush) — pins the accumulator
+    wiring, not the batching cadence (test_sse_token_batching.py)."""
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
     ui.on_content_token("Hello ")
     ui.on_content_token("world")

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -688,3 +688,26 @@ def test_giveup_removes_visibility_handler() -> None:
     rvh = re.search(r"_removeVisibilityHandler\(\)\s*\{(.*?)\n  \}", body, re.S)
     assert rvh is not None
     assert "this._hiddenDisconnect = false" in rvh.group(1)
+
+
+def test_connectsse_defers_open_when_tab_hidden() -> None:
+    """PR #805 review (Copilot + R3): connectSSE is the single connect
+    chokepoint and must not open an EventSource into a hidden tab.  The
+    fresh-connect path (_loadHistoryThenConnect) has no timer guard, so a
+    first load in a background tab would otherwise open a throttled stream —
+    the slow-consumer overflow this PR exists to prevent.  The guard sits
+    AFTER the visibilitychange-handler install (so the show edge can
+    reconnect) and AFTER the wsId assignment (so it targets the right ws),
+    and BEFORE `new EventSource` (so nothing opens)."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    start = body.index("connectSSE(wsId) {")
+    open_at = body.index("new EventSource(evtUrl)", start)
+    head = body[start:open_at]  # connectSSE up to the EventSource open
+    assert "if (document.hidden) {" in head, (
+        "connectSSE must guard on document.hidden BEFORE opening the stream"
+    )
+    assert "this._hiddenDisconnect = true;" in head, (
+        "the deferred connect must mark _hiddenDisconnect so the show edge reconnects"
+    )
+    assert head.index("this.wsId = wsId;") < head.index("if (document.hidden) {")
+    assert head.index('addEventListener("visibilitychange"') < head.index("if (document.hidden) {")

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -429,3 +429,262 @@ def test_sync_approval_state_prunes_orphan_cycles() -> None:
     assert "this.approvalCycles.delete(cid);" in tail, (
         "orphan pruning must delete the cycle from the Map"
     )
+
+
+# ---------------------------------------------------------------------------
+# SSE overflow recovery + close-on-hide (fast-stream corruption fixes)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_overflow_case_counts_and_rate_limits() -> None:
+    """The server closes an overflowed stream after an id-less
+    ``stream_overflow`` frame; the pane must count it (field
+    instrumentation for the drop-vs-render-wedge diagnosis) and route it
+    through the reconnect limiter so a persistently slow consumer trips
+    the degraded catch-up instead of churning reconnect/replay cycles."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    assert 'case "stream_overflow":' in body
+    assert "this._noteStreamOverflow();" in body
+    assert "_streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 }" in body
+    # Both wedge-class catch sites increment the render-throw counter,
+    # and the malformed-frame drop counts too — the C-OVERDETERMINED
+    # instrumentation that tells drops apart from wedges in the field.
+    assert body.count("this._streamHealth.renderThrows += 1;") == 2
+    assert "this._streamHealth.malformedFrames += 1;" in body
+    assert "this._streamHealth.overflows += 1;" in body
+
+
+def test_degraded_catchup_stops_live_stream_and_retries() -> None:
+    """Degraded catch-up contract: close the stream FIRST (which also
+    clears any earlier degraded timer — disconnectSSE owns that), show a
+    plain-language status, then arm the retry timer with a doubling
+    cooldown.  The retry must defer to the show edge when the tab is
+    hidden (reopening into a throttled tab would overflow again)."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    m = re.search(r"_enterDegradedCatchup\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert m is not None, "_enterDegradedCatchup method not found"
+    method = m.group(1)
+    # Order matters: disconnect before arming the timer, or the fresh
+    # timer would be cancelled by its own disconnect.
+    assert method.index("this.disconnectSSE()") < method.index("this._degradedTimer = setTimeout")
+    assert "Connection is slow" in method, "degraded state must use plain language"
+    assert "DEGRADED_COOLDOWN_MAX_MS" in method
+    assert "document.hidden" in method
+    # disconnectSSE owns the timer teardown (ws-switch / giveUp / destroy
+    # all supersede a pending degraded retry through it).
+    dis = re.search(r"disconnectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert dis is not None
+    assert "clearTimeout(this._degradedTimer)" in dis.group(1)
+
+
+def test_visibilitychange_closes_on_hide_reconnects_on_show() -> None:
+    """Close-on-hide / replay-on-show: a hidden tab's throttled drain is
+    the likeliest slow consumer behind server-side overflow (the old
+    "PR-G closes those connections on hide" comment described a handler
+    that never existed).  The pane installs one visibilitychange
+    listener, marks ITS OWN hide-closes via ``_hiddenDisconnect`` so a
+    show edge never resurrects a deliberately-closed stream, and the
+    factory's destroy removes the listener (it strongly references the
+    pane)."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    assert 'document.addEventListener("visibilitychange", this._visHandler);' in body
+    assert 'document.removeEventListener("visibilitychange", this._visHandler);' in body
+    vis = re.search(r"_onVisibilityChange\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert vis is not None, "_onVisibilityChange method not found"
+    method = vis.group(1)
+    assert "this.disconnectSSE();" in method
+    assert "this._hiddenDisconnect = true;" in method
+    assert "this.connectSSE(this.wsId);" in method
+    # Reconnect only consumes OUR hide-close marker.
+    assert "else if (this._hiddenDisconnect)" in method
+    # Teardown: the factory controller removes the listener on destroy.
+    assert "pane._removeVisibilityHandler();" in body
+    # The streaming buffers survive a hide-close: disconnectSSE stays
+    # transport-only (no contentBuffer wipe) so the visible tail is
+    # intact when the tab returns.
+    dis = re.search(r"disconnectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert dis is not None
+    assert "contentBuffer" not in dis.group(1)
+
+
+def test_no_global_sse_gap_detector() -> None:
+    """Live event ids are NOT strictly monotonic across concurrent
+    tool+content emit (the fan-out runs outside the listeners lock), so
+    a naive ``id !== lastEventId + 1`` gap check would false-positive.
+    Recovery is server-signalled (``stream_overflow``) + reconnect
+    replay instead.  This tripwire pins the absence of the naive
+    arithmetic — if gap detection is ever added, it must be scoped to
+    the content stream only (content-vs-content never reorders)."""
+    code = _strip_comments(_INTERACTIVE.read_text(encoding="utf-8"))
+    assert not re.search(r"_lastEventId\s*[+\-]\s*1", code), (
+        "found lastEventId +/- 1 arithmetic — a global gap detector "
+        "false-positives on legal concurrent tool/content id inversion"
+    )
+
+
+def test_overflow_window_tripped_runtime() -> None:
+    """Runtime probe for the limiter's rolling-window helper — the
+    storm-guard math is the part of Fix A the design review marked
+    UNCONFIRMED, so it gets executed, not just string-pinned: prunes
+    stale entries in place, trips at exactly K-in-window, and does not
+    trip for closes spread wider than the window."""
+    import json
+    import os
+    import subprocess
+    import tempfile
+
+    import pytest
+
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    m = re.search(
+        r"^function overflowWindowTripped\(times, nowMs, count, windowMs\) \{.*?^\}",
+        body,
+        re.S | re.M,
+    )
+    assert m is not None, "overflowWindowTripped not found (keep it a module-level function)"
+    harness = (
+        m.group(0)
+        + "\n"
+        + "// trips at exactly count-in-window\n"
+        + "let t = [1000, 2000, 3000];\n"
+        + "if (!overflowWindowTripped(t, 3000, 3, 60000)) throw new Error('K-in-window must trip');\n"
+        + "// stale entries prune in place and prevent the trip\n"
+        + "t = [1000, 2000, 70000];\n"
+        + "if (overflowWindowTripped(t, 70000, 3, 60000)) throw new Error('stale entries must not trip');\n"
+        + "if (JSON.stringify(t) !== '[70000]') throw new Error('prune in place failed: ' + JSON.stringify(t));\n"
+        + "// boundary: an entry exactly windowMs old is still counted\n"
+        + "t = [10000, 70000];\n"
+        + "if (!overflowWindowTripped(t, 70000, 2, 60000)) throw new Error('boundary entry must count');\n"
+        + "// below threshold never trips\n"
+        + "t = [];\n"
+        + "if (overflowWindowTripped(t, 1, 1, 60000) !== false) throw new Error('empty must not trip');\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(harness)
+        tmp = f.name
+    try:
+        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
+    assert proc.returncode == 0, (
+        f"overflowWindowTripped runtime probe failed. stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    assert json.dumps  # keep the import shape consistent with test_app_js probes
+
+
+def test_degraded_cooldown_ladder_escalates_and_resets_runtime() -> None:
+    """Review finding [0] regression: the degraded-catchup cooldown ladder
+    must actually ESCALATE across consecutive trips (15→30→60→120s, capped)
+    and reset to base only after a genuine quiet gap.  The original bug
+    cleared _overflowTimes in _enterDegradedCatchup, so _noteStreamOverflow's
+    empty-window check reset the cooldown to base on every storm's first
+    overflow and the doubling never took effect.  The fix keys the ladder off
+    a last-trip timestamp via the pure degradedCooldownStep helper, exercised
+    here directly."""
+    import json
+    import os
+    import subprocess
+    import tempfile
+
+    import pytest
+
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    m = re.search(
+        r"^function degradedCooldownStep\(.*?\) \{.*?^\}",
+        body,
+        re.S | re.M,
+    )
+    assert m is not None, "degradedCooldownStep not found (keep it a module-level function)"
+    harness = (
+        m.group(0)
+        + "\n"
+        + "const BASE=15000, MAX=120000, RESET=300000;\n"
+        + "function assert(c,msg){ if(!c) throw new Error(msg); }\n"
+        + "// First trip: gap since lastTrip(0) exceeds RESET -> base, next doubles.\n"
+        + "let s = degradedCooldownStep(BASE, 0, 1000000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===15000, 'first trip cooldown '+s.cooldown);\n"
+        + "assert(s.nextCooldownMs===30000, 'first next '+s.nextCooldownMs);\n"
+        + "// Second trip recurs within RESET -> escalates (uses the doubled prev).\n"
+        + "s = degradedCooldownStep(30000, 1000000, 1030000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===30000, 'second trip must ESCALATE not reset, got '+s.cooldown);\n"
+        + "assert(s.nextCooldownMs===60000, 'second next '+s.nextCooldownMs);\n"
+        + "// Third + fourth keep escalating and cap at MAX.\n"
+        + "s = degradedCooldownStep(60000, 1030000, 1060000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===60000 && s.nextCooldownMs===120000, 'third '+JSON.stringify(s));\n"
+        + "s = degradedCooldownStep(120000, 1060000, 1090000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===120000 && s.nextCooldownMs===120000, 'fourth must cap at MAX '+JSON.stringify(s));\n"
+        + "// A quiet gap longer than RESET resets the ladder to base.\n"
+        + "s = degradedCooldownStep(120000, 1090000, 1090000+RESET+1, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===15000, 'quiet gap must reset to base, got '+s.cooldown);\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(harness)
+        tmp = f.name
+    try:
+        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
+    assert proc.returncode == 0, (
+        f"degradedCooldownStep escalation probe failed. stderr={proc.stderr!r}"
+    )
+    assert json.dumps
+
+
+def test_note_stream_overflow_does_not_reset_cooldown() -> None:
+    """The exact finding [0] bug shape must not regress: _noteStreamOverflow
+    only counts + trips; it must NOT touch _degradedCooldownMs (the reset
+    that defeated the ladder lived here).  The ladder decision lives solely
+    in _enterDegradedCatchup, keyed off _lastDegradedAt via
+    degradedCooldownStep."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    note = re.search(r"_noteStreamOverflow\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert note is not None, "_noteStreamOverflow not found"
+    assert "_degradedCooldownMs" not in note.group(1), (
+        "_noteStreamOverflow must not write _degradedCooldownMs — that reset "
+        "was the bug that stopped the ladder escalating"
+    )
+    enter = re.search(r"_enterDegradedCatchup\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert enter is not None
+    assert "degradedCooldownStep(" in enter.group(1)
+    assert "this._lastDegradedAt = now" in enter.group(1)
+
+
+def test_recover_beat_defers_reconnect_when_tab_hidden() -> None:
+    """Review round-2 finding [1]: the factory's transient-error recovery
+    beat (recoverTimer) must NOT reopen an EventSource into a hidden tab —
+    that re-creates the throttled slow-consumer overflow that close-on-hide
+    exists to prevent.  It guards on document.hidden and defers to the
+    visibilitychange show edge (marking _hiddenDisconnect)."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    beat = re.search(r"recoverTimer = setTimeout\(\(\) => \{(.*?)\n      \}, 5000\);", body, re.S)
+    assert beat is not None, "recoverTimer setTimeout body not found"
+    b = beat.group(1)
+    assert "document.hidden" in b, "recovery beat must guard on document.hidden"
+    assert "pane._hiddenDisconnect = true" in b, (
+        "recovery beat must defer to the show edge when hidden"
+    )
+    # The hidden guard must precede the reconnect (connectSSE) so it can't fall
+    # through to reopening the stream.
+    assert b.index("document.hidden") < b.index("pane.connectSSE(pane.wsId)")
+
+
+def test_giveup_removes_visibility_handler() -> None:
+    """Review round-2 finding [3]: giveUp() (markDead) must detach the
+    visibility handler and clear _hiddenDisconnect, or a tab hidden before
+    the give-up resurrects the dead controller's stream on return (the show
+    edge would connectSSE the closed ws and 404-reconnect it forever)."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    give = re.search(r"const giveUp = function \(\) \{(.*?)\n  \};", body, re.S)
+    assert give is not None, "giveUp function body not found"
+    g = give.group(1)
+    assert "pane._removeVisibilityHandler();" in g, (
+        "giveUp must remove the visibility handler so a show edge can't resurrect a dead controller"
+    )
+    # _removeVisibilityHandler also clears _hiddenDisconnect (pinned in its body).
+    rvh = re.search(r"_removeVisibilityHandler\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert rvh is not None
+    assert "this._hiddenDisconnect = false" in rvh.group(1)

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -39,6 +39,23 @@ def _make_ui(ws_id: str = "ws-1", user_id: str = "u1") -> _ConcreteUI:
     return _ConcreteUI(ws_id=ws_id, user_id=user_id)
 
 
+@pytest.fixture(autouse=True)
+def _per_token_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force per-token flushes (batch window 0) for this whole file.
+
+    These tests pin per-emit invariants — seq advance, mid-stream
+    inflight buffer state, snapshot atomicity — that predate emit-time
+    token batching and remain the contract AT each flush boundary;
+    window 0 makes every token its own flush, which is exactly the
+    emit shape they were written against.  Batching cadence itself
+    (window/size coalescing, pending-batch visibility, flush-before-
+    non-token ordering) is pinned in ``test_sse_token_batching.py``.
+    """
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+
+
 # ---------------------------------------------------------------------------
 # Listener fan-out
 # ---------------------------------------------------------------------------

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -51,9 +51,8 @@ def _per_token_flush(monkeypatch: pytest.MonkeyPatch) -> None:
     (window/size coalescing, pending-batch visibility, flush-before-
     non-token ordering) is pinned in ``test_sse_token_batching.py``.
     """
-    import turnstone.core.session_ui_base as suib
 
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -271,9 +271,8 @@ def test_event_id_persists_across_turn_boundaries(monkeypatch: Any) -> None:
 
     Batch window forced to 0 (per-token flush) — this test pins id
     numbering across turn boundaries, not the batching cadence."""
-    import turnstone.core.session_ui_base as suib
 
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui.on_content_token("turn-N tok1 ")
     ui.on_content_token("turn-N tok2 ")
@@ -334,9 +333,7 @@ def test_truncated_path_snapshot_captures_real_snap_seq(monkeypatch: Any) -> Non
     the truncation scenario needs 10 distinct buffered events."""
     import collections
 
-    import turnstone.core.session_ui_base as suib
-
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui._event_buffer = collections.deque(maxlen=3)
     # Fire enough events to trigger truncation on reconnect with a
@@ -592,9 +589,8 @@ def test_handler_replay_ok_skips_snapshot_emits_id(monkeypatch: Any) -> None:
 
     Batch window forced to 0 so the two tokens are two ring entries
     (the assertion wants two distinct ``id:`` lines)."""
-    import turnstone.core.session_ui_base as suib
 
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui.on_content_token("hello ")
     ui.on_content_token("world")
@@ -619,9 +615,7 @@ def test_handler_truncated_emits_envelope_then_snapshot(monkeypatch: Any) -> Non
     the truncation scenario needs the deque to evict."""
     import collections
 
-    import turnstone.core.session_ui_base as suib
-
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui._event_buffer = collections.deque(maxlen=3)
     for i in range(10):

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -20,6 +20,7 @@ The browser-side guard for the ``onerror`` close pattern lives in
 from __future__ import annotations
 
 import asyncio
+import queue
 import threading
 from types import SimpleNamespace as SimpleNS
 from typing import Any
@@ -199,17 +200,17 @@ def test_event_id_monotonic_under_concurrent_writers() -> None:
 
 
 def test_event_id_does_not_skip_when_listener_queue_full() -> None:
-    """If a slow listener's queue is full, the per-listener
-    ``put_nowait`` is silently dropped — but the counter must NOT
-    skip.  A subsequently-registered listener with
-    ``Last-Event-ID=0`` must see ALL the ids from the buffer
-    (1..N), not a sparse subset.  Pre-bug-class: moving the
-    id-increment inside the per-listener loop would create phantom
-    "gaps" the truncation detector would misread."""
+    """If a slow listener's queue is full, the per-listener put is
+    rejected (the first rejection poisons the listener; later ones are
+    latch refusals) — but the counter must NOT skip.  A subsequently-
+    registered listener with ``Last-Event-ID=0`` must see ALL the ids
+    from the buffer (1..N), not a sparse subset.  Pre-bug-class:
+    moving the id-increment inside the per-listener loop would create
+    phantom "gaps" the truncation detector would misread."""
     ui = _make_ui()
     slow_lq = ui._register_listener(maxsize=1)
     slow_lq.put_nowait({"placeholder": True})  # full immediately
-    # Fire 10 events — 9 will hit queue.Full and be suppressed.
+    # Fire 10 events — none can land in the full/poisoned queue.
     for i in range(10):
         ui._enqueue({"type": "tool_started", "name": f"t{i}"})
     # Replay from id=0 — fresh listener gets all 10, ids 1..10 dense.
@@ -261,12 +262,18 @@ def test_cross_thread_writer_and_replay_observer_consistent() -> None:
         )
 
 
-def test_event_id_persists_across_turn_boundaries() -> None:
+def test_event_id_persists_across_turn_boundaries(monkeypatch: Any) -> None:
     """Resetting ``_event_id`` to 0 at turn boundaries would silently
     mis-replay a long-lived SSE subscriber whose ``Last-Event-ID``
     was from a prior turn.  Mirrors the pre-existing
     ``test_inflight_seq_monotonic_across_turn_boundaries`` invariant
-    on the snap_seq side, extended to the buffer/replay side."""
+    on the snap_seq side, extended to the buffer/replay side.
+
+    Batch window forced to 0 (per-token flush) — this test pins id
+    numbering across turn boundaries, not the batching cadence."""
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui.on_content_token("turn-N tok1 ")
     ui.on_content_token("turn-N tok2 ")
@@ -305,7 +312,7 @@ def test_replay_ok_skips_in_progress_snapshot_path() -> None:
     assert snap["seq"] >= 1
 
 
-def test_truncated_path_snapshot_captures_real_snap_seq() -> None:
+def test_truncated_path_snapshot_captures_real_snap_seq(monkeypatch: Any) -> None:
     """Regression for PR #542 review comment 1 (Copilot, low-confidence).
 
     On the truncated path the caller used to set ``snap_seq=0``, which
@@ -321,9 +328,15 @@ def test_truncated_path_snapshot_captures_real_snap_seq() -> None:
     ``register_listener_with_replay`` under the same nested-lock
     acquire as the listener registration + buffer slice + counter
     read, so ``snap_seq`` returned in the snapshot is the exact
-    high-water mark the snapshot text corresponds to."""
+    high-water mark the snapshot text corresponds to.
+
+    Batch window forced to 0 so each token is its own ring entry —
+    the truncation scenario needs 10 distinct buffered events."""
     import collections
 
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui._event_buffer = collections.deque(maxlen=3)
     # Fire enough events to trigger truncation on reconnect with a
@@ -362,15 +375,15 @@ def test_snap_seq_high_water_mark_holds_under_writer_race() -> None:
     double-render.
 
     The race window in plain Python is narrow (a few bytecodes
-    between lock release and the ``_enqueue`` call), so a pure
-    barrier-based race rarely hits it.  This test injects a
-    deterministic sleep into ``_enqueue`` via monkey-patch to
-    widen the window enough to be reliably observed under the
-    pre-fix code path — AND to be reliably AVOIDED under the
-    post-fix code path (because the post-fix
-    ``on_content_token`` calls ``_enqueue`` while still holding
-    ``_ws_lock``, so the snapshot reader can't acquire
-    ``_ws_lock`` until the writer is fully done).
+    between lock release and the emit call), so a pure barrier-based
+    race rarely hits it.  This test injects a deterministic sleep
+    into ``_enqueue_direct`` — the inner emit point the token
+    batcher's flush calls under ``_ws_lock`` — to widen the window
+    enough to be reliably observed if the flush's inflight-append
+    and enqueue are ever split across ``_ws_lock`` sections, AND to
+    be reliably AVOIDED under the correct code path (the flush holds
+    ``_ws_lock`` across both, so the snapshot reader can't acquire
+    it until the writer is fully done).
     """
     import queue
     import threading
@@ -378,20 +391,20 @@ def test_snap_seq_high_water_mark_holds_under_writer_race() -> None:
 
     ui = _make_ui()
     marker = "RACE-MARKER"
-    original_enqueue = ui._enqueue
+    original_direct = ui._enqueue_direct
 
-    # Widen the race window: sleep just BEFORE the original
-    # ``_enqueue`` runs (which is where ``_event_id`` would advance).
-    # Post-fix this sleep happens while the writer still holds
-    # ``_ws_lock`` — readers block.  Pre-fix the writer has
-    # released ``_ws_lock`` before reaching this monkey-patch, so
-    # the reader gets a clean window to capture an inconsistent
-    # ``(inflight, _event_id)`` pair.
-    def slow_enqueue(data: dict[str, Any]) -> None:
+    # Widen the race window: sleep just BEFORE the inner emit runs
+    # (which is where ``_event_id`` advances).  Under the correct
+    # locking this sleep happens while the writer still holds
+    # ``_ws_lock`` — readers block.  If the flush ever releases
+    # ``_ws_lock`` before its enqueue, the reader gets a clean
+    # window to capture an inconsistent ``(inflight, _event_id)``
+    # pair and the invariant below trips.
+    def slow_direct(data: dict[str, Any]) -> int:
         time.sleep(0.05)  # 50 ms — orders of magnitude wider than the GIL switch interval
-        return original_enqueue(data)
+        return original_direct(data)
 
-    ui._enqueue = slow_enqueue  # type: ignore[method-assign]
+    ui._enqueue_direct = slow_direct  # type: ignore[method-assign]
 
     snap_box: dict[str, Any] = {}
     writer_done = threading.Event()
@@ -572,10 +585,16 @@ def test_handler_emits_retry_on_first_yield() -> None:
     assert 2500 <= retry <= 4500, f"retry {retry} outside jitter band [2500, 4500]"
 
 
-def test_handler_replay_ok_skips_snapshot_emits_id() -> None:
+def test_handler_replay_ok_skips_snapshot_emits_id(monkeypatch: Any) -> None:
     """``Last-Event-ID`` + buffer covers gap → emit buffered events
     with SSE ``id:`` field, SKIP the in-progress snapshot (it would
-    double-render content the buffered events already carry)."""
+    double-render content the buffered events already carry).
+
+    Batch window forced to 0 so the two tokens are two ring entries
+    (the assertion wants two distinct ``id:`` lines)."""
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui.on_content_token("hello ")
     ui.on_content_token("world")
@@ -590,13 +609,19 @@ def test_handler_replay_ok_skips_snapshot_emits_id() -> None:
     assert "id: 2" in blob, f"missing id: 2 in:\n{blob}"
 
 
-def test_handler_truncated_emits_envelope_then_snapshot() -> None:
+def test_handler_truncated_emits_envelope_then_snapshot(monkeypatch: Any) -> None:
     """Stale ``Last-Event-ID`` + buffer too short → emit
     ``replay_truncated`` envelope, THEN fall through to the
     fresh-style replay (state_change + in_progress_snapshot) as the
-    recovery floor."""
+    recovery floor.
+
+    Batch window forced to 0 so each token is its own ring entry —
+    the truncation scenario needs the deque to evict."""
     import collections
 
+    import turnstone.core.session_ui_base as suib
+
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     ui._event_buffer = collections.deque(maxlen=3)
     for i in range(10):
@@ -717,3 +742,382 @@ def test_handler_replay_ok_does_not_resurface_last_error(monkeypatch: Any) -> No
     ui.on_content_token("hi")  # one buffered event so Last-Event-ID=0 → replay_ok
     _, blob = _drain_handler_yields(ui, headers={"Last-Event-ID": "0"}, state="error", max_yields=8)
     assert "boom" not in blob
+
+
+# ---------------------------------------------------------------------------
+# Poison-on-overflow (Fix A) — queue.Full stops being a silent drop
+# ---------------------------------------------------------------------------
+#
+# Silent per-listener drops at queue.Full left permanent holes BELOW the
+# client's advancing lastEventId (scattered interleaved drops once the
+# queue saturates), which reconnect-with-replay can never heal (the slice
+# is ``eid > last_event_id`` only).  The listener queue now latches
+# ``poisoned`` atomically at the FIRST rejected put and refuses every
+# later put, freezing its contents as a contiguous prefix; the drain
+# loop closes the stream (after an id-less ``stream_overflow`` frame)
+# and the native EventSource reconnect replays the contiguous tail.
+#
+# Poisoning at the first full (not after N) is load-bearing: any
+# delivered-while-dropping window advances lastEventId past interior
+# holes -> permanent gap even after a "successful" reconnect.
+
+
+def _fake_live_request(*, path_params: dict[str, str] | None = None) -> Request:
+    """A request whose ``receive()`` never resolves, so
+    ``is_disconnected()`` stays ``False`` — the poison check, not
+    disconnect detection, must be what terminates the drain loop."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "headers": [],
+        "path": "/events",
+        "raw_path": b"/events",
+        "query_string": b"",
+        "path_params": path_params or {},
+        "app": MagicMock(),
+    }
+
+    async def _recv() -> dict[str, Any]:
+        await asyncio.Event().wait()  # pends forever
+        return {"type": "http.disconnect"}  # unreachable
+
+    return Request(scope, receive=_recv)
+
+
+def test_listener_queue_poisons_at_first_full_and_refuses_after() -> None:
+    """The first rejected put latches ``poisoned`` (atomically, under
+    the queue's own mutex) and every later put is refused even if the
+    consumer frees slots — otherwise a racing consumer pop would let a
+    later event land BEHIND the hole and the drain would deliver past
+    it, advancing lastEventId beyond an unreplayable gap."""
+    ui = _make_ui()
+    lq = ui._register_listener(maxsize=2)
+    ui._enqueue({"type": "a"})
+    ui._enqueue({"type": "b"})
+    assert getattr(lq, "poisoned", None) is False
+    ui._enqueue({"type": "c"})  # first overflow -> latch
+    assert lq.poisoned is True
+    lq.get_nowait()  # consumer frees a slot
+    ui._enqueue({"type": "d"})  # must be refused — queue contents frozen
+    leftover = []
+    while True:
+        try:
+            leftover.append(lq.get_nowait())
+        except queue.Empty:
+            break
+    assert [ev["type"] for ev in leftover] == ["b"], (
+        "a post-poison put landed in the freed slot — interior hole"
+    )
+    # The ring is untouched by listener poisoning: ids stay dense.
+    _, replay, status, _, _, _ = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    assert [ev["_event_id"] for ev in replay] == [1, 2, 3, 4]
+
+
+def test_poisoned_gap_is_contiguous_tail_fully_replayable() -> None:
+    """Recovery math at the poison instant: delivered ids form a
+    contiguous prefix, the ring holds everything, and a reconnect with
+    ``Last-Event-ID = <last delivered>`` replays exactly the missing
+    tail — no duplicate, no loss, no off-by-one."""
+    ui = _make_ui()
+    lq = ui._register_listener(maxsize=3)
+    for i in range(5):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    # Queue froze at [1,2,3]; 4 latched poison; 5 was refused.
+    delivered = []
+    while True:
+        try:
+            delivered.append(lq.get_nowait()["_event_id"])
+        except queue.Empty:
+            break
+    assert delivered == [1, 2, 3]
+    _, replay, status, lost, _, _ = ui.register_listener_with_replay(delivered[-1])
+    assert status == "replay_ok"
+    assert lost == 0
+    assert [ev["_event_id"] for ev in replay] == [4, 5]
+    assert delivered + [ev["_event_id"] for ev in replay] == [1, 2, 3, 4, 5]
+
+
+def test_poison_isolated_to_slow_listener() -> None:
+    """One slow tab must not degrade its siblings: the healthy listener
+    keeps receiving every event after the slow one is poisoned (and the
+    poisoned one stops consuming fan-out puts entirely)."""
+    ui = _make_ui()
+    slow = ui._register_listener(maxsize=1)
+    healthy = ui._register_listener(maxsize=100)
+    for i in range(6):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    assert slow.poisoned is True
+    got = []
+    while True:
+        try:
+            got.append(healthy.get_nowait()["name"])
+        except queue.Empty:
+            break
+    assert got == [f"t{i}" for i in range(6)]
+
+
+def test_drain_loop_closes_with_overflow_frame_on_poison() -> None:
+    """Once its queue is poisoned the drain loop must terminate the SSE
+    response — discarding the queued backlog (the replay covers it) —
+    after yielding a final id-less ``stream_overflow`` frame so the
+    client can count overflow closes (reconnect-limiter + the
+    drop-vs-render-wedge field instrumentation) without advancing
+    ``lastEventId`` past the gap."""
+    from turnstone.core.session_ui_base import _DEFAULT_LISTENER_QUEUE_MAX
+
+    ui = _make_ui()
+    handler = _wire_events_handler(ui)
+    req = _fake_live_request(path_params={"ws_id": ui.ws_id})
+
+    async def _run() -> list[Any]:
+        resp = await handler(req)
+        agen = resp.body_iterator
+        yields = [await agen.__anext__()]  # retry frame
+        yields.append(await agen.__anext__())  # synthetic state_change
+        # Overflow the registered listener's queue: cap fills, +1 poisons.
+        for i in range(_DEFAULT_LISTENER_QUEUE_MAX + 1):
+            ui._enqueue({"type": "info", "message": f"m{i}"})
+        yields.append(await agen.__anext__())  # overflow frame, then close
+        try:
+            extra = await agen.__anext__()
+        except StopAsyncIteration:
+            extra = None
+        yields.append(extra)
+        return yields
+
+    yields = asyncio.run(_run())
+    assert yields[-1] is None, "drain loop kept yielding after poison"
+    overflow = yields[-2]
+    assert isinstance(overflow, dict)
+    assert "stream_overflow" in overflow["data"]
+    assert "id" not in overflow, (
+        "the overflow frame must not carry an SSE id — advancing "
+        "lastEventId here would strand the dropped gap below the cursor"
+    )
+    # The 500-event backlog was discarded, not delivered: nothing
+    # between the synthetic replay and the overflow frame.
+    assert all("m0" not in str(y) for y in yields)
+
+
+def test_drain_loop_delivers_until_poison_then_stops_before_backlog() -> None:
+    """Pre-poison delivery works normally; at poison the loop closes
+    BEFORE delivering the queued backlog (check precedes the blocking
+    get), so the client's lastEventId freezes at the contiguous prefix
+    and reconnect replays everything else."""
+    from turnstone.core.session_ui_base import _DEFAULT_LISTENER_QUEUE_MAX
+
+    ui = _make_ui()
+    handler = _wire_events_handler(ui)
+    req = _fake_live_request(path_params={"ws_id": ui.ws_id})
+
+    async def _run() -> tuple[list[Any], Any, Any]:
+        resp = await handler(req)
+        agen = resp.body_iterator
+        head = [await agen.__anext__(), await agen.__anext__()]  # retry + state
+        ui._enqueue({"type": "info", "message": "live-1"})
+        live = await agen.__anext__()
+        for i in range(_DEFAULT_LISTENER_QUEUE_MAX + 1):
+            ui._enqueue({"type": "info", "message": f"m{i}"})
+        tail = await agen.__anext__()
+        try:
+            await agen.__anext__()
+            closed = False
+        except StopAsyncIteration:
+            closed = True
+        return head, live, (tail, closed)
+
+    _, live, (tail, closed) = asyncio.run(_run())
+    assert "live-1" in live["data"]
+    assert "stream_overflow" in tail["data"]
+    assert closed, "generator must return right after the overflow frame"
+
+
+def test_overflow_reconnect_replays_full_gap_through_handler() -> None:
+    """End-to-end recovery shape: after an overflow close, a reconnect
+    carrying the pre-poison ``Last-Event-ID`` replays the whole gap via
+    ``replay_ok`` — the poisoned stream lost nothing durable."""
+    ui = _make_ui()
+    lq = ui._register_listener(maxsize=3)
+    for i in range(5):
+        ui._enqueue({"type": "tool_started", "name": f"t{i}"})
+    delivered_ids = []
+    while True:
+        try:
+            delivered_ids.append(lq.get_nowait()["_event_id"])
+        except queue.Empty:
+            break
+    ui._unregister_listener(lq)  # what the drain loop's finally does
+    _, blob = _drain_handler_yields(
+        ui, headers={"Last-Event-ID": str(delivered_ids[-1])}, max_yields=6
+    )
+    assert "replay_truncated" not in blob
+    assert "t3" in blob
+    assert "t4" in blob
+
+
+def test_listener_queue_basic_put_get_semantics() -> None:
+    """Stdlib-drift canary for ``_ListenerQueue.put_nowait``'s
+    reimplementation against ``queue.Queue``'s documented extension
+    surface (``mutex`` / ``_qsize`` / ``_put`` / ``unfinished_tasks`` /
+    ``not_empty``): normal put/get round-trips work, FIFO order holds,
+    a blocked ``get(timeout=...)`` is woken by a put (the
+    ``not_empty.notify`` path the drain loop's executor get relies on),
+    and the poison latch engages exactly at the first rejected put."""
+    from turnstone.core.session_ui_base import _ListenerQueue
+
+    q = _ListenerQueue(maxsize=2)
+    q.put_nowait({"n": 1})
+    q.put_nowait({"n": 2})
+    assert q.qsize() == 2
+    try:
+        q.put_nowait({"n": 3})
+        raise AssertionError("third put must raise queue.Full")
+    except queue.Full:
+        pass
+    assert q.poisoned is True
+    assert q.get_nowait()["n"] == 1  # FIFO preserved
+    try:
+        q.put_nowait({"n": 4})
+        raise AssertionError("post-poison put must be refused")
+    except queue.Full:
+        pass
+    assert q.get_nowait()["n"] == 2
+
+    # A blocked get() must be woken by a concurrent put_nowait — the
+    # notify path the events handler's executor get depends on.
+    fresh = _ListenerQueue(maxsize=2)
+    got: list[dict[str, Any]] = []
+
+    def _getter() -> None:
+        got.append(fresh.get(timeout=5))
+
+    t = threading.Thread(target=_getter)
+    t.start()
+    fresh.put_nowait({"n": 42})
+    t.join(timeout=5)
+    assert not t.is_alive(), "get(timeout) never woke — not_empty.notify broken"
+    assert got == [{"n": 42}]
+
+
+def test_closing_queue_unwinds_clean_not_overflow_when_poisoned() -> None:
+    """Review finding [1]: a ws closing/evicting while a slow pane's
+    queue is full must unwind as a CLEAN close, not a false
+    ``stream_overflow``.  The poison latch rejects the in-band
+    ``ws_closed`` sentinel, so ``mark_closing`` carries the signal
+    out-of-band and the drain loop honours it BEFORE the poison check —
+    otherwise a clean close of a slow consumer is mis-reported as a
+    send-overflow (polluting the client's drop-vs-wedge counter and
+    tripping its reconnect limiter on a ws that is simply gone)."""
+    ui = _make_ui()
+    handler = _wire_events_handler(ui)
+    req = _fake_live_request(path_params={"ws_id": ui.ws_id})
+
+    async def _run() -> tuple[Any, bool]:
+        resp = await handler(req)
+        agen = resp.body_iterator
+        await agen.__anext__()  # retry frame
+        await agen.__anext__()  # synthetic state_change
+        # Overflow the listener queue so it poisons, exactly as a slow
+        # consumer would, THEN close the ws (evict/delete/close path).
+        from turnstone.core.session_ui_base import _DEFAULT_LISTENER_QUEUE_MAX
+
+        for i in range(_DEFAULT_LISTENER_QUEUE_MAX + 1):
+            ui._enqueue({"type": "info", "message": f"m{i}"})
+        assert ui._listeners, "listener should still be registered pre-close"
+        lq = ui._listeners[0]
+        assert lq.poisoned is True
+        # Simulate _broadcast_ws_closed_to_listeners' out-of-band flag.
+        lq.mark_closing()
+        try:
+            frame = await agen.__anext__()
+            closed = False
+        except StopAsyncIteration:
+            frame = None
+            closed = True
+        return frame, closed
+
+    frame, closed = asyncio.run(_run())
+    assert closed, "closing queue must end the stream"
+    assert frame is None, f"closing ws must NOT emit a stream_overflow frame; got {frame!r}"
+
+
+def test_broadcast_ws_closed_marks_closing_on_poisoned_queue() -> None:
+    """The teardown broadcaster must set the out-of-band ``closing``
+    flag even when the queue is poisoned/full (its in-band ``ws_closed``
+    put is refused by the poison latch).  Pins the wiring finding [1]
+    depends on: ``mark_closing`` is called for every listener."""
+    from turnstone.core.adapters._ui_cleanup import _broadcast_ws_closed_to_listeners
+
+    ui = _make_ui()
+    lq = ui._register_listener(maxsize=2)
+    ui._enqueue({"type": "a"})
+    ui._enqueue({"type": "b"})
+    ui._enqueue({"type": "c"})  # overflow -> poison
+    assert lq.poisoned is True
+    assert lq.closing is False
+    _broadcast_ws_closed_to_listeners(ui)
+    assert lq.closing is True, "teardown must flag the poisoned queue closing"
+    # Broadcaster clears the listener list (no re-fire on a closed ws).
+    assert ui._listeners == []
+
+
+def test_healthy_queue_close_still_delivers_ws_closed_sentinel() -> None:
+    """The out-of-band flag must not regress the normal path: a
+    non-full queue still receives the in-band ``ws_closed`` sentinel
+    (so a drain loop blocked in ``get`` wakes immediately) AND gets the
+    ``closing`` flag."""
+    from turnstone.core.adapters._ui_cleanup import _broadcast_ws_closed_to_listeners
+
+    ui = _make_ui()
+    lq = ui._register_listener(maxsize=100)
+    _broadcast_ws_closed_to_listeners(ui)
+    assert lq.closing is True
+    drained = []
+    while True:
+        try:
+            drained.append(lq.get_nowait())
+        except queue.Empty:
+            break
+    assert {ev["type"] for ev in drained} == {"ws_closed"}
+
+
+def test_healthy_closing_queue_drains_tail_before_close() -> None:
+    """Review round-2 finding [0]: a healthy (non-poisoned) client that is
+    momentarily behind must still receive its queued tail — the turn's
+    final content batch + ``stream_end`` — at ws teardown.  A close has no
+    reconnect+replay, so dropping that tail truncates the last assistant
+    message permanently.  The ``closing`` flag must therefore NOT
+    short-circuit the FIFO drain for a healthy queue (an earlier revision
+    checked it at the top of the loop and did exactly that); the in-band
+    ``ws_closed`` sentinel — which fits, the queue isn't full — closes the
+    stream AFTER the drain delivers everything."""
+    from turnstone.core.adapters._ui_cleanup import _broadcast_ws_closed_to_listeners
+
+    ui = _make_ui()
+    handler = _wire_events_handler(ui)
+    req = _fake_live_request(path_params={"ws_id": ui.ws_id})
+
+    async def _run() -> list[str]:
+        resp = await handler(req)
+        agen = resp.body_iterator
+        await agen.__anext__()  # retry frame
+        await agen.__anext__()  # synthetic state_change
+        # Enqueue the turn's tail into a HEALTHY (roomy) queue, then close
+        # the ws while those events are still undrained.
+        ui.on_content_token("final answer")
+        ui.on_stream_end()
+        _broadcast_ws_closed_to_listeners(ui)  # mark_closing + ws_closed sentinel
+        out: list[str] = []
+        while True:
+            try:
+                frame = await agen.__anext__()
+            except StopAsyncIteration:
+                break
+            out.append(frame["data"] if isinstance(frame, dict) else str(frame))
+        return out
+
+    blob = "\n".join(asyncio.run(_run()))
+    assert "final answer" in blob, "healthy closing queue dropped its content tail"
+    assert "stream_end" in blob, "healthy closing queue dropped stream_end"
+    assert "stream_overflow" not in blob, "a healthy close must not emit an overflow frame"

--- a/tests/test_sse_token_batching.py
+++ b/tests/test_sse_token_batching.py
@@ -38,8 +38,7 @@ from typing import Any
 
 import pytest
 
-import turnstone.core.session_ui_base as suib
-from turnstone.core.session_ui_base import SessionUIBase
+from turnstone.core.session_ui_base import _TOKEN_BATCH_WINDOW_SECS, SessionUIBase
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -68,7 +67,7 @@ def wide_window(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make the batch window effectively infinite so tests control the
     flush points explicitly (via non-token emits / size cap) and a slow
     CI machine can't turn one expected batch into two."""
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 60.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 60.0)
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +103,7 @@ def test_zero_window_flushes_every_token_individually(monkeypatch: pytest.Monkey
     """With the window forced to zero every token arrives past the
     window boundary and flushes on its own — batching self-disables
     with no behaviour change vs the pre-batching emit shape."""
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
     ui = _make_ui()
     lq = ui._register_listener()
     for i in range(4):
@@ -121,7 +120,7 @@ def test_slow_tokens_flush_individually_at_default_window() -> None:
     ui = _make_ui()
     lq = ui._register_listener()
     for i in range(3):
-        time.sleep(suib._TOKEN_BATCH_WINDOW_SECS + 0.01)
+        time.sleep(_TOKEN_BATCH_WINDOW_SECS + 0.01)
         ui.on_content_token(f"t{i}")
     events = [ev for ev in _drain(lq) if ev["type"] == "content"]
     assert [ev["text"] for ev in events] == ["t0", "t1", "t2"]
@@ -131,7 +130,7 @@ def test_batch_size_cap_triggers_flush(wide_window: None, monkeypatch: pytest.Mo
     """A pending batch reaching the size cap flushes without waiting for
     the window — bounds worst-case batch size (and client repaint cost)
     at fast rates."""
-    monkeypatch.setattr(suib, "_TOKEN_BATCH_MAX_CHARS", 8)
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_MAX_CHARS", 8)
     ui = _make_ui()
     lq = ui._register_listener()
     ui.on_content_token("x")  # immediate first flush
@@ -280,7 +279,7 @@ def test_inflight_cap_respected_and_stream_continues_past_cap(
     it did per-token: check-before-append (bounded overshoot), and the
     live stream keeps flowing past the cap — the cap bounds the
     snapshot, it is NOT a stop-streaming signal."""
-    monkeypatch.setattr(suib, "_MAX_TURN_CONTENT_CHARS", 6)
+    monkeypatch.setattr("turnstone.core.session_ui_base._MAX_TURN_CONTENT_CHARS", 6)
     ui = _make_ui()
     lq = ui._register_listener()
     ui.on_content_token("aaaa")  # immediate flush; inflight size 4 < 6

--- a/tests/test_sse_token_batching.py
+++ b/tests/test_sse_token_batching.py
@@ -1,0 +1,392 @@
+"""Emit-time micro-batching of content / reasoning tokens (SSE Fix B).
+
+At local-inference rates (500+ tok/s) the per-delta ``_enqueue`` was the
+load that overflowed listener queues (silent drops -> corrupted panes).
+:meth:`SessionUIBase.on_content_token` / :meth:`on_reasoning_token` now
+coalesce fragments over a small window and enqueue ONE event per batch.
+
+The two conditions that make batching safe are pinned here because each
+was a verified corruption mode in the design review:
+
+- **Condition 1 — atomic flush.**  The pending accumulator is invisible
+  to snapshot readers; the flush appends to the inflight buffers AND
+  enqueues the batched event inside one ``_ws_lock`` section, so
+  ``snap_seq`` stays a true high-water mark for the snapshot text.  If
+  inflight were appended per-token while enqueueing per-batch, a
+  snapshot straddling the batch would double-render (the batch arrives
+  with ``_seq > snap_seq`` carrying already-snapshotted text; the client
+  has no content dedup — its ``content`` case is a blind ``+=``).
+- **Condition 2 — every non-token emit flushes first.**  ``stream_end``
+  / ``tool_*`` / ``state_change`` bypass the batcher; if one overtook a
+  pending batch, the client would reset its streaming refs and the late
+  batch would paint into a NEW assistant bubble (the split/duplicate
+  look).  The flush lives at the top of ``_enqueue`` itself so every
+  emit path — base-class, subclass, and route-level — is covered.
+
+Negative-test discipline: the double-render tests fail if the flush's
+inflight-append + enqueue are split across ``_ws_lock`` sections, and
+the ordering tests fail if the ``_enqueue`` choke-point flush is
+removed — each was reverted-and-verified during development.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import turnstone.core.session_ui_base as suib
+from turnstone.core.session_ui_base import SessionUIBase
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteUI(SessionUIBase):
+    """Minimal concrete subclass for direct UI tests."""
+
+
+def _make_ui(ws_id: str = "ws-batch") -> _ConcreteUI:
+    return _ConcreteUI(ws_id=ws_id, user_id="u1")
+
+
+def _drain(lq: queue.Queue[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    while True:
+        try:
+            out.append(lq.get_nowait())
+        except queue.Empty:
+            return out
+
+
+@pytest.fixture
+def wide_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the batch window effectively infinite so tests control the
+    flush points explicitly (via non-token emits / size cap) and a slow
+    CI machine can't turn one expected batch into two."""
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 60.0)
+
+
+# ---------------------------------------------------------------------------
+# Coalescing shape — one fresh id per batch, first fragment immediate
+# ---------------------------------------------------------------------------
+
+
+def test_fast_tokens_coalesce_into_single_batch_event(wide_window: None) -> None:
+    """N tokens inside one window -> the first flushes immediately (the
+    time-to-first-token protection), the rest coalesce into ONE enqueued
+    event whose text is the concatenation, carrying one fresh
+    ``_event_id`` / ``_seq``."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    for i in range(6):
+        ui.on_content_token(f"t{i}")
+    ui.on_stream_end()
+    events = _drain(lq)
+    content = [ev for ev in events if ev["type"] == "content"]
+    assert [ev["text"] for ev in content] == ["t0", "t1t2t3t4t5"]
+    # One fresh id per batch, and the token-event dedup tag rides it.
+    for ev in content:
+        assert isinstance(ev["_event_id"], int)
+        assert ev["_seq"] == ev["_event_id"]
+    # The batch is one ring entry too — ids stay dense (no reserved
+    # per-token ids leak into the ring numbering).
+    _, replay, status, _, _, _ = ui.register_listener_with_replay(0)
+    assert status == "replay_ok"
+    assert [ev["_event_id"] for ev in replay] == list(range(1, len(replay) + 1))
+
+
+def test_zero_window_flushes_every_token_individually(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the window forced to zero every token arrives past the
+    window boundary and flushes on its own — batching self-disables
+    with no behaviour change vs the pre-batching emit shape."""
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+    ui = _make_ui()
+    lq = ui._register_listener()
+    for i in range(4):
+        ui.on_content_token(f"t{i}")
+    events = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in events] == ["t0", "t1", "t2", "t3"]
+
+
+def test_slow_tokens_flush_individually_at_default_window() -> None:
+    """Tokens arriving slower than the real (unpatched) window each
+    flush individually — pins the constant's scale: a human-readable
+    typewriter stream must not regress to visible 25 ms batching
+    artifacts, and a mid-turn stall must not hold tokens hostage."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    for i in range(3):
+        time.sleep(suib._TOKEN_BATCH_WINDOW_SECS + 0.01)
+        ui.on_content_token(f"t{i}")
+    events = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in events] == ["t0", "t1", "t2"]
+
+
+def test_batch_size_cap_triggers_flush(wide_window: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pending batch reaching the size cap flushes without waiting for
+    the window — bounds worst-case batch size (and client repaint cost)
+    at fast rates."""
+    monkeypatch.setattr(suib, "_TOKEN_BATCH_MAX_CHARS", 8)
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("x")  # immediate first flush
+    ui.on_content_token("aaaa")  # pending (4 < 8)
+    ui.on_content_token("bbbb")  # 8 >= 8 -> flush
+    events = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in events] == ["x", "aaaabbbb"]
+
+
+# ---------------------------------------------------------------------------
+# Condition 1 — snapshot readers never double-render across a batch
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_mid_batch_sees_only_flushed_text_no_double_render(
+    wide_window: None,
+) -> None:
+    """A snapshot taken between two tokens of a pending batch must
+    exclude the pending text (it has no event id yet), and the later
+    flush must arrive with ``_seq > snap_seq`` so the client renders
+    each character exactly once: snapshot text + post-``snap_seq`` live
+    events == the full stream, no overlap."""
+    ui = _make_ui()
+    ui.on_content_token("aa")  # immediate first flush
+    ui.on_content_token("bb")  # pending — invisible to snapshots
+    lq, snap = ui.register_listener_with_in_progress_snapshot()
+    assert snap["content"] == "aa", (
+        "pending batch text leaked into the snapshot — the flush must be "
+        "the only writer of the inflight buffers"
+    )
+    ui.on_stream_end()  # flushes the pending batch, then stream_end
+    live = [ev for ev in _drain(lq) if ev["type"] == "content" and ev["_seq"] > snap["seq"]]
+    assert "".join(ev["text"] for ev in live) == "bb"
+    assert snap["content"] + "".join(ev["text"] for ev in live) == "aabb"
+    # The flush wrote the inflight buffer too — the NEXT snapshotter
+    # sees the full text (nothing stranded in the accumulator).
+    _, snap2 = ui.register_listener_with_in_progress_snapshot()
+    assert snap2["content"] == "aabb"
+
+
+def test_replay_registration_mid_batch_no_double_render(wide_window: None) -> None:
+    """Same straddle through the ``Last-Event-ID`` reconnect path: the
+    replay slice must not contain the pending batch (not enqueued yet),
+    and the post-registration flush lands exactly once in the live
+    queue."""
+    ui = _make_ui()
+    ui.on_content_token("aa")  # immediate flush -> event id 1
+    ui.on_content_token("bb")  # pending
+    lq, replay, status, _, _, snap = ui.register_listener_with_replay(1)
+    assert status == "replay_ok"
+    assert replay == [], "pending batch must not appear in the replay slice"
+    ui.on_stream_end()
+    live = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert "".join(ev["text"] for ev in live) == "bb"
+    # Full-stream integrity for a fresh reconnect afterwards.
+    _, replay2, _, _, _, _ = ui.register_listener_with_replay(0)
+    assert "".join(ev["text"] for ev in replay2 if ev["type"] == "content") == "aabb"
+
+
+# ---------------------------------------------------------------------------
+# Condition 2 — every non-token emit flushes the pending batch first
+# ---------------------------------------------------------------------------
+
+
+def test_stream_end_flushes_pending_batch_before_itself(wide_window: None) -> None:
+    """``stream_end`` resets the client's streaming refs; a batch
+    arriving after it would paint into a NEW assistant bubble.  The
+    flush must therefore precede ``stream_end`` on the wire (strictly
+    smaller event id, earlier queue position)."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("bb")  # pending
+    ui.on_stream_end()
+    events = _drain(lq)
+    types = [ev["type"] for ev in events]
+    assert types == ["content", "content", "stream_end"]
+    assert events[1]["text"] == "bb"
+    assert events[1]["_event_id"] < events[2]["_event_id"]
+
+
+def test_direct_enqueue_flushes_pending_batch_first(wide_window: None) -> None:
+    """The flush lives at the ``_enqueue`` choke point, so even
+    route-level / subclass emits (``state_change``, ``cancelled``,
+    ``clear_ui``) deliver the pending batch first — not just the
+    ``on_*`` helpers."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("bb")  # pending
+    ui._enqueue({"type": "state_change", "state": "idle"})
+    events = _drain(lq)
+    assert [ev["type"] for ev in events] == ["content", "content", "state_change"]
+    assert events[1]["text"] == "bb"
+
+
+def test_tool_and_status_emits_flush_pending_batch(wide_window: None) -> None:
+    """Representative non-token ``on_*`` emitters (tool output chunk,
+    status) deliver a pending batch before their own event."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("bb")  # pending
+    ui.on_tool_output_chunk("call-1", "chunk")
+    ui.on_content_token("cc")  # immediate?  No — window is wide and the
+    # flush just ran, so this pends; the status emit must deliver it.
+    ui.on_status({"prompt_tokens": 1, "completion_tokens": 2}, 1000, "med")
+    events = _drain(lq)
+    types = [ev["type"] for ev in events]
+    assert types == ["content", "content", "tool_output_chunk", "content", "status"]
+    assert events[1]["text"] == "bb"
+    assert events[3]["text"] == "cc"
+
+
+def test_reasoning_batches_and_kind_switch_flushes(wide_window: None) -> None:
+    """Reasoning batches like content (own accumulator semantics), and a
+    kind switch flushes the other kind first so wire order preserves
+    arrival order between the two token streams."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_reasoning_token("r0")  # immediate first flush
+    ui.on_reasoning_token("r1")  # pending
+    ui.on_content_token("c0")  # must flush the reasoning batch first
+    ui.on_stream_end()
+    events = _drain(lq)
+    reasoning = [ev for ev in events if ev["type"] == "reasoning"]
+    content = [ev for ev in events if ev["type"] == "content"]
+    assert "".join(ev["text"] for ev in reasoning) == "r0r1"
+    assert "".join(ev["text"] for ev in content) == "c0"
+    assert max(ev["_event_id"] for ev in reasoning) < min(ev["_event_id"] for ev in content)
+    # Reasoning landed in ITS inflight buffer, content in its own.
+    _, snap = ui.register_listener_with_in_progress_snapshot()
+    assert snap["reasoning"] == "r0r1"
+    assert snap["content"] == "c0"
+
+
+# ---------------------------------------------------------------------------
+# Buffer-cap and turn-boundary semantics under batching
+# ---------------------------------------------------------------------------
+
+
+def test_inflight_cap_respected_and_stream_continues_past_cap(
+    wide_window: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 512 KiB inflight cap applies to the batched append exactly as
+    it did per-token: check-before-append (bounded overshoot), and the
+    live stream keeps flowing past the cap — the cap bounds the
+    snapshot, it is NOT a stop-streaming signal."""
+    monkeypatch.setattr(suib, "_MAX_TURN_CONTENT_CHARS", 6)
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aaaa")  # immediate flush; inflight size 4 < 6
+    ui.on_content_token("bbbb")  # pending
+    ui.on_stream_end()  # flush appends (4 < 6 -> append; size 8)
+    ui.on_content_token("cccc")  # immediate flush; 8 >= 6 -> NOT appended
+    ui.on_stream_end()
+    live = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in live] == ["aaaa", "bbbb", "cccc"], (
+        "live stream must continue past the inflight cap"
+    )
+    _, snap = ui.register_listener_with_in_progress_snapshot()
+    assert snap["content"] == "aaaabbbb", (
+        "snapshot text is capped (check-before-append overshoot only)"
+    )
+
+
+def test_on_turn_start_discards_stale_pending(wide_window: None) -> None:
+    """``on_turn_start`` covers the crashed-prior-``send()`` case; a
+    stale pending batch from that crash must be DISCARDED (never
+    enqueued), not painted into the new turn's bubble."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("stale")  # pending, then the send crashes
+    ui.on_turn_start()
+    ui.on_stream_end()
+    live = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in live] == ["aa"]
+    _, snap = ui.register_listener_with_in_progress_snapshot()
+    assert snap["content"] == ""
+
+
+def test_on_turn_committed_flushes_pending_before_reset(wide_window: None) -> None:
+    """``on_turn_committed`` runs after the assistant message committed;
+    any pending text is part of that committed message, so it flushes
+    (live view + ring stay complete) BEFORE the inflight reset."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("bb")  # pending
+    ui.on_turn_committed()
+    live = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert [ev["text"] for ev in live] == ["aa", "bb"]
+    _, snap = ui.register_listener_with_in_progress_snapshot()
+    assert snap["content"] == "", "inflight reset still runs after the flush"
+
+
+def test_idle_state_payload_includes_pending_batch(wide_window: None) -> None:
+    """``snapshot_and_consume_state_payload('idle')`` is the cancel /
+    error chokepoint that drains the turn-content accumulator; a pending
+    batch must flush into it first so the dashboard payload carries the
+    full turn."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_content_token("aa")
+    ui.on_content_token("bb")  # pending
+    payload = ui.snapshot_and_consume_state_payload("idle")
+    assert payload["content"] == "aabb"
+    live = [ev for ev in _drain(lq) if ev["type"] == "content"]
+    assert "".join(ev["text"] for ev in live) == "aabb"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — flush choke point vs a concurrent snapshot reader
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_snapshots_never_double_render_batched_stream(
+    wide_window: None,
+) -> None:
+    """Hammer test for Condition 1: a writer streams batched tokens
+    while a reader repeatedly registers snapshot listeners; for every
+    snapshot, snapshot-text + post-``snap_seq`` live events must equal
+    the full stream exactly once (no overlap, no gap) — the invariant
+    that breaks if the inflight append and the batch enqueue are ever
+    split across ``_ws_lock`` sections."""
+    ui = _make_ui()
+    n = 200
+    done = threading.Event()
+
+    def _writer() -> None:
+        for i in range(n):
+            ui.on_content_token(f"[{i}]")
+        ui.on_stream_end()
+        done.set()
+
+    results: list[tuple[str, int, queue.Queue[dict[str, Any]]]] = []
+
+    def _reader() -> None:
+        while not done.is_set():
+            lq, snap = ui.register_listener_with_in_progress_snapshot()
+            results.append((snap["content"], snap["seq"], lq))
+
+    w = threading.Thread(target=_writer)
+    r = threading.Thread(target=_reader)
+    w.start()
+    r.start()
+    w.join()
+    r.join()
+
+    full = "".join(f"[{i}]" for i in range(n))
+    for snap_content, snap_seq, lq in results:
+        live = [ev for ev in _drain(lq) if ev["type"] == "content" and ev["_seq"] > snap_seq]
+        rebuilt = snap_content + "".join(ev["text"] for ev in live)
+        assert rebuilt == full, (
+            f"client view diverged: snapshot({len(snap_content)} chars) + "
+            f"{len(live)} live events != full stream"
+        )

--- a/tests/test_webui_content.py
+++ b/tests/test_webui_content.py
@@ -38,9 +38,8 @@ class TestContentAccumulation:
         Batch window forced to 0 (per-token flush) — this pins the
         accumulator wiring, not the emit-time batching cadence (which
         coalesces fragments; see test_sse_token_batching.py)."""
-        import turnstone.core.session_ui_base as suib
 
-        monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
+        monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
         ui = _make_ui()
         ui.on_content_token("Hello ")
         ui.on_content_token("world")

--- a/tests/test_webui_content.py
+++ b/tests/test_webui_content.py
@@ -32,8 +32,15 @@ def _drain_global() -> list[dict]:
 class TestContentAccumulation:
     """WebUI should accumulate content tokens and include in idle broadcast."""
 
-    def test_content_token_accumulates(self):
-        """on_content_token should append to _ws_turn_content."""
+    def test_content_token_accumulates(self, monkeypatch):
+        """on_content_token should append to _ws_turn_content.
+
+        Batch window forced to 0 (per-token flush) — this pins the
+        accumulator wiring, not the emit-time batching cadence (which
+        coalesces fragments; see test_sse_token_batching.py)."""
+        import turnstone.core.session_ui_base as suib
+
+        monkeypatch.setattr(suib, "_TOKEN_BATCH_WINDOW_SECS", 0.0)
         ui = _make_ui()
         ui.on_content_token("Hello ")
         ui.on_content_token("world")

--- a/turnstone/core/adapters/_ui_cleanup.py
+++ b/turnstone/core/adapters/_ui_cleanup.py
@@ -84,6 +84,15 @@ def _broadcast_ws_closed_to_listeners(ui: SessionUI) -> None:
         return
     with listeners_lock:
         for lq in listeners:
+            # Mark the stream closing BEFORE attempting the sentinel: a
+            # poisoned/full ``_ListenerQueue`` rejects every put (the
+            # eviction-safe retry below can't beat the poison latch), so
+            # the drain loop needs this out-of-band flag to unwind as a
+            # clean close instead of emitting a spurious ``stream_overflow``
+            # frame.  Best-effort on plain ``queue.Queue`` (no such method).
+            mark_closing = getattr(lq, "mark_closing", None)
+            if mark_closing is not None:
+                mark_closing()
             try:
                 lq.put_nowait({"type": "ws_closed"})
             except queue.Full:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2246,18 +2246,60 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
                 # otherwise gate; shortening to 1s 5x'd the wakeup
                 # rate without any client-observable benefit).
                 #
-                # ``_seq`` filter: ``on_content_token`` /
-                # ``on_reasoning_token`` tag each emit with the
-                # per-ws event counter.  On the ``fresh`` path,
-                # events whose seq is already covered by the
-                # snapshot we just yielded get dropped to avoid
-                # double-rendering.  On ``replay_ok`` / ``truncated``
-                # paths, ``snap_seq`` is 0 so no live event is
-                # filtered — the replay buffer (or replay_truncated
-                # envelope) has already established the cutoff.
+                # ``_seq`` filter: token events are tagged with the
+                # per-ws event counter at enqueue time.  On the
+                # ``fresh`` and ``truncated`` paths, events whose seq
+                # is already covered by the snapshot we just yielded
+                # get dropped to avoid double-rendering.  On the
+                # ``replay_ok`` path ``snap_seq`` is 0 so no live
+                # event is filtered — the replayed buffer slice has
+                # already established the cutoff.
                 while True:
                     if await request.is_disconnected():
                         return
+                    if getattr(client_queue, "poisoned", False):
+                        # The queue overflowed: it latched ``poisoned``
+                        # at the FIRST rejected put, freezing its
+                        # contents as a contiguous prefix (see
+                        # ``_ListenerQueue``).
+                        if getattr(client_queue, "closing", False):
+                            # ws teardown raced the overflow: the queue is
+                            # poisoned AND its ws is closing.  Unwind as a
+                            # CLEAN close — no ``stream_overflow`` frame,
+                            # which would otherwise pollute the client's
+                            # drop-vs-wedge instrumentation and trip its
+                            # reconnect limiter on a ws that is simply gone
+                            # (the poisoned queue can't accept the in-band
+                            # ``ws_closed`` sentinel, so ``closing`` is the
+                            # only close signal it will ever see).  Recovery
+                            # of the frozen tail is the ``/history`` reload,
+                            # not a reconnect — the ws is gone.
+                            return
+                        # Genuine slow-consumer overflow (ws still live).
+                        # Close now — the queued backlog is discarded,
+                        # because the ring buffer replays everything past
+                        # the client's ``Last-Event-ID`` on the native
+                        # EventSource reconnect.  Delivering the backlog
+                        # first would only stall recovery behind the very
+                        # consumer that couldn't keep up.  The farewell
+                        # frame is id-less so ``lastEventId`` stays below
+                        # the gap; the client counts these closes for its
+                        # reconnect rate-limiter and the drop-vs-render-
+                        # wedge field instrumentation.
+                        log.info(
+                            "ws.events.overflow_close ws=%s",
+                            ws_id[:8],
+                        )
+                        yield {"data": json.dumps({"type": "stream_overflow", "ws_id": ws_id})}
+                        return
+                    # NOT poisoned: a ``closing`` ws is handled by the
+                    # in-band ``ws_closed`` sentinel below, AFTER the FIFO
+                    # drain delivers every queued event.  Returning here on
+                    # ``closing`` (as an earlier revision did) would drop a
+                    # healthy-but-slightly-behind client's queued tail (the
+                    # turn's final content batch + ``stream_end``) at
+                    # teardown — a permanent truncation, since a close has
+                    # no reconnect+replay to repaint it.
                     try:
                         event = await loop.run_in_executor(
                             live_executor,

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -114,12 +114,14 @@ class _ListenerQueue(queue.Queue[dict[str, Any]]):
         # one iteration) and by ``_enqueue_direct``'s fan-out snapshot.
         self.poisoned = False
         # Set at ws teardown by ``_broadcast_ws_closed_to_listeners``.
-        # The drain loop checks this BEFORE ``poisoned`` so a full/
-        # poisoned queue whose ws is *closing* unwinds as a CLEAN close —
-        # not a false ``stream_overflow`` frame + client reconnect.  It
+        # The drain loop consults this INSIDE its ``poisoned`` branch: a
+        # queue that is both poisoned AND closing unwinds as a CLEAN close
+        # rather than emitting a false ``stream_overflow`` frame + client
+        # reconnect.  (A healthy closing queue needs no flag — it drains
+        # its tail FIFO to the in-band ``ws_closed`` sentinel.)  The flag
         # has to travel out-of-band because a poisoned/full queue rejects
-        # the in-band ``ws_closed`` sentinel (the exact case the eviction-
-        # safe retry in ``_broadcast_ws_closed_to_listeners`` targets).
+        # that sentinel — the exact case the eviction-safe retry in
+        # ``_broadcast_ws_closed_to_listeners`` targets.
         self.closing = False
 
     def put_nowait(self, item: dict[str, Any]) -> None:

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -42,8 +42,107 @@ log = get_logger(__name__)
 
 # Matches WebUI's historical listener queue size and the coordinator
 # UI's ``_LISTENER_QUEUE_MAX``. Per-queue cap keeps a slow SSE consumer
-# from bloating memory.
+# from bloating memory.  Headroom only — the load fix for fast models
+# is emit-time token batching (below), and the recovery for a consumer
+# that still can't keep up is the poison-at-first-overflow close in
+# :class:`_ListenerQueue` + the events handler's reconnect replay.
 _DEFAULT_LISTENER_QUEUE_MAX = 500
+
+# Emit-time micro-batching of content/reasoning fragments.  At
+# local-inference rates (500-2000 tok/s) per-delta ``_enqueue`` calls
+# were the event load that overflowed listener queues; coalescing
+# fragments over a small window cuts the wire event rate 10-20x while
+# staying invisible at human reading speed (tokens already arrive
+# faster than a display frame).  A batch is assembled BEFORE
+# ``_enqueue`` and gets one fresh ``_event_id``, so it never violates
+# the no-in-ring-coalescing rule (see ``_resolve_event_buffer_max``):
+# no consumer's ``last_event_id`` can fall inside a batch.
+#
+# The window is measured from the LAST flush, checked on token
+# arrival (no timer thread): the first fragment after ≥window of
+# quiet flushes immediately (time-to-first-token protection at turn
+# starts and after tool pauses), a sustained stream flushes every
+# ~window, and a slow stream (fragments arriving further apart than
+# the window) degenerates to per-token flushes — batching
+# self-disables.  The size cap bounds worst-case batch size (client
+# repaint cost) independent of rate.  Both are read at call time so
+# tests can pin cadence-sensitive behaviour deterministically.
+_TOKEN_BATCH_WINDOW_SECS = 0.025
+_TOKEN_BATCH_MAX_CHARS = 4096
+
+
+class _ListenerOverflow(queue.Full):
+    """Raised by :meth:`_ListenerQueue.put_nowait` exactly once per queue —
+    at the rejected put that latches ``poisoned``.  A ``queue.Full``
+    subclass so any caller that suppresses ``Full`` keeps working; the
+    fan-out in ``_enqueue_direct`` catches this subclass first to log the
+    overflow transition exactly once without racy flag bookkeeping."""
+
+
+class _ListenerQueue(queue.Queue[dict[str, Any]]):
+    """Per-SSE-listener queue that poisons itself at the FIRST rejected put.
+
+    A silently-dropped event is unrecoverable: once the consumer keeps
+    draining past a drop, its ``Last-Event-ID`` advances beyond the hole
+    and the reconnect replay (``eid > last_event_id``) never revisits it —
+    scattered interleaved drops under saturation corrupt the pane
+    permanently.  Poisoning at the first full instead freezes the queue's
+    contents as a contiguous prefix: the drain loop closes the stream, the
+    client reconnects with the last id it processed, and the ring buffer
+    replays the whole gap (the rejected event included — the ring append
+    precedes the per-listener put).
+
+    The latch and the rejection are one atomic step under the queue's own
+    ``mutex`` — the same lock every ``put_nowait``/``get`` uses — and a
+    poisoned queue refuses every later put.  Without that atomicity a
+    concurrent producer could land a later event in a slot the consumer
+    freed mid-latch, leaving an interior hole BEHIND the delivered
+    high-water mark (exactly the unrecoverable shape poisoning exists to
+    prevent).
+
+    Reimplements ``put_nowait`` against the documented ``queue.Queue``
+    extension surface (``mutex`` / ``_qsize`` / ``_put`` /
+    ``unfinished_tasks`` / ``not_empty``) because the stdlib body offers
+    no hook between the full-check and the insert;
+    ``test_listener_queue_basic_put_get_semantics`` canaries stdlib drift.
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
+        # Latched under ``self.mutex``; read locklessly by the events
+        # handler's drain loop (a stale read just delays the close by
+        # one iteration) and by ``_enqueue_direct``'s fan-out snapshot.
+        self.poisoned = False
+        # Set at ws teardown by ``_broadcast_ws_closed_to_listeners``.
+        # The drain loop checks this BEFORE ``poisoned`` so a full/
+        # poisoned queue whose ws is *closing* unwinds as a CLEAN close —
+        # not a false ``stream_overflow`` frame + client reconnect.  It
+        # has to travel out-of-band because a poisoned/full queue rejects
+        # the in-band ``ws_closed`` sentinel (the exact case the eviction-
+        # safe retry in ``_broadcast_ws_closed_to_listeners`` targets).
+        self.closing = False
+
+    def put_nowait(self, item: dict[str, Any]) -> None:
+        with self.mutex:
+            if self.poisoned:
+                raise queue.Full
+            if 0 < self.maxsize <= self._qsize():
+                self.poisoned = True
+                raise _ListenerOverflow
+            self._put(item)
+            self.unfinished_tasks += 1
+            self.not_empty.notify()
+
+    def mark_closing(self) -> None:
+        """Flag this listener's stream for a clean close at ws teardown.
+
+        Out-of-band (a bare bool set under ``self.mutex``) because a
+        poisoned/full queue rejects the in-band ``ws_closed`` sentinel,
+        yet the drain loop must still unwind as a clean close rather than
+        emit a spurious overflow frame.  Idempotent."""
+        with self.mutex:
+            self.closing = True
+
 
 # Recall: how many finished task agents' projected sub-trajectories to retain
 # in memory for /history card rebuilds.  LRU-bounded so a marathon workstream
@@ -146,29 +245,35 @@ def _resolve_event_buffer_max() -> int:
     casual reading of "how many events does an SSE stream see":
 
     1. Local-inference deployments stream at 500–2000 tok/s per
-       active model.  Each token is an ``_enqueue`` call, so a single
-       active workstream can fire ~2000 events/sec sustained.  At
-       the 50000 cap that buys ~25 s of pure token streaming before
-       truncation; at typical cloud-provider rates (50–200 events/sec
-       per stream) it's minutes of coverage.
+       active model.  Emit-time batching (``_TOKEN_BATCH_*``)
+       coalesces those into ~40 events/sec of content, so the cap
+       now buys the ring MINUTES of coverage at any token rate —
+       but tool-chunk storms and multi-listener turns still burst,
+       and the cap is deliberately sized for the pre-batching worst
+       case as safety margin.
     2. Browsers throttle the SSE-drain microtask aggressively when
        the tab isn't visible (Chrome's background-tab budget drops
-       to ~1 wake/min after ~5 min hidden).  A backgrounded tab can
-       legitimately go tens of seconds without draining its
-       EventSource buffer — and PR-G (drop-pings-let-it-die)
-       deliberately closes those connections on hide.  Reconnect-with-
-       replay is the recovery path; if the buffer evicted in the
-       interim, the snapshot floor is all that's left.
+       to ~1 wake/min after ~5 min hidden).  The client closes its
+       EventSource on tab-hide and reconnects with the saved
+       ``Last-Event-ID`` on show (interactive.js ``visibilitychange``
+       handler), so the ring's job is covering that hide window;
+       a consumer that stays slow while visible is handled by the
+       listener-queue poison → reconnect-replay path instead.  If
+       the buffer evicted in the interim, the snapshot floor is all
+       that's left.
 
-    Why not coalesce consecutive content/reasoning tokens?  A naive
-    text-merge breaks the replay-slice semantic: a coalesced entry
-    has the latest ``_event_id`` but text that includes content the
-    client already received under an earlier id, so any consumer
-    with ``last_event_id`` falling INSIDE the coalesced span would
-    double-render.  A correctness-preserving coalesce would need a
-    per-consumer high-water tracker we deliberately don't maintain
-    (consumers register and disconnect independently).  Bigger cap
-    + simple per-event storage avoids the trap.
+    Why not coalesce consecutive content/reasoning tokens IN THE
+    RING?  A naive in-buffer text-merge breaks the replay-slice
+    semantic: a coalesced entry has the latest ``_event_id`` but
+    text that includes content the client already received under an
+    earlier id, so any consumer with ``last_event_id`` falling
+    INSIDE the coalesced span would double-render.  A correctness-
+    preserving coalesce would need a per-consumer high-water tracker
+    we deliberately don't maintain (consumers register and
+    disconnect independently).  Bigger cap + simple per-event
+    storage avoids the trap.  (Emit-time batching is different in
+    kind: it merges fragments BEFORE they get an id, so a batch is
+    one ordinary ring entry no cursor can fall inside.)
 
     Memory cost is ~200–500 bytes per event (deque node + dict
     overhead + payload), so 50000 × 100-ws design ceiling caps at
@@ -505,6 +610,23 @@ class SessionUIBase:
         self._ws_inflight_content_size: int = 0
         self._ws_inflight_reasoning: list[str] = []
         self._ws_inflight_reasoning_size: int = 0
+        # Emit-time token-batch accumulator (see the module-level
+        # ``_TOKEN_BATCH_*`` constants).  Holds not-yet-emitted
+        # content/reasoning fragments; at most ONE kind pends at a time
+        # (a kind switch flushes the other first, preserving arrival
+        # order on the wire).  Pending text is INVISIBLE everywhere —
+        # not in the inflight buffers, not in the ring, no event id —
+        # until ``_flush_token_batch_locked`` appends it to the inflight
+        # buffers AND enqueues the batched event inside one ``_ws_lock``
+        # section, which is what keeps a snapshot's ``snap_seq`` a true
+        # high-water mark for its text (no double-render across a
+        # straddling batch).  All four fields guarded by ``_ws_lock``.
+        self._pending_tokens: list[str] = []
+        self._pending_tokens_size: int = 0
+        self._pending_kind: str = ""
+        # ``time.monotonic()`` of the last real flush; 0.0 makes the
+        # first fragment of a fresh UI flush immediately.
+        self._last_token_flush: float = 0.0
         # Last broadcast (activity, activity_state) tuple — used by
         # :meth:`_broadcast_activity` overrides to dedup back-to-back
         # identical activity ticks. Tool-heavy turns can fire many
@@ -565,6 +687,46 @@ class SessionUIBase:
     def _enqueue(self, data: dict[str, Any]) -> int:
         """Fan ``data`` out to every registered listener queue.
 
+        This is the choke point for every NON-token emit — base-class
+        ``on_*`` hooks, subclass overrides (``state_change`` /
+        ``clear_ui`` / rename), and route-level emits (``cancelled``,
+        the interject path's synthetic ``stream_end``) all land here —
+        so it first flushes any pending token batch.  Without that, a
+        ``stream_end`` could overtake its own turn's trailing content
+        batch: the client resets its streaming refs on ``stream_end``
+        and the late batch would paint into a NEW assistant bubble.
+        Emits that happen on the worker thread (the token producer) are
+        therefore strictly ordered after the tokens that preceded them;
+        cross-thread emits (a streaming tool's background
+        ``tool_output_chunk``) keep their pre-existing best-effort
+        ordering.
+
+        MUST NOT be called while holding ``_ws_lock`` — the flush
+        acquires it (non-reentrant).  Token events never come through
+        here: :meth:`on_content_token` / :meth:`on_reasoning_token`
+        buffer under ``_ws_lock`` and their flush emits via
+        :meth:`_enqueue_direct`.  Every current call site enqueues
+        outside ``_ws_lock``; a violation deadlocks immediately (and
+        loudly) in any test that exercises the path.
+
+        Returns the monotonic ``_event_id`` assigned to this event so a
+        caller that also persists the same turn (e.g.
+        ``ChatSession._append_system_turn``) can stamp the row with the
+        matching id, keeping the ``/history`` resume cursor and the live
+        event stream aligned.
+        """
+        self._flush_token_batch()
+        return self._enqueue_direct(data)
+
+    def _enqueue_direct(self, data: dict[str, Any]) -> int:
+        """Stamp + ring-append + fan out ``data`` (no batch flush).
+
+        Only two kinds of caller: :meth:`_enqueue` (after it flushed the
+        pending token batch) and :meth:`_flush_token_batch_locked` (the
+        flush itself, which runs under ``_ws_lock`` — acquisition order
+        ``_ws_lock`` outer → ``_listeners_lock`` inner matches the
+        snapshot helpers).
+
         Stamps ``ws_id`` on the payload if not already present so the
         browser can validate it belongs to the pane's current
         workstream.  Stamps a monotonic ``_event_id`` on every event
@@ -583,11 +745,12 @@ class SessionUIBase:
         fanned out to a not-yet-registered listener AND missing from
         the replay buffer.
 
-        Returns the monotonic ``_event_id`` assigned to this event so a
-        caller that also persists the same turn (e.g.
-        ``ChatSession._append_system_turn``) can stamp the row with the
-        matching id, keeping the ``/history`` resume cursor and the live
-        event stream aligned.
+        Fan-out skips queues already poisoned (their stream is closing;
+        puts would be latch-refused anyway) and logs the poison
+        TRANSITION exactly once per listener via the
+        :class:`_ListenerOverflow` first-rejection signal — the node-side
+        visibility for an overflow that is otherwise only observable in
+        the browser (a proxied coordinator pane hides it entirely).
         """
         if "ws_id" not in data:
             data = {**data, "ws_id": self.ws_id}
@@ -607,11 +770,122 @@ class SessionUIBase:
                 # bypassing the snapshot filter by absence of ``_seq``.
                 data = {**data, "_seq": event_id}
             self._event_buffer.append((event_id, data))
-            snapshot = list(self._listeners)
+            snapshot = [lq for lq in self._listeners if not getattr(lq, "poisoned", False)]
         for lq in snapshot:
-            with contextlib.suppress(queue.Full):
+            try:
                 lq.put_nowait(data)
+            except _ListenerOverflow:
+                log.warning(
+                    "sse.listener_overflow ws=%s event_id=%d: listener queue full; "
+                    "poisoned — its drain loop will close the stream and the "
+                    "client reconnect replays the gap from the ring buffer",
+                    self.ws_id[:8],
+                    event_id,
+                )
+            except queue.Full:
+                # Poison latched by a concurrent producer between our
+                # snapshot and this put (or a raw ``queue.Queue`` a test
+                # registered directly): same silent-skip as before.
+                continue
         return event_id
+
+    def _buffer_token_locked(self, kind: str, text: str) -> None:
+        """Accumulate one content/reasoning fragment; flush on window/size.
+
+        Caller holds ``_ws_lock``.  A kind switch (reasoning→content or
+        back) flushes the other kind first so the wire preserves arrival
+        order between the two token streams.  The window is measured
+        from the last flush and checked here, on arrival — no timer
+        thread, so a mid-stream stall just holds the final partial batch
+        until the next fragment or the next non-token emit's
+        choke-point flush (``stream_end`` at the latest).
+        """
+        if self._pending_kind and self._pending_kind != kind:
+            self._flush_token_batch_locked()
+        if not self._pending_tokens:
+            self._pending_kind = kind
+        self._pending_tokens.append(text)
+        self._pending_tokens_size += len(text)
+        if (
+            time.monotonic() - self._last_token_flush >= _TOKEN_BATCH_WINDOW_SECS
+            or self._pending_tokens_size >= _TOKEN_BATCH_MAX_CHARS
+        ):
+            self._flush_token_batch_locked()
+
+    def _flush_token_batch_locked(self) -> None:
+        """Emit the pending token batch as ONE event.  Caller holds ``_ws_lock``.
+
+        The inflight-buffer append and the enqueue are deliberately one
+        critical section: ``register_listener_with_in_progress_snapshot``
+        / ``register_listener_with_replay`` capture ``(inflight text,
+        _event_id)`` under the same lock, so ``snap_seq`` stays a true
+        high-water mark for the snapshot text.  Splitting them (e.g.
+        appending inflight per-token while enqueueing per-batch) lets a
+        straddling snapshot carry text whose batch then arrives with
+        ``_seq > snap_seq`` — the client (a blind ``+=``, no content
+        dedup) double-renders it.  Pinned by
+        ``test_snapshot_mid_batch_sees_only_flushed_text_no_double_render``
+        and the writer-race test in ``test_sse_reconnect_replay.py``.
+
+        Cap semantics match the old per-token appends: check-before-
+        append, so overshoot is bounded by one batch
+        (``_TOKEN_BATCH_MAX_CHARS`` + one fragment) instead of one
+        token; the live stream continues past the cap either way.
+        """
+        if not self._pending_tokens:
+            return
+        self._last_token_flush = time.monotonic()
+        text = "".join(self._pending_tokens)
+        kind = self._pending_kind
+        self._reset_pending_locked()
+        if kind == "content":
+            if self._ws_turn_content_size < _MAX_TURN_CONTENT_CHARS:
+                self._ws_turn_content.append(text)
+                self._ws_turn_content_size += len(text)
+            if self._ws_inflight_content_size < _MAX_TURN_CONTENT_CHARS:
+                self._ws_inflight_content.append(text)
+                self._ws_inflight_content_size += len(text)
+        else:
+            if self._ws_inflight_reasoning_size < _MAX_TURN_CONTENT_CHARS:
+                self._ws_inflight_reasoning.append(text)
+                self._ws_inflight_reasoning_size += len(text)
+        self._enqueue_direct({"type": kind, "text": text})
+
+    def _flush_token_batch(self) -> None:
+        """Flush the pending token batch from OUTSIDE ``_ws_lock``.
+
+        The lockless empty-check is the fast path for every non-token
+        emit (the overwhelmingly common case).  Same-thread visibility
+        is what correctness needs: the worker that buffered the tokens
+        sees its own append when it later emits ``stream_end`` /
+        ``tool_*`` — cross-thread emits racing a concurrent append keep
+        their pre-existing best-effort ordering either way.
+        """
+        if not self._pending_tokens:
+            return
+        with self._ws_lock:
+            self._flush_token_batch_locked()
+
+    def _reset_pending_locked(self) -> None:
+        """Zero the pending token accumulator.  Caller holds ``_ws_lock``.
+
+        Single source of truth for the reset so a later accumulator field
+        can't be half-cleared by one of its two callers
+        (:meth:`_flush_token_batch_locked` after capturing the text,
+        :meth:`_discard_pending_tokens_locked` on the crash path)."""
+        self._pending_tokens = []
+        self._pending_tokens_size = 0
+        self._pending_kind = ""
+
+    def _discard_pending_tokens_locked(self) -> None:
+        """Drop a never-emitted pending batch.  Caller holds ``_ws_lock``.
+
+        Only for the stale-crash path (:meth:`on_turn_start`): the text
+        was never enqueued, never ring-buffered, never inflight — so
+        discarding it is consistent everywhere, whereas flushing it
+        would paint a dead ``send()``'s tail into the NEW turn's bubble.
+        """
+        self._reset_pending_locked()
 
     def _stamp_agent_parent(self, data: dict[str, Any]) -> dict[str, Any]:
         """Stamp ``parent_call_id`` on a sub-agent's child event.
@@ -718,7 +992,7 @@ class SessionUIBase:
         self, maxsize: int = _DEFAULT_LISTENER_QUEUE_MAX
     ) -> queue.Queue[dict[str, Any]]:
         """Create a per-client queue and register it as a listener."""
-        client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
+        client_queue: queue.Queue[dict[str, Any]] = _ListenerQueue(maxsize=maxsize)
         with self._listeners_lock:
             self._listeners.append(client_queue)
         return client_queue
@@ -769,7 +1043,7 @@ class SessionUIBase:
         duration. The shallow ``list(...)`` copies under the lock mean
         subsequent appends to the live buffers don't mutate our view.
         """
-        client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
+        client_queue: queue.Queue[dict[str, Any]] = _ListenerQueue(maxsize=maxsize)
         with self._ws_lock:
             captured_content = list(self._ws_inflight_content)
             captured_reasoning = list(self._ws_inflight_reasoning)
@@ -862,7 +1136,7 @@ class SessionUIBase:
         for the genuine cold-start case (no false ``replay_truncated``
         envelopes on freshly-opened workstreams).
         """
-        client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
+        client_queue: queue.Queue[dict[str, Any]] = _ListenerQueue(maxsize=maxsize)
         # Lock order matches writer: ``_ws_lock`` outer, ``_listeners_lock``
         # inner.  Both inflight buffers AND the buffer slice AND the
         # ``_event_id`` counter AND the listener registration captured
@@ -2655,8 +2929,13 @@ class SessionUIBase:
         stale content in the buffers. Steady-state, the buffers are
         already empty at this point because :meth:`on_turn_committed`
         cleared them right after the last assistant message committed.
+
+        A pending token batch here is the same stale-crash residue and
+        is DISCARDED (never emitted) — flushing it would paint the dead
+        ``send()``'s tail into the new turn's bubble.
         """
         with self._ws_lock:
+            self._discard_pending_tokens_locked()
             self._reset_inflight_buffers_locked()
 
     def on_turn_committed(self) -> None:
@@ -2674,8 +2953,15 @@ class SessionUIBase:
         within the current send) will override this hook to copy
         inflight reasoning to a per-message persistence store BEFORE
         clearing — keeping the `current vs historical` boundary clean.
+
+        A pending token batch here is part of the message that just
+        committed (the worker's ``stream_end`` normally flushed it
+        already), so it FLUSHES — before the reset — keeping the live
+        view and the replay ring complete rather than silently dropping
+        committed text from connected panes.
         """
         with self._ws_lock:
+            self._flush_token_batch_locked()
             self._reset_inflight_buffers_locked()
 
     def on_thinking_start(self) -> None:
@@ -2690,86 +2976,52 @@ class SessionUIBase:
         self._enqueue({"type": "thinking_stop"})
 
     def on_reasoning_token(self, text: str) -> None:
-        """Append to the inflight reasoning buffer (capped) + enqueue.
+        """Buffer one reasoning fragment into the emit-time batcher.
 
-        Mirrors :meth:`on_content_token`'s shape.  The ``_seq`` dedup
-        tag is stamped by :meth:`_enqueue` against the per-ws
-        ``_event_id`` counter, which advances on EVERY emit
-        regardless of whether the inflight cap rejected the append.
-        If the seq stalled at high-water-pre-cap, subscribers
-        registering after the cap is hit would capture
-        ``snap_seq == high-water`` and every subsequent live token
-        (with the same stalled seq) would be filter-dropped as
-        "already in your snapshot" — silently losing the rest of
-        the stream. The cap is a buffer-size limit, NOT a "stop
-        streaming" signal.
-
-        Tokens past the cap are absent from ``snap.reasoning`` (the
-        snapshot text was truncated at cap) but the live stream
-        continues normally past them — refresh-after-cap renders the
-        snapshot text up to the cap and then live tokens past it,
-        with a visual gap equal to the past-cap chunk. No silent
-        drop of subsequent tokens.
-
-        **Lock coupling**: ``_enqueue`` is called WHILE still
-        holding ``_ws_lock`` so the inflight append AND the
-        ``_event_id`` advancement happen atomically against a
-        snapshot reader.  Without this coupling a reader could
-        capture the inflight (with the new text) and read
-        ``_event_id`` BEFORE the writer's ``_enqueue`` bumped it,
-        producing a ``snap_seq`` lower than the new event's
-        ``_event_id``.  The new event would then slip past the
-        ``_seq <= snap_seq`` live-drain dedup and double-render
-        the text the snapshot already contained.  Acquisition
-        order ``_ws_lock`` (outer) → ``_listeners_lock`` (inner via
-        ``_enqueue``) matches the snapshot helpers, so no deadlock.
+        Mirrors :meth:`on_content_token`'s shape — see there for the
+        locking rationale and :meth:`_flush_token_batch_locked` for
+        where the (capped) inflight append + single-event enqueue
+        happen.  The inflight cap is a buffer-size limit, NOT a "stop
+        streaming" signal: batches past the cap skip the snapshot
+        buffers but still emit, so the live stream continues (a
+        refresh-after-cap renders the capped snapshot then live tokens
+        past it).
         """
         with self._ws_lock:
-            if self._ws_inflight_reasoning_size < _MAX_TURN_CONTENT_CHARS:
-                self._ws_inflight_reasoning.append(text)
-                self._ws_inflight_reasoning_size += len(text)
-            self._enqueue({"type": "reasoning", "text": text})
+            self._buffer_token_locked("reasoning", text)
 
     def on_content_token(self, text: str) -> None:
-        """Append to both turn-content buffers (capped) + enqueue.
+        """Buffer one content fragment into the emit-time batcher.
 
-        Writes under ``_ws_lock`` to two independent buffers:
+        Fragments accumulate under ``_ws_lock`` and flush as ONE
+        ``content`` event per batch window (see the ``_TOKEN_BATCH_*``
+        constants) — the event-rate reduction that keeps fast local
+        models (500+ tok/s) from overflowing listener queues.  The
+        flush — inside :meth:`_flush_token_batch_locked`, still under
+        the caller's ``_ws_lock`` — appends the batch to both capped
+        turn-content buffers:
+
          - ``_ws_turn_content`` (multi-turn, drained at idle/error)
            — fuels the dashboard's IDLE-piggyback content payload.
          - ``_ws_inflight_content`` (per-turn, drained at
            :meth:`on_turn_start`) — fuels the SSE ``in_progress_snapshot``
            event a reconnecting client sees on mid-stream refresh.
 
-        Both caps are checked independently.  The ``_seq`` dedup tag
-        is stamped by :meth:`_enqueue` against the per-ws
-        ``_event_id`` counter, which advances on EVERY emit
-        regardless of cap state — see :meth:`on_reasoning_token` for
-        the full rationale, including why ``_enqueue`` runs while
-        still holding ``_ws_lock`` (the lock coupling that makes
-        ``snap_seq`` a true high-water mark for the snapshot text).
-
-        The cap-check + append + size-update + enqueue all run under
-        ``_ws_lock`` so a concurrent
-        :meth:`snapshot_and_consume_state_payload` IDLE/ERROR drain or
-        a concurrent :meth:`register_listener_with_in_progress_snapshot`
-        / :meth:`register_listener_with_replay` sees a consistent
-        ``(inflight_content, _event_id)`` pair.  In production this
-        is single-writer-per-ws (the worker thread) but the snapshot
-        reader runs from coord's adapter via ``mgr.set_state``;
-        without the lock the writer's append could land in an
-        orphaned list reference the snapshot just swapped out, AND
-        the inflight/counter pair could de-sync.  Lock hold is
-        microseconds (the fan-out's ``put_nowait`` calls are O(N
-        listeners) but each is a single non-blocking enqueue).
+        and enqueues the batched event in the same critical section,
+        so a concurrent :meth:`snapshot_and_consume_state_payload`
+        IDLE/ERROR drain or a concurrent
+        :meth:`register_listener_with_in_progress_snapshot` /
+        :meth:`register_listener_with_replay` sees a consistent
+        ``(inflight_content, _event_id)`` pair — never a pending
+        fragment without its event, never an event without its text.
+        In production this is single-writer-per-ws (the worker
+        thread) but the snapshot reader runs from coord's adapter via
+        ``mgr.set_state``.  Acquisition order ``_ws_lock`` (outer) →
+        ``_listeners_lock`` (inner, via ``_enqueue_direct``) matches
+        the snapshot helpers, so no deadlock.
         """
         with self._ws_lock:
-            if self._ws_turn_content_size < _MAX_TURN_CONTENT_CHARS:
-                self._ws_turn_content.append(text)
-                self._ws_turn_content_size += len(text)
-            if self._ws_inflight_content_size < _MAX_TURN_CONTENT_CHARS:
-                self._ws_inflight_content.append(text)
-                self._ws_inflight_content_size += len(text)
-            self._enqueue({"type": "content", "text": text})
+            self._buffer_token_locked("content", text)
 
     def on_stream_end(self) -> None:
         with self._ws_lock:
@@ -3092,6 +3344,13 @@ class SessionUIBase:
         """
         captured_content: list[str] = []
         with self._ws_lock:
+            # Deliver any pending token batch first: this is the
+            # cancel/error chokepoint (see the idle-branch comment
+            # below), and the terminal-state payload must carry the
+            # full turn text — a batch stranded in the accumulator
+            # would otherwise vanish from the dashboard payload AND
+            # from connected panes.
+            self._flush_token_batch_locked()
             tokens = self._ws_prompt_tokens + self._ws_completion_tokens
             ctx = self._ws_context_ratio
             activity = self._ws_current_activity

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -1241,6 +1241,20 @@ class Pane {
       this._visHandler = () => this._onVisibilityChange();
       document.addEventListener("visibilitychange", this._visHandler);
     }
+    // Never open an EventSource into a hidden (throttled) tab — including on a
+    // FIRST load in a background tab, where the close-on-hide handler never
+    // fires because there was no open stream to close (a throttled hidden tab
+    // is the worst-case slow consumer that overflows the server send queue).
+    // This is the single connect chokepoint, so it backstops every caller —
+    // fresh connect, degraded retry, recover beat, show edge; the wsId + the
+    // visibilitychange handler installed just above make the show edge
+    // reconnect (replay_ok from the ring). The timer callbacks keep their own
+    // pre-checks (the recover beat's also gates failCount), so this is the
+    // net that closes the fresh-connect gap they never covered.
+    if (document.hidden) {
+      this._hiddenDisconnect = true;
+      return;
+    }
     this.evtSource = new EventSource(evtUrl);
 
     this.evtSource.onopen = () => {

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -173,6 +173,57 @@ const INTERACTIVE_DEFAULT_HOST = {
   onPreview() {},
 };
 
+// Overflow-reconnect limiter (client half of the SSE overflow recovery).
+// The server closes a stream whose listener queue overflowed — after an
+// id-less `stream_overflow` frame — and the native EventSource reconnect
+// replays the gap from the server's ring buffer.  For a consumer that
+// STAYS too slow that cycle would churn forever (reconnect → replay
+// burst → re-saturate → re-close, stalling ~3-5 s per retry round), so
+// after OVERFLOW_TRIP_COUNT overflow closes inside a rolling
+// OVERFLOW_TRIP_WINDOW_MS the pane drops to a degraded catch-up: stop
+// live streaming, say so plainly, and re-try after a doubling cooldown —
+// the eventual reconnect replays the gap, or falls to the
+// replay_truncated → /history floor once the gap outgrows the ring.
+const OVERFLOW_TRIP_COUNT = 3;
+const OVERFLOW_TRIP_WINDOW_MS = 60000;
+const DEGRADED_COOLDOWN_BASE_MS = 15000;
+const DEGRADED_COOLDOWN_MAX_MS = 120000;
+// Reset the cooldown ladder back to base only after this long WITHOUT a
+// degraded trip.  Deliberately larger than DEGRADED_COOLDOWN_MAX_MS: a
+// persistently-slow consumer trips again roughly one cooldown apart, so
+// keying the reset off the (shorter) trip window would let the gap
+// between top-of-ladder trips exceed the window and oscillate the
+// cooldown back to base — the escalation must survive its own backoff.
+const DEGRADED_COOLDOWN_RESET_MS = 300000;
+
+// Rolling-window trip check.  Prunes `times` in place (entries older
+// than windowMs against nowMs) and reports whether count-or-more
+// remain.  A standalone pure function so the trip logic can be lifted
+// verbatim into a bare `node -e` runtime probe (test_app_js.py style).
+function overflowWindowTripped(times, nowMs, count, windowMs) {
+  while (times.length && nowMs - times[0] > windowMs) times.shift();
+  return times.length >= count;
+}
+
+// Cooldown-ladder step for degraded catch-up.  Escalates (double, capped
+// at maxMs) when a trip recurs within resetMs of the last one; resets to
+// baseMs only after a genuine quiet gap.  Pure — keyed off the last-trip
+// TIMESTAMP, never the overflow-window array (which _enterDegradedCatchup
+// clears each trip, so keying off it would reset the ladder on every
+// storm's first overflow and the doubling would never escalate).  Split
+// out so the escalation is runtime-testable without a DOM-bound Pane.
+function degradedCooldownStep(
+  prevCooldownMs,
+  lastTripAtMs,
+  nowMs,
+  baseMs,
+  maxMs,
+  resetMs,
+) {
+  const cooldown = nowMs - lastTripAtMs > resetMs ? baseMs : prevCooldownMs;
+  return { cooldown, nextCooldownMs: Math.min(cooldown * 2, maxMs) };
+}
+
 class Pane {
   constructor(wsId, opts) {
     opts = opts || {};
@@ -252,6 +303,29 @@ class Pane {
     // Set when replay_truncated arrives mid-stream (refetching then would
     // detach the live bubble); consumed on the next idle edge.
     this._pendingTruncatedResync = false;
+    // Field instrumentation for the two distinct "output stops while the
+    // backend is healthy" causes: server-signalled overflow closes
+    // (dropped-events class) vs client dispatch/render throws (wedge
+    // class).  The console lines at each increment carry the running
+    // count, so a field report shows which class fired without a
+    // debugger attached.
+    this._streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 };
+    // Rolling timestamps of stream_overflow closes — input to the
+    // degraded catch-up limiter (see overflowWindowTripped above).
+    this._overflowTimes = [];
+    this._degradedTimer = null;
+    this._degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
+    // Timestamp of the last degraded-catchup trip; drives the cooldown
+    // ladder's escalate-vs-reset decision independently of _overflowTimes.
+    this._lastDegradedAt = 0;
+    // Close-on-hide bookkeeping.  A hidden tab's throttled event loop is
+    // the likeliest too-slow SSE consumer, so the visibilitychange
+    // handler closes the stream on hide and reconnects with the saved
+    // Last-Event-ID on show (replay_ok covers the gap).
+    // _hiddenDisconnect marks that WE closed for hide, so show never
+    // resurrects a stream that was closed deliberately elsewhere.
+    this._visHandler = null;
+    this._hiddenDisconnect = false;
     this._cancelTimeout = null;
     this._forceTimeout = null;
     this._pendingEditSend = null;
@@ -301,6 +375,15 @@ class Pane {
     if (this._forceTimeout) {
       clearTimeout(this._forceTimeout);
       this._forceTimeout = null;
+    }
+    // Any pending degraded-catch-up reconnect is owned by the stream
+    // lifecycle: whoever closes the stream (ws switch, giveUp, destroy,
+    // or a fresh manual connect — connectSSE's first line lands here)
+    // supersedes it.  _enterDegradedCatchup re-arms AFTER its own
+    // disconnect, so this never cancels the timer it is about to set.
+    if (this._degradedTimer) {
+      clearTimeout(this._degradedTimer);
+      this._degradedTimer = null;
     }
     if (this.evtSource) {
       this.evtSource.close();
@@ -1148,6 +1231,16 @@ class Pane {
     if (this._lastEventId != null) {
       evtUrl += "?last_event_id=" + encodeURIComponent(this._lastEventId);
     }
+    // Close-on-hide / replay-on-show: installed once per pane, removed
+    // by the factory's destroy().  A hidden tab's throttled drain is the
+    // likeliest slow consumer behind server-side queue overflow, and an
+    // idle hidden tab holds a node connection for nothing — closing on
+    // hide removes both, and the saved _lastEventId makes the show-edge
+    // reconnect lossless (replay_ok from the server's ring buffer).
+    if (!this._visHandler) {
+      this._visHandler = () => this._onVisibilityChange();
+      document.addEventListener("visibilitychange", this._visHandler);
+    }
     this.evtSource = new EventSource(evtUrl);
 
     this.evtSource.onopen = () => {
@@ -1180,7 +1273,13 @@ class Pane {
       try {
         data = JSON.parse(e.data);
       } catch (err) {
-        console.warn("interactive: dropping malformed SSE frame", err);
+        this._streamHealth.malformedFrames += 1;
+        console.warn(
+          "interactive: dropping malformed SSE frame (total " +
+            this._streamHealth.malformedFrames +
+            ")",
+          err,
+        );
         return;
       }
       // Tag the event with its own SSE id so the system_turn handler can
@@ -1191,8 +1290,13 @@ class Pane {
       try {
         this.handleEvent(data);
       } catch (err) {
+        this._streamHealth.renderThrows += 1;
         console.error(
-          "interactive: handleEvent failed for " + (data && data.type),
+          "interactive: handleEvent failed for " +
+            (data && data.type) +
+            " (render-throw total " +
+            this._streamHealth.renderThrows +
+            ")",
           err,
         );
       }
@@ -1219,6 +1323,98 @@ class Pane {
       // reconnect alone.
       this._host.onStreamError(this);
     };
+  }
+
+  _onVisibilityChange() {
+    if (document.hidden) {
+      // Closing beats letting the hidden tab's throttled event loop
+      // starve the drain until the server-side queue overflows.  The
+      // streaming refs (contentBuffer / currentAssistantEl) survive —
+      // disconnectSSE is transport-only — so the visible tail is intact
+      // when the tab comes back.
+      if (this.evtSource) {
+        this.disconnectSSE();
+        this._hiddenDisconnect = true;
+      }
+    } else if (this._hiddenDisconnect) {
+      this._hiddenDisconnect = false;
+      if (this.wsId) this.connectSSE(this.wsId);
+    }
+  }
+
+  _removeVisibilityHandler() {
+    if (this._visHandler) {
+      document.removeEventListener("visibilitychange", this._visHandler);
+      this._visHandler = null;
+    }
+    this._hiddenDisconnect = false;
+  }
+
+  _noteStreamOverflow() {
+    this._streamHealth.overflows += 1;
+    const now = Date.now();
+    this._overflowTimes.push(now);
+    console.warn(
+      "interactive: server closed the stream after a send-queue overflow " +
+        "(total " +
+        this._streamHealth.overflows +
+        "); reconnect will replay the gap",
+    );
+    // Trip when OVERFLOW_TRIP_COUNT closes land inside the rolling window.
+    // The cooldown-ladder reset lives in _enterDegradedCatchup (keyed off
+    // _lastDegradedAt), NOT here — this method only counts and trips.
+    if (
+      overflowWindowTripped(
+        this._overflowTimes,
+        now,
+        OVERFLOW_TRIP_COUNT,
+        OVERFLOW_TRIP_WINDOW_MS,
+      )
+    ) {
+      this._enterDegradedCatchup();
+    }
+  }
+
+  _enterDegradedCatchup() {
+    // Repeated overflow closes inside one window: this consumer cannot
+    // keep up with live streaming right now, and each reconnect round
+    // just stalls rendering behind the 2.5-4.5 s retry before
+    // re-saturating.  Stop the churn: close the stream, say so in plain
+    // language, and come back after a (doubling) cooldown — that
+    // reconnect replays the gap from the server's ring buffer, or falls
+    // to the replay_truncated → /history resync floor once the gap has
+    // outgrown it.  Either path is lossless for committed turns.
+    const now = Date.now();
+    // Escalate the cooldown when trips recur; reset to base only after a
+    // genuine quiet gap.  Keyed off _lastDegradedAt (a timestamp), NOT
+    // _overflowTimes — this method clears that array below, so keying the
+    // reset off it would restart the ladder on the next storm's first
+    // overflow and the doubling (15→30→60→120s) would never take effect.
+    const step = degradedCooldownStep(
+      this._degradedCooldownMs,
+      this._lastDegradedAt,
+      now,
+      DEGRADED_COOLDOWN_BASE_MS,
+      DEGRADED_COOLDOWN_MAX_MS,
+      DEGRADED_COOLDOWN_RESET_MS,
+    );
+    this._lastDegradedAt = now;
+    this._degradedCooldownMs = step.nextCooldownMs;
+    this._overflowTimes.length = 0;
+    this.disconnectSSE(); // also cancels any earlier degraded timer
+    this.statusBarEl.classList.add("ws-sb-disconnected");
+    this._sbTokens.textContent = "Connection is slow — catching up…";
+    const cooldown = step.cooldown;
+    this._degradedTimer = setTimeout(() => {
+      this._degradedTimer = null;
+      if (document.hidden) {
+        // Reopening into a throttled hidden tab would overflow again —
+        // defer to the visibilitychange show edge instead.
+        this._hiddenDisconnect = true;
+        return;
+      }
+      if (this.wsId) this.connectSSE(this.wsId);
+    }, cooldown);
   }
 
   _loadHistoryThenConnect(wsId) {
@@ -1487,7 +1683,13 @@ class Pane {
           try {
             streamingRenderFinalize(doneBodyEl, doneBuffer);
           } catch (err) {
-            console.warn("interactive: streamingRenderFinalize failed", err);
+            this._streamHealth.renderThrows += 1;
+            console.warn(
+              "interactive: streamingRenderFinalize failed (render-throw total " +
+                this._streamHealth.renderThrows +
+                ")",
+              err,
+            );
             doneBodyEl.textContent = doneBuffer;
           }
         }
@@ -1834,6 +2036,16 @@ class Pane {
         } else {
           this._pendingTruncatedResync = true;
         }
+        break;
+
+      case "stream_overflow":
+        // The server poisoned this listener at its first queue overflow
+        // and closes the stream right after this frame.  The frame is
+        // id-less, so lastEventId still points below the gap and the
+        // native EventSource reconnect replays it losslessly from the
+        // ring buffer.  Count the close: a persistently slow consumer
+        // trips the degraded catch-up instead of churning reconnects.
+        this._noteStreamOverflow();
         break;
     }
   }
@@ -4376,6 +4588,14 @@ function createInteractivePane(root, wsId, opts) {
     // reopen a stream for a session we just declared dead.
     pane._historyLoadToken = (pane._historyLoadToken || 0) + 1;
     pane.disconnectSSE();
+    // Detach the visibility handler and clear the hide-close marker: a dead
+    // controller must NOT be resurrected by a tab-visibility change.  Without
+    // this, a tab hidden BEFORE the give-up (which set _hiddenDisconnect) would,
+    // on return, fire _onVisibilityChange and connectSSE() the closed ws —
+    // reopening a stream the shell has declared gone and 404-reconnecting it
+    // forever (onStreamError early-returns when dead, so nothing stops it).
+    // Idempotent with destroy()'s own _removeVisibilityHandler call.
+    pane._removeVisibilityHandler();
     // Terminal wording — the transient error path says "Reconnecting…".
     pane.statusBarEl.classList.add("ws-sb-disconnected");
     pane._sbTokens.textContent = "Disconnected";
@@ -4405,6 +4625,15 @@ function createInteractivePane(root, wsId, opts) {
       if (recoverTimer) clearTimeout(recoverTimer);
       recoverTimer = setTimeout(() => {
         recoverTimer = null;
+        if (document.hidden) {
+          // Don't reopen an EventSource into a hidden (throttled) tab —
+          // that re-creates the slow-consumer overflow close-on-hide
+          // exists to prevent.  Mark it so the visibilitychange show edge
+          // owns the reconnect (a hide close normally set this already;
+          // set it defensively for the error-before-hide ordering).
+          pane._hiddenDisconnect = true;
+          return;
+        }
         if (
           pane.evtSource &&
           pane.evtSource.readyState !== EventSource.CLOSED
@@ -4504,6 +4733,10 @@ function createInteractivePane(root, wsId, opts) {
         recoverTimer = null;
       }
       pane.disconnectSSE();
+      // The document-level visibilitychange listener holds a strong ref
+      // to the pane — leaving it registered would both leak the pane and
+      // let a show edge reopen a stream for a destroyed controller.
+      pane._removeVisibilityHandler();
       // Terminal cleanup that transport-only reconnects must NOT do (see
       // disconnectSSE): cancel orphan grace timers so a post-destroy escape
       // can't paint into the detached pane / shared announcer, release the

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -2339,8 +2339,10 @@ window.addEventListener("beforeunload", function () {
 // close paths may leave it non-null in CLOSED state.  Either way means
 // "not actively streaming for a pane that has a workstream attached".
 //
-// Out of scope here: visibility-based DISCONNECT (close-on-hidden to
-// support many tabs).  That belongs to the fan-in design — issue #540.
+// Per-pane visibility-based DISCONNECT (close-on-hidden) lives in the
+// shared Pane itself (interactive.js visibilitychange handler), which
+// also reconnects its own stream with the saved Last-Event-ID on show —
+// this helper only revives the GLOBAL list stream.
 function _reconnectDeadSSEs() {
   if (!globalEvtSource || globalEvtSource.readyState === EventSource.CLOSED) {
     connectGlobalSSE();


### PR DESCRIPTION
A long live session driven by a fast local model (500-2000 tok/s) showed
corrupted / missing spans of assistant text while the backend stayed
healthy. Root cause: on_content_token/on_reasoning_token enqueued one SSE
event per model delta, so the per-listener queue (cap 500) overflowed
against any slow consumer; put_nowait on a full queue silently dropped the
newest event. Once saturated, drops scatter (the consumer keeps freeing
single slots), so the client's lastEventId sails past the holes and
reconnect-replay (eid > last_event_id) can never heal them. A dropped
fence-closer reshapes all downstream markdown -> reads as heavy corruption.

Fix B (primary) - emit-time micro-batching:
Coalesce content/reasoning fragments over a ~25 ms window (or 4 KB) into
one _enqueue, cutting the wire event rate ~10-20x at local-inference
speeds. A batch is assembled before it gets an _event_id, so it is one
ordinary ring entry no cursor can fall inside (unlike the forbidden
in-ring coalesce). Two conditions are load-bearing and pinned:
  1. The inflight-buffer append and the enqueue are one _ws_lock section,
     so a snapshot's snap_seq stays a true high-water mark for its text.
     Splitting them lets a straddling snapshot double-render (the client
     content path is a blind +=, no dedup).
  2. Every non-token emit flushes the pending batch first, enforced at the
     single _enqueue choke point, so stream_end/tool_*/state_change can't
     overtake trailing content and repaint it into a new bubble.

Fix A (recovery net) - poison-at-first-overflow:
_ListenerQueue latches `poisoned` atomically at the FIRST rejected put and
refuses every later put, freezing its contents as a contiguous prefix; the
drain loop closes the stream after an id-less stream_overflow frame and the
native EventSource reconnect replays the whole gap from the ring buffer.
Poisoning at the first full (not after N) is required: any deliver-while-
dropping window advances lastEventId past interior holes that reconnect
can't replay. A ws teardown that races the overflow sets an out-of-band
`closing` flag (mark_closing), checked inside the drain loop's poison
branch: a poisoned+closing queue returns clean (no false overflow frame),
while a healthy closing queue still drains its full tail FIFO to the in-band
ws_closed sentinel -- so a slow-but-unpoisoned client never loses the turn's
final content batch + stream_end at teardown.

Client (interactive.js):
- Reconnect storm guard: after 3 overflow closes in 60 s the pane drops to
  a degraded catch-up (stop live streaming, "connection is slow" state,
  reconnect after a doubling 15->120 s cooldown that resyncs from the ring
  or the uncapped /history floor). The cooldown ladder is keyed off a
  last-trip timestamp, not the overflow-window array (which the trip
  clears), so the escalation survives its own backoff.
- Close-on-hide / replay-on-show: a visibilitychange handler closes the
  EventSource on tab-hide (a throttled hidden tab is the likeliest slow
  consumer) and reconnects with the saved Last-Event-ID on show. The
  factory recovery beat defers when hidden, and giveUp() detaches the
  handler, so a dead or backgrounded controller can't reopen a stream.
- Drop-vs-render-wedge counters distinguish this bug (server overflow
  closes) from the handler-wedge class (render/finalize throws) in the
  field. No global gap-detector: live ids are not strictly monotonic
  across concurrent tool+content emit, so a naive id!=last+1 check would
  false-positive; recovery is server-signalled instead.

Corrects the stale _resolve_event_buffer_max comment that justified the
50k ring on a "PR-G closes connections on hide" mitigation that never
existed (the close-on-hide handler above is the real one).

Negative-tested (revert the guarantee, confirm the pin fails, restore):
per-token inflight append -> snapshot straddle double-render; removed
choke-point flush -> stream_end split; no poison latch -> silent drops;
top-of-loop closing check -> healthy-close tail loss; missing mark_closing
wiring / drain closing check -> clean close mis-reported as overflow;
_noteStreamOverflow cooldown reset -> ladder never escalates; removed
hidden-tab recovery guard / giveUp handler removal -> hidden-tab reconnect.


## Testing
- Full suite both CI invocations green on the rebased tree: `pytest tests/ -m "not live"` (sqlite, 8874 passed) and `--storage-backend=postgresql` (8881 passed), full order.
- ~34 new tests: batching conditions (single-id-per-batch, snapshot-straddle, stream_end-flush, slow-rate self-disable), poison-at-first-full + contiguous-gap replay, the healthy-vs-poisoned close paths, the degraded-cooldown escalation ladder (runtime-probed), and close-on-hide/giveUp lifecycle.
- Three workflow review rounds (correctness clean at R3); every fix negative-tested (revert the guarantee, confirm the pin fails, restore).

## Follow-ups (not in this PR)
- **Coordinator/CLI client parity.** The server-side fixes (batching, `_ListenerQueue` poison, `closing`) cover every SSE stream via the shared base. The *client* companions (`stream_overflow` degraded-mode handling, close-on-hide, drop-vs-wedge counters) are `interactive.js`-only; `coordinator.js` still recovers via native reconnect + ring-replay but lacks the storm guard + counter. Low-rate coord streams make overflow unlikely; same shape as the existing coordinator-pane parity follow-up. CLI is unaffected (overrides `on_content_token`, no queue).
- **Centralize the hidden-tab guard** at the `connectSSE` chokepoint (currently in three timer/handler sites; the fresh-connect path is unguarded). Placement must be after the visibility-handler install and before `new EventSource`.
- **In-band gap-event alternative** to poison+reconnect: on overflow, emit a `replay_truncated`-shaped event on the same connection and heal from `/history` — no reconnect/storm, but trades away the transient-slow fast recovery. Worth evaluating as a client simplification (a replacement, not an addition).
