### PR TITLE
feat(webui): port SSE overflow-recovery companions to the coordinator pane

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1592,6 +1592,287 @@ def test_coord_connectsse_onerror_preserves_native_reconnect() -> None:
     assert passed, f"coordinator.js connectSSE.onerror regressed: {reason}"
 
 
+# ---------------------------------------------------------------------------
+# Coordinator-pane parity for the SSE overflow-recovery companions (issue #806).
+# The server-side fixes (emit-time batching, _ListenerQueue poison, out-of-band
+# closing) live in SessionUIBase and already cover EVERY SSE stream; these pin
+# the CLIENT-side companions ported into coordinator.js so it stops relying on
+# native reconnect alone — storm guard + degraded catch-up, close-on-hide /
+# replay-on-show, and drop-vs-render-wedge counters.
+# ---------------------------------------------------------------------------
+
+
+def test_coord_imports_shared_overflow_helpers() -> None:
+    """coordinator.js consumes the SAME sse_overflow.js helpers as the
+    interactive pane (over the /shared mount) so the trip threshold and cooldown
+    ladder cannot drift between the two surfaces."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    m = re.search(
+        r"import \{([^}]*)\} from \"/shared/sse_overflow\.js\";",
+        body,
+        re.S,
+    )
+    assert m is not None, "coordinator must import the shared overflow helpers"
+    imported = m.group(1)
+    for name in (
+        "OVERFLOW_TRIP_COUNT",
+        "OVERFLOW_TRIP_WINDOW_MS",
+        "DEGRADED_COOLDOWN_BASE_MS",
+        "DEGRADED_COOLDOWN_MAX_MS",
+        "DEGRADED_COOLDOWN_RESET_MS",
+        "overflowWindowTripped",
+        "degradedCooldownStep",
+    ):
+        assert name in imported, f"{name} must be imported from /shared/sse_overflow.js"
+    # No local fork of the extracted pure functions on the coordinator side.
+    assert not re.search(r"^\s*function overflowWindowTripped\(", body, re.M)
+    assert not re.search(r"^\s*function degradedCooldownStep\(", body, re.M)
+
+
+def test_coord_stream_overflow_case_counts_and_rate_limits() -> None:
+    """The coordinator handles the id-less ``stream_overflow`` frame: count it
+    (drop-vs-wedge field instrumentation) and feed the rolling-window storm
+    guard, exactly like the interactive pane."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    assert 'case "stream_overflow":' in body
+    assert "noteStreamOverflow();" in body
+    # The three-way health counter distinguishes dropped events (overflow /
+    # malformed frame) from render wedges (dispatch / render throw).
+    assert "streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 }" in body
+    assert "streamHealth.overflows += 1;" in body
+    assert "streamHealth.malformedFrames += 1;" in body
+    # Exactly two render-throw increment sites: the noteRenderThrow helper
+    # (all three contained render/finalize catches route through it — they
+    # recover with a plain-text fallback, so console.warn) and the onmessage
+    # dispatch catch (console.error class — the event is dropped outright).
+    # The three recovered call sites are pinned by label so a new render path
+    # that forgets to count surfaces loudly.
+    assert body.count("streamHealth.renderThrows += 1;") == 2
+    helper = re.search(r"function noteRenderThrow\(where, err\)\s*\{(.*?)\n  \}", body, re.S)
+    assert helper is not None, "noteRenderThrow helper not found"
+    assert "streamHealth.renderThrows += 1;" in helper.group(1)
+    assert 'noteRenderThrow("streamingRender", e);' in body
+    assert 'noteRenderThrow("in_progress_snapshot render", e);' in body
+    assert 'noteRenderThrow("streamingRenderFinalize", e);' in body
+    note = re.search(r"function noteStreamOverflow\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert note is not None, "noteStreamOverflow not found"
+    assert "overflowWindowTripped(" in note.group(1)
+    assert "enterDegradedCatchup()" in note.group(1)
+    # The trip handler only counts + trips; the cooldown reset lives in
+    # enterDegradedCatchup (keyed off lastDegradedAt) — the finding [0] shape.
+    assert "degradedCooldownMs" not in note.group(1), (
+        "noteStreamOverflow must not touch the cooldown — that reset defeated the ladder escalation"
+    )
+
+
+def test_coord_handleevent_dispatch_is_wedge_guarded() -> None:
+    """A throw escaping onmessage does NOT close the EventSource, so an
+    unguarded handler throw left the streaming refs stale and wedged every later
+    turn.  The coordinator wraps the dispatch and counts the throw (render-wedge
+    class) so a field report tells it apart from a dropped-events gap."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    m = re.search(r"try \{\s*handleEvent\(data\);\s*\} catch \(err\) \{(.*?)\}", body, re.S)
+    assert m is not None, "handleEvent(data) must be wrapped in try/catch in onmessage"
+    assert "streamHealth.renderThrows += 1;" in m.group(1)
+
+
+def test_coord_degraded_catchup_stops_live_stream_and_retries() -> None:
+    """Three overflow closes inside the window drop the coordinator to a
+    degraded catch-up: suspend the live stream, say so plainly, and reconnect
+    after a doubling cooldown — the reconnect replays the gap (or falls to the
+    /history floor once it outgrows the ring)."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    m = re.search(r"function enterDegradedCatchup\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert m is not None, "enterDegradedCatchup not found"
+    method = m.group(1)
+    assert "degradedCooldownStep(" in method
+    assert "lastDegradedAt = now" in method
+    # Suspend the stream BEFORE arming the retry timer (mirrors interactive's
+    # disconnect-then-rearm ordering) or the fresh timer is cancelled at once.
+    assert method.index("suspendStream()") < method.index("degradedTimer = setTimeout")
+    # Plain-language status, not a silent stall.
+    assert "catching up" in method
+    # A fresh connect must cancel a pending degraded timer so it can't
+    # double-open behind the retry — connectSSE's prologue routes through the
+    # shared closeStreamTransport teardown, which owns that clear (alongside
+    # the reconnect timer + the EventSource close/null).
+    conn = re.search(r"function connectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert conn is not None
+    assert "closeStreamTransport();" in conn.group(1)
+    teardown = re.search(r"function closeStreamTransport\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert teardown is not None, "closeStreamTransport not found"
+    assert "clearTimeout(degradedTimer)" in teardown.group(1)
+    assert "clearTimeout(reconnectTimer)" in teardown.group(1)
+    assert "evtSource = null;" in teardown.group(1)
+
+
+def test_coord_visibilitychange_closes_on_hide_reconnects_on_show() -> None:
+    """A hidden tab's throttled drain is the worst-case slow SSE consumer.  The
+    coordinator installs a visibilitychange handler that closes the stream on
+    hide (marking its OWN close via hiddenDisconnect) and reconnects on show from
+    the saved lastEventId, and removes the listener on teardown."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    assert 'document.addEventListener("visibilitychange", visHandler);' in body
+    assert 'document.removeEventListener("visibilitychange", visHandler);' in body
+    vis = re.search(r"function onVisibilityChange\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert vis is not None, "onVisibilityChange not found"
+    method = vis.group(1)
+    assert "document.hidden" in method
+    assert "suspendStream()" in method
+    assert "hiddenDisconnect = true;" in method
+    assert "else if (hiddenDisconnect)" in method
+    assert "connectSSE();" in method
+
+
+def test_coord_connectsse_defers_open_when_tab_hidden() -> None:
+    """connectSSE must never open an EventSource into a hidden tab — the single
+    chokepoint that also backstops a FIRST connect in a background tab (where the
+    close-on-hide handler never fires because there was no open stream).  It
+    marks hiddenDisconnect so the show edge owns the reconnect, marks the
+    deferral as a GAP (markStreamGap) so the eventual open runs the post-gap
+    recovery — without the mark a pane first opened in a background tab
+    silently missed every child/task created while hidden — and reports an
+    honest paused status instead of pinning "connecting" with no attempt in
+    flight."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    conn = re.search(r"function connectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert conn is not None
+    method = conn.group(1)
+    guard = method.index("if (document.hidden)")
+    open_idx = method.index("new EventSource(")
+    assert guard < open_idx, "the hidden guard must precede new EventSource"
+    head = method[guard:open_idx]
+    assert "markStreamGap();" in head, "the hidden deferral must count as a stream gap"
+    assert "hiddenDisconnect = true;" in head
+    assert "return;" in head
+    assert 'setSseStatus("paused' in head, "the deferral must report paused, not connecting"
+    # "connecting" is claimed only once an attempt actually starts — after
+    # the hidden guard, immediately before the EventSource construction.
+    connecting = method.index('setSseStatus("connecting')
+    assert guard < connecting < open_idx
+
+
+def test_coord_destroy_removes_visibility_handler_and_stream_transport() -> None:
+    """Teardown must detach the document-level visibilitychange listener (it
+    holds a strong ref to the closure) and tear down the stream transport —
+    closeStreamTransport closes the EventSource and cancels the reconnect +
+    degraded retry timers (pinned in the degraded-catchup test) — or a
+    destroyed pane leaks and a show edge / pending retry reopens its stream."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    d = re.search(r"function destroy\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert d is not None, "destroy not found"
+    method = d.group(1)
+    assert "removeVisibilityHandler();" in method
+    assert "closeStreamTransport();" in method
+
+
+def test_coord_close_session_detaches_visibility_reopen() -> None:
+    """coordCloseSession suspends the stream AND removes the visibilitychange
+    handler BEFORE awaiting the /close POST: a tab hide→show while the POST is
+    in flight must not reopen a stream against the workstream the server is
+    tearing down (404 / reconnect churn against a dead session).  The failure
+    paths resume via connectSSE, which reinstalls the handler at its
+    install-once chokepoint — so close-on-hide survives a failed close."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    m = re.search(r"async function coordCloseSession\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert m is not None, "coordCloseSession not found"
+    method = m.group(1)
+    suspend = method.index("suspendStream();")
+    unhook = method.index("removeVisibilityHandler();")
+    # The quoted URL fragment, not the bare word (comments mention /close too).
+    post = method.index('"/close"')
+    assert suspend < post, "stream suspension must precede the /close POST"
+    assert unhook < post, "visibility detach must precede the /close POST"
+    assert "resumeSse()" in method
+
+
+def test_coord_post_gap_sidebar_refresh_is_replay_aware() -> None:
+    """The replace-mode children/tasks refresh (a sidebar rebuild) must NOT
+    fire on every reconnect: child_ws_* / task-mutating events are ordinary
+    ring-buffer entries, so a cursor reconnect (replay_ok) redelivers them and
+    the sidebar heals through the normal handlers — a momentary blur→focus
+    under close-on-hide must not rebuild the sidebar.  The refresh fires
+    exactly when the replay cannot vouch for the gap: no resume cursor or an
+    over-threshold gap at onopen, or the server's replay_truncated envelope
+    (ring evicted), deduped per open via gapRefreshedAtOpen."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    conn = re.search(r"function connectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert conn is not None
+    method = conn.group(1)
+    gate = re.search(
+        r"wasReconnecting &&\s*\(lastEventId == null \|\| gapMs > GAP_REFRESH_THRESHOLD_MS\)",
+        method,
+    )
+    assert gate is not None, "onopen must gate the sidebar refresh on replay coverage"
+    assert "refreshSidebarAfterGap();" in method
+    assert "gapRefreshedAtOpen = true;" in method
+    # The ring-evicted signal triggers the same refresh (deduped per open).
+    trunc = re.search(r'case "replay_truncated":(.*?)break;', body, re.S)
+    assert trunc is not None, "replay_truncated case not found"
+    assert "refreshSidebarAfterGap()" in trunc.group(1)
+    assert "gapRefreshedAtOpen" in trunc.group(1)
+    # Deliberate suspends (hide / overflow / close-session) mark the gap so
+    # the next open participates in the recovery decision at all.
+    sus = re.search(r"function suspendStream\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert sus is not None, "suspendStream not found"
+    assert "markStreamGap();" in sus.group(1)
+    # The refresh helper carries the whole replace-mode bundle: children,
+    # tasks, and the live-badge purge (permanent 403/404 entries preserved).
+    ref = re.search(r"function refreshSidebarAfterGap\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert ref is not None, "refreshSidebarAfterGap not found"
+    assert "loadChildren({ replace: true });" in ref.group(1)
+    assert "loadTasks();" in ref.group(1)
+    assert "_liveBadgeCacheDelete(id)" in ref.group(1)
+
+
+def test_coord_defers_truncated_resync_and_consumes_at_idle() -> None:
+    """replay_truncated seen mid-stream must be DEFERRED, not dropped (matches
+    interactive's _pendingTruncatedResync): refetching immediately would detach
+    the live bubble (content OR a reasoning-only one), but skipping outright
+    leaves the ring-evicted turns lost for the session.  The guard covers both
+    streaming targets and latches otherwise; the next state_change=idle consumes
+    the flag — which also repairs a turn stranded by close-on-hide (stream_end
+    evicted while hidden), resetting the streaming refs first since
+    refetchHistory does not null them."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    trunc = re.search(r'case "replay_truncated":(.*?)break;', body, re.S)
+    assert trunc is not None, "replay_truncated case not found"
+    t = trunc.group(1)
+    assert "if (!currentAssistantEl && !currentReasoningEl)" in t
+    assert "refetchHistory();" in t
+    assert "pendingTruncatedResync = true;" in t
+    st = re.search(r'case "state_change":(.*?)\n      case ', body, re.S)
+    assert st is not None, "state_change case not found"
+    s = st.group(1)
+    assert "if (pendingTruncatedResync)" in s
+    assert "pendingTruncatedResync = false;" in s
+    assert "currentAssistantEl = null;" in s
+    assert "refetchHistory();" in s
+    # Consume the latch, THEN reset the dangling refs and refetch.
+    consume = s.index("pendingTruncatedResync = false;")
+    refetch = s.index("refetchHistory();")
+    assert consume < refetch
+
+
+def test_coord_detects_server_restart_by_backwards_event_id() -> None:
+    """A coordinator process restart resets the per-ws event counter, and the
+    replay path reports replay_ok for a stale-high cursor (past the new max), so
+    the gap is unsignalled and the sidebar goes stale.  onmessage catches it: a
+    live event id below the saved cursor == the counter reset → pull
+    authoritative sidebar state (deduped per open against onopen's refresh),
+    checked BEFORE the cursor is overwritten."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    m = re.search(r"evtSource\.onmessage = function \(event\) \{(.*?)\n    \};", body, re.S)
+    assert m is not None, "onmessage handler not found"
+    handler = m.group(1)
+    assert "Number(evtSource.lastEventId) < Number(lastEventId)" in handler
+    assert "!gapRefreshedAtOpen" in handler
+    assert "refreshSidebarAfterGap();" in handler
+    check = handler.index("Number(evtSource.lastEventId) < Number(lastEventId)")
+    overwrite = handler.index("lastEventId = evtSource.lastEventId;")
+    assert check < overwrite
+
+
 def test_interactive_history_is_rest_first_not_sse() -> None:
     """PR A converged interactive onto coord's REST-first history
     model: first paint and post-rewind re-render fetch ``GET /history``

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -522,116 +522,41 @@ def test_no_global_sse_gap_detector() -> None:
     )
 
 
-def test_overflow_window_tripped_runtime() -> None:
-    """Runtime probe for the limiter's rolling-window helper — the
-    storm-guard math is the part of Fix A the design review marked
-    UNCONFIRMED, so it gets executed, not just string-pinned: prunes
-    stale entries in place, trips at exactly K-in-window, and does not
-    trip for closes spread wider than the window."""
-    import json
-    import os
-    import subprocess
-    import tempfile
-
-    import pytest
-
+def test_overflow_helpers_extracted_to_shared_module() -> None:
+    """The storm-guard constants + the two pure helpers were extracted to the
+    shared ``sse_overflow.js`` module (its own runtime probes live in
+    ``test_sse_overflow_js.py``) so the interactive and coordinator panes can't
+    drift.  Pin that the pane IMPORTS them rather than re-declaring a local
+    copy: a stray local ``function overflowWindowTripped`` / ``const
+    OVERFLOW_TRIP_COUNT`` would silently fork the trip math again."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     m = re.search(
-        r"^function overflowWindowTripped\(times, nowMs, count, windowMs\) \{.*?^\}",
+        r"import \{([^}]*)\} from \"\./sse_overflow\.js\";",
         body,
-        re.S | re.M,
+        re.S,
     )
-    assert m is not None, "overflowWindowTripped not found (keep it a module-level function)"
-    harness = (
-        m.group(0)
-        + "\n"
-        + "// trips at exactly count-in-window\n"
-        + "let t = [1000, 2000, 3000];\n"
-        + "if (!overflowWindowTripped(t, 3000, 3, 60000)) throw new Error('K-in-window must trip');\n"
-        + "// stale entries prune in place and prevent the trip\n"
-        + "t = [1000, 2000, 70000];\n"
-        + "if (overflowWindowTripped(t, 70000, 3, 60000)) throw new Error('stale entries must not trip');\n"
-        + "if (JSON.stringify(t) !== '[70000]') throw new Error('prune in place failed: ' + JSON.stringify(t));\n"
-        + "// boundary: an entry exactly windowMs old is still counted\n"
-        + "t = [10000, 70000];\n"
-        + "if (!overflowWindowTripped(t, 70000, 2, 60000)) throw new Error('boundary entry must count');\n"
-        + "// below threshold never trips\n"
-        + "t = [];\n"
-        + "if (overflowWindowTripped(t, 1, 1, 60000) !== false) throw new Error('empty must not trip');\n"
+    assert m is not None, "interactive pane must import the shared overflow helpers"
+    imported = m.group(1)
+    for name in (
+        "OVERFLOW_TRIP_COUNT",
+        "OVERFLOW_TRIP_WINDOW_MS",
+        "DEGRADED_COOLDOWN_BASE_MS",
+        "DEGRADED_COOLDOWN_MAX_MS",
+        "DEGRADED_COOLDOWN_RESET_MS",
+        "overflowWindowTripped",
+        "degradedCooldownStep",
+    ):
+        assert name in imported, f"{name} must be imported from sse_overflow.js"
+    # No local fork of the extracted definitions.
+    assert not re.search(r"^function overflowWindowTripped\(", body, re.M), (
+        "overflowWindowTripped must be imported, not re-declared locally"
     )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
-        f.write(harness)
-        tmp = f.name
-    try:
-        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
-    except FileNotFoundError:
-        pytest.skip("node binary not available on PATH")
-    finally:
-        os.unlink(tmp)
-    assert proc.returncode == 0, (
-        f"overflowWindowTripped runtime probe failed. stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert not re.search(r"^function degradedCooldownStep\(", body, re.M), (
+        "degradedCooldownStep must be imported, not re-declared locally"
     )
-    assert json.dumps  # keep the import shape consistent with test_app_js probes
-
-
-def test_degraded_cooldown_ladder_escalates_and_resets_runtime() -> None:
-    """Review finding [0] regression: the degraded-catchup cooldown ladder
-    must actually ESCALATE across consecutive trips (15→30→60→120s, capped)
-    and reset to base only after a genuine quiet gap.  The original bug
-    cleared _overflowTimes in _enterDegradedCatchup, so _noteStreamOverflow's
-    empty-window check reset the cooldown to base on every storm's first
-    overflow and the doubling never took effect.  The fix keys the ladder off
-    a last-trip timestamp via the pure degradedCooldownStep helper, exercised
-    here directly."""
-    import json
-    import os
-    import subprocess
-    import tempfile
-
-    import pytest
-
-    body = _INTERACTIVE.read_text(encoding="utf-8")
-    m = re.search(
-        r"^function degradedCooldownStep\(.*?\) \{.*?^\}",
-        body,
-        re.S | re.M,
+    assert not re.search(r"^const OVERFLOW_TRIP_COUNT\s*=", body, re.M), (
+        "the trip constants must be imported, not re-declared locally"
     )
-    assert m is not None, "degradedCooldownStep not found (keep it a module-level function)"
-    harness = (
-        m.group(0)
-        + "\n"
-        + "const BASE=15000, MAX=120000, RESET=300000;\n"
-        + "function assert(c,msg){ if(!c) throw new Error(msg); }\n"
-        + "// First trip: gap since lastTrip(0) exceeds RESET -> base, next doubles.\n"
-        + "let s = degradedCooldownStep(BASE, 0, 1000000, BASE, MAX, RESET);\n"
-        + "assert(s.cooldown===15000, 'first trip cooldown '+s.cooldown);\n"
-        + "assert(s.nextCooldownMs===30000, 'first next '+s.nextCooldownMs);\n"
-        + "// Second trip recurs within RESET -> escalates (uses the doubled prev).\n"
-        + "s = degradedCooldownStep(30000, 1000000, 1030000, BASE, MAX, RESET);\n"
-        + "assert(s.cooldown===30000, 'second trip must ESCALATE not reset, got '+s.cooldown);\n"
-        + "assert(s.nextCooldownMs===60000, 'second next '+s.nextCooldownMs);\n"
-        + "// Third + fourth keep escalating and cap at MAX.\n"
-        + "s = degradedCooldownStep(60000, 1030000, 1060000, BASE, MAX, RESET);\n"
-        + "assert(s.cooldown===60000 && s.nextCooldownMs===120000, 'third '+JSON.stringify(s));\n"
-        + "s = degradedCooldownStep(120000, 1060000, 1090000, BASE, MAX, RESET);\n"
-        + "assert(s.cooldown===120000 && s.nextCooldownMs===120000, 'fourth must cap at MAX '+JSON.stringify(s));\n"
-        + "// A quiet gap longer than RESET resets the ladder to base.\n"
-        + "s = degradedCooldownStep(120000, 1090000, 1090000+RESET+1, BASE, MAX, RESET);\n"
-        + "assert(s.cooldown===15000, 'quiet gap must reset to base, got '+s.cooldown);\n"
-    )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
-        f.write(harness)
-        tmp = f.name
-    try:
-        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
-    except FileNotFoundError:
-        pytest.skip("node binary not available on PATH")
-    finally:
-        os.unlink(tmp)
-    assert proc.returncode == 0, (
-        f"degradedCooldownStep escalation probe failed. stderr={proc.stderr!r}"
-    )
-    assert json.dumps
 
 
 def test_note_stream_overflow_does_not_reset_cooldown() -> None:

--- a/tests/test_sse_overflow_js.py
+++ b/tests/test_sse_overflow_js.py
@@ -1,0 +1,140 @@
+"""Static + runtime guards for the shared SSE overflow-recovery helper.
+
+``turnstone/shared_static/sse_overflow.js`` is the client half of the SSE
+overflow recovery — the storm-guard threshold, the cooldown-ladder constants,
+and the two pure helpers (``overflowWindowTripped`` / ``degradedCooldownStep``)
+— extracted so BOTH the interactive pane (``shared_static/interactive.js``) and
+the coordinator pane (``console/static/coordinator/coordinator.js``) share one
+source of truth for the trip math instead of drifting copies.  The panes keep
+their own transport/DOM glue; only the pure core lives here.
+
+Like the rest of the WebUI the module has no JS test framework, so these are
+Python-side string-presence assertions plus two ``node`` runtime probes that
+execute the extracted pure functions — the storm-guard math is the part the
+design review marked UNCONFIRMED, so it gets run, not just string-pinned.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SSE_OVERFLOW = _ROOT / "turnstone/shared_static/sse_overflow.js"
+
+
+def test_module_exports_constants_and_pure_helpers() -> None:
+    """The single source of truth exports the five tuning constants and the two
+    pure helpers.  Both panes import these by name (pinned in their own suites),
+    so a rename here is a breaking change that must surface loudly."""
+    body = _SSE_OVERFLOW.read_text(encoding="utf-8")
+    for const, value in (
+        ("OVERFLOW_TRIP_COUNT", "3"),
+        ("OVERFLOW_TRIP_WINDOW_MS", "60000"),
+        ("DEGRADED_COOLDOWN_BASE_MS", "15000"),
+        ("DEGRADED_COOLDOWN_MAX_MS", "120000"),
+        ("DEGRADED_COOLDOWN_RESET_MS", "300000"),
+    ):
+        assert f"export const {const} = {value};" in body, f"missing export const {const}"
+    assert "export function overflowWindowTripped(" in body
+    assert "export function degradedCooldownStep(" in body
+
+
+def test_overflow_window_tripped_runtime() -> None:
+    """Runtime probe for the limiter's rolling-window helper — the storm-guard
+    math is the part of Fix A the design review marked UNCONFIRMED, so it gets
+    executed, not just string-pinned: prunes stale entries in place, trips at
+    exactly K-in-window, and does not trip for closes spread wider than the
+    window."""
+    body = _SSE_OVERFLOW.read_text(encoding="utf-8")
+    m = re.search(
+        r"^export function overflowWindowTripped\(times, nowMs, count, windowMs\) \{.*?^\}",
+        body,
+        re.S | re.M,
+    )
+    assert m is not None, "overflowWindowTripped not found (keep it a module-level export)"
+    harness = (
+        m.group(0)
+        + "\n"
+        + "// trips at exactly count-in-window\n"
+        + "let t = [1000, 2000, 3000];\n"
+        + "if (!overflowWindowTripped(t, 3000, 3, 60000)) throw new Error('K-in-window must trip');\n"
+        + "// stale entries prune in place and prevent the trip\n"
+        + "t = [1000, 2000, 70000];\n"
+        + "if (overflowWindowTripped(t, 70000, 3, 60000)) throw new Error('stale entries must not trip');\n"
+        + "if (JSON.stringify(t) !== '[70000]') throw new Error('prune in place failed: ' + JSON.stringify(t));\n"
+        + "// boundary: an entry exactly windowMs old is still counted\n"
+        + "t = [10000, 70000];\n"
+        + "if (!overflowWindowTripped(t, 70000, 2, 60000)) throw new Error('boundary entry must count');\n"
+        + "// below threshold never trips\n"
+        + "t = [];\n"
+        + "if (overflowWindowTripped(t, 1, 1, 60000) !== false) throw new Error('empty must not trip');\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(harness)
+        tmp = f.name
+    try:
+        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
+    assert proc.returncode == 0, (
+        f"overflowWindowTripped runtime probe failed. stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+
+
+def test_degraded_cooldown_ladder_escalates_and_resets_runtime() -> None:
+    """Review finding [0] regression: the degraded-catchup cooldown ladder must
+    actually ESCALATE across consecutive trips (15→30→60→120s, capped) and reset
+    to base only after a genuine quiet gap.  The original bug cleared the
+    overflow-window array in the trip handler, so the empty-window check reset
+    the cooldown to base on every storm's first overflow and the doubling never
+    took effect.  The fix keys the ladder off a last-trip timestamp via the pure
+    degradedCooldownStep helper, exercised here directly."""
+    body = _SSE_OVERFLOW.read_text(encoding="utf-8")
+    m = re.search(
+        r"^export function degradedCooldownStep\(.*?\) \{.*?^\}",
+        body,
+        re.S | re.M,
+    )
+    assert m is not None, "degradedCooldownStep not found (keep it a module-level export)"
+    harness = (
+        m.group(0)
+        + "\n"
+        + "const BASE=15000, MAX=120000, RESET=300000;\n"
+        + "function assert(c,msg){ if(!c) throw new Error(msg); }\n"
+        + "// First trip: gap since lastTrip(0) exceeds RESET -> base, next doubles.\n"
+        + "let s = degradedCooldownStep(BASE, 0, 1000000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===15000, 'first trip cooldown '+s.cooldown);\n"
+        + "assert(s.nextCooldownMs===30000, 'first next '+s.nextCooldownMs);\n"
+        + "// Second trip recurs within RESET -> escalates (uses the doubled prev).\n"
+        + "s = degradedCooldownStep(30000, 1000000, 1030000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===30000, 'second trip must ESCALATE not reset, got '+s.cooldown);\n"
+        + "assert(s.nextCooldownMs===60000, 'second next '+s.nextCooldownMs);\n"
+        + "// Third + fourth keep escalating and cap at MAX.\n"
+        + "s = degradedCooldownStep(60000, 1030000, 1060000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===60000 && s.nextCooldownMs===120000, 'third '+JSON.stringify(s));\n"
+        + "s = degradedCooldownStep(120000, 1060000, 1090000, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===120000 && s.nextCooldownMs===120000, 'fourth must cap at MAX '+JSON.stringify(s));\n"
+        + "// A quiet gap longer than RESET resets the ladder to base.\n"
+        + "s = degradedCooldownStep(120000, 1090000, 1090000+RESET+1, BASE, MAX, RESET);\n"
+        + "assert(s.cooldown===15000, 'quiet gap must reset to base, got '+s.cooldown);\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(harness)
+        tmp = f.name
+    try:
+        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
+    assert proc.returncode == 0, (
+        f"degradedCooldownStep escalation probe failed. stderr={proc.stderr!r}"
+    )

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -41,6 +41,15 @@ import {
   indexLabel,
 } from "/shared/conversation.js";
 import { redactCredentials } from "/shared/redact_credentials.js";
+import {
+  OVERFLOW_TRIP_COUNT,
+  OVERFLOW_TRIP_WINDOW_MS,
+  DEGRADED_COOLDOWN_BASE_MS,
+  DEGRADED_COOLDOWN_MAX_MS,
+  DEGRADED_COOLDOWN_RESET_MS,
+  overflowWindowTripped,
+  degradedCooldownStep,
+} from "/shared/sse_overflow.js";
 
 function buildCoordChrome(root, opts) {
   opts = opts || {};
@@ -430,15 +439,40 @@ function createCoordinatorPane(root, wsId, opts) {
 
   let evtSource = null;
   let reconnectAttempts = 0;
-  // Flag set in onerror, cleared in onopen.  Drives the "did we
-  // just recover from a gap?" decision in onopen so the replace-
-  // mode refresh of children/tasks/wait/badge caches fires on
-  // every reconnect — including the common case where native
-  // EventSource auto-reconnect handles the underlying SSE transition
-  // without scheduleReconnect running (which used to be the only
-  // place reconnectAttempts incremented; that path is rarely hit
-  // now that native reconnect handles transient errors).
-  let disconnectedSinceLastOpen = false;
+  // Wall-clock start of the CURRENT gap (0 = no gap in progress).  Stamped by
+  // markStreamGap (from onerror and every deliberate suspend), cleared by
+  // onopen.  A non-zero value IS the "did we just recover from a gap?" flag
+  // that drives onopen's replace-mode children/tasks/badge refresh — no
+  // separate boolean is kept in lockstep with it.  Kept at the EARLIEST mark
+  // so repeated onerror fires during one outage don't shrink the measured gap.
+  // (The scheduleReconnect-after-CLOSED path bumps reconnectAttempts instead;
+  // wasReconnecting ORs the two — that path is rarely hit now that native
+  // reconnect handles transient errors.)
+  let disconnectedAt = 0;
+  // Reconnect-replay trust window for the sidebar.  child_ws_* / task events
+  // are ordinary ring-buffer entries, so a cursor reconnect (replay_ok)
+  // redelivers them and the sidebar heals without any REST refetch; gaps the
+  // ring could NOT cover announce themselves via replay_truncated.  The one
+  // blind spot is a stale cursor the server no longer recognises (process
+  // restart resets event ids; the empty/reset ring reports replay_ok and
+  // silently skips the gap).  Past this gap length we stop trusting the cursor
+  // and pull authoritative /children + /tasks state; a FASTER restart (under
+  // the threshold) is caught instead by the backwards-event-id check in
+  // onmessage (a live id below our saved cursor == the counter reset).
+  // Momentary blur/focus cycles stay well below the threshold — no rebuild
+  // flicker on an alt-tab.
+  const GAP_REFRESH_THRESHOLD_MS = 60000;
+  // True when THIS connection's onopen already ran refreshSidebarAfterGap —
+  // lets the replay_truncated handler (first frame after open) skip a
+  // back-to-back duplicate of the refresh it would otherwise trigger.
+  let gapRefreshedAtOpen = false;
+  // Set when replay_truncated arrives while a turn is mid-stream (refetching
+  // then would detach the live bubble); consumed on the next state_change=idle.
+  // Mirrors interactive.js's _pendingTruncatedResync — the deferral keeps a
+  // ring-evicted gap from going unrepaired for the rest of the session, and
+  // also catches a turn stranded by close-on-hide (finished while hidden, its
+  // stream_end evicted before the show-edge reconnect).
+  let pendingTruncatedResync = false;
   // Saved high-water mark for the manual-reconnect path.  The
   // EventSource constructor can't set custom headers, so when we
   // construct a fresh source we thread ``?last_event_id=N`` instead
@@ -449,6 +483,28 @@ function createCoordinatorPane(root, wsId, opts) {
   // close).
   let lastEventId = null;
   let reconnectTimer = null;
+  // --- SSE overflow-recovery state (client half — mirrors interactive.js) ---
+  // Field instrumentation for the two distinct "output stops while the backend
+  // is healthy" causes: server-signalled overflow closes (dropped-events
+  // class) vs client dispatch/render throws (wedge class).  The console line
+  // at each increment carries the running count, so a field report shows which
+  // class fired without a debugger attached.
+  const streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 };
+  // Rolling timestamps of stream_overflow closes feeding the degraded-catchup
+  // limiter (overflowWindowTripped); plus the cooldown-ladder state, keyed off
+  // the last-trip timestamp via degradedCooldownStep — never off overflowTimes
+  // (enterDegradedCatchup clears it each trip).  See enterDegradedCatchup.
+  const overflowTimes = [];
+  let degradedTimer = null;
+  let degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
+  let lastDegradedAt = 0;
+  // Close-on-hide / replay-on-show bookkeeping.  A hidden tab's throttled event
+  // loop is the likeliest too-slow SSE consumer, so the visibilitychange
+  // handler closes the stream on hide and reconnects with the saved lastEventId
+  // on show (replay_ok covers the gap).  hiddenDisconnect marks that WE closed
+  // for hide, so show never resurrects a stream closed deliberately elsewhere.
+  let visHandler = null;
+  let hiddenDisconnect = false;
   // Ids of operator-context system turns already painted from /history.  A
   // later SSE replay that redelivers one (resume-cursor overlap) is skipped
   // by the system_turn handler — reset per refetchHistory.  Mirrors
@@ -1681,7 +1737,7 @@ function createCoordinatorPane(root, wsId, opts) {
       try {
         streamingRender(body, currentAssistantBuf);
       } catch (e) {
-        console.warn("coordinator streamingRender failed", e);
+        noteRenderThrow("streamingRender", e);
         body.textContent = currentAssistantBuf;
       }
     } else if (body) {
@@ -1719,7 +1775,7 @@ function createCoordinatorPane(root, wsId, opts) {
         try {
           streamingRenderFinalize(body, currentAssistantBuf);
         } catch (e) {
-          console.warn("coordinator streamingRenderFinalize failed", e);
+          noteRenderThrow("streamingRenderFinalize", e);
         }
       }
     }
@@ -2090,11 +2146,13 @@ function createCoordinatorPane(root, wsId, opts) {
       }
     };
     try {
-      if (evtSource) evtSource.close();
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
+      suspendStream();
+      // Session teardown owns the stream from here: a tab hide→show while
+      // the /close POST is in flight must NOT reopen a stream against the
+      // workstream the server is tearing down (404 / reconnect churn against
+      // a dead session).  connectSSE reinstalls the handler, so the failure
+      // paths below get close-on-hide back for free via resumeSse.
+      removeVisibilityHandler();
     } catch (_) {
       /* best-effort suspension */
     }
@@ -2184,32 +2242,47 @@ function createCoordinatorPane(root, wsId, opts) {
     }
   }
 
-  function connectSSE() {
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+  // The transport-teardown chokepoint: close + null the EventSource and
+  // cancel BOTH pending retry timers (reconnect backoff + degraded catch-up).
+  // Every teardown path routes through here — connectSSE's redial prologue,
+  // suspendStream (overflow / hide / close-session), destroy — so a new
+  // transport timer gets cancelled in one place instead of by hand at each
+  // call site.  Cancelling the degraded timer on redial also keeps a pending
+  // catch-up retry from firing mid-stream and double-opening;
+  // enterDegradedCatchup re-arms AFTER its own suspend, so this never cancels
+  // the timer it is about to set.  Gap accounting stays OUT of this helper —
+  // a redial is not itself a gap (suspendStream layers markStreamGap on top).
+  function closeStreamTransport() {
     if (evtSource) {
       try {
         evtSource.close();
       } catch (_) {
         /* noop */
       }
+      evtSource = null;
     }
-    setSseStatus("connecting…", "");
-    // Snapshot whether this is a reconnect BEFORE resetting
-    // reconnectAttempts in onopen — child_ws_* events dispatched while
-    // we were disconnected aren't replayed by the events SSE handler,
-    // so the client has to pull authoritative state after any gap.
-    // Snapshot whether this connect attempt follows a prior
-    // disconnect.  Native EventSource auto-reconnect no longer
-    // routes through scheduleReconnect on the transient-error path,
-    // so the legacy ``reconnectAttempts > 0`` check is always false
-    // after PR-D — use ``disconnectedSinceLastOpen`` (set by onerror,
-    // cleared by onopen below) as the authoritative "was-gap" flag.
-    // Falls back to the legacy semantic for the genuinely manual
-    // case (scheduleReconnect-driven reconnect after CLOSED state).
-    const wasReconnecting = disconnectedSinceLastOpen || reconnectAttempts > 0;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (degradedTimer) {
+      clearTimeout(degradedTimer);
+      degradedTimer = null;
+    }
+  }
+
+  function connectSSE() {
+    closeStreamTransport();
+    // Snapshot whether this connect attempt follows a prior disconnect
+    // BEFORE onopen resets the flags — onopen's post-gap sidebar recovery
+    // keys off it.  Native EventSource auto-reconnect no longer routes
+    // through scheduleReconnect on the transient-error path, so the legacy
+    // ``reconnectAttempts > 0`` check is always false after PR-D — use
+    // ``disconnectedAt`` (stamped by markStreamGap from onerror and from every
+    // deliberate suspend, cleared by onopen below) as the authoritative
+    // "was-gap" flag.  Falls back to the legacy semantic for the genuinely
+    // manual case (scheduleReconnect-driven reconnect after CLOSED state).
+    const wasReconnecting = disconnectedAt !== 0 || reconnectAttempts > 0;
     let url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
     // ``!= null`` (not truthiness): a resume cursor of 0 is valid (the
     // ring buffer's first emitted event is id 1), and a brand-new ws's
@@ -2218,12 +2291,47 @@ function createCoordinatorPane(root, wsId, opts) {
     if (lastEventId != null) {
       url += "?last_event_id=" + encodeURIComponent(lastEventId);
     }
+    // Close-on-hide / replay-on-show: install once per pane, removed by
+    // destroy().  A hidden tab's throttled drain is the likeliest slow consumer
+    // behind a server-side queue overflow, and an idle hidden tab holds a node
+    // connection for nothing — closing on hide removes both, and the saved
+    // lastEventId makes the show-edge reconnect lossless (replay_ok).
+    if (!visHandler) {
+      // onVisibilityChange is a plain closure function (no `this` to bind), so
+      // it serves directly as the once-install sentinel AND the
+      // add/removeEventListener handle — no wrapper needed.
+      visHandler = onVisibilityChange;
+      document.addEventListener("visibilitychange", visHandler);
+    }
+    // Never open an EventSource into a hidden (throttled) tab — including a
+    // FIRST connect in a background tab, where the close-on-hide handler never
+    // fires because there was no open stream to close.  This single connect
+    // chokepoint backstops every caller (init, scheduleReconnect, degraded
+    // retry, show edge); the saved lastEventId + the handler installed just
+    // above make the show-edge reconnect replay the gap.  The deferral IS a
+    // gap — everything until the show edge is missed exactly as if the
+    // transport had dropped — so mark it like one: without the mark, a pane
+    // first opened in a background tab skipped onopen's post-gap recovery and
+    // the sidebar silently missed every child/task the backend created while
+    // hidden.  And say so honestly — "connecting…" (set below, only when an
+    // attempt really starts) used to pin here forever with nothing in flight.
+    if (document.hidden) {
+      markStreamGap();
+      hiddenDisconnect = true;
+      setSseStatus("paused — tab hidden", "");
+      return;
+    }
+    setSseStatus("connecting…", "");
     evtSource = new EventSource(url, { withCredentials: true });
     evtSource.onopen = function () {
       reconnectAttempts = 0;
-      // Clear the "was disconnected" flag now that the gap is
-      // closed.  Future onerror fires will set it again.
-      disconnectedSinceLastOpen = false;
+      // Measure the gap this open just closed, then clear it (disconnectedAt is
+      // the was-gap flag).  A gap with no start stamp (legacy scheduleReconnect
+      // path) reads as Infinity — unknown length means we can't argue the
+      // replay covered it, so refresh below.
+      const gapMs = disconnectedAt ? Date.now() - disconnectedAt : Infinity;
+      disconnectedAt = 0;
+      gapRefreshedAtOpen = false;
       setSseStatus("live", "ok");
       // Lift the disconnected dim treatment + restore the last known
       // counters; the replay phase will overwrite with authoritative
@@ -2236,26 +2344,22 @@ function createCoordinatorPane(root, wsId, opts) {
       statusBarEl.classList.remove("ws-sb-disconnected");
       if (lastStatusEvt) updateStatusBar(lastStatusEvt);
       else StatusBar.resetTokensPlaceholder(sbTokensEl);
-      if (wasReconnecting) {
-        // Replace-mode refresh: the server is authoritative after a
-        // gap; any SSE-only rows the client accumulated before
-        // disconnect are stale.
-        loadChildren({ replace: true });
-        loadTasks();
-        // Drop the live-badge cache too — entries within the 5s TTL
-        // can carry stale pending_approval_details (the child may
-        // have resolved its approval during the SSE gap).  Without
-        // this clear, inline approve/deny buttons could render on
-        // a row whose approval was resolved elsewhere; the next
-        // scheduleLiveFetch from loadChildren's finally branch
-        // (which fires for every visible row) repopulates with
-        // authoritative state. Preserve `permanent: true` entries
-        // (set on 403/404 — denied by permission/identity, not by
-        // state) so a user lacking admin.cluster.inspect doesn't
-        // pay one 403 per denied id on every reconnect.
-        for (const [id, c] of liveBadgeCache) {
-          if (!c || !c.permanent) _liveBadgeCacheDelete(id);
-        }
+      // Post-gap sidebar recovery.  child_ws_* / task-mutating events are
+      // ordinary ring-buffer entries, so a cursor reconnect (replay_ok)
+      // redelivers them and the normal handlers heal the sidebar — no REST
+      // refetch, no replace-mode rebuild flicker on a momentary blur/focus.
+      // Refresh eagerly only when the replay CANNOT vouch for the gap: no
+      // cursor to resume from (the fresh path's synthetic replay carries no
+      // child events), or a gap long enough that a stale cursor could be
+      // lying (see GAP_REFRESH_THRESHOLD_MS).  The ring-evicted case
+      // announces itself — the replay_truncated handler runs the same
+      // refresh on arrival (gapRefreshedAtOpen keeps the two from stacking).
+      if (
+        wasReconnecting &&
+        (lastEventId == null || gapMs > GAP_REFRESH_THRESHOLD_MS)
+      ) {
+        refreshSidebarAfterGap();
+        gapRefreshedAtOpen = true;
       }
     };
     evtSource.onerror = function () {
@@ -2267,7 +2371,7 @@ function createCoordinatorPane(root, wsId, opts) {
       // reconnect, which is exactly the reconnect-with-replay defect
       // PR-D ships to fix.  See
       // tests/test_app_js.py::test_coord_connectsse_onerror_preserves_native_reconnect.
-      disconnectedSinceLastOpen = true;
+      markStreamGap();
       setSseStatus("disconnected", "err");
       // Dim the status bar so a stale reading doesn't read as live.
       statusBarEl.classList.add("ws-sb-disconnected");
@@ -2362,18 +2466,59 @@ function createCoordinatorPane(root, wsId, opts) {
       // doesn't desync the manual-reconnect fallback from native
       // auto-reconnect.
       if (evtSource && evtSource.lastEventId) {
+        // A live event id BELOW our saved cursor means the server's per-ws
+        // event counter reset — a coordinator process restart with a fresh,
+        // empty ring.  The replay path can't flag that (a cursor at/above the
+        // ring's earliest id reports replay_ok even when it's past the new
+        // max), so the gap is silent and the sidebar's pre-restart rows go
+        // stale with nothing to replay them.  Catch it here and pull
+        // authoritative state — deduped per open against onopen's /
+        // replay_truncated's own refresh.  (Gaps that DON'T reset the counter
+        // are handled at onopen by the cursor-trust window.)
+        if (
+          lastEventId != null &&
+          !gapRefreshedAtOpen &&
+          Number(evtSource.lastEventId) < Number(lastEventId)
+        ) {
+          refreshSidebarAfterGap();
+          gapRefreshedAtOpen = true;
+        }
         lastEventId = evtSource.lastEventId;
       }
       let data = null;
       try {
         data = JSON.parse(event.data);
-      } catch (_) {
+      } catch (err) {
+        streamHealth.malformedFrames += 1;
+        console.warn(
+          "coordinator: dropping malformed SSE frame (total " +
+            streamHealth.malformedFrames +
+            ")",
+          err,
+        );
         return;
       }
       // Tag the event with its own SSE id so the system_turn handler can dedup
       // a turn already painted from /history (mirrors ui/static/app.js).
       if (event.lastEventId) data._event_id = event.lastEventId;
-      handleEvent(data);
+      // Guard the dispatch: an exception escaping onmessage does NOT close the
+      // EventSource, so an unhandled throw here leaves the streaming refs stale
+      // and every later turn paints into the poisoned segment — the "output
+      // stops while the backend is healthy" wedge.  Count it (render-throw
+      // class) so a field report tells it apart from a dropped-events gap.
+      try {
+        handleEvent(data);
+      } catch (err) {
+        streamHealth.renderThrows += 1;
+        console.error(
+          "coordinator: handleEvent failed for " +
+            (data && data.type) +
+            " (render-throw total " +
+            streamHealth.renderThrows +
+            ")",
+          err,
+        );
+      }
     };
   }
 
@@ -2382,6 +2527,168 @@ function createCoordinatorPane(root, wsId, opts) {
     const jitter = Math.floor(Math.random() * 500);
     reconnectAttempts += 1;
     reconnectTimer = setTimeout(connectSSE, base + jitter);
+  }
+
+  // ------------------------------------------------------------------
+  // SSE overflow recovery (client half) — mirrors interactive.js.  The
+  // trip threshold + cooldown-ladder math is shared via sse_overflow.js;
+  // the stateful glue below is coupled to this closure's evtSource seam.
+  // ------------------------------------------------------------------
+
+  // Transport-only stream suspension for the overflow / visibility /
+  // close-session paths: the closeStreamTransport teardown WITHOUT the full
+  // destroy() cleanup (observers, task timers), plus gap accounting.
+  // connectSSE re-opens from the saved lastEventId, so this is lossless for
+  // committed turns.
+  function suspendStream() {
+    closeStreamTransport();
+    // A deliberate suspend is still a gap.  The transient-error path marks
+    // it via onerror; the overflow/hide/close-session paths self-close (no
+    // onerror fires after .close()), so mark it here instead.
+    markStreamGap();
+  }
+
+  // Open a gap in the stream's coverage: stamp its wall-clock start, which
+  // doubles as the was-reconnecting flag the next onopen snapshots (see
+  // connectSSE).  Keep the EARLIEST stamp when marks pile up (repeated onerror
+  // fires, hide followed by a deferred connect) so onopen measures the whole
+  // outage, not just its last slice.  onopen clears it.
+  function markStreamGap() {
+    if (!disconnectedAt) disconnectedAt = Date.now();
+  }
+
+  // Replace-mode sidebar re-sync after a gap the reconnect replay could not
+  // (or might not) have covered — the server is authoritative; any SSE-only
+  // child/task rows accumulated before the disconnect are stale.  Two
+  // callers: onopen (no-cursor / over-threshold gaps) and the
+  // replay_truncated handler (ring-evicted gaps).  Ordinary short gaps need
+  // neither — the ring replay redelivers child_ws_* / task events itself.
+  function refreshSidebarAfterGap() {
+    loadChildren({ replace: true });
+    loadTasks();
+    // Drop the live-badge cache too — entries within the 5s TTL can carry
+    // stale pending_approval_details (the child may have resolved its
+    // approval during the SSE gap).  Without this clear, inline approve/deny
+    // buttons could render on a row whose approval was resolved elsewhere;
+    // the next scheduleLiveFetch from loadChildren's finally branch (which
+    // fires for every visible row) repopulates with authoritative state.
+    // Preserve `permanent: true` entries (set on 403/404 — denied by
+    // permission/identity, not by state) so a user lacking
+    // admin.cluster.inspect doesn't pay one 403 per denied id on every
+    // refresh.
+    for (const [id, c] of liveBadgeCache) {
+      if (!c || !c.permanent) _liveBadgeCacheDelete(id);
+    }
+  }
+
+  // Count + log a caught render throw (wedge-class instrumentation).  The
+  // running total rides in the log line so a field report shows which class
+  // fired — dropped events vs render wedge — without a debugger attached.
+  // console.warn, not error: every caller recovers (plain-text fallback or
+  // keeping the already-streamed text).  The onmessage dispatch catch keeps
+  // its own inline increment — that one is console.error (the whole event is
+  // dropped, nothing recovers it) and names the event type.
+  function noteRenderThrow(where, err) {
+    streamHealth.renderThrows += 1;
+    console.warn(
+      "coordinator " +
+        where +
+        " failed (render-throw total " +
+        streamHealth.renderThrows +
+        ")",
+      err,
+    );
+  }
+
+  function noteStreamOverflow() {
+    streamHealth.overflows += 1;
+    const now = Date.now();
+    overflowTimes.push(now);
+    console.warn(
+      "coordinator: server closed the stream after a send-queue overflow " +
+        "(total " +
+        streamHealth.overflows +
+        "); reconnect will replay the gap",
+    );
+    // Trip when OVERFLOW_TRIP_COUNT closes land inside the rolling window.  The
+    // cooldown-ladder reset lives in enterDegradedCatchup (keyed off
+    // lastDegradedAt), NOT here — this only counts and trips.
+    if (
+      overflowWindowTripped(
+        overflowTimes,
+        now,
+        OVERFLOW_TRIP_COUNT,
+        OVERFLOW_TRIP_WINDOW_MS,
+      )
+    ) {
+      enterDegradedCatchup();
+    }
+  }
+
+  function enterDegradedCatchup() {
+    // Repeated overflow closes inside one window: this consumer cannot keep up
+    // with live streaming right now, and each reconnect round just stalls
+    // rendering behind the retry before re-saturating.  Stop the churn: close
+    // the stream, say so in plain language, and come back after a (doubling)
+    // cooldown — that reconnect replays the gap from the server's ring buffer,
+    // or falls to the replay_truncated → /history resync floor once the gap
+    // has outgrown it.  Either path is lossless for committed turns.
+    const now = Date.now();
+    // Escalate the cooldown when trips recur; reset to base only after a
+    // genuine quiet gap.  Keyed off lastDegradedAt (a timestamp), NOT
+    // overflowTimes — this clears that array below, so keying the reset off it
+    // would restart the ladder on the next storm's first overflow and the
+    // doubling (15→30→60→120s) would never take effect.
+    const step = degradedCooldownStep(
+      degradedCooldownMs,
+      lastDegradedAt,
+      now,
+      DEGRADED_COOLDOWN_BASE_MS,
+      DEGRADED_COOLDOWN_MAX_MS,
+      DEGRADED_COOLDOWN_RESET_MS,
+    );
+    lastDegradedAt = now;
+    degradedCooldownMs = step.nextCooldownMs;
+    overflowTimes.length = 0;
+    suspendStream(); // also cancels any earlier degraded timer
+    setSseStatus("catching up…", "err");
+    statusBarEl.classList.add("ws-sb-disconnected");
+    sbTokensEl.textContent = "Connection is slow — catching up…";
+    const cooldown = step.cooldown;
+    degradedTimer = setTimeout(function () {
+      degradedTimer = null;
+      if (document.hidden) {
+        // Reopening into a throttled hidden tab would overflow again — defer to
+        // the visibilitychange show edge instead.
+        hiddenDisconnect = true;
+        return;
+      }
+      connectSSE();
+    }, cooldown);
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      // Closing beats letting the hidden tab's throttled event loop starve the
+      // drain until the server-side queue overflows.  The streaming buffers
+      // (currentAssistantBuf / currentAssistantEl) survive — suspendStream is
+      // transport-only — so the visible tail is intact when the tab returns.
+      if (evtSource) {
+        suspendStream();
+        hiddenDisconnect = true;
+      }
+    } else if (hiddenDisconnect) {
+      hiddenDisconnect = false;
+      connectSSE();
+    }
+  }
+
+  function removeVisibilityHandler() {
+    if (visHandler) {
+      document.removeEventListener("visibilitychange", visHandler);
+      visHandler = null;
+    }
+    hiddenDisconnect = false;
   }
 
   // ------------------------------------------------------------------
@@ -2428,7 +2735,7 @@ function createCoordinatorPane(root, wsId, opts) {
             try {
               streamingRender(abody, currentAssistantBuf);
             } catch (e) {
-              console.warn("coordinator streamingRender failed", e);
+              noteRenderThrow("in_progress_snapshot render", e);
               abody.textContent = currentAssistantBuf;
             }
           } else if (abody) {
@@ -2439,6 +2746,15 @@ function createCoordinatorPane(root, wsId, opts) {
         break;
       case "stream_end":
         finishAssistantStream();
+        break;
+      case "stream_overflow":
+        // The server poisoned this listener at its first queue overflow and
+        // closes the stream right after this id-less frame.  lastEventId still
+        // points below the gap, so native EventSource reconnect replays it
+        // losslessly from the ring buffer.  Count the close: a persistently
+        // slow consumer trips the degraded catch-up instead of churning
+        // reconnects.
+        noteStreamOverflow();
         break;
       case "tool_result":
         appendToolResult(
@@ -2641,6 +2957,24 @@ function createCoordinatorPane(root, wsId, opts) {
         // reset, idle-after-error). Mirrors the interactive pane.
         if (ev.state === "idle" || ev.state === "error") {
           setBusy(false);
+          // Deferred replay_truncated re-sync: the truncation arrived while a
+          // turn was mid-stream (refetching then would have detached the live
+          // bubble), so repair the ring-evicted gap now that the turn is
+          // settled and /history is complete.  Also repairs a turn stranded by
+          // close-on-hide — hidden mid-turn, its stream_end evicted, so the
+          // show-edge replay_truncated latched the flag and the live bubble
+          // never finalized.  Reset the streaming refs first: refetchHistory
+          // replaceChildren()s the DOM but does NOT null them, and a dangling
+          // ref would strand the NEXT turn's tokens into a detached node.
+          // Mirrors interactive.js.
+          if (pendingTruncatedResync) {
+            pendingTruncatedResync = false;
+            currentAssistantEl = null;
+            currentAssistantBuf = "";
+            currentReasoningEl = null;
+            currentReasoningBuf = "";
+            refetchHistory();
+          }
         } else if (
           ev.state === "running" ||
           ev.state === "thinking" ||
@@ -2739,9 +3073,24 @@ function createCoordinatorPane(root, wsId, opts) {
       }
       case "replay_truncated":
         // Reconnect buffer evicted past our last-seen id — re-sync from REST.
-        // Skip mid-stream: in_progress_snapshot already paints the live turn
-        // and a replaceChildren() would detach the streaming bubble.
-        if (!currentAssistantEl) refetchHistory();
+        // Skip while a turn is mid-stream (BOTH a content bubble and a
+        // reasoning-only one are detachable): the recovery floor's
+        // in_progress_snapshot repaints it, and an async refetch's
+        // replaceChildren() would detach the live bubble so deltas render
+        // nowhere.  Mid-stream the resync is DEFERRED, not dropped — skipping
+        // outright left the ring-evicted gap unrepaired for the rest of the
+        // session (no clean reconnect may come for hours); the idle edge
+        // consumes the flag.  Mirrors interactive.js's _pendingTruncatedResync.
+        if (!currentAssistantEl && !currentReasoningEl) {
+          refetchHistory();
+        } else {
+          pendingTruncatedResync = true;
+        }
+        // The evicted slice may have carried child_ws_* / task events the
+        // sidebar will never see replayed — this is the server saying the
+        // gap was NOT covered, so pull authoritative state (unless onopen
+        // already did, milliseconds ago, for this same reconnect).
+        if (!gapRefreshedAtOpen) refreshSidebarAfterGap();
         break;
       case "tool_pending":
         // Early paint — render the batch the instant the model commits to
@@ -4959,10 +5308,8 @@ function createCoordinatorPane(root, wsId, opts) {
   //  login out to every open pane.)
   function onLogin() {
     reconnectAttempts = 0;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    // connectSSE's closeStreamTransport prologue cancels any pending
+    // reconnect / degraded timers before dialling.
     connectSSE();
   }
 
@@ -4970,20 +5317,21 @@ function createCoordinatorPane(root, wsId, opts) {
   // per-instance pane must release the stream + every timer/observer or a
   // backgrounded pane keeps an SSE open and fires renders into detached DOM.
   function destroy() {
-    if (evtSource) {
-      evtSource.close();
-      evtSource = null;
-    }
+    // Stream + both retry timers (reconnect backoff, degraded catch-up).
+    closeStreamTransport();
     [
-      reconnectTimer,
       cancelTimeoutId,
       forceTimeoutId,
       tasksRefreshTimer,
       liveBadgeFlushTimer,
     ].forEach((t) => t && clearTimeout(t));
-    reconnectTimer = cancelTimeoutId = forceTimeoutId = null;
+    cancelTimeoutId = forceTimeoutId = null;
     tasksRefreshTimer = liveBadgeFlushTimer = null;
     if (pruneTimer) clearInterval(pruneTimer);
+    // The document-level visibilitychange listener holds a strong ref to this
+    // closure — leaving it registered would both leak the pane and let a show
+    // edge reopen a stream for a destroyed pane.
+    removeVisibilityHandler();
     if (_childObserver && _childObserver.disconnect)
       _childObserver.disconnect();
   }

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -48,6 +48,15 @@ import { createQueueController } from "./composer_queue.js";
 import { StatusBar } from "./status_bar.js";
 import { streamingRender, streamingRenderFinalize } from "./renderer.js";
 import { setMarkdown, operatorSourceLabel } from "./utils.js";
+import {
+  OVERFLOW_TRIP_COUNT,
+  OVERFLOW_TRIP_WINDOW_MS,
+  DEGRADED_COOLDOWN_BASE_MS,
+  DEGRADED_COOLDOWN_MAX_MS,
+  DEGRADED_COOLDOWN_RESET_MS,
+  overflowWindowTripped,
+  degradedCooldownStep,
+} from "./sse_overflow.js";
 
 let _paneCounter = 0;
 
@@ -173,56 +182,12 @@ const INTERACTIVE_DEFAULT_HOST = {
   onPreview() {},
 };
 
-// Overflow-reconnect limiter (client half of the SSE overflow recovery).
-// The server closes a stream whose listener queue overflowed — after an
-// id-less `stream_overflow` frame — and the native EventSource reconnect
-// replays the gap from the server's ring buffer.  For a consumer that
-// STAYS too slow that cycle would churn forever (reconnect → replay
-// burst → re-saturate → re-close, stalling ~3-5 s per retry round), so
-// after OVERFLOW_TRIP_COUNT overflow closes inside a rolling
-// OVERFLOW_TRIP_WINDOW_MS the pane drops to a degraded catch-up: stop
-// live streaming, say so plainly, and re-try after a doubling cooldown —
-// the eventual reconnect replays the gap, or falls to the
-// replay_truncated → /history floor once the gap outgrows the ring.
-const OVERFLOW_TRIP_COUNT = 3;
-const OVERFLOW_TRIP_WINDOW_MS = 60000;
-const DEGRADED_COOLDOWN_BASE_MS = 15000;
-const DEGRADED_COOLDOWN_MAX_MS = 120000;
-// Reset the cooldown ladder back to base only after this long WITHOUT a
-// degraded trip.  Deliberately larger than DEGRADED_COOLDOWN_MAX_MS: a
-// persistently-slow consumer trips again roughly one cooldown apart, so
-// keying the reset off the (shorter) trip window would let the gap
-// between top-of-ladder trips exceed the window and oscillate the
-// cooldown back to base — the escalation must survive its own backoff.
-const DEGRADED_COOLDOWN_RESET_MS = 300000;
-
-// Rolling-window trip check.  Prunes `times` in place (entries older
-// than windowMs against nowMs) and reports whether count-or-more
-// remain.  A standalone pure function so the trip logic can be lifted
-// verbatim into a bare `node -e` runtime probe (test_app_js.py style).
-function overflowWindowTripped(times, nowMs, count, windowMs) {
-  while (times.length && nowMs - times[0] > windowMs) times.shift();
-  return times.length >= count;
-}
-
-// Cooldown-ladder step for degraded catch-up.  Escalates (double, capped
-// at maxMs) when a trip recurs within resetMs of the last one; resets to
-// baseMs only after a genuine quiet gap.  Pure — keyed off the last-trip
-// TIMESTAMP, never the overflow-window array (which _enterDegradedCatchup
-// clears each trip, so keying off it would reset the ladder on every
-// storm's first overflow and the doubling would never escalate).  Split
-// out so the escalation is runtime-testable without a DOM-bound Pane.
-function degradedCooldownStep(
-  prevCooldownMs,
-  lastTripAtMs,
-  nowMs,
-  baseMs,
-  maxMs,
-  resetMs,
-) {
-  const cooldown = nowMs - lastTripAtMs > resetMs ? baseMs : prevCooldownMs;
-  return { cooldown, nextCooldownMs: Math.min(cooldown * 2, maxMs) };
-}
+// The SSE overflow-recovery limiter (storm-guard threshold, cooldown-ladder
+// constants, and the two pure helpers overflowWindowTripped /
+// degradedCooldownStep) lives in ./sse_overflow.js — imported above and shared
+// with the coordinator pane so the trip math has a single source of truth.
+// The stateful glue (_noteStreamOverflow / _enterDegradedCatchup below) stays
+// here because it is coupled to this class's disconnectSSE/connectSSE seam.
 
 class Pane {
   constructor(wsId, opts) {

--- a/turnstone/shared_static/sse_overflow.js
+++ b/turnstone/shared_static/sse_overflow.js
@@ -1,0 +1,60 @@
+// Client half of the SSE overflow recovery — the storm-guard math and the
+// degraded-catchup cooldown ladder, shared by every pane that consumes a
+// per-workstream SSE stream (the interactive pane and the coordinator pane).
+//
+// The server closes a stream whose listener queue overflowed — after an
+// id-less `stream_overflow` frame — and the native EventSource reconnect
+// replays the gap from the server's ring buffer.  For a consumer that STAYS
+// too slow that cycle would churn forever (reconnect → replay burst →
+// re-saturate → re-close, stalling ~3-5 s per retry round), so after
+// OVERFLOW_TRIP_COUNT overflow closes inside a rolling OVERFLOW_TRIP_WINDOW_MS
+// the pane drops to a degraded catch-up: stop live streaming, say so plainly,
+// and re-try after a doubling cooldown — the eventual reconnect replays the
+// gap, or falls to the replay_truncated → /history floor once the gap
+// outgrows the ring.
+//
+// The two surfaces keep their OWN transport/DOM glue (interactive.js is a
+// class whose methods hang off `this` and route through disconnectSSE;
+// coordinator.js is a closure with an inline stream close) but share these two
+// pure helpers + the constants, so the trip threshold and the escalation
+// ladder — the review-hardened, drift-prone part — have a single source of
+// truth instead of two copies that silently diverge.
+export const OVERFLOW_TRIP_COUNT = 3;
+export const OVERFLOW_TRIP_WINDOW_MS = 60000;
+export const DEGRADED_COOLDOWN_BASE_MS = 15000;
+export const DEGRADED_COOLDOWN_MAX_MS = 120000;
+// Reset the cooldown ladder back to base only after this long WITHOUT a
+// degraded trip.  Deliberately larger than DEGRADED_COOLDOWN_MAX_MS: a
+// persistently-slow consumer trips again roughly one cooldown apart, so keying
+// the reset off the (shorter) trip window would let the gap between
+// top-of-ladder trips exceed the window and oscillate the cooldown back to
+// base — the escalation must survive its own backoff.
+export const DEGRADED_COOLDOWN_RESET_MS = 300000;
+
+// Rolling-window trip check.  Prunes `times` in place (entries older than
+// windowMs against nowMs) and reports whether count-or-more remain.  A
+// standalone pure function so the trip logic can be lifted verbatim into a
+// bare `node` runtime probe (see tests/test_sse_overflow_js.py).
+export function overflowWindowTripped(times, nowMs, count, windowMs) {
+  while (times.length && nowMs - times[0] > windowMs) times.shift();
+  return times.length >= count;
+}
+
+// Cooldown-ladder step for degraded catch-up.  Escalates (double, capped at
+// maxMs) when a trip recurs within resetMs of the last one; resets to baseMs
+// only after a genuine quiet gap.  Pure — keyed off the last-trip TIMESTAMP,
+// never the overflow-window array (which the caller clears each trip, so
+// keying off it would reset the ladder on every storm's first overflow and
+// the doubling would never escalate).  Split out so the escalation is
+// runtime-testable without a DOM-bound pane.
+export function degradedCooldownStep(
+  prevCooldownMs,
+  lastTripAtMs,
+  nowMs,
+  baseMs,
+  maxMs,
+  resetMs,
+) {
+  const cooldown = nowMs - lastTripAtMs > resetMs ? baseMs : prevCooldownMs;
+  return { cooldown, nextCooldownMs: Math.min(cooldown * 2, maxMs) };
+}


### PR DESCRIPTION
Closes #806. Follow-up to #805 (SSE fast-stream corruption).

The server-side overflow protections from #805 live in `SessionUIBase` /
`_ListenerQueue` and already apply to every SSE stream (interactive + coordinator).
The **client-side** companions, though, existed only in the shared `interactive.js`
pane. This ports them to the coordinator pane and extracts the drift-prone pure core
into a shared module.

## What's here

- **`shared_static/sse_overflow.js` (new)** — the storm-guard constants +
  `overflowWindowTripped` + `degradedCooldownStep`, imported by both panes so the trip
  threshold and cooldown ladder have one source of truth. `interactive.js` now imports
  them instead of holding local copies; its two `node` runtime probes moved to
  `tests/test_sse_overflow_js.py`.
- **`coordinator.js`** gains the three companions:
  1. **Storm guard -> degraded catch-up** — `stream_overflow` handling with a 3-in-60s
     trip and a doubling cooldown; the reconnect replays from the ring, or falls to the
     `replay_truncated -> /history` floor.
  2. **Close-on-hide / replay-on-show** — a `visibilitychange` handler plus a
     `document.hidden` guard at the `connectSSE` chokepoint (also backstops a first
     connect in a background tab).
  3. **Drop-vs-render-wedge counters** — `streamHealth`; `onmessage` now wraps the
     dispatch in try/catch (the coordinator previously had **no** wedge guard, so a
     handler throw silently poisoned every later turn).

## Notable design points (shaped by review)

- **Replay-aware sidebar refresh.** `child_ws_*` / task events are ordinary ring-buffer
  entries, so a short cursor reconnect replays them and heals the sidebar with no REST
  rebuild — a momentary blur/focus rebuilds nothing. The replace-mode refresh fires only
  when replay cannot cover the gap: no cursor, `replay_truncated`, a gap beyond the 60s
  cursor-trust window, or a live event-id below the saved cursor (a process restart that
  reset the counter, which the replay path reports as a false `replay_ok`).
- **Truncated-resync deferral.** A `replay_truncated` seen mid-stream is deferred
  (guarding both the content and a reasoning-only bubble) and consumed on the next idle —
  matching interactive's `_pendingTruncatedResync`. Repairs both a ring-evicted gap and a
  turn stranded by close-on-hide (its `stream_end` evicted while hidden).
- The extraction stops at the pure core: `interactive.js`'s stateful glue is hard-pinned
  by its source-assertion suite, so its class-method shape stays put and the coordinator
  reimplements the equivalent glue as closure functions.

## Follow-up (not in this PR)

The coordinator's `refetchHistory` lacks interactive's `_beginReplayQuiesce` +
`_historyLoadToken`, so an un-awaited refetch can blank the pane on a transient `/history`
failure or race concurrent paint. This is **pre-existing across all of its callers**; a
proper fix is a separate quiesce+token port.

## Testing

All JS-source suites green (`test_app_js.py`, `test_sse_overflow_js.py`,
`test_interactive_pane_js.py`, `test_coordinator_page.py`, `test_conversation_js.py`,
`test_shell_js.py`), plus the `node` runtime probes for the pure helpers. The CLI is
unaffected: it overrides `on_content_token` to write stdout (bypassing the batcher) and
has no listener queue.
