### PR TITLE
fix(bash): do not hang when a command backgrounds a long-lived process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,193 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) for
 version numbers (`X.Y.Z`, with `X.Y.ZaN` / `bN` / `rcN` for pre-releases).
 
-Three release tracks are maintained — the current stable, one prior
-stable, and the experimental line:
+Two active release tracks are maintained — the current stable and the
+experimental line:
 
-- **`stable/1.5`** — patch-only (`v1.5.x`)
-- **`stable/1.6`** — patch-only (`v1.6.x`)
+- **`stable/1.7`** — patch-only (`v1.7.x`)
 - **`main`** — experimental (next major)
+
+Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
+
+## [Unreleased]
+
+### Fixed
+
+- **bash tool: never hang on a backgrounded child.** A command that left a
+  long-lived process running (`server &`, a daemon) could wedge the whole
+  workstream forever — the tool read stdout/stderr to EOF, which never arrived
+  because the child inherited the pipe, and the timeout watchdog bailed once the
+  foreground `bash` had exited. The tool now waits on the tracked process
+  (bounded by the tool timeout) and terminates its whole process group on
+  return, so the call always completes. Undecodable output is preserved
+  (`errors="replace"`) instead of being dropped as a spurious error.
+  - **Behavior change:** a process the command backgrounds no longer survives
+    the call — nothing persists across bash invocations. (First-class
+    "run this in the background" support is planned as a separate change.)
+
+## [1.7.3]
+
+A small feature and maintenance patch for the 1.7 line. No schema migrations
+and no new configuration knobs.
+
+### Added
+
+- **OpenAI GPT-5.6 (Sol/Terra/Luna) support** — the Responses provider
+  understands the GPT-5.6 family: the `reasoning.mode` control, the new
+  `max` effort tier, and `text.verbosity`, with golden wire payloads pinning
+  the request shapes. The `openai` dependency floor moves to `>=2.44`.
+
+### Changed
+
+- **Engineer base prompt hardened with process discipline** — the default
+  base prompt for non-coordinator sessions now works in phases scaled to the
+  size of the change, defaults to red-green for testable work, scopes to the
+  smallest sufficient diff, stops to report after repeated failed attempts
+  instead of thrashing, reports only observed results, and delegates
+  exploration to `task_agent`. Persona prompts freeze into the workstream
+  stamp at creation, so this reaches new workstreams only.
+
+### Fixed
+
+- **Unknown reasoning-mode warnings name the allowed modes** — a model
+  definition with an unrecognized reasoning mode now logs the valid options
+  instead of leaving the operator to guess.
+
+### Documentation
+
+- **HYPOTHESIS.md / PRIMER.md** — the control normal form is tightened and
+  the factored Q_E reading is carried into the glossary; the plain-language
+  PRIMER stays in sync.
+
+## [1.7.2]
+
+A feature-bearing patch for the 1.7 line. Rather than hold this work for the
+larger 1.8 churn, the fixes and the smaller features that had already
+stabilised on `main` are rolled into the stable line now: a rich preview
+pane, persona/project settings on scheduled tasks, and a batch of streaming,
+rendering, and nudge-delivery hardening.
+
+> **⚠️ Before upgrading:** 1.7.2 adds Alembic migration `066`, applied
+> automatically on first start. It adds two `Text NOT NULL DEFAULT ''`
+> columns (`persona`, `project_id`) to the `scheduled_tasks` table; existing
+> rows migrate to the empty default, which is byte-identical to pre-066
+> dispatch behaviour. The change is additive and reversible, but — as always
+> — back up your storage before upgrading (`pg_dump` for PostgreSQL; copy the
+> database file for SQLite).
+
+### Added
+
+- **Rich preview pane + `open_preview` tool** — a workstream can now open a
+  rendered preview (HTML, Markdown, and other kinds) in a pane beside the
+  conversation via the new `open_preview` tool. Guarded fetches stream under
+  a byte budget whose ceiling tracks the widest per-kind cap, preview blob
+  ids are salted, and a preflight probe handles legacy charsets and a
+  remote-assets opt-in. See `docs/tools.md`.
+- **`allow_private_network` opt-in for `web_fetch` / `open_preview`** —
+  private-address fetch and preview targets stay blocked by default; an
+  operator can opt a workstream in through the settings registry when a
+  private endpoint is genuinely intended. (Distinct from the 1.7.1 `[oidc]`
+  flag of the same name, which governs identity-provider discovery.)
+- **Persona + project settings on scheduled tasks** (migration `066`) — a
+  scheduled task can now pin the **persona** and **project** of the
+  workstream it dispatches, matching the levers a manually-created workstream
+  already carries. Both default to empty (kind-default persona / no project),
+  so existing schedules dispatch exactly as before.
+
+### Fixed
+
+- **Streaming fast-path overflow recovery** — fast-stream tokens are now
+  batched and overflowed SSE listeners recover instead of stalling (and
+  `connectSSE` no longer opens into a hidden background tab). The same
+  overflow-recovery companions were carried to the coordinator pane, so a
+  coordinator watching many children recovers dropped listeners the same way
+  the live-session view does.
+- **Renderer containment** — markdown sentinel-forgery and recursive-frame
+  content loss are contained, and an indented fence close no longer drags its
+  indent into the enclosed code content.
+- **Idle nudge / wake delivery** — nudge and wake delivery is hardened across
+  session eviction, cancellation, and identity rebinds; the wake gate now
+  requires a real nudge queue, refused wakes are logged, and
+  `initial_message_status` is typed as a closed enum on the wire.
+- **`web_fetch` extraction inherits model settings** — the completion that
+  extracts content from a fetched page now inherits the workstream's model
+  settings instead of falling back to defaults.
+- **UI panes** — ephemeral panes close on split-dismiss instead of orphaning
+  a tab, and an unsplit skips the redundant refresh after an ephemeral pane
+  closes.
+- **Shared code-highlight CSS** — renderer-output CSS is shared so the console
+  and coordinator panes highlight code identically.
+
+### Security
+
+- **`Content-Disposition` filenames made wire-safe** — download filenames
+  derived from user-controlled text are sanitised (latin-1- and
+  control-char-safe, quoting-safe) before they reach the `Content-Disposition`
+  response header, including the fallback path.
+
+### Documentation
+
+- **HYPOTHESIS.md: daemons + the outer loop, plus a plain-language PRIMER** —
+  the harness north-star document gains its daemon / outer-loop treatment and
+  a new top-level `PRIMER.md`.
+
+## [1.7.1]
+
+A maintenance and hardening patch for the 1.7 line. No schema migrations;
+the credential-redaction work below is additive and needs no configuration
+change. The one new operator-facing knob is the opt-in `[oidc]
+allow_private_network` flag (default off).
+
+### Security
+
+- **Credential redaction hardened across the tool-call surface** — the
+  redactor that scrubs secrets from tool arguments and log previews was
+  reworked on both the backend and the browser to close several leak paths
+  and to fix false-positive and performance issues. Malformed tool-call
+  arguments are now legalised before they reach the wire; the tool-args log
+  preview scrubs credentials and control characters; and the coordinator's
+  tool-call cards gain a matching client-side redaction pass so the JS and
+  backend redactors stay at parity. Pattern coverage now includes
+  `secret_access_key` / `aws_secret_access_key` multi-segment keys, bare
+  `token=` / `key=` forms (guarded by a negative lookbehind to avoid
+  false positives), and SQLAlchemy `+driver`-qualified connection-string
+  schemes matched case-insensitively.
+- **OIDC SSRF guard: `[oidc] allow_private_network` opt-in** — self-hosted
+  identity providers on private networks can now be reached by setting
+  `allow_private_network = true` under `[oidc]` (default off; the MCP OAuth
+  path stays strict). Rejections of discovered endpoints carry the opt-in
+  hint so the misconfiguration is self-explanatory. See `docs/oidc.md`.
+
+### Added
+
+- **Persona discoverability + forgiving name resolution** — personas are
+  now discoverable by agents, and persona-name resolution tolerates
+  case/whitespace variation; a not-found resolution reports the offending
+  input verbatim instead of a bare error.
+
+### Fixed
+
+- **MCP transport lifecycles routed through per-entry owner tasks**
+  (#787/#788) — static and pooled MCP transport lifecycles are now driven
+  by per-server / per-entry owner tasks, with a hardened disarm-sweep loop
+  guard and targeted exception handling in place of a broad `BaseException`
+  arm, so a dying transport can no longer spin the CPU or strand delivery.
+- **Client-construction failures surface as misconfiguration, not raw
+  500s** — a model whose client cannot be constructed now reports a factory
+  misconfiguration, and the raw exception text is kept out of the resulting
+  503 response.
+- **Postgres history search survives oversized rows** — a conversation row
+  exceeding Postgres' full-text limits no longer aborts history search.
+- **Agent-tool render is idempotent** — tool rendering no longer deep-copies
+  a tool definition until a description actually changes, so no-persona
+  sessions share the tool constant (correctness plus a hot-path allocation
+  win).
+- **Private-project workstream visibility scoped to members** — workstreams
+  in a private project are visible to project members only, not to every
+  admin; coordinator tenancy checks now use request-scoped storage.
+- **Pane hotkeys work off macOS and match across surfaces** — the pane
+  keyboard shortcuts no longer collide with browser accelerators on
+  non-macOS platforms and behave consistently across surfaces.
 
 ## [1.7.0]
 

--- a/tests/test_bash_tool_background_hang.py
+++ b/tests/test_bash_tool_background_hang.py
@@ -1,0 +1,184 @@
+"""Regression tests for the bash tool hanging on a backgrounded child.
+
+A bash command that backgrounds a long-lived process (``server &``,
+``python -m http.server &``, any daemon) used to wedge the whole workstream
+forever: the child inherits the tool's stdout/stderr pipe, so the foreground
+read never hit EOF, and the timeout watchdog bailed the moment the tracked
+``bash`` exited.  ``_exec_bash`` now waits on the tracked process (not pipe
+EOF) bounded by ``tool_timeout`` and kills the whole session group on exit, so
+the call always returns and never leaks the background child.
+"""
+
+import contextlib
+import os
+import signal
+import tempfile
+import threading
+import time
+
+from tests._session_helpers import NullUI, make_session
+from turnstone.core.trajectory import EffectStatus
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _kill_pid(pid: int) -> None:
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def _run_in_thread(fn, timeout):
+    """Run ``fn`` in a daemon thread; return ``(finished, result)``."""
+    box = {}
+
+    def _target():
+        box["result"] = fn()
+
+    t = threading.Thread(target=_target, daemon=True)
+    t.start()
+    t.join(timeout)
+    return (not t.is_alive()), box.get("result")
+
+
+def test_backgrounded_child_does_not_hang_and_is_reaped():
+    """Foreground exits immediately but leaves ``sleep 60 &`` holding the pipe.
+
+    Old behaviour: infinite hang (EOF never arrives, watchdog bails once the
+    tracked bash exits).  New behaviour: returns promptly and the background
+    child is reaped by the session-group kill.
+    """
+    pidfile = tempfile.mktemp(suffix=".pid")
+    # A generous tool_timeout proves the return comes from foreground-exit, not
+    # from the deadline firing.
+    session = make_session(tool_timeout=30)
+    command = f"sleep 60 & echo $! > {pidfile}; echo done"
+    bg_pid = None
+    try:
+        finished, result = _run_in_thread(
+            lambda: session._exec_bash({"call_id": "c1", "command": command}),
+            timeout=15,
+        )
+        assert finished, "_exec_bash hung on a backgrounded child"
+        assert result is not None
+        call_id, output = result
+        assert call_id == "c1"
+        assert "done" in output
+
+        # The backgrounded process must have been reaped by the group kill.
+        with open(pidfile) as f:
+            bg_pid = int(f.read().strip())
+        deadline = time.monotonic() + 5
+        while _pid_alive(bg_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not _pid_alive(bg_pid), f"backgrounded child {bg_pid} leaked"
+    finally:
+        if bg_pid is not None:
+            _kill_pid(bg_pid)
+        if os.path.exists(pidfile):
+            os.unlink(pidfile)
+
+
+def test_timeout_still_fires_with_backgrounded_child():
+    """A silent foreground command plus a backgrounded child still hits the
+    deadline: the watchdog kills the whole group and the result reads UNKNOWN
+    (the ``unknown, never none`` timeout discipline)."""
+    session = make_session(tool_timeout=1)
+    command = "sleep 60 & sleep 60"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=10,
+    )
+    assert finished, "_exec_bash did not return at its deadline"
+    assert result is not None
+    call_id, output = result
+    assert call_id == "c1"
+    assert "timed out" in output.lower()
+    assert "UNKNOWN" in output
+    assert session._tool_status.get("c1") is EffectStatus.UNKNOWN
+
+
+def test_undecodable_output_is_preserved_not_swallowed():
+    """Undecodable bytes on stdout must not silently vanish.
+
+    The drain's broad ``except (ValueError, OSError)`` would otherwise catch the
+    ``UnicodeDecodeError`` (a ``ValueError``) and kill the thread before any line
+    was yielded — dropping ALL output and reporting a clean success.  ``Popen``
+    now decodes with ``errors="replace"`` so output always survives.
+    """
+    session = make_session(tool_timeout=30)
+    # Valid lines bracketing a raw invalid-UTF-8 byte sequence.
+    command = r"printf 'before\n'; printf '\xff\xfe'; printf 'after\n'"
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished
+    assert result is not None
+    _call_id, output = result
+    assert output != "(no output)"
+    assert "before" in output
+    assert "after" in output
+
+
+def test_stdout_streams_to_ui_from_drain_thread():
+    """stdout chunks are now emitted from the drain thread; they must still reach
+    ``on_tool_output_chunk``."""
+    chunks: list[str] = []
+
+    class RecordingUI(NullUI):
+        def on_tool_output_chunk(self, call_id, chunk):
+            chunks.append(chunk)
+
+    session = make_session(tool_timeout=30, ui=RecordingUI())
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": "echo streamed-line"}),
+        timeout=15,
+    )
+    assert finished
+    assert any("streamed-line" in c for c in chunks)
+
+
+def test_cancel_midbash_reports_unknown():
+    """An external ``cancel()`` during a running bash unblocks the process-bounded
+    wait and reports UNKNOWN (unknown-never-none), not a clean result."""
+    session = make_session(tool_timeout=30)
+
+    def _cancel_soon():
+        time.sleep(0.5)
+        session.cancel()
+
+    threading.Thread(target=_cancel_soon, daemon=True).start()
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": "sleep 30"}),
+        timeout=15,
+    )
+    assert finished, "cancel did not unblock _exec_bash"
+    assert result is not None
+    _call_id, output = result
+    assert "cancelled" in output.lower()
+    assert session._tool_status.get("c1") is EffectStatus.UNKNOWN
+
+
+def test_popen_failure_reports_cleanly(monkeypatch):
+    """If ``Popen`` itself raises, the ``finally`` must not mask the real error
+    with ``UnboundLocalError`` — ``proc`` is pre-bound to ``None``."""
+    from turnstone.core import session as session_mod
+
+    session = make_session(tool_timeout=30)
+
+    def _boom(*args, **kwargs):
+        raise OSError("cannot fork")
+
+    monkeypatch.setattr(session_mod.subprocess, "Popen", _boom)
+    call_id, output = session._exec_bash({"call_id": "c1", "command": "echo hi"})
+    assert call_id == "c1"
+    assert "cannot fork" in output

--- a/tests/test_bash_tool_background_hang.py
+++ b/tests/test_bash_tool_background_hang.py
@@ -12,7 +12,6 @@ the call always returns and never leaks the background child.
 import contextlib
 import os
 import signal
-import tempfile
 import threading
 import time
 
@@ -48,14 +47,14 @@ def _run_in_thread(fn, timeout):
     return (not t.is_alive()), box.get("result")
 
 
-def test_backgrounded_child_does_not_hang_and_is_reaped():
+def test_backgrounded_child_does_not_hang_and_is_reaped(tmp_path):
     """Foreground exits immediately but leaves ``sleep 60 &`` holding the pipe.
 
     Old behaviour: infinite hang (EOF never arrives, watchdog bails once the
     tracked bash exits).  New behaviour: returns promptly and the background
     child is reaped by the session-group kill.
     """
-    pidfile = tempfile.mktemp(suffix=".pid")
+    pidfile = str(tmp_path / "bg.pid")
     # A generous tool_timeout proves the return comes from foreground-exit, not
     # from the deadline firing.
     session = make_session(tool_timeout=30)
@@ -82,8 +81,6 @@ def test_backgrounded_child_does_not_hang_and_is_reaped():
     finally:
         if bg_pid is not None:
             _kill_pid(bg_pid)
-        if os.path.exists(pidfile):
-            os.unlink(pidfile)
 
 
 def test_timeout_still_fires_with_backgrounded_child():

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -432,6 +432,10 @@ _SEARCH_DRAIN_CHUNK: int = 8192
 # exits. The thread reads from a closed pipe at that point; a small
 # timeout keeps shutdown bounded if the OS hasn't propagated EOF yet.
 _SEARCH_DRAIN_JOIN_TIMEOUT: float = 2.0
+
+# Poll granularity while waiting for a bash command to exit — bounds how long a
+# cooperative cancel or the wall-clock ``timeout`` can go unnoticed.
+_BASH_WAIT_POLL_S: float = 0.1
 # Excluded directory patterns — hit by both backends. ripgrep also respects
 # ``.gitignore`` and skips hidden directories by default, so most of these
 # are belt-and-suspenders for the rg path; they're load-bearing for grep.
@@ -14033,6 +14037,9 @@ class ChatSession:
                     preamble += "set -e\n"
                 f.write(preamble + command)
                 script_path = f.name
+            # Pre-bind so the ``finally`` can't raise ``UnboundLocalError`` and
+            # mask the real error if ``Popen`` below fails.
+            proc: subprocess.Popen[str] | None = None
             try:
                 from turnstone.core.env import scrubbed_env
 
@@ -14041,67 +14048,114 @@ class ChatSession:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
+                    errors="replace",
                     start_new_session=True,
                     env=scrubbed_env(extra=self._skill_resource_env()),
                 )
                 with self._procs_lock:
                     self._active_procs.add(proc)
-                # Drain stderr in background thread to avoid pipe deadlock
+                # Drain stdout and stderr in background threads.  Reading the
+                # pipes to EOF in the foreground is unsafe: a command that
+                # backgrounds a long-lived child (``server &``) leaks the pipe
+                # write-end to that child, so EOF never arrives and the read —
+                # hence the whole tool call — would hang forever, with the
+                # timeout defeated once the tracked ``bash`` has exited.  Instead
+                # we wait on the tracked process bounded by ``timeout`` and tear
+                # down its whole session group on exit, reaping any such survivor.
+                stdout_parts: list[str] = []
                 stderr_lines: list[str] = []
 
-                def drain_stderr() -> None:
-                    assert proc.stderr is not None
-                    for line in proc.stderr:
-                        stderr_lines.append(line)
+                def _drain(pipe: Any, sink: list[str], to_ui: bool) -> None:
+                    try:
+                        for line in pipe:
+                            sink.append(line)
+                            if to_ui:
+                                try:
+                                    self.ui.on_tool_output_chunk(call_id, line)
+                                except Exception:
+                                    log.debug(
+                                        "UI callback error during tool output",
+                                        exc_info=True,
+                                    )
+                    except (ValueError, OSError):
+                        # Pipe torn down by the session-group kill below is the
+                        # expected case; anything else must not kill the drain
+                        # silently.  (Undecodable bytes can't land here — the
+                        # ``errors="replace"`` on Popen pre-empts UnicodeDecodeError,
+                        # which is a ValueError that would otherwise drop all output.)
+                        log.debug("bash.drain_read_error", exc_info=True)
 
-                stderr_thread = threading.Thread(target=drain_stderr, daemon=True)
+                assert proc.stdout is not None and proc.stderr is not None
+                stdout_thread = threading.Thread(
+                    target=_drain,
+                    args=(proc.stdout, stdout_parts, True),
+                    name=f"bash-drain-out-{call_id}",
+                    daemon=True,
+                )
+                stderr_thread = threading.Thread(
+                    target=_drain,
+                    args=(proc.stderr, stderr_lines, False),
+                    name=f"bash-drain-err-{call_id}",
+                    daemon=True,
+                )
+                stdout_thread.start()
                 stderr_thread.start()
 
-                # Stream stdout line-by-line with process-group timeout
-                stdout_parts: list[str] = []
+                # Snapshot the session-group id while the leader is alive
+                # (``start_new_session=True`` makes ``pgid == proc.pid``).  While
+                # any member survives, the group names only our own descendants;
+                # once they have all exited it is empty and the kill below is a
+                # harmless no-op.  (A pid-wraparound landing a fresh session
+                # leader on this exact id in the microseconds after a normal-exit
+                # reap is the standard accepted TOCTOU — negligible, and only when
+                # nothing needs killing anyway.)
+                try:
+                    pgid = os.getpgid(proc.pid)
+                except OSError:
+                    pgid = proc.pid
+
+                # Wait for the tracked command, bounded by ``timeout`` and
+                # cooperatively cancellable.  Keyed on process exit, never pipe
+                # EOF, so a leaked background child cannot extend the wait.
                 timed_out = threading.Event()
+                deadline = time.monotonic() + timeout
+                while True:
+                    if cancel.is_set():
+                        break
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        timed_out.set()
+                        break
+                    try:
+                        proc.wait(timeout=min(remaining, _BASH_WAIT_POLL_S))
+                        break
+                    except subprocess.TimeoutExpired:
+                        continue
 
-                def _on_timeout() -> None:
-                    if proc.poll() is not None:
-                        return  # process already exited
-                    timed_out.set()
-                    with contextlib.suppress(OSError, ProcessLookupError):
-                        try:
-                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                        except OSError:
-                            with contextlib.suppress(OSError, ProcessLookupError):
-                                proc.kill()
+                # Terminate the whole session group on every exit path: reaps a
+                # backgrounded child that would otherwise leak (ports, PIDs) or
+                # hold the output pipe open, and forces the drain threads to EOF.
+                with contextlib.suppress(OSError, ProcessLookupError):
+                    os.killpg(pgid, signal.SIGKILL)
 
-                timer = threading.Timer(timeout, _on_timeout)
-                timer.start()
-                try:
-                    assert proc.stdout is not None
-                    for line in proc.stdout:
-                        stdout_parts.append(line)
-                        try:
-                            self.ui.on_tool_output_chunk(call_id, line)
-                        except Exception:
-                            log.debug("UI callback error during tool output", exc_info=True)
-                        # Check cancellation during long-running commands
-                        if cancel.is_set():
-                            with contextlib.suppress(OSError, ProcessLookupError):
-                                try:
-                                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                                except OSError:
-                                    with contextlib.suppress(OSError, ProcessLookupError):
-                                        proc.kill()
-                            raise GenerationCancelled()
-                finally:
-                    timer.cancel()
-
-                try:
+                with contextlib.suppress(subprocess.TimeoutExpired):
                     proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    log.warning("Process did not exit after SIGKILL, pid=%d", proc.pid)
+                if proc.returncode is None:
+                    # Survived SIGKILL (uninterruptible sleep — NFS, a driver).
+                    # Restores the diagnostic the old Timer path emitted.
+                    log.warning("bash.survived_sigkill", pid=proc.pid)
+                # Writers are gone, so the drains hit EOF promptly.  They are
+                # daemon threads: a pathological double-``setsid`` grandchild
+                # that escaped the group cannot wedge shutdown — it leaks its
+                # drain (logged below) until it dies.
+                stdout_thread.join(timeout=5)
                 stderr_thread.join(timeout=5)
+                if stdout_thread.is_alive() or stderr_thread.is_alive():
+                    log.warning("bash.drain_leaked", call_id=call_id, pid=proc.pid)
             finally:
-                with self._procs_lock:
-                    self._active_procs.discard(proc)
+                if proc is not None:
+                    with self._procs_lock:
+                        self._active_procs.discard(proc)
                 os.unlink(script_path)
 
             if timed_out.is_set():
@@ -14110,9 +14164,9 @@ class ChatSession:
             # Distinguish user cancel from unexpected SIGKILL.
             # Popen.returncode is negative of the signal number when killed.
             if cancel.is_set() and proc.returncode == -signal.SIGKILL:
-                # SIGKILL'd mid-flight (the command was parked on a silent
-                # read, so the in-loop cooperative check never fired).  Its
-                # side effects are unobserved: record outcome UNKNOWN and
+                # SIGKILL'd mid-flight by our session-group kill once the
+                # bounded wait observed the cancel.  Its side effects are
+                # unobserved: record outcome UNKNOWN and
                 # mark it an error, not a clean empty success — a destructive
                 # command killed here must not read as "did not run" on
                 # replay.  Keep whatever partial stdout we captured.

--- a/turnstone/tools/bash.json
+++ b/turnstone/tools/bash.json
@@ -1,6 +1,6 @@
 {
   "name": "bash",
-  "description": "Execute a bash command and return stdout + stderr. Use for running programs, git, tests, system commands, installing packages, etc. Environment questions ('What Python version?', 'Is X installed?') are tool-use tasks — e.g. bash(command='python --version'). For file creation use write_file instead; for man pages use man instead. Long output is truncated (head+tail preserved, middle elided). Stderr lines prefixed with [stderr].",
+  "description": "Execute a bash command and return stdout + stderr. Use for running programs, git, tests, system commands, installing packages, etc. Environment questions ('What Python version?', 'Is X installed?') are tool-use tasks — e.g. bash(command='python --version'). For file creation use write_file instead; for man pages use man instead. Long output is truncated (head+tail preserved, middle elided). Stderr lines prefixed with [stderr]. Runs to completion and returns: any process the command leaves running in the background (e.g. 'server &') is terminated when the command returns — nothing persists across calls.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Problem

A `bash` tool call that leaves a long-lived process running in the background (`python -m http.server &`, a dev server, any daemon) could wedge the entire workstream **forever**. Root cause:

- The tool read `stdout`/`stderr` to **EOF**, which never arrives because the backgrounded child inherits a copy of the pipe write-end.
- The timeout watchdog was defeated — it bailed (`if proc.poll() is not None: return`) the moment the foreground `bash` exited, so it never killed the survivors.

Observed in the wild: a sub-agent launched a `livepass` UX-preview harness (`python -m http.server`), which pinned the session in `running` — no CPU, no error logged, no recovery.

## Fix

- Drain **both** `stdout` and `stderr` in daemon threads.
- Wait on the **tracked process**, bounded by the tool timeout — keyed on process exit, never pipe EOF, so a leaked background child cannot extend the wait.
- **`killpg` the whole session group on every exit path** (normal, timeout, cancel): reaps backgrounded survivors, forces the drains to EOF, leaks nothing.
- Decode with `errors="replace"` so undecodable output is preserved rather than silently dropped and mis-reported as clean success.
- Pre-bind `proc` so a `Popen()` failure surfaces the real error instead of an `UnboundLocalError` from the `finally`.

### Behavior change

A process a command backgrounds **no longer survives the call** — nothing persists across `bash` invocations (documented in `bash.json`). First-class opt-in "run this in the background" support is planned as a separate change.

## Tests

New `tests/test_bash_tool_background_hang.py` (6):

- background child does not hang and is reaped
- timeout still fires with a backgrounded child present
- undecodable output is preserved, not swallowed
- stdout still streams to the UI from the drain thread
- cancel mid-bash reports `UNKNOWN` (unknown-never-none preserved)
- a `Popen()` failure surfaces cleanly

`test_cancel.py` (50) stays green — cancellation semantics unchanged.

## Changelog

Also brings `main`'s CHANGELOG up to date with the `1.7.1`–`1.7.3` release notes (and the two-track preamble) that shipped on `stable/1.7`, plus an `[Unreleased]` entry for this fix.
