### PR TITLE
fix(judge): thread model-definition capabilities into judge completions

### DIFF
--- a/docs/judge.md
+++ b/docs/judge.md
@@ -249,8 +249,14 @@ are withheld from the live surfaces (a reused call_id must never ride a stale
 `approve` into Smart Approvals) but still persist with
 `user_decision = "superseded"` so the audit trail records the judge's answer.
 
-Sub-agents (plan agent, task agent) are exempt from intent validation -- they
-always get full tool visibility without judge evaluation.
+Sub-agent (task agent) tool calls are judge-gated too. Each runs the same
+intent pipeline as its own `agent_gate` generation, grounded in that sub-agent's
+own trajectory -- its task prompt is the delegation contract the operator
+approved, so "does this call serve the task" is the right local question.
+Agent-gate generations never occupy the main loop's supersede slot (parallel
+siblings would otherwise make each other's verdicts look stale); per-cycle
+generation checks enforce staleness instead, and `judge.cancel_on_approval`
+fires per gate exactly like the main loop.
 
 ---
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -71,7 +71,7 @@ def _make_judge(
         session_provider=provider,
         session_client=client,
         session_model="test-model",
-        context_window=100_000,
+        session_capabilities=MagicMock(context_window=100_000),
     )
 
 
@@ -892,14 +892,82 @@ class TestModelAliasResolution:
         alias_provider: MagicMock,
         alias_client: MagicMock,
         underlying_model: str,
+        *,
+        capabilities: dict[str, Any] | None = None,
     ) -> MagicMock:
         registry = MagicMock()
         cfg = MagicMock()
         cfg.context_window = 50_000
+        cfg.capabilities = capabilities if capabilities is not None else {}
         registry.has_alias.side_effect = lambda a: a == alias
         registry.resolve.return_value = (alias_client, underlying_model, cfg)
         registry.get_provider.return_value = alias_provider
         return registry
+
+    def test_alias_capabilities_merged_and_threaded_to_wire(self):
+        """#823: a judge alias's model-definition ``capabilities`` are merged
+        onto the provider base AND passed to ``create_completion`` — the same
+        contract as the session / utility / sub-agent lanes.  Without threading,
+        operator overrides (effort passthrough, tool support) were silently
+        ignored on judge calls; deleting ``capabilities=self._capabilities`` from
+        the call site, or breaking the merge, must fail here."""
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        base = ModelCapabilities(supports_tools=True, effort_passthrough=False)
+        alias_provider = _make_mock_provider(response_content=_good_verdict_json())
+        alias_provider.get_capabilities = MagicMock(return_value=base)
+        registry = self._make_alias_registry(
+            "judge-mini",
+            alias_provider,
+            MagicMock(base_url="https://a/v1", api_key="k"),
+            "local-9b",
+            capabilities={"supports_tools": False, "effort_passthrough": True},
+        )
+        judge = IntentJudge(
+            config=JudgeConfig(enabled=True, model="judge-mini"),
+            session_provider=_make_mock_provider(),
+            session_client=MagicMock(base_url="https://s/v1", api_key="s"),
+            session_model="session-model",
+            session_capabilities=MagicMock(context_window=100_000),
+            model_registry=registry,
+        )
+        # Merged at construction: overrides applied, untouched fields survive.
+        assert judge._capabilities.supports_tools is False
+        assert judge._capabilities.effort_passthrough is True
+        assert judge._capabilities.context_window == base.context_window
+        # ...and the SAME merged object reaches the wire.
+        judge._evaluate_single(
+            _make_item(),
+            [{"role": "user", "content": "x"}],
+            cancel_event=None,
+            client=MagicMock(),
+        )
+        passed = alias_provider.create_completion.call_args.kwargs["capabilities"]
+        assert passed is judge._capabilities
+
+    def test_fallback_threads_session_capabilities_to_wire(self):
+        """No judge alias → the judge inherits the session model AND the
+        session's resolved capabilities, threaded to ``create_completion``."""
+        from turnstone.core.providers._protocol import ModelCapabilities
+
+        sess_caps = ModelCapabilities(context_window=54_321, effort_passthrough=True)
+        provider = _make_mock_provider(response_content=_good_verdict_json())
+        judge = IntentJudge(
+            config=JudgeConfig(enabled=True, model=""),  # no alias → fallback
+            session_provider=provider,
+            session_client=MagicMock(base_url="https://s/v1", api_key="s"),
+            session_model="session-model",
+            session_capabilities=sess_caps,
+        )
+        assert judge._capabilities is sess_caps
+        assert judge._judge_context_window == 54_321
+        judge._evaluate_single(
+            _make_item(),
+            [{"role": "user", "content": "x"}],
+            cancel_event=None,
+            client=MagicMock(),
+        )
+        assert provider.create_completion.call_args.kwargs["capabilities"] is sess_caps
 
     def test_alias_uses_registry_provider_not_session_provider(self):
         """Judge with model=alias should resolve via registry — provider, client,
@@ -932,7 +1000,6 @@ class TestModelAliasResolution:
             session_provider=session_provider,
             session_client=session_client,
             session_model="session-default-model",
-            context_window=100_000,
             model_registry=registry,
         )
 
@@ -959,7 +1026,6 @@ class TestModelAliasResolution:
             session_provider=_make_mock_provider(),
             session_client=MagicMock(base_url="https://s/v1", api_key="s"),
             session_model="session-model",
-            context_window=100_000,
             model_registry=registry,
         )
         assert judge._judge_context_window == 50_000
@@ -980,7 +1046,7 @@ class TestModelAliasResolution:
             session_provider=_make_mock_provider(),
             session_client=MagicMock(base_url="http://s", api_key="s"),
             session_model="session-model",
-            context_window=100_000,
+            session_capabilities=MagicMock(context_window=100_000),
             model_registry=registry,
         )
         assert judge._judge_context_window == 100_000  # session window, not 0
@@ -1008,7 +1074,7 @@ class TestModelAliasResolution:
             session_provider=session_provider,
             session_client=session_client,
             session_model="session-default-model",
-            context_window=100_000,
+            session_capabilities=MagicMock(context_window=100_000),
             model_registry=registry,
         )
 
@@ -1031,7 +1097,6 @@ class TestModelAliasResolution:
             session_provider=session_provider,
             session_client=session_client,
             session_model="session-default-model",
-            context_window=100_000,
         )
 
         assert judge._provider is session_provider

--- a/tests/test_output_guard_judge.py
+++ b/tests/test_output_guard_judge.py
@@ -15,6 +15,7 @@ from turnstone.core.output_guard_judge import (
     OutputJudgeVerdict,
     _extract_json,
 )
+from turnstone.core.providers._protocol import ModelCapabilities
 
 
 def _make_provider(
@@ -66,6 +67,76 @@ def _make_judge(
     )
     judge._create_client = lambda: client  # type: ignore[method-assign]
     return judge
+
+
+class TestCapabilityThreading:
+    """#823: the output-guard judge threads resolved capabilities to
+    create_completion, like every other create_completion caller."""
+
+    @staticmethod
+    def _recording_provider() -> tuple[Any, dict[str, Any]]:
+        captured: dict[str, Any] = {}
+
+        def _cc(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            result = MagicMock()
+            result.content = '{"risk_level": "none", "flags": []}'
+            return result
+
+        provider = MagicMock()
+        provider.provider_name = "openai"
+        provider.get_capabilities = MagicMock(
+            return_value=ModelCapabilities(context_window=200_000)
+        )
+        provider.create_completion = MagicMock(side_effect=_cc)
+        return provider, captured
+
+    def test_fallback_threads_session_capabilities(self) -> None:
+        provider, captured = self._recording_provider()
+        sess_caps = ModelCapabilities(context_window=40_000, effort_passthrough=True)
+        client = MagicMock(base_url="http://s", api_key="k")
+        judge = OutputGuardJudge(
+            config=JudgeConfig(output_guard_llm=True),  # no alias → fallback
+            session_provider=provider,
+            session_client=client,
+            session_model="m",
+            session_capabilities=sess_caps,
+        )
+        judge._create_client = lambda: client  # type: ignore[method-assign]
+        assert judge._capabilities is sess_caps
+        v = judge.evaluate("a small, safe output", func_name="bash", call_id="c1")
+        assert v.succeeded
+        assert captured["capabilities"] is sess_caps
+
+    def test_alias_merges_operator_capabilities(self) -> None:
+        provider, captured = self._recording_provider()
+        provider.get_capabilities = MagicMock(return_value=ModelCapabilities(supports_tools=True))
+        cfg = MagicMock()
+        cfg.context_window = 64_000
+        cfg.capabilities = {"supports_tools": False}
+        registry = MagicMock()
+        registry.has_alias.return_value = True
+        registry.resolve.return_value = (
+            MagicMock(base_url="http://a", api_key="k"),
+            "local-9b",
+            cfg,
+        )
+        registry.get_provider.return_value = provider
+        client = MagicMock(base_url="http://s", api_key="k")
+        judge = OutputGuardJudge(
+            config=JudgeConfig(output_guard_llm=True, output_guard_model="og"),
+            session_provider=_make_provider(),
+            session_client=client,
+            session_model="m",
+            session_capabilities=MagicMock(context_window=100_000),
+            model_registry=registry,
+        )
+        judge._create_client = lambda: client  # type: ignore[method-assign]
+        assert judge._capabilities.supports_tools is False  # operator override applied
+        v = judge.evaluate("a small, safe output", func_name="bash", call_id="c1")
+        assert v.succeeded
+        assert captured["capabilities"] is judge._capabilities
+        assert captured["capabilities"].supports_tools is False
 
 
 class TestVerdictDataclass:
@@ -291,14 +362,16 @@ class TestOversizeGuard:
             session_provider=provider,
             session_client=MagicMock(base_url="http://test", api_key="k"),
             session_model="test-model",
-            context_window=40_000,  # the session's real window
+            # The session's real window rides in the resolved caps the caller
+            # passes; the guard must key off it, not provider.get_capabilities().
+            session_capabilities=MagicMock(context_window=40_000),
         )
         assert judge._judge_context_window == 40_000
 
     def test_zero_window_coerced_away_on_both_paths(self) -> None:
         """A config.toml context_window=0 (present but unusable) must not zero
         the guard: coerce to the session window (alias path) / the default."""
-        from turnstone.core.output_guard_judge import _DEFAULT_JUDGE_CONTEXT_WINDOW
+        from turnstone.core.judge import _DEFAULT_JUDGE_CONTEXT_WINDOW
 
         # Alias path: ModelConfig.context_window == 0 → session window.
         cfg = MagicMock()
@@ -313,7 +386,7 @@ class TestOversizeGuard:
             session_client=MagicMock(base_url="http://s", api_key="s"),
             session_model="m",
             model_registry=registry,
-            context_window=64_000,
+            session_capabilities=MagicMock(context_window=64_000),
         )
         assert alias_judge._judge_context_window == 64_000
 

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -15,7 +15,7 @@ import re
 import threading
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, replace
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -30,7 +30,7 @@ from turnstone.core.log import get_logger
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from turnstone.core.providers._protocol import LLMProvider
+    from turnstone.core.providers._protocol import LLMProvider, ModelCapabilities
 
 log = get_logger(__name__)
 
@@ -844,6 +844,33 @@ def _positive_window(*candidates: Any, floor: int = _DEFAULT_JUDGE_CONTEXT_WINDO
     return floor
 
 
+def _resolve_model_capabilities(provider: LLMProvider, model: str, cfg: Any) -> ModelCapabilities:
+    """Provider base capabilities with a model definition's ``capabilities``
+    overrides applied — the same lowering ``ChatSession._resolve_capabilities``
+    performs for the session, utility, and sub-agent completion lanes.
+
+    The judges are the only completion callers that live outside ``ChatSession``,
+    so they cannot reach ``self._resolve_capabilities``; this mirrors it so a
+    judge alias honors operator-declared capabilities (effort passthrough, tool
+    support, temperature, verbosity) exactly like the main loop.  ``cfg`` is the
+    alias's ``ModelConfig``; a missing or non-dict ``capabilities`` is ignored
+    rather than raised — capability resolution must never crash a judge turn.
+
+    It does NOT fold in ``ModelConfig.context_window``: that is a separate field,
+    not part of the capabilities JSON, and the caller sizes the judge's window
+    budget off it directly (the static caps table reports 200000 for local
+    models, which would silently over-budget them).
+    """
+    caps = provider.get_capabilities(model)
+    overrides = getattr(cfg, "capabilities", None)
+    if isinstance(overrides, dict) and overrides:
+        names = {f.name for f in fields(type(caps))}
+        applied = {k: v for k, v in overrides.items() if k in names}
+        if applied:
+            caps = replace(caps, **applied)
+    return caps
+
+
 def honest_truncate(text: str, budget: int) -> str:
     """Return *text* untouched when it fits *budget* characters, otherwise the
     leading ``budget`` characters followed by an explicit note of exactly how
@@ -971,13 +998,21 @@ class IntentJudge:
         session_provider: LLMProvider,
         session_client: Any,
         session_model: str,
-        context_window: int = 200_000,
+        session_capabilities: ModelCapabilities | None = None,
         rule_registry: Any | None = None,
         model_registry: Any | None = None,
     ) -> None:
         self._config = config
-        self._context_window = context_window
         self._rule_registry = rule_registry
+        # The caller (ChatSession) resolves the session model's real caps from
+        # _get_capabilities (config/registry-aware) and passes them in; they are
+        # this judge's wire capabilities and window when it inherits the session
+        # model.  The window is taken ONLY from these resolved caps (else a
+        # floor) — NEVER provider.get_capabilities(), whose static 200000 for a
+        # local model would blind the budget to overflow.
+        session_window = (
+            session_capabilities.context_window if session_capabilities is not None else None
+        )
 
         # Resolve judge model via ModelRegistry alias, otherwise self-
         # consistency on the session model.  ``judge.model`` is alias-only
@@ -1001,6 +1036,9 @@ class IntentJudge:
                         self._provider.provider_name,
                     )
                     self._model = model_name
+                    self._capabilities = _resolve_model_capabilities(
+                        self._provider, self._model, model_cfg
+                    )
                     # Use the registry's per-model context window, NOT
                     # ``provider.get_capabilities().context_window``: the static
                     # capability table returns 200000 for every model absent
@@ -1013,7 +1051,8 @@ class IntentJudge:
                     # the session ``context_window`` then a floor, so it neither
                     # aborts resolution nor zeroes the budgets.
                     self._judge_context_window = _positive_window(
-                        getattr(model_cfg, "context_window", None), context_window
+                        getattr(model_cfg, "context_window", None),
+                        session_window,
                     )
                     resolved = True
             except Exception:
@@ -1034,8 +1073,15 @@ class IntentJudge:
                 session_provider.provider_name,
             )
             self._model = session_model
+            # Wire caps: the caller's resolved session caps, or the provider's
+            # static table as a last resort for degraded / legacy callers.
+            self._capabilities = (
+                session_capabilities
+                if session_capabilities is not None
+                else session_provider.get_capabilities(session_model)
+            )
             # Coerce here too, defensively against a non-positive session window.
-            self._judge_context_window = _positive_window(context_window)
+            self._judge_context_window = _positive_window(session_window)
 
     # -- Client lifecycle helpers -------------------------------------------
 
@@ -1336,6 +1382,13 @@ class IntentJudge:
                         max_tokens=2048,
                         temperature=0.0,
                         reasoning_effort="medium",
+                        # Thread the judge model's operator-declared capabilities
+                        # onto the wire like every other lane — resolved from the
+                        # judge alias's model definition, or the session model on
+                        # fallback.  Without this the provider would fall back to
+                        # its static capability table and silently ignore the
+                        # definition's overrides on judge calls alone.
+                        capabilities=self._capabilities,
                     ),
                     timeout=per_call_timeout,
                     cancel_event=cancel_event,

--- a/turnstone/core/output_guard_judge.py
+++ b/turnstone/core/output_guard_judge.py
@@ -50,8 +50,8 @@ from turnstone.core.deadline import (
 )
 from turnstone.core.judge import (
     _CHARS_PER_TOKEN,
-    _DEFAULT_JUDGE_CONTEXT_WINDOW,
     _positive_window,
+    _resolve_model_capabilities,
 )
 from turnstone.core.log import get_logger
 
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     import threading
 
     from turnstone.core.judge import JudgeConfig
-    from turnstone.core.providers._protocol import LLMProvider
+    from turnstone.core.providers._protocol import LLMProvider, ModelCapabilities
 
 log = get_logger(__name__)
 
@@ -247,7 +247,7 @@ class OutputGuardJudge:
     Construction resolves the configured ``judge.output_guard_model``
     alias inline; on resolution failure (alias unset or unknown) the
     session model is used as a fallback.  Mirrors :class:`IntentJudge`'s
-    own resolution at ``judge.py:917-960``.
+    own alias resolution.
 
     The HTTP client is lazy-initialised on the first ``evaluate()`` call
     and reused for the lifetime of the judge instance — see
@@ -267,16 +267,23 @@ class OutputGuardJudge:
         session_client: Any,
         session_model: str,
         model_registry: Any | None = None,
-        context_window: int = _DEFAULT_JUDGE_CONTEXT_WINDOW,
+        session_capabilities: ModelCapabilities | None = None,
     ) -> None:
         self._config = config
-        # Alias resolution mirrors IntentJudge.__init__ at judge.py:917-960.
+        # Caller's resolved session-model caps (config/registry-aware): the wire
+        # capabilities + window when this judge inherits the session model, and
+        # the alias path's window fallback.  The window comes ONLY from these
+        # (else a floor), never provider.get_capabilities() — see below.
+        session_window = (
+            session_capabilities.context_window if session_capabilities is not None else None
+        )
+        # Alias resolution mirrors IntentJudge.__init__.
         # An empty / unset alias falls through to the session model silently;
         # a set-but-unknown alias logs a warning and also falls through.
         # Judge model's context window drives the oversize-output guard in
         # ``evaluate``.  It comes from the registry's ModelConfig on the alias
-        # path and the session's real window (``context_window``, resolved by
-        # the caller from _get_capabilities) on the fallback path — NEVER
+        # path and the session's real window (``session_capabilities``, resolved
+        # by the caller from _get_capabilities) on the fallback path — NEVER
         # ``provider.get_capabilities()``, which returns a static 200000 for
         # every model absent from its table (i.e. every local / self-hosted
         # judge), so a guard keyed off it would never trip for the small-window
@@ -296,8 +303,12 @@ class OutputGuardJudge:
                     )
                     self._model = model_name
                     self._judge_model_alias = config.output_guard_model
+                    self._capabilities = _resolve_model_capabilities(
+                        self._provider, self._model, model_cfg
+                    )
                     self._judge_context_window = _positive_window(
-                        getattr(model_cfg, "context_window", None), context_window
+                        getattr(model_cfg, "context_window", None),
+                        session_window,
                     )
                     resolved = True
             except Exception:
@@ -321,12 +332,19 @@ class OutputGuardJudge:
             )
             self._model = session_model
             self._judge_model_alias = ""
+            # Wire caps: the caller's resolved session caps, or the provider's
+            # static table as a last resort for degraded / legacy callers.
+            self._capabilities = (
+                session_capabilities
+                if session_capabilities is not None
+                else session_provider.get_capabilities(session_model)
+            )
             # Session-model fallback: use the session's real context window
             # (the caller resolved it from _get_capabilities, config/registry-
             # aware) — NOT provider.get_capabilities(), which reports 200000 for
             # a local session model and would leave the guard blind to overflow,
             # the very failure this fixes.  Mirrors IntentJudge's fallback.
-            self._judge_context_window = _positive_window(context_window)
+            self._judge_context_window = _positive_window(session_window)
 
         # Lazy-init in _create_client(); reused across evaluate() calls.
         # Session swaps the entire OutputGuardJudge on credential / model
@@ -341,7 +359,7 @@ class OutputGuardJudge:
 
         Reads ``base_url`` and ``api_key`` from the client and returns
         the dict ``turnstone.core.providers.create_client`` accepts.
-        Inlined from IntentJudge's helper at ``judge.py:965-969``.
+        Inlined from IntentJudge's ``_extract_client_config``.
         """
         base_url = str(getattr(client, "base_url", getattr(client, "_base_url", "")))
         api_key = getattr(client, "api_key", "") or ""
@@ -491,6 +509,10 @@ class OutputGuardJudge:
                     max_tokens=512,
                     temperature=0.0,
                     reasoning_effort="low",
+                    # Operator-declared capabilities reach the wire like every
+                    # other lane — from the output_guard alias's definition, or
+                    # the session model on fallback.  See IntentJudge for why.
+                    capabilities=self._capabilities,
                 ),
                 timeout=timeout,
                 cancel_event=cancel_event,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -8015,7 +8015,7 @@ class ChatSession:
                 session_provider=self._provider,
                 session_client=self.client,
                 session_model=self.model,
-                context_window=caps.context_window,
+                session_capabilities=caps,
                 rule_registry=self._rule_registry,
                 model_registry=self._registry,
             )
@@ -8047,10 +8047,11 @@ class ChatSession:
                 session_client=self.client,
                 session_model=self.model,
                 model_registry=self._registry,
-                # Session's real (config/registry-aware) window, so the oversize
-                # guard is accurate when output_guard_model is unset — same
+                # Session's resolved (config/registry-aware) capabilities, so the
+                # oversize guard's window is accurate and operator-declared caps
+                # reach the judge wire when output_guard_model is unset — same
                 # source IntentJudge gets via _ensure_judge.
-                context_window=self._get_capabilities().context_window,
+                session_capabilities=self._get_capabilities(),
             )
         except Exception:
             log.warning("output_guard_judge.init_failed", exc_info=True)


### PR DESCRIPTION
## Summary

The intent judge and output-guard judge were the only `create_completion` callers that never threaded model-definition capabilities onto the wire. Every in-`ChatSession` lane (main send, utility completions, task sub-agents) resolves capabilities via `ChatSession._resolve_capabilities` and passes `capabilities=` into `create_completion`; the two judges are the only completion consumers that live *outside* `ChatSession`, so that primitive never reached them. The result: operator-declared capabilities on a judge model definition — effort passthrough, tool support, temperature, verbosity — were silently ignored on judge calls alone.

This aligns the judges with every other lane.

## Changes

- **`turnstone/core/judge.py`** — new shared `_resolve_model_capabilities(provider, model, cfg)` helper mirroring `ChatSession._resolve_capabilities` (base provider caps + model-definition `capabilities` JSON overrides via `dataclasses.replace`). `IntentJudge` resolves `self._capabilities` and passes `capabilities=` into `create_completion`.
- **`turnstone/core/output_guard_judge.py`** — same treatment, reusing the helper.
- **Constructor change** — each judge's `context_window: int` arg is replaced by `session_capabilities: ModelCapabilities | None`. The session-model-fallback window now derives from `session_capabilities.context_window` (identical to what the session passed before); the alias path still reads `ModelConfig.context_window` — a separate field, not part of the capabilities JSON, so the merged caps' `context_window` (a generic default for unknown/local models) must not feed the budget. Window fallback and wire-caps fallback are deliberately decoupled: the window trusts only the passed caps (floor otherwise), never `get_capabilities()`.
- **`turnstone/core/session.py`** — both construction sites pass `session_capabilities=self._get_capabilities()`.
- **`docs/judge.md`** — replace the stale "sub-agents are exempt from intent validation" note with the current behavior (task agents run the intent pipeline as their own `agent_gate` generation since #773).

## Scope

Closes #823 — the capability-threading cause is fixed here: judge calls now honor the model definition's capabilities exactly like sessions do.

The issue's second cause (evidence tools attached to models that don't advertise tool support) has an immediate operator lever — `judge.read_only_tools = false` runs the judge single-shot with no tools attached — and a proper capability-gated fix tracked in #827, which also covers modernizing the judge onto Turn IR (the judges hand-build OpenAI-shaped messages today, which is why the intent judge also runs tool-blind on Gemini).

## Testing

- New body-inspecting tests assert the merged capabilities reach `create_completion` (alias merge + session fallback, both judges) — the behavior that deleting `capabilities=self._capabilities` would silently break.
- Existing window-provenance tests migrated to the `session_capabilities` contract.
- ruff + mypy clean; 270 judge-suite tests + 48 downstream construction-site tests pass.
