### PR TITLE
Align GPT-5.6 support with the GA API surface

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -458,7 +458,7 @@ Each item in `items` (shared by `tool_info` and `approve_request`):
 | `context_window`         | int    | Total context window size in tokens                  |
 | `pct`                    | float  | Percentage of context window used                    |
 | `effort`                 | string | Reasoning effort level (`low`/`medium`/`high`)       |
-| `cache_creation_tokens`  | int    | Tokens written to prompt cache (Anthropic)           |
+| `cache_creation_tokens`  | int    | Tokens written to prompt cache (Anthropic + OpenAI)  |
 | `cache_read_tokens`      | int    | Tokens served from prompt cache (Anthropic + OpenAI) |
 
 **`info`** -- an informational message (e.g. command output).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -622,19 +622,19 @@ LLMProvider (protocol)
 |------|--------|
 | `StreamChunk` | `content_delta`, `reasoning_delta`, `tool_call_deltas`, `info_delta`, `usage`, `finish_reason`, `provider_blocks` |
 | `CompletionResult` | `content`, `tool_calls`, `finish_reason`, `usage`, `provider_blocks` |
-| `ModelCapabilities` | `context_window`, `max_output_tokens`, `supports_temperature`, `token_param`, `thinking_mode`, `supports_effort`, `supports_web_search`, `supports_tool_search`, `supports_vision`, `supports_reasoning_replay` |
+| `ModelCapabilities` | `context_window`, `max_output_tokens`, `supports_temperature`, `token_param`, `thinking_mode`, `supports_effort`, `supports_web_search`, `supports_tool_search`, `supports_vision`, `supports_reasoning_replay`, `supports_verbosity`, `verbosity`, `supports_pro_mode`, `reasoning_mode` |
 | `UsageInfo` | `prompt_tokens`, `completion_tokens`, `total_tokens`, `cache_creation_tokens`, `cache_read_tokens` |
 
 **OpenAIProvider** (`_openai.py`): passes messages through unchanged (they are
 already in OpenAI format), including multi-part content blocks (text + images)
-in tool results. Model capability lookup table covers GPT-5/5.1/5.2/5.3/5.4,
+in tool results. Model capability lookup covers GPT-5 through GPT-5.6,
 O-series, and search models (`gpt-5-search-api`) — all with `supports_vision`.
 For search models, injects `web_search_options` and removes the `web_search`
 function tool (the model always searches). Citations from `url_citation`
-annotations are formatted as footnotes. Extended prompt cache retention
-(`prompt_cache_retention: "24h"`) is enabled for GPT-5.x models at no
-additional cost. Cached token counts are extracted from
-`usage.prompt_tokens_details.cached_tokens`. Unknown models get permissive
+annotations are formatted as footnotes. Pre-5.6 GPT-5 models request extended
+prompt-cache retention (`prompt_cache_retention: "24h"`); GPT-5.6 uses
+`prompt_cache_options.ttl: "30m"`. Cache reads and writes are extracted from
+`cached_tokens` and `cache_write_tokens`. Unknown models get permissive
 defaults with `supports_vision=False` and use SearxNG for web search. The
 `openai-compatible` lane never consults this table at all — on either API
 surface (the responses pin is served by a compat-mode
@@ -642,8 +642,9 @@ surface (the responses pin is served by a compat-mode
 local server serves whatever the operator named it (vLLM
 `--served-model-name` is a free string), so a prefix collision with a cloud
 model id must not inherit that model's sampling/effort contract — every
-local model gets the plain defaults, and anything beyond them is declared on
-the model definition (capabilities JSON + `server_compat`), matching the
+local model gets the plain defaults, commercial prompt-cache controls are not
+injected by model-name prefix, and anything beyond those defaults is declared
+on the model definition (capabilities JSON + `server_compat`), matching the
 `anthropic-compatible` lane.
 
 **AnthropicProvider** (`_anthropic.py`): converts OpenAI-format messages to

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -131,9 +131,12 @@ Per-LLM-request token and tool call metrics:
   LLM response with prompt/completion tokens, cache tokens, tool call count,
   model, ws_id
 - **Prompt caching**: Anthropic automatic caching (`cache_control: ephemeral`)
-  and OpenAI extended retention (`prompt_cache_retention: 24h` for GPT-5.x)
-  are enabled by default. `cache_creation_tokens` and `cache_read_tokens` are
-  tracked per request in `usage_events` and surfaced in the Usage admin tab
+  and OpenAI caching are enabled by default. Pre-5.6 GPT-5 models request
+  `prompt_cache_retention: 24h`; GPT-5.6 uses
+  `prompt_cache_options: {"ttl": "30m"}`. GPT-5.6 cache writes use the
+  provider's 1.25× input-token rate. `cache_creation_tokens` and
+  `cache_read_tokens` are tracked per request in `usage_events` and surfaced
+  in the Usage admin tab
 - **Querying**: `GET /v1/api/admin/usage` with `group_by` (day/hour/model/user)
   and time range filtering — includes cache token aggregates
 - **Prometheus**: `turnstone_tokens_total{type="cache_creation|cache_read"}`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -54,6 +54,23 @@ When a per-model override is `NULL` (empty in the UI), the global default is
 used. Switching models via `/model <alias>` re-resolves sampling parameters
 from the new model's overrides or global defaults.
 
+### Responses output controls (per-model)
+
+Models whose capability table declares Responses output controls expose two
+additional fields in the Models create/edit shelf:
+
+| Field | Stored capability | Values | Effect |
+|-------|-------------------|--------|--------|
+| Output verbosity | `verbosity` | `low`, `medium`, `high` | Controls answer length independently of reasoning effort. |
+| Reasoning mode | `reasoning_mode` | `standard`, `pro` | Selects standard or higher-compute Pro execution without changing the model ID. |
+
+An empty selection means provider default and omits the capability key. Known
+GPT-5.6 models inherit support from the built-in table without persisting
+redundant support flags. An OpenAI-compatible model pinned to the Responses API
+can opt in with the `supports_verbosity` and `supports_pro_mode` capability
+tiles. Chat Completions and non-Responses providers do not surface or submit
+these controls.
+
 **Removed settings:** `model.name` and `model.context_window` have been removed
 from ConfigStore. Model names and context windows are now configured per-model
 in the Models tab. A startup warning is logged if these keys appear in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "openai>=2.44",  # GPT-5.6 (Sol/Terra/Luna): Responses reasoning.mode + effort "max" + text.verbosity
+    "openai>=2.45",  # GPT-5.6: typed reasoning.mode, prompt_cache_options, and cache_write_tokens
     "anthropic>=0.108",  # claude-fable-5 support; hard runtime floor is 0.105 (mid-conversation system blocks)
     "httpx>=0.28",
     "mcp>=1.27,<2",  # v2 is a breaking rewrite (2.0.0a1 live 2026-06-11; stable ~2026-07-27) — streamablehttp_client removed, 2-tuple transport, snake_case types; migrate deliberately

--- a/tests/data/wire_payloads/openai_responses_max__text.json
+++ b/tests/data/wire_payloads/openai_responses_max__text.json
@@ -21,7 +21,9 @@
   ],
   "max_output_tokens": 4096,
   "model": "gpt-5.6-sol",
-  "prompt_cache_retention": "24h",
+  "prompt_cache_options": {
+    "ttl": "30m"
+  },
   "reasoning": {
     "effort": "max"
   },

--- a/tests/data/wire_payloads/openai_responses_max__toolcall_complete.json
+++ b/tests/data/wire_payloads/openai_responses_max__toolcall_complete.json
@@ -27,7 +27,9 @@
   ],
   "max_output_tokens": 4096,
   "model": "gpt-5.6-sol",
-  "prompt_cache_retention": "24h",
+  "prompt_cache_options": {
+    "ttl": "30m"
+  },
   "reasoning": {
     "effort": "max"
   },

--- a/tests/data/wire_payloads/openai_responses_verbosity_pro__text.json
+++ b/tests/data/wire_payloads/openai_responses_verbosity_pro__text.json
@@ -21,7 +21,9 @@
   ],
   "max_output_tokens": 4096,
   "model": "gpt-5.6-sol",
-  "prompt_cache_retention": "24h",
+  "prompt_cache_options": {
+    "ttl": "30m"
+  },
   "reasoning": {
     "effort": "high",
     "mode": "pro"

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -722,7 +722,22 @@ def test_model_response_controls_are_capability_driven_and_sparse() -> None:
     assert identity is not None
     assert 'provider === "openai-compatible"' in identity
     assert ': ""' in identity
-    assert "if (_modelResponseDirty[spec.key]) delete caps[spec.key]" in admin
+    merge = _slice_function_body(admin, "_mergeModelResponseControls")
+    assert merge is not None
+    # The dirty flag (select touched) may only override Advanced JSON for
+    # the identity that made it dirty — a stale flag from a renamed row
+    # must not delete a hand-typed JSON key.
+    assert "if (_modelResponseDirty[spec.key] && sameIdentity) delete caps[spec.key]" in merge
+    # The captured-value fallback is load-bearing, not a gating bug: a value
+    # lifted out of the row JSON on edit-open must stay visible and re-save
+    # for the same identity even when the baseline table says unsupported.
+    # The baseline arrives async (or never, on the compat lane); yielding to
+    # it would silently drop the pinned value on an unrelated edit-save.
+    # Wire safety lives server-side (emission gates on merged supports_*).
+    for body in (visibility, merge):
+        assert "_modelGetTile(spec.supportKey) || capturedFallback" in body
+        assert "sameIdentity" in body
+        assert "!(spec.supportKey in _modelCapsExplicit)" in body
 
     create = _slice_function_body(admin, "showCreateModelModal")
     assert create is not None

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -677,6 +677,67 @@ def test_audio_roles_gated_to_openai_sdk_providers() -> None:
     assert '_providerCarriesAudio((md && md.provider) || "openai")' in body
 
 
+def test_model_response_controls_are_capability_driven_and_sparse() -> None:
+    """The model shelf surfaces Responses-only scalar controls without
+    hard-coding GPT-5.6 IDs or pinning inherited capability-table values."""
+    html = _CONSOLE_INDEX.read_text(encoding="utf-8")
+    admin = _CONSOLE_ADMIN_JS.read_text(encoding="utf-8")
+
+    assert 'id="model-response-controls"' in html
+    assert 'aria-labelledby="model-response-controls-title"' in html
+    assert 'id="model-output-verbosity"' in html
+    assert 'for="model-output-verbosity"' in html
+    assert 'id="model-reasoning-mode"' in html
+    assert 'for="model-reasoning-mode"' in html
+    for value in ("low", "medium", "high"):
+        assert f'<option value="{value}">' in html
+    for value in ("standard", "pro"):
+        assert f'<option value="{value}">' in html
+    assert 'data-cap="supports_verbosity"' in html
+    assert 'data-cap="supports_pro_mode"' in html
+
+    assert '"supports_verbosity"' in admin
+    assert '"supports_pro_mode"' in admin
+    surface = _slice_function_body(admin, "_modelUsesResponsesSurface")
+    assert surface is not None
+    assert 'provider === "openai"' in surface
+    assert 'provider === "openai-compatible"' in surface
+    assert 'value === "responses"' in surface
+    visibility = _slice_function_body(admin, "_updateModelResponseControls")
+    assert visibility is not None
+    assert "_modelGetTile(spec.supportKey)" in visibility
+    assert 'supportKey: "supports_verbosity"' in admin
+    assert 'supportKey: "supports_pro_mode"' in admin
+    assert "gpt-5.6" not in visibility, "visibility must come from capabilities, not model IDs"
+
+    assert "function _captureModelResponseControls(" in admin
+    assert "function _mergeModelResponseControls(" in admin
+    assert "_captureModelResponseControls(capsObj)" in admin
+    assert "_mergeModelResponseControls(caps)" in admin
+    assert "let _modelResponseCaptured = {};" in admin
+    assert "let _modelResponseDirty = {};" in admin
+    assert "_modelResponseCaptured[spec.key] = value" in admin
+    assert "nextIdentity === _modelResponseInitialIdentity" in admin
+    identity = _slice_function_body(admin, "_modelIdentity")
+    assert identity is not None
+    assert 'provider === "openai-compatible"' in identity
+    assert ': ""' in identity
+    assert "if (_modelResponseDirty[spec.key]) delete caps[spec.key]" in admin
+
+    create = _slice_function_body(admin, "showCreateModelModal")
+    assert create is not None
+    assert "_modelCapsSeq++" in create, "a fresh shelf must invalidate prior lookups"
+
+    assert "displayCaps.supports_verbosity !== false" in admin
+    assert "displayCaps.supports_pro_mode !== false" in admin
+
+    change = _slice_function_body(admin, "_onModelFieldChange")
+    assert change is not None
+    assert "_modelCapsSeq++" in change, "model changes must invalidate in-flight baselines"
+    assert "_modelCapsBaseline = {}" in change
+    assert 'apiSurfEl.addEventListener("change", _onModelFieldChange)' in admin
+
+
 def test_shared_utils_defines_set_markdown_helper() -> None:
     """The ``setMarkdown`` helper in ``shared/utils.js`` is the single
     audited entry point for rendering markdown content into a DOM

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -16,6 +16,7 @@ from turnstone.core.providers._openai_common import (
     apply_cache_retention,
     apply_temperature_and_effort,
     apply_tool_search,
+    extract_usage,
     format_citations,
     lookup_openai_capabilities,
     sanitize_messages,
@@ -2236,15 +2237,14 @@ class TestOpenAIParameterGating:
         assert "max" in lookup_openai_capabilities("gpt-5.6-sol").reasoning_effort_values
         assert "max" in lookup_openai_capabilities("gpt-5.6-2026-07-09").reasoning_effort_values
 
-    def test_gpt56_terra_luna_max_snaps_to_xhigh_ceiling(self) -> None:
-        """GPT-5.6 Terra and Luna have no "max" (Sol-only); the knob's "max"
-        snaps DOWN to the declared "xhigh" ceiling rather than being dropped."""
+    def test_gpt56_terra_luna_support_max_effort(self) -> None:
+        """Every GPT-5.6 tier accepts the documented "max" effort."""
         for tier in ("gpt-5.6-terra", "gpt-5.6-luna"):
             caps = lookup_openai_capabilities(tier)
-            assert "max" not in caps.reasoning_effort_values, tier
+            assert "max" in caps.reasoning_effort_values, tier
             kwargs: dict[str, Any] = {}
             apply_temperature_and_effort(kwargs, caps, temperature=0.7, reasoning_effort="max")
-            assert kwargs["reasoning_effort"] == "xhigh", tier
+            assert kwargs["reasoning_effort"] == "max", tier
 
 
 class TestAnthropicOrphanedToolUse:
@@ -3495,6 +3495,31 @@ class TestModelCapabilitiesToolSearch:
         caps = ModelCapabilities()
         assert caps.supports_tool_search is False
 
+    def test_public_positional_prefix_remains_stable(self) -> None:
+        """New optional fields must not shift the exported constructor's existing slots."""
+        caps = ModelCapabilities(
+            100000,
+            10000,
+            False,
+            False,
+            False,
+            "max_tokens",
+            "manual",
+            "thinking",
+            "reasoning_effort",
+            True,
+            ("low",),
+            ("low",),
+            "low",
+            True,
+            True,
+            True,
+            True,
+        )
+        assert caps.supports_web_search is True
+        assert caps.supports_tool_search is True
+        assert caps.supports_vision is True
+
 
 class TestMidConversationSystemCapability:
     """supports_mid_conversation_system — NextOpus (claude-opus-4-8) only."""
@@ -3943,8 +3968,50 @@ class TestOpenAIPromptCaching:
     def setup_method(self) -> None:
         self.provider = OpenAIProvider()
 
-    def test_cache_retention_set_for_gpt5(self) -> None:
-        """GPT-5.x models get prompt_cache_retention=24h."""
+    @pytest.mark.parametrize("model", ("gpt-5.5-local-lora", "gpt-5.6-local-lora"))
+    def test_chat_compat_streaming_omits_commercial_cache_params(self, model: str) -> None:
+        """A local model name must not activate commercial OpenAI cache controls."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = iter(())
+
+        list(
+            self.provider.create_streaming(
+                client=client,
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+
+        sent = client.chat.completions.create.call_args.kwargs
+        assert "prompt_cache_retention" not in sent
+        assert "prompt_cache_options" not in sent
+
+    @pytest.mark.parametrize("model", ("gpt-5.5-local-lora", "gpt-5.6-local-lora"))
+    def test_chat_compat_completion_omits_commercial_cache_params(self, model: str) -> None:
+        """The non-streaming local lane has the same cache-parameter isolation."""
+        response = MagicMock()
+        response.choices = [
+            MagicMock(
+                message=MagicMock(content="hello", tool_calls=None, annotations=None),
+                finish_reason="stop",
+            )
+        ]
+        response.usage = None
+        client = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        self.provider.create_completion(
+            client=client,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        sent = client.chat.completions.create.call_args.kwargs
+        assert "prompt_cache_retention" not in sent
+        assert "prompt_cache_options" not in sent
+
+    def test_cache_retention_set_for_pre_gpt56_models(self) -> None:
+        """Pre-5.6 GPT-5 models retain the legacy 24-hour cache policy."""
         for model in (
             "gpt-5",
             "gpt-5.1",
@@ -3953,16 +4020,21 @@ class TestOpenAIPromptCaching:
             "gpt-5.4-pro",
             "gpt-5.5",
             "gpt-5.5-pro",
-            "gpt-5.6",
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-            "gpt-5.6-luna",
             "gpt-5-mini",
             "gpt-5-pro",
         ):
             kwargs: dict[str, Any] = {}
             apply_cache_retention(kwargs, model)
             assert kwargs.get("prompt_cache_retention") == "24h", f"Failed for {model}"
+            assert "prompt_cache_options" not in kwargs
+
+    def test_gpt56_uses_prompt_cache_options(self) -> None:
+        """GPT-5.6 uses the replacement cache API introduced in SDK 2.45."""
+        for model in ("gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            kwargs: dict[str, Any] = {}
+            apply_cache_retention(kwargs, model)
+            assert kwargs.get("prompt_cache_options") == {"ttl": "30m"}, model
+            assert "prompt_cache_retention" not in kwargs
 
     def test_cache_retention_not_set_for_non_gpt5(self) -> None:
         """Non-GPT-5 models do not get cache retention."""
@@ -3970,6 +4042,38 @@ class TestOpenAIPromptCaching:
             kwargs: dict[str, Any] = {}
             apply_cache_retention(kwargs, model)
             assert "prompt_cache_retention" not in kwargs, f"Unexpected retention for {model}"
+            assert "prompt_cache_options" not in kwargs, f"Unexpected options for {model}"
+
+    def test_cache_write_tokens_from_responses_usage(self) -> None:
+        """GPT-5.6 cache writes flow into normalized usage accounting."""
+        usage = MagicMock()
+        usage.prompt_tokens = None
+        usage.input_tokens = 100
+        usage.completion_tokens = None
+        usage.output_tokens = 20
+        usage.total_tokens = 120
+        usage.prompt_tokens_details = None
+        usage.input_tokens_details = MagicMock(cached_tokens=30, cache_write_tokens=70)
+
+        normalized = extract_usage(usage)
+
+        assert normalized is not None
+        assert normalized.cache_read_tokens == 30
+        assert normalized.cache_creation_tokens == 70
+
+    def test_cache_write_tokens_from_chat_usage(self) -> None:
+        """The Chat Completions usage shape reports the same cache-write metric."""
+        usage = MagicMock()
+        usage.prompt_tokens = 100
+        usage.completion_tokens = 20
+        usage.total_tokens = 120
+        usage.prompt_tokens_details = MagicMock(cached_tokens=30, cache_write_tokens=70)
+
+        normalized = extract_usage(usage)
+
+        assert normalized is not None
+        assert normalized.cache_read_tokens == 30
+        assert normalized.cache_creation_tokens == 70
 
     def test_streaming_cached_tokens_from_usage(self) -> None:
         """Streaming usage extracts cached_tokens from prompt_tokens_details."""
@@ -4393,8 +4497,7 @@ class TestResponsesParamBuilding:
         assert kwargs["reasoning"] == {"effort": "high", "mode": "pro"}
 
     def test_pro_mode_rejected_when_unsupported(self) -> None:
-        """A pro reasoning_mode on Terra/Luna (supports_pro_mode False) is
-        dropped — effort still rides, mode does not."""
+        """A pro mode on a model without reasoning-mode support is dropped."""
         caps = ModelCapabilities(
             supports_pro_mode=False,
             reasoning_mode="pro",
@@ -4409,6 +4512,16 @@ class TestResponsesParamBuilding:
         caps = ModelCapabilities(supports_pro_mode=True, reasoning_mode="pro")
         kwargs = self._build(caps, reasoning_effort="medium")
         assert kwargs["reasoning"] == {"mode": "pro"}
+
+    def test_standard_reasoning_mode_is_accepted(self) -> None:
+        """The SDK's explicit standard mode is valid even though omission is equivalent."""
+        caps = ModelCapabilities(
+            supports_pro_mode=True,
+            reasoning_mode="standard",
+            reasoning_effort_values=("low", "medium", "high"),
+        )
+        kwargs = self._build(caps, reasoning_effort="high")
+        assert kwargs["reasoning"] == {"effort": "high", "mode": "standard"}
 
     def test_verbosity_unknown_value_dropped(self) -> None:
         """A verbosity outside {low,medium,high} is dropped, not sent — an
@@ -4426,9 +4539,23 @@ class TestResponsesParamBuilding:
         kwargs = self._build(caps, reasoning_effort="high")
         assert kwargs["reasoning"] == {"effort": "high"}
 
-    def test_gpt56_terra_max_snaps_to_xhigh_on_responses_wire(self) -> None:
-        """Terra's knob "max" snaps to the xhigh ceiling on the ACTUAL
-        Responses wire path (_build_kwargs), not only the shared resolver."""
+    def test_verbosity_non_string_value_dropped(self) -> None:
+        """Malformed operator JSON must not crash request construction."""
+        kwargs = self._build(ModelCapabilities(supports_verbosity=True, verbosity=["low"]))
+        assert "text" not in kwargs
+
+    def test_pro_mode_non_string_value_dropped(self) -> None:
+        """Malformed operator JSON must not crash request construction."""
+        caps = ModelCapabilities(
+            supports_pro_mode=True,
+            reasoning_mode=["pro"],
+            reasoning_effort_values=("low", "medium", "high"),
+        )
+        kwargs = self._build(caps, reasoning_effort="high")
+        assert kwargs["reasoning"] == {"effort": "high"}
+
+    def test_gpt56_terra_max_reaches_responses_wire(self) -> None:
+        """Terra sends the documented max effort on the actual Responses path."""
         kwargs = self.provider._build_kwargs(
             model="gpt-5.6-terra",
             messages=[{"role": "user", "content": "Hi"}],
@@ -4438,19 +4565,14 @@ class TestResponsesParamBuilding:
             reasoning_effort="max",
             deferred_names=None,
         )
-        assert kwargs["reasoning"] == {"effort": "xhigh"}
+        assert kwargs["reasoning"] == {"effort": "max"}
 
     def test_gpt56_verbosity_and_pro_flags(self) -> None:
-        """The static rows carry the right capability flags: verbosity on all
-        three tiers, pro mode on Sol/alias only."""
-        sol = lookup_openai_capabilities("gpt-5.6-sol")
-        assert sol.supports_verbosity is True
-        assert sol.supports_pro_mode is True
-        assert lookup_openai_capabilities("gpt-5.6").supports_pro_mode is True
-        for tier in ("gpt-5.6-terra", "gpt-5.6-luna"):
+        """Every GPT-5.6 tier supports verbosity and pro reasoning mode."""
+        for tier in ("gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
             caps = lookup_openai_capabilities(tier)
             assert caps.supports_verbosity is True
-            assert caps.supports_pro_mode is False
+            assert caps.supports_pro_mode is True
 
     def _kwargs_with(self, tools: list[dict[str, Any]], caps: ModelCapabilities) -> dict[str, Any]:
         return self.provider._build_kwargs(
@@ -4502,6 +4624,34 @@ class TestResponsesParamBuilding:
             deferred_names=None,
         )
         assert kwargs["prompt_cache_retention"] == "24h"
+
+    def test_compat_responses_omits_commercial_cache_params(self) -> None:
+        provider = type(self.provider)(compat=True)
+        for model in ("gpt-5.5-local-lora", "gpt-5.6-local-lora"):
+            kwargs = provider._build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=None,
+                max_tokens=4096,
+                temperature=0.5,
+                reasoning_effort="medium",
+                deferred_names=None,
+            )
+            assert "prompt_cache_retention" not in kwargs, model
+            assert "prompt_cache_options" not in kwargs, model
+
+    def test_cache_options_for_gpt56(self) -> None:
+        kwargs = self.provider._build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=4096,
+            temperature=0.5,
+            reasoning_effort="medium",
+            deferred_names=None,
+        )
+        assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in kwargs
 
     def test_instructions_from_system_messages(self) -> None:
         kwargs = self.provider._build_kwargs(

--- a/tests/test_wire_payload_golden.py
+++ b/tests/test_wire_payload_golden.py
@@ -311,8 +311,8 @@ def test_wire_payload_anthropic_compat(fixture_id: str) -> None:
     _assert_golden(f"anthropic_compat__{fixture_id}", payload)
 
 
-# GPT-5.6 Sol is the first COMMERCIAL OpenAI model to expose the "max"
-# reasoning effort (Terra/Luna cap at "xhigh"; see OPENAI_CAPABILITIES).
+# GPT-5.6 is the first commercial OpenAI family to expose the "max"
+# reasoning effort across Sol, Terra, and Luna (see OPENAI_CAPABILITIES).
 # The base matrix above pins only the default-effort Responses shape
 # (gpt-5 → "medium"), so freeze a max-effort request to prove the new
 # level compiles onto the native ``reasoning={"effort": "max"}`` param.

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6296,13 +6296,23 @@ function _updateModelResponseControls() {
     const field = document.getElementById(spec.fieldId);
     const select = document.getElementById(spec.elementId);
     if (!field || !select) return;
+    // A value _captureModelResponseControls lifted out of the row's JSON
+    // stays visible (and re-saveable) while the identity still matches the
+    // row being edited, deliberately NOT consulting the capability
+    // baseline: the baseline arrives async (or never, on the compat lane),
+    // and yielding to it would hide the pinned value and silently drop it
+    // on save — the same lift-then-restore contract as server_compat,
+    // rerank calibration, and thinking_param. Wire safety is server-side:
+    // emission gates on the merged supports_* flag, so a pinned value on
+    // an unsupported model is inert; "Provider default" explicitly clears
+    // it. An explicit tile override (either polarity) supersedes the
+    // fallback — unchecking the tile is the operator's way to retire it.
     const capturedFallback =
       sameIdentity &&
       !(spec.supportKey in _modelCapsExplicit) &&
       _modelResponseValueValid(spec, select.value);
     const visible =
-      responseSurface &&
-      (_modelGetTile(spec.supportKey) || capturedFallback);
+      responseSurface && (_modelGetTile(spec.supportKey) || capturedFallback);
     field.hidden = !visible;
     anyVisible = anyVisible || visible;
   });
@@ -6344,10 +6354,18 @@ function _mergeModelResponseControls(caps) {
     _modelResponseInitialIdentity &&
     _modelIdentity() === _modelResponseInitialIdentity;
   _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
-    if (_modelResponseDirty[spec.key]) delete caps[spec.key];
+    // Dirty (select touched this session) lets the select override a
+    // stale JSON key, but only for the identity that made it dirty —
+    // after a model/provider/surface change the flag describes the OLD
+    // row, and honoring it would delete a key hand-typed into the
+    // Advanced JSON for the new one.
+    if (_modelResponseDirty[spec.key] && sameIdentity) delete caps[spec.key];
     else if (spec.key in caps) return; // Advanced JSON wins.
     const select = document.getElementById(spec.elementId);
     if (!select || !_modelResponseValueValid(spec, select.value)) return;
+    // Same capturedFallback contract as _updateModelResponseControls
+    // (rationale there): a lifted same-identity value must re-save, or an
+    // unrelated edit silently drops it from the row.
     const capturedFallback =
       sameIdentity && !(spec.supportKey in _modelCapsExplicit);
     if (_modelGetTile(spec.supportKey) || capturedFallback) {

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -6185,7 +6185,7 @@ let _modelDefaultAlias = "";
 // and are re-merged on save. Reset per modal open.
 let _rerankCalFields = {};
 
-// Capability tile matrix — sparse-override semantics. The 9 tiles display
+// Capability tile matrix — sparse-override semantics. The tiles display
 // merge(dataclass defaults, known-model table baseline, explicit overrides);
 // only EXPLICIT keys persist (saved keys + tiles the user toggled), so a
 // known model keeps tracking future table updates instead of being pinned.
@@ -6197,6 +6197,8 @@ const _MODEL_CAP_KEYS = [
   "supports_web_search",
   "supports_temperature",
   "supports_effort",
+  "supports_verbosity",
+  "supports_pro_mode",
   "supports_transcription",
   "supports_speech_synthesis",
   "supports_audio_input",
@@ -6210,6 +6212,8 @@ const _MODEL_CAP_DEFAULTS = {
   supports_web_search: false,
   supports_temperature: true,
   supports_effort: false,
+  supports_verbosity: false,
+  supports_pro_mode: false,
   supports_transcription: false,
   supports_speech_synthesis: false,
   supports_audio_input: false,
@@ -6233,6 +6237,134 @@ function _modelRenderTiles() {
     else if (k in _modelCapsBaseline) el.checked = !!_modelCapsBaseline[k];
     else el.checked = _MODEL_CAP_DEFAULTS[k];
   });
+  _updateModelResponseControls();
+}
+
+const _MODEL_RESPONSE_CONTROLS = [
+  {
+    key: "verbosity",
+    supportKey: "supports_verbosity",
+    elementId: "model-output-verbosity",
+    fieldId: "model-output-verbosity-field",
+    values: ["low", "medium", "high"],
+  },
+  {
+    key: "reasoning_mode",
+    supportKey: "supports_pro_mode",
+    elementId: "model-reasoning-mode",
+    fieldId: "model-reasoning-mode-field",
+    values: ["standard", "pro"],
+  },
+];
+let _modelResponseInitialIdentity = "";
+let _modelResponseCurrentIdentity = "";
+let _modelResponseCaptured = {};
+let _modelResponseDirty = {};
+
+function _modelIdentity() {
+  const provider = document.getElementById("model-provider").value;
+  const model = document.getElementById("model-name").value.trim();
+  const surface =
+    provider === "openai-compatible"
+      ? document.getElementById("model-api-surface").value
+      : "";
+  return provider + "\n" + model + "\n" + surface;
+}
+
+function _modelUsesResponsesSurface() {
+  const provider = document.getElementById("model-provider").value;
+  if (provider === "openai") return true;
+  return (
+    provider === "openai-compatible" &&
+    document.getElementById("model-api-surface").value === "responses"
+  );
+}
+
+function _modelResponseValueValid(spec, value) {
+  return typeof value === "string" && spec.values.indexOf(value) !== -1;
+}
+
+function _updateModelResponseControls() {
+  const group = document.getElementById("model-response-controls");
+  if (!group) return;
+  const responseSurface = _modelUsesResponsesSurface();
+  const sameIdentity =
+    _modelResponseInitialIdentity &&
+    _modelIdentity() === _modelResponseInitialIdentity;
+  let anyVisible = false;
+  _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+    const field = document.getElementById(spec.fieldId);
+    const select = document.getElementById(spec.elementId);
+    if (!field || !select) return;
+    const capturedFallback =
+      sameIdentity &&
+      !(spec.supportKey in _modelCapsExplicit) &&
+      _modelResponseValueValid(spec, select.value);
+    const visible =
+      responseSurface &&
+      (_modelGetTile(spec.supportKey) || capturedFallback);
+    field.hidden = !visible;
+    anyVisible = anyVisible || visible;
+  });
+  group.hidden = !anyVisible;
+}
+
+function _resetModelResponseControls() {
+  _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+    const select = document.getElementById(spec.elementId);
+    if (select) select.value = "";
+  });
+  _modelResponseInitialIdentity = "";
+  _modelResponseCurrentIdentity = _modelIdentity();
+  _modelResponseCaptured = {};
+  _modelResponseDirty = {};
+  _updateModelResponseControls();
+}
+
+function _captureModelResponseControls(capsObj) {
+  if (!_modelUsesResponsesSurface()) return;
+  _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+    const select = document.getElementById(spec.elementId);
+    if (!select) return;
+    const explicitlyUnsupported =
+      spec.supportKey in _modelCapsExplicit &&
+      !_modelCapsExplicit[spec.supportKey];
+    const value = capsObj[spec.key];
+    if (!explicitlyUnsupported && _modelResponseValueValid(spec, value)) {
+      select.value = value;
+      _modelResponseCaptured[spec.key] = value;
+      delete capsObj[spec.key];
+    }
+  });
+}
+
+function _mergeModelResponseControls(caps) {
+  if (!_modelUsesResponsesSurface()) return;
+  const sameIdentity =
+    _modelResponseInitialIdentity &&
+    _modelIdentity() === _modelResponseInitialIdentity;
+  _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+    if (_modelResponseDirty[spec.key]) delete caps[spec.key];
+    else if (spec.key in caps) return; // Advanced JSON wins.
+    const select = document.getElementById(spec.elementId);
+    if (!select || !_modelResponseValueValid(spec, select.value)) return;
+    const capturedFallback =
+      sameIdentity && !(spec.supportKey in _modelCapsExplicit);
+    if (_modelGetTile(spec.supportKey) || capturedFallback) {
+      caps[spec.key] = select.value;
+    }
+  });
+}
+
+function _rememberModelResponseControl(spec) {
+  _modelResponseDirty[spec.key] = true;
+  if (_modelIdentity() !== _modelResponseInitialIdentity) return;
+  const select = document.getElementById(spec.elementId);
+  if (select && _modelResponseValueValid(spec, select.value)) {
+    _modelResponseCaptured[spec.key] = select.value;
+  } else {
+    delete _modelResponseCaptured[spec.key];
+  }
 }
 
 // Roles surfaced in the Models → Roles sub-tab.  Each entry maps a
@@ -6768,6 +6900,25 @@ function _renderModels(items) {
     if (m.max_tokens != null) overrides.push("max_tok=" + m.max_tokens);
     if (m.reasoning_effort != null)
       overrides.push("effort=" + m.reasoning_effort);
+    let displayCaps = m.capabilities;
+    if (typeof displayCaps === "string") {
+      try {
+        displayCaps = JSON.parse(displayCaps || "{}");
+      } catch (e) {
+        displayCaps = {};
+      }
+    }
+    if (!_isPlainObject(displayCaps)) displayCaps = {};
+    if (
+      displayCaps.supports_verbosity !== false &&
+      ["low", "medium", "high"].indexOf(displayCaps.verbosity) !== -1
+    )
+      overrides.push("verbosity=" + displayCaps.verbosity);
+    if (
+      displayCaps.supports_pro_mode !== false &&
+      ["standard", "pro"].indexOf(displayCaps.reasoning_mode) !== -1
+    )
+      overrides.push("mode=" + displayCaps.reasoning_mode);
     // Reasoning persistence flags surface only when non-default
     // (persist=False is the operator opt-out; replay=True is the
     // operator opt-in). Default values are silent.
@@ -6985,8 +7136,10 @@ function showCreateModelModal() {
   if (_calChip) _calChip.style.display = "none";
   const _recalBtn = document.getElementById("model-recalibrate-btn");
   if (_recalBtn) _recalBtn.hidden = true;
+  _modelCapsSeq++; // invalidate lookups from a prior shelf lifecycle
   _modelCapsBaseline = {};
   _modelCapsExplicit = {};
+  _resetModelResponseControls();
   _modelRenderTiles();
   document.getElementById("model-autofill").hidden = true;
   _refreshModelSuggestions();
@@ -7082,7 +7235,7 @@ function showEditModelModal(definitionId) {
           }
         },
       );
-      // Lift the 9 matrix keys out of the JSON into the tiles — they are
+      // Lift the capability keys out of the JSON into the tiles — they are
       // the row's explicit overrides and the textarea holds the remainder.
       _modelCapsExplicit = {};
       _MODEL_CAP_KEYS.forEach(function (k) {
@@ -7091,6 +7244,9 @@ function showEditModelModal(definitionId) {
           delete capsObj[k];
         }
       });
+      _modelResponseInitialIdentity = _modelIdentity();
+      _modelResponseCurrentIdentity = _modelResponseInitialIdentity;
+      _captureModelResponseControls(capsObj);
       _modelRenderTiles();
       _modelCapsRefreshBaseline();
       _scheduleEffortLadder();
@@ -7259,6 +7415,7 @@ function submitCreateModel() {
   Object.keys(_modelCapsExplicit).forEach(function (k) {
     if (!(k in caps)) caps[k] = _modelGetTile(k);
   });
+  _mergeModelResponseControls(caps);
 
   // Re-merge reranker calibration fields extracted on edit so an unrelated edit
   // doesn't silently drop the calibration. A field typed directly into the
@@ -7688,12 +7845,34 @@ function recalibrateModel() {
 }
 
 /* Capability auto-fill: when the user types a known model name or
-   changes the provider, look up static capabilities and pre-fill
-   context_window and the capabilities textarea. */
+   changes the provider, look up static capabilities and refresh the
+   context window, capability tiles, and conditional response controls. */
 let _capsTimer = null;
 let _modelCapsSeq = 0;
 function _onModelFieldChange() {
   clearTimeout(_capsTimer);
+  const nextIdentity = _modelIdentity();
+  if (
+    _modelResponseCurrentIdentity &&
+    nextIdentity !== _modelResponseCurrentIdentity
+  ) {
+    _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+      const select = document.getElementById(spec.elementId);
+      if (!select) return;
+      const captured = _modelResponseCaptured[spec.key];
+      select.value =
+        nextIdentity === _modelResponseInitialIdentity &&
+        _modelResponseValueValid(spec, captured)
+          ? captured
+          : "";
+    });
+  }
+  _modelResponseCurrentIdentity = nextIdentity;
+  _modelCapsSeq++; // invalidate any capability lookup already in flight
+  _modelCapsBaseline = {};
+  const banner = document.getElementById("model-autofill");
+  if (banner) banner.hidden = true;
+  _modelRenderTiles();
   _capsTimer = setTimeout(_modelCapsRefreshBaseline, 500);
   _scheduleEffortLadder();
 }
@@ -7822,6 +8001,7 @@ function _modelCapsRefreshBaseline() {
   const provider = document.getElementById("model-provider").value;
   const modelName = document.getElementById("model-name").value.trim();
   const banner = document.getElementById("model-autofill");
+  const seq = ++_modelCapsSeq;
   if (
     !modelName ||
     provider === "openai-compatible" ||
@@ -7834,7 +8014,6 @@ function _modelCapsRefreshBaseline() {
   }
   // Two type-then-pause cycles can have both fetches in flight; a reordered
   // older response must not clobber the tiles (the _schPreviewSeq pattern).
-  const seq = ++_modelCapsSeq;
   authFetch(
     "/v1/api/admin/model-capabilities?provider=" +
       encodeURIComponent(provider) +
@@ -7918,6 +8097,7 @@ function _applyProviderDefaults() {
   if (serverFieldsRow) {
     serverFieldsRow.hidden = provider === "anthropic-compatible";
   }
+  _updateModelResponseControls();
 }
 
 /* Populate the model name datalist with known model prefixes for the
@@ -7957,14 +8137,26 @@ function _refreshModelSuggestions() {
   const tmEl = document.getElementById("model-thinking-mode");
   if (tmEl) tmEl.addEventListener("change", _toggleThinkingParam);
   if (tmEl) tmEl.addEventListener("change", _scheduleEffortLadder);
+  _MODEL_RESPONSE_CONTROLS.forEach(function (spec) {
+    const select = document.getElementById(spec.elementId);
+    if (select)
+      select.addEventListener("change", function () {
+        _rememberModelResponseControl(spec);
+      });
+  });
   ["model-thinking-param", "model-effort-param", "model-capabilities"].forEach(
     function (id) {
       const el = document.getElementById(id);
       if (el) el.addEventListener("input", _scheduleEffortLadder);
     },
   );
+  const rawCapsEl = document.getElementById("model-capabilities");
+  if (rawCapsEl)
+    rawCapsEl.addEventListener("input", function () {
+      _modelResponseDirty = {};
+    });
   const apiSurfEl = document.getElementById("model-api-surface");
-  if (apiSurfEl) apiSurfEl.addEventListener("change", _scheduleEffortLadder);
+  if (apiSurfEl) apiSurfEl.addEventListener("change", _onModelFieldChange);
   const grid = document.getElementById("model-capgrid");
   if (grid) {
     grid.addEventListener("change", function (e) {
@@ -7972,6 +8164,17 @@ function _refreshModelSuggestions() {
       if (!cap) return;
       // a toggle IS the override decision — the key persists from here on
       _modelCapsExplicit[cap] = e.target.checked;
+      if (cap === "supports_verbosity" || cap === "supports_pro_mode") {
+        const spec = _MODEL_RESPONSE_CONTROLS.find(function (item) {
+          return item.supportKey === cap;
+        });
+        if (spec && !e.target.checked) {
+          const select = document.getElementById(spec.elementId);
+          if (select) select.value = "";
+          delete _modelResponseCaptured[spec.key];
+        }
+        _updateModelResponseControls();
+      }
       if (cap === "supports_rerank") {
         const recalBtn = document.getElementById("model-recalibrate-btn");
         if (recalBtn)

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -1744,6 +1744,46 @@
                 <option value="max">Max</option>
               </select>
 
+              <div
+                id="model-response-controls"
+                role="group"
+                aria-labelledby="model-response-controls-title"
+                hidden
+              >
+                <div class="sh-section" id="model-response-controls-title">
+                  Response controls
+                </div>
+                <div class="field-pair">
+                  <div id="model-output-verbosity-field" hidden>
+                    <label for="model-output-verbosity"
+                      >Output verbosity
+                      <span class="label-hint"
+                        >answer length, independent of effort</span
+                      ></label
+                    >
+                    <select id="model-output-verbosity">
+                      <option value="">Provider default</option>
+                      <option value="low">Low — concise</option>
+                      <option value="medium">Medium — balanced</option>
+                      <option value="high">High — detailed</option>
+                    </select>
+                  </div>
+                  <div id="model-reasoning-mode-field" hidden>
+                    <label for="model-reasoning-mode"
+                      >Reasoning mode
+                      <span class="label-hint"
+                        >Pro applies more work before answering</span
+                      ></label
+                    >
+                    <select id="model-reasoning-mode">
+                      <option value="">Provider default</option>
+                      <option value="standard">Standard</option>
+                      <option value="pro">Pro</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
               <div id="model-server-compat-section" hidden>
                 <div class="sh-section">Server compatibility</div>
                 <div class="field-pair" id="model-server-fields-row">
@@ -1881,6 +1921,20 @@
                     class="cap-led"
                   ></span
                   ><span class="cap-name">Reasoning-effort control</span></label
+                >
+                <label class="cap"
+                  ><input
+                    type="checkbox"
+                    data-cap="supports_verbosity"
+                  /><span class="cap-led"></span
+                  ><span class="cap-name">Output verbosity</span></label
+                >
+                <label class="cap"
+                  ><input
+                    type="checkbox"
+                    data-cap="supports_pro_mode"
+                  /><span class="cap-led"></span
+                  ><span class="cap-name">Standard / Pro mode</span></label
                 >
                 <label class="cap"
                   ><input

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -16,7 +16,6 @@ import structlog
 from turnstone.core.providers._openai_common import (
     OPENAI_COMPAT_DEFAULT,
     RETRYABLE_ERROR_NAMES,
-    apply_cache_retention,
     apply_temperature_and_effort,
     apply_tool_search,
     extract_usage,
@@ -178,7 +177,6 @@ class OpenAIChatCompletionsProvider:
             "stream_options": {"include_usage": True},
         }
         apply_temperature_and_effort(kwargs, caps, temperature, reasoning_effort)
-        apply_cache_retention(kwargs, model)
         tools = self._apply_web_search(kwargs, caps, tools)
         tools = apply_tool_search(caps, tools, deferred_names)
         if tools:
@@ -313,7 +311,6 @@ class OpenAIChatCompletionsProvider:
             "stream": False,
         }
         apply_temperature_and_effort(kwargs, caps, temperature, reasoning_effort)
-        apply_cache_retention(kwargs, model)
         tools = self._apply_web_search(kwargs, caps, tools)
         tools = apply_tool_search(caps, tools, deferred_names)
         if tools:

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -173,22 +173,11 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_reasoning_replay=True,
     ),
     # GPT-5.6 (Sol / Terra / Luna) — released 2026-07-09.  The bare
-    # "gpt-5.6" alias routes to Sol (developers.openai.com/api/docs/guides/
-    # latest-model, 2026-07 check), so this catch-all row carries Sol's
-    # caps and also covers dated Sol snapshots ("gpt-5.6-2026-..") and the
-    # explicit "gpt-5.6-sol" id by longest-prefix match.  Sol is the ONLY
-    # 5.6 tier that unlocks the new "max" reasoning effort — the first
-    # COMMERCIAL OpenAI model to use it (KNOB_EFFORT_ORDER already ranks
-    # "max" for the Anthropic lane, so the ordinal snap and effort ladder
-    # need no change).  Sol also has a Sol-only "ultra" multi-agent mode
-    # that Turnstone does NOT expose (only "pro" is wired — see below).
-    # Default effort is "medium" like gpt-5.5; temperature is accepted only at
-    # reasoning_effort="none" (the "none"-in-values gate).  There is NO
-    # gpt-5.6-pro model: "pro" is now a reasoning.mode="pro" request param,
-    # not a separate model id.  Context window is not yet on the model page
-    # (limited preview); 1.05M mirrors the 5.4/5.5 lineage — override via
-    # the DB model definition if OpenAI publishes a different window (a
-    # smaller Luna window has been reported but is unconfirmed).
+    # "gpt-5.6" alias routes to Sol, so this catch-all row also covers the
+    # explicit "gpt-5.6-sol" id by longest-prefix match.  Every tier supports
+    # the family reasoning ladder through "max", output verbosity, and
+    # reasoning.mode="pro"; there is no separate gpt-5.6-pro model.  Default
+    # effort is "medium" and temperature is accepted only when effort="none".
     "gpt-5.6": ModelCapabilities(
         context_window=1050000,
         max_output_tokens=128000,
@@ -199,32 +188,33 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_pdf=True,
         supports_reasoning_replay=True,
         supports_verbosity=True,
-        supports_pro_mode=True,  # Sol-only reasoning.mode="pro"
+        supports_pro_mode=True,
     ),
-    # GPT-5.6 Terra — balanced tier; Sol's ladder minus "max" (Sol-only),
-    # so the knob's "max" snaps to the "xhigh" ceiling.  No pro mode.
+    # GPT-5.6 Terra — balanced intelligence/cost tier.
     "gpt-5.6-terra": ModelCapabilities(
         context_window=1050000,
         max_output_tokens=128000,
-        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh", "max"),
         default_reasoning_effort="medium",
         supports_tool_search=True,
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
         supports_verbosity=True,
+        supports_pro_mode=True,
     ),
-    # GPT-5.6 Luna — fastest/cheapest tier; no "max" effort, no pro mode.
+    # GPT-5.6 Luna — cost-sensitive, high-volume tier.
     "gpt-5.6-luna": ModelCapabilities(
         context_window=1050000,
         max_output_tokens=128000,
-        reasoning_effort_values=("none", "low", "medium", "high", "xhigh"),
+        reasoning_effort_values=("none", "low", "medium", "high", "xhigh", "max"),
         default_reasoning_effort="medium",
         supports_tool_search=True,
         supports_vision=True,
         supports_pdf=True,
         supports_reasoning_replay=True,
         supports_verbosity=True,
+        supports_pro_mode=True,
     ),
     # O-series reasoning models
     "o1": ModelCapabilities(
@@ -415,14 +405,15 @@ def apply_temperature_and_effort(
 
 
 def apply_cache_retention(kwargs: dict[str, Any], model: str) -> None:
-    """Enable 24-hour extended prompt cache retention for GPT-5.x models.
+    """Configure the prompt-cache lifetime supported by each GPT-5 generation.
 
-    OpenAI caching is automatic (no code changes for basic caching), but
-    the default TTL is only 5-10 minutes.  Extended retention keeps cached
-    KV tensors for up to 24 hours at no additional cost, which is valuable
-    for workstreams with bursty activity patterns.
+    GPT-5.6 replaces the deprecated ``prompt_cache_retention`` field with
+    ``prompt_cache_options.ttl``; 30 minutes is currently its only accepted
+    minimum lifetime.  Earlier GPT-5 models retain the 24-hour policy.
     """
-    if model.startswith("gpt-5"):
+    if model.startswith("gpt-5.6"):
+        kwargs["prompt_cache_options"] = {"ttl": "30m"}
+    elif model.startswith("gpt-5"):
         kwargs["prompt_cache_retention"] = "24h"
 
 
@@ -439,7 +430,7 @@ def apply_cache_retention(kwargs: dict[str, Any], model: str) -> None:
 # The emission sites drop unknown values with a warning instead, mirroring
 # how ``model_registry`` clamps out-of-range temperature / max_tokens.
 VERBOSITY_LEVELS: frozenset[str] = frozenset({"low", "medium", "high"})
-REASONING_MODES: frozenset[str] = frozenset({"pro"})
+REASONING_MODES: frozenset[str] = frozenset({"standard", "pro"})
 
 
 def apply_verbosity(kwargs: dict[str, Any], caps: ModelCapabilities) -> None:
@@ -456,7 +447,14 @@ def apply_verbosity(kwargs: dict[str, Any], caps: ModelCapabilities) -> None:
     ``apply_temperature``); a value outside ``VERBOSITY_LEVELS`` is dropped
     with a warning (an operator typo must not 400 every request).
     """
-    if not (caps.supports_verbosity and caps.verbosity):
+    if not caps.supports_verbosity or caps.verbosity == "":
+        return
+    if not isinstance(caps.verbosity, str):
+        log.warning(
+            "openai.responses: ignoring non-string verbosity",
+            value=caps.verbosity,
+            expected=sorted(VERBOSITY_LEVELS),
+        )
         return
     if caps.verbosity not in VERBOSITY_LEVELS:
         log.warning(
@@ -818,11 +816,13 @@ def extract_usage(usage_obj: Any) -> UsageInfo | None:
     if ptd is None:
         ptd = getattr(usage_obj, "input_tokens_details", None)
     cached = getattr(ptd, "cached_tokens", 0) if ptd is not None else 0
+    cache_written = getattr(ptd, "cache_write_tokens", 0) if ptd is not None else 0
 
     return UsageInfo(
         prompt_tokens=pt,
         completion_tokens=ct,
         total_tokens=tt if isinstance(tt, int) else (pt + ct),
+        cache_creation_tokens=cache_written if isinstance(cache_written, int) else 0,
         cache_read_tokens=cached if isinstance(cached, int) else 0,
     )
 

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -438,7 +438,7 @@ class OpenAIResponsesProvider:
         apply_temperature(kwargs, caps, temperature, reasoning_effort)
 
         # Reasoning params → {"effort": ..., "mode": ...} (Responses format).
-        # "mode": "pro" (GPT-5.6 Sol) applies more model work before a single
+        # "mode": "pro" (GPT-5.6) applies more model work before a single
         # final answer; it rides with or without an effort level (effort
         # defaults to medium in pro mode), and effort still rides without a
         # mode.  Both are operator-declared and gated by their static
@@ -447,8 +447,14 @@ class OpenAIResponsesProvider:
         effort = resolve_reasoning_effort(caps, reasoning_effort)
         if effort:
             reasoning["effort"] = effort
-        if caps.supports_pro_mode and caps.reasoning_mode:
-            if caps.reasoning_mode in REASONING_MODES:
+        if caps.supports_pro_mode and caps.reasoning_mode != "":
+            if not isinstance(caps.reasoning_mode, str):
+                log.warning(
+                    "openai.responses: ignoring non-string reasoning mode",
+                    value=caps.reasoning_mode,
+                    expected=sorted(REASONING_MODES),
+                )
+            elif caps.reasoning_mode in REASONING_MODES:
                 reasoning["mode"] = caps.reasoning_mode
             else:
                 log.warning(
@@ -460,7 +466,8 @@ class OpenAIResponsesProvider:
             kwargs["reasoning"] = reasoning
 
         apply_verbosity(kwargs, caps)
-        apply_cache_retention(kwargs, model)
+        if not self._compat:
+            apply_cache_retention(kwargs, model)
         return kwargs
 
     # -- streaming -----------------------------------------------------------

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -102,23 +102,6 @@ class ModelCapabilities:
     # this False: there, an empty values list means the model has no
     # effort control at all (o1-mini) and the param must be omitted.
     effort_passthrough: bool = False
-    # Responses-API output-length control (GPT-5 family): "low"/"medium"/
-    # "high", separate from reasoning effort.  ``supports_verbosity`` is the
-    # static capability; ``verbosity`` is the operator-declared value
-    # (model-definition capabilities JSON, merged via
-    # ``ChatSession._resolve_capabilities``), "" = omit.  Nests under
-    # ``text.verbosity`` on the Responses wire (a top-level ``verbosity``
-    # 400s there); the Chat/compat lane never emits it.  A value set on a
-    # model whose ``supports_verbosity`` is False is dropped, not sent.
-    supports_verbosity: bool = False
-    verbosity: str = ""
-    # Responses-API ``reasoning.mode`` (GPT-5.6 Sol): "pro" applies more
-    # model work before a single final answer.  ``supports_pro_mode`` is the
-    # static capability (Sol-only); ``reasoning_mode`` is the
-    # operator-declared value, "" = omit (normal reasoning).  There is no
-    # gpt-5.6-pro *model* — "pro" is this request-level mode instead.
-    supports_pro_mode: bool = False
-    reasoning_mode: str = ""
     supports_web_search: bool = False
     supports_tool_search: bool = False
     supports_vision: bool = False
@@ -170,6 +153,20 @@ class ModelCapabilities:
     rerank_threshold: float = 0.0
     rerank_scale: str = ""
     rerank_separated: bool = False
+    # Responses-API output-length control (GPT-5 family): "low"/"medium"/
+    # "high", separate from reasoning effort.  Appended rather than inserted
+    # above to preserve the public dataclass constructor's positional order.
+    # ``supports_verbosity`` is the static capability; ``verbosity`` is the
+    # operator-declared value (model-definition capabilities JSON, merged via
+    # ``ChatSession._resolve_capabilities``), "" = omit.  Nests under
+    # ``text.verbosity`` on the Responses wire.
+    supports_verbosity: bool = False
+    verbosity: str = ""
+    # Responses-API ``reasoning.mode`` for GPT-5.6.  ``supports_pro_mode`` is
+    # the static capability; ``reasoning_mode`` is the operator-declared value,
+    # "" = omit (standard reasoning).  There is no gpt-5.6-pro model.
+    supports_pro_mode: bool = False
+    reasoning_mode: str = ""
 
 
 # The session effort knob is ORDINAL — snapping must respect this order.

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.44.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1485,9 +1485,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]
@@ -2544,7 +2544,7 @@ requires-dist = [
     { name = "lacme", specifier = ">=1.0.5" },
     { name = "mcp", specifier = ">=1.27,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
-    { name = "openai", specifier = ">=2.44" },
+    { name = "openai", specifier = ">=2.45" },
     { name = "pillow", specifier = ">=10" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Live-testing the freshly onboarded GPT-5.6 support against the GA endpoints surfaced several gaps between the 07-09 onboarding and the API as shipped. This branch closes them.

**Providers / wire**
- All three tiers (Sol, Terra, Luna) accept effort `max` and `reasoning.mode` (`standard`/`pro`); the Sol-only gating came from a stale GA-day docs reading.
- GPT-5.6 deprecates `prompt_cache_retention`: send `prompt_cache_options={"ttl": "30m"}` (its only supported lifetime) instead. Pre-5.6 models keep the 24h retention policy.
- Commercial cache params no longer leak into local lanes: dropped from the Chat Completions lane (which serves only openai-compatible and google) and gated off the compat-pinned Responses lane. A `gpt-5*` served-model name on a local box no longer inherits OpenAI cache controls.
- Cache writes are accounted: `*_tokens_details.cache_write_tokens` flows into `cache_creation_tokens` (5.6 bills writes at 1.25x the uncached input rate).
- Non-string `verbosity`/`reasoning_mode` capability overrides are dropped with a warning instead of raising on unhashable capability-JSON values.
- `ModelCapabilities` keeps its public positional prefix: the verbosity/pro fields moved to the tail of the dataclass, pinned by a constructor test.
- `openai` floor 2.44 -> 2.45, the first release with the typed `prompt_cache_options` kwarg.

**Console**
- Capability-gated "Response controls" (Output verbosity, Standard/Pro reasoning mode) on the Models create/edit shelf, shown only for Responses-surface models; the empty selection means provider default and omits the capability key.
- Values lift out of / merge back into the capabilities JSON with identity tracking so a provider/model/surface change resets them; the Advanced JSON textarea wins unless the select was touched last. In-flight capability lookups are invalidated on field changes and modal open.
- Model list rows surface `verbosity=` / `mode=` override chips.

## Verification

- OpenAI prompt-caching guide: retention deprecated for 5.6+, `ttl: "30m"` is the only supported value, writes billed at 1.25x, `cache_write_tokens` present in both usage shapes.
- OpenAI latest-model guide: "Pro mode works with any GPT-5.6 model"; the family effort list includes `max` with no tier restriction.
- Installed-SDK introspection: 2.45 types `Reasoning.mode` as `Literal['standard', 'pro']`, includes `max` in `ReasoningEffort`, carries the `prompt_cache_options` kwarg on `Responses.create`, and adds `cache_write_tokens` to `InputTokensDetails`.
- The documented `gpt-5.6` -> Sol alias row is intentionally kept: OpenAI routes the bare id to Sol server-side, and dated snapshots resolve through it.
- 431 tests across the touched files; wire goldens updated; ruff, ruff format, and mypy clean.