### PR TITLE
fix(admin): add create-admin CLI; stop run.sh onboarding into a role-less user

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -366,11 +366,14 @@ ${GREEN}${BOLD}Turnstone is running${RESET} (${NODE_COUNT} node$([ "$NODE_COUNT"
               ${DIM}cd $INSTALL_DIR && $DOCKER compose exec caddy cat /data/caddy/pki/authorities/local/root.crt${RESET}
 
   Finish setup
-    1. Create the first admin user:
-       ${DIM}cd $INSTALL_DIR && $DOCKER compose exec node-1 turnstone-admin create-user --username admin --name "Admin"${RESET}
-    2. Open ${url}, log in, and add a model backend in the ${BOLD}Models${RESET} tab —
+    1. Open ${BOLD}${url}${RESET} and create the admin account when prompted —
+       the first user created there gets full admin access.
+    2. Log in, then add a model backend in the ${BOLD}Models${RESET} tab —
        a local server (vLLM / llama.cpp) or an OpenAI / Anthropic / Gemini key.
        Nodes boot without a model and pick it up live; no restart needed.
+
+    ${DIM}No browser? Create the admin from the CLI instead:
+    cd $INSTALL_DIR && $DOCKER compose exec node-1 turnstone-admin create-admin --username admin --name "Admin"${RESET}
 
   Scale       Running ${scale}
 

--- a/tests/test_admin_create_admin.py
+++ b/tests/test_admin_create_admin.py
@@ -1,0 +1,170 @@
+"""Tests for ``turnstone-admin create-admin`` (issue #824).
+
+``create-user`` creates a role-less user; the web UI derives a login's scopes
+purely from assigned roles, so that account logs in read-only and hits
+"Forbidden: token lacks 'approve' scope" on any admin action.  ``create-admin``
+assigns the built-in admin role — mirroring the web setup wizard
+(``POST /api/auth/setup``) — and promotes an existing role-less user, which is
+the recovery path for anyone already stuck.
+
+Each test drives the real ``_cmd_create_admin`` handler against a real,
+fully-migrated SQLite DB: the ``builtin-admin`` role is seeded by migration
+008, so the DB must be migrated (not just ``create_all``-built) for the role
+to exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from turnstone.admin import _cmd_create_admin, _cmd_create_user
+from turnstone.core.auth import _load_user_permissions, _permissions_to_scopes
+from turnstone.core.storage import init_storage, reset_storage
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _reset_storage_singleton() -> Iterator[None]:
+    """Keep the module-global storage singleton from leaking across tests."""
+    reset_storage()
+    yield
+    reset_storage()
+
+
+def _db_args(db_path: str, **overrides: Any) -> argparse.Namespace:
+    """Build the Namespace ``_cmd_create_admin`` (and ``_cmd_create_user``) expect.
+
+    Pins every DB field so ``_get_storage`` resolves to the tmp sqlite file and
+    never leaks a ``TURNSTONE_DB_*`` env var (it only falls back when the attr
+    ``is None``).  ``token``/``scopes`` are only read by ``_cmd_create_user``.
+    """
+    base: dict[str, Any] = {
+        "username": "admin",
+        "name": "",
+        "password": "",
+        "token": False,
+        "scopes": "read,write,approve",
+        "db_backend": "sqlite",
+        "db_path": db_path,
+        "db_url": "",
+        "db_pool_size": 2,
+        "db_sslmode": "",
+        "db_sslrootcert": "",
+        "db_sslcert": "",
+        "db_sslkey": "",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _migrated_storage(db_path: str) -> Any:
+    """Return a fully-migrated storage singleton (seeds the ``builtin-admin`` role)."""
+    return init_storage("sqlite", path=db_path, run_migrations=True)
+
+
+def _has_admin_role(storage: Any, user_id: str) -> bool:
+    return any(r.get("role_id") == "builtin-admin" for r in storage.list_user_roles(user_id))
+
+
+def _login_scopes(storage: Any, user_id: str) -> frozenset[str]:
+    """Scopes a password login would grant this user — the real lockout surface."""
+    return _permissions_to_scopes(_load_user_permissions(storage, user_id))
+
+
+def test_create_admin_fresh_user_gets_approve_scope(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "admin.db")
+    storage = _migrated_storage(db_path)
+
+    _cmd_create_admin(_db_args(db_path, username="admin", name="Admin", password="hunter2!pw"))
+
+    user = storage.get_user_by_username("admin")
+    assert user is not None
+    assert _has_admin_role(storage, user["user_id"])
+    # The exact bug surface: a web login for this account must carry `approve`.
+    assert "approve" in _login_scopes(storage, user["user_id"])
+
+
+def test_create_admin_defaults_display_name_to_username(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "admin.db")
+    storage = _migrated_storage(db_path)
+
+    _cmd_create_admin(_db_args(db_path, username="root", name="", password="hunter2!pw"))
+
+    user = storage.get_user_by_username("root")
+    assert user is not None
+    assert user["display_name"] == "root"
+
+
+def test_create_admin_promotes_existing_read_only_user(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #824 recovery path: a role-less create-user account, then create-admin."""
+    db_path = str(tmp_path / "admin.db")
+    storage = _migrated_storage(db_path)
+
+    # Reproduce the locked-out account exactly (role-less create-user).
+    _cmd_create_user(_db_args(db_path, username="admin", name="Admin", password="hunter2!pw"))
+    user = storage.get_user_by_username("admin")
+    assert user is not None
+    assert not _has_admin_role(storage, user["user_id"])
+    assert "approve" not in _login_scopes(storage, user["user_id"])  # locked out
+
+    # Unstick without recreating the user.
+    _cmd_create_admin(_db_args(db_path, username="admin"))
+
+    assert _has_admin_role(storage, user["user_id"])
+    assert "approve" in _login_scopes(storage, user["user_id"])
+    assert "Granted the admin role" in capsys.readouterr().out
+
+
+def test_create_admin_already_admin_is_idempotent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = str(tmp_path / "admin.db")
+    storage = _migrated_storage(db_path)
+
+    _cmd_create_admin(_db_args(db_path, username="admin", name="Admin", password="hunter2!pw"))
+    capsys.readouterr()  # drop first-run output
+
+    _cmd_create_admin(_db_args(db_path, username="admin"))
+
+    user = storage.get_user_by_username("admin")
+    assert user is not None
+    admin_rows = [
+        r for r in storage.list_user_roles(user["user_id"]) if r.get("role_id") == "builtin-admin"
+    ]
+    assert len(admin_rows) == 1  # not duplicated
+    assert "already an admin" in capsys.readouterr().out
+
+
+def test_create_admin_short_password_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = str(tmp_path / "admin.db")
+    storage = _migrated_storage(db_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_create_admin(_db_args(db_path, username="admin", name="Admin", password="short"))
+
+    assert exc_info.value.code == 1
+    assert "at least 8" in capsys.readouterr().err
+    assert storage.get_user_by_username("admin") is None  # nothing created
+
+
+def test_create_admin_invalid_username_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = str(tmp_path / "admin.db")
+    _migrated_storage(db_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_create_admin(_db_args(db_path, username="bad user!", name="X", password="hunter2!pw"))
+
+    assert exc_info.value.code == 1
+    assert "invalid username" in capsys.readouterr().err

--- a/turnstone/admin.py
+++ b/turnstone/admin.py
@@ -101,6 +101,73 @@ def _cmd_create_user(args: argparse.Namespace) -> None:
         print("  (Save this token now — it cannot be retrieved again)")
 
 
+def _cmd_create_admin(args: argparse.Namespace) -> None:
+    """Create an admin user (or promote an existing one) with full access.
+
+    Unlike ``create-user`` — which creates a role-less user that logs into the
+    web UI read-only — this assigns the built-in admin role, mirroring the web
+    first-run setup wizard (``POST /api/auth/setup``).  Use it for headless
+    installs, or to unstick a ``create-user`` account that logs in only to hit
+    "Forbidden: token lacks 'approve' scope".
+    """
+    import getpass
+
+    from turnstone.core.auth import hash_password, is_valid_username
+
+    if not is_valid_username(args.username):
+        print("Error: invalid username (1-64 chars: letters, digits, . _ -)", file=sys.stderr)
+        sys.exit(1)
+
+    storage = _get_storage(args)
+
+    # The admin role is seeded by DB migrations; without it we'd leave the
+    # account read-only — the exact lockout this command exists to prevent.
+    if storage.get_role("builtin-admin") is None:
+        print(
+            "Error: the built-in admin role is missing — run database migrations first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Promote an existing user (recovery path: create-user assigns no role).
+    existing = storage.get_user_by_username(args.username)
+    if existing is not None:
+        user_id = existing["user_id"]
+        already_admin = any(
+            r.get("role_id") == "builtin-admin" for r in storage.list_user_roles(user_id)
+        )
+        storage.assign_role(user_id, "builtin-admin", "")
+        if already_admin:
+            print(f"User '{args.username}' is already an admin (user {user_id}); no change.")
+        else:
+            print(f"Granted the admin role to existing user '{args.username}' (user {user_id}).")
+            print("  Log out and back in for the new access to take effect.")
+        return
+
+    # Create a fresh admin user.
+    password = args.password
+    if not password:
+        password = getpass.getpass("Password: ")
+        confirm = getpass.getpass("Confirm password: ")
+        if password != confirm:
+            print("Error: passwords do not match", file=sys.stderr)
+            sys.exit(1)
+    # Match the web setup wizard's floor for the most privileged account.
+    if len(password) < 8:
+        print("Error: password must be at least 8 characters", file=sys.stderr)
+        sys.exit(1)
+
+    display_name = args.name or args.username
+    user_id = uuid.uuid4().hex
+    pw_hash = hash_password(password)
+    storage.create_user(user_id, args.username, display_name, pw_hash)
+    storage.assign_role(user_id, "builtin-admin", "")
+    print(f"Created admin user: {user_id}")
+    print(f"  Username: {args.username}")
+    print(f"  Name: {display_name}")
+    print("  Role: admin (full access)")
+
+
 def _cmd_create_token(args: argparse.Namespace) -> None:
     from turnstone.core.auth import (
         generate_token,
@@ -596,6 +663,18 @@ def main() -> None:
     p_cu.add_argument("--token", action="store_true", help="Also create an initial API token")
     p_cu.add_argument("--scopes", default="read,write,approve", help="Scopes for initial token")
 
+    p_ca = sub.add_parser(
+        "create-admin",
+        help="Create an admin user (or promote an existing one) with full access",
+    )
+    p_ca.add_argument("--username", required=True, help="Login username")
+    p_ca.add_argument("--name", default="", help="Display name (defaults to the username)")
+    p_ca.add_argument(
+        "--password",
+        default="",
+        help="Password (prompted if omitted; ignored when promoting an existing user)",
+    )
+
     p_ct = sub.add_parser("create-token", help="Create an API token for a user")
     p_ct.add_argument("--user", required=True, help="User ID")
     p_ct.add_argument("--name", default="", help="Human label for the token")
@@ -690,6 +769,7 @@ def main() -> None:
 
     dispatch = {
         "create-user": _cmd_create_user,
+        "create-admin": _cmd_create_admin,
         "create-token": _cmd_create_token,
         "list-users": _cmd_list_users,
         "list-tokens": _cmd_list_tokens,


### PR DESCRIPTION
## Problem

`run.sh`'s "Finish setup" instructs `turnstone-admin create-user`, which creates a user with **no role**. Web login derives scopes solely from assigned roles (`_load_user_permissions` → `_permissions_to_scopes`; empty perms → `read` only), so that admin logs in read-only and every admin action returns `Forbidden: token lacks 'approve' scope`.

Worse, creating any user makes `count_users > 0`, which flips `setup_required` to false — so the browser first-run wizard (`POST /api/auth/setup`), the one path that actually assigns `builtin-admin`, never appears. The installer was steering users straight past the only correct path.

Reported in #824.

## Changes

- **run.sh** — "Finish setup" now points at the browser wizard (the first user created there gets full admin). The CLI fallback uses the new `create-admin` instead of `create-user`.
- **admin.py** — new `create-admin` command: creates a user + assigns `builtin-admin`, or promotes an existing role-less user (idempotent). Guards on the seeded admin role (clear error if migrations haven't run) and enforces the wizard's 8-char minimum for fresh accounts. This also gives already-stuck users a non-destructive recovery: `create-admin --username <them>`.
- **tests** — `test_admin_create_admin.py`: fresh grant (asserts `approve` reaches the derived login scope), the promote/recovery path, idempotency, short-password and invalid-username exits.

## Verification

- `create-admin` driven end-to-end against a real migrated SQLite DB: fresh-create, promote, and re-run (idempotent).
- ruff + mypy clean; new tests plus adjacent admin/auth suites green (53 passing).

Fixes #824
