### PR TITLE
fix(web_fetch): inherit model settings for the extraction completion

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7033,6 +7033,73 @@ def test_utility_completion_defers_temperature_to_session():
     assert kw2["temperature"] == 0.9  # explicit override still honored
 
 
+def test_web_fetch_extraction_inherits_session_max_tokens_and_effort():
+    """web_fetch's extraction call must inherit the session/registry max_tokens
+    and reasoning_effort rather than forcing constants.  Hard-coding
+    max_tokens=8192 / reasoning_effort="low" broke local-inference models whose
+    registry entry advertises a tighter output limit or a reasoning config the
+    forced values fought — this lane now behaves like the main turn."""
+    from unittest.mock import patch
+
+    from turnstone.core.providers._protocol import CompletionResult
+
+    session = _make_session(max_tokens=512, reasoning_effort="high")
+
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.headers = {"content-type": "text/plain"}
+    resp.text = "The page body that holds the answer."
+
+    with (
+        patch("turnstone.core.session.fetch_with_ssrf_guard", return_value=resp),
+        patch.object(
+            session,
+            "_utility_completion",
+            return_value=CompletionResult(content="Extracted answer."),
+        ) as uc,
+    ):
+        call_id, answer = session._exec_web_fetch({"call_id": "c1", "url": "https://example.com/"})
+
+    assert call_id == "c1"
+    assert answer == "Extracted answer."
+    _, kw = uc.call_args
+    # 512 < context_window // 4 (8192), so the tighter session value passes
+    # through unclamped — inheritance, not the old hard-coded 8192.
+    assert kw["max_tokens"] == 512
+    assert kw["reasoning_effort"] == "high"  # session value, not the old "low"
+
+
+def test_web_fetch_extraction_caps_max_tokens_to_window_reserve():
+    """The extraction request is capped to the ~25% window slice Phase 2
+    reserves (``context_window // 4``), matching the main turn's response
+    reserve — so a large operator ``max_tokens`` on a small-context local
+    model can't push prompt + output past the window."""
+    from unittest.mock import patch
+
+    from turnstone.core.providers._protocol import CompletionResult
+
+    # context_window=8192 -> reserve 2048; the session budget is far larger.
+    session = _make_session(max_tokens=16384, context_window=8192)
+
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.headers = {"content-type": "text/plain"}
+    resp.text = "The page body that holds the answer."
+
+    with (
+        patch("turnstone.core.session.fetch_with_ssrf_guard", return_value=resp),
+        patch.object(
+            session,
+            "_utility_completion",
+            return_value=CompletionResult(content="Extracted answer."),
+        ) as uc,
+    ):
+        session._exec_web_fetch({"call_id": "c1", "url": "https://example.com/"})
+
+    _, kw = uc.call_args
+    assert kw["max_tokens"] == 2048  # context_window // 4, not the 16384 session value
+
+
 def test_record_aux_usage_skips_when_usage_missing():
     """A provider that reports no usage object must not emit a phantom
     zero-token row."""

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -16195,10 +16195,17 @@ class ChatSession:
             text = text[:max_content] + f"\n\n... [{len(text) - max_content} chars truncated] ...\n"
 
         # Phase 3: summarization API call.
-        # Use a generous max_tokens so thinking models don't starve the
-        # visible answer, and pass reasoning_effort="low" to avoid wasting
-        # budget on deep reasoning for a simple extraction task.  Temperature
-        # is left to the session/registry default rather than overridden here.
+        # Inherit the operator's per-model settings — reasoning_effort and
+        # (via the default) temperature from the session/registry — rather
+        # than forcing constants here: hard-coding reasoning_effort="low" and
+        # a fixed max_tokens kept breaking local-inference models whose
+        # registry entry advertises a different reasoning config or a tighter
+        # output limit.  max_tokens is the session budget, but capped to the
+        # ~25% window slice Phase 2 reserved above — the same bound the main
+        # turn puts on its response reserve (``_remaining_token_budget``).
+        # That honors a tighter registry max_tokens while keeping prompt +
+        # output from overflowing a small context window on strict runtimes
+        # (the old fixed 8192 was exactly this reserve for the 32k default).
         try:
             result = self._utility_completion(
                 [
@@ -16221,7 +16228,8 @@ class ChatSession:
                         ),
                     },
                 ],
-                max_tokens=8192,
+                max_tokens=min(self.max_tokens, self.context_window // 4),
+                reasoning_effort=self.reasoning_effort,
             )
             answer = result.content or ""
             if not answer:


### PR DESCRIPTION
## Summary

The `web_fetch` URL-extraction completion hard-coded `max_tokens=8192` and rode `_utility_completion`'s `reasoning_effort="low"` default. On local-inference models whose model-registry entry advertises a tighter output limit or a different reasoning config, forcing those constants kept breaking the call. This inherits the operator's per-model settings instead — the same knobs the main turn uses.

## Change

`_exec_web_fetch` (Phase 3) now passes:

- **`max_tokens=min(self.max_tokens, self.context_window // 4)`** — the session/registry budget, capped to the ~25% output slice Phase 2 already reserves. This matches the main turn's response reserve (`_remaining_token_budget`), so a large operator budget can't push prompt + output past a small context window on strict runtimes. The old fixed `8192` was exactly `32768 // 4`, so this generalizes it rather than changing default-window behavior.
- **`reasoning_effort=self.reasoning_effort`** — inherited rather than forced to `"low"`.
- Temperature was already inherited via `_utility_completion`'s `None` sentinel.

Scope is deliberately just this call site. Title-gen (`_TITLE_MAX_TOKENS`) and compaction (`_summary_output_tokens()`) keep their own purpose-computed, window-aware caps and the protective `"low"` default — only web_fetch's constants were arbitrary.

### Tradeoff (accepted)

A reasoning model configured with a very small `max_tokens` could now spend its budget on reasoning and starve the answer — but that config already hurts the main turn, so this lane simply behaves like it. That is the point of the change.

## Testing

- New `test_web_fetch_extraction_inherits_session_max_tokens_and_effort` — asserts the session `max_tokens`/`reasoning_effort` reach the completion (session `512`/`"high"` vs. the old `8192`/`"low"`).
- New `test_web_fetch_extraction_caps_max_tokens_to_window_reserve` — `context_window=8192`, session `max_tokens=16384` → request capped to `2048`.
- `ruff check` + `ruff format --check` clean; `mypy` (strict) clean.
